### PR TITLE
Add Reddit auto-posting to r/creditodds

### DIFF
--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -131,9 +131,13 @@ async function publishToAyrshare(postText, url, ogImageUrl) {
 
   const body = {
     post: fullPost,
-    platforms: ['twitter', 'facebook', 'linkedin'],
+    platforms: ['twitter', 'facebook', 'linkedin', 'reddit'],
     mediaUrls: [ogImageUrl],
     shortenLinks: true,
+    redditOptions: {
+      title: postText,
+      subreddit: 'creditodds',
+    },
   };
 
   const response = await fetch('https://app.ayrshare.com/api/post', {


### PR DESCRIPTION
## Summary
- Add Reddit to the Ayrshare platforms list
- Posts go to r/creditodds with the generated text as the title and the article URL as the link

## Test plan
- [ ] Ensure Reddit is linked in the Ayrshare dashboard
- [ ] Next news push should post to X, Facebook, LinkedIn, and Reddit

🤖 Generated with [Claude Code](https://claude.com/claude-code)