### PR TITLE
Add check odds CTA link on landing page

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -27,6 +27,13 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
               Explore what it takes to get approved.
             </p>
             <CardSelect allCards={initialCards} />
+            <p className="mt-3 text-sm text-gray-500 text-center lg:text-left">
+              Or{" "}
+              <Link href="/check-odds" className="underline hover:text-indigo-600">
+                check your odds against all cards
+              </Link>{" "}
+              &rarr;
+            </p>
           </div>
         </div>
         <div className="relative w-screen h-64 sm:h-72 md:h-96 lg:absolute lg:inset-y-0 lg:right-0 lg:w-1/2 lg:h-full">


### PR DESCRIPTION
## Summary
- Adds a "check your odds against all cards →" link below the card search on the landing page hero
- Links to `/check-odds` so users can discover the odds checker flow
- Styled as subtle secondary text (gray, small font, centered on mobile / left-aligned on desktop)

## Test plan
- [ ] Run `npm run dev` and verify link appears below the card search
- [ ] Confirm link navigates to `/check-odds`
- [ ] Check responsive layout (centered on mobile, left-aligned on lg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)