### PR TITLE
Add Check Your Odds feature

### DIFF
--- a/apps/api/migrations/007_create_approval_searches.sql
+++ b/apps/api/migrations/007_create_approval_searches.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS approval_searches (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL,
+  credit_score INT NOT NULL,
+  income INT NOT NULL,
+  length_credit INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_user_id (user_id),
+  UNIQUE KEY unique_user_search (user_id, credit_score, income, length_credit)
+);

--- a/apps/api/src/handlers/check-odds.js
+++ b/apps/api/src/handlers/check-odds.js
@@ -1,0 +1,330 @@
+const https = require('https');
+
+const mysql = require("serverless-mysql")({
+  config: {
+    host: process.env.ENDPOINT,
+    database: process.env.DATABASE,
+    user: process.env.USERNAME,
+    password: process.env.PASSWORD,
+  },
+});
+
+const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+// Fetch cards.json from CloudFront
+async function fetchCardsFromCDN() {
+  return new Promise((resolve, reject) => {
+    https.get(CARDS_URL, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          resolve(json.cards);
+        } catch (err) {
+          reject(new Error('Failed to parse cards.json'));
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+// Fetch card stats and metadata from MySQL
+async function fetchCardStatsAndMetadata() {
+  const [statsResults, cardResults] = await Promise.all([
+    mysql.query(`
+      SELECT
+        card_id,
+        COUNT(*) as total_records,
+        SUM(CASE WHEN result = 1 THEN 1 ELSE 0 END) as approved_count,
+        SUM(CASE WHEN result = 0 THEN 1 ELSE 0 END) as rejected_count
+      FROM records
+      WHERE admin_review = 1
+      GROUP BY card_id
+    `),
+    mysql.query(`
+      SELECT card_id, card_name, card_image_link, accepting_applications, tags
+      FROM cards
+    `)
+  ]);
+
+  const statsMap = {};
+  for (const row of statsResults) {
+    statsMap[row.card_id] = row;
+  }
+
+  const cardMap = {};
+  for (const row of cardResults) {
+    let tags = row.tags;
+    if (typeof tags === 'string') {
+      try { tags = JSON.parse(tags); } catch (e) { tags = null; }
+    }
+    cardMap[row.card_name] = {
+      db_card_id: row.card_id,
+      card_image_link: row.card_image_link,
+      accepting_applications: row.accepting_applications === 1,
+      tags: tags || []
+    };
+  }
+
+  return { statsMap, cardMap };
+}
+
+// Compute medians for all cards using ROW_NUMBER() CTEs
+async function fetchApprovedMedians() {
+  const [creditScoreResults, incomeResults, lengthCreditResults] = await Promise.all([
+    mysql.query(`
+      WITH ranked AS (
+        SELECT card_id, credit_score,
+          ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY credit_score) AS rn,
+          COUNT(*) OVER (PARTITION BY card_id) AS cnt
+        FROM records
+        WHERE admin_review = 1 AND result = 1
+      )
+      SELECT card_id,
+        AVG(credit_score) AS median_credit_score,
+        MAX(cnt) AS approved_count
+      FROM ranked
+      WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
+      GROUP BY card_id
+    `),
+    mysql.query(`
+      WITH ranked AS (
+        SELECT card_id, listed_income,
+          ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY listed_income) AS rn,
+          COUNT(*) OVER (PARTITION BY card_id) AS cnt
+        FROM records
+        WHERE admin_review = 1 AND result = 1
+      )
+      SELECT card_id,
+        AVG(listed_income) AS median_income
+      FROM ranked
+      WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
+      GROUP BY card_id
+    `),
+    mysql.query(`
+      WITH ranked AS (
+        SELECT card_id, length_credit,
+          ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY length_credit) AS rn,
+          COUNT(*) OVER (PARTITION BY card_id) AS cnt
+        FROM records
+        WHERE admin_review = 1 AND result = 1
+      )
+      SELECT card_id,
+        AVG(length_credit) AS median_length_credit
+      FROM ranked
+      WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
+      GROUP BY card_id
+    `)
+  ]);
+
+  const medianMap = {};
+
+  for (const row of creditScoreResults) {
+    medianMap[row.card_id] = {
+      median_credit_score: Math.round(row.median_credit_score),
+      approved_count: row.approved_count,
+    };
+  }
+  for (const row of incomeResults) {
+    if (medianMap[row.card_id]) {
+      medianMap[row.card_id].median_income = Math.round(row.median_income);
+    }
+  }
+  for (const row of lengthCreditResults) {
+    if (medianMap[row.card_id]) {
+      medianMap[row.card_id].median_length_credit = Math.round(row.median_length_credit);
+    }
+  }
+
+  return medianMap;
+}
+
+// Validate input
+function validateInput(body) {
+  const errors = [];
+
+  if (body.credit_score == null || typeof body.credit_score !== 'number') {
+    errors.push('credit_score is required and must be a number');
+  } else if (body.credit_score < 300 || body.credit_score > 850) {
+    errors.push('credit_score must be between 300 and 850');
+  }
+
+  if (body.income == null || typeof body.income !== 'number') {
+    errors.push('income is required and must be a number');
+  } else if (body.income < 0) {
+    errors.push('income must be 0 or greater');
+  }
+
+  if (body.length_credit == null || typeof body.length_credit !== 'number') {
+    errors.push('length_credit is required and must be a number');
+  } else if (body.length_credit < 0 || body.length_credit > 100) {
+    errors.push('length_credit must be between 0 and 100');
+  }
+
+  return errors;
+}
+
+exports.CheckOddsHandler = async (event) => {
+  console.info("CheckOdds received:", event);
+
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ statusText: "OK" }),
+    };
+  }
+
+  const userId = event.requestContext?.authorizer?.sub;
+  if (!userId) {
+    return {
+      statusCode: 401,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: "Unauthorized" }),
+    };
+  }
+
+  switch (event.httpMethod) {
+    case "POST": {
+      try {
+        const body = JSON.parse(event.body || '{}');
+        const errors = validateInput(body);
+        if (errors.length > 0) {
+          return {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ errors }),
+          };
+        }
+
+        const { credit_score, income, length_credit } = body;
+
+        // Save search (deduplicated by unique key)
+        await mysql.query(
+          `INSERT IGNORE INTO approval_searches (user_id, credit_score, income, length_credit)
+           VALUES (?, ?, ?, ?)`,
+          [userId, credit_score, income, length_credit]
+        );
+
+        // Fetch all data in parallel
+        const [cards, { statsMap, cardMap }, medianMap] = await Promise.all([
+          fetchCardsFromCDN(),
+          fetchCardStatsAndMetadata(),
+          fetchApprovedMedians(),
+        ]);
+
+        await mysql.end();
+
+        // Merge and enrich card data
+        const enrichedCards = cards
+          .filter(card => {
+            const dbCard = cardMap[card.card_name] || cardMap[card.name] || {};
+            return dbCard.accepting_applications !== false && card.accepting_applications !== false;
+          })
+          .map(card => {
+            const dbCard = cardMap[card.card_name] || cardMap[card.name] || {};
+            const stats = statsMap[dbCard.db_card_id] || {};
+            const medians = medianMap[dbCard.db_card_id] || {};
+
+            const approvedCount = medians.approved_count || 0;
+            const hasEnoughData = approvedCount >= 5;
+
+            let matchScore = 0;
+            if (hasEnoughData) {
+              if (credit_score >= medians.median_credit_score) matchScore++;
+              if (income >= medians.median_income) matchScore++;
+              if (length_credit >= medians.median_length_credit) matchScore++;
+            }
+
+            return {
+              card_id: card.card_id,
+              card_name: card.card_name,
+              slug: card.slug,
+              bank: card.bank,
+              card_image_link: dbCard.card_image_link || card.image || null,
+              annual_fee: card.annual_fee,
+              reward_type: card.reward_type,
+              tags: dbCard.tags || card.tags || [],
+              approved_count: stats.approved_count || 0,
+              total_records: stats.total_records || 0,
+              approved_data_points: approvedCount,
+              has_enough_data: hasEnoughData,
+              median_credit_score: hasEnoughData ? medians.median_credit_score : null,
+              median_income: hasEnoughData ? medians.median_income : null,
+              median_length_credit: hasEnoughData ? medians.median_length_credit : null,
+              above_credit_score: hasEnoughData ? credit_score >= medians.median_credit_score : null,
+              above_income: hasEnoughData ? income >= medians.median_income : null,
+              above_length_credit: hasEnoughData ? length_credit >= medians.median_length_credit : null,
+              match_score: matchScore,
+            };
+          });
+
+        // Sort by match score desc, then by total records desc
+        enrichedCards.sort((a, b) => {
+          if (b.match_score !== a.match_score) return b.match_score - a.match_score;
+          if (b.has_enough_data !== a.has_enough_data) return b.has_enough_data ? 1 : -1;
+          return (b.total_records || 0) - (a.total_records || 0);
+        });
+
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({
+            cards: enrichedCards,
+            search: { credit_score, income, length_credit },
+          }),
+        };
+      } catch (error) {
+        console.error('Error in POST /check-odds:', error);
+        return {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: `Failed to check odds: ${error.message}` }),
+        };
+      }
+    }
+
+    case "GET": {
+      try {
+        const searches = await mysql.query(
+          `SELECT id, credit_score, income, length_credit, created_at
+           FROM approval_searches
+           WHERE user_id = ?
+           ORDER BY created_at DESC
+           LIMIT 20`,
+          [userId]
+        );
+        await mysql.end();
+
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify(searches),
+        };
+      } catch (error) {
+        console.error('Error in GET /check-odds:', error);
+        return {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: `Failed to fetch searches: ${error.message}` }),
+        };
+      }
+    }
+
+    default:
+      return {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: JSON.stringify({ error: `Method ${event.httpMethod} not allowed` }),
+      };
+  }
+};

