### PR TITLE
Add APR data to card system

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -323,10 +323,21 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
                     </span>
                   </>
                 )}
+                {card.apr && (card.apr.purchase_intro || card.apr.balance_transfer_intro) && (() => {
+                  const intro = card.apr.balance_transfer_intro || card.apr.purchase_intro;
+                  return (
+                    <>
+                      <span className="text-gray-300">&middot;</span>
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-50 text-cyan-700">
+                        {intro!.rate}% Intro APR {intro!.months}mo
+                      </span>
+                    </>
+                  );
+                })()}
               </div>
 
-              {/* Rewards + Signup Bonus Card */}
-              {(card.rewards && card.rewards.length > 0 || card.signup_bonus) && (
+              {/* Rewards + Signup Bonus + APR Card */}
+              {(card.rewards && card.rewards.length > 0 || card.signup_bonus || card.apr) && (
                 <div className="mt-4 bg-white shadow rounded-lg overflow-hidden">
                   {card.rewards && card.rewards.length > 0 && (
                     <div className="p-4">
@@ -394,6 +405,29 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
                         after spending ${card.signup_bonus.spend_requirement.toLocaleString()} in{" "}
                         {card.signup_bonus.timeframe_months} month{card.signup_bonus.timeframe_months !== 1 ? "s" : ""}
                       </p>
+                    </div>
+                  )}
+                  {card.apr && (card.apr.purchase_intro || card.apr.balance_transfer_intro) && (
+                    <div className={`bg-cyan-50 px-4 py-3 border-t border-cyan-100 ${
+                      !(card.rewards && card.rewards.length > 0) && !card.signup_bonus ? "rounded-t-lg" : ""
+                    }`}>
+                      <div className="text-sm font-medium text-cyan-900">
+                        {card.apr.balance_transfer_intro && (
+                          <p>
+                            <span className="font-bold">{card.apr.balance_transfer_intro.rate}% Intro APR</span> for {card.apr.balance_transfer_intro.months} months on balance transfers
+                          </p>
+                        )}
+                        {card.apr.purchase_intro && (
+                          <p className={card.apr.balance_transfer_intro ? "mt-1" : ""}>
+                            <span className="font-bold">{card.apr.purchase_intro.rate}% Intro APR</span> for {card.apr.purchase_intro.months} months on purchases
+                          </p>
+                        )}
+                      </div>
+                      {card.apr.regular && (
+                        <p className="text-xs text-cyan-600 mt-1">
+                          Then {card.apr.regular.min}%&ndash;{card.apr.regular.max}% variable APR
+                        </p>
+                      )}
                     </div>
                   )}
                 </div>

--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -92,6 +92,9 @@ export function CreditCardSchema({ card }: CreditCardSchemaProps) {
       bestRating: 5,
       worstRating: 1,
     } : undefined,
+    ...(card.apr?.regular ? {
+      annualPercentageRate: card.apr.regular.max,
+    } : {}),
     additionalProperty: [
       {
         '@type': 'PropertyValue',
@@ -108,6 +111,21 @@ export function CreditCardSchema({ card }: CreditCardSchemaProps) {
         name: 'Median Length of Credit History',
         value: card.approved_median_length_credit ? `${card.approved_median_length_credit} years` : 'N/A',
       },
+      ...(card.apr?.purchase_intro ? [{
+        '@type': 'PropertyValue',
+        name: 'Intro APR on Purchases',
+        value: `${card.apr.purchase_intro.rate}% for ${card.apr.purchase_intro.months} months`,
+      }] : []),
+      ...(card.apr?.balance_transfer_intro ? [{
+        '@type': 'PropertyValue',
+        name: 'Intro APR on Balance Transfers',
+        value: `${card.apr.balance_transfer_intro.rate}% for ${card.apr.balance_transfer_intro.months} months`,
+      }] : []),
+      ...(card.apr?.regular ? [{
+        '@type': 'PropertyValue',
+        name: 'Regular APR',
+        value: `${card.apr.regular.min}%-${card.apr.regular.max}%`,
+      }] : []),
     ],
   };
 

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -29,6 +29,22 @@ export interface SignupBonus {
   timeframe_months: number;
 }
 
+export interface IntroAPR {
+  rate: number;
+  months: number;
+}
+
+export interface RegularAPR {
+  min: number;
+  max: number;
+}
+
+export interface CardAPR {
+  purchase_intro?: IntroAPR;
+  balance_transfer_intro?: IntroAPR;
+  regular?: RegularAPR;
+}
+
 export interface Card {
   card_id: string | number;
   db_card_id?: number;
@@ -53,6 +69,7 @@ export interface Card {
   reward_type?: 'cashback' | 'points' | 'miles';
   rewards?: Reward[];
   signup_bonus?: SignupBonus;
+  apr?: CardAPR;
 }
 
 // GraphData is an array of series data

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-28T15:24:51.126Z",
+  "generated_at": "2026-02-28T18:36:22.627Z",
   "count": 142,
   "categories": [
     {
@@ -600,6 +600,20 @@
       "image": "bankamericard.png",
       "category": "other",
       "annual_fee": 0,
+      "apr": {
+        "purchase_intro": {
+          "rate": 0,
+          "months": 21
+        },
+        "balance_transfer_intro": {
+          "rate": 0,
+          "months": 21
+        },
+        "regular": {
+          "min": 16.24,
+          "max": 26.24
+        }
+      },
       "card_id": "bankamericard",
       "card_name": "BankAmericard"
     },
@@ -1258,6 +1272,16 @@
       "accepting_applications": true,
       "category": "other",
       "annual_fee": 0,
+      "apr": {
+        "balance_transfer_intro": {
+          "rate": 0,
+          "months": 21
+        },
+        "regular": {
+          "min": 22.49,
+          "max": 31.24
+        }
+      },
       "card_id": "chase-slate-edge",
       "card_name": "Chase Slate Edge"
     },
@@ -1341,6 +1365,20 @@
       "image": "citi_diamond_preferred.png",
       "accepting_applications": true,
       "annual_fee": 0,
+      "apr": {
+        "purchase_intro": {
+          "rate": 0,
+          "months": 12
+        },
+        "balance_transfer_intro": {
+          "rate": 0,
+          "months": 21
+        },
+        "regular": {
+          "min": 18.24,
+          "max": 29.24
+        }
+      },
       "card_id": "citi-diamond-preferred",
       "card_name": "Citi Diamond Preferred"
     },
@@ -1414,6 +1452,20 @@
       "accepting_applications": true,
       "image": "citi-simplicity.png",
       "annual_fee": 0,
+      "apr": {
+        "purchase_intro": {
+          "rate": 0,
+          "months": 12
+        },
+        "balance_transfer_intro": {
+          "rate": 0,
+          "months": 21
+        },
+        "regular": {
+          "min": 19.24,
+          "max": 29.99
+        }
+      },
       "card_id": "citi-simplicity-card",
       "card_name": "Citi Simplicity"
     },
@@ -2523,6 +2575,16 @@
       "image": "us-bank-shield.png",
       "accepting_applications": true,
       "annual_fee": 0,
+      "apr": {
+        "purchase_intro": {
+          "rate": 0,
+          "months": 15
+        },
+        "balance_transfer_intro": {
+          "rate": 0,
+          "months": 15
+        }
+      },
       "card_id": "us-bank-shield",
       "card_name": "US Bank Shield"
     },
@@ -2712,6 +2774,20 @@
       "accepting_applications": true,
       "category": "other",
       "annual_fee": 0,
+      "apr": {
+        "purchase_intro": {
+          "rate": 0,
+          "months": 21
+        },
+        "balance_transfer_intro": {
+          "rate": 0,
+          "months": 21
+        },
+        "regular": {
+          "min": 24.49,
+          "max": 34.49
+        }
+      },
       "card_id": "wells-fargo-reflect",
       "card_name": "Wells Fargo Reflect"
     },

--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -5,3 +5,13 @@ accepting_applications: true
 image: "bankamericard.png"
 category: "other"
 annual_fee: 0
+apr:
+  purchase_intro:
+    rate: 0
+    months: 21
+  balance_transfer_intro:
+    rate: 0
+    months: 21
+  regular:
+    min: 16.24
+    max: 26.24

--- a/data/cards/chase-slate-edge.yaml
+++ b/data/cards/chase-slate-edge.yaml
@@ -5,3 +5,10 @@ image: "chase-slate-edge.png"
 accepting_applications: true
 category: "other"
 annual_fee: 0
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 21
+  regular:
+    min: 22.49
+    max: 31.24

--- a/data/cards/citi-diamond-preferred.yaml
+++ b/data/cards/citi-diamond-preferred.yaml
@@ -4,3 +4,13 @@ slug: "citi-diamond-preferred"
 image: "citi_diamond_preferred.png"
 accepting_applications: true
 annual_fee: 0
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 21
+  regular:
+    min: 18.24
+    max: 29.24

--- a/data/cards/citi-simplicity-card.yaml
+++ b/data/cards/citi-simplicity-card.yaml
@@ -4,3 +4,13 @@ slug: "citi-simplicity-card"
 accepting_applications: true
 image: "citi-simplicity.png"
 annual_fee: 0
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 21
+  regular:
+    min: 19.24
+    max: 29.99

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -136,6 +136,40 @@
       },
       "additionalProperties": false,
       "description": "Welcome/signup bonus details (optional)"
