### PR TITLE
Fix Delta SkyMiles reward category validation

### DIFF
--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -9,9 +9,10 @@ tags:
   - airline
   - travel
 rewards:
-  - category: delta_purchases
+  - category: airlines
     value: 2
     unit: points_per_dollar
+    note: "Delta purchases"
   - category: dining
     value: 2
     unit: points_per_dollar

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -10,9 +10,10 @@ tags:
   - travel
   - rewards
 rewards:
-  - category: delta_purchases
+  - category: airlines
     value: 2
     unit: points_per_dollar
+    note: "Delta purchases"
   - category: dining
     value: 2
     unit: points_per_dollar

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -10,9 +10,10 @@ tags:
   - travel
   - premium
 rewards:
-  - category: delta_purchases
+  - category: airlines
     value: 3
     unit: points_per_dollar
+    note: "Delta purchases"
   - category: hotels
     value: 3
     unit: points_per_dollar

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -10,9 +10,10 @@ tags:
   - travel
   - premium
 rewards:
-  - category: delta_purchases
+  - category: airlines
     value: 3
     unit: points_per_dollar
+    note: "Delta purchases"
   - category: everything_else
     value: 1
     unit: points_per_dollar


### PR DESCRIPTION
## Summary
- Changed `delta_purchases` to `airlines` (with "Delta purchases" note) on all 4 Delta SkyMiles cards
- `delta_purchases` wasn't in `categories.yaml`, so rewards weren't passing validation in `build:cards`

🤖 Generated with [Claude Code](https://claude.com/claude-code)