### PR TITLE
Add news sidebars to profile and bank pages

### DIFF
--- a/apps/web-next/src/app/api/news/route.ts
+++ b/apps/web-next/src/app/api/news/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+
+const NEWS_CDN_URL = 'https://d2hxvzw7msbtvt.cloudfront.net/news.json';
+
+export async function GET() {
+  try {
+    const res = await fetch(NEWS_CDN_URL, {
+      next: { revalidate: 300 }, // Revalidate every 5 minutes
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch news' },
+        { status: res.status }
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching news:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -53,14 +53,19 @@ export const tagColors: Record<NewsTag, string> = {
 
 const NEWS_CDN_URL = 'https://d2hxvzw7msbtvt.cloudfront.net/news.json';
 
+// Check if running in the browser
+const isBrowser = typeof window !== 'undefined';
+
 export async function getNews(): Promise<NewsItem[]> {
   try {
-    const res = await fetch(NEWS_CDN_URL, {
-      next: { revalidate: 300 }, // Revalidate every 5 minutes
+    // Use local API route on client to avoid CORS, direct CDN on server
+    const url = isBrowser ? '/api/news' : NEWS_CDN_URL;
+    const res = await fetch(url, isBrowser ? {} : {
+      next: { revalidate: 300 }, // Revalidate every 5 minutes (server only)
     });
 
     if (!res.ok) {
-      console.error('Failed to fetch news from CDN:', res.status);
+      console.error('Failed to fetch news:', res.status);
       return [];
     }
 


### PR DESCRIPTION
## Summary
- Add 1/3 news sidebar to bank page showing bank-specific news
- Remove median credit score and income columns from bank page table
- Improve profile news matching with card_id lookup and case-insensitive bank matching
- Add /api/news route to proxy CDN requests and fix CORS errors on profile page

## Test plan
- [x] Verify bank page shows news sidebar with bank-specific news
- [x] Verify profile page news loads without CORS errors
- [x] Verify news matches cards in user's wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)