### PR TITLE
Fix footer floating above bottom on short pages

### DIFF
--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -52,13 +52,13 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://d3ay3etzd1512y.cloudfront.net" />
         <link rel="dns-prefetch" href="https://d2ojrhbh2dincr.cloudfront.net" />
       </head>
-      <body>
+      <body className="min-h-screen flex flex-col">
         <OrganizationSchema />
         <WebsiteSchema />
         <AuthProvider>
           <SkipLink />
           <Navbar />
-          <main id="main-content">{children}</main>
+          <main id="main-content" className="flex-grow">{children}</main>
           <Footer />
           <ToastContainer />
           <WebVitalsReporter />


### PR DESCRIPTION
## Summary
- Add `min-h-screen flex flex-col` to `<body>` and `flex-grow` to `<main>` in root layout
- Ensures footer always sits at the bottom of the viewport on pages with little content (e.g. card pages with few records, terms, privacy)

## Test plan
- [ ] Check short pages (card pages with few records, /terms, /privacy) — footer should be at viewport bottom
- [ ] Check long pages (landing, explore) — no visual change, footer stays after content

🤖 Generated with [Claude Code](https://claude.com/claude-code)