### PR TITLE
Add reward_type to 110 card YAML files

### DIFF
--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -4,3 +4,4 @@ slug: "aer-lingus-visa-signature-card"
 accepting_applications: true
 image: "aer-lingus.png"
 annual_fee: 95
+reward_type: "miles"

--- a/data/cards/amazon-business-prime-american-express-card.yaml
+++ b/data/cards/amazon-business-prime-american-express-card.yaml
@@ -4,4 +4,5 @@ slug: "amazon-business-prime-american-express-card"
 accepting_applications: true
 category: "business"
 annual_fee: 0
+reward_type: "cashback"
 image: "amazon-business-prime.png"

--- a/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
+++ b/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
@@ -4,3 +4,4 @@ slug: "american-airlines-aadvantage-mileu-mastercard"
 accepting_applications: true
 image: "american-aadvantage.jpeg"
 annual_fee: 0
+reward_type: "miles"

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 category: "business"
 image: "american-express-business-gold.png"
 annual_fee: 375
+reward_type: "points"
 tags:
   - business
   - rewards

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -4,6 +4,7 @@ slug: "american-express-green-card"
 image: "amex_green_card.png"
 accepting_applications: true
 annual_fee: 150
+reward_type: "points"
 tags:
   - travel
   - dining

--- a/data/cards/amex-everyday-credit-card.yaml
+++ b/data/cards/amex-everyday-credit-card.yaml
@@ -4,3 +4,4 @@ slug: "amex-everyday-credit-card"
 image: "amex_everyday.png"
 accepting_applications: false
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/amex-everyday-preferred-credit-card.yaml
+++ b/data/cards/amex-everyday-preferred-credit-card.yaml
@@ -4,3 +4,4 @@ slug: "amex-everyday-preferred-credit-card"
 accepting_applications: false
 image: "everyday-preferred.png"
 annual_fee: 95
+reward_type: "points"

--- a/data/cards/at-t-access-card-from-citi.yaml
+++ b/data/cards/at-t-access-card-from-citi.yaml
@@ -4,3 +4,4 @@ slug: "at-t-access-card-from-citi"
 accepting_applications: false
 image: "citi-att-access.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "secured"
 image: "bank-of-america-customized-cash-secured.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 image: "customized-cash-rewards.png"
 category: "cashback"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 image: "premium-rewards.png"
 category: "travel"
 annual_fee: 550
+reward_type: "points"

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -5,3 +5,4 @@ image: "premium-rewards.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 95
+reward_type: "points"

--- a/data/cards/bank-of-america-travel-rewards.yaml
+++ b/data/cards/bank-of-america-travel-rewards.yaml
@@ -5,3 +5,4 @@ image: "travelrewards.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/bank-of-america-unlimited-cash-rewards.yaml
+++ b/data/cards/bank-of-america-unlimited-cash-rewards.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "cashback"
 image: "unlimited-cash-rewards.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -4,6 +4,7 @@ slug: "bilt-blue"
 image: "bilt_blue.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "points"
 release_date: "2025-01-15"
 tags:
   - rewards

--- a/data/cards/bilt-mastercard.yaml
+++ b/data/cards/bilt-mastercard.yaml
@@ -6,4 +6,5 @@ accepting_applications: false
 active: false
 category: "rewards"
 annual_fee: 0
+reward_type: "points"
 release_date: "2022-06-01"

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -4,6 +4,7 @@ slug: "bilt-obsidian"
 image: "bilt_obsidian.png"
 accepting_applications: true
 annual_fee: 95
+reward_type: "points"
 release_date: "2025-01-15"
 tags:
   - rewards

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -4,6 +4,7 @@ slug: "bilt-palladium"
 image: "bilt_palladium.png"
 accepting_applications: true
 annual_fee: 495
+reward_type: "points"
 release_date: "2025-01-15"
 tags:
   - rewards

--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -4,6 +4,7 @@ slug: "blue-business-cash-card-from-american-express"
 accepting_applications: true
 category: "business"
 annual_fee: 0
+reward_type: "cashback"
 image: "blue-business-cash.png"
 tags:
   - business

--- a/data/cards/blue-business-plus-credit-card-from-american-express.yaml
+++ b/data/cards/blue-business-plus-credit-card-from-american-express.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 category: "business"
 image: "blue-business-plus.png"
 annual_fee: 0
