### PR TITLE
Add news: SoFi adding $10 monthly fee for some cardholders

### DIFF
--- a/data/news/2026-02-23-sofi-credit-card-monthly-fee.yaml
+++ b/data/news/2026-02-23-sofi-credit-card-monthly-fee.yaml
@@ -1,0 +1,37 @@
+id: "sofi-credit-card-monthly-fee"
+date: "2026-02-23"
+title: "SoFi Adding $10 Monthly Fee for Some Credit Cardholders"
+summary: "SoFi is introducing a $10 monthly fee for a subset of its Unlimited 2% Credit Card holders, effective February 23, 2026. Affected cardholders can avoid the fee by closing the account or upgrading to SoFi Plus ($10/month) for 2.2% cashback."
+tags:
+  - "fee-change"
+bank: "SoFi"
+card_name: "SoFi Unlimited 2% Credit Card"
+source: "Doctor of Credit"
+source_url: "https://www.doctorofcredit.com/sofi-adding-10-monthly-fee-for-some-credit-cardholders/"
+body: |
+  SoFi has begun notifying a select group of credit cardholders that a **$10 monthly fee** will be added to their accounts, marking a significant change for the fintech company's credit card offering. The fee applies to holders of the **SoFi Unlimited 2% Credit Card**, though SoFi says only "a small portion" of cardholders are affected.
+
+  ## What's Changing
+
+  Starting **February 23, 2026**, affected cardholders will see a **$10 monthly fee** ($120 annually) charged to their credit card account. In a notification sent to impacted users, SoFi stated:
+
+  > "Starting February 23, 2026, a $10 monthly fee will be added to your credit card account. This will help us continue to provide the benefits, protection, and service that our members expect from SoFi."
+
+  SoFi has not disclosed the criteria used to determine which cardholders will be charged the fee, and most cardholders report not receiving the notification. Customer service representatives have confirmed the fee targets only a subset of users.
+
+  ## How to Avoid the Fee
+
+  Affected cardholders have two options to avoid the new charge:
+
+  - **Close the credit card account** before the fee takes effect
+  - **Upgrade to SoFi Plus** ($10/month), which bumps the cashback rate from 2% to 2.2% and includes additional SoFi ecosystem benefits
+
+  The SoFi Plus option effectively replaces the card-specific fee with a broader membership fee that provides benefits across SoFi's product suite, including higher APY on savings accounts and reduced loan rates.
+
+  ## What This Means for Cardholders
+
+  For cardholders who don't spend enough to offset a $120 annual cost through 2% cashback, this fee significantly reduces the card's value proposition. To break even on the fee alone at 2% cashback, a cardholder would need to spend **$6,000 per year** (or $500 per month) on the card — and that's just to cover the fee, not to earn any net rewards.
+
+  Cardholders who receive the notification should carefully evaluate whether their spending justifies the fee or whether alternative no-annual-fee cashback cards offer better value. Several competitors offer flat-rate cashback of 1.5% to 2% with no monthly or annual fee.
+
+  This move is particularly notable because the SoFi Unlimited 2% card had been positioned as a straightforward, no-fee cashback option. The selective introduction of fees may signal a broader shift in SoFi's credit card strategy.


### PR DESCRIPTION
## Summary
- New news item: SoFi introducing a $10/month fee for a subset of Unlimited 2% Credit Card holders
- Source: Doctor of Credit
- This will also test the new social media auto-posting workflow

## Test plan
- [ ] Verify news.json builds cleanly
- [ ] After merge, check GitHub Actions for the social media posting step
- [ ] Verify post appears on social platforms via Ayrshare dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)