### PR TITLE
Remove support email from contact page

### DIFF
--- a/apps/web-next/src/app/contact/page.tsx
+++ b/apps/web-next/src/app/contact/page.tsx
@@ -28,11 +28,6 @@ export default function ContactPage() {
             Have questions, feedback, or suggestions? We&apos;d love to hear from you!
           </p>
 
-          <h2>Email</h2>
-          <p>
-            <a href="mailto:support@creditodds.com">support@creditodds.com</a>
-          </p>
-
           <h2>Twitter</h2>
           <p>
             Follow us on Twitter:{" "}


### PR DESCRIPTION
## Summary
- Removes the `support@creditodds.com` mailto link from the contact page since there is no active email address at the moment
- Contact page still shows Twitter and GitHub as contact methods

## Test plan
- [ ] Verify the contact page renders correctly without the email section

🤖 Generated with [Claude Code](https://claude.com/claude-code)