### PR TITLE
Add ability for users to delete their referrals

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -225,6 +225,13 @@ Resources:
             Method: POST
             RestApiId:
               Ref: CreditCardOddsAPI
+        DELETECreditCardOddsAPI:
+          Type: Api
+          Properties:
+            Path: /referrals
+            Method: DELETE
+            RestApiId:
+              Ref: CreditCardOddsAPI
 
   UserProfileFunction:
     Type: AWS::Serverless::Function

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -130,6 +130,17 @@ export async function createReferral(data: unknown, token: string) {
   return res.json();
 }
 
+export async function deleteReferral(referralId: number, token: string) {
+  const res = await fetch(`${API_BASE}/referrals?referral_id=${referralId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) throw new Error('Failed to delete referral');
+  return res.json();
+}
+
 export async function getProfile(token: string) {
   const res = await fetch(`${API_BASE}/profile`, {
     headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
## Summary
- Add DELETE endpoint to user-referrals API handler
- Verify ownership before deletion (user can only delete their own referrals)
- Delete associated referral_stats when deleting a referral
- Add delete button to referrals table in profile page

## Test plan
- [ ] Test deleting a referral from the profile page
- [ ] Verify the referral is removed from the database
- [ ] Verify associated stats are also deleted
- [ ] Verify user cannot delete another user's referral

🤖 Generated with [Claude Code](https://claude.com/claude-code)