### PR TITLE
Add rewards details for Delta SkyMiles Gold

### DIFF
--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -9,8 +9,23 @@ tags:
   - airline
   - travel
   - rewards
+rewards:
+  - category: delta_purchases
+    value: 2
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+    note: "U.S. supermarkets"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 90000
-  type: "miles"
+  type: miles
   spend_requirement: 5000
   timeframe_months: 6
+  note: "70k after $3k spend + 20k after additional $2k spend"


### PR DESCRIPTION
## Summary
- Added rewards categories: 2x on Delta/dining/U.S. supermarkets, 1x everything else
- Added note to signup bonus clarifying tiered structure (70k + 20k)
- Source: [Official Delta card page](https://creditcard.delta.com/us/credit-cards/offers/card/delta-skymiles-gold-american-express-card/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)