### PR TITLE
Add articles section for SEO-focused long-form content

### DIFF
--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -1,0 +1,221 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { CalendarIcon, UserIcon, ClockIcon } from "@heroicons/react/24/outline";
+import { getArticle, getArticles, tagLabels, tagColors, ArticleTag } from "@/lib/articles";
+import { ArticleContent } from "@/components/articles/ArticleContent";
+import { RelatedCards } from "@/components/articles/RelatedCards";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function TagBadge({ tag }: { tag: ArticleTag }) {
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${tagColors[tag]}`}>
+      {tagLabels[tag]}
+    </span>
+  );
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const article = await getArticle(slug);
+
+  if (!article) {
+    return {
+      title: "Article Not Found",
+    };
+  }
+
+  const openGraphImages = article.image
+    ? [{ url: `https://d2hxvzw7msbtvt.cloudfront.net/article_images/${article.image}` }]
+    : undefined;
+
+  return {
+    title: article.seo_title || `${article.title} | CreditOdds`,
+    description: article.seo_description || article.summary,
+    openGraph: {
+      title: article.seo_title || article.title,
+      description: article.seo_description || article.summary,
+      url: `https://creditodds.com/articles/${article.slug}`,
+      type: "article",
+      publishedTime: article.date,
+      authors: [article.author],
+      images: openGraphImages,
+    },
+    alternates: {
+      canonical: `https://creditodds.com/articles/${article.slug}`,
+    },
+  };
+}
+
+export async function generateStaticParams() {
+  const articles = await getArticles();
+  return articles.map((article) => ({
+    slug: article.slug,
+  }));
+}
+
+// Revalidate every 5 minutes
+export const revalidate = 300;
+
+export default async function ArticlePage({ params }: Props) {
+  const { slug } = await params;
+  const article = await getArticle(slug);
+
+  if (!article) {
+    notFound();
+  }
+
+  // Schema.org Article structured data
+  const jsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: article.title,
+    description: article.summary,
+    author: {
+      "@type": "Person",
+      name: article.author,
+    },
+    datePublished: article.date,
+    publisher: {
+      "@type": "Organization",
+      name: "CreditOdds",
+      url: "https://creditodds.com",
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `https://creditodds.com/articles/${article.slug}`,
+    },
+  };
+
+  if (article.image) {
+    jsonLd.image = `https://d2hxvzw7msbtvt.cloudfront.net/article_images/${article.image}`;
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <div className="min-h-screen bg-gray-50">
+        {/* Breadcrumbs */}
+        <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <ol className="flex items-center space-x-4 py-4">
+              <li>
+                <Link href="/" className="text-gray-400 hover:text-gray-500">
+                  Home
+                </Link>
+              </li>
+              <li>
+                <div className="flex items-center">
+                  <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                  </svg>
+                  <Link href="/articles" className="ml-4 text-gray-400 hover:text-gray-500">
+                    Articles
+                  </Link>
+                </div>
+              </li>
+              <li>
+                <div className="flex items-center">
+                  <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                  </svg>
+                  <span className="ml-4 text-sm font-medium text-gray-500 truncate sm:whitespace-normal">
+                    {article.title}
+                  </span>
+                </div>
+              </li>
+            </ol>
+          </div>
+        </nav>
+
+        <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+          {/* Article Header */}
+          <header className="mb-10">
+            {/* Tags */}
+            <div className="flex flex-wrap gap-2 mb-4">
+              {article.tags.map((tag) => (
+                <TagBadge key={tag} tag={tag} />
+              ))}
+            </div>
+
+            {/* Title */}
+            <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 leading-tight mb-6">
+              {article.title}
+            </h1>
+
+            {/* Meta */}
+            <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500">
+              <div className="flex items-center gap-1.5">
+                <UserIcon className="h-4 w-4" />
+                <span>{article.author}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <CalendarIcon className="h-4 w-4" />
+                <span>{formatDate(article.date)}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <ClockIcon className="h-4 w-4" />
+                <span>{article.reading_time} min read</span>
+              </div>
+            </div>
+          </header>
+
+          {/* Hero Image */}
+          {article.image && (
+            <div className="mb-8 rounded-lg overflow-hidden shadow-sm border border-gray-200">
+              <Image
+                src={`https://d2hxvzw7msbtvt.cloudfront.net/article_images/${article.image}`}
+                alt={article.image_alt || article.title}
+                width={896}
+                height={504}
+                className="w-full h-auto object-cover"
+                priority
+                unoptimized
+              />
+            </div>
+          )}
+
+          {/* Article Content */}
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 sm:p-10">
+            <ArticleContent content={article.content} />
+
+            {/* Related Cards */}
+            {article.related_cards_info && article.related_cards_info.length > 0 && (
+              <RelatedCards cards={article.related_cards_info} />
+            )}
+          </div>
+
+          {/* Back Link */}
+          <div className="mt-8 text-center">
+            <Link
+              href="/articles"
+              className="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium"
+            >
+              <svg className="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              Back to Articles
+            </Link>
+          </div>
+        </article>
+      </div>
+    </>
+  );
+}

