### PR TITLE
Replace Ayrshare with direct Twitter/X posting

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -79,5 +79,8 @@ jobs:
         if: steps.new-files.outputs.files != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          AYRSHARE_API_KEY: ${{ secrets.AYRSHARE_API_KEY }}
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
         run: node scripts/post-social.js --type article --files ${{ steps.new-files.outputs.files }}

--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -79,5 +79,8 @@ jobs:
         if: steps.new-files.outputs.files != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          AYRSHARE_API_KEY: ${{ secrets.AYRSHARE_API_KEY }}
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
         run: node scripts/post-social.js --type news --files ${{ steps.new-files.outputs.files }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.0",
+        "twitter-api-v2": "^1.29.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -16078,6 +16079,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/twitter-api-v2": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.29.0.tgz",
+      "integrity": "sha512-v473q5bwme4N+DWSg6qY+JCvfg1nSJRWwui3HUALafxfqCvVkKiYmS/5x/pVeJwTmyeBxexMbzHwnzrH4h6oYQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "npm run lint --workspaces --if-present"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "twitter-api-v2": "^1.29.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- Replaces Ayrshare API with direct Twitter/X v2 API using `twitter-api-v2` package
- Updates both build-news and build-articles workflows to pass Twitter secrets
- Removes Ayrshare dependency (free plan was adding branding tags to posts)
- Facebook, LinkedIn, and Reddit posting removed for now (can add back later with direct APIs)

## Setup required
Add these GitHub Actions secrets:
- `TWITTER_API_KEY`
- `TWITTER_API_SECRET`
- `TWITTER_ACCESS_TOKEN`
- `TWITTER_ACCESS_TOKEN_SECRET`

## Test plan
- [ ] Next news item merged to main triggers a tweet on @creditodds
- [ ] Tweet contains generated text + creditodds.com link
- [ ] No Ayrshare branding tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)