### PR TITLE
Add auto social media posting for news and articles via Ayrshare

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -1,11 +1,11 @@
-name: Build and Deploy News
+name: Build and Deploy Articles
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'data/news/**'
+      - 'data/articles/**'
   workflow_dispatch:  # Allow manual trigger
 
 permissions:
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build news.json
-        run: npm run build:news
+      - name: Build articles.json
+        run: npm run build:articles
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -40,12 +40,12 @@ jobs:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2
 
-      - name: Upload news.json to S3
-        run: aws s3 cp data/news.json s3://${{ secrets.S3_BUCKET_NAME }}/news.json --content-type application/json --cache-control "max-age=300"
+      - name: Upload articles.json to S3
+        run: aws s3 cp data/articles.json s3://${{ secrets.S3_BUCKET_NAME }}/articles.json --content-type application/json --cache-control "max-age=300"
 
       - name: Invalidate CloudFront cache
         run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/news.json"
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/articles.json"
 
       - name: Wait for CloudFront invalidation
         run: |
@@ -63,21 +63,21 @@ jobs:
             echo "Skipping Amplify rebuild (no webhook URL configured)"
           fi
 
-      - name: Detect new news files
+      - name: Detect new article files
         id: new-files
         run: |
-          NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- 'data/news/*.yaml' 'data/news/*.yml' 2>/dev/null || echo "")
+          NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- 'data/articles/*.yaml' 'data/articles/*.yml' 2>/dev/null || echo "")
           echo "files=$NEW_FILES" >> $GITHUB_OUTPUT
           if [ -n "$NEW_FILES" ]; then
-            echo "New news files detected:"
+            echo "New article files detected:"
             echo "$NEW_FILES"
           else
-            echo "No new news files detected"
+            echo "No new article files detected"
           fi
 
-      - name: Post new news to social media
+      - name: Post new articles to social media
         if: steps.new-files.outputs.files != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AYRSHARE_API_KEY: ${{ secrets.AYRSHARE_API_KEY }}
-        run: node scripts/post-social.js --type news --files ${{ steps.new-files.outputs.files }}
+        run: node scripts/post-social.js --type article --files ${{ steps.new-files.outputs.files }}