+reward_type: "points"
 tags:
   - business
   - rewards

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -5,5 +5,6 @@ image: "amex_blue_cash_everyday.png"
 accepting_applications: true
 card_referral_link: "https://americanexpress.com/en-us/referral/blue-cash-everyday-credit-card?ref="
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - cashback

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -4,6 +4,7 @@ slug: "blue-cash-preferred-card"
 image: "amex_blue_cash_preferred.png"
 accepting_applications: true
 annual_fee: 95
+reward_type: "cashback"
 tags:
   - cashback
   - shopping

--- a/data/cards/blue-from-american-express.yaml
+++ b/data/cards/blue-from-american-express.yaml
@@ -3,3 +3,4 @@ bank: "American Express"
 slug: "blue-from-american-express"
 accepting_applications: false
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -4,3 +4,4 @@ slug: "british-airways-visa-signature-card"
 accepting_applications: true
 image: "british-airways.png"
 annual_fee: 95
+reward_type: "miles"

--- a/data/cards/capital-one-quicksilver-secured.yaml
+++ b/data/cards/capital-one-quicksilver-secured.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 category: "secured"
 image: "capital-one-quicksilver-secured.png"
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - secured
   - cashback

--- a/data/cards/capital-one-quicksilver.yaml
+++ b/data/cards/capital-one-quicksilver.yaml
@@ -5,6 +5,7 @@ image: "capital_one_quicksilver.png"
 accepting_applications: true
 category: "cashback"
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - cashback
   - rewards

--- a/data/cards/capital-one-quicksilverone.yaml
+++ b/data/cards/capital-one-quicksilverone.yaml
@@ -5,3 +5,4 @@ image: "capital_one_quicksilverone.png"
 accepting_applications: true
 category: "cashback"
 annual_fee: 39
+reward_type: "cashback"

--- a/data/cards/capital-one-savor-student.yaml
+++ b/data/cards/capital-one-savor-student.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 image: "capital-one-savor-student.png"
 category: "student"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 image: "capital-one-savor-cash-rewards.png"
 category: "cashback"
 annual_fee: 95
+reward_type: "cashback"
 tags:
   - cashback
   - dining

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 category: "travel"
 image: "capital-one-venture-rewards.png"
 annual_fee: 95
+reward_type: "miles"
 tags:
   - travel
   - rewards

--- a/data/cards/capital-one-ventureone-rewards.yaml
+++ b/data/cards/capital-one-ventureone-rewards.yaml
@@ -5,3 +5,4 @@ image: "capital_one_ventureone.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 0
+reward_type: "miles"

--- a/data/cards/cash-magnet-card.yaml
+++ b/data/cards/cash-magnet-card.yaml
@@ -4,3 +4,4 @@ slug: "cash-magnet-card"
 image: "amex_cash_magnet.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -3,6 +3,7 @@ bank: "Chase"
 slug: "ihg-rewards-premier-business"
 accepting_applications: true
 annual_fee: 0
+reward_type: "points"
 image: "chase-ihg-one-rewards-premier-business.png"
 tags:
   - hotel

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -5,6 +5,7 @@ image: "chase_ink_business_cash.png"
 accepting_applications: true
 category: "business"
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - business
   - cashback

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -5,6 +5,7 @@ image: "chase_ink_business_preferred.png"
 accepting_applications: true
 category: "business"
 annual_fee: 95
+reward_type: "points"
 tags:
   - business
   - travel

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -5,6 +5,7 @@ image: "chase_ink_business_unlimited.png"
 accepting_applications: true
 category: "business"
 annual_fee: 0
+reward_type: "points"
 tags:
   - business
   - cashback

--- a/data/cards/chase-united-presidential-plus.yaml
+++ b/data/cards/chase-united-presidential-plus.yaml
@@ -5,6 +5,7 @@ image: "chase-united-presidential-plus.png"
 accepting_applications: false
 active: true
 annual_fee: 495
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -3,4 +3,5 @@ bank: "Citi"
 slug: "citi-aadvantage-executive-world-elite-masterc"
 accepting_applications: true
 annual_fee: 595
