### PR TITLE
Add full article bodies to news items

### DIFF
--- a/apps/web-next/src/app/bank/[name]/page.tsx
+++ b/apps/web-next/src/app/bank/[name]/page.tsx
@@ -134,7 +134,15 @@ export default async function BankPage({ params }: BankPageProps) {
                           </span>
                         ))}
                       </div>
-                      <p className="text-sm font-medium text-gray-900 line-clamp-2">{news.title}</p>
+                      <p className="text-sm font-medium text-gray-900 line-clamp-2">
+                        {news.body ? (
+                          <Link href={`/news/${news.id}`} className="hover:text-indigo-600 transition-colors">
+                            {news.title}
+                          </Link>
+                        ) : (
+                          news.title
+                        )}
+                      </p>
                       {news.card_slugs && news.card_names && news.card_slugs.length > 0 && (
                         <div className="mt-1 text-xs">
                           {news.card_slugs.map((s, i) => (

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -519,7 +519,15 @@ export default function CardClient({ card, graphData, news }: CardClientProps) {
                       </span>
                     ))}
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-1">{item.title}</h3>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-1">
+                    {item.body ? (
+                      <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                        {item.title}
+                      </Link>
+                    ) : (
+                      item.title
+                    )}
+                  </h3>
                   <p className="text-gray-600">{item.summary}</p>
                   {item.source_url && (
                     <a

--- a/apps/web-next/src/app/news/[id]/opengraph-image.tsx
+++ b/apps/web-next/src/app/news/[id]/opengraph-image.tsx
@@ -1,0 +1,151 @@
+import { ImageResponse } from 'next/og';
+import { getNewsItem } from '@/lib/news';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'edge';
+
+export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const item = await getNewsItem(id);
+
+  const title = item?.title || 'Card News';
+  const date = item?.date
+    ? new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+    : '';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          position: 'relative',
+          background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        {/* Background pattern overlay */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundImage: 'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.1) 0%, transparent 50%)',
+            display: 'flex',
+          }}
+        />
+
+        {/* Main content */}
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            padding: '60px 80px',
+          }}
+        >
+          {/* Date */}
+          {date && (
+            <div
+              style={{
+                color: 'rgba(255,255,255,0.7)',
+                fontSize: 24,
+                marginBottom: 16,
+              }}
+            >
+              {date}
+            </div>
+          )}
+
+          {/* Title */}
+          <div
+            style={{
+              color: 'white',
+              fontSize: title.length > 80 ? 40 : 48,
+              fontWeight: 'bold',
+              letterSpacing: -1,
+              lineHeight: 1.2,
+              maxWidth: 1000,
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {title}
+          </div>
+
+          {/* Tag line */}
+          <div
+            style={{
+              display: 'flex',
+              marginTop: 32,
+              gap: 12,
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '8px 20px',
+                background: 'rgba(255,255,255,0.15)',
+                borderRadius: 50,
+                color: 'white',
+                fontSize: 18,
+              }}
+            >
+              Card News
+            </div>
+          </div>
+        </div>
+
+        {/* Logo in bottom left corner */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 40,
+            left: 50,
+            display: 'flex',
+            alignItems: 'center',
+            color: 'white',
+          }}
+        >
+          <svg
+            width="48"
+            height="48"
+            viewBox="0 0 180 180"
+            style={{ marginRight: 12 }}
+          >
+            <ellipse cx="138.19" cy="63.59" rx="9" ry="10.38" fill="white" />
+            <ellipse cx="161.11" cy="68.38" rx="7.02" ry="8.09" fill="white" />
+            <ellipse cx="138.71" cy="97.12" rx="9" ry="10.38" fill="white" />
+            <ellipse cx="161.63" cy="101.92" rx="7.02" ry="8.09" fill="white" />
+            <path
+              d="M114.57,53.6V33.17c0-4.47-3.53-7.45-6.66-5.63l-42.9,24.98c-1.7,0.99-2.8,3.2-2.8,5.63v17.29L114.57,53.6z"
+              fill="white"
+            />
+            <path
+              d="M62.22,91.14v30.3c0,3.41,2.12,6.17,4.73,6.17h42.9c2.61,0,4.73-2.76,4.73-6.17V74.71L62.22,91.14z"
+              fill="white"
+            />
+          </svg>
+          <span style={{ fontSize: 32, fontWeight: 'bold', letterSpacing: -0.5 }}>
+            CreditOdds
+          </span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -1,0 +1,207 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { NewspaperIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { getNews, getNewsItem, tagLabels, tagColors } from "@/lib/news";
+import { ArticleContent } from "@/components/articles/ArticleContent";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
+
+interface NewsDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const revalidate = 300;
+
+export async function generateStaticParams() {
+  const items = await getNews();
+  return items
+    .filter(item => item.body)
+    .map(item => ({ id: item.id }));
+}
+
+export async function generateMetadata({ params }: NewsDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const item = await getNewsItem(id);
+
+  if (!item) {
+    return { title: "News Not Found" };
+  }
+
+  return {
+    title: `${item.title} | Card News`,
+    description: item.summary,
+    openGraph: {
+      title: `${item.title} | CreditOdds`,
+      description: item.summary,
+      url: `https://creditodds.com/news/${item.id}`,
+      type: "article",
+      publishedTime: item.date,
+    },
+    alternates: {
+      canonical: `https://creditodds.com/news/${item.id}`,
+    },
+  };
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
+  const { id } = await params;
+  const item = await getNewsItem(id);
+
+  if (!item) {
+    notFound();
+  }
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    headline: item.title,
+    description: item.summary,
+    datePublished: item.date,
+    url: `https://creditodds.com/news/${item.id}`,
+    publisher: {
+      "@type": "Organization",
+      name: "CreditOdds",
+      url: "https://creditodds.com",
+    },
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Card News', url: 'https://creditodds.com/news' },
+        { name: item.title, url: `https://creditodds.com/news/${item.id}` },
+      ]} />
+
+      {/* Breadcrumbs */}
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">
+                Home
+              </Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/news" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">
+                  Card News
+                </Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 line-clamp-1">{item.title}</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      {/* Article */}
+      <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <header className="mb-8">
+          {/* Tags */}
+          <div className="flex flex-wrap gap-2 mb-4">
+            {item.tags.map((tag) => (
+              <span
+                key={tag}
+                className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium ${tagColors[tag]}`}
+              >
+                {tagLabels[tag]}
+              </span>
+            ))}
+          </div>
+
+          {/* Title */}
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 tracking-tight">
+            {item.title}
+          </h1>
+
+          {/* Meta row */}
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mt-4 text-sm text-gray-500">
+            <time dateTime={item.date}>{formatDate(item.date)}</time>
+            {item.bank && (
+              <>
+                <span className="text-gray-300">|</span>
+                <span>{item.bank}</span>
+              </>
+            )}
+          </div>
+
+          {/* Card links */}
+          {item.card_slugs && item.card_names && item.card_slugs.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-4">
+              {item.card_slugs.map((slug, i) => (
+                <Link
+                  key={slug}
+                  href={`/card/${slug}`}
+                  className="inline-flex items-center px-3 py-1.5 bg-indigo-50 text-indigo-700 rounded-full text-sm font-medium hover:bg-indigo-100 transition-colors"
+                >
+                  {item.card_names![i]}
+                </Link>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {/* Body */}
+        <div className="bg-white shadow rounded-lg p-6 sm:p-8">
+          {item.body ? (
+            <ArticleContent content={item.body} />
+          ) : (
+            <p className="text-gray-600 text-lg leading-relaxed">{item.summary}</p>
+          )}
+        </div>
+
+        {/* Source attribution */}
+        {item.source_url && (
+          <div className="mt-6 p-4 bg-gray-100 rounded-lg">
+            <p className="text-sm text-gray-500">
+              Source:{' '}
+              <a
+                href={item.source_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-indigo-600 hover:text-indigo-800 underline"
+              >
+                {item.source || item.source_url}
+              </a>
+            </p>
+          </div>
+        )}
+
+        {/* Back link */}
+        <div className="mt-8">
+          <Link
+            href="/news"
+            className="inline-flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          >
+            <ArrowLeftIcon className="h-4 w-4" />
+            Back to Card News
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/news/[id]/twitter-image.tsx
+++ b/apps/web-next/src/app/news/[id]/twitter-image.tsx
@@ -1,0 +1,5 @@
+// Re-export the OpenGraph image for Twitter cards
+export { default, size, contentType } from './opengraph-image';
+
+// Runtime must be defined directly, not re-exported
+export const runtime = 'edge';

--- a/apps/web-next/src/components/news/NewsTable.tsx
+++ b/apps/web-next/src/components/news/NewsTable.tsx
@@ -171,7 +171,13 @@ export default function NewsTable({ newsItems }: { newsItems: NewsItem[] }) {
                       )}
                     </div>
                     <div className="text-sm font-medium text-gray-900">
-                      {item.title}
+                      {item.body ? (
+                        <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                          {item.title}
+                        </Link>
+                      ) : (
+                        item.title
+                      )}
                     </div>
                     <ExpandableText
                       text={item.summary}

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -25,6 +25,7 @@ export interface NewsItem {
   card_image_links?: string[];
   source?: string;
   source_url?: string;
+  body?: string;
 }
 
 export interface NewsResponse {
@@ -59,6 +60,11 @@ const NEWS_CDN_URL = 'https://d2hxvzw7msbtvt.cloudfront.net/news.json';
 
 // Check if running in the browser
 const isBrowser = typeof window !== 'undefined';
+
+export async function getNewsItem(id: string): Promise<NewsItem | null> {
+  const items = await getNews();
+  return items.find(item => item.id === id) || null;
+}
 
 export async function getNews(): Promise<NewsItem[]> {
   try {

--- a/data/news/schema.json
+++ b/data/news/schema.json
@@ -79,6 +79,11 @@
       "type": "string",
       "format": "uri",
       "description": "Source URL (optional)"
+    },
+    "body": {
+      "type": "string",
+      "maxLength": 15000,
+      "description": "Full article body in markdown (optional)"
     }
   }
 }

--- a/scripts/build-news.js
+++ b/scripts/build-news.js
@@ -73,6 +73,15 @@ function validateNewsItem(item, schema) {
     }
   }
 
+  // Validate body if present
+  if (item.body !== undefined) {
+    if (typeof item.body !== 'string') {
+      errors.push('body must be a string');
+    } else if (item.body.length > 15000) {
+      errors.push(`body is too long (${item.body.length} chars, max 15000)`);
+    }
+  }
+
   // Validate card_slug pattern if present
   if (item.card_slug && !/^[a-z0-9-]+$/.test(item.card_slug)) {
     errors.push(`Invalid card_slug format: ${item.card_slug} (must be lowercase with hyphens only)`);


### PR DESCRIPTION
## Summary
- Adds optional `body` field (markdown, max 15k chars) to news schema and TypeScript types
- Creates `/news/[id]` detail page with SEO metadata, JSON-LD, OG/Twitter images, breadcrumbs, and article rendering via `ArticleContent`
- Makes news titles clickable (linking to detail page) in NewsTable, CardClient, and bank page — only when a `body` exists
- Auto-news script now generates full article bodies via Claude Sonnet after creating the summary
- Build script validates body field (type + length)

## Test plan
- [ ] Run `npm run build:news` — confirm it passes with existing YAML files (no body field yet)
- [ ] Add a test YAML with a `body` field, rebuild — confirm it appears in news.json
- [ ] Run `npm run dev`, visit `/news` — titles with body are clickable, others are not
- [ ] Visit `/news/[id]` — detail page renders with full article, metadata, breadcrumbs
- [ ] Check card page and bank page news sections for clickable titles
- [ ] Verify OG image renders at `/news/[id]/opengraph-image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)