### PR TITLE
Add related cards and news to miles converter pages

### DIFF
--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -130,7 +130,7 @@ export default async function ArticlePage({ params }: Props) {
         {/* Breadcrumbs */}
         <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <ol className="flex items-center space-x-4 py-4">
+            <ol className="flex items-center space-x-4 py-4 overflow-hidden">
               <li>
                 <Link href="/" className="text-gray-400 hover:text-gray-500">
                   Home
@@ -151,7 +151,7 @@ export default async function ArticlePage({ params }: Props) {
                   <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
                     <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                   </svg>
-                  <span className="ml-4 text-sm font-medium text-gray-500 truncate sm:whitespace-normal">
+                  <span className="ml-4 text-sm font-medium text-gray-500 truncate">
                     {article.title}
                   </span>
                 </div>

--- a/apps/web-next/src/app/articles/author/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/author/[slug]/page.tsx
@@ -62,7 +62,7 @@ export default async function AuthorPage({ params }: Props) {
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <ol className="flex items-center space-x-4 py-4">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
             <li>
               <Link href="/" className="text-gray-400 hover:text-gray-500">
                 Home
@@ -83,7 +83,7 @@ export default async function AuthorPage({ params }: Props) {
                 <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                 </svg>
-                <span className="ml-4 text-sm font-medium text-gray-500">{author.name}</span>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">{author.name}</span>
               </div>
             </li>
           </ol>

--- a/apps/web-next/src/app/articles/category/[tag]/page.tsx
+++ b/apps/web-next/src/app/articles/category/[tag]/page.tsx
@@ -59,7 +59,7 @@ export default async function CategoryPage({ params }: Props) {
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <ol className="flex items-center space-x-4 py-4">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
             <li>
               <Link href="/" className="text-gray-400 hover:text-gray-500">
                 Home
@@ -80,7 +80,7 @@ export default async function CategoryPage({ params }: Props) {
                 <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                 </svg>
-                <span className="ml-4 text-sm font-medium text-gray-500">{tagLabel}</span>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">{tagLabel}</span>
               </div>
             </li>
           </ol>

--- a/apps/web-next/src/app/bank/[name]/page.tsx
+++ b/apps/web-next/src/app/bank/[name]/page.tsx
@@ -69,7 +69,7 @@ export default async function BankPage({ params }: BankPageProps) {
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <ol className="flex items-center space-x-4 py-4">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
             <li>
               <Link href="/" className="text-gray-400 hover:text-gray-500">
                 Home
@@ -80,7 +80,7 @@ export default async function BankPage({ params }: BankPageProps) {
                 <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                 </svg>
-                <span className="ml-4 text-sm font-medium text-gray-500">{bankName}</span>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">{bankName}</span>
               </div>
             </li>
           </ol>

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -134,7 +134,7 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
-          <ol className="flex items-center space-x-4 py-4">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
             <li>
               <Link href="/" className="text-gray-400 hover:text-gray-500">
                 Home
@@ -155,7 +155,7 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
                 <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                 </svg>
-                <span className="ml-4 text-sm font-medium text-gray-500">{card.card_name}</span>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">{card.card_name}</span>
               </div>
             </li>
           </ol>

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -107,7 +107,7 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <ol className="flex items-center space-x-4 py-4">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
             <li>
               <Link href="/" className="text-gray-400 hover:text-gray-500">
                 Home
@@ -128,7 +128,7 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
                 <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                 </svg>
-                <span className="ml-4 text-sm font-medium text-gray-500 truncate sm:whitespace-normal">
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">
                   {item.title}
                 </span>
               </div>

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
@@ -1,6 +1,9 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import Image from 'next/image';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 
 export const metadata: Metadata = {
@@ -8,7 +11,17 @@ export const metadata: Metadata = {
   description: 'Convert Delta SkyMiles to their estimated USD value. Free calculator using the standard 1.1 cents per mile valuation.',
 };
 
-export default function DeltaSkyMilesToUsdPage() {
+export default async function DeltaSkyMilesToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('delta') && c.accepting_applications
+  );
+  const news = allNews.filter(n =>
+    n.title.toLowerCase().includes('delta') ||
+    n.summary.toLowerCase().includes('delta')
+  );
+
   return (
     <div className="bg-gray-50 min-h-screen">
       <BreadcrumbSchema items={[
@@ -50,6 +63,66 @@ export default function DeltaSkyMilesToUsdPage() {
         </p>
 
         <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Delta Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Delta News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
@@ -1,6 +1,9 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import Image from 'next/image';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 
 export const metadata: Metadata = {
@@ -8,7 +11,17 @@ export const metadata: Metadata = {
   description: 'Convert United MileagePlus miles to their estimated USD value. Free calculator using the standard 1.2 cents per mile valuation.',
 };
 
-export default function UnitedMilesToUsdPage() {
+export default async function UnitedMilesToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('united') && c.accepting_applications
+  );
+  const news = allNews.filter(n =>
+    n.title.toLowerCase().includes('united') ||
+    n.summary.toLowerCase().includes('united')
+  );
+
   return (
     <div className="bg-gray-50 min-h-screen">
       <BreadcrumbSchema items={[
@@ -50,6 +63,66 @@ export default function UnitedMilesToUsdPage() {
         </p>
 
         <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">United Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">United News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- United converter page now shows United credit cards and United-related news articles
- Delta converter page now shows Delta credit cards and Delta-related news articles
- Cards filtered by name match + active status, news filtered by title/summary match
- Server-side data fetching with ISR caching

## Test plan
- [ ] `/tools/united-miles-to-usd` — shows United cards grid and any United news below the converter
- [ ] `/tools/delta-skymiles-to-usd` — shows Delta cards grid and any Delta news below the converter
- [ ] Card links navigate to correct card pages
- [ ] News articles with body link to article page, others show title only

🤖 Generated with [Claude Code](https://claude.com/claude-code)