+reward_type: "miles"
 image: "citi-aadvantage-executive-world-elite.png"

--- a/data/cards/citi-aadvantage-globe.yaml
+++ b/data/cards/citi-aadvantage-globe.yaml
@@ -3,4 +3,5 @@ bank: "Citi"
 slug: "citi-aadvantage-globe"
 accepting_applications: true
 annual_fee: 350
+reward_type: "miles"
 image: "citi-aadvantage-globe.png"

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -3,4 +3,5 @@ bank: "Citi"
 slug: "citi-aadvantage-platinum-select-world-elite-m"
 accepting_applications: true
 annual_fee: 99
+reward_type: "miles"
 image: "citi-aadvantage-platinum-select-world-elite.png"

--- a/data/cards/citi-custom-cash.yaml
+++ b/data/cards/citi-custom-cash.yaml
@@ -4,6 +4,7 @@ slug: "citi-custom-cash"
 image: "citi_custom_cash.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - cashback
   - rewards

--- a/data/cards/citi-prestige.yaml
+++ b/data/cards/citi-prestige.yaml
@@ -4,3 +4,4 @@ slug: "citi-prestige"
 accepting_applications: false
 image: "citi-prestige.png"
 annual_fee: 495
+reward_type: "points"

--- a/data/cards/citi-rewards.yaml
+++ b/data/cards/citi-rewards.yaml
@@ -3,4 +3,5 @@ bank: "Citi"
 slug: "citi-rewards"
 accepting_applications: false
 annual_fee: 0
+reward_type: "points"
 image: "citi-rewards-plus.png"

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "travel"
 image: "citi-strata-elite.png"
 annual_fee: 595
+reward_type: "points"

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -5,3 +5,4 @@ image: "citi_strata_premier.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 95
+reward_type: "points"

--- a/data/cards/citi-strata.yaml
+++ b/data/cards/citi-strata.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "travel"
 image: "citi-strata.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -4,3 +4,4 @@ slug: "citibusiness-aadvantage-platinum-select-maste"
 accepting_applications: true
 image: "citi-business-aadvantage-platinum-select.png"
 annual_fee: 99
+reward_type: "miles"

--- a/data/cards/coinbase-one.yaml
+++ b/data/cards/coinbase-one.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 release_date: "2025-10-22"
 category: "rewards"
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - rewards
   - crypto

--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -4,3 +4,4 @@ slug: "costco-anywhere-visa-business-card-by-citi"
 accepting_applications: true
 image: "citi-costco-anywhere-business.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/costco-anywhere-visa-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-card-by-citi.yaml
@@ -4,3 +4,4 @@ slug: "costco-anywhere-visa-card-by-citi"
 accepting_applications: true
 image: "citi-costco-anywhere.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -4,6 +4,7 @@ slug: "delta-skymiles-blue-american-express-card"
 image: "amex_delta_blue_skymiles.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -4,6 +4,7 @@ slug: "delta-skymiles-gold-american-express-card"
 image: "amex_delta_skymiles_gold.png"
 accepting_applications: true
 annual_fee: 150
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -4,6 +4,7 @@ slug: "delta-skymiles-platinum-american-express-card"
 image: "amex_delta_skymiles_platinum.png"
 accepting_applications: true
 annual_fee: 350
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -4,6 +4,7 @@ slug: "delta-skymiles-reserve-american-express-card"
 image: "amex_delta_skymiles_reserve.png"
 accepting_applications: true
 annual_fee: 650
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/discover-it-for-students-card.yaml
+++ b/data/cards/discover-it-for-students-card.yaml
@@ -4,6 +4,7 @@ slug: "discover-it-for-students-card"
 accepting_applications: true
 image: "discover-it-student-cash-back.png"
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - student
   - cashback

--- a/data/cards/discover-it-gas-and-restaurants.yaml
+++ b/data/cards/discover-it-gas-and-restaurants.yaml
@@ -4,3 +4,4 @@ slug: "discover-it-gas-and-restaurants"
 accepting_applications: false
 image: "discover-it-gas-restaurants.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/discover-it-miles.yaml
+++ b/data/cards/discover-it-miles.yaml
@@ -4,6 +4,7 @@ slug: "discover-it-miles"
 accepting_applications: true
 image: "discover-it-miles.png"
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - travel
   - rewards

