### PR TITLE
Optimize page load with parallel API calls

### DIFF
--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -50,15 +50,11 @@ export default async function CardPage({ params }: CardPageProps) {
   const cardName = decodeURIComponent(name);
 
   try {
-    const card = await getCard(cardName);
-
-    // Try to get graph data, but use empty array if it fails (for new cards with no data)
-    let graphData: GraphData[] = [];
-    try {
-      graphData = await getCardGraphs(cardName);
-    } catch {
-      // Keep empty array for new cards with no data
-    }
+    // Fetch card and graph data in parallel for faster loading
+    const [card, graphData] = await Promise.all([
+      getCard(cardName),
+      getCardGraphs(cardName).catch(() => [] as GraphData[]), // Empty array for new cards with no data
+    ]);
 
     return <CardClient card={card} graphData={graphData} />;
   } catch {


### PR DESCRIPTION
## Summary
- Profile page: run 5 API calls concurrently instead of sequentially using `Promise.allSettled()`
- Card page: fetch card data and graph data in parallel using `Promise.all()`

This significantly reduces page load time by making independent API calls run simultaneously rather than waiting for each to complete before starting the next.

## Test plan
- [ ] Verify profile page loads faster and all data (records, referrals, wallet, profile) still displays correctly
- [ ] Verify card detail pages load faster and both card info and graphs render correctly
- [ ] Test error handling - individual API failures should not break the entire page

🤖 Generated with [Claude Code](https://claude.com/claude-code)