### PR TITLE
Fix article breadcrumb width to match content

### DIFF
--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -129,7 +129,7 @@ export default async function ArticlePage({ params }: Props) {
       <div className="min-h-screen bg-gray-50">
         {/* Breadcrumbs */}
         <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <ol className="flex items-center space-x-4 py-4">
               <li>
                 <Link href="/" className="text-gray-400 hover:text-gray-500">


### PR DESCRIPTION
## Summary
- Changed article detail page breadcrumb container from `max-w-7xl` to `max-w-4xl`
- Aligns breadcrumbs with article content width, matching the news detail page pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)