### PR TITLE
Add news improvements, update card fees, and improve explore page

### DIFF
--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -374,7 +374,7 @@ function RecordsTab({
                   </span>
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap">
-                  <div className="text-sm text-gray-900">{record.submitter_email || 'Unknown'}</div>
+                  <div className="text-sm text-gray-900 font-mono text-xs">{record.submitter_id || 'Unknown'}</div>
                   <div className="text-xs text-gray-400">{record.submitter_ip_address}</div>
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
@@ -480,8 +480,8 @@ function ReferralsTab({
                   <div>{referral.impressions} views</div>
                   <div>{referral.clicks} clicks</div>
                 </td>
-                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
-                  {referral.submitter_email || 'Unknown'}
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900 font-mono text-xs">
+                  {referral.submitter_id || 'Unknown'}
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
                   {new Date(referral.submit_datetime).toLocaleDateString()}

--- a/apps/web-next/src/app/api/news/route.ts
+++ b/apps/web-next/src/app/api/news/route.ts
@@ -1,9 +1,19 @@
 import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
 
 const NEWS_CDN_URL = 'https://d2hxvzw7msbtvt.cloudfront.net/news.json';
 
 export async function GET() {
   try {
+    // In development, read from local file
+    if (process.env.NODE_ENV === 'development') {
+      const filePath = path.join(process.cwd(), '..', '..', 'data', 'news.json');
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      const data = JSON.parse(fileContent);
+      return NextResponse.json(data);
+    }
+
     const res = await fetch(NEWS_CDN_URL, {
       next: { revalidate: 300 }, // Revalidate every 5 minutes
     });

--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -32,6 +32,7 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
   const [sortBy, setSortBy] = useState<SortOption>('name');
   const [activeEmoji, setActiveEmoji] = useState<string | null>(null);
   const [showArchived, setShowArchived] = useState(false);
+  const [showBusiness, setShowBusiness] = useState(false);
 
   // Get recently released cards (cards with release_date, sorted by most recent)
   const recentlyReleased = useMemo(() => {
@@ -60,7 +61,11 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
       // Hide archived cards unless showArchived is true
       const matchesStatus = showArchived || card.accepting_applications;
 
-      return matchesSearch && matchesBank && matchesEmoji && matchesStatus;
+      // Hide business cards unless showBusiness is true or actively filtering for business
+      const isBusiness = card.tags?.includes('business') || card.category === 'business';
+      const matchesBusiness = showBusiness || !isBusiness || activeEmoji === '💼';
+
+      return matchesSearch && matchesBank && matchesEmoji && matchesStatus && matchesBusiness;
     });
 
     // Sort based on selected option
@@ -85,11 +90,16 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
     }
 
     return filtered;
-  }, [cards, search, selectedBank, sortBy, activeEmoji, showArchived]);
+  }, [cards, search, selectedBank, sortBy, activeEmoji, showArchived, showBusiness]);
 
   // Count archived cards
   const archivedCount = useMemo(() => {
     return cards.filter(card => !card.accepting_applications).length;
+  }, [cards]);
+
+  // Count business cards
+  const businessCount = useMemo(() => {
+    return cards.filter(card => card.tags?.includes('business') || card.category === 'business').length;
   }, [cards]);
 
   return (
@@ -197,31 +207,53 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
         </div>
       </div>
 
-      {/* Results count and archived toggle */}
-      <div className="mt-4 flex items-center justify-between">
+      {/* Results count and toggles */}
+      <div className="mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <p className="text-sm text-gray-500">
           Showing {filteredCards.length} of {cards.length} cards
         </p>
-        <label className="flex items-center cursor-pointer">
-          <span className="text-sm text-gray-500 mr-2">
-            Show archived ({archivedCount})
-          </span>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={showArchived}
-            onClick={() => setShowArchived(!showArchived)}
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
-              showArchived ? 'bg-indigo-600' : 'bg-gray-200'
-            }`}
-          >
-            <span
-              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                showArchived ? 'translate-x-5' : 'translate-x-0'
+        <div className="flex items-center gap-4">
+          <label className="flex items-center cursor-pointer">
+            <span className="text-sm text-gray-500 mr-2">
+              Business ({businessCount})
+            </span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showBusiness}
+              onClick={() => setShowBusiness(!showBusiness)}
+              className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+                showBusiness ? 'bg-indigo-600' : 'bg-gray-200'
               }`}
