### PR TITLE
Use true median instead of average for card stats

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -322,7 +322,7 @@ export default function CardClient({ card, graphData, news }: CardClientProps) {
                 {(card.approved_count || 0) > 0 ? (
                   <>
                     <h3 className="text-lg leading-6 font-medium text-gray-900 text-center sm:text-left mb-4">
-                      On average people who got <b>accepted</b> for the card had...
+                      The median applicant who got <b>accepted</b> for the card had...
                     </h3>
 
                     <div className="bg-white shadow rounded-lg overflow-hidden">

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({ params }: CardPageProps): Promise<Metad
       description,
       openGraph: {
         title: `${seoName} | CreditOdds`,
-        description: `See approval odds for ${seoName}${card.approved_median_credit_score ? `. Average approved credit score: ${card.approved_median_credit_score}` : ''}`,
+        description: `See approval odds for ${seoName}${card.approved_median_credit_score ? `. Median approved credit score: ${card.approved_median_credit_score}` : ''}`,
         siteName: 'CreditOdds',
         type: 'website',
         url: `https://creditodds.com/card/${card.slug}`,


### PR DESCRIPTION
## Summary
- Replace `AVG()` SQL with proper median calculation using `ORDER BY` + `LIMIT`/`OFFSET` for credit score, income, and credit length
- Update card detail header from "On average people who got accepted..." to "The median applicant who got accepted..."
- Update OpenGraph description from "Average approved credit score" to "Median approved credit score"

## Test plan
- [ ] Deploy API with `sam build && sam deploy` and verify median values differ from old averages on cards with skewed data
- [ ] Check card detail page renders stats correctly with updated header text
- [ ] Verify OG meta tag shows "Median approved credit score" via view-source or social preview tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)