### PR TITLE
Fix profile tabs horizontal scroll on mobile

### DIFF
--- a/apps/web-next/src/app/globals.css
+++ b/apps/web-next/src/app/globals.css
@@ -4,6 +4,7 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  overflow-x: hidden;
 }
 
 /* Accessibility: Improved focus styles */

--- a/apps/web-next/src/app/globals.css
+++ b/apps/web-next/src/app/globals.css
@@ -71,3 +71,12 @@ body {
 .animate-ticker:hover {
   animation-play-state: paused;
 }
+
+/* Hide scrollbar while keeping scroll functionality */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -464,8 +464,8 @@ export default function ProfileClient() {
         </div>
 
         {/* Tabs */}
-        <div className="border-b border-gray-200 mb-6">
-          <nav className="-mb-px flex space-x-4 sm:space-x-8">
+        <div className="border-b border-gray-200 mb-6 overflow-x-auto scrollbar-hide">
+          <nav className="-mb-px flex space-x-4 sm:space-x-8 whitespace-nowrap">
             <button
               onClick={() => setActiveTab('wallet')}
               className={`flex items-center gap-2 py-4 px-1 border-b-2 font-medium text-sm ${


### PR DESCRIPTION
## Summary
- Add `overflow-x-auto` to tab container so tabs scroll within their own area
- Add `whitespace-nowrap` to prevent tabs from wrapping
- Add `scrollbar-hide` utility to keep the UI clean (no visible scrollbar)
- Prevents the entire page from scrolling horizontally when the Advanced tab is off-screen

## Test plan
- [ ] On mobile, swipe left/right on the tab bar to see all tabs
- [ ] Verify the page itself does not scroll horizontally
- [ ] Verify no visible scrollbar on the tab row

🤖 Generated with [Claude Code](https://claude.com/claude-code)