### PR TITLE
Exclude NULL values from median calculations

### DIFF
--- a/apps/api/src/handlers/card-by-id.js
+++ b/apps/api/src/handlers/card-by-id.js
@@ -70,7 +70,7 @@ async function fetchCardFromDB(cardName) {
               ROW_NUMBER() OVER (ORDER BY credit_score) AS rn,
               COUNT(*) OVER () AS cnt
             FROM records
-            WHERE card_id = ? AND result = 1 AND admin_review = 1
+            WHERE card_id = ? AND result = 1 AND admin_review = 1 AND credit_score IS NOT NULL
           ) t WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
           ) as approved_median_credit_score,
           (SELECT ROUND(AVG(val)) FROM (
@@ -78,7 +78,7 @@ async function fetchCardFromDB(cardName) {
               ROW_NUMBER() OVER (ORDER BY listed_income) AS rn,
               COUNT(*) OVER () AS cnt
             FROM records
-            WHERE card_id = ? AND result = 1 AND admin_review = 1
+            WHERE card_id = ? AND result = 1 AND admin_review = 1 AND listed_income IS NOT NULL
           ) t WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
           ) as approved_median_income,
           (SELECT ROUND(AVG(val)) FROM (
@@ -86,7 +86,7 @@ async function fetchCardFromDB(cardName) {
               ROW_NUMBER() OVER (ORDER BY length_credit) AS rn,
               COUNT(*) OVER () AS cnt
             FROM records
-            WHERE card_id = ? AND result = 1 AND admin_review = 1
+            WHERE card_id = ? AND result = 1 AND admin_review = 1 AND length_credit IS NOT NULL
           ) t WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
           ) as approved_median_length_credit
         FROM records


### PR DESCRIPTION
## Summary
- Add `IS NOT NULL` filters to each median subquery so NULL column values don't skew the median position or produce NULL results
- Fixes `approved_median_length_credit` returning NULL when enough records lacked that field

## Test plan
- [x] Deployed and verified: Amex Gold now returns `approved_median_length_credit: 5` instead of `null`
- [x] Income median corrected from $45,000 to $58,500 after excluding NULL rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)