### PR TITLE
Fix duplicate card lookup returning wrong card_id

### DIFF
--- a/apps/api/src/handlers/get-card-graphs.js
+++ b/apps/api/src/handlers/get-card-graphs.js
@@ -68,11 +68,17 @@ exports.getCardGraphsHandler = async (event) => {
           const card_name = cdnCard ? (cdnCard.card_name || cdnCard.name) : cardNameParam;
 
           // Get card_id from cards table (with fuzzy matching for card suffix)
+          // Order by exact match first, then by card_id to get the oldest (original) entry
           let cardResult = await mysql.query(
             `SELECT card_id FROM cards
              WHERE card_name = ? OR card_name = ? OR ? LIKE CONCAT(card_name, '%')
+             ORDER BY
+               CASE WHEN card_name = ? THEN 0
+                    WHEN card_name = ? THEN 1
+                    ELSE 2 END,
+               card_id ASC
              LIMIT 1`,
-            [card_name, card_name.replace(/ Card$/, ''), card_name]
+            [card_name, card_name.replace(/ Card$/, ''), card_name, card_name, card_name.replace(/ Card$/, '')]
           );
           await mysql.end();
 


### PR DESCRIPTION
## Summary
- Added ORDER BY to card lookup queries to prefer exact name matches
- Falls back to oldest card_id when multiple cards match
- Fixes charts not showing for cards with duplicate database entries

## Root Cause
The Blue Cash Everyday Card had two entries in the database:
- card_id 56 (original, has 15 records)
- card_id 245 (duplicate, has 0 records)

Without ORDER BY, `LIMIT 1` returned unpredictable results, causing the graphs handler to find the wrong card.

## Test plan
- [x] Blue Cash Everyday Card now shows charts
- [x] Verified logs show correct card_id (56) being used

🤖 Generated with [Claude Code](https://claude.com/claude-code)