### PR TITLE
Fix branch collision in auto card update

### DIFF
--- a/.github/workflows/auto-card-update.yml
+++ b/.github/workflows/auto-card-update.yml
@@ -42,7 +42,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -n "$(git status --porcelain data/cards/)" ]; then
-            BRANCH="auto-card-update-$(date +%Y-%m-%d)"
+            BRANCH="auto-card-update-$(date +%Y-%m-%d-%H%M%S)"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary
- Adds timestamp to branch name (`auto-card-update-2026-02-23-163000`) to prevent collisions on same-day reruns

🤖 Generated with [Claude Code](https://claude.com/claude-code)