### PR TITLE
Add news for Jan/Feb 2026 credit card updates

### DIFF
--- a/data/news/2026-01-22-chase-sapphire-bonus-eligibility.yaml
+++ b/data/news/2026-01-22-chase-sapphire-bonus-eligibility.yaml
@@ -1,0 +1,11 @@
+id: "chase-sapphire-bonus-eligibility"
+date: "2026-01-22"
+title: "Chase Simplifies Sapphire Bonus Rules"
+summary: "Chase now allows cardholders to earn a welcome bonus on each Sapphire card (Preferred and Reserve) as long as they've never received that specific card's bonus before. Previously, holding one Sapphire card blocked bonuses on the other."
+tags:
+  - policy-change
+bank: "Chase"
+card_slug: "chase-sapphire-preferred"
+card_name: "Chase Sapphire Preferred Card"
+source: "The Points Guy"
+source_url: "https://thepointsguy.com/news/chase-sapphire-bonus-eligibility-changes-2026/"

--- a/data/news/2026-02-01-capital-one-venture-x-lounge-changes.yaml
+++ b/data/news/2026-02-01-capital-one-venture-x-lounge-changes.yaml
@@ -1,0 +1,11 @@
+id: "capital-one-venture-x-lounge-changes"
+date: "2026-02-01"
+title: "Capital One Venture X Removes Free Lounge Guest Access"
+summary: "Capital One Venture X now charges $45 per guest at Capital One lounges and $35 at Priority Pass lounges. Authorized users also lose complimentary lounge access unless the primary cardholder pays $125/year per user. Only cardholders spending $75,000+ annually retain complimentary guest privileges."
+tags:
+  - benefit-change
+bank: "Capital One"
+card_slug: "capital-one-venture-x"
+card_name: "Capital One Venture X Rewards Credit Card"
+source: "The Points Guy"
+source_url: "https://thepointsguy.com/credit-cards/capital-one-set-to-change-lounge-access/"


### PR DESCRIPTION
## Summary
- **Chase Sapphire Bonus Eligibility** (Jan 22, 2026): Chase simplified bonus rules - cardholders can now earn a welcome bonus on each Sapphire card regardless of holding another Sapphire product
- **Capital One Venture X Lounge Changes** (Feb 1, 2026): Free guest access removed - guests now cost $45 at Capital One lounges, $35 at Priority Pass. Authorized users lose complimentary access unless primary cardholder pays $125/user/year

## Test plan
- [ ] Verify `npm run build:news` succeeds
- [ ] Check news entries appear correctly in the news feed
- [ ] Verify card links work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)