--- a/data/cards/discover-it-secured-credit-card.yaml
+++ b/data/cards/discover-it-secured-credit-card.yaml
@@ -4,6 +4,7 @@ slug: "discover-it-secured-credit-card"
 accepting_applications: true
 image: "discover-it-secured.png"
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - secured
   - cashback

--- a/data/cards/discover-it-student-chrome-card.yaml
+++ b/data/cards/discover-it-student-chrome-card.yaml
@@ -4,3 +4,4 @@ slug: "discover-it-student-chrome-card"
 accepting_applications: true
 image: "discover-it-student-chrome.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -5,6 +5,7 @@ image: "chase-disney-inspire.png"
 accepting_applications: true
 category: "rewards"
 annual_fee: 149
+reward_type: "cashback"
 tags:
   - rewards
   - disney

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -4,3 +4,4 @@ slug: "disney-premier-visa-card"
 accepting_applications: true
 image: "chase-disney-premier.png"
 annual_fee: 49
+reward_type: "cashback"

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -4,3 +4,4 @@ slug: "disney-visa-card"
 accepting_applications: true
 image: "chase-disney.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/expedia-rewards-card-from-citi.yaml
+++ b/data/cards/expedia-rewards-card-from-citi.yaml
@@ -4,3 +4,4 @@ slug: "expedia-rewards-card-from-citi"
 accepting_applications: false
 image: "citi-expedia-rewards.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/expedia-rewards-voyager-card-from-citi.yaml
+++ b/data/cards/expedia-rewards-voyager-card-from-citi.yaml
@@ -4,3 +4,4 @@ slug: "expedia-rewards-voyager-card-from-citi"
 accepting_applications: false
 image: "citi-expedia-rewards-voyager.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/gemini-credit.yaml
+++ b/data/cards/gemini-credit.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 release_date: "2022-04-14"
 category: "rewards"
 annual_fee: 0
+reward_type: "cashback"
 tags:
   - rewards
   - crypto

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "travel"
 image: "barclays-hawaiian.png"
 annual_fee: 99
+reward_type: "miles"

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -4,6 +4,7 @@ slug: "hilton-honors-american-express-aspire-card"
 image: "amex_hilton_honors_aspire.png"
 accepting_applications: true
 annual_fee: 550
+reward_type: "points"
 tags:
   - hotel
   - travel

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -4,6 +4,7 @@ slug: "hilton-honors-american-express-surpass-card"
 image: "amex_hilton_honors_surpass.png"
 accepting_applications: true
 annual_fee: 150
+reward_type: "points"
 tags:
   - hotel
   - travel

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -5,6 +5,7 @@ image: "amex_hilton_honors.png"
 accepting_applications: true
 card_referral_link: "https://www.americanexpress.com/en-us/credit-cards/referral/prospect/hilton-honors/personal?ref="
 annual_fee: 0
+reward_type: "points"
 tags:
   - hotel
   - travel

--- a/data/cards/hotels-com-rewards-visa.yaml
+++ b/data/cards/hotels-com-rewards-visa.yaml
@@ -4,3 +4,4 @@ slug: "hotels-com-rewards-visa"
 accepting_applications: false
 image: "wells-fargo-hotels-com.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -4,3 +4,4 @@ slug: "iberia-visa-signature-card"
 accepting_applications: true
 image: "iberia-plus.png"
 annual_fee: 95
+reward_type: "miles"

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -4,6 +4,7 @@ slug: "ihg-rewards-club-premier-credit-card"
 accepting_applications: true
 image: "chase-ihg-one-rewards-premier.png"
 annual_fee: 99
+reward_type: "points"
 tags:
   - hotel
   - travel

--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -3,6 +3,7 @@ bank: "Chase"
 slug: "ihg-rewards-club-traveler-credit-card"
 accepting_applications: true
 annual_fee: 0
+reward_type: "points"
 image: "chase-ihg-one-rewards-traveler.png"
 tags:
   - hotel

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "business"
 image: "barclays-jetblue-business.png"
 annual_fee: 99
+reward_type: "points"

--- a/data/cards/jetblue-card.yaml
+++ b/data/cards/jetblue-card.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "travel"
 image: "barclays-jetblue.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "travel"
 image: "barclays-jetblue-plus.png"
 annual_fee: 99
