### PR TITLE
Add 44 new US market credit cards

### DIFF
--- a/data/cards/amazon-business-prime-american-express-card.yaml
+++ b/data/cards/amazon-business-prime-american-express-card.yaml
@@ -1,0 +1,6 @@
+name: "Amazon Business Prime American Express Card"
+bank: "American Express"
+slug: "amazon-business-prime-american-express-card"
+accepting_applications: true
+category: "business"
+annual_fee: 0

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -1,0 +1,6 @@
+name: "American Express Business Gold Card"
+bank: "American Express"
+slug: "american-express-business-gold-card"
+accepting_applications: true
+category: "business"
+annual_fee: 375

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -1,0 +1,6 @@
+name: "Bank of America Cash Rewards Secured Credit Card"
+bank: "Bank of America"
+slug: "bank-of-america-cash-rewards-secured"
+accepting_applications: true
+category: "secured"
+annual_fee: 0

--- a/data/cards/bank-of-america-cash-rewards.yaml
+++ b/data/cards/bank-of-america-cash-rewards.yaml
@@ -1,0 +1,6 @@
+name: "Bank of America Cash Rewards Credit Card"
+bank: "Bank of America"
+slug: "bank-of-america-cash-rewards"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -1,0 +1,6 @@
+name: "Bank of America Customized Cash Rewards Credit Card"
+bank: "Bank of America"
+slug: "bank-of-america-customized-cash-rewards"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -1,0 +1,6 @@
+name: "Bank of America Premium Rewards Elite Credit Card"
+bank: "Bank of America"
+slug: "bank-of-america-premium-rewards-elite"
+accepting_applications: true
+category: "travel"
+annual_fee: 550

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -1,0 +1,6 @@
+name: "Bank of America Premium Rewards Credit Card"
+bank: "Bank of America"
+slug: "bank-of-america-premium-rewards"
+accepting_applications: true
+category: "travel"
+annual_fee: 95

--- a/data/cards/bank-of-america-travel-rewards.yaml
+++ b/data/cards/bank-of-america-travel-rewards.yaml
@@ -1,0 +1,6 @@
+name: "Bank of America Travel Rewards Credit Card"
+bank: "Bank of America"
+slug: "bank-of-america-travel-rewards"
+accepting_applications: true
+category: "travel"
+annual_fee: 0

--- a/data/cards/bank-of-america-unlimited-cash-rewards.yaml
+++ b/data/cards/bank-of-america-unlimited-cash-rewards.yaml
@@ -1,0 +1,6 @@
+name: "Bank of America Unlimited Cash Rewards Credit Card"
+bank: "Bank of America"
+slug: "bank-of-america-unlimited-cash-rewards"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -1,0 +1,6 @@
+name: "BankAmericard Credit Card"
+bank: "Bank of America"
+slug: "bankamericard"
+accepting_applications: true
+category: "other"
+annual_fee: 0

--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -1,0 +1,6 @@
+name: "Blue Business Cash Card from American Express"
+bank: "American Express"
+slug: "blue-business-cash-card-from-american-express"
+accepting_applications: true
+category: "business"
+annual_fee: 0

--- a/data/cards/blue-business-plus-credit-card-from-american-express.yaml
+++ b/data/cards/blue-business-plus-credit-card-from-american-express.yaml
@@ -1,0 +1,6 @@
+name: "Blue Business Plus Credit Card from American Express"
+bank: "American Express"
+slug: "blue-business-plus-credit-card-from-american-express"
+accepting_applications: true
+category: "business"
+annual_fee: 0

--- a/data/cards/capital-one-platinum-secured.yaml
+++ b/data/cards/capital-one-platinum-secured.yaml
@@ -1,0 +1,6 @@
+name: "Capital One Platinum Secured Credit Card"
+bank: "Capital One"
+slug: "capital-one-platinum-secured"
+accepting_applications: true
+category: "secured"
+annual_fee: 0

--- a/data/cards/capital-one-platinum.yaml
+++ b/data/cards/capital-one-platinum.yaml
@@ -1,0 +1,6 @@
+name: "Capital One Platinum Credit Card"
+bank: "Capital One"
+slug: "capital-one-platinum"
+accepting_applications: true
+category: "rewards"
+annual_fee: 0

--- a/data/cards/capital-one-quicksilver-secured.yaml
+++ b/data/cards/capital-one-quicksilver-secured.yaml
@@ -1,0 +1,6 @@
+name: "Capital One Quicksilver Secured Cash Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-quicksilver-secured"
+accepting_applications: true
+category: "secured"
+annual_fee: 0

