### PR TITLE
Add Advanced tab with application rules tracker

### DIFF
--- a/apps/web-next/src/components/charts/RuleProgressChart.tsx
+++ b/apps/web-next/src/components/charts/RuleProgressChart.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useMemo } from 'react';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { RuleResult } from '@/lib/applicationRules';
+
+interface RuleProgressChartProps {
+  rule: RuleResult;
+}
+
+export default function RuleProgressChart({ rule }: RuleProgressChartProps) {
+  const { ruleName, current, limit, periodDescription, isSafe } = rule;
+
+  // Determine color based on status
+  const getBarColor = () => {
+    if (current > limit) return '#ef4444'; // red-500 - over limit
+    if (current === limit) return '#eab308'; // yellow-500 - at limit
+    return '#22c55e'; // green-500 - safe
+  };
+
+  const chartOptions = useMemo(
+    () => ({
+      chart: {
+        type: 'column',
+        height: 200,
+        backgroundColor: 'transparent',
+      },
+      title: {
+        text: ruleName,
+        style: {
+          fontSize: '14px',
+          fontWeight: '600',
+        },
+      },
+      subtitle: {
+        text: periodDescription,
+        style: {
+          fontSize: '12px',
+          color: '#6b7280',
+        },
+      },
+      xAxis: {
+        categories: [''],
+        visible: false,
+      },
+      yAxis: {
+        min: 0,
+        max: Math.max(limit + 1, current + 1),
+        title: {
+          text: null,
+        },
+        plotLines: [
+          {
+            value: limit,
+            color: '#9ca3af',
+            dashStyle: 'Dash' as const,
+            width: 2,
+            label: {
+              text: `Limit: ${limit}`,
+              align: 'right' as const,
+              style: {
+                fontSize: '11px',
+                color: '#6b7280',
+              },
+            },
+            zIndex: 5,
+          },
+        ],
+        gridLineWidth: 0,
+      },
+      legend: {
+        enabled: false,
+      },
+      tooltip: {
+        formatter: function () {
+          return `<b>${ruleName}</b><br/>Current: ${current} / ${limit}`;
+        },
+      },
+      plotOptions: {
+        column: {
+          borderRadius: 4,
+          dataLabels: {
+            enabled: true,
+            format: '{y}',
+            style: {
+              fontSize: '14px',
+              fontWeight: '600',
+            },
+          },
+        },
+      },
+      series: [
+        {
+          name: 'Current',
+          data: [current],
+          color: getBarColor(),
+        },
+      ],
+      credits: {
+        enabled: false,
+      },
+    }),
+    [ruleName, current, limit, periodDescription]
+  );
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+      <div className="mt-2 text-center">
+        <span
+          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+            !isSafe
+              ? current > limit
+                ? 'bg-red-100 text-red-800'
+                : 'bg-yellow-100 text-yellow-800'
+              : 'bg-green-100 text-green-800'
+          }`}
+        >
+          {current > limit ? 'Over Limit' : current === limit ? 'At Limit' : 'Safe'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/applicationRules.ts
+++ b/apps/web-next/src/lib/applicationRules.ts
@@ -1,0 +1,139 @@
+import { WalletCard } from './api';
+
+export interface RuleResult {
+  ruleName: string;
+  bank: string;
+  current: number;
+  limit: number;
+  periodDescription: string;
+  isSafe: boolean;
+}
+
+/**
+ * Get cards acquired within a date range
+ */
+function getCardsInRange(
+  cards: WalletCard[],
+  months: number,
+  bankFilter?: string
+): WalletCard[] {
+  const now = new Date();
+  const cutoffDate = new Date(now);
+  cutoffDate.setMonth(cutoffDate.getMonth() - months);
+
+  return cards.filter((card) => {
+    // Skip cards without acquisition date
+    if (!card.acquired_year) return false;
+
+    // Build card date (use month if available, otherwise assume January)
+    const cardMonth = card.acquired_month ? card.acquired_month - 1 : 0;
+    const cardDate = new Date(card.acquired_year, cardMonth, 1);
+
+    // Check if within range
+    if (cardDate < cutoffDate) return false;
+
+    // Apply bank filter if specified
+    if (bankFilter) {
+      return card.bank.toLowerCase().includes(bankFilter.toLowerCase());
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Get cards acquired within a number of days
+ */
+function getCardsInDays(
+  cards: WalletCard[],
+  days: number,
+  bankFilter?: string
+): WalletCard[] {
+  const now = new Date();
+  const cutoffDate = new Date(now);
+  cutoffDate.setDate(cutoffDate.getDate() - days);
+
+  return cards.filter((card) => {
+    // Skip cards without acquisition date
+    if (!card.acquired_year || !card.acquired_month) return false;
+
+    // Build card date (assume 15th of month for day-based calculations)
+    const cardDate = new Date(card.acquired_year, card.acquired_month - 1, 15);
+
+    // Check if within range
+    if (cardDate < cutoffDate) return false;
+
+    // Apply bank filter if specified
+    if (bankFilter) {
+      return card.bank.toLowerCase().includes(bankFilter.toLowerCase());
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Calculate Chase 5/24 rule
+ * 5 new cards (any bank) in 24 months
+ */
+function calculateChase524(cards: WalletCard[]): RuleResult {
+  const cardsIn24Months = getCardsInRange(cards, 24);
+  return {
+    ruleName: 'Chase 5/24',
+    bank: 'Chase',
+    current: cardsIn24Months.length,
+    limit: 5,
+    periodDescription: '24 months',
+    isSafe: cardsIn24Months.length < 5,
+  };
+}
+
+/**
+ * Calculate Amex 2/90 rule
+ * 2 Amex cards in 90 days
+ */
+function calculateAmex290(cards: WalletCard[]): RuleResult {
+  const amexCardsIn90Days = getCardsInDays(cards, 90, 'american express');
+  return {
+    ruleName: 'Amex 2/90',
+    bank: 'American Express',
+    current: amexCardsIn90Days.length,
+    limit: 2,
+    periodDescription: '90 days',
+    isSafe: amexCardsIn90Days.length < 2,
+  };
+}
+
+/**
+ * Calculate Capital One 1/6 rule
+ * 1 Capital One card in 6 months
+ */
+function calculateCapOne16(cards: WalletCard[]): RuleResult {
+  const capOneCardsIn6Months = getCardsInRange(cards, 6, 'capital one');
+  return {
+    ruleName: 'Capital One 1/6',
+    bank: 'Capital One',
+    current: capOneCardsIn6Months.length,
+    limit: 1,
+    periodDescription: '6 months',
+    isSafe: capOneCardsIn6Months.length < 1,
+  };
+}
+
+/**
+ * Calculate all application rules from wallet cards
+ */
+export function calculateApplicationRules(cards: WalletCard[]): RuleResult[] {
+  return [
+    calculateChase524(cards),
+    calculateAmex290(cards),
+    calculateCapOne16(cards),
+  ];
+}
+
+/**
+ * Count cards missing acquisition dates
+ */
+export function countCardsMissingDates(cards: WalletCard[]): number {
+  return cards.filter((card) => !card.acquired_year).length;
+}


### PR DESCRIPTION
## Summary
- Add new "Advanced" tab to profile page
- Track credit card application velocity against common bank rules:
  - Chase 5/24 (5 cards from any bank in 24 months)
  - Amex 2/90 (2 Amex cards in 90 days)
  - Capital One 1/6 (1 Capital One card in 6 months)
- Column charts show progress toward each rule's limit
- Warning banner when cards are missing acquisition dates

## Test plan
- [ ] Log in and go to Profile page
- [ ] Click "Advanced" tab
- [ ] Verify charts display for each rule
- [ ] Test with cards that have/don't have acquisition dates
- [ ] Verify warning appears when dates are missing
- [ ] Click "Go to Wallet" button in warning to verify navigation

🤖 Generated with [Claude Code](https://claude.ai/code)