### PR TITLE
Fix auto-news workflow: update Claude model and Brave rate limit

### DIFF
--- a/scripts/auto-news-update.js
+++ b/scripts/auto-news-update.js
@@ -240,7 +240,7 @@ source_url: "https://example.com/article"
       'anthropic-version': '2023-06-01',
     },
     body: JSON.stringify({
-      model: 'claude-3-5-haiku-20241022',
+      model: 'claude-haiku-4-5-20251001',
       max_tokens: 4096,
       messages: [
         { role: 'user', content: prompt }
@@ -402,8 +402,8 @@ async function main() {
         }
       }
 
-      // Rate limit between requests
-      await new Promise(resolve => setTimeout(resolve, 200));
+      // Rate limit between requests (Brave free tier allows ~1 req/sec)
+      await new Promise(resolve => setTimeout(resolve, 1200));
     } catch (err) {
       console.warn(`  Warning: Search failed for "${query}": ${err.message}`);
     }


### PR DESCRIPTION
## Summary
- Updated deprecated `claude-3-5-haiku-20241022` model to `claude-haiku-4-5-20251001` — the old model was removed by Anthropic, causing a 404 fatal error
- Increased Brave Search delay from 200ms to 1200ms to stay within the free tier's ~1 req/sec limit, which was causing 5/7 queries to get 429 rate-limited

## Test plan
- [ ] Verify the next scheduled Auto News Update run completes successfully
- [ ] Confirm Brave Search queries no longer hit 429 rate limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)