### PR TITLE
Add SEO structured data to news and article pages

### DIFF
--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { TableOfContents } from "@/components/articles/TableOfContents";
 import { ReadingProgressBar } from "@/components/articles/ReadingProgressBar";
 import { ShareButtons } from "@/components/articles/ShareButtons";
 import { RelatedArticles } from "@/components/articles/RelatedArticles";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -99,23 +100,28 @@ export default async function ArticlePage({ params }: Props) {
     author: {
       "@type": "Person",
       name: article.author,
+      url: `https://creditodds.com/articles/author/${authorSlug}`,
     },
     datePublished: article.date,
     dateModified: article.updated_at || article.date,
+    image: article.image
+      ? `https://d2hxvzw7msbtvt.cloudfront.net/article_images/${article.image}`
+      : `https://creditodds.com/articles/${article.slug}/opengraph-image`,
     publisher: {
       "@type": "Organization",
       name: "CreditOdds",
       url: "https://creditodds.com",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://creditodds.com/logo.png",
+      },
     },
     mainEntityOfPage: {
       "@type": "WebPage",
       "@id": articleUrl,
     },
+    isAccessibleForFree: true,
   };
-
-  if (article.image) {
-    jsonLd.image = `https://d2hxvzw7msbtvt.cloudfront.net/article_images/${article.image}`;
-  }
 
   return (
     <>
@@ -123,6 +129,11 @@ export default async function ArticlePage({ params }: Props) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Articles', url: 'https://creditodds.com/articles' },
+        { name: article.title, url: articleUrl },
+      ]} />
 
       <ReadingProgressBar />
 

--- a/apps/web-next/src/app/articles/author/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/author/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { UserIcon } from "@heroicons/react/24/outline";
 import { getArticles, getUniqueAuthors, generateAuthorSlug } from "@/lib/articles";
 import { ArticleCard } from "@/components/articles/ArticleCard";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -57,8 +58,34 @@ export default async function AuthorPage({ params }: Props) {
     return articleAuthorSlug === slug;
   });
 
+  const collectionJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `Articles by ${author.name}`,
+    description: `Read ${author.count} article${author.count !== 1 ? 's' : ''} by ${author.name} about credit card strategies and guides.`,
+    url: `https://creditodds.com/articles/author/${slug}`,
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: articles.slice(0, 10).map((article, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `https://creditodds.com/articles/${article.slug}`,
+      })),
+    },
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
+      />
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Articles', url: 'https://creditodds.com/articles' },
+        { name: author.name, url: `https://creditodds.com/articles/author/${slug}` },
+      ]} />
+
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/apps/web-next/src/app/articles/category/[tag]/page.tsx
+++ b/apps/web-next/src/app/articles/category/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { TagIcon } from "@heroicons/react/24/outline";
 import { getArticlesByTag, tagLabels, tagColors, tagDescriptions, ArticleTag } from "@/lib/articles";
 import { ArticleCard } from "@/components/articles/ArticleCard";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 
 interface Props {
   params: Promise<{ tag: string }>;
@@ -54,8 +55,34 @@ export default async function CategoryPage({ params }: Props) {
   const tagDescription = tagDescriptions[tag as ArticleTag];
   const tagColor = tagColors[tag as ArticleTag];
 
+  const collectionJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `${tagLabel} Articles`,
+    description: tagDescription,
+    url: `https://creditodds.com/articles/category/${tag}`,
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: articles.slice(0, 10).map((article, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `https://creditodds.com/articles/${article.slug}`,
+      })),
+    },
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
+      />
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Articles', url: 'https://creditodds.com/articles' },
+        { name: tagLabel, url: `https://creditodds.com/articles/category/${tag}` },
+      ]} />
+
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/apps/web-next/src/app/articles/page.tsx
+++ b/apps/web-next/src/app/articles/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { DocumentTextIcon } from "@heroicons/react/24/outline";
 import { getArticles } from "@/lib/articles";
 import { ArticlesListClient } from "@/components/articles/ArticlesListClient";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 
 export const metadata: Metadata = {
   title: "Credit Card Articles - Guides & Strategies",
@@ -23,8 +24,33 @@ export const revalidate = 300;
 export default async function ArticlesPage() {
   const articles = await getArticles();
 
+  const collectionJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Credit Card Articles",
+    description: "In-depth guides, strategies, and analysis to help you maximize your credit card rewards and make smarter financial decisions.",
+    url: "https://creditodds.com/articles",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: articles.slice(0, 10).map((article, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `https://creditodds.com/articles/${article.slug}`,
+      })),
+    },
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
+      />
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Articles', url: 'https://creditodds.com/articles' },
+      ]} />
+
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -75,18 +75,34 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
     }
   }
 
+  const url = `https://creditodds.com/news/${item.id}`;
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "NewsArticle",
     headline: item.title,
     description: item.summary,
     datePublished: item.date,
-    url: `https://creditodds.com/news/${item.id}`,
+    dateModified: item.date,
+    url,
+    image: `https://creditodds.com/news/${item.id}/opengraph-image`,
+    author: {
+      "@type": "Organization",
+      name: "CreditOdds",
+    },
     publisher: {
       "@type": "Organization",
       name: "CreditOdds",
       url: "https://creditodds.com",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://creditodds.com/logo.png",
+      },
     },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+    isAccessibleForFree: true,
   };
 
   return (

--- a/apps/web-next/src/app/news/page.tsx
+++ b/apps/web-next/src/app/news/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { NewspaperIcon, PlusCircleIcon } from "@heroicons/react/24/outline";
 import { getNews } from "@/lib/news";
 import NewsTable from "@/components/news/NewsTable";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 
 export const metadata: Metadata = {
   title: "Card News - Credit Card Updates",
@@ -23,8 +24,33 @@ export const revalidate = 300;
 export default async function NewsPage() {
   const newsItems = await getNews();
 
+  const collectionJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Card News",
+    description: "Stay up to date with the latest credit card news, bonus changes, new card launches, and policy updates from major banks.",
+    url: "https://creditodds.com/news",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: newsItems.slice(0, 10).map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `https://creditodds.com/news/${item.id}`,
+      })),
+    },
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
+      />
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Card News', url: 'https://creditodds.com/news' },
+      ]} />
+
       {/* Breadcrumbs */}
       <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- **News detail pages**: Enriched `NewsArticle` JSON-LD with author, image, dateModified, mainEntityOfPage, isAccessibleForFree, and publisher logo
- **Article detail pages**: Added author URL, fallback OG image, isAccessibleForFree, publisher logo, and rendered `BreadcrumbSchema`
- **Listing pages** (`/news`, `/articles`, `/articles/category/*`, `/articles/author/*`): Added `CollectionPage` + `ItemList` (first 10 items) for Google carousel eligibility, plus `BreadcrumbSchema`

## Test plan
- [ ] Visit a news detail page → view source, verify enriched `NewsArticle` JSON-LD
- [ ] Visit an article detail page → verify enriched `Article` JSON-LD + `BreadcrumbList`
- [ ] Visit /news, /articles, category, and author pages → verify `CollectionPage` + `ItemList` + `BreadcrumbList`
- [ ] Validate with https://search.google.com/test/rich-results

🤖 Generated with [Claude Code](https://claude.com/claude-code)