### PR TITLE
Add Google News RSS and 3x daily auto-news

### DIFF
--- a/.github/workflows/auto-news.yml
+++ b/.github/workflows/auto-news.yml
@@ -2,7 +2,9 @@ name: Auto News Update
 
 on:
   schedule:
-    - cron: '0 14 * * *'  # Daily at 2 PM UTC / 9 AM EST
+    - cron: '0 12 * * *'  # 12 PM UTC / 7 AM EST
+    - cron: '0 18 * * *'  # 6 PM UTC / 1 PM EST
+    - cron: '0 0 * * *'   # 12 AM UTC / 7 PM EST
   workflow_dispatch:       # Manual trigger
 
 permissions:
@@ -37,7 +39,7 @@ jobs:
         run: |
           # Check if any new files were created
           if [ -n "$(git status --porcelain data/news/)" ]; then
-            BRANCH="auto-news-$(date +%Y-%m-%d)"
+            BRANCH="auto-news-$(date +%Y-%m-%d-%H%M%S)"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary
- Add Google News RSS as an additional news source alongside Brave Search (no API key needed, returns ~100 results per query)
- Change auto-news cron from 1x/day to 3x/day (7AM, 1PM, 7PM EST)
- Add timestamp to auto-news branch names to avoid same-day collisions

## Test plan
- [x] Tested Google News RSS parsing locally — returns 100 results
- [ ] Trigger workflow manually after merge to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)