### PR TITLE
Fix bank rule tooltip clipped by table overflow

### DIFF
--- a/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
+++ b/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -590,31 +591,63 @@ function RuleProgressBar({ rule, size }: { rule: RuleResult; size: 'sm' | 'md' }
   );
 }
 
+function Tooltip({ text, children }: { text: string; children: React.ReactNode }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [show, setShow] = useState(false);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+
+  const handleEnter = () => {
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setPos({ top: rect.top - 6, left: rect.left + rect.width / 2 });
+    }
+    setShow(true);
+  };
+
+  return (
+    <span
+      ref={ref}
+      onMouseEnter={handleEnter}
+      onMouseLeave={() => setShow(false)}
+      className="cursor-default"
+    >
+      {children}
+      {show && createPortal(
+        <div
+          style={{ position: 'fixed', top: pos.top, left: pos.left, transform: 'translate(-50%, -100%)' }}
+          className="pointer-events-none z-50 w-48 rounded bg-gray-900 px-2 py-1.5 text-xs text-white text-center"
+        >
+          {text}
+        </div>,
+        document.body
+      )}
+    </span>
+  );
+}
+
 function RuleCaution({ rule, size }: { rule: RuleResult; size: 'sm' | 'md' }) {
   const tooltip = `Add cards to your wallet to track progress towards ${rule.ruleName}`;
 
   if (size === 'sm') {
     return (
-      <span className="relative group/tip text-[11px] text-amber-600 cursor-default">
-        &#9888; {rule.ruleName}
-        <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden group-hover/tip:block w-44 rounded bg-gray-900 px-2 py-1 text-[10px] text-white text-center z-10">
-          {tooltip}
+      <Tooltip text={tooltip}>
+        <span className="text-[11px] text-amber-600">
+          &#9888; {rule.ruleName}
         </span>
-      </span>
+      </Tooltip>
     );
   }
 
   return (
-    <div className="relative group/tip flex flex-col items-center gap-0.5 cursor-default">
-      <span className="text-xs text-amber-600">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 inline -mt-0.5">
-          <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 6a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 6Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
-        </svg>
-        {' '}{rule.ruleName}
-      </span>
-      <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden group-hover/tip:block w-48 rounded bg-gray-900 px-2 py-1.5 text-xs text-white text-center z-10">
-        {tooltip}
-      </span>
-    </div>
+    <Tooltip text={tooltip}>
+      <div className="flex flex-col items-center gap-0.5">
+        <span className="text-xs text-amber-600">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 inline -mt-0.5">
+            <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 6a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 6Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+          </svg>
+          {' '}{rule.ruleName}
+        </span>
+      </div>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces CSS absolute-positioned tooltip with a portal-based tooltip rendered on `document.body`
- The table wrapper has `overflow-hidden` for rounded corners/shadow, which was clipping the tooltip at the table edge
- Portal + `position: fixed` renders the tooltip above the page overlay, independent of any parent overflow

## Test plan
- [ ] Hover over amber caution icon in Bank Rules column — tooltip appears fully visible above the icon
- [ ] Tooltip is not clipped by table edges
- [ ] Works on both desktop column and mobile inline views
- [ ] Tooltip disappears when mouse leaves the icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)