### PR TITLE
Add rewards and signup bonuses for Delta SkyMiles Blue, Platinum, Reserve

### DIFF
--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -8,3 +8,18 @@ reward_type: "miles"
 tags:
   - airline
   - travel
+rewards:
+  - category: delta_purchases
+    value: 2
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 10000
+  type: miles
+  spend_requirement: 1000
+  timeframe_months: 6

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -9,3 +9,27 @@ tags:
   - airline
   - travel
   - premium
+rewards:
+  - category: delta_purchases
+    value: 3
+    unit: points_per_dollar
+  - category: hotels
+    value: 3
+    unit: points_per_dollar
+    note: "Direct hotel purchases"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+    note: "U.S. supermarkets"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 100000
+  type: miles
+  spend_requirement: 6000
+  timeframe_months: 6
+  note: "80k after $4k spend + 20k after additional $2k spend"

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -9,3 +9,16 @@ tags:
   - airline
   - travel
   - premium
+rewards:
+  - category: delta_purchases
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 125000
+  type: miles
+  spend_requirement: 9000
+  timeframe_months: 6
+  note: "100k after $6k spend + 25k after additional $3k spend"


### PR DESCRIPTION
## Summary
Completes the Delta SkyMiles card family with rewards and signup bonus data.

### Delta SkyMiles Blue ($0 AF)
- 2x miles on Delta purchases and dining
- 1x on everything else
- 10,000 bonus miles / $1k spend / 6 months

### Delta SkyMiles Platinum ($350 AF)
- 3x miles on Delta and direct hotel purchases
- 2x on dining and U.S. supermarkets
- 1x on everything else
- 100,000 bonus miles (80k + 20k tiered) / $6k spend / 6 months

### Delta SkyMiles Reserve ($650 AF)
- 3x miles on Delta purchases
- 1x on everything else
- 125,000 bonus miles (100k + 25k tiered) / $9k spend / 6 months

## Sources
- [Delta personal cards page](https://www.delta.com/us/en/skymiles/airline-credit-cards/american-express-personal-cards)
- [Amex Delta Blue](https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-blue-american-express-card/)
- [Amex Delta Platinum](https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-platinum-american-express-card/)
- [Amex Delta Reserve](https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-reserve-american-express-card/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)