### PR TITLE
Add day_offset input to auto card update

### DIFF
--- a/.github/workflows/auto-card-update.yml
+++ b/.github/workflows/auto-card-update.yml
@@ -3,7 +3,12 @@ name: Auto Card Update
 on:
   schedule:
     - cron: '0 15 * * *'  # Daily at 3 PM UTC / 10 AM EST
-  workflow_dispatch:       # Manual trigger
+  workflow_dispatch:
+    inputs:
+      day_offset:
+        description: 'Offset day-of-year to select a different card batch (e.g. 1, 2, 3)'
+        required: false
+        default: '0'
 
 permissions:
   contents: write
@@ -29,6 +34,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
+          DAY_OFFSET: ${{ github.event.inputs.day_offset || '0' }}
         run: node scripts/auto-card-update.js
 
       - name: Create PR if changes found

--- a/scripts/auto-card-update.js
+++ b/scripts/auto-card-update.js
@@ -53,9 +53,10 @@ function selectCardsForToday(allCards) {
     .sort((a, b) => a.slug.localeCompare(b.slug));
 
   const now = new Date();
+  const dayOffset = parseInt(process.env.DAY_OFFSET || '0', 10);
   const dayOfYear = Math.floor(
     (now - new Date(now.getFullYear(), 0, 0)) / (1000 * 60 * 60 * 24)
-  );
+  ) + dayOffset;
 
   const selected = [];
 


### PR DESCRIPTION
## Summary
- Adds `day_offset` input to workflow_dispatch for selecting different card batches
- Useful for testing: `gh workflow run "Auto Card Update" -f day_offset=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)