--- a/apps/web-next/src/app/articles/page.tsx
+++ b/apps/web-next/src/app/articles/page.tsx
@@ -1,0 +1,93 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { DocumentTextIcon } from "@heroicons/react/24/outline";
+import { getArticles } from "@/lib/articles";
+import { ArticleCard } from "@/components/articles/ArticleCard";
+
+export const metadata: Metadata = {
+  title: "Credit Card Articles - Guides & Strategies",
+  description: "In-depth guides, strategies, and analysis to help you maximize your credit card rewards and make smarter financial decisions.",
+  openGraph: {
+    title: "Credit Card Articles | CreditOdds",
+    description: "Guides, strategies, and analysis for credit card rewards optimization.",
+    url: "https://creditodds.com/articles",
+  },
+  alternates: {
+    canonical: "https://creditodds.com/articles",
+  },
+};
+
+// Revalidate every 5 minutes
+export const revalidate = 300;
+
+export default async function ArticlesPage() {
+  const articles = await getArticles();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Breadcrumbs */}
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">
+                Home
+              </Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500">Articles</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <div className="text-center mb-10">
+          <div className="flex items-center justify-center gap-3 mb-2">
+            <DocumentTextIcon className="h-8 w-8 text-indigo-600" aria-hidden="true" />
+            <h1 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
+              Articles
+            </h1>
+          </div>
+          <p className="mt-2 text-lg text-gray-500 max-w-2xl mx-auto">
+            In-depth guides, strategies, and analysis to help you maximize your credit card rewards
+          </p>
+        </div>
+
+        {/* Articles Grid */}
+        {articles.length > 0 ? (
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {articles.map((article) => (
+              <ArticleCard key={article.id} article={article} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <DocumentTextIcon className="mx-auto h-12 w-12 text-gray-400" />
+            <h3 className="mt-2 text-sm font-medium text-gray-900">No articles yet</h3>
+            <p className="mt-1 text-sm text-gray-500">Check back soon for guides and strategies.</p>
+          </div>
+        )}
+
+        {/* CTA */}
+        <div className="mt-12 text-center">
+          <p className="text-gray-600 mb-4">
+            Ready to find your next card?
+          </p>
+          <Link
+            href="/explore"
+            className="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+          >
+            Explore All Cards
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/articles/ArticleCard.tsx
+++ b/apps/web-next/src/components/articles/ArticleCard.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { Article, ArticleTag, tagLabels, tagColors } from "@/lib/articles";
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function TagBadge({ tag }: { tag: ArticleTag }) {
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${tagColors[tag]}`}>
+      {tagLabels[tag]}
+    </span>
+  );
+}
+
+interface ArticleCardProps {
+  article: Article;
+}
+
+export function ArticleCard({ article }: ArticleCardProps) {
+  return (
+    <Link
+      href={`/articles/${article.slug}`}
+      className="block bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md hover:border-indigo-300 transition-all duration-200"
+    >
+      <div className="p-5">
+        {/* Tags */}
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {article.tags.map((tag) => (
+            <TagBadge key={tag} tag={tag} />
+          ))}
+        </div>
+
+        {/* Title */}
+        <h2 className="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
+          {article.title}
+        </h2>
+
+        {/* Summary */}
+        <p className="text-sm text-gray-600 mb-4 line-clamp-2">
+          {article.summary}
+        </p>
+
+        {/* Meta */}
+        <div className="flex items-center justify-between text-xs text-gray-500">
+          <div className="flex items-center gap-2">
+            <span>{article.author}</span>
+            <span className="text-gray-300">|</span>
+            <span>{formatDate(article.date)}</span>
+          </div>
+          <span>{article.reading_time} min read</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web-next/src/components/articles/ArticleContent.tsx
+++ b/apps/web-next/src/components/articles/ArticleContent.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useMemo } from "react";
+
+interface ArticleContentProps {
+  content: string;
+}
+
+// Simple markdown to HTML converter for article content
+function markdownToHtml(markdown: string): string {
+  let html = markdown;
+
+  // Headers
+  html = html.replace(/^### (.*$)/gim, '<h3>$1</h3>');
+  html = html.replace(/^## (.*$)/gim, '<h2>$1</h2>');
+  html = html.replace(/^# (.*$)/gim, '<h1>$1</h1>');
+
+  // Bold
+  html = html.replace(/\*\*(.*?)\*\*/gim, '<strong>$1</strong>');
+
+  // Italic
+  html = html.replace(/\*(.*?)\*/gim, '<em>$1</em>');
+
+  // Links
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/gim, '<a href="$2" class="text-indigo-600 hover:text-indigo-800 underline">$1</a>');
+
+  // Horizontal rules
+  html = html.replace(/^---$/gim, '<hr class="my-8 border-gray-200" />');
+
+  // Unordered lists
+  html = html.replace(/^\s*[-*]\s+(.*)$/gim, '<li>$1</li>');
+
+  // Ordered lists (numbered)
+  html = html.replace(/^\s*\d+\.\s+(.*)$/gim, '<li>$1</li>');
+
+  // Wrap consecutive <li> in <ul> or <ol>
+  html = html.replace(/(<li>.*<\/li>\n?)+/gi, (match) => {
+    return `<ul class="list-disc pl-6 my-4 space-y-1">${match}</ul>`;
+  });
+
+  // Tables (basic support)
+  html = html.replace(/^\|(.+)\|$/gim, (match, content) => {
+    if (content.includes('---')) {
+      return ''; // Skip separator row
+    }
+    const cells = content.split('|').map((cell: string) => cell.trim());
+    const isHeader = match.includes('---') === false && html.indexOf(match) === html.indexOf('|');
+    const cellTag = 'td';
+    const cellsHtml = cells.map((cell: string) => `<${cellTag} class="border border-gray-200 px-4 py-2">${cell}</${cellTag}>`).join('');
+    return `<tr>${cellsHtml}</tr>`;
+  });
+
+  // Wrap consecutive <tr> in <table>
+  html = html.replace(/(<tr>.*<\/tr>\n?)+/gi, (match) => {
+    return `<div class="overflow-x-auto my-6"><table class="min-w-full border-collapse border border-gray-200">${match}</table></div>`;
+  });
+
+  // Paragraphs - wrap lines that aren't already wrapped
+  const lines = html.split('\n');
+  const processedLines = lines.map((line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return '';
+    if (trimmed.startsWith('<')) return line;
+    return `<p>${trimmed}</p>`;
+  });
+  html = processedLines.join('\n');
+
+  // Clean up empty paragraphs
+  html = html.replace(/<p><\/p>/g, '');
+
+  return html;
+}
+
+export function ArticleContent({ content }: ArticleContentProps) {
+  const htmlContent = useMemo(() => markdownToHtml(content), [content]);
+
+  return (
+    <div
+      className="prose prose-indigo prose-lg max-w-none
+        prose-headings:font-bold prose-headings:text-gray-900
+        prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4
+        prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3
+        prose-p:text-gray-600 prose-p:leading-relaxed prose-p:my-4
+        prose-li:text-gray-600 prose-li:my-1
+        prose-strong:text-gray-900
+        prose-a:text-indigo-600 prose-a:no-underline hover:prose-a:underline"
+      dangerouslySetInnerHTML={{ __html: htmlContent }}
+    />
+  );
+}

--- a/apps/web-next/src/components/articles/RelatedCards.tsx
+++ b/apps/web-next/src/components/articles/RelatedCards.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import Image from "next/image";
+import { CreditCardIcon } from "@heroicons/react/24/outline";
+import { RelatedCardInfo } from "@/lib/articles";
+
+interface RelatedCardsProps {
+  cards: RelatedCardInfo[];
+}
+
+export function RelatedCards({ cards }: RelatedCardsProps) {
+  if (!cards || cards.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-12 pt-8 border-t border-gray-200">
+      <h2 className="text-xl font-bold text-gray-900 mb-4 flex items-center gap-2">
+        <CreditCardIcon className="h-6 w-6 text-indigo-600" />
+        Related Cards
+      </h2>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map((card) => (
+          <Link
+            key={card.slug}
+            href={`/card/${card.slug}`}
+            className="flex items-center gap-4 p-4 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-sm transition-all"
+          >
+            {card.image ? (
+              <Image
+                src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.image}`}
+                alt={card.name}
+                width={64}
+                height={40}
+                className="rounded object-contain flex-shrink-0"
+                unoptimized
+              />
+            ) : (
+              <div className="w-16 h-10 bg-gray-100 rounded flex items-center justify-center flex-shrink-0">
+                <CreditCardIcon className="h-6 w-6 text-gray-400" />
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-900 truncate">{card.name}</p>
+              <p className="text-xs text-gray-500">{card.bank}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/articles.ts
+++ b/apps/web-next/src/lib/articles.ts
@@ -1,0 +1,96 @@
+// Articles API types and fetching
+
+export type ArticleTag =
+  | 'strategy'
+  | 'guide'
+  | 'analysis'
+  | 'news-analysis'
+  | 'beginner';
+
+export interface RelatedCardInfo {
+  slug: string;
+  name: string;
+  image: string;
+  bank: string;
+}
+
+export interface Article {
+  id: string;
+  slug: string;
+  title: string;
+  date: string;
+  author: string;
+  summary: string;
+  tags: ArticleTag[];
+  related_cards?: string[];
+  related_cards_info?: RelatedCardInfo[];
+  seo_title?: string;
+  seo_description?: string;
+  image?: string;
+  image_alt?: string;
+  content: string;
+  reading_time: number;
+}
+
+export interface ArticlesResponse {
+  generated_at: string;
+  count: number;
+  articles: Article[];
+}
+
+export const tagLabels: Record<ArticleTag, string> = {
+  'strategy': 'Strategy',
+  'guide': 'Guide',
+  'analysis': 'Analysis',
+  'news-analysis': 'News Analysis',
+  'beginner': 'Beginner',
+};
+
+export const tagColors: Record<ArticleTag, string> = {
+  'strategy': 'bg-purple-100 text-purple-800',
+  'guide': 'bg-blue-100 text-blue-800',
+  'analysis': 'bg-green-100 text-green-800',
+  'news-analysis': 'bg-orange-100 text-orange-800',
+  'beginner': 'bg-teal-100 text-teal-800',
+};
+
+const ARTICLES_CDN_URL = 'https://d2hxvzw7msbtvt.cloudfront.net/articles.json';
+
+// Check if running in the browser
+const isBrowser = typeof window !== 'undefined';
+
+export async function getArticles(): Promise<Article[]> {
+  try {
+    // In development on the server, read from local file
+    if (!isBrowser && process.env.NODE_ENV === 'development') {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const filePath = path.join(process.cwd(), '..', '..', 'data', 'articles.json');
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      const data: ArticlesResponse = JSON.parse(fileContent);
+      return data.articles || [];
+    }
+
+    // Use local API route on client to avoid CORS, direct CDN on server
+    const url = isBrowser ? '/api/articles' : ARTICLES_CDN_URL;
+    const res = await fetch(url, isBrowser ? {} : {
+      next: { revalidate: 300 }, // Revalidate every 5 minutes (server only)
+    });
+
+    if (!res.ok) {
+      console.error('Failed to fetch articles:', res.status);
+      return [];
+    }
+
+    const data: ArticlesResponse = await res.json();
+    return data.articles || [];
+  } catch (error) {
+    console.error('Error fetching articles:', error);
+    return [];
+  }
+}
+
+export async function getArticle(slug: string): Promise<Article | null> {
+  const articles = await getArticles();
+  return articles.find(article => article.slug === slug) || null;
+}

--- a/data/articles.json
+++ b/data/articles.json
@@ -1,0 +1,140 @@
+{
+  "generated_at": "2026-02-04T19:49:06.721Z",
+  "count": 3,
+  "articles": [
+    {
+      "id": "multiple-citi-custom-cash-cards",
+      "slug": "multiple-citi-custom-cash-cards",
+      "title": "Can You Get Multiple Citi Custom Cash Cards to Maximize 5%?",
+      "date": "2026-02-04",
+      "author": "Max Melcher",
+      "summary": "Learn how to stack multiple Citi Custom Cash cards to earn 5% back on several spending categories at once.",
+      "tags": [
+        "strategy",
+        "guide"
+      ],
+      "related_cards": [
+        "citi-custom-cash",
+        "citi-double-cash"
+      ],
+      "seo_title": "Multiple Citi Custom Cash Cards Strategy | CreditOdds",
+      "seo_description": "Can you have multiple Citi Custom Cash cards? Yes! Learn how to maximize 5% cash back across multiple spending categories.",
+      "content": "The Citi Custom Cash card offers an attractive 5% cash back on your highest spending category each billing cycle, up to $500 in purchases. But what if you could earn 5% back on *multiple* categories? The good news is: you can.\n\n## The Multi-Card Strategy\n\nCiti allows cardholders to have **multiple Custom Cash cards** — up to a rumored limit of around 4-5 cards per person. This opens up a powerful strategy for maximizing your cash back rewards.\n\n### How It Works\n\nEach Citi Custom Cash card tracks its own spending independently. So if you have two cards:\n\n- **Card 1** could earn 5% on groceries\n- **Card 2** could earn 5% on gas stations\n\nYou'd earn 5% back on both categories, effectively doubling your bonus category coverage.\n\n## The Eligible 5% Categories\n\nThe Citi Custom Cash earns 5% on whichever of these categories you spend the most in each billing cycle:\n\n- Restaurants\n- Gas stations\n- Grocery stores\n- Select travel (airlines, hotels, car rentals)\n- Select transit (taxis, rideshare, trains)\n- Select streaming services\n- Drugstores\n- Home improvement stores\n- Fitness clubs\n- Live entertainment\n\n## Practical Implementation\n\nHere's how to set up a multi-card system:\n\n### Step 1: Identify Your Top Spending Categories\n\nReview your spending over the past 3-6 months. Which categories consistently hit or exceed the $500/month threshold? Common candidates include:\n\n- Groceries ($400-600/month for many families)\n- Gas ($200-400/month for commuters)\n- Dining out ($200-500/month)\n\n### Step 2: Apply for Additional Cards\n\nSpace out your applications by 3-6 months to minimize hard inquiry impact. Citi is generally friendly to existing customers, especially those with good payment history.\n\n### Step 3: Dedicate Each Card\n\nAssign each card to a specific category. Some people even label their cards or use card management apps to keep track.\n\n## The Math\n\nLet's say you spend:\n- $500/month on groceries → $25 back (5%)\n- $400/month on gas → $20 back (5%)\n- $300/month on dining → $15 back (5%)\n\nWith three Custom Cash cards, you'd earn **$60/month** or **$720/year** in cash back on these categories alone.\n\nCompare that to a flat 2% card: the same $1,200 spending would earn just $24/month or $288/year.\n\n**That's an extra $432/year** from the multi-card strategy.\n\n## Considerations\n\n### Pros\n- No annual fee on any of the cards\n- 5% is among the highest category rates available\n- Flexibility to adjust as spending patterns change\n\n### Cons\n- Managing multiple cards requires organization\n- Each card has a separate $500 cap per billing cycle\n- Too many applications in a short period can hurt your credit\n\n## Pairing with Citi Double Cash\n\nFor spending that doesn't fit neatly into the 5% categories, the Citi Double Cash is an excellent companion card. It earns a flat 2% on everything (1% when you buy, 1% when you pay), making it perfect for miscellaneous purchases.\n\n## The Bottom Line\n\nYes, you can absolutely have multiple Citi Custom Cash cards, and doing so is one of the most effective no-annual-fee cash back strategies available. If you're organized enough to manage multiple cards and your spending aligns with the bonus categories, this approach can significantly boost your rewards.\n\nStart with one card, get comfortable with the system, then consider adding more as you identify additional high-spend categories in your budget.\n",
+      "reading_time": 3,
+      "related_cards_info": [
+        {
+          "slug": "citi-custom-cash",
+          "name": "Citi Custom Cash",
+          "image": "citi_custom_cash.png",
+          "bank": "Citi"
+        },
+        {
+          "slug": "citi-double-cash",
+          "name": "Citi Double Cash",
+          "image": "citi_double_cash.png",
+          "bank": "Citi"
+        }
+      ]
+    },
+    {
+      "id": "chase-5-24-rule-explained",
+      "slug": "chase-5-24-rule-explained",
+      "title": "The Chase 5/24 Rule Explained: What It Is and How to Work Around It",
+      "date": "2026-02-03",
+      "author": "Max Melcher",
+      "summary": "Everything you need to know about Chase's infamous 5/24 rule and strategies to maximize your approvals.",
+      "tags": [
+        "guide",
+        "strategy",
+        "beginner"
+      ],
+      "related_cards": [
+        "chase-sapphire-preferred",
+        "chase-freedom-flex",
+        "chase-freedom-unlimited"
+      ],
+      "seo_title": "Chase 5/24 Rule Explained | CreditOdds",
+      "seo_description": "Learn what the Chase 5/24 rule is, which cards it applies to, and strategies to work around this approval restriction.",
+      "image": "chase-5-24-rule.jpg",
+      "image_alt": "Chase credit cards spread out showing various card options",
+      "content": "If you're interested in credit card rewards, you've probably heard of the Chase 5/24 rule. It's one of the most important concepts to understand before applying for Chase cards, and it can significantly impact your approval odds.\n\n## What is the 5/24 Rule?\n\nThe Chase 5/24 rule is an unofficial policy that Chase uses when evaluating credit card applications. Here's the simple version:\n\n**If you've opened 5 or more personal credit cards (from any bank) in the past 24 months, Chase will automatically deny your application for most Chase cards.**\n\nThis applies regardless of your credit score, income, or relationship with Chase.\n\n## What Counts Toward 5/24?\n\nUnderstanding what counts is crucial for planning your applications:\n\n### Does Count:\n- Personal credit cards from any issuer\n- Store cards (Target, Amazon, etc.)\n- Being added as an authorized user on someone else's card\n- Some business cards that report to personal credit bureaus\n\n### Does NOT Count:\n- Most business credit cards (Chase Ink, Amex Business, etc.)\n- Corporate cards\n- Charge cards (in most cases)\n- Credit limit increases on existing cards\n- Product changes between cards\n\n## Which Chase Cards Are Affected?\n\nMost Chase personal cards are subject to 5/24:\n\n- Chase Sapphire Preferred\n- Chase Sapphire Reserve\n- Chase Freedom Flex\n- Chase Freedom Unlimited\n- Chase Freedom Rise\n- United Explorer and Club cards\n- Southwest cards\n- Marriott Bonvoy cards\n- IHG cards\n- British Airways card\n- Aer Lingus card\n\n### Cards NOT Subject to 5/24\n\nA few Chase cards have been known to bypass the rule:\n\n- Amazon Prime Visa\n- Disney Visa cards\n- Some co-branded hotel cards (varies)\n\nHowever, these exceptions can change, so always verify current data points before applying.\n\n## How to Check Your 5/24 Status\n\n1. **Pull your credit report** from annualcreditreport.com\n2. **Count accounts opened** in the last 24 months\n3. **Include authorized user accounts** in your count\n4. **Exclude business cards** that don't appear on personal reports\n\nMany people use a simple spreadsheet to track their \"5/24 count\" over time.\n\n## Strategies for Working With 5/24\n\n### Strategy 1: Prioritize Chase Cards First\n\nIf you're new to credit card rewards, apply for Chase cards before other issuers. Once you're over 5/24, you can still get cards from Amex, Capital One, Citi, and others.\n\n**Recommended Chase order:**\n1. Chase Sapphire Preferred or Reserve (best sign-up bonuses)\n2. Chase Freedom Flex (5% rotating categories)\n3. Chase Freedom Unlimited (1.5% on everything)\n4. Co-branded cards based on your travel preferences\n\n### Strategy 2: Space Out Applications\n\nIf you're at 4/24, you might want to wait before opening any new cards. Chase cards often have the best sign-up bonuses, so preserving a slot can be valuable.\n\n### Strategy 3: Remove Authorized User Accounts\n\nIf authorized user accounts are pushing you over 5/24, you can:\n1. Ask the primary cardholder to remove you\n2. Contact Chase directly during reconsideration and explain you're an AU, not the primary holder\n\nChase may be willing to overlook AU accounts in some cases.\n\n### Strategy 4: Wait It Out\n\nCards fall off your 5/24 count exactly 24 months after the account open date. If you're at 6/24 but a card will age out in 2 months, it might be worth waiting.\n\n## The Modified Double Dip (MDD)\n\nAdvanced users sometimes use a technique called the Modified Double Dip to get two Chase cards in rapid succession. This involves:\n\n1. Applying for Card A\n2. Getting approved\n3. Applying for Card B the very next day (before the first card reports)\n\n**Warning:** This is an aggressive strategy that Chase may not appreciate. Use at your own risk, and never apply for more cards than you can responsibly manage.\n\n## Common 5/24 Myths\n\n**Myth:** \"Having a Chase bank account helps bypass 5/24\"\n**Reality:** Your banking relationship does not override 5/24.\n\n**Myth:** \"High income or excellent credit can override 5/24\"\n**Reality:** 5/24 is a hard rule applied before other factors.\n\n**Myth:** \"Calling reconsideration will get you approved\"\n**Reality:** 5/24 denials cannot typically be overturned through recon.\n\n## Planning Your Card Strategy\n\nHere's a sample timeline for someone starting fresh:\n\n- **Month 0:** Chase Sapphire Preferred (1/24)\n- **Month 3:** Chase Freedom Flex (2/24)\n- **Month 6:** Chase Freedom Unlimited (3/24)\n- **Month 9:** Chase co-branded card of choice (4/24)\n- **Month 12:** One more Chase card or start branching out (5/24)\n- **Month 15+:** Amex, Citi, Capital One cards\n\n## The Bottom Line\n\nThe 5/24 rule is frustrating, but understanding it puts you ahead of most applicants. Plan your applications strategically, prioritize Chase cards early, and you'll maximize your chances of building a powerful rewards portfolio.\n\nRemember: slow and steady wins the rewards game. Don't rush into applications just to hit a number — make sure each card genuinely fits your spending and travel goals.\n",
+      "reading_time": 5,
+      "related_cards_info": [
+        {
+          "slug": "chase-sapphire-preferred",
+          "name": "Chase Sapphire Preferred Card",
+          "image": "chase-sapphire-preferred.png",
+          "bank": "Chase"
+        },
+        {
+          "slug": "chase-freedom-flex",
+          "name": "Chase Freedom Flex",
+          "image": "freedom_flex_card.png",
+          "bank": "Chase"
+        },
+        {
+          "slug": "chase-freedom-unlimited",
+          "name": "Chase Freedom Unlimited",
+          "image": "freedom_unlimited_card.png",
+          "bank": "Chase"
+        }
+      ]
+    },
+    {
+      "id": "best-no-annual-fee-cashback-2026",
+      "slug": "best-no-annual-fee-cashback-2026",
+      "title": "Best No-Annual-Fee Cash Back Cards in 2026",
+      "date": "2026-02-01",
+      "author": "Max Melcher",
+      "summary": "Our top picks for no-annual-fee cash back credit cards, from flat-rate simplicity to category maximizers.",
+      "tags": [
+        "analysis",
+        "guide",
+        "beginner"
+      ],
+      "related_cards": [
+        "citi-double-cash",
+        "chase-freedom-unlimited",
+        "chase-freedom-flex",
+        "discover-it-cash-back",
+        "wells-fargo-active-cash"
+      ],
+      "seo_title": "Best No-Annual-Fee Cash Back Cards 2026 | CreditOdds",
+      "seo_description": "Compare the best no-annual-fee cash back credit cards in 2026. Find flat-rate and category cards to maximize your rewards.",
+      "content": "Not everyone wants to pay an annual fee for a credit card — and honestly, you don't have to. The no-annual-fee cash back card market is incredibly competitive, with several options offering 2% or more on all purchases and others providing 5%+ on specific categories.\n\nHere's our breakdown of the best no-annual-fee cash back cards available in 2026.\n\n## Best Flat-Rate Cards\n\nThese cards keep it simple: earn the same rate on every purchase, no categories to track.\n\n### Wells Fargo Active Cash Card\n\n**Earn:** 2% cash back on all purchases\n\n**Why it stands out:** The Active Cash is one of the simplest and most rewarding flat-rate cards available. No caps, no categories, just straight 2% on everything.\n\n**Best for:** People who want maximum simplicity without sacrificing rewards.\n\n**Sign-up bonus:** Typically $200 after spending $500 in the first 3 months.\n\n---\n\n### Citi Double Cash Card\n\n**Earn:** 2% cash back (1% when you buy, 1% when you pay)\n\n**Why it stands out:** A pioneer in the 2% cash back space, the Double Cash remains a solid choice. The split earning structure means you need to pay your bill to get the full 2%, encouraging good habits.\n\n**Best for:** Responsible cardholders who always pay their balance.\n\n**Sign-up bonus:** Occasionally available, usually around $200.\n\n---\n\n### Chase Freedom Unlimited\n\n**Earn:** 1.5% cash back on all purchases, 3% on dining and drugstores, 5% on travel through Chase\n\n**Why it stands out:** While the base rate is lower at 1.5%, the bonus categories bump your effective rate higher. Plus, if you have a Chase Sapphire card, you can transfer these points to travel partners.\n\n**Best for:** Chase ecosystem users who want flexibility between cash back and travel points.\n\n## Best Category Cards\n\nThese cards offer higher rates in specific categories. They require more management but can yield significantly higher rewards.\n\n### Chase Freedom Flex\n\n**Earn:** 5% on rotating quarterly categories (up to $1,500/quarter), 3% on dining and drugstores, 1% on everything else\n\n**Why it stands out:** The 5% rotating categories can include gas, groceries, Amazon, PayPal, and more. Combined with solid base categories, it's one of the most versatile no-fee cards.\n\n**Best for:** Active rewards optimizers willing to track and activate quarterly categories.\n\n**Sign-up bonus:** Usually $200 after spending $500 in 3 months.\n\n---\n\n### Discover it Cash Back\n\n**Earn:** 5% on rotating quarterly categories (up to $1,500/quarter), 1% on everything else\n\n**Why it stands out:** Discover matches all the cash back you earn in your first year — effectively doubling your rewards. That's 10% back on categories and 2% on everything else for year one.\n\n**Best for:** New cardholders who can maximize the first-year match, plus it's a great option for those building credit.\n\n**Sign-up bonus:** Cashback Match (all rewards doubled year one).\n\n---\n\n### Citi Custom Cash\n\n**Earn:** 5% on your highest spending category each billing cycle (up to $500), 1% on everything else\n\n**Why it stands out:** Unlike rotating category cards, the Custom Cash automatically applies 5% to whatever you spend most on. No activation required.\n\n**Best for:** People with one dominant spending category (groceries, gas, dining, etc.).\n\n## Best for Specific Categories\n\n### Best for Groceries: Blue Cash Everyday from Amex\n\n**Earn:** 3% at U.S. supermarkets (up to $6,000/year), 2% at gas stations and select department stores, 1% on everything else\n\nWhile 3% is lower than some 5% options, the $6,000 annual cap is generous. Great for families with moderate grocery spending.\n\n### Best for Dining: Capital One SavorOne\n\n**Earn:** 3% on dining, entertainment, popular streaming, and grocery stores, 1% on everything else\n\nSolid across multiple lifestyle categories, especially if you dine out frequently.\n\n### Best for Amazon: Amazon Prime Rewards Visa\n\n**Earn:** 5% at Amazon and Whole Foods (Prime members), 2% at restaurants, gas, and drugstores\n\nIf you're a Prime member who shops Amazon regularly, this is a no-brainer. Note: Requires Prime membership, which does have an annual cost.\n\n## Building Your No-Fee Card Portfolio\n\nThe real power of no-annual-fee cards comes from combining them strategically:\n\n| Spending Category | Best Card | Earn Rate |\n|-------------------|-----------|-----------|\n| Everything (default) | Wells Fargo Active Cash | 2% |\n| Groceries | Citi Custom Cash #1 | 5% |\n| Gas | Citi Custom Cash #2 | 5% |\n| Dining | Capital One SavorOne | 3% |\n| Rotating categories | Chase Freedom Flex | 5% |\n\nWith this setup, you'd earn 3-5% on most spending without paying a single annual fee.\n\n## What About Sign-Up Bonuses?\n\nWhile no-fee cards typically have smaller bonuses than premium cards, they still add up:\n\n- Wells Fargo Active Cash: ~$200\n- Chase Freedom Flex: ~$200\n- Chase Freedom Unlimited: ~$200\n- Discover it: Cashback Match (variable but valuable)\n- Capital One SavorOne: ~$200\n\nThat's potentially $800+ in first-year bonuses from completely free cards.\n\n## Our Top Picks Summary\n\n1. **Best Overall:** Wells Fargo Active Cash — Simple 2% on everything\n2. **Best for Category Spending:** Citi Custom Cash — Automatic 5% on top category\n3. **Best for New Users:** Discover it — First-year match doubles everything\n4. **Best for Flexibility:** Chase Freedom Unlimited — Cash or points, your choice\n5. **Best for Active Optimizers:** Chase Freedom Flex — Rotating 5% categories\n\n## The Bottom Line\n\nYou don't need to pay annual fees to earn great cash back rewards. The cards above prove that no-fee options can be just as powerful as their premium counterparts — especially when used in combination.\n\nStart with one card that matches your highest spending category, then expand your portfolio over time. Before you know it, you'll be earning 3-5% on nearly everything you buy.\n",
+      "reading_time": 5,
+      "related_cards_info": [
+        {
+          "slug": "citi-double-cash",
+          "name": "Citi Double Cash",
+          "image": "citi_double_cash.png",
+          "bank": "Citi"
+        },
+        {
+          "slug": "chase-freedom-unlimited",
+          "name": "Chase Freedom Unlimited",
+          "image": "freedom_unlimited_card.png",
+          "bank": "Chase"
+        },
+        {
+          "slug": "chase-freedom-flex",
+          "name": "Chase Freedom Flex",
+          "image": "freedom_flex_card.png",
+          "bank": "Chase"
+        },
+        {
+          "slug": "discover-it-cash-back",
+          "name": "Discover it Cash Back",
+          "image": "discover_it_cash.png",
+          "bank": "Discover"
+        },
+        {
+          "slug": "wells-fargo-active-cash",
+          "name": "Wells Fargo Active Cash Card",
+          "image": "wells_fargo_active_cash.png",
+          "bank": "Wells Fargo"
+        }
+      ]
+    }
+  ]
+}

--- a/data/articles/best-no-annual-fee-cashback-2026.yaml
+++ b/data/articles/best-no-annual-fee-cashback-2026.yaml
@@ -1,0 +1,154 @@
+id: "best-no-annual-fee-cashback-2026"
+slug: "best-no-annual-fee-cashback-2026"
+title: "Best No-Annual-Fee Cash Back Cards in 2026"
+date: "2026-02-01"
+author: "Max Melcher"
+summary: "Our top picks for no-annual-fee cash back credit cards, from flat-rate simplicity to category maximizers."
+tags:
+  - analysis
+  - guide
+  - beginner
+related_cards:
+  - citi-double-cash
+  - chase-freedom-unlimited
+  - chase-freedom-flex
+  - discover-it-cash-back
+  - wells-fargo-active-cash
+seo_title: "Best No-Annual-Fee Cash Back Cards 2026 | CreditOdds"
+seo_description: "Compare the best no-annual-fee cash back credit cards in 2026. Find flat-rate and category cards to maximize your rewards."
+content: |
+  Not everyone wants to pay an annual fee for a credit card — and honestly, you don't have to. The no-annual-fee cash back card market is incredibly competitive, with several options offering 2% or more on all purchases and others providing 5%+ on specific categories.
+
+  Here's our breakdown of the best no-annual-fee cash back cards available in 2026.
+
+  ## Best Flat-Rate Cards
+
+  These cards keep it simple: earn the same rate on every purchase, no categories to track.
+
+  ### Wells Fargo Active Cash Card
+
+  **Earn:** 2% cash back on all purchases
+
+  **Why it stands out:** The Active Cash is one of the simplest and most rewarding flat-rate cards available. No caps, no categories, just straight 2% on everything.
+
+  **Best for:** People who want maximum simplicity without sacrificing rewards.
+
+  **Sign-up bonus:** Typically $200 after spending $500 in the first 3 months.
+
+  ---
+
+  ### Citi Double Cash Card
+
+  **Earn:** 2% cash back (1% when you buy, 1% when you pay)
+
+  **Why it stands out:** A pioneer in the 2% cash back space, the Double Cash remains a solid choice. The split earning structure means you need to pay your bill to get the full 2%, encouraging good habits.
+
+  **Best for:** Responsible cardholders who always pay their balance.
+
+  **Sign-up bonus:** Occasionally available, usually around $200.
+
+  ---
+
+  ### Chase Freedom Unlimited
+
+  **Earn:** 1.5% cash back on all purchases, 3% on dining and drugstores, 5% on travel through Chase
+
+  **Why it stands out:** While the base rate is lower at 1.5%, the bonus categories bump your effective rate higher. Plus, if you have a Chase Sapphire card, you can transfer these points to travel partners.
+
+  **Best for:** Chase ecosystem users who want flexibility between cash back and travel points.
+
+  ## Best Category Cards
+
+  These cards offer higher rates in specific categories. They require more management but can yield significantly higher rewards.
+
+  ### Chase Freedom Flex
+
+  **Earn:** 5% on rotating quarterly categories (up to $1,500/quarter), 3% on dining and drugstores, 1% on everything else
+
+  **Why it stands out:** The 5% rotating categories can include gas, groceries, Amazon, PayPal, and more. Combined with solid base categories, it's one of the most versatile no-fee cards.
+
+  **Best for:** Active rewards optimizers willing to track and activate quarterly categories.
+
+  **Sign-up bonus:** Usually $200 after spending $500 in 3 months.
+
+  ---
+
+  ### Discover it Cash Back
+
+  **Earn:** 5% on rotating quarterly categories (up to $1,500/quarter), 1% on everything else
+
+  **Why it stands out:** Discover matches all the cash back you earn in your first year — effectively doubling your rewards. That's 10% back on categories and 2% on everything else for year one.
+
+  **Best for:** New cardholders who can maximize the first-year match, plus it's a great option for those building credit.
+
+  **Sign-up bonus:** Cashback Match (all rewards doubled year one).
+
+  ---
+
+  ### Citi Custom Cash
+
+  **Earn:** 5% on your highest spending category each billing cycle (up to $500), 1% on everything else
+
+  **Why it stands out:** Unlike rotating category cards, the Custom Cash automatically applies 5% to whatever you spend most on. No activation required.
+
+  **Best for:** People with one dominant spending category (groceries, gas, dining, etc.).
+
+  ## Best for Specific Categories
+
+  ### Best for Groceries: Blue Cash Everyday from Amex
+
+  **Earn:** 3% at U.S. supermarkets (up to $6,000/year), 2% at gas stations and select department stores, 1% on everything else
+
+  While 3% is lower than some 5% options, the $6,000 annual cap is generous. Great for families with moderate grocery spending.
+
+  ### Best for Dining: Capital One SavorOne
+
+  **Earn:** 3% on dining, entertainment, popular streaming, and grocery stores, 1% on everything else
+
+  Solid across multiple lifestyle categories, especially if you dine out frequently.
+
+  ### Best for Amazon: Amazon Prime Rewards Visa
+
+  **Earn:** 5% at Amazon and Whole Foods (Prime members), 2% at restaurants, gas, and drugstores
+
+  If you're a Prime member who shops Amazon regularly, this is a no-brainer. Note: Requires Prime membership, which does have an annual cost.
+
+  ## Building Your No-Fee Card Portfolio
+
+  The real power of no-annual-fee cards comes from combining them strategically:
+
+  | Spending Category | Best Card | Earn Rate |
+  |-------------------|-----------|-----------|
+  | Everything (default) | Wells Fargo Active Cash | 2% |
+  | Groceries | Citi Custom Cash #1 | 5% |
+  | Gas | Citi Custom Cash #2 | 5% |
+  | Dining | Capital One SavorOne | 3% |
+  | Rotating categories | Chase Freedom Flex | 5% |
+
+  With this setup, you'd earn 3-5% on most spending without paying a single annual fee.
+
+  ## What About Sign-Up Bonuses?
+
+  While no-fee cards typically have smaller bonuses than premium cards, they still add up:
+
+  - Wells Fargo Active Cash: ~$200
+  - Chase Freedom Flex: ~$200
+  - Chase Freedom Unlimited: ~$200
+  - Discover it: Cashback Match (variable but valuable)
+  - Capital One SavorOne: ~$200
+
+  That's potentially $800+ in first-year bonuses from completely free cards.
+
+  ## Our Top Picks Summary
+
+  1. **Best Overall:** Wells Fargo Active Cash — Simple 2% on everything
+  2. **Best for Category Spending:** Citi Custom Cash — Automatic 5% on top category
+  3. **Best for New Users:** Discover it — First-year match doubles everything
+  4. **Best for Flexibility:** Chase Freedom Unlimited — Cash or points, your choice
+  5. **Best for Active Optimizers:** Chase Freedom Flex — Rotating 5% categories
+
+  ## The Bottom Line
+
+  You don't need to pay annual fees to earn great cash back rewards. The cards above prove that no-fee options can be just as powerful as their premium counterparts — especially when used in combination.
+
+  Start with one card that matches your highest spending category, then expand your portfolio over time. Before you know it, you'll be earning 3-5% on nearly everything you buy.

--- a/data/articles/chase-5-24-rule-explained.yaml
+++ b/data/articles/chase-5-24-rule-explained.yaml
@@ -1,0 +1,146 @@
+id: "chase-5-24-rule-explained"
+slug: "chase-5-24-rule-explained"
+title: "The Chase 5/24 Rule Explained: What It Is and How to Work Around It"
+date: "2026-02-03"
+author: "Max Melcher"
+summary: "Everything you need to know about Chase's infamous 5/24 rule and strategies to maximize your approvals."
+tags:
+  - guide
+  - strategy
+  - beginner
+related_cards:
+  - chase-sapphire-preferred
+  - chase-freedom-flex
+  - chase-freedom-unlimited
+seo_title: "Chase 5/24 Rule Explained | CreditOdds"
+seo_description: "Learn what the Chase 5/24 rule is, which cards it applies to, and strategies to work around this approval restriction."
+image: "chase-5-24-rule.jpg"
+image_alt: "Chase credit cards spread out showing various card options"
+content: |
+  If you're interested in credit card rewards, you've probably heard of the Chase 5/24 rule. It's one of the most important concepts to understand before applying for Chase cards, and it can significantly impact your approval odds.
+
+  ## What is the 5/24 Rule?
+
+  The Chase 5/24 rule is an unofficial policy that Chase uses when evaluating credit card applications. Here's the simple version:
+
+  **If you've opened 5 or more personal credit cards (from any bank) in the past 24 months, Chase will automatically deny your application for most Chase cards.**
+
+  This applies regardless of your credit score, income, or relationship with Chase.
+
+  ## What Counts Toward 5/24?
+
+  Understanding what counts is crucial for planning your applications:
+
+  ### Does Count:
+  - Personal credit cards from any issuer
+  - Store cards (Target, Amazon, etc.)
+  - Being added as an authorized user on someone else's card
+  - Some business cards that report to personal credit bureaus
+
+  ### Does NOT Count:
+  - Most business credit cards (Chase Ink, Amex Business, etc.)
+  - Corporate cards
+  - Charge cards (in most cases)
+  - Credit limit increases on existing cards
+  - Product changes between cards
+
+  ## Which Chase Cards Are Affected?
+
+  Most Chase personal cards are subject to 5/24:
+
+  - Chase Sapphire Preferred
+  - Chase Sapphire Reserve
+  - Chase Freedom Flex
+  - Chase Freedom Unlimited
+  - Chase Freedom Rise
+  - United Explorer and Club cards
+  - Southwest cards
+  - Marriott Bonvoy cards
+  - IHG cards
+  - British Airways card
+  - Aer Lingus card
+
+  ### Cards NOT Subject to 5/24
+
+  A few Chase cards have been known to bypass the rule:
+
+  - Amazon Prime Visa
+  - Disney Visa cards
+  - Some co-branded hotel cards (varies)
+
+  However, these exceptions can change, so always verify current data points before applying.
+
+  ## How to Check Your 5/24 Status
+
+  1. **Pull your credit report** from annualcreditreport.com
+  2. **Count accounts opened** in the last 24 months
+  3. **Include authorized user accounts** in your count
+  4. **Exclude business cards** that don't appear on personal reports
+
+  Many people use a simple spreadsheet to track their "5/24 count" over time.
+
+  ## Strategies for Working With 5/24
+
+  ### Strategy 1: Prioritize Chase Cards First
+
+  If you're new to credit card rewards, apply for Chase cards before other issuers. Once you're over 5/24, you can still get cards from Amex, Capital One, Citi, and others.
+
+  **Recommended Chase order:**
+  1. Chase Sapphire Preferred or Reserve (best sign-up bonuses)
+  2. Chase Freedom Flex (5% rotating categories)
+  3. Chase Freedom Unlimited (1.5% on everything)
+  4. Co-branded cards based on your travel preferences
+
+  ### Strategy 2: Space Out Applications
+
+  If you're at 4/24, you might want to wait before opening any new cards. Chase cards often have the best sign-up bonuses, so preserving a slot can be valuable.
+
+  ### Strategy 3: Remove Authorized User Accounts
+
+  If authorized user accounts are pushing you over 5/24, you can:
+  1. Ask the primary cardholder to remove you
+  2. Contact Chase directly during reconsideration and explain you're an AU, not the primary holder
+
+  Chase may be willing to overlook AU accounts in some cases.
+
+  ### Strategy 4: Wait It Out
+
+  Cards fall off your 5/24 count exactly 24 months after the account open date. If you're at 6/24 but a card will age out in 2 months, it might be worth waiting.
+
+  ## The Modified Double Dip (MDD)
+
+  Advanced users sometimes use a technique called the Modified Double Dip to get two Chase cards in rapid succession. This involves:
+
+  1. Applying for Card A
+  2. Getting approved
+  3. Applying for Card B the very next day (before the first card reports)
+
+  **Warning:** This is an aggressive strategy that Chase may not appreciate. Use at your own risk, and never apply for more cards than you can responsibly manage.
+
+  ## Common 5/24 Myths
+
+  **Myth:** "Having a Chase bank account helps bypass 5/24"
+  **Reality:** Your banking relationship does not override 5/24.
+
+  **Myth:** "High income or excellent credit can override 5/24"
+  **Reality:** 5/24 is a hard rule applied before other factors.
+
+  **Myth:** "Calling reconsideration will get you approved"
+  **Reality:** 5/24 denials cannot typically be overturned through recon.
+
+  ## Planning Your Card Strategy
+
+  Here's a sample timeline for someone starting fresh:
+
+  - **Month 0:** Chase Sapphire Preferred (1/24)
+  - **Month 3:** Chase Freedom Flex (2/24)
+  - **Month 6:** Chase Freedom Unlimited (3/24)
+  - **Month 9:** Chase co-branded card of choice (4/24)
+  - **Month 12:** One more Chase card or start branching out (5/24)
+  - **Month 15+:** Amex, Citi, Capital One cards
+
+  ## The Bottom Line
+
+  The 5/24 rule is frustrating, but understanding it puts you ahead of most applicants. Plan your applications strategically, prioritize Chase cards early, and you'll maximize your chances of building a powerful rewards portfolio.
+
+  Remember: slow and steady wins the rewards game. Don't rush into applications just to hit a number — make sure each card genuinely fits your spending and travel goals.

--- a/data/articles/multiple-citi-custom-cash-cards.yaml
+++ b/data/articles/multiple-citi-custom-cash-cards.yaml
@@ -1,0 +1,99 @@
+id: "multiple-citi-custom-cash-cards"
+slug: "multiple-citi-custom-cash-cards"
+title: "Can You Get Multiple Citi Custom Cash Cards to Maximize 5%?"
+date: "2026-02-04"
+author: "Max Melcher"
+summary: "Learn how to stack multiple Citi Custom Cash cards to earn 5% back on several spending categories at once."
+tags:
+  - strategy
+  - guide
+related_cards:
+  - citi-custom-cash
+  - citi-double-cash
+seo_title: "Multiple Citi Custom Cash Cards Strategy | CreditOdds"
+seo_description: "Can you have multiple Citi Custom Cash cards? Yes! Learn how to maximize 5% cash back across multiple spending categories."
+content: |
+  The Citi Custom Cash card offers an attractive 5% cash back on your highest spending category each billing cycle, up to $500 in purchases. But what if you could earn 5% back on *multiple* categories? The good news is: you can.
+
+  ## The Multi-Card Strategy
+
+  Citi allows cardholders to have **multiple Custom Cash cards** — up to a rumored limit of around 4-5 cards per person. This opens up a powerful strategy for maximizing your cash back rewards.
+
+  ### How It Works
+
+  Each Citi Custom Cash card tracks its own spending independently. So if you have two cards:
+
+  - **Card 1** could earn 5% on groceries
+  - **Card 2** could earn 5% on gas stations
+
+  You'd earn 5% back on both categories, effectively doubling your bonus category coverage.
+
+  ## The Eligible 5% Categories
+
+  The Citi Custom Cash earns 5% on whichever of these categories you spend the most in each billing cycle:
+
+  - Restaurants
+  - Gas stations
+  - Grocery stores
+  - Select travel (airlines, hotels, car rentals)
+  - Select transit (taxis, rideshare, trains)
+  - Select streaming services
+  - Drugstores
+  - Home improvement stores
+  - Fitness clubs
+  - Live entertainment
+
+  ## Practical Implementation
+
+  Here's how to set up a multi-card system:
+
+  ### Step 1: Identify Your Top Spending Categories
+
+  Review your spending over the past 3-6 months. Which categories consistently hit or exceed the $500/month threshold? Common candidates include:
+
+  - Groceries ($400-600/month for many families)
+  - Gas ($200-400/month for commuters)
+  - Dining out ($200-500/month)
+
+  ### Step 2: Apply for Additional Cards
+
+  Space out your applications by 3-6 months to minimize hard inquiry impact. Citi is generally friendly to existing customers, especially those with good payment history.
+
+  ### Step 3: Dedicate Each Card
+
+  Assign each card to a specific category. Some people even label their cards or use card management apps to keep track.
+
+  ## The Math
+
+  Let's say you spend:
+  - $500/month on groceries → $25 back (5%)
+  - $400/month on gas → $20 back (5%)
+  - $300/month on dining → $15 back (5%)
+
+  With three Custom Cash cards, you'd earn **$60/month** or **$720/year** in cash back on these categories alone.
+
+  Compare that to a flat 2% card: the same $1,200 spending would earn just $24/month or $288/year.
+
+  **That's an extra $432/year** from the multi-card strategy.
+
+  ## Considerations
+
+  ### Pros
+  - No annual fee on any of the cards
+  - 5% is among the highest category rates available
+  - Flexibility to adjust as spending patterns change
+
+  ### Cons
+  - Managing multiple cards requires organization
+  - Each card has a separate $500 cap per billing cycle
+  - Too many applications in a short period can hurt your credit
+
+  ## Pairing with Citi Double Cash
+
+  For spending that doesn't fit neatly into the 5% categories, the Citi Double Cash is an excellent companion card. It earns a flat 2% on everything (1% when you buy, 1% when you pay), making it perfect for miscellaneous purchases.
+
+  ## The Bottom Line
+
+  Yes, you can absolutely have multiple Citi Custom Cash cards, and doing so is one of the most effective no-annual-fee cash back strategies available. If you're organized enough to manage multiple cards and your spending aligns with the bonus categories, this approach can significantly boost your rewards.
+
+  Start with one card, get comfortable with the system, then consider adding more as you identify additional high-spend categories in your budget.

--- a/data/articles/schema.json
+++ b/data/articles/schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "slug", "title", "date", "author", "summary", "tags", "content"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$",
+      "description": "Unique identifier (lowercase with hyphens)"
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$",
+      "description": "URL slug for the article"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Article title"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Publication date in YYYY-MM-DD format"
+    },
+    "author": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Author name"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Brief description under 200 characters"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "strategy",
+          "guide",
+          "analysis",
+          "news-analysis",
+          "beginner"
+        ]
+      },
+      "minItems": 1,
+      "description": "Tags categorizing the article"
+    },
+    "related_cards": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$"
+      },
+      "description": "Array of related card slugs (optional)"
+    },
+    "seo_title": {
+      "type": "string",
+      "maxLength": 70,
+      "description": "SEO title for search engines (optional)"
+    },
+    "seo_description": {
+      "type": "string",
+      "maxLength": 160,
+      "description": "Meta description for search engines (optional)"
+    },
+    "image": {
+      "type": "string",
+      "description": "Hero image filename (stored in article_images/, optional)"
+    },
+    "image_alt": {
+      "type": "string",
+      "description": "Alt text for the hero image (optional)"
+    },
+    "content": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Full article content in Markdown format"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:web-next": "npm run build -w @creditodds/web-next",
     "build:cards": "node scripts/build-cards.js",
     "build:news": "node scripts/build-news.js",
