### PR TITLE
Add search aliases and fix build error

### DIFF
--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Card } from "@/lib/api";
+import { cardMatchesSearch } from "@/lib/searchAliases";
 
 interface ExploreClientProps {
   cards: Card[];
@@ -44,9 +45,7 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
 
   const filteredCards = useMemo(() => {
     let filtered = cards.filter(card => {
-      const matchesSearch = search === "" ||
-        card.card_name.toLowerCase().includes(search.toLowerCase()) ||
-        card.bank.toLowerCase().includes(search.toLowerCase());
+      const matchesSearch = cardMatchesSearch(card.card_name, card.bank, search);
       const matchesBank = selectedBank === "" || card.bank === selectedBank;
 
       // Apply emoji filter if active (filter by tag)

--- a/apps/web-next/src/components/ui/CardSelect.tsx
+++ b/apps/web-next/src/components/ui/CardSelect.tsx
@@ -6,6 +6,7 @@ import Downshift from "downshift";
 import Image from "next/image";
 import { ClockIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { Card } from "@/lib/api";
+import { cardMatchesSearch } from "@/lib/searchAliases";
 
 interface CardSelectProps {
   allCards: Card[];
@@ -75,13 +76,10 @@ export default function CardSelect({ allCards }: CardSelectProps) {
         selectedItem,
         getRootProps,
       }) => {
-        // Filter cards based on input, then sort with archived cards at the bottom
+        // Filter cards based on input (with alias support), then sort with archived cards at the bottom
         const filteredCards = allCards
           .filter(
-            (item) =>
-              !inputValue ||
-              item.card_name.toLowerCase().includes(inputValue.toLowerCase()) ||
-              item.bank.toLowerCase().includes(inputValue.toLowerCase())
+            (item) => cardMatchesSearch(item.card_name, item.bank, inputValue || '')
           )
           .sort((a, b) => {
             // Active cards first, archived cards last

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -20,6 +20,7 @@ export interface Card {
   rejected_count?: number;
   release_date?: string;
   tags?: string[];
+  category?: string;
   annual_fee?: number;
   apply_link?: string;
   card_referral_link?: string;

--- a/apps/web-next/src/lib/searchAliases.ts
+++ b/apps/web-next/src/lib/searchAliases.ts
@@ -1,0 +1,53 @@
+// Search aliases for common abbreviations and nicknames
+// Maps search terms to bank/card name patterns they should match
+
+const bankAliases: Record<string, string[]> = {
+  'amex': ['american express'],
+  'bofa': ['bank of america'],
+  'boa': ['bank of america'],
+  'csp': ['chase sapphire preferred'],
+  'csr': ['chase sapphire reserve'],
+  'cfu': ['chase freedom unlimited'],
+  'cff': ['chase freedom flex'],
+  'wf': ['wells fargo'],
+  'usb': ['u.s. bank', 'us bank'],
+  'cap one': ['capital one'],
+  'capone': ['capital one'],
+};
+
+/**
+ * Expands a search term to include aliases
+ * Returns an array of terms to search for
+ */
+export function expandSearchTerm(term: string): string[] {
+  const lowerTerm = term.toLowerCase();
+  const terms = [lowerTerm];
+
+  // Check if the search term matches any alias
+  for (const [alias, expansions] of Object.entries(bankAliases)) {
+    if (lowerTerm.includes(alias)) {
+      terms.push(...expansions);
+    }
+  }
+
+  return terms;
+}
+
+/**
+ * Check if a card matches the search input, including aliases
+ */
+export function cardMatchesSearch(
+  cardName: string,
+  bank: string,
+  searchInput: string
+): boolean {
+  if (!searchInput) return true;
+
+  const searchTerms = expandSearchTerm(searchInput);
+  const lowerCardName = cardName.toLowerCase();
+  const lowerBank = bank.toLowerCase();
+
+  return searchTerms.some(term =>
+    lowerCardName.includes(term) || lowerBank.includes(term)
+  );
+}


### PR DESCRIPTION
## Summary
- Add search aliases for common abbreviations (amex → American Express, bofa → Bank of America, etc.)
- Add category field to Card interface to fix TypeScript build error

## Test plan
- [x] Build passes
- [ ] Search "amex" returns American Express cards
- [ ] Search "bofa" returns Bank of America cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)