### PR TITLE
News: Discover Q2 2026 5% cash back categories

### DIFF
--- a/data/news/2026-02-28-discover-q2-2026-cash-back-categories.yaml
+++ b/data/news/2026-02-28-discover-q2-2026-cash-back-categories.yaml
@@ -1,0 +1,43 @@
+id: "discover-q2-2026-cash-back-categories"
+date: "2026-02-28"
+title: "Discover Announces Q2 2026 5% Cash Back Categories: Restaurants and Home Improvement Stores"
+summary: "Discover has revealed its rotating 5% cash back categories for Q2 2026 (April through June). Cardholders can earn 5% back at restaurants and home improvement stores on up to $1,500 in combined purchases after activation."
+tags:
+  - "bonus-change"
+bank: "Discover"
+card_slug: "discover-it-cash-back"
+card_name: "Discover it Cash Back"
+source: "CNBC Select"
+source_url: "https://www.cnbc.com/select/discover-cash-back-calendar/"
+body: |
+  Discover has announced its rotating 5% cash back bonus categories for Q2 2026, covering April through June. Cardholders with eligible Discover cards can earn **5% cash back at restaurants and home improvement stores** on up to $1,500 in combined purchases for the quarter after activating the offer.
+
+  ## Q2 2026 Categories: April - June
+
+  The two bonus categories for the second quarter of 2026 are:
+
+  **Restaurants** — This includes purchases at full-service restaurants, cafes, cafeterias, fast-food locations, and caterers. Both dine-in and takeout purchases qualify.
+
+  **Home Improvement Stores** — This covers online and in-store purchases at home improvement retail stores, building supply stores, home furnishing stores, home appliance stores, and floor covering stores. Lawn, nursery, and garden supply stores also count toward the category.
+
+  ## How to Earn 5% Cash Back
+
+  Like every quarter, cardholders must **activate the bonus categories** to earn the elevated 5% rate. Activation is available from April 1 through June 30, 2026, and can be done through the Discover app, online account, or by calling customer service.
+
+  Once activated, you earn 5% cash back on up to **$1,500 in combined purchases** across both categories for the quarter. That works out to a maximum of **$75 in bonus cash back**. All spending beyond the $1,500 cap earns the standard 1% cash back rate.
+
+  Unlike some competitors, Discover's bonus activation is **not retroactive** — you only earn 5% on purchases made after you activate, so it's worth doing on day one.
+
+  ## Q1 2026 Recap
+
+  The current Q1 categories (January through March) are **grocery stores, wholesale clubs, and select streaming services**. Cardholders have until March 31 to maximize their 5% earnings in these categories before the Q2 rotation begins.
+
+  ## Which Cards Are Eligible
+
+  The rotating 5% bonus categories apply to the Discover it Cash Back card. The first-year **Cashback Match** promotion doubles all cash back earned in the first 12 months, effectively making the bonus rate **10% back** at restaurants and home improvement stores for new cardholders.
+
+  ## Looking Ahead
+
+  Discover typically announces each quarter's categories about a month before they go live. The Q3 2026 (July through September) and Q4 2026 (October through December) categories have not yet been announced. Historically, popular Q2 and Q3 categories have included gas stations, Amazon, Target, and PayPal.
+
+  Cardholders should mark their calendars for **April 1** to activate the new categories and start earning 5% back on spring dining and home improvement purchases.


### PR DESCRIPTION
## Summary
- Adds news post about Discover's Q2 2026 rotating 5% cash back categories
- Q2 categories (April-June): **Restaurants** and **Home Improvement Stores**
- Up to $1,500 in combined purchases after activation
- Links to Discover it Cash Back card page
- Source: [CNBC Select](https://www.cnbc.com/select/discover-cash-back-calendar/)

## Test plan
- [x] `npm run build:news` passes validation
- [ ] News post appears on site after deploy
- [ ] Auto-tweet fires from build-news workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)