+    "build:articles": "node scripts/build-articles.js",
     "start:web": "npm run start -w @creditodds/web",
     "start:web-next": "npm run dev -w @creditodds/web-next",
     "dev:web-next": "npm run dev -w @creditodds/web-next",

--- a/scripts/build-articles.js
+++ b/scripts/build-articles.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ARTICLES_DIR = path.join(__dirname, '..', 'data', 'articles');
+const OUTPUT_FILE = path.join(__dirname, '..', 'data', 'articles.json');
+const SCHEMA_FILE = path.join(ARTICLES_DIR, 'schema.json');
+const CARDS_FILE = path.join(__dirname, '..', 'data', 'cards.json');
+
+const VALID_TAGS = [
+  'strategy',
+  'guide',
+  'analysis',
+  'news-analysis',
+  'beginner'
+];
+
+function loadSchema() {
+  const schemaContent = fs.readFileSync(SCHEMA_FILE, 'utf8');
+  return JSON.parse(schemaContent);
+}
+
+function loadCardsLookup() {
+  try {
+    const cardsContent = fs.readFileSync(CARDS_FILE, 'utf8');
+    const cardsData = JSON.parse(cardsContent);
+    const lookup = {};
+    for (const card of cardsData.cards) {
+      lookup[card.slug] = card;
+    }
+    return lookup;
+  } catch (err) {
+    console.warn('Warning: Could not load cards.json for card lookup:', err.message);
+    return {};
+  }
+}
+
+function validateArticle(item, schema) {
+  const errors = [];
+
+  // Check required fields
+  for (const field of schema.required) {
+    if (item[field] === undefined || item[field] === null || item[field] === '') {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+
+  // Validate id pattern
+  if (item.id && !/^[a-z0-9-]+$/.test(item.id)) {
+    errors.push(`Invalid id format: ${item.id} (must be lowercase with hyphens only)`);
+  }
+
+  // Validate slug pattern
+  if (item.slug && !/^[a-z0-9-]+$/.test(item.slug)) {
+    errors.push(`Invalid slug format: ${item.slug} (must be lowercase with hyphens only)`);
+  }
+
+  // Validate date format
+  if (item.date && !/^\d{4}-\d{2}-\d{2}$/.test(item.date)) {
+    errors.push(`Invalid date format: ${item.date} (must be YYYY-MM-DD)`);
+  }
+
+  // Validate summary length
+  if (item.summary && item.summary.length > 200) {
+    errors.push(`Summary too long: ${item.summary.length} chars (max 200)`);
+  }
+
+  // Validate tags
+  if (item.tags) {
+    if (!Array.isArray(item.tags)) {
+      errors.push('Tags must be an array');
+    } else {
+      for (const tag of item.tags) {
+        if (!VALID_TAGS.includes(tag)) {
+          errors.push(`Invalid tag: ${tag}. Valid tags: ${VALID_TAGS.join(', ')}`);
+        }
+      }
+    }
+  }
+
+  // Validate related_cards patterns if present
+  if (item.related_cards) {
+    if (!Array.isArray(item.related_cards)) {
+      errors.push('related_cards must be an array');
+    } else {
+      for (const cardSlug of item.related_cards) {
+        if (!/^[a-z0-9-]+$/.test(cardSlug)) {
+          errors.push(`Invalid related_cards slug format: ${cardSlug} (must be lowercase with hyphens only)`);
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+function calculateReadingTime(content) {
+  // Average reading speed is about 200 words per minute
+  const wordCount = content.split(/\s+/).length;
+  const minutes = Math.ceil(wordCount / 200);
+  return minutes;
+}
+
+function buildArticles() {
+  console.log('Building articles.json from YAML files...\n');
+
+  const schema = loadSchema();
+  const cardsLookup = loadCardsLookup();
+  const articles = [];
+  const errors = [];
+
+  // Read all YAML files in the articles directory
+  const files = fs.readdirSync(ARTICLES_DIR).filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
+
+  console.log(`Found ${files.length} article file(s)\n`);
+
+  for (const file of files) {
+    const filePath = path.join(ARTICLES_DIR, file);
+    console.log(`Processing: ${file}`);
+
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      const item = yaml.load(content);
+
+      // Validate the article
+      const validationErrors = validateArticle(item, schema);
+      if (validationErrors.length > 0) {
+        errors.push({ file, errors: validationErrors });
+        console.log(`  ERROR: ${validationErrors.join(', ')}`);
+        continue;
+      }
+
+      // Calculate reading time
+      item.reading_time = calculateReadingTime(item.content);
+
+      // Enrich related_cards with card info
+      if (item.related_cards && item.related_cards.length > 0) {
+        item.related_cards_info = item.related_cards
+          .filter(slug => cardsLookup[slug])
+          .map(slug => ({
+            slug: slug,
+            name: cardsLookup[slug].name,
+            image: cardsLookup[slug].image,
+            bank: cardsLookup[slug].bank
+          }));
+      }
+
+      articles.push(item);
+      console.log(`  OK: ${item.title} (${item.reading_time} min read)`);
+    } catch (err) {
+      errors.push({ file, errors: [err.message] });
+      console.log(`  ERROR: ${err.message}`);
+    }
+  }
+
+  console.log('\n---');
+
+  if (errors.length > 0) {
+    console.error(`\nValidation failed with ${errors.length} error(s):`);
+    for (const { file, errors: fileErrors } of errors) {
+      console.error(`  ${file}:`);
+      for (const err of fileErrors) {
+        console.error(`    - ${err}`);
+      }
+    }
+    process.exit(1);
+  }
+
+  // Sort articles by date (newest first)
+  articles.sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  // Write output
+  const output = {
+    generated_at: new Date().toISOString(),
+    count: articles.length,
+    articles: articles,
+  };
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2));
+  console.log(`\nSuccessfully built ${articles.length} article(s) to ${OUTPUT_FILE}`);
+}
+
+buildArticles();


### PR DESCRIPTION
## Summary
- Create data layer with YAML schema and build script for articles
- Add 3 initial articles: Citi Custom Cash strategy, Chase 5/24 guide, best no-fee cashback cards
- Create listing page at `/articles` with card grid layout
- Create detail page with markdown rendering, related cards, and Schema.org structured data
- Support optional hero images on articles
- Add `build:articles` npm script

## New Files
- `data/articles/` - YAML article files and schema
- `scripts/build-articles.js` - Build script following news pattern
- `apps/web-next/src/lib/articles.ts` - Types and data fetching
- `apps/web-next/src/app/articles/` - Listing and detail pages
- `apps/web-next/src/components/articles/` - ArticleCard, ArticleContent, RelatedCards

## Test plan
- [ ] Run `npm run build:articles` - generates `data/articles.json`
- [ ] Visit `/articles` - shows 3 article cards
- [ ] Click an article - shows full content with proper typography
- [ ] Verify related cards display and link correctly
- [ ] Check Schema.org markup in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)