--- a/data/cards/capital-one-quicksilver.yaml
+++ b/data/cards/capital-one-quicksilver.yaml
@@ -1,0 +1,6 @@
+name: "Capital One Quicksilver Cash Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-quicksilver"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/capital-one-quicksilverone.yaml
+++ b/data/cards/capital-one-quicksilverone.yaml
@@ -1,0 +1,6 @@
+name: "Capital One QuicksilverOne Cash Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-quicksilverone"
+accepting_applications: true
+category: "cashback"
+annual_fee: 39

--- a/data/cards/capital-one-savor-student.yaml
+++ b/data/cards/capital-one-savor-student.yaml
@@ -1,0 +1,6 @@
+name: "Capital One SavorOne Student Cash Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-savor-student"
+accepting_applications: true
+category: "student"
+annual_fee: 0

--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -1,0 +1,6 @@
+name: "Capital One Savor Cash Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-savor"
+accepting_applications: true
+category: "cashback"
+annual_fee: 95

--- a/data/cards/capital-one-savorone.yaml
+++ b/data/cards/capital-one-savorone.yaml
@@ -1,0 +1,6 @@
+name: "Capital One SavorOne Cash Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-savorone"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -1,0 +1,6 @@
+name: "Capital One Venture Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-venture-rewards"
+accepting_applications: true
+category: "travel"
+annual_fee: 95

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -1,0 +1,6 @@
+name: "Capital One Venture X Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-venture-x"
+accepting_applications: true
+category: "travel"
+annual_fee: 395

--- a/data/cards/capital-one-ventureone-rewards.yaml
+++ b/data/cards/capital-one-ventureone-rewards.yaml
@@ -1,0 +1,6 @@
+name: "Capital One VentureOne Rewards Credit Card"
+bank: "Capital One"
+slug: "capital-one-ventureone-rewards"
+accepting_applications: true
+category: "travel"
+annual_fee: 0

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -1,0 +1,6 @@
+name: "Ink Business Cash Credit Card"
+bank: "Chase"
+slug: "chase-ink-business-cash"
+accepting_applications: true
+category: "business"
+annual_fee: 0

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -1,0 +1,6 @@
+name: "Ink Business Preferred Credit Card"
+bank: "Chase"
+slug: "chase-ink-business-preferred"
+accepting_applications: true
+category: "business"
+annual_fee: 95

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -1,0 +1,6 @@
+name: "Ink Business Unlimited Credit Card"
+bank: "Chase"
+slug: "chase-ink-business-unlimited"
+accepting_applications: true
+category: "business"
+annual_fee: 0

--- a/data/cards/chase-slate-edge.yaml
+++ b/data/cards/chase-slate-edge.yaml
@@ -1,0 +1,6 @@
+name: "Chase Slate Edge"
+bank: "Chase"
+slug: "chase-slate-edge"
+accepting_applications: true
+category: "other"
+annual_fee: 0

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -1,0 +1,6 @@
+name: "Citi Strata Elite Card"
+bank: "Citi"
+slug: "citi-strata-elite"
+accepting_applications: true
+category: "travel"
+annual_fee: 495

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -1,0 +1,6 @@
+name: "Citi Strata Premier Card"
+bank: "Citi"
+slug: "citi-strata-premier"
+accepting_applications: true
+category: "travel"
+annual_fee: 95

--- a/data/cards/citi-strata.yaml
+++ b/data/cards/citi-strata.yaml
@@ -1,0 +1,6 @@
+name: "Citi Strata Card"
+bank: "Citi"
+slug: "citi-strata"
+accepting_applications: true
+category: "travel"
+annual_fee: 0

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -1,0 +1,6 @@
+name: "Hawaiian Airlines World Elite Mastercard"
+bank: "Barclays"
+slug: "hawaiian-airlines-world-elite-mastercard"
+accepting_applications: true
+category: "travel"
+annual_fee: 99

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -1,0 +1,6 @@
+name: "JetBlue Business Card"
+bank: "Barclays"
+slug: "jetblue-business-card"
+accepting_applications: true
+category: "business"
+annual_fee: 99

