### PR TITLE
Fix Bilt news: It's a transition, not a shutdown

### DIFF
--- a/data/news/2025-01-30-bilt-card-shutdown.yaml
+++ b/data/news/2025-01-30-bilt-card-shutdown.yaml
@@ -1,9 +1,0 @@
-id: "bilt-card-shutdown"
-date: "2025-01-30"
-title: "Bilt Mastercard Program Shutting Down"
-summary: "Bilt has announced they are discontinuing the Bilt Mastercard program. Existing cardholders will have until March 31, 2025 to redeem their points."
-tags:
-  - discontinued
-bank: "Bilt"
-card_slug: "bilt-mastercard"
-card_name: "Bilt Mastercard"

--- a/data/news/2026-01-14-bilt-card-transition.yaml
+++ b/data/news/2026-01-14-bilt-card-transition.yaml
@@ -1,0 +1,12 @@
+id: "bilt-card-transition"
+date: "2026-01-14"
+title: "Bilt Transitioning to New Card Program (Bilt 2.0)"
+summary: "Bilt is ending its Wells Fargo partnership and launching Bilt 2.0 with three new cards ($0, $95, $495 annual fees) issued by Column N.A. Existing cardholders must choose a new card by Jan 30, 2026. Old cards stop working Feb 7, 2026. Points and status are safe."
+tags:
+  - policy-change
+  - benefit-change
+bank: "Bilt"
+card_slug: "bilt-mastercard"
+card_name: "Bilt Mastercard"
+source: "Bilt Rewards"
+source_url: "https://support.biltrewards.com/hc/en-us/articles/40834037331085-Bilt-Card-2-0-Program-Transition"


### PR DESCRIPTION
## Summary
The Bilt Mastercard news item was incorrect. It's not shutting down - Bilt is transitioning to a new card program (Bilt 2.0) with a new issuer.

**Corrected information:**
- Wells Fargo and Bilt are ending their partnership
- Bilt is launching 3 new cards ($0, $95, $495 annual fees) issued by Column N.A. via Cardless
- Key dates:
  - Jan 14, 2026: Preorder opens
  - Jan 30, 2026: Deadline to choose new card
  - Feb 7, 2026: Old cards stop working
- Points and status are safe

## Changes
- Renamed file to `2026-01-14-bilt-card-transition.yaml`
- Updated title, summary, and dates
- Changed tags from "discontinued" to "policy-change" and "benefit-change"
- Added source URL

## Sources
- [Bilt Support: Card 2.0 Transition](https://support.biltrewards.com/hc/en-us/articles/40834037331085-Bilt-Card-2-0-Program-Transition)
- [CNBC: Bilt transition timeline](https://www.cnbc.com/select/bilt-mastercard-transition-timeline-what-to-know/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)