### PR TITLE
Add reward_type and rewards to Apple Card

### DIFF
--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -4,5 +4,26 @@ slug: "apple-card"
 image: "apple_card.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: cashback
+rewards:
+  - category: everything_else
+    value: 1
+    unit: percent
+  - category: online_shopping
+    value: 3
+    unit: percent
+    note: "Apple purchases"
+  - category: dining
+    value: 2
+    unit: percent
+    note: "Via Apple Pay"
+  - category: transit
+    value: 2
+    unit: percent
+    note: "Via Apple Pay"
+  - category: groceries
+    value: 2
+    unit: percent
+    note: "Via Apple Pay"
 tags:
   - cashback


### PR DESCRIPTION
## Summary
- Adds `reward_type: cashback` to Apple Card YAML
- Adds rewards breakdown: 3% Apple purchases, 2% Apple Pay (dining, transit, groceries), 1% everything else

🤖 Generated with [Claude Code](https://claude.com/claude-code)