### PR TITLE
Fix multi-file news posting breaking workflow

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Detect new article files
         id: new-files
         run: |
-          NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- 'data/articles/*.yaml' 'data/articles/*.yml' 2>/dev/null || echo "")
+          NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- 'data/articles/*.yaml' 'data/articles/*.yml' 2>/dev/null | tr '\n' ' ' | xargs)
           echo "files=$NEW_FILES" >> $GITHUB_OUTPUT
           if [ -n "$NEW_FILES" ]; then
             echo "New article files detected:"

--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -75,7 +75,7 @@ jobs:
             echo "Test mode: using provided file"
             echo "files=${{ inputs.test_post_file }}" >> $GITHUB_OUTPUT
           else
-            NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- 'data/news/*.yaml' 'data/news/*.yml' 2>/dev/null || echo "")
+            NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- 'data/news/*.yaml' 'data/news/*.yml' 2>/dev/null | tr '\n' ' ' | xargs)
             echo "files=$NEW_FILES" >> $GITHUB_OUTPUT
             if [ -n "$NEW_FILES" ]; then
               echo "New news files detected:"


### PR DESCRIPTION
## Summary
When multiple news files are added in a single commit, `git diff` returns newline-separated paths which breaks `$GITHUB_OUTPUT`. This joins them into a space-separated string.

Fixes the failed run from the 2026-02-27 auto-news merge (2 articles).

Also fixes the same bug in build-articles workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)