### PR TITLE
Improve referral modal base link display

### DIFF
--- a/apps/web-next/src/components/forms/ReferralModal.tsx
+++ b/apps/web-next/src/components/forms/ReferralModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle, Listbox, ListboxButton, ListboxOption, ListboxOptions, Label } from "@headlessui/react";
-import { LinkIcon, CheckIcon, ChevronUpDownIcon } from "@heroicons/react/24/outline";
+import { LinkIcon, CheckIcon, ChevronUpDownIcon, ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useAuth } from "@/auth/AuthProvider";
@@ -40,6 +40,7 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
 
   const [selected, setSelected] = useState<OpenReferral>(defaultCard);
   const [submitting, setSubmitting] = useState(false);
+  const [showFullBaseLink, setShowFullBaseLink] = useState(false);
 
   const formik = useFormik({
     initialValues: {
@@ -102,6 +103,7 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
   const handleModalClose = () => {
     formik.resetForm();
     setSelected(defaultCard);
+    setShowFullBaseLink(false);
     handleClose();
   };
 
@@ -208,20 +210,41 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
               </label>
               <div className="mt-1">
                 {selected.card_referral_link ? (
-                  <div className="flex rounded-md shadow-sm">
-                    <span className="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 px-3 text-gray-500 sm:text-sm whitespace-nowrap">
-                      {selected.card_referral_link}
-                    </span>
+                  <div className="space-y-2">
+                    {/* Collapsible base link display */}
+                    <div className="rounded-md border border-gray-200 bg-gray-50 overflow-hidden">
+                      <button
+                        type="button"
+                        onClick={() => setShowFullBaseLink(!showFullBaseLink)}
+                        className="w-full px-3 py-2 flex items-center justify-between text-left hover:bg-gray-100 transition-colors"
+                      >
+                        <div className="flex-1 min-w-0 mr-2">
+                          <span className="text-xs text-gray-500 block">Base URL</span>
+                          <span className={`text-sm text-gray-600 block ${showFullBaseLink ? 'break-all' : 'truncate'}`}>
+                            {selected.card_referral_link}
+                          </span>
+                        </div>
+                        {showFullBaseLink ? (
+                          <ChevronUpIcon className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                        ) : (
+                          <ChevronDownIcon className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                        )}
+                      </button>
+                    </div>
+                    {/* Input for unique code */}
                     <input
                       type="text"
                       name="referral_link"
                       id="referral_link"
-                      className="block w-full min-w-0 flex-1 rounded-none rounded-r-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                      placeholder="Your unique code"
+                      className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                      placeholder="Your unique referral code"
                       onChange={formik.handleChange}
                       onBlur={formik.handleBlur}
                       value={formik.values.referral_link}
                     />
+                    <p className="text-xs text-gray-500">
+                      Enter only the unique part of your referral link (the code that comes after the base URL)
+                    </p>
                   </div>
                 ) : (
                   <input


### PR DESCRIPTION
## Summary
- Show base URL in a collapsible section above the input instead of inline
- Truncated by default with click to expand for long URLs
- Gives more space for user input field
- Added helper text explaining what to enter

## Test plan
- [ ] Open referral modal for a card with a long base referral URL
- [ ] Verify base URL is truncated by default
- [ ] Click to expand and see full URL
- [ ] Verify input field has full width for entering code

🤖 Generated with [Claude Code](https://claude.com/claude-code)