### PR TITLE
Fix TypeScript error breaking Amplify build

### DIFF
--- a/apps/web-next/src/components/ui/DataPointPrompt.tsx
+++ b/apps/web-next/src/components/ui/DataPointPrompt.tsx
@@ -68,7 +68,7 @@ function CardPicker({
                     <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
                   </div>
                   <input
-                    {...getInputProps({ ref: searchInputRef })}
+                    {...getInputProps({ ref: searchInputRef as React.RefObject<HTMLInputElement> })}
                     className="w-full border border-gray-300 rounded-lg pl-10 pr-3 py-2.5 text-sm focus:ring-indigo-500 focus:border-indigo-500"
                     placeholder="Search cards..."
                     type="search"


### PR DESCRIPTION
## Summary
- Fixes TypeScript compilation error in `DataPointPrompt.tsx` that was failing Amplify builds
- The `useRef<HTMLInputElement>(null)` returns `RefObject<HTMLInputElement | null>` but Downshift's `getInputProps` expects `RefObject<HTMLInputElement>` — added a type cast to resolve the mismatch

## Test plan
- [x] `npx tsc --noEmit` passes locally
- [ ] Amplify build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)