### PR TITLE
Add Amplify webhook triggers and fix docs

### DIFF
--- a/.github/workflows/build-cards.yml
+++ b/.github/workflows/build-cards.yml
@@ -76,3 +76,9 @@ jobs:
           if [ "$http_code" -ne 200 ]; then
             echo "Warning: Card sync returned non-200 status"
           fi
+
+      - name: Trigger Amplify rebuild
+        if: ${{ secrets.AMPLIFY_WEBHOOK_URL != '' }}
+        run: |
+          echo "Triggering Amplify rebuild to update sitemap..."
+          curl -s -X POST "${{ secrets.AMPLIFY_WEBHOOK_URL }}" || echo "Warning: Amplify webhook failed"

--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -44,3 +44,14 @@ jobs:
       - name: Invalidate CloudFront cache
         run: |
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/news.json"
+
+      - name: Wait for CloudFront invalidation
+        run: |
+          echo "Waiting 30 seconds for CloudFront cache invalidation..."
+          sleep 30
+
+      - name: Trigger Amplify rebuild
+        if: ${{ secrets.AMPLIFY_WEBHOOK_URL != '' }}
+        run: |
+          echo "Triggering Amplify rebuild..."
+          curl -s -X POST "${{ secrets.AMPLIFY_WEBHOOK_URL }}" || echo "Warning: Amplify webhook failed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 ## Deployment
 
 - Backend: `cd apps/api && sam build && sam deploy`
-- Frontend: Deployed via Vercel (automatic on push)
+- Frontend: Deployed via AWS Amplify (automatic on push)
 - Cards data: Run `npm run build-cards` in web-next to rebuild cards.json
 
 ## Database


### PR DESCRIPTION
## Summary
- Add Amplify rebuild webhook triggers to both `build-cards.yml` and `build-news.yml` GitHub Actions
- Update CLAUDE.md to reflect that frontend is deployed via AWS Amplify (not Vercel)

## Why
This ensures the sitemap gets regenerated when cards or news data are updated via GitHub Actions. Previously, only the CDN data was updated but the Amplify app wouldn't rebuild, meaning the sitemap would be stale.

## Setup Required
You'll need to add the `AMPLIFY_WEBHOOK_URL` secret to the GitHub repository settings. To get the webhook URL:
1. Go to AWS Amplify Console
2. Select your app
3. Go to App settings → Webhooks
4. Create a new webhook for the `main` branch
5. Copy the webhook URL and add it as a secret in GitHub

## Test plan
- [ ] Add AMPLIFY_WEBHOOK_URL secret to GitHub
- [ ] Trigger build-cards or build-news workflow manually
- [ ] Verify Amplify rebuild is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)