### PR TITLE
Fix GitHub Actions workflow secrets syntax

### DIFF
--- a/.github/workflows/build-cards.yml
+++ b/.github/workflows/build-cards.yml
@@ -78,7 +78,12 @@ jobs:
           fi
 
       - name: Trigger Amplify rebuild
-        if: ${{ secrets.AMPLIFY_WEBHOOK_URL != '' }}
+        env:
+          AMPLIFY_WEBHOOK_URL: ${{ secrets.AMPLIFY_WEBHOOK_URL }}
         run: |
-          echo "Triggering Amplify rebuild to update sitemap..."
-          curl -s -X POST "${{ secrets.AMPLIFY_WEBHOOK_URL }}" || echo "Warning: Amplify webhook failed"
+          if [ -n "$AMPLIFY_WEBHOOK_URL" ]; then
+            echo "Triggering Amplify rebuild to update sitemap..."
+            curl -s -X POST "$AMPLIFY_WEBHOOK_URL" || echo "Warning: Amplify webhook failed"
+          else
+            echo "Skipping Amplify rebuild (no webhook URL configured)"
+          fi

--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -51,7 +51,12 @@ jobs:
           sleep 30
 
       - name: Trigger Amplify rebuild
-        if: ${{ secrets.AMPLIFY_WEBHOOK_URL != '' }}
+        env:
+          AMPLIFY_WEBHOOK_URL: ${{ secrets.AMPLIFY_WEBHOOK_URL }}
         run: |
-          echo "Triggering Amplify rebuild..."
-          curl -s -X POST "${{ secrets.AMPLIFY_WEBHOOK_URL }}" || echo "Warning: Amplify webhook failed"
+          if [ -n "$AMPLIFY_WEBHOOK_URL" ]; then
+            echo "Triggering Amplify rebuild..."
+            curl -s -X POST "$AMPLIFY_WEBHOOK_URL" || echo "Warning: Amplify webhook failed"
+          else
+            echo "Skipping Amplify rebuild (no webhook URL configured)"
+          fi


### PR DESCRIPTION
## Summary
Fix the workflow file syntax error that was causing builds to fail.

The `if` expression in GitHub Actions cannot access the `secrets` context directly. This moves the secret check into the `run` command using an environment variable instead.

## Changes
- `build-cards.yml`: Use `env` block and shell check for AMPLIFY_WEBHOOK_URL
- `build-news.yml`: Use `env` block and shell check for AMPLIFY_WEBHOOK_URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)