### PR TITLE
Add missing Wells Fargo cards and fix Bilt issuer

### DIFF
--- a/data/cards/bilt-mastercard.yaml
+++ b/data/cards/bilt-mastercard.yaml
@@ -1,5 +1,7 @@
 name: "Bilt Mastercard"
-bank: "Wells Fargo"
+bank: "Bilt"
 slug: "bilt-mastercard"
 image: "bilt_mastercard.png"
-accepting_applications: false
+accepting_applications: true
+category: "rewards"
+annual_fee: 0

--- a/data/cards/wells-fargo-active-cash.yaml
+++ b/data/cards/wells-fargo-active-cash.yaml
@@ -1,0 +1,6 @@
+name: "Wells Fargo Active Cash Card"
+bank: "Wells Fargo"
+slug: "wells-fargo-active-cash"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -1,0 +1,6 @@
+name: "Wells Fargo Attune Card"
+bank: "Wells Fargo"
+slug: "wells-fargo-attune"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -1,0 +1,6 @@
+name: "Wells Fargo Autograph Journey Card"
+bank: "Wells Fargo"
+slug: "wells-fargo-autograph-journey"
+accepting_applications: true
+category: "travel"
+annual_fee: 95

--- a/data/cards/wells-fargo-autograph.yaml
+++ b/data/cards/wells-fargo-autograph.yaml
@@ -1,0 +1,6 @@
+name: "Wells Fargo Autograph Card"
+bank: "Wells Fargo"
+slug: "wells-fargo-autograph"
+accepting_applications: true
+category: "rewards"
+annual_fee: 0

--- a/data/cards/wells-fargo-reflect.yaml
+++ b/data/cards/wells-fargo-reflect.yaml
@@ -1,0 +1,6 @@
+name: "Wells Fargo Reflect Card"
+bank: "Wells Fargo"
+slug: "wells-fargo-reflect"
+accepting_applications: true
+category: "other"
+annual_fee: 0

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -1,0 +1,6 @@
+name: "Wells Fargo Signify Business Cash Card"
+bank: "Wells Fargo"
+slug: "wells-fargo-signify-business-cash"
+accepting_applications: true
+category: "business"
+annual_fee: 0


### PR DESCRIPTION
New Wells Fargo cards added:
- Wells Fargo Active Cash Card (2% unlimited cashback)
- Wells Fargo Autograph Card (3X points on categories)
- Wells Fargo Autograph Journey Card (travel card, $95 fee)
- Wells Fargo Reflect Card (0% APR balance transfer)
- Wells Fargo Attune Card (4% wellness/environment)
- Wells Fargo Signify Business Cash Card (2% business)

Fixed:
- Bilt Mastercard: Changed bank from "Wells Fargo" to "Bilt" (Bilt is issued by Evolve Bank & Trust, not Wells Fargo)
- Updated Bilt to accepting_applications: true