+reward_type: "points"

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -4,6 +4,7 @@ slug: "marriott-bonvoy-bold-credit-card"
 image: "chase-marriott-bonvoy-bold.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "points"
 tags:
   - hotel
   - travel

--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -4,6 +4,7 @@ slug: "marriott-bonvoy-boundless-credit-card"
 image: "marriott_bonvoy_boundless.png"
 accepting_applications: true
 annual_fee: 95
+reward_type: "points"
 tags:
   - hotel
   - travel

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -4,6 +4,7 @@ slug: "marriott-bonvoy-brilliant-american-express"
 image: "amex_marriott_bonvoy_brilliant.png"
 accepting_applications: true
 annual_fee: 650
+reward_type: "points"
 tags:
   - hotel
   - travel

--- a/data/cards/nhl-discover-it.yaml
+++ b/data/cards/nhl-discover-it.yaml
@@ -4,3 +4,4 @@ slug: "nhl-discover-it"
 accepting_applications: true
 image: "discover-it-nhl.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "travel"
 image: "barclays-princess.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -3,6 +3,7 @@ bank: "Chase"
 slug: "southwest-rapid-rewards-plus-credit-card"
 accepting_applications: true
 annual_fee: 99
+reward_type: "points"
 image: "chase-southwest-rapid-rewards-plus.png"
 tags:
   - airline

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -4,6 +4,7 @@ slug: "southwest-rapid-rewards-premier-credit-card"
 accepting_applications: true
 image: "chase-southwest-rapid-rewards-premier.png"
 annual_fee: 149
+reward_type: "points"
 tags:
   - airline
   - travel

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -4,6 +4,7 @@ slug: "southwest-rapid-rewards-priority-credit-card"
 image: "southwest_priority.png"
 accepting_applications: true
 annual_fee: 229
+reward_type: "points"
 tags:
   - airline
   - travel

--- a/data/cards/starbucks-rewards-visa-card.yaml
+++ b/data/cards/starbucks-rewards-visa-card.yaml
@@ -4,3 +4,4 @@ slug: "starbucks-rewards-visa-card"
 image: "chase-starbucks-rewards.png"
 accepting_applications: false
 annual_fee: 49
+reward_type: "points"

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 category: "business"
 image: "business-platinum.png"
 annual_fee: 895
+reward_type: "points"
 tags:
   - business
   - travel

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -5,6 +5,7 @@ image: "amex_the_platinum_card.png"
 accepting_applications: true
 card_referral_link: "https://americanexpress.com/en-us/referral/platinum-card?ref="
 annual_fee: 895
+reward_type: "points"
 tags:
   - travel
   - premium

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -4,6 +4,7 @@ slug: "united-club-infinite"
 image: "united_club_infinite.png"
 accepting_applications: true
 annual_fee: 695
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -4,6 +4,7 @@ slug: "united-explorer"
 image: "united_explorer.png"
 accepting_applications: true
 annual_fee: 150
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/united-gateway.yaml
+++ b/data/cards/united-gateway.yaml
@@ -4,6 +4,7 @@ slug: "united-gateway"
 image: "united_gateway.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -4,6 +4,7 @@ slug: "united-quest"
 image: "united_quest.png"
 accepting_applications: true
 annual_fee: 350
+reward_type: "miles"
 tags:
   - airline
   - travel

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -4,3 +4,4 @@ slug: "us-bank-altitude-connect"
 image: "altitude-connect.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/us-bank-altitude-go-visa-signature.yaml
+++ b/data/cards/us-bank-altitude-go-visa-signature.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "travel"
 image: "us-bank-altitude-go.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -5,3 +5,4 @@ accepting_applications: false
 category: "travel"
 image: "us-bank-altitude-reserve.png"
 annual_fee: 400
+reward_type: "points"

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -4,4 +4,5 @@ slug: "us-bank-cash-plus-visa-signature"
 accepting_applications: true
 category: "cashback"
 annual_fee: 0
+reward_type: "cashback"
 image: "us-bank-cash-plus-signature.png"

--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -4,3 +4,4 @@ slug: "us-bank-shopper"
 image: "us-bank-shopper.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/us-bank-smartly-visa-signature.yaml
