### PR TITLE
Add Tools section with miles-to-USD converters

### DIFF
--- a/apps/web-next/src/app/sitemap.ts
+++ b/apps/web-next/src/app/sitemap.ts
@@ -40,6 +40,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.85,
     },
     {
+      url: `${baseUrl}/tools`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/tools/united-miles-to-usd`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/tools/delta-skymiles-to-usd`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/leaderboard`,
       lastModified: new Date(),
       changeFrequency: 'daily',

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/ConverterClient.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+
+const CENTS_PER_MILE = 1.1;
+const RATE = CENTS_PER_MILE / 100; // 0.011
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [miles, setMiles] = useState('');
+
+  const milesValue = parseNumber(miles);
+  const usdValue = milesValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="miles" className="block text-sm font-medium text-gray-700">
+          Delta SkyMiles
+        </label>
+        <div className="mt-1">
+          <input
+            id="miles"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={miles}
+            onChange={(e) => setMiles(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {milesValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(milesValue))} miles &times; {CENTS_PER_MILE}&cent; per mile
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_MILE} cents per mile. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
@@ -1,0 +1,56 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Delta SkyMiles to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Delta SkyMiles to their estimated USD value. Free calculator using the standard 1.1 cents per mile valuation.',
+};
+
+export default function DeltaSkyMilesToUsdPage() {
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Delta SkyMiles to USD', url: 'https://creditodds.com/tools/delta-skymiles-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500">Delta SkyMiles to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Delta SkyMiles to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Delta SkyMiles.
+        </p>
+
+        <ConverterClient />
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/page.tsx
+++ b/apps/web-next/src/app/tools/page.tsx
@@ -1,0 +1,85 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+
+export const metadata: Metadata = {
+  title: 'Tools | CreditOdds',
+  description: 'Free credit card tools and calculators. Convert miles to dollars, estimate point values, and more.',
+};
+
+const tools = [
+  {
+    name: 'United Miles to USD',
+    description: 'Convert United MileagePlus miles to their estimated dollar value.',
+    href: '/tools/united-miles-to-usd',
+    icon: (
+      <svg className="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+      </svg>
+    ),
+  },
+  {
+    name: 'Delta SkyMiles to USD',
+    description: 'Convert Delta SkyMiles to their estimated dollar value.',
+    href: '/tools/delta-skymiles-to-usd',
+    icon: (
+      <svg className="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+      </svg>
+    ),
+  },
+];
+
+export default function ToolsPage() {
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500">Tools</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Tools</h1>
+        <p className="mt-2 text-gray-600">Free calculators and converters for credit card rewards.</p>
+
+        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {tools.map((tool) => (
+            <Link
+              key={tool.href}
+              href={tool.href}
+              className="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow group"
+            >
+              <div className="flex items-center gap-4">
+                {tool.icon}
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900 group-hover:text-indigo-600">
+                    {tool.name}
+                  </h2>
+                  <p className="mt-1 text-sm text-gray-500">{tool.description}</p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/united-miles-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/ConverterClient.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+
+const CENTS_PER_MILE = 1.2;
+const RATE = CENTS_PER_MILE / 100; // 0.012
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [miles, setMiles] = useState('');
+
+  const milesValue = parseNumber(miles);
+  const usdValue = milesValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="miles" className="block text-sm font-medium text-gray-700">
+          United MileagePlus Miles
+        </label>
+        <div className="mt-1">
+          <input
+            id="miles"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={miles}
+            onChange={(e) => setMiles(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {milesValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(milesValue))} miles &times; {CENTS_PER_MILE}&cent; per mile
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_MILE} cents per mile. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
@@ -1,0 +1,56 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'United Miles to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert United MileagePlus miles to their estimated USD value. Free calculator using the standard 1.2 cents per mile valuation.',
+};
+
+export default function UnitedMilesToUsdPage() {
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'United Miles to USD', url: 'https://creditodds.com/tools/united-miles-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500">United Miles to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">United Miles to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your United MileagePlus miles.
+        </p>
+
+        <ConverterClient />
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -70,6 +70,17 @@ export default function Navbar() {
                   >
                     Card News
                   </Link>
+                  <Link
+                    href="/tools"
+                    className={classNames(
+                      isActive('/tools')
+                        ? 'border-indigo-500 text-gray-900'
+                        : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+                      'inline-flex items-center px-1 pt-1 border-b-2 text-md font-medium'
+                    )}
+                  >
+                    Tools
+                  </Link>
                 </nav>
               </div>
               <div className="hidden sm:ml-6 sm:flex sm:items-center">
@@ -206,6 +217,18 @@ export default function Navbar() {
                 )}
               >
                 Card News
+              </Link>
+              <Link
+                href="/tools"
+                onClick={() => close()}
+                className={classNames(
+                  isActive('/tools')
+                    ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+                    : 'border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700',
+                  'block pl-3 pr-4 py-2 border-l-4 text-base font-medium'
+                )}
+              >
+                Tools
               </Link>
             </nav>
             <div className="pb-3 border-t border-gray-200">


### PR DESCRIPTION
## Summary
- Adds a new `/tools` section with an index page listing available calculators
- Adds United MileagePlus to USD converter (1.2 cents/mile)
- Adds Delta SkyMiles to USD converter (1.1 cents/mile)
- Adds "Tools" link to desktop and mobile navbar
- Adds tools pages to sitemap

## Test plan
- [ ] Visit `/tools` — index page shows both converter cards
- [ ] Click through to `/tools/united-miles-to-usd` — type 10,000 → shows $120.00
- [ ] Click through to `/tools/delta-skymiles-to-usd` — type 10,000 → shows $110.00
- [ ] Navbar shows "Tools" link on desktop and mobile, highlights on /tools pages
- [ ] Breadcrumbs navigate correctly on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)