### PR TITLE
Fix: filter no-op changes in auto card update

### DIFF
--- a/scripts/auto-card-update.js
+++ b/scripts/auto-card-update.js
@@ -223,11 +223,19 @@ If NO changes found for ANY card, return: []`;
 
   try {
     const results = JSON.parse(jsonStr);
-    // Filter to high-confidence changes only
+    // Filter to high-confidence changes where values actually differ
     return results
       .map((card) => ({
         ...card,
-        changes: card.changes.filter((c) => c.confidence === 'high'),
+        changes: card.changes.filter((c) => {
+          if (c.confidence !== 'high') return false;
+          // Skip no-op changes (old_value === new_value)
+          if (JSON.stringify(c.old_value) === JSON.stringify(c.new_value)) {
+            console.log(`  Skipping no-op change for "${card.card_name}": ${c.field} (${JSON.stringify(c.old_value)} unchanged)`);
+            return false;
+          }
+          return true;
+        }),
       }))
       .filter((card) => card.changes.length > 0);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Filters out false positive changes where `old_value === new_value` (e.g., Platinum Card annual_fee 895 → 895)
- This was caused by YAML reformatting triggering a "change" even when the actual value didn't change

## Context
First test run of auto-card-update produced a false positive for The Platinum Card where the annual fee was reported as changing from 895 to 895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)