+    },
+    "apr": {
+      "type": "object",
+      "properties": {
+        "purchase_intro": {
+          "type": "object",
+          "required": ["rate", "months"],
+          "properties": {
+            "rate": { "type": "number", "minimum": 0, "description": "Intro APR rate (e.g., 0 for 0%)" },
+            "months": { "type": "integer", "minimum": 1, "description": "Intro period in months" }
+          },
+          "additionalProperties": false
+        },
+        "balance_transfer_intro": {
+          "type": "object",
+          "required": ["rate", "months"],
+          "properties": {
+            "rate": { "type": "number", "minimum": 0, "description": "Intro APR rate (e.g., 0 for 0%)" },
+            "months": { "type": "integer", "minimum": 1, "description": "Intro period in months" }
+          },
+          "additionalProperties": false
+        },
+        "regular": {
+          "type": "object",
+          "required": ["min", "max"],
+          "properties": {
+            "min": { "type": "number", "minimum": 0, "description": "Minimum regular APR" },
+            "max": { "type": "number", "minimum": 0, "description": "Maximum regular APR" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "description": "APR details including intro offers and regular rate (optional)"
     }
   },
   "additionalProperties": false

--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -4,3 +4,10 @@ slug: "us-bank-shield"
 image: "us-bank-shield.png"
 accepting_applications: true
 annual_fee: 0
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15

--- a/data/cards/wells-fargo-reflect.yaml
+++ b/data/cards/wells-fargo-reflect.yaml
@@ -5,3 +5,13 @@ image: "wells_fargo_reflect.png"
 accepting_applications: true
 category: "other"
 annual_fee: 0
+apr:
+  purchase_intro:
+    rate: 0
+    months: 21
+  balance_transfer_intro:
+    rate: 0
+    months: 21
+  regular:
+    min: 24.49
+    max: 34.49

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -95,6 +95,41 @@ function validateCard(card, schema, categoryIds) {
     }
   }
 
+  // Validate APR
+  if (card.apr) {
+    if (typeof card.apr !== 'object' || Array.isArray(card.apr)) {
+      errors.push('apr must be an object');
+    } else {
+      if (card.apr.purchase_intro) {
+        if (typeof card.apr.purchase_intro.rate !== 'number') {
+          errors.push('apr.purchase_intro.rate must be a number');
+        }
+        if (typeof card.apr.purchase_intro.months !== 'number' || card.apr.purchase_intro.months < 1) {
+          errors.push('apr.purchase_intro.months must be a positive integer');
+        }
+      }
+      if (card.apr.balance_transfer_intro) {
+        if (typeof card.apr.balance_transfer_intro.rate !== 'number') {
+          errors.push('apr.balance_transfer_intro.rate must be a number');
+        }
+        if (typeof card.apr.balance_transfer_intro.months !== 'number' || card.apr.balance_transfer_intro.months < 1) {
+          errors.push('apr.balance_transfer_intro.months must be a positive integer');
+        }
+      }
+      if (card.apr.regular) {
+        if (typeof card.apr.regular.min !== 'number') {
+          errors.push('apr.regular.min must be a number');
+        }
+        if (typeof card.apr.regular.max !== 'number') {
+          errors.push('apr.regular.max must be a number');
+        }
+        if (typeof card.apr.regular.min === 'number' && typeof card.apr.regular.max === 'number' && card.apr.regular.min > card.apr.regular.max) {
+          errors.push('apr.regular.min must be <= apr.regular.max');
+        }
+      }
+    }
+  }
+
   return errors;
 }
 


### PR DESCRIPTION
## Summary
- Add optional `apr` field to card schema with `purchase_intro`, `balance_transfer_intro`, and `regular` APR sub-objects
- Add build validation in `build-cards.js` for APR type checks and min <= max constraint
- Add `IntroAPR`, `RegularAPR`, `CardAPR` TypeScript interfaces and `apr` field on `Card`
- Display cyan badge ("0% Intro APR 21mo") in card header and cyan highlight box with BT/purchase intro details on card detail page
- Add `annualPercentageRate` and APR `PropertyValue` entries to SEO structured data
- Populate APR data for 6 balance transfer / intro APR cards: Citi Diamond Preferred, Citi Simplicity, Wells Fargo Reflect, Chase Slate Edge, BankAmericard, US Bank Shield

## Test plan
- [x] `npm run build:cards` passes with all 142 cards
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Visit card detail pages for the 6 updated cards to verify cyan APR badge and highlight box render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)