### PR TITLE
Hide Tools link from navbar

### DIFF
--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -70,17 +70,6 @@ export default function Navbar() {
                   >
                     Card News
                   </Link>
-                  <Link
-                    href="/tools"
-                    className={classNames(
-                      isActive('/tools')
-                        ? 'border-indigo-500 text-gray-900'
-                        : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
-                      'inline-flex items-center px-1 pt-1 border-b-2 text-md font-medium'
-                    )}
-                  >
-                    Tools
-                  </Link>
                 </nav>
               </div>
               <div className="hidden sm:ml-6 sm:flex sm:items-center">
@@ -217,18 +206,6 @@ export default function Navbar() {
                 )}
               >
                 Card News
-              </Link>
-              <Link
-                href="/tools"
-                onClick={() => close()}
-                className={classNames(
-                  isActive('/tools')
-                    ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
-                    : 'border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700',
-                  'block pl-3 pr-4 py-2 border-l-4 text-base font-medium'
-                )}
-              >
-                Tools
               </Link>
             </nav>
             <div className="pb-3 border-t border-gray-200">


### PR DESCRIPTION
## Summary
- Removes Tools link from desktop and mobile navbar
- Tools pages remain accessible via direct URL

The previous squash merge didn't include this removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)