### PR TITLE
Improve mobile UI across multiple pages

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -16,10 +16,10 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
 
   return (
     <>
-      <main className="lg:relative">
+      <section className="lg:relative overflow-x-hidden">
         <div className="mx-auto max-w-7xl w-full pt-16 pb-20 text-center lg:py-72 lg:text-left">
           <div className="px-4 lg:w-1/2 sm:px-8 xl:pr-16">
-            <h1 className="text-4xl tracking-tight font-extrabold text-gray-900 sm:text-5xl md:text-6xl lg:text-5xl xl:text-6xl">
+            <h1 className="text-5xl tracking-tight font-extrabold text-gray-900 sm:text-5xl md:text-6xl lg:text-5xl xl:text-6xl">
               <span className="block xl:inline">Can I get this </span>
               <span className="block text-indigo-600 xl:inline">card?</span>
             </h1>
@@ -29,7 +29,7 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
             <CardSelect allCards={initialCards} />
           </div>
         </div>
-        <div className="relative w-full h-64 sm:h-72 md:h-96 lg:absolute lg:inset-y-0 lg:right-0 lg:w-1/2 lg:h-full">
+        <div className="relative w-screen h-64 sm:h-72 md:h-96 lg:absolute lg:inset-y-0 lg:right-0 lg:w-1/2 lg:h-full">
           <Image
             className="absolute inset-0 w-full h-full object-cover"
             src="/assets/Graphic-02.svg"
@@ -37,7 +37,7 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
             fill
           />
         </div>
-      </main>
+      </section>
       <div className="bg-indigo-900">
         <div className="max-w-7xl mx-auto py-12 px-4 sm:py-16 sm:px-6 lg:px-8 lg:py-20">
           <div className="max-w-4xl mx-auto text-center">

--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -257,7 +257,7 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
 
       {/* Cards Table */}
       <div className="mt-4 flex flex-col">
-        <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+        <div className="-my-2 sm:-mx-6 lg:-mx-8">
           <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
             <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
               <table className="min-w-full divide-y divide-gray-300">
@@ -269,7 +269,7 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
                     <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 hidden sm:table-cell">
                       Annual Fee
                     </th>
-                    <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                    <th scope="col" className="px-3 py-3.5 text-right text-sm font-semibold text-gray-900 hidden sm:table-cell">
                       Status
                     </th>
                   </tr>
@@ -302,9 +302,9 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
                   ) : (
                     filteredCards.map((card) => (
                       <tr key={card.card_id} className="hover:bg-gray-50">
-                        <td className="whitespace-nowrap py-4 pl-4 pr-3 sm:pl-6">
+                        <td className="py-3 pl-3 pr-2 sm:py-4 sm:pl-6 sm:pr-3">
                           <Link href={`/card/${card.slug}`} className="flex items-center group">
-                            <div className="h-10 w-16 flex-shrink-0 mr-4 hidden sm:block">
+                            <div className="h-8 w-12 sm:h-10 sm:w-16 flex-shrink-0 mr-3">
                               <Image
                                 src={card.card_image_link
                                   ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
@@ -312,15 +312,26 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
                                 alt={card.card_name}
                                 width={64}
                                 height={40}
-                                className="h-10 w-16 object-contain"
+                                className="h-8 w-12 sm:h-10 sm:w-16 object-contain"
                               />
                             </div>
-                            <div>
-                              <div className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900">
+                            <div className="min-w-0 flex-1">
+                              <div className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">
                                 {card.card_name}
                               </div>
-                              <div className="text-xs text-gray-500">
-                                {card.bank}
+                              <div className="text-xs text-gray-500 flex flex-wrap items-center gap-x-2">
+                                <span>{card.bank}</span>
+                                {/* Show fee and status on mobile inline */}
+                                <span className="sm:hidden">
+                                  {card.annual_fee !== undefined && card.annual_fee > 0 && (
+                                    <span className="text-gray-400">· ${card.annual_fee}/yr</span>
+                                  )}
+                                </span>
+                                {!card.accepting_applications && (
+                                  <span className="sm:hidden inline-flex rounded-full bg-gray-100 px-1.5 text-xs font-medium text-gray-600">
+                                    Archived
+                                  </span>
+                                )}
                               </div>
                             </div>
                           </Link>
@@ -328,7 +339,7 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
                         <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500 hidden sm:table-cell">
                           {card.annual_fee !== undefined ? (card.annual_fee === 0 ? '$0' : `$${card.annual_fee}`) : '—'}
                         </td>
-                        <td className="whitespace-nowrap px-3 py-4 text-sm">
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-right hidden sm:table-cell">
                           {card.accepting_applications ? (
                             <span className="inline-flex rounded-full bg-green-100 px-2 text-xs font-semibold leading-5 text-green-800">
                               Active

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -20,7 +20,7 @@ export default function Navbar() {
 
   return (
     <Disclosure as="nav" className="bg-white shadow">
-      {({ open }) => (
+      {({ open, close }) => (
         <>
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex justify-between h-16">
@@ -162,6 +162,7 @@ export default function Navbar() {
             <nav className="pt-2 pb-3 space-y-1">
               <Link
                 href="/explore"
+                onClick={() => close()}
                 className={classNames(
                   isActive('/explore')
                     ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
@@ -173,6 +174,7 @@ export default function Navbar() {
               </Link>
               <Link
                 href="/news"
+                onClick={() => close()}
                 className={classNames(
                   isActive('/news')
                     ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
@@ -189,6 +191,7 @@ export default function Navbar() {
                   <>
                     <Link
                       href="/profile"
+                      onClick={() => close()}
                       className={classNames(
                         isActive('/profile')
                           ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
@@ -200,7 +203,7 @@ export default function Navbar() {
                       Your Wallet
                     </Link>
                     <button
-                      onClick={logout}
+                      onClick={() => { close(); logout(); }}
                       className="block w-full text-left px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100"
                     >
                       Sign out
@@ -209,6 +212,7 @@ export default function Navbar() {
                 ) : (
                   <Link
                     href="/login"
+                    onClick={() => close()}
                     className="block px-4 py-2 text-base font-medium text-indigo-600 hover:text-indigo-800 hover:bg-gray-100"
                   >
                     Sign In

--- a/apps/web-next/src/components/ui/Skeleton.tsx
+++ b/apps/web-next/src/components/ui/Skeleton.tsx
@@ -74,29 +74,29 @@ export function ProfileSkeleton() {
               </div>
               <Skeleton className="h-8 w-8 rounded-full" />
             </div>
-            {/* Stats pills */}
-            <div className="flex items-center gap-2 sm:gap-3">
-              <Skeleton className="h-14 w-20 rounded-lg" />
-              <Skeleton className="h-14 w-20 rounded-lg" />
-              <Skeleton className="h-14 w-20 rounded-lg" />
-              <Skeleton className="h-14 w-20 rounded-lg" />
+            {/* Stats pills - 4 columns on mobile */}
+            <div className="grid grid-cols-4 gap-2 sm:flex sm:items-center sm:gap-3">
+              <Skeleton className="h-14 w-full sm:w-20 rounded-lg" />
+              <Skeleton className="h-14 w-full sm:w-20 rounded-lg" />
+              <Skeleton className="h-14 w-full sm:w-20 rounded-lg" />
+              <Skeleton className="h-14 w-full sm:w-20 rounded-lg" />
             </div>
           </div>
         </div>
 
         {/* Tabs */}
-        <div className="border-b border-gray-200 mb-6">
-          <nav className="-mb-px flex space-x-8">
-            <Skeleton className="h-10 w-24" />
-            <Skeleton className="h-10 w-24" />
-            <Skeleton className="h-10 w-24" />
+        <div className="border-b border-gray-200 mb-6 overflow-x-auto">
+          <nav className="-mb-px flex space-x-4 sm:space-x-8 min-w-max">
+            <Skeleton className="h-10 w-20 sm:w-24" />
+            <Skeleton className="h-10 w-20 sm:w-24" />
+            <Skeleton className="h-10 w-20 sm:w-24" />
           </nav>
         </div>
 
-        {/* Main Content Grid */}
-        <div className="grid grid-cols-3 gap-4 sm:gap-6">
-          {/* Left Column - Tab Content (2/3) */}
-          <div className="col-span-2">
+        {/* Main Content Grid - Single column on mobile */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Left Column - Tab Content (full width on mobile, 2/3 on desktop) */}
+          <div className="col-span-1 lg:col-span-2">
             <div className="bg-white shadow rounded-lg p-6 animate-pulse">
               <div className="flex items-center justify-between mb-4">
                 <Skeleton className="h-6 w-24" />
@@ -104,7 +104,7 @@ export function ProfileSkeleton() {
               </div>
               {/* Wallet cards grid */}
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                {[...Array(5)].map((_, i) => (
+                {[...Array(4)].map((_, i) => (
                   <div key={i} className="rounded-lg p-3 bg-gray-50">
                     <Skeleton className="aspect-[1.586/1] w-full mb-2 rounded" />
                     <Skeleton className="h-3 w-3/4 mb-1" />
@@ -115,7 +115,7 @@ export function ProfileSkeleton() {
             </div>
           </div>
 
-          {/* Right Column - News Sidebar (1/3) */}
+          {/* Right Column - News Sidebar (1/3 on desktop, below on mobile) */}
           <div className="col-span-1">
             <div className="bg-white shadow rounded-lg overflow-hidden animate-pulse">
               <div className="px-4 py-4 border-b border-gray-200">


### PR DESCRIPTION
## Summary
- **Landing page**: Make "Can I get this card?" heading bigger on mobile (text-5xl)
- **Landing page**: Fix small white space on left/right of hero image using full viewport width
- **Navbar**: Mobile menu now closes when navigation links are clicked
- **Profile skeleton**: Updated to match mobile layout with 4-column stats grid
- **Explore page**: Card images now show on mobile (smaller size)
- **Explore page**: Removed horizontal scroll by condensing table - annual fee and status shown inline on mobile

## Test plan
- [ ] Check landing page heading size on mobile
- [ ] Check landing page hero image extends edge-to-edge
- [ ] Click mobile menu links and verify menu closes
- [ ] Check profile page loading skeleton on mobile
- [ ] Check explore page shows card images on mobile
- [ ] Verify no horizontal scroll on explore page mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)