--- a/data/cards/jetblue-card.yaml
+++ b/data/cards/jetblue-card.yaml
@@ -1,0 +1,6 @@
+name: "JetBlue Card"
+bank: "Barclays"
+slug: "jetblue-card"
+accepting_applications: true
+category: "travel"
+annual_fee: 0

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -1,0 +1,6 @@
+name: "JetBlue Plus Card"
+bank: "Barclays"
+slug: "jetblue-plus-card"
+accepting_applications: true
+category: "travel"
+annual_fee: 99

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -1,0 +1,6 @@
+name: "Princess Cruises Rewards Visa Card"
+bank: "Barclays"
+slug: "princess-cruises-rewards-visa-card"
+accepting_applications: true
+category: "travel"
+annual_fee: 0

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -1,0 +1,6 @@
+name: "The Business Platinum Card from American Express"
+bank: "American Express"
+slug: "the-business-platinum-card-from-american-express"
+accepting_applications: true
+category: "business"
+annual_fee: 895

--- a/data/cards/us-bank-altitude-go-visa-signature.yaml
+++ b/data/cards/us-bank-altitude-go-visa-signature.yaml
@@ -1,0 +1,6 @@
+name: "U.S. Bank Altitude Go Visa Signature Card"
+bank: "U.S. Bank"
+slug: "us-bank-altitude-go-visa-signature"
+accepting_applications: true
+category: "travel"
+annual_fee: 0

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -1,0 +1,6 @@
+name: "U.S. Bank Altitude Reserve Visa Infinite Card"
+bank: "U.S. Bank"
+slug: "us-bank-altitude-reserve-visa-infinite"
+accepting_applications: false
+category: "travel"
+annual_fee: 400

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -1,0 +1,6 @@
+name: "U.S. Bank Cash+ Visa Signature Card"
+bank: "U.S. Bank"
+slug: "us-bank-cash-plus-visa-signature"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/us-bank-smartly-visa-signature.yaml
+++ b/data/cards/us-bank-smartly-visa-signature.yaml
@@ -1,0 +1,6 @@
+name: "U.S. Bank Smartly Visa Signature Card"
+bank: "U.S. Bank"
+slug: "us-bank-smartly-visa-signature"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -1,0 +1,6 @@
+name: "World of Hyatt Business Credit Card"
+bank: "Chase"
+slug: "world-of-hyatt-business-credit-card"
+accepting_applications: true
+category: "business"
+annual_fee: 199

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -1,0 +1,6 @@
+name: "Wyndham Rewards Earner Business Card"
+bank: "Barclays"
+slug: "wyndham-rewards-earner-business-card"
+accepting_applications: true
+category: "business"
+annual_fee: 95

--- a/data/cards/wyndham-rewards-earner-card.yaml
+++ b/data/cards/wyndham-rewards-earner-card.yaml
@@ -1,0 +1,6 @@
+name: "Wyndham Rewards Earner Card"
+bank: "Barclays"
+slug: "wyndham-rewards-earner-card"
+accepting_applications: true
+category: "travel"
+annual_fee: 0

--- a/data/cards/wyndham-rewards-earner-plus-card.yaml
+++ b/data/cards/wyndham-rewards-earner-plus-card.yaml
@@ -1,0 +1,6 @@
+name: "Wyndham Rewards Earner Plus Card"
+bank: "Barclays"
+slug: "wyndham-rewards-earner-plus-card"
+accepting_applications: true
+category: "travel"
+annual_fee: 75


### PR DESCRIPTION
Adds cards from major issuers that were missing from the database:

Capital One (11 cards):
- Venture Rewards, Venture X, VentureOne Rewards
- Quicksilver, QuicksilverOne, Quicksilver Secured
- Savor, SavorOne, SavorOne Student
- Platinum, Platinum Secured

Bank of America (8 cards):
- Unlimited Cash Rewards, Customized Cash Rewards, Cash Rewards
- Travel Rewards, Premium Rewards, Premium Rewards Elite
- BankAmericard, Cash Rewards Secured

Barclays (8 cards):
- JetBlue Plus, JetBlue, JetBlue Business
- Wyndham Rewards Earner Plus, Earner, Earner Business
- Hawaiian Airlines World Elite Mastercard
- Princess Cruises Rewards Visa

U.S. Bank (4 cards):
- Smartly Visa Signature, Cash+ Visa Signature
- Altitude Go Visa Signature, Altitude Reserve Visa Infinite

Citi (3 cards):
- Strata Premier, Strata Elite, Strata

American Express Business (5 cards):
- Business Gold, Business Platinum
- Blue Business Cash, Blue Business Plus
- Amazon Business Prime

Chase Business (5 cards):
- Ink Business Preferred, Unlimited, Cash
- Slate Edge, World of Hyatt Business