### PR TITLE
Prevent auto card update from producing invalid data

### DIFF
--- a/.github/workflows/auto-card-update.yml
+++ b/.github/workflows/auto-card-update.yml
@@ -37,6 +37,17 @@ jobs:
           DAY_OFFSET: ${{ github.event.inputs.day_offset || '0' }}
         run: node scripts/auto-card-update.js
 
+      - name: Validate card data
+        run: |
+          if [ -n "$(git status --porcelain data/cards/)" ]; then
+            echo "Validating updated card data..."
+            if ! npm run build:cards; then
+              echo "::error::Card validation failed! Reverting changes."
+              git checkout -- data/cards/
+              exit 1
+            fi
+          fi
+
       - name: Create PR if changes found
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -17,7 +17,7 @@ rewards:
     value: 3
     unit: "percent"
     note: "U.S. gas stations, up to $6,000 per year then 1%"
-  - category: "online_retail"
+  - category: "online_shopping"
     value: 3
     unit: "percent"
     note: "U.S. online retail purchases, up to $6,000 per year then 1%"

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -20,9 +20,10 @@ rewards:
   - category: "streaming"
     value: 3
     unit: "points_per_dollar"
-  - category: "online_groceries"
+  - category: "online_shopping"
     value: 3
     unit: "points_per_dollar"
+    note: "Online grocery purchases (excluding Target, Walmart, wholesale clubs)"
   - category: "travel"
     value: 2
     unit: "points_per_dollar"

--- a/data/cards/starbucks-rewards-visa-card.yaml
+++ b/data/cards/starbucks-rewards-visa-card.yaml
@@ -3,5 +3,5 @@ bank: "Chase"
 slug: "starbucks-rewards-visa-card"
 image: "chase-starbucks-rewards.png"
 accepting_applications: false
-annual_fee: null
+annual_fee: 0
 reward_type: null


### PR DESCRIPTION
## Summary
- **Fixed Claude prompt**: Replaced vague category "examples" with the exact list of valid categories loaded from `data/categories.yaml`
- **Reinforced annual_fee rules**: Prompt now explicitly says "NEVER use null, use 0 for no annual fee"
- **Added post-parse validation**: Invalid categories and null/negative annual fees are rejected before changes are applied
- **Added build validation step**: Workflow runs `npm run build:cards` before creating a PR, reverting changes if validation fails

## Test plan
- [x] `npm run build:cards` passes cleanly
- [ ] Verify next auto-card-update workflow run produces only valid data
- [ ] Confirm invalid categories (e.g. `online_retail`) would be caught by post-parse validation
- [ ] Confirm `annual_fee: null` would be caught by post-parse validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)