### PR TITLE
Add admin manual data point submission

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -517,6 +517,13 @@ Resources:
             Method: GET
             RestApiId:
               Ref: CreditCardOddsAPI
+        PostRecord:
+          Type: Api
+          Properties:
+            Path: /admin/records
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
         DeleteRecord:
           Type: Api
           Properties:

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -396,6 +396,25 @@ export async function getAdminRecords(
   return res.json();
 }
 
+export async function createAdminRecord(
+  data: unknown,
+  token: string
+): Promise<{ message: string; record_id: number }> {
+  const res = await fetch(`${API_BASE}/admin/records`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to create record: ${errorText}`);
+  }
+  return res.json();
+}
+
 export async function deleteAdminRecord(
   recordId: number,
   token: string


### PR DESCRIPTION
## Summary
- Add POST endpoint to `/admin/records` for admin-submitted data points
- New "Submit Record" tab on admin page with card search, submitter name, and all standard record fields
- Submitter identity tracked via free-text `submitter_name` field, logged in audit log as `ADMIN_CREATE`
- Skips per-user duplicate/limit checks (admin-only spam prevention bypass)

## Test plan
- [ ] Go to admin page, click "Submit Record" tab
- [ ] Search and select a card, fill in submitter name and record fields
- [ ] Submit and verify record appears in Records tab
- [ ] Check Audit Log tab shows `ADMIN_CREATE` with blue badge and submitter_name in details

🤖 Generated with [Claude Code](https://claude.com/claude-code)