### PR TITLE
Add "Best X" comparison pages system

### DIFF
--- a/.github/workflows/build-best.yml
+++ b/.github/workflows/build-best.yml
@@ -1,0 +1,62 @@
+name: Build and Deploy Best Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'data/best/**'
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build best.json
+        run: npm run build:best
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
+          aws-region: us-east-2
+
+      - name: Upload best.json to S3
+        run: aws s3 cp data/best.json s3://${{ secrets.S3_BUCKET_NAME }}/best.json --content-type application/json --cache-control "max-age=300"
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/best.json"
+
+      - name: Wait for CloudFront invalidation
+        run: |
+          echo "Waiting 30 seconds for CloudFront cache invalidation..."
+          sleep 30
+
+      - name: Trigger Amplify rebuild
+        env:
+          AMPLIFY_WEBHOOK_URL: ${{ secrets.AMPLIFY_WEBHOOK_URL }}
+        run: |
+          if [ -n "$AMPLIFY_WEBHOOK_URL" ]; then
+            echo "Triggering Amplify rebuild..."
+            curl -s -X POST "$AMPLIFY_WEBHOOK_URL" || echo "Warning: Amplify webhook failed"
+          else
+            echo "Skipping Amplify rebuild (no webhook URL configured)"
+          fi

--- a/apps/web-next/src/app/api/best/route.ts
+++ b/apps/web-next/src/app/api/best/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const BEST_CDN_URL = 'https://d2hxvzw7msbtvt.cloudfront.net/best.json';
+
+export async function GET() {
+  try {
+    // In development, read from local file
+    if (process.env.NODE_ENV === 'development') {
+      const filePath = path.join(process.cwd(), '..', '..', 'data', 'best.json');
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      const data = JSON.parse(fileContent);
+      return NextResponse.json(data);
+    }
+
+    const res = await fetch(BEST_CDN_URL, {
+      next: { revalidate: 300 },
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch best pages' },
+        { status: res.status }
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching best pages:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -146,7 +146,7 @@ export default async function BestDetailPage({ params }: Props) {
           </div>
         </nav>
 
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Header */}
           <header className="mb-8">
             <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 leading-tight mb-4">

--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { CalendarIcon, UserIcon, ArrowPathIcon } from "@heroicons/react/24/outline";
+import { CalendarIcon, ArrowPathIcon } from "@heroicons/react/24/outline";
 import { getBestPage, getBestPages } from "@/lib/best";
 import { getAllCards } from "@/lib/api";
 import { BestCardList } from "@/components/best/BestCardList";
@@ -42,7 +42,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       type: "article",
       publishedTime: page.date,
       modifiedTime: page.updated_at || page.date,
-      authors: [page.author],
     },
     alternates: {
       canonical: `https://creditodds.com/best/${page.slug}`,
@@ -82,7 +81,6 @@ export default async function BestDetailPage({ params }: Props) {
     }));
 
   const pageUrl = `https://creditodds.com/best/${page.slug}`;
-  const authorSlug = page.author_slug || page.author.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 
   // ItemList JSON-LD for the ranked card list
   const jsonLd = {
@@ -156,10 +154,6 @@ export default async function BestDetailPage({ params }: Props) {
               {page.description}
             </p>
             <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500">
-              <div className="flex items-center gap-1.5">
-                <UserIcon className="h-4 w-4" />
-                <span>{page.author}</span>
-              </div>
               <div className="flex items-center gap-1.5">
                 <CalendarIcon className="h-4 w-4" />
                 <span>{formatDate(page.date)}</span>

--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -1,0 +1,202 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { CalendarIcon, UserIcon, ArrowPathIcon } from "@heroicons/react/24/outline";
+import { getBestPage, getBestPages } from "@/lib/best";
+import { getAllCards } from "@/lib/api";
+import { BestCardList } from "@/components/best/BestCardList";
+import { ArticleContent } from "@/components/articles/ArticleContent";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const page = await getBestPage(slug);
+
+  if (!page) {
+    return { title: "Not Found" };
+  }
+
+  const title = page.seo_title || `${page.title} | CreditOdds`;
+  const description = page.seo_description || page.description;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title: page.seo_title || page.title,
+      description,
+      url: `https://creditodds.com/best/${page.slug}`,
+      type: "article",
+      publishedTime: page.date,
+      modifiedTime: page.updated_at || page.date,
+      authors: [page.author],
+    },
+    alternates: {
+      canonical: `https://creditodds.com/best/${page.slug}`,
+    },
+  };
+}
+
+export async function generateStaticParams() {
+  const pages = await getBestPages();
+  return pages.map((page) => ({
+    slug: page.slug,
+  }));
+}
+
+export const revalidate = 300;
+
+export default async function BestDetailPage({ params }: Props) {
+  const { slug } = await params;
+  const [page, allCards] = await Promise.all([
+    getBestPage(slug),
+    getAllCards(),
+  ]);
+
+  if (!page) {
+    notFound();
+  }
+
+  // Build a lookup map from slug to card
+  const cardsBySlug = new Map(allCards.map(card => [card.slug, card]));
+
+  // Merge curated card list with live card data
+  const enrichedCards = page.cards
+    .filter(entry => cardsBySlug.has(entry.slug))
+    .map(entry => ({
+      ...entry,
+      card: cardsBySlug.get(entry.slug)!,
+    }));
+
+  const pageUrl = `https://creditodds.com/best/${page.slug}`;
+  const authorSlug = page.author_slug || page.author.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+  // ItemList JSON-LD for the ranked card list
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: page.title,
+    description: page.description,
+    url: pageUrl,
+    numberOfItems: enrichedCards.length,
+    itemListElement: enrichedCards.map((entry, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: entry.card.card_name,
+      url: `https://creditodds.com/card/${entry.card.slug}`,
+    })),
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Best Cards', url: 'https://creditodds.com/best' },
+        { name: page.title, url: pageUrl },
+      ]} />
+
+      <div className="min-h-screen bg-gray-50">
+        {/* Breadcrumbs */}
+        <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+              <li>
+                <Link href="/" className="text-gray-400 hover:text-gray-500">
+                  Home
+                </Link>
+              </li>
+              <li>
+                <div className="flex items-center">
+                  <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                  </svg>
+                  <Link href="/best" className="ml-4 text-gray-400 hover:text-gray-500">
+                    Best Cards
+                  </Link>
+                </div>
+              </li>
+              <li>
+                <div className="flex items-center">
+                  <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                  </svg>
+                  <span className="ml-4 text-sm font-medium text-gray-500 truncate">
+                    {page.title}
+                  </span>
+                </div>
+              </li>
+            </ol>
+          </div>
+        </nav>
+
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          {/* Header */}
+          <header className="mb-8">
+            <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 leading-tight mb-4">
+              {page.title}
+            </h1>
+            <p className="text-lg text-gray-500 mb-4">
+              {page.description}
+            </p>
+            <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500">
+              <div className="flex items-center gap-1.5">
+                <UserIcon className="h-4 w-4" />
+                <span>{page.author}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <CalendarIcon className="h-4 w-4" />
+                <span>{formatDate(page.date)}</span>
+              </div>
+              {page.updated_at && page.updated_at !== page.date && (
+                <div className="flex items-center gap-1.5 text-green-600">
+                  <ArrowPathIcon className="h-4 w-4" />
+                  <span>Updated {formatDate(page.updated_at)}</span>
+                </div>
+              )}
+            </div>
+          </header>
+
+          {/* Intro text */}
+          {page.intro && (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 sm:p-8 mb-8">
+              <ArticleContent content={page.intro} />
+            </div>
+          )}
+
+          {/* Ranked card list */}
+          <BestCardList cards={enrichedCards} />
+
+          {/* Back link */}
+          <div className="mt-8 text-center">
+            <Link
+              href="/best"
+              className="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium"
+            >
+              <svg className="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              Back to Best Cards
+            </Link>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web-next/src/app/best/page.tsx
+++ b/apps/web-next/src/app/best/page.tsx
@@ -1,0 +1,146 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { TrophyIcon, CalendarIcon } from "@heroicons/react/24/outline";
+import { getBestPages } from "@/lib/best";
+import { BreadcrumbSchema } from "@/components/seo/JsonLd";
+
+export const metadata: Metadata = {
+  title: "Best Credit Cards - Top Picks & Comparisons",
+  description: "Curated rankings of the best credit cards across categories. Data-driven picks updated with live approval odds and bonus values.",
+  openGraph: {
+    title: "Best Credit Cards | CreditOdds",
+    description: "Curated rankings of the best credit cards across categories.",
+    url: "https://creditodds.com/best",
+  },
+  alternates: {
+    canonical: "https://creditodds.com/best",
+  },
+};
+
+export const revalidate = 300;
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default async function BestIndexPage() {
+  const pages = await getBestPages();
+
+  const collectionJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Best Credit Cards",
+    description: "Curated rankings of the best credit cards across categories.",
+    url: "https://creditodds.com/best",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: pages.slice(0, 10).map((page, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `https://creditodds.com/best/${page.slug}`,
+      })),
+    },
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
+      />
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Best Cards', url: 'https://creditodds.com/best' },
+      ]} />
+
+      {/* Breadcrumbs */}
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">
+                Home
+              </Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500">Best Cards</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <div className="text-center mb-10">
+          <div className="flex items-center justify-center gap-3 mb-2">
+            <TrophyIcon className="h-8 w-8 text-indigo-600" aria-hidden="true" />
+            <h1 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
+              Best Cards
+            </h1>
+          </div>
+          <p className="mt-2 text-lg text-gray-500 max-w-2xl mx-auto">
+            Curated rankings of the best credit cards, updated with live data
+          </p>
+        </div>
+
+        {/* Pages Grid */}
+        {pages.length > 0 ? (
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {pages.map((page) => (
+              <Link
+                key={page.id}
+                href={`/best/${page.slug}`}
+                className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all"
+              >
+                <h2 className="text-lg font-bold text-gray-900 mb-2">
+                  {page.title}
+                </h2>
+                <p className="text-sm text-gray-500 mb-4">
+                  {page.description}
+                </p>
+                <div className="flex items-center justify-between text-xs text-gray-400">
+                  <div className="flex items-center gap-1">
+                    <CalendarIcon className="h-3.5 w-3.5" />
+                    <span>{formatDate(page.updated_at || page.date)}</span>
+                  </div>
+                  <span className="font-medium text-indigo-600">
+                    {page.cards.length} cards
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <TrophyIcon className="mx-auto h-12 w-12 text-gray-400" />
+            <h3 className="mt-2 text-sm font-medium text-gray-900">No rankings yet</h3>
+            <p className="mt-1 text-sm text-gray-500">Check back soon for curated card rankings.</p>
+          </div>
+        )}
+
+        {/* CTA */}
+        <div className="mt-12 text-center">
+          <p className="text-gray-600 mb-4">
+            Want to explore all cards?
+          </p>
+          <Link
+            href="/explore"
+            className="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+          >
+            Explore All Cards
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/sitemap.ts
+++ b/apps/web-next/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next';
 import { getAllCards, getAllBanks } from '@/lib/api';
 import { getNews } from '@/lib/news';
+import { getBestPages } from '@/lib/best';
 
 // Required for static export
 export const dynamic = 'force-static';
@@ -37,6 +38,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${baseUrl}/news`,
       lastModified: new Date(),
       changeFrequency: 'daily',
+      priority: 0.85,
+    },
+    {
+      url: `${baseUrl}/best`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
       priority: 0.85,
     },
     {
@@ -139,5 +146,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error('Error generating sitemap for news:', error);
   }
 
-  return [...staticPages, ...bankPages, ...cardPages, ...newsPages];
+  // Dynamic best pages
+  let bestPages: MetadataRoute.Sitemap = [];
+  try {
+    const bestItems = await getBestPages();
+    bestPages = bestItems.map((item) => ({
+      url: `${baseUrl}/best/${item.slug}`,
+      lastModified: new Date(item.updated_at || item.date),
+      changeFrequency: 'weekly' as const,
+      priority: 0.85,
+    }));
+  } catch (error) {
+    console.error('Error generating sitemap for best pages:', error);
+  }
+
+  return [...staticPages, ...bankPages, ...cardPages, ...newsPages, ...bestPages];
 }

--- a/apps/web-next/src/components/best/ApplyButtons.tsx
+++ b/apps/web-next/src/components/best/ApplyButtons.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useMemo, useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { CardReferral, trackReferralEvent } from '@/lib/api';
+
+interface ApplyButtonsProps {
+  slug: string;
+  applyLink?: string;
+  referrals?: CardReferral[];
+  acceptingApplications: boolean;
+}
+
+export function ApplyButtons({ slug, applyLink, referrals, acceptingApplications }: ApplyButtonsProps) {
+  const selectedReferral = useMemo(() => {
+    if (referrals && referrals.length > 0) {
+      const randomIndex = Math.floor(Math.random() * referrals.length);
+      return referrals[randomIndex];
+    }
+    return null;
+  }, [referrals]);
+
+  const randomReferralUrl = selectedReferral?.referral_link || null;
+
+  const impressionTracked = useRef(false);
+  useEffect(() => {
+    if (selectedReferral && !impressionTracked.current) {
+      impressionTracked.current = true;
+      trackReferralEvent(selectedReferral.referral_id, 'impression').catch(() => {});
+    }
+  }, [selectedReferral]);
+
+  const handleReferralClick = () => {
+    if (selectedReferral) {
+      trackReferralEvent(selectedReferral.referral_id, 'click').catch(() => {});
+    }
+  };
+
+  if (!acceptingApplications) return null;
+
+  const hasButtons = applyLink || randomReferralUrl;
+  if (!hasButtons) return null;
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-2 items-start">
+      {applyLink && (
+        <a
+          href={applyLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 transition-colors"
+        >
+          Apply Now
+        </a>
+      )}
+      {randomReferralUrl && (
+        <a
+          href={randomReferralUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleReferralClick}
+          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white transition-colors animate-shimmer bg-[length:200%_100%]"
+          style={{
+            backgroundImage: 'linear-gradient(110deg, #5b21b6 0%, #6d28d9 45%, #8b5cf6 55%, #6d28d9 100%)',
+          }}
+        >
+          Apply with Referral
+        </a>
+      )}
+      <Link
+        href={`/card/${slug}`}
+        className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+      >
+        See Approval Odds
+      </Link>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/best/BestCardList.tsx
+++ b/apps/web-next/src/components/best/BestCardList.tsx
@@ -1,0 +1,162 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { Card } from '@/lib/api';
+import { BestPageCard } from '@/lib/best';
+import { ApplyButtons } from './ApplyButtons';
+
+interface EnrichedCard extends BestPageCard {
+  card: Card;
+}
+
+interface BestCardListProps {
+  cards: EnrichedCard[];
+}
+
+function formatBonusValue(card: Card): string {
+  if (!card.signup_bonus) return '';
+  const { value, type } = card.signup_bonus;
+  if (type === 'cash' || type === 'cashback') {
+    return `$${value.toLocaleString()}`;
+  }
+  return `${value.toLocaleString()} ${type}`;
+}
+
+function formatBonusRequirement(card: Card): string {
+  if (!card.signup_bonus) return '';
+  const { spend_requirement, timeframe_months } = card.signup_bonus;
+  return `after $${spend_requirement.toLocaleString()} in ${timeframe_months} month${timeframe_months !== 1 ? 's' : ''}`;
+}
+
+function formatAnnualFee(fee: number | undefined): string {
+  if (fee === undefined || fee === null) return 'N/A';
+  if (fee === 0) return '$0';
+  return `$${fee}`;
+}
+
+function RewardTypeBadge({ type }: { type?: string }) {
+  if (!type) return null;
+  const colors: Record<string, string> = {
+    cashback: 'bg-green-100 text-green-800',
+    points: 'bg-blue-100 text-blue-800',
+    miles: 'bg-purple-100 text-purple-800',
+  };
+  const labels: Record<string, string> = {
+    cashback: 'Cash Back',
+    points: 'Points',
+    miles: 'Miles',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors[type] || 'bg-gray-100 text-gray-800'}`}>
+      {labels[type] || type}
+    </span>
+  );
+}
+
+export function BestCardList({ cards }: BestCardListProps) {
+  return (
+    <div className="space-y-6">
+      {cards.map((entry, index) => {
+        const { card } = entry;
+        const rank = index + 1;
+        const topRewards = (card.rewards || []).slice(0, 3);
+
+        return (
+          <div
+            key={card.slug}
+            className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden"
+          >
+            {/* Header with rank and badge */}
+            <div className="flex items-center gap-3 px-4 sm:px-6 py-3 bg-gray-50 border-b border-gray-200">
+              <span className="flex items-center justify-center w-8 h-8 rounded-full bg-indigo-600 text-white text-sm font-bold flex-shrink-0">
+                {rank}
+              </span>
+              <Link href={`/card/${card.slug}`} className="text-lg font-bold text-gray-900 hover:text-indigo-600 transition-colors">
+                {card.card_name}
+              </Link>
+              {entry.badge && (
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-800 whitespace-nowrap">
+                  {entry.badge}
+                </span>
+              )}
+            </div>
+
+            <div className="p-4 sm:p-6">
+              <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
+                {/* Card image */}
+                <div className="flex-shrink-0">
+                  <Link href={`/card/${card.slug}`}>
+                    {card.card_image_link ? (
+                      <Image
+                        src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
+                        alt={card.card_name}
+                        width={160}
+                        height={100}
+                        className="rounded-lg shadow-sm"
+                      />
+                    ) : (
+                      <div className="w-40 h-25 bg-gray-200 rounded-lg flex items-center justify-center">
+                        <span className="text-gray-400 text-xs">No image</span>
+                      </div>
+                    )}
+                  </Link>
+                </div>
+
+                {/* Card details */}
+                <div className="flex-1 min-w-0">
+                  {/* Bank + badges row */}
+                  <div className="flex flex-wrap items-center gap-2 mb-3">
+                    <span className="text-sm text-gray-500">{card.bank}</span>
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
+                      {formatAnnualFee(card.annual_fee)} / yr
+                    </span>
+                    <RewardTypeBadge type={card.reward_type} />
+                  </div>
+
+                  {/* Signup bonus */}
+                  {card.signup_bonus && (
+                    <div className="bg-amber-50 border border-amber-100 rounded-lg px-4 py-3 mb-3">
+                      <p className="text-sm font-medium text-amber-900">
+                        Earn{' '}
+                        <span className="font-bold text-base">{formatBonusValue(card)}</span>{' '}
+                        {formatBonusRequirement(card)}
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Top reward categories */}
+                  {topRewards.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-3">
+                      {topRewards.map((reward, i) => (
+                        <span
+                          key={i}
+                          className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-indigo-50 text-indigo-700"
+                        >
+                          {reward.value}{reward.unit === '%' ? '%' : 'x'} {reward.category}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Editorial highlight */}
+                  {entry.highlight && (
+                    <p className="text-sm text-gray-600 mb-4">
+                      {entry.highlight}
+                    </p>
+                  )}
+
+                  {/* Apply buttons */}
+                  <ApplyButtons
+                    slug={card.slug}
+                    applyLink={card.apply_link}
+                    referrals={card.referrals}
+                    acceptingApplications={card.accepting_applications}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web-next/src/components/best/BestCardList.tsx
+++ b/apps/web-next/src/components/best/BestCardList.tsx
@@ -161,6 +161,32 @@ export function BestCardList({ cards }: BestCardListProps) {
                     </div>
                   )}
 
+                  {/* Intro APR */}
+                  {!card.signup_bonus && card.apr && (card.apr.purchase_intro || card.apr.balance_transfer_intro) && (
+                    <div className="bg-sky-50 border border-sky-100 rounded-lg px-4 py-3 mb-3">
+                      <p className="text-sm font-medium text-sky-900">
+                        {card.apr.purchase_intro && card.apr.balance_transfer_intro ? (
+                          <>
+                            <span className="font-bold text-base">{card.apr.purchase_intro.rate}% intro APR</span> for {card.apr.purchase_intro.months} months on purchases
+                            {card.apr.balance_transfer_intro.months !== card.apr.purchase_intro.months ? (
+                              <> &amp; {card.apr.balance_transfer_intro.months} months on balance transfers</>
+                            ) : (
+                              <> &amp; balance transfers</>
+                            )}
+                          </>
+                        ) : card.apr.balance_transfer_intro ? (
+                          <>
+                            <span className="font-bold text-base">{card.apr.balance_transfer_intro.rate}% intro APR</span> for {card.apr.balance_transfer_intro.months} months on balance transfers
+                          </>
+                        ) : card.apr.purchase_intro ? (
+                          <>
+                            <span className="font-bold text-base">{card.apr.purchase_intro.rate}% intro APR</span> for {card.apr.purchase_intro.months} months on purchases
+                          </>
+                        ) : null}
+                      </p>
+                    </div>
+                  )}
+
                   {/* Top reward categories */}
                   {topRewards.length > 0 && (
                     <div className="flex flex-wrap gap-2 mb-3">

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -70,6 +70,17 @@ export default function Navbar() {
                   >
                     Card News
                   </Link>
+                  <Link
+                    href="/best"
+                    className={classNames(
+                      isActive('/best') || pathname.startsWith('/best/')
+                        ? 'border-indigo-500 text-gray-900'
+                        : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+                      'inline-flex items-center px-1 pt-1 border-b-2 text-md font-medium'
+                    )}
+                  >
+                    Best Cards
+                  </Link>
                 </nav>
               </div>
               <div className="hidden sm:ml-6 sm:flex sm:items-center">
@@ -206,6 +217,18 @@ export default function Navbar() {
                 )}
               >
                 Card News
+              </Link>
+              <Link
+                href="/best"
+                onClick={() => close()}
+                className={classNames(
+                  isActive('/best') || pathname.startsWith('/best/')
+                    ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+                    : 'border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700',
+                  'block pl-3 pr-4 py-2 border-l-4 text-base font-medium'
+                )}
+              >
+                Best Cards
               </Link>
             </nav>
             <div className="pb-3 border-t border-gray-200">

--- a/apps/web-next/src/lib/best.ts
+++ b/apps/web-next/src/lib/best.ts
@@ -1,0 +1,69 @@
+// Best pages API types and fetching
+
+export interface BestPageCard {
+  slug: string;
+  highlight?: string;
+  badge?: string;
+}
+
+export interface BestPage {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  updated_at?: string;
+  author: string;
+  author_slug?: string;
+  seo_title?: string;
+  seo_description?: string;
+  intro?: string;
+  cards: BestPageCard[];
+}
+
+export interface BestPagesResponse {
+  generated_at: string;
+  count: number;
+  pages: BestPage[];
+}
+
+const BEST_CDN_URL = 'https://d2hxvzw7msbtvt.cloudfront.net/best.json';
+
+// Check if running in the browser
+const isBrowser = typeof window !== 'undefined';
+
+export async function getBestPages(): Promise<BestPage[]> {
+  try {
+    // In development on the server, read from local file
+    if (!isBrowser && process.env.NODE_ENV === 'development') {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const filePath = path.join(process.cwd(), '..', '..', 'data', 'best.json');
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      const data: BestPagesResponse = JSON.parse(fileContent);
+      return data.pages || [];
+    }
+
+    // Use local API route on client to avoid CORS, direct CDN on server
+    const url = isBrowser ? '/api/best' : BEST_CDN_URL;
+    const res = await fetch(url, isBrowser ? {} : {
+      next: { revalidate: 300 },
+    });
+
+    if (!res.ok) {
+      console.error('Failed to fetch best pages:', res.status);
+      return [];
+    }
+
+    const data: BestPagesResponse = await res.json();
+    return data.pages || [];
+  } catch (error) {
+    console.error('Error fetching best pages:', error);
+    return [];
+  }
+}
+
+export async function getBestPage(slug: string): Promise<BestPage | null> {
+  const pages = await getBestPages();
+  return pages.find(page => page.slug === slug) || null;
+}

--- a/apps/web-next/src/lib/best.ts
+++ b/apps/web-next/src/lib/best.ts
@@ -13,7 +13,7 @@ export interface BestPage {
   description: string;
   date: string;
   updated_at?: string;
-  author: string;
+  author?: string;
   author_slug?: string;
   seo_title?: string;
   seo_description?: string;

--- a/data/best.json
+++ b/data/best.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-02-28T20:12:45.391Z",
+  "generated_at": "2026-02-28T20:20:29.732Z",
   "count": 1,
   "pages": [
     {
       "id": "best-signup-bonuses",
       "slug": "best-signup-bonuses",
-      "title": "Best Credit Card Sign Up Bonuses",
-      "description": "The most valuable credit card sign up bonuses available right now, ranked by bonus value and overall appeal.",
+      "title": "Best Credit Card Signup Bonuses",
+      "description": "The most valuable credit card signup bonuses available right now, ranked by bonus value and overall appeal.",
       "date": "2026-02-28",
       "author": "Maxwell Melcher",
-      "seo_title": "Best Credit Card Sign Up Bonuses of 2026",
-      "seo_description": "Compare the best credit card sign up bonuses of 2026. Ranked by value — from 140k points to $200 cash back.",
-      "intro": "Sign up bonuses are the fastest way to earn a big chunk of rewards from a new credit card. We've ranked the best offers available right now based on bonus value, ease of earning, and overall card quality. All data is pulled live from our card database so bonus values, annual fees, and apply links are always current.\n",
+      "seo_title": "Best Credit Card Signup Bonuses of 2026",
+      "seo_description": "Compare the best credit card signup bonuses of 2026. Ranked by value — from 140k points to $200 cash back.",
+      "intro": "Signup bonuses are the fastest way to earn a big chunk of rewards from a new credit card. We've ranked the best offers available right now based on bonus value, ease of earning, and overall card quality. All data is pulled live from our card database so bonus values, annual fees, and apply links are always current.\n",
       "cards": [
         {
           "slug": "ihg-rewards-premier-business",
           "badge": "Best Overall",
-          "highlight": "The highest sign up bonus available right now — 140,000 IHG points after $4,000 in 3 months. IHG points are worth around 0.5 cents each, making this worth roughly $700 in hotel stays."
+          "highlight": "The highest signup bonus available right now — 140,000 IHG points after $4,000 in 3 months. IHG points are worth around 0.5 cents each, making this worth roughly $700 in hotel stays."
         },
         {
           "slug": "delta-skymiles-reserve-american-express-card",

--- a/data/best.json
+++ b/data/best.json
@@ -1,7 +1,230 @@
 {
-  "generated_at": "2026-02-28T20:20:29.732Z",
-  "count": 1,
+  "generated_at": "2026-02-28T20:27:07.238Z",
+  "count": 5,
   "pages": [
+    {
+      "id": "best-0-apr-cards",
+      "slug": "best-0-apr-cards",
+      "title": "Best 0% APR Credit Cards",
+      "description": "The best 0% intro APR credit cards for purchases and balance transfers, all with no annual fee.",
+      "date": "2026-02-28",
+      "author": "Maxwell Melcher",
+      "seo_title": "Best 0% APR Credit Cards of 2026",
+      "seo_description": "Compare the best 0% intro APR credit cards of 2026. Up to 21 months of 0% APR on purchases and balance transfers.",
+      "intro": "A 0% intro APR card lets you make purchases or transfer balances and pay no interest for an extended period — typically 12 to 21 months. These cards are ideal for financing a large purchase over time or consolidating existing credit card debt. Every card on this list has a $0 annual fee.\n",
+      "cards": [
+        {
+          "slug": "wells-fargo-reflect",
+          "badge": "Best Overall",
+          "highlight": "21 months of 0% APR on both purchases and balance transfers — the longest intro period available. No rewards, but as a pure interest-saving tool it's hard to beat."
+        },
+        {
+          "slug": "bankamericard",
+          "badge": "Longest 0% Period",
+          "highlight": "21 months of 0% APR on both purchases and balance transfers, matching the longest periods on the market. A straightforward no-frills card focused entirely on interest savings."
+        },
+        {
+          "slug": "citi-simplicity-card",
+          "badge": "No Late Fees",
+          "highlight": "21 months 0% on balance transfers and 12 months on purchases. The standout feature — no late fees ever. If you're worried about missing a payment during your payoff plan, this is the safest pick."
+        },
+        {
+          "slug": "citi-diamond-preferred",
+          "highlight": "Same 21-month balance transfer period as the Simplicity, with 12 months 0% on purchases. A solid choice if you're mainly focused on paying down transferred balances."
+        },
+        {
+          "slug": "chase-slate-edge",
+          "highlight": "21 months of 0% APR on balance transfers. Chase also offers an automatic APR reduction if you pay on time and keep utilization under 30% — a unique perk for long-term cardholders."
+        },
+        {
+          "slug": "us-bank-shield",
+          "highlight": "15 months of 0% APR on both purchases and balance transfers. Shorter than the top picks but still a generous window for interest-free financing."
+        }
+      ],
+      "author_slug": "maxwell-melcher"
+    },
+    {
+      "id": "best-airline-cards",
+      "slug": "best-airline-cards",
+      "title": "Best Airline Credit Cards",
+      "description": "The top co-branded airline credit cards ranked by signup bonuses, earning rates, and travel perks.",
+      "date": "2026-02-28",
+      "author": "Maxwell Melcher",
+      "seo_title": "Best Airline Credit Cards of 2026",
+      "seo_description": "Compare the best airline credit cards of 2026. Delta, United, Southwest, JetBlue, and more — ranked by value.",
+      "intro": "Airline credit cards earn miles in a specific loyalty program and come with perks like free checked bags, priority boarding, and lounge access. They're best for travelers loyal to one airline or alliance. We've ranked these by overall value — factoring in signup bonuses, earning rates, annual fees, and travel benefits.\n",
+      "cards": [
+        {
+          "slug": "delta-skymiles-reserve-american-express-card",
+          "badge": "Best Premium",
+          "highlight": "125,000 SkyMiles signup bonus, Delta Sky Club access, and a companion certificate. The ultimate Delta card for frequent flyers willing to pay the $650 annual fee."
+        },
+        {
+          "slug": "delta-skymiles-platinum-american-express-card",
+          "badge": "Best Delta Value",
+          "highlight": "100,000 SkyMiles with a companion certificate and solid travel protections. A strong step up from the Gold at $350/year without the Reserve's premium price."
+        },
+        {
+          "slug": "delta-skymiles-gold-american-express-card",
+          "badge": "Best Mid-Tier",
+          "highlight": "90,000 SkyMiles signup bonus with a $150 annual fee. Includes a free first checked bag and 2x earning on dining, groceries, and Delta purchases."
+        },
+        {
+          "slug": "united-explorer",
+          "highlight": "A well-rounded United card with a free first checked bag, two United Club one-time passes, and expanded award availability. Good for occasional to moderate United flyers."
+        },
+        {
+          "slug": "united-quest",
+          "highlight": "Premium United card with up to $250 in annual travel credits. 3x miles on United purchases and a stronger earning structure than the Explorer."
+        },
+        {
+          "slug": "united-club-infinite",
+          "highlight": "United Club lounge access, Premier 1K-level upgrades, and the strongest United earning structure. Worth it if you fly United frequently and value lounge access."
+        },
+        {
+          "slug": "southwest-rapid-rewards-priority-credit-card",
+          "highlight": "$75 annual travel credit, 4 upgraded boardings per year, and 7,500 anniversary points. The best Southwest card for earning toward the Companion Pass."
+        },
+        {
+          "slug": "southwest-rapid-rewards-premier-credit-card",
+          "highlight": "Solid mid-tier Southwest option with 2x on Southwest and Rapid Rewards hotel/car purchases. Lower annual fee than the Priority with core travel benefits."
+        },
+        {
+          "slug": "southwest-rapid-rewards-plus-credit-card",
+          "highlight": "The entry-level Southwest card at $99/year. 2x on Southwest purchases and 1x on everything else, plus anniversary points toward the Companion Pass."
+        },
+        {
+          "slug": "delta-skymiles-blue-american-express-card",
+          "highlight": "No annual fee entry point into the Delta ecosystem. 2x miles on dining and Delta purchases. A great starter airline card."
+        },
+        {
+          "slug": "united-gateway",
+          "highlight": "No annual fee United card. A free first checked bag on United and basic miles earning. Best for infrequent United travelers who want the checked bag perk."
+        },
+        {
+          "slug": "jetblue-plus-card",
+          "highlight": "6x points on JetBlue, a free first checked bag, and 50% savings on inflight purchases. A solid co-brand for Northeast and Florida travelers."
+        },
+        {
+          "slug": "jetblue-card",
+          "highlight": "No annual fee JetBlue card with 3x on JetBlue purchases and 2x on dining and groceries. Good for casual JetBlue flyers."
+        },
+        {
+          "slug": "american-airlines-aadvantage-mileu-mastercard",
+          "highlight": "No annual fee American Airlines card. Earns 2x on eligible AA purchases and is the only free entry into the AAdvantage program via a credit card."
+        },
+        {
+          "slug": "hawaiian-airlines-world-elite-mastercard",
+          "highlight": "3x miles on Hawaiian Airlines, 2x on dining and gas. Includes a companion fare discount and no foreign transaction fees — ideal for Hawaii-bound travelers."
+        }
+      ],
+      "author_slug": "maxwell-melcher"
+    },
+    {
+      "id": "best-dining-grocery-cards",
+      "slug": "best-dining-grocery-cards",
+      "title": "Best Credit Cards for Dining and Groceries",
+      "description": "The top credit cards for earning rewards on restaurants and grocery store purchases, from premium to no-annual-fee options.",
+      "date": "2026-02-28",
+      "author": "Maxwell Melcher",
+      "seo_title": "Best Credit Cards for Dining and Groceries of 2026",
+      "seo_description": "Compare the best dining and grocery credit cards of 2026. Earn 3-4x points or up to 6% cash back on food spending.",
+      "intro": "Dining and groceries are two of the biggest spending categories for most people. The right card can earn you serious rewards on money you're already spending. We've ranked these cards by their earning rates on dining and groceries, factoring in annual fees and overall card value.\n",
+      "cards": [
+        {
+          "slug": "american-express-gold-card",
+          "badge": "Best Overall",
+          "highlight": "4x Membership Rewards points on dining and groceries is the highest ongoing earn rate in both categories from a single card. The $325 annual fee is offset by monthly dining and Uber credits."
+        },
+        {
+          "slug": "capital-one-savorone",
+          "badge": "Best No-Fee Card",
+          "highlight": "3% cash back on dining, groceries, entertainment, and streaming with no annual fee. The best all-around no-fee card for food spending."
+        },
+        {
+          "slug": "chase-sapphire-preferred",
+          "highlight": "3x points on dining make this a strong everyday earner. Points transfer to Hyatt, United, and other partners, giving you outsized value for a $95 annual fee."
+        },
+        {
+          "slug": "chase-sapphire-reserve",
+          "highlight": "3x on dining with a $300 travel credit and 50% bonus when redeeming through Chase Travel. The premium option for frequent travelers who also dine out a lot."
+        },
+        {
+          "slug": "chase-freedom-flex",
+          "highlight": "3% back on dining at restaurants with no annual fee, plus 5% rotating categories that sometimes include grocery stores. A great starter or pairing card."
+        },
+        {
+          "slug": "chase-freedom-unlimited",
+          "highlight": "3% on dining plus 1.5% on everything else, no annual fee. Pairs perfectly with a Sapphire card to transfer points to travel partners."
+        },
+        {
+          "slug": "wells-fargo-autograph",
+          "highlight": "3x points on dining with no annual fee. Also earns 3x on travel, gas, transit, and streaming — a versatile everyday card."
+        },
+        {
+          "slug": "blue-cash-everyday-card",
+          "highlight": "3% cash back at U.S. supermarkets (up to $6,000/year) with no annual fee. One of the best standalone grocery cards for most households."
+        },
+        {
+          "slug": "atmos-rewards-summit",
+          "highlight": "3x points on dining plus a strong rewards structure across travel and everyday categories. A newer card with competitive earning rates."
+        },
+        {
+          "slug": "delta-skymiles-gold-american-express-card",
+          "highlight": "2x miles on dining and U.S. supermarkets. A strong pick if you fly Delta — the dining and grocery earnings fuel your miles balance between flights."
+        },
+        {
+          "slug": "rakuten-american-express",
+          "highlight": "2% back on dining and groceries with no annual fee. Also earns elevated rates on Rakuten shopping portal purchases — a solid secondary card."
+        },
+        {
+          "slug": "atmos-rewards-ascent",
+          "highlight": "3x on dining with a lower annual fee than the Summit. A good mid-tier option if you want elevated dining rewards without the premium price tag."
+        }
+      ],
+      "author_slug": "maxwell-melcher"
+    },
+    {
+      "id": "best-secured-cards",
+      "slug": "best-secured-cards",
+      "title": "Best Secured Credit Cards",
+      "description": "The best secured credit cards for building or rebuilding credit, all with no annual fee.",
+      "date": "2026-02-28",
+      "author": "Maxwell Melcher",
+      "seo_title": "Best Secured Credit Cards of 2026",
+      "seo_description": "Compare the best secured credit cards of 2026 for building credit. All have $0 annual fees and report to all three bureaus.",
+      "intro": "Secured credit cards require a refundable security deposit that typically becomes your credit limit. They're designed for people building credit for the first time or rebuilding after a setback. Every card on this list has no annual fee and reports to all three major credit bureaus, so responsible use will help your credit score grow over time.\n",
+      "cards": [
+        {
+          "slug": "discover-it-secured-credit-card",
+          "badge": "Best Overall",
+          "highlight": "The only secured card that earns meaningful cash back — 2% at gas stations and restaurants (up to $1,000/quarter) and 1% on everything else. Discover also matches all cash back earned in your first year, effectively doubling your rewards."
+        },
+        {
+          "slug": "capital-one-quicksilver-secured",
+          "badge": "Best for Rewards",
+          "highlight": "Earns 1.5% cash back on every purchase with no annual fee. One of the few secured cards with a flat-rate rewards structure, making it feel like a regular credit card."
+        },
+        {
+          "slug": "bank-of-america-cash-rewards-secured",
+          "highlight": "Earns cash back in a category of your choice (gas, online shopping, dining, travel, drug stores, or home improvement). A good pick if your spending is concentrated in one area."
+        },
+        {
+          "slug": "capital-one-platinum-secured",
+          "badge": "Easiest Approval",
+          "highlight": "No rewards, but one of the easiest secured cards to get approved for. Minimum deposit as low as $49 depending on creditworthiness. A strong starter card for those with very limited credit history."
+        },
+        {
+          "slug": "citi-secured-mastercard",
+          "highlight": "A straightforward secured card with no rewards but wide Mastercard acceptance. Reports to all three bureaus and has a path to upgrade to an unsecured Citi card over time."
+        },
+        {
+          "slug": "us-bank-secured",
+          "highlight": "A basic secured Visa card with no rewards. U.S. Bank reviews your account for an upgrade to an unsecured card automatically. A solid option if you already bank with U.S. Bank."
+        }
+      ],
+      "author_slug": "maxwell-melcher"
+    },
     {
       "id": "best-signup-bonuses",
       "slug": "best-signup-bonuses",

--- a/data/best.json
+++ b/data/best.json
@@ -1,0 +1,85 @@
+{
+  "generated_at": "2026-02-28T20:12:45.391Z",
+  "count": 1,
+  "pages": [
+    {
+      "id": "best-signup-bonuses",
+      "slug": "best-signup-bonuses",
+      "title": "Best Credit Card Sign Up Bonuses",
+      "description": "The most valuable credit card sign up bonuses available right now, ranked by bonus value and overall appeal.",
+      "date": "2026-02-28",
+      "author": "Maxwell Melcher",
+      "seo_title": "Best Credit Card Sign Up Bonuses of 2026",
+      "seo_description": "Compare the best credit card sign up bonuses of 2026. Ranked by value — from 140k points to $200 cash back.",
+      "intro": "Sign up bonuses are the fastest way to earn a big chunk of rewards from a new credit card. We've ranked the best offers available right now based on bonus value, ease of earning, and overall card quality. All data is pulled live from our card database so bonus values, annual fees, and apply links are always current.\n",
+      "cards": [
+        {
+          "slug": "ihg-rewards-premier-business",
+          "badge": "Best Overall",
+          "highlight": "The highest sign up bonus available right now — 140,000 IHG points after $4,000 in 3 months. IHG points are worth around 0.5 cents each, making this worth roughly $700 in hotel stays."
+        },
+        {
+          "slug": "delta-skymiles-reserve-american-express-card",
+          "badge": "Best for Premium Travel",
+          "highlight": "125,000 Delta SkyMiles is an enormous haul. The Reserve card also includes Delta Sky Club access and a companion certificate — ideal for frequent Delta flyers."
+        },
+        {
+          "slug": "delta-skymiles-platinum-american-express-card",
+          "badge": "Best Delta Value",
+          "highlight": "100,000 SkyMiles for a lower annual fee than the Reserve. You still get a companion certificate and solid travel perks without the ultra-premium price tag."
+        },
+        {
+          "slug": "delta-skymiles-gold-american-express-card",
+          "highlight": "90,000 SkyMiles is a top-tier bonus for a mid-tier card. Great entry point into the Delta ecosystem with a reasonable $150 annual fee."
+        },
+        {
+          "slug": "atmos-rewards-summit",
+          "highlight": "80,000 Atmos points with a $4,000 spend requirement. Atmos is a newer player but their redemption rates are competitive with major programs."
+        },
+        {
+          "slug": "capital-one-venture-x",
+          "badge": "Best Travel Card",
+          "highlight": "75,000 miles after $4,000 in 3 months. The Venture X also comes with a $300 travel credit and 10,000 anniversary miles, effectively making the $395 annual fee very manageable."
+        },
+        {
+          "slug": "atmos-rewards-ascent",
+          "highlight": "70,000 Atmos points with only $3,000 in spending required. A lower spend threshold makes this one of the easier big bonuses to earn."
+        },
+        {
+          "slug": "chase-sapphire-preferred",
+          "highlight": "60,000 Ultimate Rewards points are worth at least $750 when redeemed through Chase Travel. One of the most versatile points currencies available."
+        },
+        {
+          "slug": "american-express-gold-card",
+          "highlight": "60,000 Membership Rewards points after $6,000 in 6 months. The Gold Card is a powerhouse for dining and groceries with 4x earning in both categories."
+        },
+        {
+          "slug": "chase-sapphire-reserve",
+          "highlight": "60,000 Ultimate Rewards points plus a $300 annual travel credit. Points are worth 50% more through Chase Travel, making this bonus worth up to $900."
+        },
+        {
+          "slug": "world-of-hyatt-business-credit-card",
+          "highlight": "60,000 World of Hyatt points can easily be worth $1,200+ in hotel stays. Hyatt consistently offers the best value among hotel loyalty programs."
+        },
+        {
+          "slug": "wells-fargo-signify-business-cash",
+          "badge": "Best Cash Back",
+          "highlight": "A straightforward $500 cash back after $5,000 in 3 months. No points to figure out, no transfer partners — just cash in your account."
+        },
+        {
+          "slug": "chase-freedom-flex",
+          "highlight": "$200 cash back after just $500 in spending — one of the easiest bonuses to earn. Plus 5% rotating categories and a strong everyday rewards structure."
+        },
+        {
+          "slug": "wells-fargo-active-cash",
+          "highlight": "$200 cash back with a low $500 spend requirement. Pairs well with the 2% flat cash back on everything, making it a solid daily driver."
+        },
+        {
+          "slug": "capital-one-savorone",
+          "highlight": "$200 cash back after $500 in 3 months. The SavorOne also earns 3% on dining, entertainment, groceries, and streaming — a great all-around no-annual-fee card."
+        }
+      ],
+      "author_slug": "maxwell-melcher"
+    }
+  ]
+}

--- a/data/best.json
+++ b/data/best.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-28T20:27:07.238Z",
+  "generated_at": "2026-02-28T20:28:35.555Z",
   "count": 5,
   "pages": [
     {
@@ -8,7 +8,6 @@
       "title": "Best 0% APR Credit Cards",
       "description": "The best 0% intro APR credit cards for purchases and balance transfers, all with no annual fee.",
       "date": "2026-02-28",
-      "author": "Maxwell Melcher",
       "seo_title": "Best 0% APR Credit Cards of 2026",
       "seo_description": "Compare the best 0% intro APR credit cards of 2026. Up to 21 months of 0% APR on purchases and balance transfers.",
       "intro": "A 0% intro APR card lets you make purchases or transfer balances and pay no interest for an extended period — typically 12 to 21 months. These cards are ideal for financing a large purchase over time or consolidating existing credit card debt. Every card on this list has a $0 annual fee.\n",
@@ -40,8 +39,7 @@
           "slug": "us-bank-shield",
           "highlight": "15 months of 0% APR on both purchases and balance transfers. Shorter than the top picks but still a generous window for interest-free financing."
         }
-      ],
-      "author_slug": "maxwell-melcher"
+      ]
     },
     {
       "id": "best-airline-cards",
@@ -49,7 +47,6 @@
       "title": "Best Airline Credit Cards",
       "description": "The top co-branded airline credit cards ranked by signup bonuses, earning rates, and travel perks.",
       "date": "2026-02-28",
-      "author": "Maxwell Melcher",
       "seo_title": "Best Airline Credit Cards of 2026",
       "seo_description": "Compare the best airline credit cards of 2026. Delta, United, Southwest, JetBlue, and more — ranked by value.",
       "intro": "Airline credit cards earn miles in a specific loyalty program and come with perks like free checked bags, priority boarding, and lounge access. They're best for travelers loyal to one airline or alliance. We've ranked these by overall value — factoring in signup bonuses, earning rates, annual fees, and travel benefits.\n",
@@ -117,8 +114,7 @@
           "slug": "hawaiian-airlines-world-elite-mastercard",
           "highlight": "3x miles on Hawaiian Airlines, 2x on dining and gas. Includes a companion fare discount and no foreign transaction fees — ideal for Hawaii-bound travelers."
         }
-      ],
-      "author_slug": "maxwell-melcher"
+      ]
     },
     {
       "id": "best-dining-grocery-cards",
@@ -126,7 +122,6 @@
       "title": "Best Credit Cards for Dining and Groceries",
       "description": "The top credit cards for earning rewards on restaurants and grocery store purchases, from premium to no-annual-fee options.",
       "date": "2026-02-28",
-      "author": "Maxwell Melcher",
       "seo_title": "Best Credit Cards for Dining and Groceries of 2026",
       "seo_description": "Compare the best dining and grocery credit cards of 2026. Earn 3-4x points or up to 6% cash back on food spending.",
       "intro": "Dining and groceries are two of the biggest spending categories for most people. The right card can earn you serious rewards on money you're already spending. We've ranked these cards by their earning rates on dining and groceries, factoring in annual fees and overall card value.\n",
@@ -181,8 +176,7 @@
           "slug": "atmos-rewards-ascent",
           "highlight": "3x on dining with a lower annual fee than the Summit. A good mid-tier option if you want elevated dining rewards without the premium price tag."
         }
-      ],
-      "author_slug": "maxwell-melcher"
+      ]
     },
     {
       "id": "best-secured-cards",
@@ -190,7 +184,6 @@
       "title": "Best Secured Credit Cards",
       "description": "The best secured credit cards for building or rebuilding credit, all with no annual fee.",
       "date": "2026-02-28",
-      "author": "Maxwell Melcher",
       "seo_title": "Best Secured Credit Cards of 2026",
       "seo_description": "Compare the best secured credit cards of 2026 for building credit. All have $0 annual fees and report to all three bureaus.",
       "intro": "Secured credit cards require a refundable security deposit that typically becomes your credit limit. They're designed for people building credit for the first time or rebuilding after a setback. Every card on this list has no annual fee and reports to all three major credit bureaus, so responsible use will help your credit score grow over time.\n",
@@ -222,8 +215,7 @@
           "slug": "us-bank-secured",
           "highlight": "A basic secured Visa card with no rewards. U.S. Bank reviews your account for an upgrade to an unsecured card automatically. A solid option if you already bank with U.S. Bank."
         }
-      ],
-      "author_slug": "maxwell-melcher"
+      ]
     },
     {
       "id": "best-signup-bonuses",
@@ -231,7 +223,6 @@
       "title": "Best Credit Card Signup Bonuses",
       "description": "The most valuable credit card signup bonuses available right now, ranked by bonus value and overall appeal.",
       "date": "2026-02-28",
-      "author": "Maxwell Melcher",
       "seo_title": "Best Credit Card Signup Bonuses of 2026",
       "seo_description": "Compare the best credit card signup bonuses of 2026. Ranked by value — from 140k points to $200 cash back.",
       "intro": "Signup bonuses are the fastest way to earn a big chunk of rewards from a new credit card. We've ranked the best offers available right now based on bonus value, ease of earning, and overall card quality. All data is pulled live from our card database so bonus values, annual fees, and apply links are always current.\n",
@@ -301,8 +292,7 @@
           "slug": "capital-one-savorone",
           "highlight": "$200 cash back after $500 in 3 months. The SavorOne also earns 3% on dining, entertainment, groceries, and streaming — a great all-around no-annual-fee card."
         }
-      ],
-      "author_slug": "maxwell-melcher"
+      ]
     }
   ]
 }

--- a/data/best/best-0-apr-cards.yaml
+++ b/data/best/best-0-apr-cards.yaml
@@ -3,7 +3,6 @@ slug: best-0-apr-cards
 title: Best 0% APR Credit Cards
 description: The best 0% intro APR credit cards for purchases and balance transfers, all with no annual fee.
 date: "2026-02-28"
-author: Maxwell Melcher
 seo_title: Best 0% APR Credit Cards of 2026
 seo_description: Compare the best 0% intro APR credit cards of 2026. Up to 21 months of 0% APR on purchases and balance transfers.
 intro: |

--- a/data/best/best-0-apr-cards.yaml
+++ b/data/best/best-0-apr-cards.yaml
@@ -1,0 +1,32 @@
+id: best-0-apr-cards
+slug: best-0-apr-cards
+title: Best 0% APR Credit Cards
+description: The best 0% intro APR credit cards for purchases and balance transfers, all with no annual fee.
+date: "2026-02-28"
+author: Maxwell Melcher
+seo_title: Best 0% APR Credit Cards of 2026
+seo_description: Compare the best 0% intro APR credit cards of 2026. Up to 21 months of 0% APR on purchases and balance transfers.
+intro: |
+  A 0% intro APR card lets you make purchases or transfer balances and pay no interest for an extended period — typically 12 to 21 months. These cards are ideal for financing a large purchase over time or consolidating existing credit card debt. Every card on this list has a $0 annual fee.
+
+cards:
+  - slug: wells-fargo-reflect
+    badge: Best Overall
+    highlight: 21 months of 0% APR on both purchases and balance transfers — the longest intro period available. No rewards, but as a pure interest-saving tool it's hard to beat.
+
+  - slug: bankamericard
+    badge: Longest 0% Period
+    highlight: 21 months of 0% APR on both purchases and balance transfers, matching the longest periods on the market. A straightforward no-frills card focused entirely on interest savings.
+
+  - slug: citi-simplicity-card
+    badge: No Late Fees
+    highlight: 21 months 0% on balance transfers and 12 months on purchases. The standout feature — no late fees ever. If you're worried about missing a payment during your payoff plan, this is the safest pick.
+
+  - slug: citi-diamond-preferred
+    highlight: Same 21-month balance transfer period as the Simplicity, with 12 months 0% on purchases. A solid choice if you're mainly focused on paying down transferred balances.
+
+  - slug: chase-slate-edge
+    highlight: 21 months of 0% APR on balance transfers. Chase also offers an automatic APR reduction if you pay on time and keep utilization under 30% — a unique perk for long-term cardholders.
+
+  - slug: us-bank-shield
+    highlight: 15 months of 0% APR on both purchases and balance transfers. Shorter than the top picks but still a generous window for interest-free financing.

--- a/data/best/best-airline-cards.yaml
+++ b/data/best/best-airline-cards.yaml
@@ -1,0 +1,59 @@
+id: best-airline-cards
+slug: best-airline-cards
+title: Best Airline Credit Cards
+description: The top co-branded airline credit cards ranked by signup bonuses, earning rates, and travel perks.
+date: "2026-02-28"
+author: Maxwell Melcher
+seo_title: Best Airline Credit Cards of 2026
+seo_description: Compare the best airline credit cards of 2026. Delta, United, Southwest, JetBlue, and more — ranked by value.
+intro: |
+  Airline credit cards earn miles in a specific loyalty program and come with perks like free checked bags, priority boarding, and lounge access. They're best for travelers loyal to one airline or alliance. We've ranked these by overall value — factoring in signup bonuses, earning rates, annual fees, and travel benefits.
+
+cards:
+  - slug: delta-skymiles-reserve-american-express-card
+    badge: Best Premium
+    highlight: 125,000 SkyMiles signup bonus, Delta Sky Club access, and a companion certificate. The ultimate Delta card for frequent flyers willing to pay the $650 annual fee.
+
+  - slug: delta-skymiles-platinum-american-express-card
+    badge: Best Delta Value
+    highlight: 100,000 SkyMiles with a companion certificate and solid travel protections. A strong step up from the Gold at $350/year without the Reserve's premium price.
+
+  - slug: delta-skymiles-gold-american-express-card
+    badge: Best Mid-Tier
+    highlight: 90,000 SkyMiles signup bonus with a $150 annual fee. Includes a free first checked bag and 2x earning on dining, groceries, and Delta purchases.
+
+  - slug: united-explorer
+    highlight: A well-rounded United card with a free first checked bag, two United Club one-time passes, and expanded award availability. Good for occasional to moderate United flyers.
+
+  - slug: united-quest
+    highlight: Premium United card with up to $250 in annual travel credits. 3x miles on United purchases and a stronger earning structure than the Explorer.
+
+  - slug: united-club-infinite
+    highlight: United Club lounge access, Premier 1K-level upgrades, and the strongest United earning structure. Worth it if you fly United frequently and value lounge access.
+
+  - slug: southwest-rapid-rewards-priority-credit-card
+    highlight: $75 annual travel credit, 4 upgraded boardings per year, and 7,500 anniversary points. The best Southwest card for earning toward the Companion Pass.
+
+  - slug: southwest-rapid-rewards-premier-credit-card
+    highlight: Solid mid-tier Southwest option with 2x on Southwest and Rapid Rewards hotel/car purchases. Lower annual fee than the Priority with core travel benefits.
+
+  - slug: southwest-rapid-rewards-plus-credit-card
+    highlight: The entry-level Southwest card at $99/year. 2x on Southwest purchases and 1x on everything else, plus anniversary points toward the Companion Pass.
+
+  - slug: delta-skymiles-blue-american-express-card
+    highlight: No annual fee entry point into the Delta ecosystem. 2x miles on dining and Delta purchases. A great starter airline card.
+
+  - slug: united-gateway
+    highlight: No annual fee United card. A free first checked bag on United and basic miles earning. Best for infrequent United travelers who want the checked bag perk.
+
+  - slug: jetblue-plus-card
+    highlight: 6x points on JetBlue, a free first checked bag, and 50% savings on inflight purchases. A solid co-brand for Northeast and Florida travelers.
+
+  - slug: jetblue-card
+    highlight: No annual fee JetBlue card with 3x on JetBlue purchases and 2x on dining and groceries. Good for casual JetBlue flyers.
+
+  - slug: american-airlines-aadvantage-mileu-mastercard
+    highlight: No annual fee American Airlines card. Earns 2x on eligible AA purchases and is the only free entry into the AAdvantage program via a credit card.
+
+  - slug: hawaiian-airlines-world-elite-mastercard
+    highlight: 3x miles on Hawaiian Airlines, 2x on dining and gas. Includes a companion fare discount and no foreign transaction fees — ideal for Hawaii-bound travelers.

--- a/data/best/best-airline-cards.yaml
+++ b/data/best/best-airline-cards.yaml
@@ -3,7 +3,6 @@ slug: best-airline-cards
 title: Best Airline Credit Cards
 description: The top co-branded airline credit cards ranked by signup bonuses, earning rates, and travel perks.
 date: "2026-02-28"
-author: Maxwell Melcher
 seo_title: Best Airline Credit Cards of 2026
 seo_description: Compare the best airline credit cards of 2026. Delta, United, Southwest, JetBlue, and more — ranked by value.
 intro: |

--- a/data/best/best-dining-grocery-cards.yaml
+++ b/data/best/best-dining-grocery-cards.yaml
@@ -3,7 +3,6 @@ slug: best-dining-grocery-cards
 title: Best Credit Cards for Dining and Groceries
 description: The top credit cards for earning rewards on restaurants and grocery store purchases, from premium to no-annual-fee options.
 date: "2026-02-28"
-author: Maxwell Melcher
 seo_title: Best Credit Cards for Dining and Groceries of 2026
 seo_description: Compare the best dining and grocery credit cards of 2026. Earn 3-4x points or up to 6% cash back on food spending.
 intro: |

--- a/data/best/best-dining-grocery-cards.yaml
+++ b/data/best/best-dining-grocery-cards.yaml
@@ -1,0 +1,49 @@
+id: best-dining-grocery-cards
+slug: best-dining-grocery-cards
+title: Best Credit Cards for Dining and Groceries
+description: The top credit cards for earning rewards on restaurants and grocery store purchases, from premium to no-annual-fee options.
+date: "2026-02-28"
+author: Maxwell Melcher
+seo_title: Best Credit Cards for Dining and Groceries of 2026
+seo_description: Compare the best dining and grocery credit cards of 2026. Earn 3-4x points or up to 6% cash back on food spending.
+intro: |
+  Dining and groceries are two of the biggest spending categories for most people. The right card can earn you serious rewards on money you're already spending. We've ranked these cards by their earning rates on dining and groceries, factoring in annual fees and overall card value.
+
+cards:
+  - slug: american-express-gold-card
+    badge: Best Overall
+    highlight: 4x Membership Rewards points on dining and groceries is the highest ongoing earn rate in both categories from a single card. The $325 annual fee is offset by monthly dining and Uber credits.
+
+  - slug: capital-one-savorone
+    badge: Best No-Fee Card
+    highlight: 3% cash back on dining, groceries, entertainment, and streaming with no annual fee. The best all-around no-fee card for food spending.
+
+  - slug: chase-sapphire-preferred
+    highlight: 3x points on dining make this a strong everyday earner. Points transfer to Hyatt, United, and other partners, giving you outsized value for a $95 annual fee.
+
+  - slug: chase-sapphire-reserve
+    highlight: 3x on dining with a $300 travel credit and 50% bonus when redeeming through Chase Travel. The premium option for frequent travelers who also dine out a lot.
+
+  - slug: chase-freedom-flex
+    highlight: 3% back on dining at restaurants with no annual fee, plus 5% rotating categories that sometimes include grocery stores. A great starter or pairing card.
+
+  - slug: chase-freedom-unlimited
+    highlight: 3% on dining plus 1.5% on everything else, no annual fee. Pairs perfectly with a Sapphire card to transfer points to travel partners.
+
+  - slug: wells-fargo-autograph
+    highlight: 3x points on dining with no annual fee. Also earns 3x on travel, gas, transit, and streaming — a versatile everyday card.
+
+  - slug: blue-cash-everyday-card
+    highlight: 3% cash back at U.S. supermarkets (up to $6,000/year) with no annual fee. One of the best standalone grocery cards for most households.
+
+  - slug: atmos-rewards-summit
+    highlight: 3x points on dining plus a strong rewards structure across travel and everyday categories. A newer card with competitive earning rates.
+
+  - slug: delta-skymiles-gold-american-express-card
+    highlight: 2x miles on dining and U.S. supermarkets. A strong pick if you fly Delta — the dining and grocery earnings fuel your miles balance between flights.
+
+  - slug: rakuten-american-express
+    highlight: 2% back on dining and groceries with no annual fee. Also earns elevated rates on Rakuten shopping portal purchases — a solid secondary card.
+
+  - slug: atmos-rewards-ascent
+    highlight: 3x on dining with a lower annual fee than the Summit. A good mid-tier option if you want elevated dining rewards without the premium price tag.

--- a/data/best/best-secured-cards.yaml
+++ b/data/best/best-secured-cards.yaml
@@ -1,0 +1,32 @@
+id: best-secured-cards
+slug: best-secured-cards
+title: Best Secured Credit Cards
+description: The best secured credit cards for building or rebuilding credit, all with no annual fee.
+date: "2026-02-28"
+author: Maxwell Melcher
+seo_title: Best Secured Credit Cards of 2026
+seo_description: Compare the best secured credit cards of 2026 for building credit. All have $0 annual fees and report to all three bureaus.
+intro: |
+  Secured credit cards require a refundable security deposit that typically becomes your credit limit. They're designed for people building credit for the first time or rebuilding after a setback. Every card on this list has no annual fee and reports to all three major credit bureaus, so responsible use will help your credit score grow over time.
+
+cards:
+  - slug: discover-it-secured-credit-card
+    badge: Best Overall
+    highlight: The only secured card that earns meaningful cash back — 2% at gas stations and restaurants (up to $1,000/quarter) and 1% on everything else. Discover also matches all cash back earned in your first year, effectively doubling your rewards.
+
+  - slug: capital-one-quicksilver-secured
+    badge: Best for Rewards
+    highlight: Earns 1.5% cash back on every purchase with no annual fee. One of the few secured cards with a flat-rate rewards structure, making it feel like a regular credit card.
+
+  - slug: bank-of-america-cash-rewards-secured
+    highlight: Earns cash back in a category of your choice (gas, online shopping, dining, travel, drug stores, or home improvement). A good pick if your spending is concentrated in one area.
+
+  - slug: capital-one-platinum-secured
+    badge: Easiest Approval
+    highlight: No rewards, but one of the easiest secured cards to get approved for. Minimum deposit as low as $49 depending on creditworthiness. A strong starter card for those with very limited credit history.
+
+  - slug: citi-secured-mastercard
+    highlight: A straightforward secured card with no rewards but wide Mastercard acceptance. Reports to all three bureaus and has a path to upgrade to an unsecured Citi card over time.
+
+  - slug: us-bank-secured
+    highlight: A basic secured Visa card with no rewards. U.S. Bank reviews your account for an upgrade to an unsecured card automatically. A solid option if you already bank with U.S. Bank.

--- a/data/best/best-secured-cards.yaml
+++ b/data/best/best-secured-cards.yaml
@@ -3,7 +3,6 @@ slug: best-secured-cards
 title: Best Secured Credit Cards
 description: The best secured credit cards for building or rebuilding credit, all with no annual fee.
 date: "2026-02-28"
-author: Maxwell Melcher
 seo_title: Best Secured Credit Cards of 2026
 seo_description: Compare the best secured credit cards of 2026 for building credit. All have $0 annual fees and report to all three bureaus.
 intro: |

--- a/data/best/best-signup-bonuses.yaml
+++ b/data/best/best-signup-bonuses.yaml
@@ -3,7 +3,6 @@ slug: best-signup-bonuses
 title: Best Credit Card Signup Bonuses
 description: The most valuable credit card signup bonuses available right now, ranked by bonus value and overall appeal.
 date: "2026-02-28"
-author: Maxwell Melcher
 seo_title: Best Credit Card Signup Bonuses of 2026
 seo_description: Compare the best credit card signup bonuses of 2026. Ranked by value — from 140k points to $200 cash back.
 intro: |

--- a/data/best/best-signup-bonuses.yaml
+++ b/data/best/best-signup-bonuses.yaml
@@ -1,18 +1,18 @@
 id: best-signup-bonuses
 slug: best-signup-bonuses
-title: Best Credit Card Sign Up Bonuses
-description: The most valuable credit card sign up bonuses available right now, ranked by bonus value and overall appeal.
+title: Best Credit Card Signup Bonuses
+description: The most valuable credit card signup bonuses available right now, ranked by bonus value and overall appeal.
 date: "2026-02-28"
 author: Maxwell Melcher
-seo_title: Best Credit Card Sign Up Bonuses of 2026
-seo_description: Compare the best credit card sign up bonuses of 2026. Ranked by value — from 140k points to $200 cash back.
+seo_title: Best Credit Card Signup Bonuses of 2026
+seo_description: Compare the best credit card signup bonuses of 2026. Ranked by value — from 140k points to $200 cash back.
 intro: |
-  Sign up bonuses are the fastest way to earn a big chunk of rewards from a new credit card. We've ranked the best offers available right now based on bonus value, ease of earning, and overall card quality. All data is pulled live from our card database so bonus values, annual fees, and apply links are always current.
+  Signup bonuses are the fastest way to earn a big chunk of rewards from a new credit card. We've ranked the best offers available right now based on bonus value, ease of earning, and overall card quality. All data is pulled live from our card database so bonus values, annual fees, and apply links are always current.
 
 cards:
   - slug: ihg-rewards-premier-business
     badge: Best Overall
-    highlight: The highest sign up bonus available right now — 140,000 IHG points after $4,000 in 3 months. IHG points are worth around 0.5 cents each, making this worth roughly $700 in hotel stays.
+    highlight: The highest signup bonus available right now — 140,000 IHG points after $4,000 in 3 months. IHG points are worth around 0.5 cents each, making this worth roughly $700 in hotel stays.
 
   - slug: delta-skymiles-reserve-american-express-card
     badge: Best for Premium Travel

--- a/data/best/best-signup-bonuses.yaml
+++ b/data/best/best-signup-bonuses.yaml
@@ -1,0 +1,61 @@
+id: best-signup-bonuses
+slug: best-signup-bonuses
+title: Best Credit Card Sign Up Bonuses
+description: The most valuable credit card sign up bonuses available right now, ranked by bonus value and overall appeal.
+date: "2026-02-28"
+author: Maxwell Melcher
+seo_title: Best Credit Card Sign Up Bonuses of 2026
+seo_description: Compare the best credit card sign up bonuses of 2026. Ranked by value — from 140k points to $200 cash back.
+intro: |
+  Sign up bonuses are the fastest way to earn a big chunk of rewards from a new credit card. We've ranked the best offers available right now based on bonus value, ease of earning, and overall card quality. All data is pulled live from our card database so bonus values, annual fees, and apply links are always current.
+
+cards:
+  - slug: ihg-rewards-premier-business
+    badge: Best Overall
+    highlight: The highest sign up bonus available right now — 140,000 IHG points after $4,000 in 3 months. IHG points are worth around 0.5 cents each, making this worth roughly $700 in hotel stays.
+
+  - slug: delta-skymiles-reserve-american-express-card
+    badge: Best for Premium Travel
+    highlight: 125,000 Delta SkyMiles is an enormous haul. The Reserve card also includes Delta Sky Club access and a companion certificate — ideal for frequent Delta flyers.
+
+  - slug: delta-skymiles-platinum-american-express-card
+    badge: Best Delta Value
+    highlight: 100,000 SkyMiles for a lower annual fee than the Reserve. You still get a companion certificate and solid travel perks without the ultra-premium price tag.
+
+  - slug: delta-skymiles-gold-american-express-card
+    highlight: 90,000 SkyMiles is a top-tier bonus for a mid-tier card. Great entry point into the Delta ecosystem with a reasonable $150 annual fee.
+
+  - slug: atmos-rewards-summit
+    highlight: 80,000 Atmos points with a $4,000 spend requirement. Atmos is a newer player but their redemption rates are competitive with major programs.
+
+  - slug: capital-one-venture-x
+    badge: Best Travel Card
+    highlight: 75,000 miles after $4,000 in 3 months. The Venture X also comes with a $300 travel credit and 10,000 anniversary miles, effectively making the $395 annual fee very manageable.
+
+  - slug: atmos-rewards-ascent
+    highlight: 70,000 Atmos points with only $3,000 in spending required. A lower spend threshold makes this one of the easier big bonuses to earn.
+
+  - slug: chase-sapphire-preferred
+    highlight: 60,000 Ultimate Rewards points are worth at least $750 when redeemed through Chase Travel. One of the most versatile points currencies available.
+
+  - slug: american-express-gold-card
+    highlight: 60,000 Membership Rewards points after $6,000 in 6 months. The Gold Card is a powerhouse for dining and groceries with 4x earning in both categories.
+
+  - slug: chase-sapphire-reserve
+    highlight: 60,000 Ultimate Rewards points plus a $300 annual travel credit. Points are worth 50% more through Chase Travel, making this bonus worth up to $900.
+
+  - slug: world-of-hyatt-business-credit-card
+    highlight: 60,000 World of Hyatt points can easily be worth $1,200+ in hotel stays. Hyatt consistently offers the best value among hotel loyalty programs.
+
+  - slug: wells-fargo-signify-business-cash
+    badge: Best Cash Back
+    highlight: A straightforward $500 cash back after $5,000 in 3 months. No points to figure out, no transfer partners — just cash in your account.
+
+  - slug: chase-freedom-flex
+    highlight: $200 cash back after just $500 in spending — one of the easiest bonuses to earn. Plus 5% rotating categories and a strong everyday rewards structure.
+
+  - slug: wells-fargo-active-cash
+    highlight: $200 cash back with a low $500 spend requirement. Pairs well with the 2% flat cash back on everything, making it a solid daily driver.
+
+  - slug: capital-one-savorone
+    highlight: $200 cash back after $500 in 3 months. The SavorOne also earns 3% on dining, entertainment, groceries, and streaming — a great all-around no-annual-fee card.

--- a/data/best/schema.json
+++ b/data/best/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["id", "slug", "title", "description", "date", "author", "cards"],
+  "required": ["id", "slug", "title", "description", "date", "cards"],
   "properties": {
     "id": {
       "type": "string",

--- a/data/best/schema.json
+++ b/data/best/schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "slug", "title", "description", "date", "author", "cards"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$",
+      "description": "Unique identifier (lowercase with hyphens)"
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$",
+      "description": "URL slug for the best page"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Page title (no year suffix)"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 300,
+      "description": "Short description for listing pages and meta"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Publication date in YYYY-MM-DD format"
+    },
+    "updated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Last updated date in YYYY-MM-DD format"
+    },
+    "author": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Author name"
+    },
+    "author_slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$",
+      "description": "Author URL slug (auto-generated from author name if not provided)"
+    },
+    "seo_title": {
+      "type": "string",
+      "maxLength": 70,
+      "description": "SEO title for search engines (typically includes year)"
+    },
+    "seo_description": {
+      "type": "string",
+      "maxLength": 160,
+      "description": "Meta description for search engines"
+    },
+    "intro": {
+      "type": "string",
+      "description": "Optional intro text in Markdown format"
+    },
+    "cards": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["slug"],
+        "properties": {
+          "slug": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$",
+            "description": "Card slug (must match a card in cards.json)"
+          },
+          "highlight": {
+            "type": "string",
+            "description": "Editorial highlight text for this card"
+          },
+          "badge": {
+            "type": "string",
+            "description": "Badge label (e.g. 'Best Overall', 'Best Value')"
+          }
+        }
+      },
+      "description": "Ordered list of curated cards"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:cards": "node scripts/build-cards.js",
     "build:news": "node scripts/build-news.js",
     "build:articles": "node scripts/build-articles.js",
