### PR TITLE
Add Disney Inspire Visa Card (inactive)

### DIFF
--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -1,0 +1,11 @@
+name: "Disney Inspire Visa Card"
+bank: "Chase"
+slug: "disney-inspire-visa"
+image: "disney-inspire-visa.png"
+accepting_applications: false
+category: "rewards"
+annual_fee: 149
+tags:
+  - rewards
+  - disney
+  - entertainment


### PR DESCRIPTION
## Summary
- Adds the new Disney Inspire Visa Card from Chase
- Set to `accepting_applications: false` until official launch

## Card Details
- **Annual Fee:** $149
- **Welcome Bonus:** Up to $600 ($300 Disney Gift Card + $300 statement credit)
- **Earning Rates:**
  - 10% on Disney+/Hulu/ESPN+
  - 3% at Disney locations and gas stations
  - 2% at grocery stores and restaurants
  - 1% everywhere else
- **Annual Perks:** Up to $420 in Disney credits

Sources: [The Points Guy](https://thepointsguy.com/credit-cards/disney-inspire-visa-new-premium-card-benefits/), [Chase Press Release](https://media.chase.com/news/chase-and-disney-launch-the-disney-inspire-visa-card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)