--- a/apps/api/src/handlers/delete-account.js
+++ b/apps/api/src/handlers/delete-account.js
@@ -81,7 +81,13 @@ exports.DeleteAccountHandler = async (event) => {
       [userId]
     );
 
-    // 5. Anonymize records (keep data points but remove user association)
+    // 5. Delete user's approval searches
+    await mysql.query(
+      "DELETE FROM approval_searches WHERE user_id = ?",
+      [userId]
+    );
+
+    // 6. Anonymize records (keep data points but remove user association)
     // Set submitter_id to NULL to preserve data integrity while removing PII
     await mysql.query(
       "UPDATE records SET submitter_id = NULL WHERE submitter_id = ?",
@@ -90,7 +96,7 @@ exports.DeleteAccountHandler = async (event) => {
 
     await mysql.end();
 
-    // 6. Delete Firebase user account
+    // 7. Delete Firebase user account
     try {
       await admin.auth().deleteUser(userId);
       console.info(`Firebase user ${userId} deleted successfully`);

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -587,6 +587,46 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  CheckOddsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/check-odds.CheckOddsHandler
+      Runtime: nodejs18.x
+      MemorySize: 256
+      Timeout: 100
+      Description: Check approval odds across all cards for a given credit profile
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+          CardsJsonUrl: !Ref CardsJsonUrl
+      Events:
+        PostCheckOdds:
+          Type: Api
+          Properties:
+            Path: /check-odds
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        GetCheckOdds:
+          Type: Api
+          Properties:
+            Path: /check-odds
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        CheckOddsOptions:
+          Type: Api
+          Properties:
+            Path: /check-odds
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
   AdminAuditFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
+++ b/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+import { useState, useMemo, useEffect, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { useAuth } from "@/auth/AuthProvider";
+import { checkOdds, CheckOddsCard, CheckOddsResponse } from "@/lib/api";
+import { cardMatchesSearch } from "@/lib/searchAliases";
+
+type SortOption = 'match' | 'name' | 'bank';
+
+function formatIncome(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseIncome(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function CheckOddsClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { authState, getToken } = useAuth();
+
+  // Form state
+  const [creditScore, setCreditScore] = useState(searchParams.get('cs') || '');
+  const [income, setIncome] = useState(
+    searchParams.get('income') ? formatIncome(searchParams.get('income')!) : ''
+  );
+  const [lengthCredit, setLengthCredit] = useState(searchParams.get('cl') || '');
+
+  // Results state
+  const [results, setResults] = useState<CheckOddsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  // Filter state
+  const [search, setSearch] = useState('');
+  const [sortBy, setSortBy] = useState<SortOption>('match');
+
+  const handleSubmit = useCallback(async (cs?: string, inc?: string, cl?: string) => {
+    const csVal = parseInt(cs || creditScore);
+    const incVal = parseIncome(inc || income);
+    const clVal = parseInt(cl || lengthCredit);
+
+    if (!csVal || csVal < 300 || csVal > 850) {
+      setError('Credit score must be between 300 and 850');
+      return;
+    }
+    if (incVal < 0) {
+      setError('Income must be 0 or greater');
+      return;
+    }
+    if (isNaN(clVal) || clVal < 0 || clVal > 100) {
+      setError('Credit length must be between 0 and 100 years');
+      return;
+    }
+
+    // If not authenticated, redirect to login with params
+    if (!authState.isAuthenticated) {
+      const params = new URLSearchParams({
+        redirect: '/check-odds',
+        cs: csVal.toString(),
+        income: incVal.toString(),
+        cl: clVal.toString(),
+      });
+      router.push(`/login?${params.toString()}`);
+      return;
+    }
+
+    setError('');
+    setLoading(true);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error('Not authenticated');
+      const data = await checkOdds(
+        { credit_score: csVal, income: incVal, length_credit: clVal },
+        token
+      );
+      setResults(data);
+    } catch (err: unknown) {
+      const error = err as Error;
+      setError(error.message || 'Failed to check odds');
+    } finally {
+      setLoading(false);
+    }
+  }, [creditScore, income, lengthCredit, authState.isAuthenticated, getToken, router]);
+
+  // Auto-submit if URL has params and user is authenticated
+  useEffect(() => {
+    const cs = searchParams.get('cs');
+    const inc = searchParams.get('income');
+    const cl = searchParams.get('cl');
+
+    if (cs && inc && cl && authState.isAuthenticated && !authState.isLoading && !results) {
+      setCreditScore(cs);
+      setIncome(formatIncome(inc));
+      setLengthCredit(cl);
+      handleSubmit(cs, inc, cl);
+    }
+  }, [authState.isAuthenticated, authState.isLoading, searchParams, handleSubmit, results]);
+
+  // Filter and sort results
+  const filteredCards = useMemo(() => {
+    if (!results) return [];
+
+    let filtered = results.cards.filter(card =>
+      cardMatchesSearch(card.card_name, card.bank, search)
+    );
+
+    switch (sortBy) {
+      case 'match':
+        filtered.sort((a, b) => {
+          if (b.match_score !== a.match_score) return b.match_score - a.match_score;
+          if (b.has_enough_data !== a.has_enough_data) return b.has_enough_data ? 1 : -1;
+          return (b.total_records || 0) - (a.total_records || 0);
+        });
+        break;
+      case 'name':
+        filtered.sort((a, b) => a.card_name.localeCompare(b.card_name));
+        break;
+      case 'bank':
+        filtered.sort((a, b) => a.bank.localeCompare(b.bank) || a.card_name.localeCompare(b.card_name));
+        break;
+    }
+
+    return filtered;
+  }, [results, search, sortBy]);
+
+  const matchCounts = useMemo(() => {
+    if (!results) return { three: 0, two: 0, one: 0, zero: 0, noData: 0 };
+    const cards = results.cards;
+    return {
+      three: cards.filter(c => c.has_enough_data && c.match_score === 3).length,
+      two: cards.filter(c => c.has_enough_data && c.match_score === 2).length,
+      one: cards.filter(c => c.has_enough_data && c.match_score === 1).length,
+      zero: cards.filter(c => c.has_enough_data && c.match_score === 0).length,
+      noData: cards.filter(c => !c.has_enough_data).length,
+    };
+  }, [results]);
+
+  return (
+    <>
+      {/* Header */}
+      <div className="flex items-center justify-center gap-3">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-8 w-8 text-indigo-600" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+        </svg>
+        <h1 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
+          Check Your Odds
+        </h1>
+      </div>
+      <p className="mt-2 text-center text-lg text-gray-500">
+        Enter your credit profile and see how you stack up against approved applicants
+      </p>
+
+      {/* Input Form */}
+      <div className="mt-6 bg-white shadow rounded-lg p-6 max-w-2xl mx-auto">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+          className="space-y-4"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div>
+              <label htmlFor="credit-score" className="block text-sm font-medium text-gray-700">
+                Credit Score
+              </label>
+              <input
+                id="credit-score"
+                type="number"
+                min={300}
+                max={850}
+                required
+                placeholder="300-850"
+                value={creditScore}
+                onChange={(e) => setCreditScore(e.target.value)}
+                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+              />
+            </div>
+            <div>
+              <label htmlFor="income" className="block text-sm font-medium text-gray-700">
+                Annual Income
+              </label>
+              <div className="mt-1 relative">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <span className="text-gray-500 sm:text-sm">$</span>
+                </div>
+                <input
+                  id="income"
+                  type="text"
+                  inputMode="numeric"
+                  required
+                  placeholder="75,000"
+                  value={income}
+                  onChange={(e) => setIncome(formatIncome(e.target.value))}
+                  className="block w-full pl-7 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+            </div>
+            <div>
+              <label htmlFor="length-credit" className="block text-sm font-medium text-gray-700">
+                Credit History (years)
+              </label>
+              <input
+                id="length-credit"
+                type="number"
+                min={0}
+                max={100}
+                required
+                placeholder="0-100"
+                value={lengthCredit}
+                onChange={(e) => setLengthCredit(e.target.value)}
+                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-red-50 p-3">
+              <p className="text-sm text-red-800">{error}</p>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Checking...' : 'Check Odds'}
+          </button>
+
+          {!authState.isAuthenticated && (
+            <p className="text-xs text-center text-gray-500">
+              Sign in is required to view results
+            </p>
+          )}
+        </form>
+      </div>
+
+      {/* Results */}
+      {results && (
+        <>
+          {/* Summary */}
+          <div className="mt-6 grid grid-cols-2 sm:grid-cols-5 gap-3 max-w-3xl mx-auto">
+            <div className="bg-green-50 rounded-lg p-3 text-center">
+              <div className="text-2xl font-bold text-green-700">{matchCounts.three}</div>
+              <div className="text-xs text-green-600">3/3 Match</div>
+            </div>
+            <div className="bg-lime-50 rounded-lg p-3 text-center">
+              <div className="text-2xl font-bold text-lime-700">{matchCounts.two}</div>
+              <div className="text-xs text-lime-600">2/3 Match</div>
+            </div>
+            <div className="bg-amber-50 rounded-lg p-3 text-center">
+              <div className="text-2xl font-bold text-amber-700">{matchCounts.one}</div>
+              <div className="text-xs text-amber-600">1/3 Match</div>
+            </div>
+            <div className="bg-red-50 rounded-lg p-3 text-center">
+              <div className="text-2xl font-bold text-red-700">{matchCounts.zero}</div>
+              <div className="text-xs text-red-600">0/3 Match</div>
+            </div>
+            <div className="bg-gray-50 rounded-lg p-3 text-center col-span-2 sm:col-span-1">
+              <div className="text-2xl font-bold text-gray-500">{matchCounts.noData}</div>
+              <div className="text-xs text-gray-400">Collecting Data</div>
+            </div>
+          </div>
+
+          {/* Filters */}
+          <div className="mt-6 flex flex-col sm:flex-row gap-4">
+            <div className="flex-1">
+              <label htmlFor="result-search" className="sr-only">Search results</label>
+              <input
+                type="text"
+                id="result-search"
+                placeholder="Search cards..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+              />
+            </div>
+            <div className="sm:w-48">
+              <label htmlFor="result-sort" className="sr-only">Sort by</label>
+              <select
+                id="result-sort"
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as SortOption)}
+                className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+              >
+                <option value="match">Sort by Match Score</option>
+                <option value="name">Sort by Name</option>
+                <option value="bank">Sort by Bank</option>
+              </select>
+            </div>
+          </div>
+
+          <p className="mt-3 text-sm text-gray-500">
+            Showing {filteredCards.length} of {results.cards.length} cards
+          </p>
+
+          {/* Results Table */}
+          <div className="mt-4 flex flex-col -mx-4 sm:mx-0 overflow-hidden">
+            <div className="-my-2 sm:-mx-6 lg:-mx-8">
+              <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
+                <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+                  <table className="min-w-full divide-y divide-gray-300">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th scope="col" className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+                          Card
+                        </th>
+                        <th scope="col" className="px-3 py-3.5 text-center text-sm font-semibold text-gray-900 hidden sm:table-cell">
+                          Credit Score
+                        </th>
+                        <th scope="col" className="px-3 py-3.5 text-center text-sm font-semibold text-gray-900 hidden sm:table-cell">
+                          Income
+                        </th>
+                        <th scope="col" className="px-3 py-3.5 text-center text-sm font-semibold text-gray-900 hidden sm:table-cell">
+                          Credit History
+                        </th>
+                        <th scope="col" className="px-3 py-3.5 text-center text-sm font-semibold text-gray-900 sm:hidden">
+                          Match
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 bg-white">
+                      {filteredCards.length === 0 ? (
+                        <tr>
+                          <td colSpan={5} className="py-12 text-center text-gray-500">
+                            No cards match your search.
+                          </td>
+                        </tr>
+                      ) : (
+                        filteredCards.map((card) => (
+                          <tr key={card.card_id} className="hover:bg-gray-50">
+                            <td className="py-3 pl-3 pr-2 sm:py-4 sm:pl-6 sm:pr-3">
+                              <Link href={`/card/${card.slug}`} className="flex items-center group">
+                                <div className="h-8 w-12 sm:h-10 sm:w-16 flex-shrink-0 mr-3">
+                                  <Image
+                                    src={card.card_image_link
+                                      ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                                      : '/assets/generic-card.svg'}
+                                    alt={card.card_name}
+                                    width={64}
+                                    height={40}
+                                    className="h-8 w-12 sm:h-10 sm:w-16 object-contain"
+                                  />
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                  <div className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">
+                                    {card.card_name}
+                                  </div>
+                                  <div className="text-xs text-gray-500">{card.bank}</div>
+                                </div>
+                              </Link>
+                            </td>
+                            {card.has_enough_data ? (
+                              <>
+                                {/* Desktop columns */}
+                                <td className="whitespace-nowrap px-3 py-4 text-center text-sm hidden sm:table-cell">
+                                  <MedianIndicator
+                                    value={results.search.credit_score}
+                                    median={card.median_credit_score!}
+                                    isAbove={card.above_credit_score!}
+                                  />
+                                </td>
+                                <td className="whitespace-nowrap px-3 py-4 text-center text-sm hidden sm:table-cell">
+                                  <MedianIndicator
+                                    value={results.search.income}
+                                    median={card.median_income!}
+                                    isAbove={card.above_income!}
+                                    isCurrency
+                                  />
+                                </td>
+                                <td className="whitespace-nowrap px-3 py-4 text-center text-sm hidden sm:table-cell">
+                                  <MedianIndicator
+                                    value={results.search.length_credit}
+                                    median={card.median_length_credit!}
+                                    isAbove={card.above_length_credit!}
+                                    suffix=" yr"
+                                  />
+                                </td>
+                                {/* Mobile column */}
+                                <td className="whitespace-nowrap px-3 py-4 text-center text-sm sm:hidden">
+                                  <MatchBadge score={card.match_score} />
+                                </td>
+                              </>
+                            ) : (
+                              <>
+                                <td colSpan={3} className="whitespace-nowrap px-3 py-4 text-center text-sm text-gray-400 italic hidden sm:table-cell">
+                                  Still collecting results ({card.approved_data_points}/5 approved)
+                                </td>
+                                <td className="whitespace-nowrap px-3 py-4 text-center text-sm text-gray-400 italic sm:hidden">
+                                  N/A
+                                </td>
+                              </>
+                            )}
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+function MedianIndicator({
+  value,
+  median,
+  isAbove,
+  isCurrency,
+  suffix,
+}: {
+  value: number;
+  median: number;
+  isAbove: boolean;
+  isCurrency?: boolean;
+  suffix?: string;
+}) {
+  const formatVal = (n: number) => {
+    if (isCurrency) return `$${n.toLocaleString()}`;
+    return `${n.toLocaleString()}${suffix || ''}`;
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <span className={`inline-flex items-center text-xs font-medium ${isAbove ? 'text-green-700' : 'text-red-700'}`}>
+        {isAbove ? (
+          <svg className="w-3 h-3 mr-0.5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clipRule="evenodd" /></svg>
+        ) : (
+          <svg className="w-3 h-3 mr-0.5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" /></svg>
+        )}
+        {isAbove ? 'Above' : 'Below'}
+      </span>
+      <span className="text-xs text-gray-500 mt-0.5">
+        median {formatVal(median)}
+      </span>
+    </div>
+  );
+}
+
+function MatchBadge({ score }: { score: number }) {
+  const colors = {
+    3: 'bg-green-100 text-green-800',
+    2: 'bg-lime-100 text-lime-800',
+    1: 'bg-amber-100 text-amber-800',
+    0: 'bg-red-100 text-red-800',
+  };
+
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ${colors[score as keyof typeof colors] || colors[0]}`}>
+      {score}/3
+    </span>
+  );
+}

--- a/apps/web-next/src/app/check-odds/page.tsx
+++ b/apps/web-next/src/app/check-odds/page.tsx
@@ -1,0 +1,51 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { Suspense } from "react";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
+import CheckOddsClient from "./CheckOddsClient";
+
+export const metadata: Metadata = {
+  title: "Check Your Odds",
+  description: "Enter your credit profile and see how you compare against approved applicants for every credit card. Find out which cards you're most likely to be approved for.",
+  openGraph: {
+    title: "Check Your Odds | CreditOdds",
+    description: "See your approval chances across all credit cards based on your credit profile.",
+  },
+};
+
+export default function CheckOddsPage() {
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Check Your Odds', url: 'https://creditodds.com/check-odds' }
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">
+                Home
+              </Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500">Check Your Odds</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        <Suspense>
+          <CheckOddsClient />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -49,6 +49,17 @@ export default function Navbar() {
                     Explore Cards
                   </Link>
                   <Link
+                    href="/check-odds"
+                    className={classNames(
+                      isActive('/check-odds')
+                        ? 'border-indigo-500 text-gray-900'
+                        : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+                      'inline-flex items-center px-1 pt-1 border-b-2 text-md font-medium'
+                    )}
+                  >
+                    Check Your Odds
+                  </Link>
+                  <Link
                     href="/news"
                     className={classNames(
                       isActive('/news')
@@ -171,6 +182,18 @@ export default function Navbar() {
                 )}
               >
                 Explore Cards
+              </Link>
+              <Link
+                href="/check-odds"
+                onClick={() => close()}
+                className={classNames(
+                  isActive('/check-odds')
+                    ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+                    : 'border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700',
+                  'block pl-3 pr-4 py-2 border-l-4 text-base font-medium'
+                )}
+              >
+                Check Your Odds
               </Link>
               <Link
                 href="/news"

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -336,6 +336,77 @@ export async function deleteAccount(token: string): Promise<{ message: string }>
   return res.json();
 }
 
+// Check Odds types and API functions
+export interface CheckOddsCard {
+  card_id: string | number;
+  card_name: string;
+  slug: string;
+  bank: string;
+  card_image_link?: string;
+  annual_fee?: number;
+  reward_type?: string;
+  tags?: string[];
+  approved_count: number;
+  total_records: number;
+  approved_data_points: number;
+  has_enough_data: boolean;
+  median_credit_score: number | null;
+  median_income: number | null;
+  median_length_credit: number | null;
+  above_credit_score: boolean | null;
+  above_income: boolean | null;
+  above_length_credit: boolean | null;
+  match_score: number;
+}
+
+export interface CheckOddsResponse {
+  cards: CheckOddsCard[];
+  search: {
+    credit_score: number;
+    income: number;
+    length_credit: number;
+  };
+}
+
+export interface ApprovalSearch {
+  id: number;
+  credit_score: number;
+  income: number;
+  length_credit: number;
+  created_at: string;
+}
+
+export async function checkOdds(
+  data: { credit_score: number; income: number; length_credit: number },
+  token: string
+): Promise<CheckOddsResponse> {
+  const res = await fetch(`${API_BASE}/check-odds`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to check odds: ${errorText}`);
+  }
+  return res.json();
+}
+
+export async function getApprovalSearches(token: string): Promise<ApprovalSearch[]> {
+  const res = await fetch(`${API_BASE}/check-odds`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to fetch searches: ${errorText}`);
+  }
+  return res.json();
+}
+
 // ============ ADMIN API FUNCTIONS ============
 
 // Admin Stats


### PR DESCRIPTION
## Summary
- New `/check-odds` page where users enter their credit profile (credit score, income, credit history) and see how they compare against approved applicants for every card
- Auth-gated results: unauthenticated users are redirected to login, then auto-redirected back with params preserved for auto-submit
- Backend computes batch medians using `ROW_NUMBER() OVER (PARTITION BY ...)` CTEs across all cards in parallel
- Cards with <5 approved data points show "Still collecting results"
- Results table with green/red above/below median indicators (desktop) and match score badges (mobile)
- New `approval_searches` DB table deduplicates identical searches per user (migration already deployed)
- Login page now supports `redirect` query param instead of hardcoded `/profile`
- "Check Your Odds" link added to navbar (desktop + mobile)
- Delete account handler cleans up `approval_searches` records

## Test plan
- [ ] Visit `/check-odds`, verify form renders with credit score, income, and credit history fields
- [ ] Submit without signing in — verify redirect to `/login?redirect=/check-odds&cs=X&income=Y&cl=Z`
- [ ] Sign in — verify auto-redirect back to `/check-odds` with results auto-loaded
- [ ] Verify cards with sufficient data show green/red median indicators
- [ ] Verify cards with <5 approved data points show "Still collecting results"
- [ ] Verify search and sort filters work on results
- [ ] Verify navbar link appears between "Explore Cards" and "Card News" on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)