### PR TITLE
Remove 'over the past year' from card page

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -419,7 +419,7 @@ export default function CardClient({ card, graphData, news }: CardClientProps) {
               How other people did
             </p>
             <p className="mt-4 max-w-2xl text-xl text-gray-500 lg:mx-auto">
-              User reported results when applying for the {card.card_name} over the past year.
+              User reported results when applying for the {card.card_name}.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Remove "over the past year." from the data points section subtitle since data isn't limited to the past year

🤖 Generated with [Claude Code](https://claude.com/claude-code)