### PR TITLE
Add alternateName to WebSite schema for Google site name

### DIFF
--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -44,6 +44,7 @@ export function WebsiteSchema({
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name,
+    alternateName: 'Credit Odds',
     url,
     potentialAction: {
       '@type': 'SearchAction',


### PR DESCRIPTION
## Summary
- Adds `alternateName: "Credit Odds"` to the WebSite JSON-LD structured data to strengthen the signal for Google to display "CreditOdds" instead of "creditodds.com" in search results

## Notes
- The existing `name`, `og:site_name`, and `OrganizationSchema` were already correct — this just adds one more signal
- After deploy, request re-indexing of the homepage via Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)