### PR TITLE
Add card rewards and signup bonus data

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/navigation";
 import { BuildingLibraryIcon } from "@heroicons/react/24/solid";
 import { ExclamationTriangleIcon, PencilSquareIcon, NewspaperIcon } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
-import { Card, GraphData, trackReferralEvent } from "@/lib/api";
+import { Card, GraphData, Reward, trackReferralEvent } from "@/lib/api";
 import { NewsItem, tagLabels, tagColors } from "@/lib/news";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
 import { CreditCardSchema, BreadcrumbSchema } from "@/components/seo/JsonLd";
@@ -27,6 +27,36 @@ function ChartErrorFallback() {
       <p className="text-gray-500">Unable to load chart. Please refresh the page.</p>
     </div>
   );
+}
+
+const categoryLabels: Record<string, string> = {
+  dining: "Dining",
+  groceries: "Groceries",
+  travel: "Travel",
+  gas: "Gas",
+  streaming: "Streaming",
+  transit: "Transit",
+  drugstores: "Drugstores",
+  home_improvement: "Home Improvement",
+  online_shopping: "Online Shopping",
+  hotels: "Hotels",
+  airlines: "Airlines",
+  car_rentals: "Car Rentals",
+  entertainment: "Entertainment",
+  rotating: "Rotating Categories",
+  travel_portal: "Travel (via Portal)",
+  hotels_portal: "Hotels (via Portal)",
+  flights_portal: "Flights (via Portal)",
+  hotels_car_portal: "Hotels & Car Rentals (via Portal)",
+  amazon: "Amazon.com",
+  everything_else: "Everything Else",
+};
+
+function formatRewardValue(reward: Reward): string {
+  if (reward.unit === "percent") {
+    return `${reward.value}%`;
+  }
+  return `${reward.value}x`;
 }
 
 interface CardClientProps {
@@ -220,6 +250,42 @@ export default function CardClient({ card, graphData, news }: CardClientProps) {
                     {card.annual_fee === 0 ? "$0" : `$${card.annual_fee.toLocaleString()}`}
                   </span>
                 </p>
+              )}
+
+              {/* Rewards Section */}
+              {card.rewards && card.rewards.length > 0 && (
+                <div className="mt-4">
+                  <div className="flex flex-wrap gap-2">
+                    {card.rewards.map((reward) => (
+                      <span
+                        key={reward.category}
+                        className={`inline-flex items-center px-2.5 py-1 rounded-md text-sm font-medium ${
+                          reward.category === "everything_else"
+                            ? "bg-gray-100 text-gray-700"
+                            : "bg-indigo-50 text-indigo-700"
+                        }`}
+                      >
+                        {formatRewardValue(reward)} {categoryLabels[reward.category] || reward.category}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Signup Bonus */}
+              {card.signup_bonus && (
+                <div className="mt-4 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3">
+                  <p className="text-sm font-medium text-amber-900">
+                    Earn{" "}
+                    <span className="font-bold">
+                      {card.signup_bonus.type === "cash"
+                        ? `$${card.signup_bonus.value.toLocaleString()}`
+                        : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type}`}
+                    </span>{" "}
+                    after spending ${card.signup_bonus.spend_requirement.toLocaleString()} in{" "}
+                    {card.signup_bonus.timeframe_months} month{card.signup_bonus.timeframe_months !== 1 ? "s" : ""}
+                  </p>
+                </div>
               )}
 
               {/* Stats Section */}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -5,6 +5,24 @@ export interface CardReferral {
   referral_link: string;
 }
 
+export interface RewardCategory {
+  id: string;
+  label: string;
+}
+
+export interface Reward {
+  category: string;
+  value: number;
+  unit: string;
+}
+
+export interface SignupBonus {
+  value: number;
+  type: string;
+  spend_requirement: number;
+  timeframe_months: number;
+}
+
 export interface Card {
   card_id: string | number;
   db_card_id?: number;
@@ -26,6 +44,9 @@ export interface Card {
   apply_link?: string;
   card_referral_link?: string;
   referrals?: CardReferral[];
+  reward_type?: 'cashback' | 'points' | 'miles';
+  rewards?: Reward[];
+  signup_bonus?: SignupBonus;
 }
 
 // GraphData is an array of series data

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,6 +1,88 @@
 {
-  "generated_at": "2026-01-31T22:56:27.766Z",
-  "count": 135,
+  "generated_at": "2026-02-05T20:55:04.377Z",
+  "count": 136,
+  "categories": [
+    {
+      "id": "dining",
+      "label": "Dining"
+    },
+    {
+      "id": "groceries",
+      "label": "Groceries"
+    },
+    {
+      "id": "travel",
+      "label": "Travel"
+    },
+    {
+      "id": "gas",
+      "label": "Gas"
+    },
+    {
+      "id": "streaming",
+      "label": "Streaming"
+    },
+    {
+      "id": "transit",
+      "label": "Transit"
+    },
+    {
+      "id": "drugstores",
+      "label": "Drugstores"
+    },
+    {
+      "id": "home_improvement",
+      "label": "Home Improvement"
+    },
+    {
+      "id": "online_shopping",
+      "label": "Online Shopping"
+    },
+    {
+      "id": "hotels",
+      "label": "Hotels"
+    },
+    {
+      "id": "airlines",
+      "label": "Airlines"
+    },
+    {
+      "id": "car_rentals",
+      "label": "Car Rentals"
+    },
+    {
+      "id": "entertainment",
+      "label": "Entertainment"
+    },
+    {
+      "id": "rotating",
+      "label": "Rotating Categories"
+    },
+    {
+      "id": "travel_portal",
+      "label": "Travel (via Portal)"
+    },
+    {
+      "id": "hotels_portal",
+      "label": "Hotels (via Portal)"
+    },
+    {
+      "id": "flights_portal",
+      "label": "Flights (via Portal)"
+    },
+    {
+      "id": "hotels_car_portal",
+      "label": "Hotels & Car Rentals (via Portal)"
+    },
+    {
+      "id": "amazon",
+      "label": "Amazon.com"
+    },
+    {
+      "id": "everything_else",
+      "label": "Everything Else"
+    }
+  ],
   "cards": [
     {
       "name": "Aer Lingus Visa Signature card",
@@ -34,6 +116,34 @@
         "shopping",
         "cashback",
         "rewards"
+      ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "amazon",
+          "value": 5,
+          "unit": "percent"
+        },
+        {
+          "category": "dining",
+          "value": 2,
+          "unit": "percent"
+        },
+        {
+          "category": "gas",
+          "value": 2,
+          "unit": "percent"
+        },
+        {
+          "category": "transit",
+          "value": 2,
+          "unit": "percent"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "percent"
+        }
       ],
       "card_id": "amazon-prime-rewards-visa-signature-card",
       "card_name": "Amazon Prime Rewards Visa Signature Card"
@@ -78,6 +188,35 @@
         "rewards",
         "premium"
       ],
+      "reward_type": "points",
+      "rewards": [
+        {
+          "category": "dining",
+          "value": 4,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "groceries",
+          "value": 4,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "airlines",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "points_per_dollar"
+        }
+      ],
+      "signup_bonus": {
+        "value": 60000,
+        "type": "points",
+        "spend_requirement": 6000,
+        "timeframe_months": 6
+      },
       "card_id": "american-express-gold-card",
       "card_name": "American Express Gold Card"
     },
@@ -460,6 +599,40 @@
         "dining",
         "rewards"
       ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "dining",
+          "value": 3,
+          "unit": "percent"
+        },
+        {
+          "category": "entertainment",
+          "value": 3,
+          "unit": "percent"
+        },
+        {
+          "category": "streaming",
+          "value": 3,
+          "unit": "percent"
+        },
+        {
+          "category": "groceries",
+          "value": 3,
+          "unit": "percent"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "percent"
+        }
+      ],
+      "signup_bonus": {
+        "value": 200,
+        "type": "cash",
+        "spend_requirement": 500,
+        "timeframe_months": 3
+      },
       "card_id": "capital-one-savorone",
       "card_name": "Capital One SavorOne Cash Rewards Credit Card"
     },
@@ -491,6 +664,30 @@
         "premium",
         "rewards"
       ],
+      "reward_type": "miles",
+      "rewards": [
+        {
+          "category": "hotels_car_portal",
+          "value": 10,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "flights_portal",
+          "value": 5,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "everything_else",
+          "value": 2,
+          "unit": "points_per_dollar"
+        }
+      ],
+      "signup_bonus": {
+        "value": 75000,
+        "type": "miles",
+        "spend_requirement": 4000,
+        "timeframe_months": 3
+      },
       "card_id": "capital-one-venture-x",
       "card_name": "Capital One Venture X Rewards Credit Card"
     },
@@ -526,6 +723,40 @@
         "cashback",
         "rewards"
       ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "rotating",
+          "value": 5,
+          "unit": "percent"
+        },
+        {
+          "category": "travel_portal",
+          "value": 5,
+          "unit": "percent"
+        },
+        {
+          "category": "dining",
+          "value": 3,
+          "unit": "percent"
+        },
+        {
+          "category": "drugstores",
+          "value": 3,
+          "unit": "percent"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "percent"
+        }
+      ],
+      "signup_bonus": {
+        "value": 200,
+        "type": "cash",
+        "spend_requirement": 500,
+        "timeframe_months": 3
+      },
       "card_id": "chase-freedom-flex",
       "card_name": "Chase Freedom Flex"
     },
@@ -550,6 +781,35 @@
         "cashback",
         "rewards"
       ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "travel_portal",
+          "value": 5,
+          "unit": "percent"
+        },
+        {
+          "category": "dining",
+          "value": 3,
+          "unit": "percent"
+        },
+        {
+          "category": "drugstores",
+          "value": 3,
+          "unit": "percent"
+        },
+        {
+          "category": "everything_else",
+          "value": 1.5,
+          "unit": "percent"
+        }
+      ],
+      "signup_bonus": {
+        "value": 200,
+        "type": "cash",
+        "spend_requirement": 500,
+        "timeframe_months": 3
+      },
       "card_id": "chase-freedom-unlimited",
       "card_name": "Chase Freedom Unlimited"
     },
@@ -566,6 +826,40 @@
         "dining",
         "rewards"
       ],
+      "reward_type": "points",
+      "rewards": [
+        {
+          "category": "travel_portal",
+          "value": 5,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "dining",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "streaming",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "travel",
+          "value": 2,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "points_per_dollar"
+        }
+      ],
+      "signup_bonus": {
+        "value": 60000,
+        "type": "points",
+        "spend_requirement": 4000,
+        "timeframe_months": 3
+      },
       "card_id": "chase-sapphire-preferred",
       "card_name": "Chase Sapphire Preferred Card"
     },
@@ -581,6 +875,40 @@
         "premium",
         "dining"
       ],
+      "reward_type": "points",
+      "rewards": [
+        {
+          "category": "hotels_car_portal",
+          "value": 10,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "flights_portal",
+          "value": 5,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "dining",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "travel",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "points_per_dollar"
+        }
+      ],
+      "signup_bonus": {
+        "value": 60000,
+        "type": "points",
+        "spend_requirement": 4000,
+        "timeframe_months": 3
+      },
       "card_id": "chase-sapphire-reserve",
       "card_name": "Chase Sapphire Reserve"
     },
@@ -660,6 +988,20 @@
         "cashback",
         "rewards"
       ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "everything_else",
+          "value": 2,
+          "unit": "percent"
+        }
+      ],
+      "signup_bonus": {
+        "value": 200,
+        "type": "cash",
+        "spend_requirement": 1500,
+        "timeframe_months": 6
+      },
       "card_id": "citi-double-cash",
       "card_name": "Citi Double Cash"
     },
@@ -837,8 +1179,20 @@
       "annual_fee": 0,
       "card_referral_link": "https://refer.discover.com/",
       "tags": [
-        "cashback",
-        "rewards"
+        "cashback"
+      ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "rotating",
+          "value": 5,
+          "unit": "percent"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "percent"
+        }
       ],
       "card_id": "discover-it-cash-back",
       "card_name": "Discover it Cash Back"
@@ -904,6 +1258,22 @@
       "annual_fee": 0,
       "card_id": "discover-it-student-chrome-card",
       "card_name": "Discover it Student Chrome Card"
+    },
+    {
+      "name": "Disney Inspire Visa Card",
+      "bank": "Chase",
+      "slug": "disney-inspire-visa",
+      "image": "disney-inspire-visa.png",
+      "accepting_applications": false,
+      "category": "rewards",
+      "annual_fee": 149,
+      "tags": [
+        "rewards",
+        "disney",
+        "entertainment"
+      ],
+      "card_id": "disney-inspire-visa",
+      "card_name": "Disney Inspire Visa Card"
     },
     {
       "name": "Disney Premier Visa Card",
@@ -1498,6 +1868,20 @@
         "cashback",
         "rewards"
       ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "everything_else",
+          "value": 2,
+          "unit": "percent"
+        }
+      ],
+      "signup_bonus": {
+        "value": 200,
+        "type": "cash",
+        "spend_requirement": 500,
+        "timeframe_months": 3
+      },
       "card_id": "wells-fargo-active-cash",
       "card_name": "Wells Fargo Active Cash Card"
     },
@@ -1525,6 +1909,45 @@
         "dining",
         "rewards"
       ],
+      "reward_type": "points",
+      "rewards": [
+        {
+          "category": "dining",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "travel",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "gas",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "transit",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "streaming",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "points_per_dollar"
+        }
+      ],
+      "signup_bonus": {
+        "value": 20000,
+        "type": "points",
+        "spend_requirement": 1000,
+        "timeframe_months": 3
+      },
       "card_id": "wells-fargo-autograph",
       "card_name": "Wells Fargo Autograph Card"
     },

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -8,3 +8,20 @@ tags:
   - shopping
   - cashback
   - rewards
+reward_type: "cashback"
+rewards:
+  - category: amazon
+    value: 5
+    unit: percent
+  - category: dining
+    value: 2
+    unit: percent
+  - category: gas
+    value: 2
+    unit: percent
+  - category: transit
+    value: 2
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent

--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -10,3 +10,22 @@ tags:
   - dining
   - rewards
   - premium
+reward_type: "points"
+rewards:
+  - category: dining
+    value: 4
+    unit: points_per_dollar
+  - category: groceries
+    value: 4
+    unit: points_per_dollar
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 6000
+  timeframe_months: 6

--- a/data/cards/capital-one-savorone.yaml
+++ b/data/cards/capital-one-savorone.yaml
@@ -9,3 +9,25 @@ tags:
   - cashback
   - dining
   - rewards
+reward_type: "cashback"
+rewards:
+  - category: dining
+    value: 3
+    unit: percent
+  - category: entertainment
+    value: 3
+    unit: percent
+  - category: streaming
+    value: 3
+    unit: percent
+  - category: groceries
+    value: 3
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 500
+  timeframe_months: 3

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -9,3 +9,19 @@ tags:
   - travel
   - premium
   - rewards
+reward_type: "miles"
+rewards:
+  - category: hotels_car_portal
+    value: 10
+    unit: points_per_dollar
+  - category: flights_portal
+    value: 5
+    unit: points_per_dollar
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+signup_bonus:
+  value: 75000
+  type: miles
+  spend_requirement: 4000
+  timeframe_months: 3

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -7,3 +7,25 @@ annual_fee: 0
 tags:
   - cashback
   - rewards
+reward_type: "cashback"
+rewards:
+  - category: rotating
+    value: 5
+    unit: percent
+  - category: travel_portal
+    value: 5
+    unit: percent
+  - category: dining
+    value: 3
+    unit: percent
+  - category: drugstores
+    value: 3
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 500
+  timeframe_months: 3

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -7,3 +7,22 @@ annual_fee: 0
 tags:
   - cashback
   - rewards
+reward_type: "cashback"
+rewards:
+  - category: travel_portal
+    value: 5
+    unit: percent
+  - category: dining
+    value: 3
+    unit: percent
+  - category: drugstores
+    value: 3
+    unit: percent
+  - category: everything_else
+    value: 1.5
+    unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 500
+  timeframe_months: 3

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -9,3 +9,25 @@ tags:
   - travel
   - dining
   - rewards
+reward_type: "points"
+rewards:
+  - category: travel_portal
+    value: 5
+    unit: points_per_dollar
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+  - category: streaming
+    value: 3
+    unit: points_per_dollar
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 4000
+  timeframe_months: 3

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -8,3 +8,25 @@ tags:
   - travel
   - premium
   - dining
+reward_type: "points"
+rewards:
+  - category: hotels_car_portal
+    value: 10
+    unit: points_per_dollar
+  - category: flights_portal
+    value: 5
+    unit: points_per_dollar
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+  - category: travel
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 4000
+  timeframe_months: 3

--- a/data/cards/citi-double-cash.yaml
+++ b/data/cards/citi-double-cash.yaml
@@ -7,3 +7,13 @@ annual_fee: 0
 tags:
   - cashback
   - rewards
+reward_type: "cashback"
+rewards:
+  - category: everything_else
+    value: 2
+    unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 1500
+  timeframe_months: 6

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -7,3 +7,11 @@ annual_fee: 0
 card_referral_link: "https://refer.discover.com/"
 tags:
   - cashback
+reward_type: "cashback"
+rewards:
+  - category: rotating
+    value: 5
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -56,6 +56,60 @@
       "type": "string",
       "format": "uri",
       "description": "Base URL for referral links - user codes are appended to this (optional)"
+    },
+    "reward_type": {
+      "type": "string",
+      "enum": ["cashback", "points", "miles"],
+      "description": "Type of rewards earned (optional)"
+    },
+    "rewards": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["category", "value", "unit"],
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "Spend category id from categories.yaml"
+          },
+          "value": {
+            "type": "number",
+            "description": "Reward rate (e.g., 3 for 3% or 3x)"
+          },
+          "unit": {
+            "type": "string",
+            "enum": ["percent", "points_per_dollar"],
+            "description": "Unit of the reward value"
+          }
+        },
+        "additionalProperties": false
+      },
+      "description": "Reward rates by spend category (optional)"
+    },
+    "signup_bonus": {
+      "type": "object",
+      "required": ["value", "type", "spend_requirement", "timeframe_months"],
+      "properties": {
+        "value": {
+          "type": "number",
+          "description": "Bonus amount (e.g., 60000 points)"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["cash", "points", "miles"],
+          "description": "Type of signup bonus"
+        },
+        "spend_requirement": {
+          "type": "number",
+          "description": "Minimum spend required in USD"
+        },
+        "timeframe_months": {
+          "type": "number",
+          "description": "Months to meet spend requirement"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Welcome/signup bonus details (optional)"
     }
   },
   "additionalProperties": false

--- a/data/cards/wells-fargo-active-cash.yaml
+++ b/data/cards/wells-fargo-active-cash.yaml
@@ -8,3 +8,13 @@ annual_fee: 0
 tags:
   - cashback
   - rewards
+reward_type: "cashback"
+rewards:
+  - category: everything_else
+    value: 2
+    unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 500
+  timeframe_months: 3

--- a/data/cards/wells-fargo-autograph.yaml
+++ b/data/cards/wells-fargo-autograph.yaml
@@ -9,3 +9,28 @@ tags:
   - travel
   - dining
   - rewards
+reward_type: "points"
+rewards:
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+  - category: travel
+    value: 3
+    unit: points_per_dollar
+  - category: gas
+    value: 3
+    unit: points_per_dollar
+  - category: transit
+    value: 3
+    unit: points_per_dollar
+  - category: streaming
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 20000
+  type: points
+  spend_requirement: 1000
+  timeframe_months: 3

--- a/data/categories.yaml
+++ b/data/categories.yaml
@@ -1,0 +1,41 @@
+categories:
+  - id: dining
+    label: Dining
+  - id: groceries
+    label: Groceries
+  - id: travel
+    label: Travel
+  - id: gas
+    label: Gas
+  - id: streaming
+    label: Streaming
+  - id: transit
+    label: Transit
+  - id: drugstores
+    label: Drugstores
+  - id: home_improvement
+    label: Home Improvement
+  - id: online_shopping
+    label: Online Shopping
+  - id: hotels
+    label: Hotels
+  - id: airlines
+    label: Airlines
+  - id: car_rentals
+    label: Car Rentals
+  - id: entertainment
+    label: Entertainment
+  - id: rotating
+    label: Rotating Categories
+  - id: travel_portal
+    label: Travel (via Portal)
+  - id: hotels_portal
+    label: Hotels (via Portal)
+  - id: flights_portal
+    label: Flights (via Portal)
+  - id: hotels_car_portal
+    label: Hotels & Car Rentals (via Portal)
+  - id: amazon
+    label: Amazon.com
+  - id: everything_else
+    label: Everything Else


### PR DESCRIPTION
## Summary
- Add normalized spend categories (`data/categories.yaml`) and reward/signup bonus fields to card schema
- Update `build-cards.js` to validate reward categories and include categories in output JSON
- Seed 12 popular cards with real rewards data (Chase Sapphire Preferred/Reserve, Freedom Unlimited/Flex, Citi Double Cash, Amex Gold, Capital One Venture X/SavorOne, Wells Fargo Autograph/Active Cash, Discover it Cash Back, Amazon Prime Visa)
- Display reward rate badges and signup bonus callout on card detail pages
- Add `Reward`, `SignupBonus`, `RewardCategory` TypeScript types

## Test plan
- [ ] Run `npm run build:cards` — all 136 cards should pass validation
- [ ] Verify `cards.json` includes `categories` array and rewards on 12 seeded cards
- [ ] Check card pages for seeded cards show rewards badges and signup bonus
- [ ] Verify card pages without rewards data still render correctly (no empty sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)