### PR TITLE
Switch best page icons to solid and improve SEO

### DIFF
--- a/apps/web-next/src/app/best/page.tsx
+++ b/apps/web-next/src/app/best/page.tsx
@@ -1,8 +1,10 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import {
-  TrophyIcon,
   CalendarIcon,
+} from "@heroicons/react/24/outline";
+import {
+  TrophyIcon,
   GiftIcon,
   PaperAirplaneIcon,
   PercentBadgeIcon,
@@ -10,7 +12,7 @@ import {
   ShoppingCartIcon,
   BanknotesIcon,
   GlobeAltIcon,
-} from "@heroicons/react/24/outline";
+} from "@heroicons/react/24/solid";
 
 const pageIcons: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
   'best-signup-bonuses': GiftIcon,
@@ -25,11 +27,11 @@ import { getBestPages } from "@/lib/best";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 
 export const metadata: Metadata = {
-  title: "Best Credit Cards - Top Picks & Comparisons",
-  description: "Curated rankings of the best credit cards across categories. Data-driven picks updated with live approval odds and bonus values.",
+  title: "Best Credit Cards of 2026 - Top Picks & Comparisons",
+  description: "Curated rankings of the best credit cards of 2026 across categories. Data-driven picks updated with live approval odds and bonus values.",
   openGraph: {
-    title: "Best Credit Cards | CreditOdds",
-    description: "Curated rankings of the best credit cards across categories.",
+    title: "Best Credit Cards of 2026 | CreditOdds",
+    description: "Curated rankings of the best credit cards of 2026 across categories.",
     url: "https://creditodds.com/best",
   },
   alternates: {

--- a/apps/web-next/src/app/sitemap.ts
+++ b/apps/web-next/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next';
 import { getAllCards, getAllBanks } from '@/lib/api';
 import { getNews } from '@/lib/news';
+import { getArticles } from '@/lib/articles';
 import { getBestPages } from '@/lib/best';
 
 // Required for static export
@@ -38,6 +39,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${baseUrl}/news`,
       lastModified: new Date(),
       changeFrequency: 'daily',
+      priority: 0.85,
+    },
+    {
+      url: `${baseUrl}/articles`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
       priority: 0.85,
     },
     {
@@ -146,6 +153,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error('Error generating sitemap for news:', error);
   }
 
+  // Dynamic article pages
+  let articlePages: MetadataRoute.Sitemap = [];
+  try {
+    const articleItems = await getArticles();
+    articlePages = articleItems.map((item) => ({
+      url: `${baseUrl}/articles/${item.slug}`,
+      lastModified: new Date(item.updated_at || item.date),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    }));
+  } catch (error) {
+    console.error('Error generating sitemap for articles:', error);
+  }
+
   // Dynamic best pages
   let bestPages: MetadataRoute.Sitemap = [];
   try {
@@ -160,5 +181,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error('Error generating sitemap for best pages:', error);
   }
 
-  return [...staticPages, ...bankPages, ...cardPages, ...newsPages, ...bestPages];
+  return [...staticPages, ...bankPages, ...cardPages, ...newsPages, ...articlePages, ...bestPages];
 }


### PR DESCRIPTION
## Summary
- Switch category icons on `/best` listing page from heroicons/outline to heroicons/solid for better visual weight
- Add "of 2026" to `/best` page title and OpenGraph metadata for SEO targeting
- Add `/articles` index and individual article pages to `sitemap.ts` (was missing entirely)

## SEO Checklist
All best pages already have:
- `seo_title` with "of 2026" (e.g. "Best Travel Credit Cards of 2026")
- `seo_description` with year and keywords
- OpenGraph tags with `publishedTime` and `modifiedTime`
- Canonical URLs
- JSON-LD structured data (`ItemList` on detail pages, `CollectionPage` on listing)
- `BreadcrumbSchema` on all pages
- Sitemap entries with priority 0.85 and weekly change frequency

This PR fixes the listing page title (was missing "of 2026") and adds the previously missing articles to the sitemap.

## Test plan
- [ ] Verify `/best` page renders with solid icons
- [ ] Check page source for "of 2026" in `<title>` tag on `/best`
- [ ] Verify sitemap includes `/articles` and `/articles/{slug}` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)