### PR TITLE
Add signup bonuses for JetBlue, Southwest, Hawaiian, and AA cards

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-28T20:32:27.155Z",
+  "generated_at": "2026-02-28T20:37:27.743Z",
   "count": 142,
   "categories": [
     {
@@ -194,6 +194,12 @@
       "image": "american-aadvantage.jpeg",
       "annual_fee": 0,
       "reward_type": "miles",
+      "signup_bonus": {
+        "value": 15000,
+        "type": "miles",
+        "spend_requirement": 500,
+        "timeframe_months": 3
+      },
       "card_id": "american-airlines-aadvantage-mileu-mastercard",
       "card_name": "American Airlines AAdvantage MileU Mastercard"
     },
@@ -1940,6 +1946,12 @@
       "image": "barclays-hawaiian.png",
       "annual_fee": 99,
       "reward_type": "miles",
+      "signup_bonus": {
+        "value": 50000,
+        "type": "miles",
+        "spend_requirement": 2000,
+        "timeframe_months": 3
+      },
       "card_id": "hawaiian-airlines-world-elite-mastercard",
       "card_name": "Hawaiian Airlines World Elite Mastercard"
     },
@@ -2124,6 +2136,12 @@
       "image": "barclays-jetblue.png",
       "annual_fee": 0,
       "reward_type": "points",
+      "signup_bonus": {
+        "value": 10000,
+        "type": "points",
+        "spend_requirement": 1000,
+        "timeframe_months": 3
+      },
       "card_id": "jetblue-card",
       "card_name": "JetBlue"
     },
@@ -2136,6 +2154,12 @@
       "image": "barclays-jetblue-business.png",
       "annual_fee": 99,
       "reward_type": "points",
+      "signup_bonus": {
+        "value": 60000,
+        "type": "points",
+        "spend_requirement": 2000,
+        "timeframe_months": 3
+      },
       "card_id": "jetblue-business-card",
       "card_name": "JetBlue Business"
     },
@@ -2148,6 +2172,12 @@
       "image": "barclays-jetblue-plus.png",
       "annual_fee": 99,
       "reward_type": "points",
+      "signup_bonus": {
+        "value": 70000,
+        "type": "points",
+        "spend_requirement": 1000,
+        "timeframe_months": 3
+      },
       "card_id": "jetblue-plus-card",
       "card_name": "JetBlue Plus"
     },
@@ -2302,6 +2332,12 @@
       "accepting_applications": true,
       "annual_fee": 99,
       "reward_type": "points",
+      "signup_bonus": {
+        "value": 20000,
+        "type": "points",
+        "spend_requirement": 3000,
+        "timeframe_months": 3
+      },
       "image": "chase-southwest-rapid-rewards-plus.png",
       "tags": [
         "airline",
@@ -2318,6 +2354,12 @@
       "image": "chase-southwest-rapid-rewards-premier.png",
       "annual_fee": 149,
       "reward_type": "points",
+      "signup_bonus": {
+        "value": 30000,
+        "type": "points",
+        "spend_requirement": 4000,
+        "timeframe_months": 3
+      },
       "tags": [
         "airline",
         "travel"
@@ -2333,6 +2375,12 @@
       "accepting_applications": true,
       "annual_fee": 229,
       "reward_type": "points",
+      "signup_bonus": {
+        "value": 40000,
+        "type": "points",
+        "spend_requirement": 5000,
+        "timeframe_months": 3
+      },
       "tags": [
         "airline",
         "travel",

--- a/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
+++ b/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
@@ -5,3 +5,8 @@ accepting_applications: true
 image: "american-aadvantage.jpeg"
 annual_fee: 0
 reward_type: "miles"
+signup_bonus:
+  value: 15000
+  type: miles
+  spend_requirement: 500
+  timeframe_months: 3

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -6,3 +6,8 @@ category: "travel"
 image: "barclays-hawaiian.png"
 annual_fee: 99
 reward_type: "miles"
+signup_bonus:
+  value: 50000
+  type: miles
+  spend_requirement: 2000
+  timeframe_months: 3

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -6,3 +6,8 @@ category: "business"
 image: "barclays-jetblue-business.png"
 annual_fee: 99
 reward_type: "points"
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 2000
+  timeframe_months: 3

--- a/data/cards/jetblue-card.yaml
+++ b/data/cards/jetblue-card.yaml
@@ -6,3 +6,8 @@ category: "travel"
 image: "barclays-jetblue.png"
 annual_fee: 0
 reward_type: "points"
+signup_bonus:
+  value: 10000
+  type: points
+  spend_requirement: 1000
+  timeframe_months: 3

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -6,3 +6,8 @@ category: "travel"
 image: "barclays-jetblue-plus.png"
 annual_fee: 99
 reward_type: "points"
+signup_bonus:
+  value: 70000
+  type: points
+  spend_requirement: 1000
+  timeframe_months: 3

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -4,6 +4,11 @@ slug: "southwest-rapid-rewards-plus-credit-card"
 accepting_applications: true
 annual_fee: 99
 reward_type: "points"
+signup_bonus:
+  value: 20000
+  type: points
+  spend_requirement: 3000
+  timeframe_months: 3
 image: "chase-southwest-rapid-rewards-plus.png"
 tags:
   - airline

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -5,6 +5,11 @@ accepting_applications: true
 image: "chase-southwest-rapid-rewards-premier.png"
 annual_fee: 149
 reward_type: "points"
+signup_bonus:
+  value: 30000
+  type: points
+  spend_requirement: 4000
+  timeframe_months: 3
 tags:
   - airline
   - travel

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -5,6 +5,11 @@ image: "southwest_priority.png"
 accepting_applications: true
 annual_fee: 229
 reward_type: "points"
+signup_bonus:
+  value: 40000
+  type: points
+  spend_requirement: 5000
+  timeframe_months: 3
 tags:
   - airline
   - travel


### PR DESCRIPTION
## Summary
Adds current signup bonus data to 8 airline credit cards across 4 programs.

| Card | Bonus | Spend | Timeframe |
|------|-------|-------|-----------|
| **JetBlue** | 10,000 points | $1,000 | 3 months |
| **JetBlue Plus** | 70,000 points | $1,000 | 3 months |
| **JetBlue Business** | 60,000 points | $2,000 | 3 months |
| **SW Rapid Rewards Plus** | 20,000 points | $3,000 | 3 months |
| **SW Rapid Rewards Premier** | 30,000 points | $4,000 | 3 months |
| **SW Rapid Rewards Priority** | 40,000 points | $5,000 | 3 months |
| **Hawaiian Airlines World Elite** | 50,000 miles | $2,000 | 3 months |
| **AA AAdvantage MileUp** | 15,000 miles | $500 | 3 months |

## Test plan
- [ ] `npm run build:cards` passes
- [ ] Airline card pages show signup bonus data
- [ ] Best Airline Cards page displays bonuses with estimated values

🤖 Generated with [Claude Code](https://claude.com/claude-code)