### PR TITLE
Remove Instagram from social media auto-posting

### DIFF
--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -131,7 +131,7 @@ async function publishToAyrshare(postText, url, ogImageUrl) {
 
   const body = {
     post: fullPost,
-    platforms: ['twitter', 'facebook', 'linkedin', 'instagram'],
+    platforms: ['twitter', 'facebook', 'linkedin'],
     mediaUrls: [ogImageUrl],
     shortenLinks: true,
   };


### PR DESCRIPTION
## Summary
- Remove Instagram from Ayrshare platforms list since it's not linked, causing 400 errors on every post

## Test plan
- [ ] Next news push should post to X, Facebook, LinkedIn without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)