### PR TITLE
Accept full referral URLs and add admin inline editing

### DIFF
--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -459,9 +459,7 @@ function ReferralsTab({
                 </td>
                 <td className="px-4 py-3">
                   <a
-                    href={referral.card_referral_link
-                      ? `${referral.card_referral_link}${referral.referral_link}`
-                      : referral.referral_link}
+                    href={referral.referral_link}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-sm text-indigo-600 hover:text-indigo-800 break-all max-w-[200px] block truncate"

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -24,7 +24,8 @@ import {
   ChartBarIcon,
   DocumentTextIcon,
   LinkIcon,
-  ClipboardDocumentListIcon
+  ClipboardDocumentListIcon,
+  PencilIcon
 } from "@heroicons/react/24/outline";
 
 // Master admin user ID (Firebase UID)
@@ -144,6 +145,28 @@ export default function AdminPage() {
     }
   };
 
+  const handleEditReferral = async (referralId: number, newLink: string) => {
+    setProcessingId(referralId);
+    try {
+      const token = await getToken();
+      if (!token) return;
+
+      const referral = referrals.find(r => r.referral_id === referralId);
+      if (!referral) return;
+
+      await updateReferralApproval(referralId, !!referral.admin_approved, token, newLink);
+      setReferrals(prev =>
+        prev.map(r =>
+          r.referral_id === referralId ? { ...r, referral_link: newLink } : r
+        )
+      );
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update referral link");
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
   const handleDeleteReferral = async (referralId: number) => {
     if (!confirm("Are you sure you want to delete this referral?")) return;
 
@@ -256,6 +279,7 @@ export default function AdminPage() {
             processingId={processingId}
             onApprove={handleApproveReferral}
             onDelete={handleDeleteReferral}
+            onEdit={handleEditReferral}
           />
         )}
         {activeTab === 'audit' && <AuditTab logs={auditLogs} total={auditTotal} />}
@@ -404,14 +428,19 @@ function ReferralsTab({
   total,
   processingId,
   onApprove,
-  onDelete
+  onDelete,
+  onEdit
 }: {
   referrals: AdminReferral[];
   total: number;
   processingId: number | null;
   onApprove: (id: number, approve: boolean) => void;
   onDelete: (id: number) => void;
+  onEdit: (id: number, newLink: string) => void;
 }) {
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editValue, setEditValue] = useState('');
+
   return (
     <div className="bg-white shadow rounded-lg overflow-hidden">
       <div className="px-4 py-5 sm:px-6 border-b border-gray-200">
@@ -458,14 +487,63 @@ function ReferralsTab({
                   </div>
                 </td>
                 <td className="px-4 py-3">
-                  <a
-                    href={referral.referral_link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-indigo-600 hover:text-indigo-800 break-all max-w-[200px] block truncate"
-                  >
-                    {referral.referral_link}
-                  </a>
+                  {editingId === referral.referral_id ? (
+                    <div className="flex items-center gap-1">
+                      <input
+                        type="text"
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            onEdit(referral.referral_id, editValue);
+                            setEditingId(null);
+                          } else if (e.key === 'Escape') {
+                            setEditingId(null);
+                          }
+                        }}
+                        className="text-sm border border-gray-300 rounded px-2 py-1 w-full max-w-[250px]"
+                        autoFocus
+                      />
+                      <button
+                        onClick={() => {
+                          onEdit(referral.referral_id, editValue);
+                          setEditingId(null);
+                        }}
+                        className="text-green-600 hover:text-green-800"
+                        title="Save"
+                      >
+                        <CheckIcon className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => setEditingId(null)}
+                        className="text-gray-400 hover:text-gray-600"
+                        title="Cancel"
+                      >
+                        <XMarkIcon className="h-4 w-4" />
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-1">
+                      <a
+                        href={referral.referral_link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-indigo-600 hover:text-indigo-800 break-all max-w-[200px] block truncate"
+                      >
+                        {referral.referral_link}
+                      </a>
+                      <button
+                        onClick={() => {
+                          setEditingId(referral.referral_id);
+                          setEditValue(referral.referral_link);
+                        }}
+                        className="text-gray-400 hover:text-gray-600 flex-shrink-0"
+                        title="Edit referral link"
+                      >
+                        <PencilIcon className="h-4 w-4" />
+                      </button>
+                    </div>
+                  )}
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap">
                   <span className={`px-2 py-1 text-xs font-medium rounded-full ${

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -76,20 +76,20 @@ export default function CardClient({ card, graphData, news }: CardClientProps) {
 
   // Randomly select a referral if available
   const selectedReferral = useMemo(() => {
-    if (card.referrals && card.referrals.length > 0 && card.card_referral_link) {
+    if (card.referrals && card.referrals.length > 0) {
       const randomIndex = Math.floor(Math.random() * card.referrals.length);
       return card.referrals[randomIndex];
     }
     return null;
-  }, [card.referrals, card.card_referral_link]);
+  }, [card.referrals]);
 
   // Build full referral URL
   const randomReferralUrl = useMemo(() => {
-    if (selectedReferral && card.card_referral_link) {
-      return card.card_referral_link + selectedReferral.referral_link;
+    if (selectedReferral) {
+      return selectedReferral.referral_link;
     }
     return null;
-  }, [selectedReferral, card.card_referral_link]);
+  }, [selectedReferral]);
 
   // Track impression when referral is shown
   const impressionTracked = useRef(false);

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -802,14 +802,7 @@ export default function ProfileClient({ initialCards, initialNews }: ProfileClie
             <div className="px-4 py-5 sm:px-6">
               <h2 className="text-lg font-semibold text-gray-900">Your Referrals</h2>
             <p className="mt-1 max-w-2xl text-sm text-gray-500">
-              Don&apos;t see your card as an option?{' '}
-              <a href="https://github.com/CreditOdds/creditodds/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:text-indigo-500">
-                Add the referral base URL on GitHub
-              </a>{' '}
-              or{' '}
-              <a href="https://x.com/MaxwellMelcher" target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:text-indigo-500">
-                message me on X
-              </a>.
+              Submit your full referral URL for any card in your wallet or with a submitted record.
             </p>
           </div>
           {referrals.length > 0 ? (
@@ -844,7 +837,7 @@ export default function ProfileClient({ initialCards, initialNews }: ProfileClie
                           )}
                         </div>
                         <a
-                          href={referral.card_referral_link ? `${referral.card_referral_link}${referral.referral_link}` : referral.referral_link}
+                          href={referral.referral_link}
                           target="_blank"
                           rel="noreferrer"
                           className="mt-1 text-xs text-indigo-600 hover:text-indigo-900 truncate block"
@@ -916,7 +909,7 @@ export default function ProfileClient({ initialCards, initialNews }: ProfileClie
                         </td>
                         <td className="px-4 py-3">
                           <a
-                            href={referral.card_referral_link ? `${referral.card_referral_link}${referral.referral_link}` : referral.referral_link}
+                            href={referral.referral_link}
                             target="_blank"
                             rel="noreferrer"
                             className="text-sm text-indigo-600 hover:text-indigo-900 truncate block max-w-[200px]"

--- a/apps/web-next/src/components/forms/ReferralModal.tsx
+++ b/apps/web-next/src/components/forms/ReferralModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle, Listbox, ListboxButton, ListboxOption, ListboxOptions, Label } from "@headlessui/react";
-import { LinkIcon, CheckIcon, ChevronUpDownIcon, ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
+import { LinkIcon, CheckIcon, ChevronUpDownIcon } from "@heroicons/react/24/outline";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useAuth } from "@/auth/AuthProvider";
@@ -40,7 +40,6 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
 
   const [selected, setSelected] = useState<OpenReferral>(defaultCard);
   const [submitting, setSubmitting] = useState(false);
-  const [showFullBaseLink, setShowFullBaseLink] = useState(false);
 
   const formik = useFormik({
     initialValues: {
@@ -48,8 +47,9 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
     },
     validationSchema: Yup.object({
       referral_link: Yup.string()
-        .min(3, "Referral link must be at least 3 characters")
-        .max(250, "Referral link cannot be more than 250 characters")
+        .min(10, "Referral URL must be at least 10 characters")
+        .max(500, "Referral URL cannot be more than 500 characters")
+        .matches(/^https?:\/\//, "URL must start with https://")
         .required("Required"),
     }),
     onSubmit: async (values) => {
@@ -103,7 +103,6 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
   const handleModalClose = () => {
     formik.resetForm();
     setSelected(defaultCard);
-    setShowFullBaseLink(false);
     handleClose();
   };
 
@@ -206,59 +205,20 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
 
             <form onSubmit={formik.handleSubmit} className="mt-4">
               <label htmlFor="referral_link" className="block text-sm font-medium text-gray-700 text-left">
-                Referral Link
+                Referral URL
               </label>
               <div className="mt-1">
-                {selected.card_referral_link ? (
-                  <div className="space-y-2">
-                    {/* Collapsible base link display */}
-                    <div className="rounded-md border border-gray-200 bg-gray-50 overflow-hidden">
-                      <button
-                        type="button"
-                        onClick={() => setShowFullBaseLink(!showFullBaseLink)}
-                        className="w-full px-3 py-2 flex items-center justify-between text-left hover:bg-gray-100 transition-colors"
-                      >
-                        <div className="flex-1 min-w-0 mr-2">
-                          <span className="text-xs text-gray-500 block">Base URL</span>
-                          <span className={`text-sm text-gray-600 block ${showFullBaseLink ? 'break-all' : 'truncate'}`}>
-                            {selected.card_referral_link}
-                          </span>
-                        </div>
-                        {showFullBaseLink ? (
-                          <ChevronUpIcon className="h-4 w-4 text-gray-400 flex-shrink-0" />
-                        ) : (
-                          <ChevronDownIcon className="h-4 w-4 text-gray-400 flex-shrink-0" />
-                        )}
-                      </button>
-                    </div>
-                    {/* Input for unique code */}
-                    <input
-                      type="text"
-                      name="referral_link"
-                      id="referral_link"
-                      className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                      placeholder="Your unique referral code"
-                      onChange={formik.handleChange}
-                      onBlur={formik.handleBlur}
-                      value={formik.values.referral_link}
-                    />
-                    <p className="text-xs text-gray-500">
-                      Enter only the unique part of your referral link (the code that comes after the base URL)
-                    </p>
-                  </div>
-                ) : (
-                  <input
-                    type="text"
-                    name="referral_link"
-                    id="referral_link"
-                    className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                    placeholder={selected.card_id ? "Paste your referral code" : "Select a card first"}
-                    onChange={formik.handleChange}
-                    onBlur={formik.handleBlur}
-                    value={formik.values.referral_link}
-                    disabled={!selected.card_id}
-                  />
-                )}
+                <input
+                  type="text"
+                  name="referral_link"
+                  id="referral_link"
+                  className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                  placeholder={selected.card_id ? "Paste your full referral URL" : "Select a card first"}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                  value={formik.values.referral_link}
+                  disabled={!selected.card_id}
+                />
               </div>
               {formik.touched.referral_link && formik.errors.referral_link && (
                 <p className="mt-2 text-sm text-red-600">{formik.errors.referral_link}</p>

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -456,15 +456,20 @@ export async function getAdminReferrals(
 export async function updateReferralApproval(
   referralId: number,
   approved: boolean,
-  token: string
+  token: string,
+  referralLink?: string
 ): Promise<{ message: string }> {
+  const body: Record<string, unknown> = { referral_id: referralId, approved };
+  if (referralLink) {
+    body.referral_link = referralLink;
+  }
   const res = await fetch(`${API_BASE}/admin/referrals`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ referral_id: referralId, approved }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     const errorText = await res.text().catch(() => 'Unknown error');


### PR DESCRIPTION
## Summary
- Users now submit full referral URLs instead of just codes, removing the dependency on `card_referral_link` (which ~90% of cards lacked)
- Admins can inline-edit referral URLs before approving — click the pencil icon, fix the link, then save
- Backend PUT `/admin/referrals` now accepts an optional `referral_link` field to update alongside approval status

## Test plan
- [ ] Submit a referral with a full URL on a card page and verify it saves correctly
- [ ] In the admin panel, click the pencil icon on a referral link, edit the URL, and save — verify the change persists
- [ ] Approve/unapprove referrals without editing the link — verify existing behavior is unchanged
- [ ] Click "Apply with Referral" on a card page and verify it navigates to the full referral URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)