-            />
-          </button>
-        </label>
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  showBusiness ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </label>
+          <label className="flex items-center cursor-pointer">
+            <span className="text-sm text-gray-500 mr-2">
+              Archived ({archivedCount})
+            </span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showArchived}
+              onClick={() => setShowArchived(!showArchived)}
+              className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+                showArchived ? 'bg-indigo-600' : 'bg-gray-200'
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  showArchived ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </label>
+        </div>
       </div>
 
       {/* Cards Table */}
@@ -259,6 +291,7 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
                               setSelectedBank('');
                               setActiveEmoji(null);
                               setShowArchived(false);
+                              setShowBusiness(false);
                             }}
                             className="mt-4 text-sm font-medium text-indigo-600 hover:text-indigo-500"
                           >

--- a/apps/web-next/src/app/news/page.tsx
+++ b/apps/web-next/src/app/news/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
 import { NewspaperIcon, BuildingLibraryIcon, CreditCardIcon, PlusCircleIcon } from "@heroicons/react/24/outline";
 import { getNews, tagLabels, tagColors, NewsTag } from "@/lib/news";
+import { ExpandableText } from "@/components/ui/ExpandableText";
 
 export const metadata: Metadata = {
   title: "Card News - Credit Card Updates",
@@ -118,9 +120,10 @@ export default async function NewsPage() {
                         <div className="text-sm font-medium text-gray-900">
                           {item.title}
                         </div>
-                        <div className="text-sm text-gray-500 mt-1 line-clamp-2">
-                          {item.summary}
-                        </div>
+                        <ExpandableText
+                          text={item.summary}
+                          className="text-sm text-gray-500 mt-1"
+                        />
                         {/* Mobile tags */}
                         <div className="flex flex-wrap gap-1 mt-2 md:hidden">
                           {item.tags.map((tag) => (
@@ -141,7 +144,18 @@ export default async function NewsPage() {
                               href={`/card/${item.card_slug}`}
                               className="flex items-center text-sm text-indigo-600 hover:text-indigo-900"
                             >
-                              <CreditCardIcon className="h-4 w-4 mr-1" />
+                              {item.card_image_link ? (
+                                <Image
+                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${item.card_image_link}`}
+                                  alt={item.card_name}
+                                  width={32}
+                                  height={20}
+                                  className="mr-1.5 rounded-sm object-contain"
+                                  unoptimized
+                                />
+                              ) : (
+                                <CreditCardIcon className="h-4 w-4 mr-1" />
+                              )}
                               {item.card_name}
                             </Link>
                           )}

--- a/apps/web-next/src/app/profile/page.tsx
+++ b/apps/web-next/src/app/profile/page.tsx
@@ -820,26 +820,23 @@ export default function ProfilePage() {
                 ))}
               </div>
               {/* Desktop: Table layout */}
-              <div className="hidden sm:block overflow-x-auto">
+              <div className="hidden sm:block">
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Card
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Referral Link
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Status
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Impressions
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Stats
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Clicks
-                      </th>
-                      <th className="relative px-6 py-3">
+                      <th className="relative px-4 py-3">
                         <span className="sr-only">Delete</span>
                       </th>
                     </tr>
@@ -847,62 +844,58 @@ export default function ProfilePage() {
                   <tbody className="bg-white divide-y divide-gray-200">
                     {referrals.map((referral, index) => (
                       <tr key={referral.referral_id || index}>
-                        <td className="px-6 py-4 whitespace-nowrap">
+                        <td className="px-4 py-3 whitespace-nowrap">
                           <div className="flex items-center">
                             {referral.card_image_link && (
-                              <div className="flex-shrink-0 h-10 w-16 relative">
+                              <div className="flex-shrink-0 h-8 w-12 relative">
                                 <Image
                                   className="object-contain"
                                   src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
                                   alt={referral.card_name}
                                   fill
-                                  sizes="64px"
+                                  sizes="48px"
                                 />
                               </div>
                             )}
-                            <div className="ml-4">
+                            <div className="ml-3">
                               <div className="text-sm font-medium text-gray-900">
                                 {referral.card_name}
                               </div>
                             </div>
                           </div>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="text-sm text-gray-500 truncate max-w-xs">
-                            <a
-                              href={referral.card_referral_link ? `${referral.card_referral_link}${referral.referral_link}` : referral.referral_link}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="text-indigo-600 hover:text-indigo-900"
-                            >
-                              {referral.referral_link}
-                            </a>
-                          </div>
+                        <td className="px-4 py-3">
+                          <a
+                            href={referral.card_referral_link ? `${referral.card_referral_link}${referral.referral_link}` : referral.referral_link}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-sm text-indigo-600 hover:text-indigo-900 truncate block max-w-[200px]"
+                          >
+                            {referral.referral_link}
+                          </a>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
+                        <td className="px-4 py-3 whitespace-nowrap">
                           {referral.admin_approved ? (
                             <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
                               Approved
                             </span>
                           ) : (
                             <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                              Awaiting Approval
+                              Pending
                             </span>
                           )}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {referral.impressions ?? 0}
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                          <div>{referral.impressions ?? 0} views</div>
+                          <div>{referral.clicks ?? 0} clicks</div>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {referral.clicks ?? 0}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <td className="px-4 py-3 whitespace-nowrap text-right text-sm font-medium">
                           <button
                             onClick={() => handleDeleteReferral(referral.referral_id)}
                             disabled={deletingReferralId === referral.referral_id}
                             className="text-red-600 hover:text-red-900 disabled:opacity-50"
                           >
-                            {deletingReferralId === referral.referral_id ? "Deleting..." : "Delete"}
+                            {deletingReferralId === referral.referral_id ? "..." : "Delete"}
                           </button>
                         </td>
                       </tr>

--- a/apps/web-next/src/auth/firebase.ts
+++ b/apps/web-next/src/auth/firebase.ts
@@ -32,13 +32,15 @@ function getFirebaseAuth(): Auth | undefined {
       app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
       auth = getAuth(app);
 
-      // Initialize Analytics (only in browser and if supported)
-      isSupported().then((supported) => {
-        if (supported && app && !analytics) {
-          analytics = getAnalytics(app);
-          console.log('Firebase Analytics initialized');
-        }
-      });
+      // Initialize Analytics (only in browser, if supported, and not in development)
+      if (process.env.NODE_ENV === 'production') {
+        isSupported().then((supported) => {
+          if (supported && app && !analytics) {
+            analytics = getAnalytics(app);
+            console.log('Firebase Analytics initialized');
+          }
+        });
+      }
 
       console.log('Firebase initialized successfully');
     } catch (error) {

--- a/apps/web-next/src/components/ui/ExpandableText.tsx
+++ b/apps/web-next/src/components/ui/ExpandableText.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+
+interface ExpandableTextProps {
+  text: string;
+  className?: string;
+}
+
+export function ExpandableText({ text, className = "" }: ExpandableTextProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className={className}>
+      <span className={isExpanded ? "" : "line-clamp-2"}>
+        {text}
+      </span>
+      {text.length > 120 && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="text-indigo-600 hover:text-indigo-800 text-sm ml-1"
+        >
+          {isExpanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -19,6 +19,7 @@ export interface NewsItem {
   bank?: string;
   card_slug?: string;
   card_name?: string;
+  card_image_link?: string;
   source?: string;
   source_url?: string;
 }
@@ -58,6 +59,16 @@ const isBrowser = typeof window !== 'undefined';
 
 export async function getNews(): Promise<NewsItem[]> {
   try {
+    // In development on the server, read from local file
+    if (!isBrowser && process.env.NODE_ENV === 'development') {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const filePath = path.join(process.cwd(), '..', '..', 'data', 'news.json');
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      const data: NewsResponse = JSON.parse(fileContent);
+      return data.items || [];
+    }
+
     // Use local API route on client to avoid CORS, direct CDN on server
     const url = isBrowser ? '/api/news' : NEWS_CDN_URL;
     const res = await fetch(url, isBrowser ? {} : {

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-01-31T14:48:47.801Z",
-  "count": 133,
+  "generated_at": "2026-01-31T19:30:58.385Z",
+  "count": 134,
   "cards": [
     {
       "name": "Aer Lingus Visa Signature card",
@@ -321,6 +321,7 @@
       "slug": "blue-cash-everyday-card",
       "image": "amex_blue_cash_everyday.png",
       "accepting_applications": true,
+      "card_referral_link": "https://americanexpress.com/en-us/referral/blue-cash-everyday-credit-card?ref=",
       "annual_fee": 0,
       "tags": [
         "cashback"
@@ -368,8 +369,12 @@
       "bank": "Capital One",
       "slug": "capital-one-platinum-secured",
       "accepting_applications": true,
+      "image": "capital-one-platinum-secured.png",
       "category": "secured",
       "annual_fee": 0,
+      "tags": [
+        "secured"
+      ],
       "card_id": "capital-one-platinum-secured",
       "card_name": "Capital One Platinum Secured Credit Card"
     },
@@ -394,6 +399,7 @@
       "slug": "capital-one-quicksilver-secured",
       "accepting_applications": true,
       "category": "secured",
+      "image": "capital-one-quicksilver-secured.png",
       "annual_fee": 0,
       "tags": [
         "secured",
@@ -418,6 +424,7 @@
       "bank": "Capital One",
       "slug": "capital-one-savor",
       "accepting_applications": true,
+      "image": "capital-one-savor-cash-rewards.png",
       "category": "cashback",
       "annual_fee": 95,
       "tags": [
@@ -427,6 +434,17 @@
       ],
       "card_id": "capital-one-savor",
       "card_name": "Capital One Savor Cash Rewards Credit Card"
+    },
+    {
+      "name": "Capital One Savor Student Cash Rewards Credit Card",
+      "bank": "Capital One",
+      "slug": "capital-one-savor-student",
+      "accepting_applications": true,
+      "image": "capital-one-savor-student.png",
+      "category": "student",
+      "annual_fee": 0,
+      "card_id": "capital-one-savor-student",
+      "card_name": "Capital One Savor Student Cash Rewards Credit Card"
     },
     {
       "name": "Capital One SavorOne Cash Rewards Credit Card",
@@ -445,21 +463,12 @@
       "card_name": "Capital One SavorOne Cash Rewards Credit Card"
     },
     {
-      "name": "Capital One SavorOne Student Cash Rewards Credit Card",
-      "bank": "Capital One",
-      "slug": "capital-one-savor-student",
-      "accepting_applications": true,
-      "category": "student",
-      "annual_fee": 0,
-      "card_id": "capital-one-savor-student",
-      "card_name": "Capital One SavorOne Student Cash Rewards Credit Card"
-    },
-    {
       "name": "Capital One Venture Rewards Credit Card",
       "bank": "Capital One",
       "slug": "capital-one-venture-rewards",
       "accepting_applications": true,
       "category": "travel",
+      "image": "capital-one-venture-rewards.png",
       "annual_fee": 95,
       "tags": [
         "travel",
@@ -565,7 +574,7 @@
       "slug": "chase-sapphire-reserve",
       "image": "chase_sapphire_reserve.png",
       "accepting_applications": true,
-      "annual_fee": 550,
+      "annual_fee": 795,
       "tags": [
         "travel",
         "premium",
@@ -606,14 +615,14 @@
       "card_name": "Citi AAdvantage Globe"
     },
     {
-      "name": "Citi AAdvantage Platinum Select World Elite M",
+      "name": "Citi AAdvantage Platinum Select World Elite Mastercard",
       "bank": "Citi",
       "slug": "citi-aadvantage-platinum-select-world-elite-m",
       "accepting_applications": true,
       "annual_fee": 99,
       "image": "citi-aadvantage-platinum-select-world-elite.png",
       "card_id": "citi-aadvantage-platinum-select-world-elite-m",
-      "card_name": "Citi AAdvantage Platinum Select World Elite M"
+      "card_name": "Citi AAdvantage Platinum Select World Elite Mastercard"
     },
     {
       "name": "Citi Custom Cash",
@@ -658,6 +667,7 @@
       "bank": "Citi",
       "slug": "citi-prestige",
       "accepting_applications": false,
+      "image": "citi-prestige.png",
       "annual_fee": 495,
       "card_id": "citi-prestige",
       "card_name": "Citi Prestige"
@@ -666,8 +676,9 @@
       "name": "Citi Rewards+",
       "bank": "Citi",
       "slug": "citi-rewards",
-      "accepting_applications": true,
+      "accepting_applications": false,
       "annual_fee": 0,
+      "image": "citi-rewards-plus.png",
       "card_id": "citi-rewards",
       "card_name": "Citi Rewards+"
     },
@@ -676,6 +687,7 @@
       "bank": "Citi",
       "slug": "citi-secured-mastercard",
       "accepting_applications": true,
+      "image": "citi-secured.png",
       "annual_fee": 0,
       "tags": [
         "secured"
@@ -727,13 +739,14 @@
       "card_name": "Citi Strata Premier Card"
     },
     {
-      "name": "CitiBusiness AAdvantage Platinum Select Maste",
+      "name": "CitiBusiness AAdvantage Platinum Select Mastercard",
       "bank": "Citi",
       "slug": "citibusiness-aadvantage-platinum-select-maste",
       "accepting_applications": true,
+      "image": "citi-business-aadvantage-platinum-select.png",
       "annual_fee": 99,
       "card_id": "citibusiness-aadvantage-platinum-select-maste",
-      "card_name": "CitiBusiness AAdvantage Platinum Select Maste"
+      "card_name": "CitiBusiness AAdvantage Platinum Select Mastercard"
     },
     {
       "name": "Costco Anywhere Visa Business Card by Citi",
@@ -750,6 +763,7 @@
       "bank": "Citi",
       "slug": "costco-anywhere-visa-card-by-citi",
       "accepting_applications": true,
+      "image": "citi-costco-anywhere.png",
       "annual_fee": 0,
       "card_id": "costco-anywhere-visa-card-by-citi",
       "card_name": "Costco Anywhere Visa Card by Citi"
@@ -915,6 +929,7 @@
       "bank": "Citi",
       "slug": "expedia-rewards-card-from-citi",
       "accepting_applications": false,
+      "image": "citi-expedia-rewards.png",
       "annual_fee": 0,
       "card_id": "expedia-rewards-card-from-citi",
       "card_name": "Expedia Rewards Card from Citi"
@@ -924,6 +939,7 @@
       "bank": "Citi",
       "slug": "expedia-rewards-voyager-card-from-citi",
       "accepting_applications": false,
+      "image": "citi-expedia-rewards-voyager.png",
       "annual_fee": 0,
       "card_id": "expedia-rewards-voyager-card-from-citi",
       "card_name": "Expedia Rewards Voyager Card from Citi"
@@ -933,7 +949,7 @@
       "bank": "Robinhood",
       "slug": "robinhood-gold-card",
       "accepting_applications": true,
-      "image": "robinhood-gold.png",
+      "image": "robinhood-gold-card.png",
       "release_date": "2024-03-26",
       "annual_fee": 0,
       "tags": [
@@ -989,6 +1005,7 @@
       "slug": "hilton-honors-card",
       "image": "amex_hilton_honors.png",
       "accepting_applications": true,
+      "card_referral_link": "https://www.americanexpress.com/en-us/credit-cards/referral/prospect/hilton-honors/personal?ref=",
       "annual_fee": 0,
       "tags": [
         "hotel",
@@ -1018,13 +1035,34 @@
       "card_name": "Iberia Visa Signature card"
     },
     {
-      "name": "IHG Rewards Club Premier Credit Card",
+      "name": "IHG One Rewards Premier Business Credit Card",
+      "bank": "Chase",
+      "slug": "ihg-rewards-premier-business",
+      "accepting_applications": true,
+      "annual_fee": 0,
+      "image": "chase-ihg-one-rewards-premier-business.png",
+      "tags": [
+        "hotel",
+        "travel",
+        "rewards"
+      ],
+      "card_id": "ihg-rewards-premier-business",
+      "card_name": "IHG One Rewards Premier Business Credit Card"
+    },
+    {
+      "name": "IHG One Rewards Premier Credit Card",
       "bank": "Chase",
       "slug": "ihg-rewards-club-premier-credit-card",
       "accepting_applications": true,
+      "image": "chase-ihg-one-rewards-premier.png",
       "annual_fee": 99,
+      "tags": [
+        "hotel",
+        "travel",
+        "rewards"
+      ],
       "card_id": "ihg-rewards-club-premier-credit-card",
-      "card_name": "IHG Rewards Club Premier Credit Card"
+      "card_name": "IHG One Rewards Premier Credit Card"
     },
     {
       "name": "IHG Rewards Club Traveler Credit Card",
@@ -1032,6 +1070,12 @@
       "slug": "ihg-rewards-club-traveler-credit-card",
       "accepting_applications": true,
       "annual_fee": 0,
+      "image": "chase-ihg-one-rewards-traveler.png",
+      "tags": [
+        "hotel",
+        "travel",
+        "rewards"
+      ],
       "card_id": "ihg-rewards-club-traveler-credit-card",
       "card_name": "IHG Rewards Club Traveler Credit Card"
     },
@@ -1115,9 +1159,10 @@
       "card_name": "JetBlue Plus Card"
     },
     {
-      "name": "Marriott Bonvoy Bold credit card",
+      "name": "Marriott Bonvoy Bold Credit Card",
       "bank": "Chase",
       "slug": "marriott-bonvoy-bold-credit-card",
+      "image": "chase-marriott-bonvoy-bold.png",
       "accepting_applications": true,
       "annual_fee": 0,
       "tags": [
@@ -1125,7 +1170,7 @@
         "travel"
       ],
       "card_id": "marriott-bonvoy-bold-credit-card",
-      "card_name": "Marriott Bonvoy Bold credit card"
+      "card_name": "Marriott Bonvoy Bold Credit Card"
     },
     {
       "name": "Marriott Bonvoy Boundless credit card",
@@ -1203,7 +1248,8 @@
       "bank": "Chase",
       "slug": "southwest-rapid-rewards-plus-credit-card",
       "accepting_applications": true,
-      "annual_fee": 69,
+      "annual_fee": 99,
+      "image": "chase-southwest-rapid-rewards-plus.png",
       "tags": [
         "airline",
         "travel"
@@ -1216,7 +1262,8 @@
       "bank": "Chase",
       "slug": "southwest-rapid-rewards-premier-credit-card",
       "accepting_applications": true,
-      "annual_fee": 99,
+      "image": "chase-southwest-rapid-rewards-premier.png",
+      "annual_fee": 149,
       "tags": [
         "airline",
         "travel"
@@ -1230,7 +1277,7 @@
       "slug": "southwest-rapid-rewards-priority-credit-card",
       "image": "southwest_priority.png",
       "accepting_applications": true,
-      "annual_fee": 149,
+      "annual_fee": 229,
       "tags": [
         "airline",
         "travel",
@@ -1563,6 +1610,7 @@
       "bank": "Chase",
       "slug": "world-of-hyatt-business-credit-card",
       "accepting_applications": true,
+      "image": "chase-world-of-hyatt-business.png",
       "category": "business",
       "annual_fee": 199,
       "card_id": "world-of-hyatt-business-credit-card",
@@ -1573,6 +1621,7 @@
       "bank": "Chase",
       "slug": "world-of-hyatt-credit-card",
       "accepting_applications": true,
+      "image": "chase-world-of-hyatt.png",
       "annual_fee": 95,
       "tags": [
         "hotel",

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -3,7 +3,7 @@ bank: "Chase"
 slug: "chase-sapphire-reserve"
 image: "chase_sapphire_reserve.png"
 accepting_applications: true
-annual_fee: 550
+annual_fee: 795
 tags:
   - travel
   - premium

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -3,7 +3,7 @@ bank: "Chase"
 slug: "southwest-rapid-rewards-premier-credit-card"
 accepting_applications: true
 image: "chase-southwest-rapid-rewards-premier.png"
-annual_fee: 99
+annual_fee: 149
 tags:
   - airline
   - travel

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -3,7 +3,7 @@ bank: "Chase"
 slug: "southwest-rapid-rewards-priority-credit-card"
 image: "southwest_priority.png"
 accepting_applications: true
-annual_fee: 149
+annual_fee: 229
 tags:
   - airline
   - travel

--- a/data/news/2024-01-20-wells-fargo-attune.yaml
+++ b/data/news/2024-01-20-wells-fargo-attune.yaml
@@ -5,5 +5,5 @@ summary: "Wells Fargo has introduced the Attune card, focused on sustainability 
 tags:
   - new-card
 bank: "Wells Fargo"
-card_slug: "wells-fargo-attune-card"
+card_slug: "wells-fargo-attune"
 card_name: "Wells Fargo Attune Card"

--- a/data/news/2026-01-15-bilt-blue-launch.yaml
+++ b/data/news/2026-01-15-bilt-blue-launch.yaml
@@ -1,0 +1,11 @@
+id: "bilt-blue-launch"
+date: "2026-01-15"
+title: "Bilt Blue Card Launches as No-Annual-Fee Option"
+summary: "The Bilt Blue card is the entry-level option in Bilt's new card lineup, offering no annual fee. It earns 1x Bilt points per dollar on all purchases plus 4% Bilt Cash on everyday spending. Like all Bilt 2.0 cards, it allows rent and mortgage payments with no transaction fee (using Bilt Cash to unlock points). No foreign transaction fees."
+tags:
+  - new-card
+bank: "Bilt"
+card_slug: "bilt-blue"
+card_name: "Bilt Blue"
+source: "Bilt Rewards"
+source_url: "https://newsroom.biltrewards.com/meetbiltcard2.0"

--- a/data/news/2026-01-15-bilt-obsidian-launch.yaml
+++ b/data/news/2026-01-15-bilt-obsidian-launch.yaml
@@ -1,0 +1,11 @@
+id: "bilt-obsidian-launch"
+date: "2026-01-15"
+title: "Bilt Obsidian Card Launches with $95 Annual Fee"
+summary: "The Bilt Obsidian is the mid-tier card in Bilt 2.0, featuring 3x points on your choice of dining or groceries (up to $25K/year), 2x on travel, 1.25x on housing, and 1x everywhere else, plus 4% Bilt Cash. Includes Point Accelerator access starting March 2026 to earn bonus points on everyday spending. No foreign transaction fees."
+tags:
+  - new-card
+bank: "Bilt"
+card_slug: "bilt-obsidian"
+card_name: "Bilt Obsidian"
+source: "Bilt Rewards"
+source_url: "https://newsroom.biltrewards.com/meetbiltcard2.0"

--- a/data/news/2026-01-15-bilt-palladium-launch.yaml
+++ b/data/news/2026-01-15-bilt-palladium-launch.yaml
@@ -1,0 +1,11 @@
+id: "bilt-palladium-launch"
+date: "2026-01-15"
+title: "Bilt Palladium Card Launches as Premium $495 Option"
+summary: "The Bilt Palladium is Bilt's premium card, earning 2x points plus 4% Bilt Cash on all purchases. Benefits include $400 annual Bilt Travel hotel credit, $200 annual Bilt Cash credit, $300 Bilt Cash on approval, Priority Pass lounge access for cardholder and authorized users, and 50,000 bonus points after $4K spend in 3 months. Mastercard World Legend benefits included."
+tags:
+  - new-card
+bank: "Bilt"
+card_slug: "bilt-palladium"
+card_name: "Bilt Palladium"
+source: "Bilt Rewards"
+source_url: "https://newsroom.biltrewards.com/meetbiltcard2.0"


### PR DESCRIPTION
## Summary
- Add card images to news items using card_image_link lookup
- Add expandable text for long news summaries
- Add 3 new Bilt card news items (Blue, Obsidian, Palladium)
- Update annual fees: Chase Sapphire Reserve ($795), Southwest Premier ($149), Southwest Priority ($229)
- Add business card filter to explore page (hidden by default)
- Make profile referrals table more compact
- Fix admin dashboard to show submitter_id instead of email
- Disable Firebase Analytics in development to avoid 403 errors
- Fix Wells Fargo Attune news card_slug

## Test plan
- [ ] Verify news page shows card images
- [ ] Verify expandable text works on long summaries
- [ ] Verify explore page hides business cards by default
- [ ] Verify updated annual fees display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)