### PR TITLE
Add signup bonuses for United credit cards

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-28T18:36:22.627Z",
+  "generated_at": "2026-02-28T20:32:27.155Z",
   "count": 142,
   "categories": [
     {
@@ -2476,6 +2476,12 @@
       "accepting_applications": true,
       "annual_fee": 695,
       "reward_type": "miles",
+      "signup_bonus": {
+        "value": 90000,
+        "type": "miles",
+        "spend_requirement": 5000,
+        "timeframe_months": 3
+      },
       "tags": [
         "airline",
         "travel",
@@ -2492,6 +2498,12 @@
       "accepting_applications": true,
       "annual_fee": 150,
       "reward_type": "miles",
+      "signup_bonus": {
+        "value": 70000,
+        "type": "miles",
+        "spend_requirement": 3000,
+        "timeframe_months": 3
+      },
       "tags": [
         "airline",
         "travel",
@@ -2508,6 +2520,12 @@
       "accepting_applications": true,
       "annual_fee": 0,
       "reward_type": "miles",
+      "signup_bonus": {
+        "value": 30000,
+        "type": "miles",
+        "spend_requirement": 1000,
+        "timeframe_months": 3
+      },
       "tags": [
         "airline",
         "travel"
@@ -2539,6 +2557,12 @@
       "accepting_applications": true,
       "annual_fee": 350,
       "reward_type": "miles",
+      "signup_bonus": {
+        "value": 80000,
+        "type": "miles",
+        "spend_requirement": 4000,
+        "timeframe_months": 3
+      },
       "tags": [
         "airline",
         "travel",

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -5,6 +5,11 @@ image: "united_club_infinite.png"
 accepting_applications: true
 annual_fee: 695
 reward_type: "miles"
+signup_bonus:
+  value: 90000
+  type: miles
+  spend_requirement: 5000
+  timeframe_months: 3
 tags:
   - airline
   - travel

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -5,6 +5,11 @@ image: "united_explorer.png"
 accepting_applications: true
 annual_fee: 150
 reward_type: "miles"
+signup_bonus:
+  value: 70000
+  type: miles
+  spend_requirement: 3000
+  timeframe_months: 3
 tags:
   - airline
   - travel

--- a/data/cards/united-gateway.yaml
+++ b/data/cards/united-gateway.yaml
@@ -5,6 +5,11 @@ image: "united_gateway.png"
 accepting_applications: true
 annual_fee: 0
 reward_type: "miles"
+signup_bonus:
+  value: 30000
+  type: miles
+  spend_requirement: 1000
+  timeframe_months: 3
 tags:
   - airline
   - travel

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -5,6 +5,11 @@ image: "united_quest.png"
 accepting_applications: true
 annual_fee: 350
 reward_type: "miles"
+signup_bonus:
+  value: 80000
+  type: miles
+  spend_requirement: 4000
+  timeframe_months: 3
 tags:
   - airline
   - travel


### PR DESCRIPTION
## Summary
- Adds current signup bonus data to all 4 active United MileagePlus credit cards

| Card | Bonus | Spend | Timeframe |
|------|-------|-------|-----------|
| United Gateway | 30,000 miles | $1,000 | 3 months |
| United Explorer | 70,000 miles | $3,000 | 3 months |
| United Quest | 80,000 miles | $4,000 | 3 months |
| United Club Infinite | 90,000 miles | $5,000 | 3 months |

## Test plan
- [ ] `npm run build:cards` passes
- [ ] United card pages show signup bonus data on the frontend
- [ ] Best Airline Cards page displays United bonuses with estimated values

🤖 Generated with [Claude Code](https://claude.com/claude-code)