--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/**
+ * Social Media Auto-Post Script
+ *
+ * Parses new news/article YAML files, generates an engaging social media post
+ * via Claude Haiku, and publishes to X, Facebook, LinkedIn, and Instagram
+ * via the Ayrshare API.
+ *
+ * Usage: node scripts/post-social.js --type news|article --files <yaml-paths...>
+ *
+ * Env vars: ANTHROPIC_API_KEY, AYRSHARE_API_KEY
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// Parse CLI args
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let type = null;
+  const files = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--type' && args[i + 1]) {
+      type = args[++i];
+    } else if (args[i] === '--files') {
+      // All remaining args are file paths
+      files.push(...args.slice(i + 1));
+      break;
+    }
+  }
+
+  if (!type || !['news', 'article'].includes(type)) {
+    console.error('Usage: node scripts/post-social.js --type news|article --files <yaml-paths...>');
+    process.exit(1);
+  }
+
+  if (files.length === 0) {
+    console.error('No files provided.');
+    process.exit(1);
+  }
+
+  return { type, files };
+}
+
+/**
+ * Build the public URL for a news item or article.
+ */
+function buildUrl(type, item) {
+  if (type === 'news') {
+    return `https://creditodds.com/news/${item.id}`;
+  }
+  return `https://creditodds.com/articles/${item.slug}`;
+}
+
+/**
+ * Build the OG image URL for social media previews.
+ */
+function buildOgImageUrl(type, item) {
+  if (type === 'news') {
+    return `https://creditodds.com/news/${item.id}/opengraph-image`;
+  }
+  return `https://creditodds.com/articles/${item.slug}/opengraph-image`;
+}
+
+/**
+ * Generate an engaging social media post using Claude Haiku.
+ */
+async function generatePost(type, item) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY environment variable is required');
+  }
+
+  const cardNames = item.card_name
+    || (item.related_cards && item.related_cards.length > 0
+      ? item.related_cards.join(', ')
+      : 'N/A');
+
+  const prompt = `Write a social media post for CreditOdds about this ${type}:
+Title: ${item.title}
+Summary: ${item.summary}
+Cards: ${cardNames}
+
+Max 260 characters. Informative, engaging, professional. 1-2 hashtags. Do NOT include the URL.`;
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 256,
+      messages: [
+        { role: 'user', content: prompt },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Claude API error: ${response.status} - ${errorText}`);
+  }
+
+  const data = await response.json();
+  let text = (data.content[0]?.text || '').trim();
+
+  // Safety: truncate if somehow over 280 chars (leaving room for URL)
+  if (text.length > 260) {
+    text = text.substring(0, 257) + '...';
+  }
+
+  return text;
+}
+
+/**
+ * Publish a post to social media via Ayrshare.
+ */
+async function publishToAyrshare(postText, url, ogImageUrl) {
+  const apiKey = process.env.AYRSHARE_API_KEY;
+  if (!apiKey) {
+    throw new Error('AYRSHARE_API_KEY environment variable is required');
+  }
+
+  const fullPost = `${postText}\n\n${url}`;
+
+  const body = {
+    post: fullPost,
+    platforms: ['twitter', 'facebook', 'linkedin', 'instagram'],
+    mediaUrls: [ogImageUrl],
+    shortenLinks: true,
+  };
+
+  const response = await fetch('https://app.ayrshare.com/api/post', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    console.error(`  Ayrshare API error (${response.status}):`, JSON.stringify(data));
+    return false;
+  }
+
+  console.log('  Ayrshare response:', JSON.stringify(data));
+  return true;
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  const { type, files } = parseArgs();
+
+  console.log(`=== Social Media Auto-Post (${type}) ===\n`);
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('Error: ANTHROPIC_API_KEY is not set');
+    process.exit(1);
+  }
+  if (!process.env.AYRSHARE_API_KEY) {
+    console.error('Error: AYRSHARE_API_KEY is not set');
+    process.exit(1);
+  }
+
+  for (const filePath of files) {
+    console.log(`Processing: ${filePath}`);
+
+    // Read and parse YAML
+    let item;
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      item = yaml.load(content);
+    } catch (err) {
+      console.error(`  Failed to read/parse ${filePath}: ${err.message}`);
+      continue;
+    }
+
+    if (!item || (!item.id && !item.slug)) {
+      console.error(`  Skipping ${filePath}: missing id/slug`);
+      continue;
+    }
+
+    const url = buildUrl(type, item);
+    const ogImageUrl = buildOgImageUrl(type, item);
+    console.log(`  URL: ${url}`);
+
+    // Generate post text
+    let postText;
+    try {
+      postText = await generatePost(type, item);
+      console.log(`  Generated post (${postText.length} chars): ${postText}`);
+    } catch (err) {
+      console.error(`  Failed to generate post: ${err.message}`);
+      continue;
+    }
+
+    // Publish via Ayrshare
+    try {
+      const success = await publishToAyrshare(postText, url, ogImageUrl);
+      if (success) {
+        console.log('  Published successfully!\n');
+      } else {
+        console.log('  Publishing failed (non-fatal).\n');
+      }
+    } catch (err) {
+      console.error(`  Ayrshare publish error: ${err.message}\n`);
+    }
+  }
+
+  console.log('=== Done ===');
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- **New script** `scripts/post-social.js` — parses YAML files, generates engaging posts with Claude Haiku (~260 chars), and publishes to X/Facebook/LinkedIn/Instagram via Ayrshare API
- **Modified** `build-news.yml` — detects newly added news files (`git diff --diff-filter=A`) and triggers social posting after deploy
- **New workflow** `build-articles.yml` — full deploy pipeline for articles (build → S3 → CloudFront → Amplify) plus social posting for new articles

## Test plan
- [ ] Add `AYRSHARE_API_KEY` to GitHub repo secrets ✅
- [ ] Test locally: `ANTHROPIC_API_KEY=... AYRSHARE_API_KEY=... node scripts/post-social.js --type news --files data/news/2026-02-23-chase-slate-name-change-balance-transfer-update.yaml`
- [ ] Verify Claude generates a concise engaging post
- [ ] Verify Ayrshare API returns success
- [ ] Push a test news item to main → confirm GH Actions runs social step
- [ ] Check X/Facebook/LinkedIn/Instagram for the published post

🤖 Generated with [Claude Code](https://claude.com/claude-code)