+++ b/data/cards/us-bank-smartly-visa-signature.yaml
@@ -5,4 +5,5 @@ image: "smartly-signature.png"
 accepting_applications: true
 category: "cashback"
 annual_fee: 0
+reward_type: "cashback"
 

--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "cashback"
 image: "wells-fargo-attune.png"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 image: "wells-fargo-autograph-journey.png"
 category: "travel"
 annual_fee: 95
+reward_type: "points"

--- a/data/cards/wells-fargo-cash-back-college.yaml
+++ b/data/cards/wells-fargo-cash-back-college.yaml
@@ -4,3 +4,4 @@ slug: "wells-fargo-cash-back-college"
 image: "wells_fargo_cash_back_college.png"
 accepting_applications: true
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/wells-fargo-cash-wise-visa.yaml
+++ b/data/cards/wells-fargo-cash-wise-visa.yaml
@@ -4,3 +4,4 @@ slug: "wells-fargo-cash-wise-visa"
 image: "cash_wise.png"
 accepting_applications: false
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/wells-fargo-propel-american-express.yaml
+++ b/data/cards/wells-fargo-propel-american-express.yaml
@@ -4,3 +4,4 @@ slug: "wells-fargo-propel-american-express"
 image: "propel_card.png"
 accepting_applications: false
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/wells-fargo-rewards.yaml
+++ b/data/cards/wells-fargo-rewards.yaml
@@ -4,3 +4,4 @@ slug: "wells-fargo-rewards"
 image: "wells_fargo_rewards.png"
 accepting_applications: false
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 image: "wells-fargo-signify-business-cash.png"
 category: "business"
 annual_fee: 0
+reward_type: "cashback"

--- a/data/cards/wells-fargo-visa-signature.yaml
+++ b/data/cards/wells-fargo-visa-signature.yaml
@@ -4,3 +4,4 @@ slug: "wells-fargo-visa-signature"
 image: "wells_fargo_visa_signature.png"
 accepting_applications: false
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 image: "chase-world-of-hyatt-business.png"
 category: "business"
 annual_fee: 199
+reward_type: "points"

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -4,6 +4,7 @@ slug: "world-of-hyatt-credit-card"
 accepting_applications: true
 image: "chase-world-of-hyatt.png"
 annual_fee: 95
+reward_type: "points"
 tags:
   - hotel
   - travel

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -5,3 +5,4 @@ accepting_applications: true
 category: "business"
 image: "barclays-wyndham-earner-business.png"
 annual_fee: 95
+reward_type: "points"

--- a/data/cards/wyndham-rewards-earner-card.yaml
+++ b/data/cards/wyndham-rewards-earner-card.yaml
@@ -5,3 +5,4 @@ accepting_applications: false
 category: "travel"
 image: "barclays-wyndham-earner.png"
 annual_fee: 0
+reward_type: "points"

--- a/data/cards/wyndham-rewards-earner-plus-card.yaml
+++ b/data/cards/wyndham-rewards-earner-plus-card.yaml
@@ -5,3 +5,4 @@ accepting_applications: false
 category: "travel"
 image: "barclays-wyndham-earner-plus.png"
 annual_fee: 75
+reward_type: "points"


### PR DESCRIPTION
## Summary
- Tags all remaining cards with `reward_type`: cashback, points, or miles
- **35 cashback**: Discover cards, BoA cash cards, Blue Cash, Quicksilver/Savor, Disney, Costco, Ink Cash, etc.
- **55 points**: Amex MR, Chase UR, Citi ThankYou, Bilt, hotel co-brands (Hilton/Marriott/Hyatt/IHG/Wyndham), Southwest, JetBlue, etc.
- **20 miles**: Delta SkyMiles, United, AAdvantage, Capital One Venture, British Airways/Aer Lingus/Iberia, Hawaiian
- **13 intentionally skipped** (no rewards program): BankAmericard, Capital One Platinum/Platinum Secured, Chase Slate Edge, Citi Diamond Preferred/Simplicity/Secured, Serve, US Bank Secured/Shield/Split, Wells Fargo Platinum/Reflect

🤖 Generated with [Claude Code](https://claude.com/claude-code)