### PR TITLE
Improve tweets and show card images in news OG previews

### DIFF
--- a/apps/web-next/src/app/news/[id]/opengraph-image.tsx
+++ b/apps/web-next/src/app/news/[id]/opengraph-image.tsx
@@ -19,6 +19,13 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
     ? new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
     : '';
 
+  // Single card referenced — show card image
+  const hasSingleCard = item?.card_slugs?.length === 1 && item?.card_image_links?.[0];
+  const cardImageUrl = hasSingleCard
+    ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${item!.card_image_links![0]}`
+    : null;
+  const cardName = hasSingleCard ? item!.card_names?.[0] : null;
+
   return new ImageResponse(
     (
       <div
@@ -50,64 +57,120 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
             display: 'flex',
             width: '100%',
             height: '100%',
-            flexDirection: 'column',
-            justifyContent: 'center',
+            alignItems: 'center',
             padding: '60px 80px',
           }}
         >
-          {/* Date */}
-          {date && (
-            <div
-              style={{
-                color: 'rgba(255,255,255,0.7)',
-                fontSize: 24,
-                marginBottom: 16,
-              }}
-            >
-              {date}
-            </div>
-          )}
-
-          {/* Title */}
-          <div
-            style={{
-              color: 'white',
-              fontSize: title.length > 80 ? 40 : 48,
-              fontWeight: 'bold',
-              letterSpacing: -1,
-              lineHeight: 1.2,
-              maxWidth: 1000,
-              overflow: 'hidden',
-              display: '-webkit-box',
-              WebkitLineClamp: 3,
-              WebkitBoxOrient: 'vertical',
-            }}
-          >
-            {title}
-          </div>
-
-          {/* Tag line */}
+          {/* Left side: text */}
           <div
             style={{
               display: 'flex',
-              marginTop: 32,
-              gap: 12,
+              flexDirection: 'column',
+              justifyContent: 'center',
+              flex: 1,
+              paddingRight: cardImageUrl ? 40 : 0,
             }}
           >
+            {/* Date */}
+            {date && (
+              <div
+                style={{
+                  color: 'rgba(255,255,255,0.7)',
+                  fontSize: 24,
+                  marginBottom: 16,
+                }}
+              >
+                {date}
+              </div>
+            )}
+
+            {/* Title */}
+            <div
+              style={{
+                color: 'white',
+                fontSize: cardImageUrl
+                  ? (title.length > 60 ? 34 : 40)
+                  : (title.length > 80 ? 40 : 48),
+                fontWeight: 'bold',
+                letterSpacing: -1,
+                lineHeight: 1.2,
+                maxWidth: cardImageUrl ? 650 : 1000,
+                overflow: 'hidden',
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+              }}
+            >
+              {title}
+            </div>
+
+            {/* Tag line */}
             <div
               style={{
                 display: 'flex',
-                alignItems: 'center',
-                padding: '8px 20px',
-                background: 'rgba(255,255,255,0.15)',
-                borderRadius: 50,
-                color: 'white',
-                fontSize: 18,
+                marginTop: 24,
+                gap: 12,
               }}
             >
-              Card News
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '8px 20px',
+                  background: 'rgba(255,255,255,0.15)',
+                  borderRadius: 50,
+                  color: 'white',
+                  fontSize: 18,
+                }}
+              >
+                Card News
+              </div>
             </div>
           </div>
+
+          {/* Right side: card image (single card only) */}
+          {cardImageUrl && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  borderRadius: 16,
+                  boxShadow: '0 25px 80px rgba(0,0,0,0.4), 0 10px 30px rgba(0,0,0,0.3)',
+                }}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={cardImageUrl}
+                  alt={cardName || ''}
+                  width={380}
+                  height={240}
+                  style={{
+                    borderRadius: 16,
+                  }}
+                />
+              </div>
+              {cardName && (
+                <div
+                  style={{
+                    marginTop: 16,
+                    color: 'rgba(255,255,255,0.8)',
+                    fontSize: 20,
+                    textAlign: 'center',
+                    maxWidth: 380,
+                  }}
+                >
+                  {cardName}
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Logo in bottom left corner */}

--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -70,12 +70,19 @@ async function generatePost(type, item) {
       ? item.related_cards.join(', ')
       : 'N/A');
 
-  const prompt = `Write a social media post for CreditOdds about this ${type}:
+  const prompt = `Write a short tweet for CreditOdds about this credit card ${type}:
 Title: ${item.title}
 Summary: ${item.summary}
 Cards: ${cardNames}
 
-Max 260 characters. Informative, engaging, professional. 1-2 hashtags. Do NOT include the URL.`;
+Rules:
+- Max 200 characters (shorter is better)
+- Lead with a hook like "BREAKING:" or "NEW:" or a bold statement when appropriate
+- Write like a human, not a corporate account — be direct, casual, punchy
+- No filler words, no "excited to announce", no "stay tuned"
+- 1 hashtag max, only if it adds value. Skip hashtags if the tweet is strong without one
+- Do NOT include any URL
+- Do NOT use emojis excessively — 0-1 emoji max`;
 
   const response = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- **Better tweets**: Updated Claude prompt to generate shorter, punchier posts (max 200 chars). Leads with hooks like "BREAKING:" or "NEW:", avoids filler/AI-sounding language, minimal emoji/hashtags
- **Card in OG image**: When a news article features a single card, the card image now appears on the right side of the OpenGraph preview image (visible in Twitter cards, Slack unfurls, etc.)

## Test plan
- [ ] Trigger test post — tweet should be shorter and more punchy
- [ ] Visit `/news/chase-apple-card-transition/opengraph-image` — should show Apple Card image on right side
- [ ] News articles without a card still render OG image normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)