+    "build:best": "node scripts/build-best.js",
     "start:web": "npm run start -w @creditodds/web",
     "start:web-next": "npm run dev -w @creditodds/web-next",
     "dev:web-next": "npm run dev -w @creditodds/web-next",

--- a/scripts/build-best.js
+++ b/scripts/build-best.js
@@ -29,10 +29,6 @@ function loadCardsLookup() {
   }
 }
 
-function generateAuthorSlug(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-}
-
 function validateBestPage(item, schema, cardsLookup) {
   const errors = [];
 
@@ -115,11 +111,6 @@ function buildBest() {
         errors.push({ file, errors: validationErrors });
         console.log(`  ERROR: ${validationErrors.join(', ')}`);
         continue;
-      }
-
-      // Generate author_slug if not provided
-      if (!item.author_slug && item.author) {
-        item.author_slug = generateAuthorSlug(item.author);
       }
 
       pages.push(item);

--- a/scripts/build-best.js
+++ b/scripts/build-best.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const BEST_DIR = path.join(__dirname, '..', 'data', 'best');
+const OUTPUT_FILE = path.join(__dirname, '..', 'data', 'best.json');
+const SCHEMA_FILE = path.join(BEST_DIR, 'schema.json');
+const CARDS_FILE = path.join(__dirname, '..', 'data', 'cards.json');
+
+function loadSchema() {
+  const schemaContent = fs.readFileSync(SCHEMA_FILE, 'utf8');
+  return JSON.parse(schemaContent);
+}
+
+function loadCardsLookup() {
+  try {
+    const cardsContent = fs.readFileSync(CARDS_FILE, 'utf8');
+    const cardsData = JSON.parse(cardsContent);
+    const lookup = {};
+    for (const card of cardsData.cards) {
+      lookup[card.slug] = card;
+    }
+    return lookup;
+  } catch (err) {
+    console.warn('Warning: Could not load cards.json for card lookup:', err.message);
+    return {};
+  }
+}
+
+function generateAuthorSlug(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function validateBestPage(item, schema, cardsLookup) {
+  const errors = [];
+
+  // Check required fields
+  for (const field of schema.required) {
+    if (item[field] === undefined || item[field] === null || item[field] === '') {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+
+  // Validate id pattern
+  if (item.id && !/^[a-z0-9-]+$/.test(item.id)) {
+    errors.push(`Invalid id format: ${item.id} (must be lowercase with hyphens only)`);
+  }
+
+  // Validate slug pattern
+  if (item.slug && !/^[a-z0-9-]+$/.test(item.slug)) {
+    errors.push(`Invalid slug format: ${item.slug} (must be lowercase with hyphens only)`);
+  }
+
+  // Validate date format
+  if (item.date && !/^\d{4}-\d{2}-\d{2}$/.test(item.date)) {
+    errors.push(`Invalid date format: ${item.date} (must be YYYY-MM-DD)`);
+  }
+
+  // Validate updated_at format if present
+  if (item.updated_at && !/^\d{4}-\d{2}-\d{2}$/.test(item.updated_at)) {
+    errors.push(`Invalid updated_at format: ${item.updated_at} (must be YYYY-MM-DD)`);
+  }
+
+  // Validate author_slug pattern if present
+  if (item.author_slug && !/^[a-z0-9-]+$/.test(item.author_slug)) {
+    errors.push(`Invalid author_slug format: ${item.author_slug} (must be lowercase with hyphens only)`);
+  }
+
+  // Validate cards array
+  if (item.cards) {
+    if (!Array.isArray(item.cards)) {
+      errors.push('cards must be an array');
+    } else {
+      for (const card of item.cards) {
+        if (!card.slug) {
+          errors.push('Each card entry must have a slug');
+        } else if (!/^[a-z0-9-]+$/.test(card.slug)) {
+          errors.push(`Invalid card slug format: ${card.slug} (must be lowercase with hyphens only)`);
+        } else if (!cardsLookup[card.slug]) {
+          errors.push(`Card slug not found in cards.json: ${card.slug}`);
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+function buildBest() {
+  console.log('Building best.json from YAML files...\n');
+
+  const schema = loadSchema();
+  const cardsLookup = loadCardsLookup();
+  const pages = [];
+  const errors = [];
+
+  // Read all YAML files in the best directory
+  const files = fs.readdirSync(BEST_DIR).filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
+
+  console.log(`Found ${files.length} best page file(s)\n`);
+
+  for (const file of files) {
+    const filePath = path.join(BEST_DIR, file);
+    console.log(`Processing: ${file}`);
+
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      const item = yaml.load(content);
+
+      // Validate the best page
+      const validationErrors = validateBestPage(item, schema, cardsLookup);
+      if (validationErrors.length > 0) {
+        errors.push({ file, errors: validationErrors });
+        console.log(`  ERROR: ${validationErrors.join(', ')}`);
+        continue;
+      }
+
+      // Generate author_slug if not provided
+      if (!item.author_slug && item.author) {
+        item.author_slug = generateAuthorSlug(item.author);
+      }
+
+      pages.push(item);
+      console.log(`  OK: ${item.title} (${item.cards.length} cards)`);
+    } catch (err) {
+      errors.push({ file, errors: [err.message] });
+      console.log(`  ERROR: ${err.message}`);
+    }
+  }
+
+  console.log('\n---');
+
+  if (errors.length > 0) {
+    console.error(`\nValidation failed with ${errors.length} error(s):`);
+    for (const { file, errors: fileErrors } of errors) {
+      console.error(`  ${file}:`);
+      for (const err of fileErrors) {
+        console.error(`    - ${err}`);
+      }
+    }
+    process.exit(1);
+  }
+
+  // Sort pages by date (newest first)
+  pages.sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  // Write output
+  const output = {
+    generated_at: new Date().toISOString(),
+    count: pages.length,
+    pages: pages,
+  };
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2));
+  console.log(`\nSuccessfully built ${pages.length} best page(s) to ${OUTPUT_FILE}`);
+}
+
+buildBest();


### PR DESCRIPTION
## Summary
- Adds a new data-driven "Best X" pages pipeline following the existing articles pattern (YAML → build script → JSON → CDN → Next.js ISR)
- Pages pull live card data at render time so bonus values, APR, apply links, and referral buttons stay current without manual updates
- Includes the first page: **Best Credit Card Sign Up Bonuses** with 15 curated cards ranked by value

## New Files
| File | Purpose |
|------|---------|
| `data/best/schema.json` | JSON Schema for YAML validation |
| `data/best/best-signup-bonuses.yaml` | First content — 15 cards with editorial highlights & badges |
| `scripts/build-best.js` | Build script: validates YAML against schema + cards.json, outputs `data/best.json` |
| `apps/web-next/src/lib/best.ts` | Data fetching lib (dev: local file, prod: CDN with ISR 300s) |
| `apps/web-next/src/app/api/best/route.ts` | API proxy route for client-side fetching |
| `apps/web-next/src/components/best/BestCardList.tsx` | Ranked card list with images, bonuses, reward categories |
| `apps/web-next/src/components/best/ApplyButtons.tsx` | Client component — referral selection, impression/click tracking |
| `apps/web-next/src/app/best/page.tsx` | Listing page with CollectionPage + ItemList JSON-LD |
| `apps/web-next/src/app/best/[slug]/page.tsx` | Detail page — merges YAML config with live `getAllCards()` data |
| `.github/workflows/build-best.yml` | CI/CD: build → S3 → CloudFront invalidation → Amplify rebuild |

## Modified Files
- `package.json` — added `build:best` script
- `apps/web-next/src/app/sitemap.ts` — added `/best` static entry + dynamic best page entries (priority 0.85)

## Test plan
- [ ] `npm run build:best` passes with no errors
- [ ] `npx tsc --noEmit` in `apps/web-next` passes
- [ ] Visit `/best` — shows listing page with card count and date
- [ ] Visit `/best/best-signup-bonuses` — shows 15 ranked cards with live data
- [ ] Verify card images, bonus values, annual fees, and apply/referral buttons render
- [ ] Verify JSON-LD structured data (ItemList + BreadcrumbList) in page source
- [ ] Verify sitemap includes `/best` and `/best/best-signup-bonuses`

🤖 Generated with [Claude Code](https://claude.com/claude-code)