### PR TITLE
Redesign card detail page with two-column layout

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -5,8 +5,27 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { BuildingLibraryIcon } from "@heroicons/react/24/solid";
-import { ExclamationTriangleIcon, PencilSquareIcon, NewspaperIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import {
+  BuildingLibraryIcon,
+} from "@heroicons/react/24/solid";
+import {
+  ExclamationTriangleIcon,
+  PencilSquareIcon,
+  NewspaperIcon,
+  XMarkIcon,
+  InformationCircleIcon,
+  GlobeAltIcon,
+  ShoppingBagIcon,
+  TruckIcon,
+  SparklesIcon,
+  BanknotesIcon,
+  FireIcon,
+  HomeModernIcon,
+  FilmIcon,
+  ComputerDesktopIcon,
+  TicketIcon,
+  CreditCardIcon,
+} from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
 import { Card, GraphData, Reward, trackReferralEvent, getRecords } from "@/lib/api";
 import { NewsItem, tagLabels, tagColors } from "@/lib/news";
@@ -52,6 +71,62 @@ const categoryLabels: Record<string, string> = {
   amazon: "Amazon.com",
   everything_else: "Everything Else",
 };
+
+// Map category to icon component
+function CategoryIcon({ category, className }: { category: string; className?: string }) {
+  const iconClass = className || "h-5 w-5";
+  switch (category) {
+    case "dining":
+      return (
+        <svg className={iconClass} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M7 3v7a3 3 0 003 3v0a3 3 0 003-3V3M7 3H5m2 0h2m0 0h2m0 0h2M10 13v8m0 0H8m2 0h2M17 3v4a2 2 0 01-2 2v0a2 2 0 01-2-2V3m2 18V9" />
+        </svg>
+      );
+    case "groceries":
+      return <ShoppingBagIcon className={iconClass} />;
+    case "travel":
+    case "travel_portal":
+      return (
+        <svg className={iconClass} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L10.93 3.555a1.126 1.126 0 00-1.006 0L2.547 7.242A1.125 1.125 0 002 8.185v11.264c0 .756.794 1.245 1.473.89l4.23-2.21a1.126 1.126 0 011.006 0l3.86 2.02a1.126 1.126 0 001.006 0l2.928-1.533z" />
+        </svg>
+      );
+    case "gas":
+      return <FireIcon className={iconClass} />;
+    case "streaming":
+      return <ComputerDesktopIcon className={iconClass} />;
+    case "transit":
+      return <TruckIcon className={iconClass} />;
+    case "drugstores":
+      return <BuildingLibraryIcon className={iconClass} />;
+    case "home_improvement":
+      return <HomeModernIcon className={iconClass} />;
+    case "online_shopping":
+    case "amazon":
+      return <ShoppingBagIcon className={iconClass} />;
+    case "hotels":
+    case "hotels_portal":
+    case "hotels_car_portal":
+      return <HomeModernIcon className={iconClass} />;
+    case "airlines":
+    case "flights_portal":
+      return (
+        <svg className={iconClass} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M21 16v-2l-8-5V3.5A1.5 1.5 0 0011.5 2 1.5 1.5 0 0010 3.5V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z" />
+        </svg>
+      );
+    case "car_rentals":
+      return <TruckIcon className={iconClass} />;
+    case "entertainment":
+      return <FilmIcon className={iconClass} />;
+    case "rotating":
+      return <SparklesIcon className={iconClass} />;
+    case "everything_else":
+      return <GlobeAltIcon className={iconClass} />;
+    default:
+      return <CreditCardIcon className={iconClass} />;
+  }
+}
 
 function formatRewardValue(reward: Reward): string {
   if (reward.unit === "percent") {
@@ -158,8 +233,18 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
     router.refresh();
   };
 
+  // Format credit length with "Years" unit
+  const formatCreditLength = (value: string | number | undefined) => {
+    if (value === undefined || value === null) return { number: "—", unit: "" };
+    const num = typeof value === "string" ? parseFloat(value) : value;
+    if (isNaN(num)) return { number: String(value), unit: "" };
+    return { number: String(num), unit: num === 1 ? "Year" : "Years" };
+  };
+
+  const creditLength = formatCreditLength(card.approved_median_length_credit);
+
   return (
-    <div className="bg-gray-50">
+    <div className="bg-gray-50 min-h-screen">
       {/* JSON-LD Structured Data (#12) */}
       <CreditCardSchema card={card} />
       <BreadcrumbSchema items={[
@@ -254,245 +339,270 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
         </div>
       )}
 
-      <div className="mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="max-w-7xl mx-auto">
-          {/* Card Header & Info Section */}
-          <div className="sm:flex sm:items-start pt-6 pb-6 sm:pt-14 sm:pb-10">
-            {/* Card Image - Left side */}
-            <div className="mb-4 flex-shrink-0 sm:mb-0 sm:mr-8">
-              <Image
-                src={card.card_image_link
-                  ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                  : '/assets/generic-card.svg'}
-                alt={card.card_name}
-                className="h-30 w-45 md:h-56 md:w-94 mx-auto sm:mx-0"
-                width={376}
-                height={224}
-                priority
-                sizes="(max-width: 768px) 180px, 376px"
-              />
-              {/* Apply Buttons under card image */}
-              {card.accepting_applications && (card.apply_link || randomReferralUrl) && (
-                <div className="mt-4 flex flex-col sm:flex-row gap-2 justify-center sm:justify-start">
-                  {card.apply_link && (
-                    <a
-                      href={card.apply_link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 transition-colors"
-                    >
-                      Apply Now
-                    </a>
-                  )}
-                  {randomReferralUrl && (
-                    <a
-                      href={randomReferralUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={handleReferralClick}
-                      className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white transition-colors animate-shimmer bg-[length:200%_100%]"
-                      style={{
-                        backgroundImage: 'linear-gradient(110deg, #5b21b6 0%, #6d28d9 45%, #8b5cf6 55%, #6d28d9 100%)',
-                      }}
-                    >
-                      Apply with Referral
-                    </a>
-                  )}
+      {/* Main Content Card */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
+        <div className="bg-white rounded-2xl shadow-[0_4px_40px_rgba(0,0,0,0.08)] overflow-hidden">
+          <div className="p-6 sm:p-10">
+            {/* Two-column layout */}
+            <div className="lg:grid lg:grid-cols-12 lg:gap-12">
+
+              {/* Left Column - Card Image & Signup Bonus */}
+              <div className="lg:col-span-4 flex flex-col items-center">
+                {/* Card Image */}
+                <div className="w-full max-w-sm lg:max-w-[330px] mx-auto lg:mx-0">
+                  <Image
+                    src={card.card_image_link
+                      ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                      : '/assets/generic-card.svg'}
+                    alt={card.card_name}
+                    className="w-full rounded-xl shadow-[0_12px_40px_rgba(0,0,0,0.2)]"
+                    width={360}
+                    height={227}
+                    priority
+                    sizes="(max-width: 768px) 75vw, (max-width: 1024px) 40vw, 330px"
+                  />
                 </div>
-              )}
-            </div>
 
-            {/* Card Details - Right side */}
-            <div className="flex-1 text-center sm:text-left">
-              <h1 className="text-2xl sm:text-4xl font-extrabold text-gray-900 tracking-wide">
-                {card.card_name}
-              </h1>
-
-              {/* Compact metadata row */}
-              <div className="flex flex-wrap items-center justify-center sm:justify-start gap-x-2 gap-y-1 mt-2 text-sm text-gray-500">
-                <Link href={`/bank/${encodeURIComponent(card.bank)}`} className="inline-flex items-center group">
-                  <BuildingLibraryIcon className="h-4 w-4 text-gray-400 group-hover:text-indigo-500 mr-1" aria-hidden="true" />
-                  <span className="group-hover:text-indigo-600">{card.bank}</span>
-                </Link>
-                {card.annual_fee !== undefined && (
-                  <>
-                    <span className="text-gray-300">&middot;</span>
-                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                      card.annual_fee === 0
-                        ? "bg-green-50 text-green-700"
-                        : "bg-gray-100 text-gray-700"
-                    }`}>
-                      {card.annual_fee === 0 ? "$0 Annual Fee" : `$${card.annual_fee.toLocaleString()} Annual Fee`}
-                    </span>
-                  </>
-                )}
-                {card.reward_type && (
-                  <>
-                    <span className="text-gray-300">&middot;</span>
-                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                      card.reward_type === 'cashback'
-                        ? "bg-green-50 text-green-700"
-                        : card.reward_type === 'points'
-                          ? "bg-blue-50 text-blue-700"
-                          : "bg-purple-50 text-purple-700"
-                    }`}>
-                      {card.reward_type === 'cashback' ? 'Cashback' : card.reward_type === 'points' ? 'Points' : 'Miles'}
-                    </span>
-                  </>
-                )}
-                {card.apr && (card.apr.purchase_intro || card.apr.balance_transfer_intro) && (() => {
-                  const intro = card.apr.balance_transfer_intro || card.apr.purchase_intro;
-                  return (
-                    <>
-                      <span className="text-gray-300">&middot;</span>
-                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-50 text-cyan-700">
-                        {intro!.rate}% Intro APR {intro!.months}mo
-                      </span>
-                    </>
-                  );
-                })()}
-              </div>
-
-              {/* Rewards + Signup Bonus + APR Card */}
-              {(card.rewards && card.rewards.length > 0 || card.signup_bonus || card.apr) && (
-                <div className="mt-4 bg-white shadow rounded-lg overflow-hidden">
-                  {card.rewards && card.rewards.length > 0 && (
-                    <div className="p-4">
-                      <p className="text-xs uppercase text-gray-500 font-semibold mb-2 tracking-wide">Rewards</p>
-                      <div className="flex flex-col gap-2">
-                        <div className="flex flex-wrap gap-2">
-                          {card.rewards.map((reward) => {
-                            const label = reward.category === "rotating" && reward.mode
-                              ? reward.mode === "quarterly_rotating"
-                                ? "Rotating Categories"
-                                : reward.mode === "user_choice"
-                                  ? `Choose ${reward.choices || ''} Categories`
-                                  : reward.mode === "auto_top_spend"
-                                    ? "Top Spend Category"
-                                    : categoryLabels[reward.category] || reward.category
-                              : categoryLabels[reward.category] || reward.category;
-
-                            return (
-                              <span
-                                key={reward.category}
-                                className={`inline-flex items-center px-2.5 py-1 rounded-md text-sm font-medium ${
-                                  reward.category === "everything_else"
-                                    ? "bg-gray-100 text-gray-700"
-                                    : "bg-indigo-50 text-indigo-700"
-                                }`}
-                              >
-                                {formatRewardValue(reward)} {label}
-                              </span>
-                            );
-                          })}
-                        </div>
-                        {card.rewards.filter(r => r.category === "rotating" && r.mode).map((reward) => (
-                          <div key={`${reward.category}-detail`} className="text-xs text-gray-500 px-1">
-                            {reward.mode === "quarterly_rotating" && reward.current_categories && reward.current_period && (
-                              <span>
-                                {reward.current_period}: {reward.current_categories.map(c => categoryLabels[c] || c).join(', ')}
-                              </span>
-                            )}
-                            {(reward.mode === "user_choice" || reward.mode === "auto_top_spend") && reward.eligible_categories && (
-                              <span>
-                                Eligible: {reward.eligible_categories.map(c => categoryLabels[c] || c).join(', ')}
-                              </span>
-                            )}
-                          </div>
-                        ))}
-                        {card.rewards.filter(r => r.note).map((reward) => (
-                          <p key={`${reward.category}-note`} className="text-xs text-gray-400 px-1">
-                            {reward.note}
-                          </p>
-                        ))}
+                {/* Signup Bonus Card - below image */}
+                {card.signup_bonus && (
+                  <div className="mt-6 w-full bg-gradient-to-br from-amber-50 to-amber-100/80 border border-amber-200/60 rounded-xl p-5">
+                    <div className="flex items-start gap-3">
+                      <div className="flex-shrink-0 p-2 bg-amber-200/50 rounded-lg">
+                        <BanknotesIcon className="h-5 w-5 text-amber-700" />
                       </div>
-                    </div>
-                  )}
-                  {card.signup_bonus && (
-                    <div className={`bg-amber-50 px-4 py-3 border-t border-amber-100 ${
-                      !(card.rewards && card.rewards.length > 0) ? "rounded-t-lg" : ""
-                    }`}>
-                      <p className="text-sm font-medium text-amber-900">
-                        Earn{" "}
-                        <span className="font-bold">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-1">Signup Bonus</p>
+                        <p className="text-xl font-bold text-amber-900">
                           {card.signup_bonus.type === "cash"
                             ? `$${card.signup_bonus.value.toLocaleString()}`
-                            : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type}`}
-                        </span>{" "}
-                        after spending ${card.signup_bonus.spend_requirement.toLocaleString()} in{" "}
-                        {card.signup_bonus.timeframe_months} month{card.signup_bonus.timeframe_months !== 1 ? "s" : ""}
-                      </p>
+                            : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type.charAt(0).toUpperCase() + card.signup_bonus.type.slice(1)}`}
+                        </p>
+                        <p className="text-sm text-amber-800/70 mt-1">
+                          After spending ${card.signup_bonus.spend_requirement.toLocaleString()} in{" "}
+                          {card.signup_bonus.timeframe_months} month{card.signup_bonus.timeframe_months !== 1 ? "s" : ""}
+                        </p>
+                      </div>
                     </div>
+                  </div>
+                )}
+
+                {/* Apply Buttons */}
+                {card.accepting_applications && (card.apply_link || randomReferralUrl) && (
+                  <div className="mt-5 w-full flex flex-col gap-2.5">
+                    {card.apply_link && (
+                      <a
+                        href={card.apply_link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center px-5 py-3.5 border border-transparent text-sm font-semibold rounded-xl text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-sm"
+                      >
+                        Apply Now
+                      </a>
+                    )}
+                    {randomReferralUrl && (
+                      <a
+                        href={randomReferralUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={handleReferralClick}
+                        className="inline-flex items-center justify-center px-5 py-3.5 border border-transparent text-sm font-semibold rounded-xl text-white transition-colors shadow-sm animate-shimmer bg-[length:200%_100%]"
+                        style={{
+                          backgroundImage: 'linear-gradient(110deg, #5b21b6 0%, #6d28d9 45%, #8b5cf6 55%, #6d28d9 100%)',
+                        }}
+                      >
+                        Apply with Referral
+                      </a>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* Right Column - Details */}
+              <div className="lg:col-span-8 mt-8 lg:mt-0">
+                {/* Title */}
+                <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 tracking-tight text-center lg:text-left">
+                  {card.card_name}
+                </h1>
+
+                {/* Metadata Row */}
+                <div className="flex flex-wrap items-center justify-center lg:justify-start gap-x-3 gap-y-2 mt-3">
+                  <Link href={`/bank/${encodeURIComponent(card.bank)}`} className="inline-flex items-center group">
+                    <BuildingLibraryIcon className="h-4 w-4 text-gray-400 group-hover:text-indigo-500 mr-1" aria-hidden="true" />
+                    <span className="text-sm text-gray-600 group-hover:text-indigo-600 font-medium">{card.bank}</span>
+                  </Link>
+                  {card.annual_fee !== undefined && (
+                    <>
+                      <span className="text-gray-300">&middot;</span>
+                      <span className="text-sm text-gray-600 font-medium">
+                        {card.annual_fee === 0 ? "$0 Annual Fee" : `$${card.annual_fee.toLocaleString()} Annual Fee`}
+                      </span>
+                    </>
                   )}
-                  {card.apr && (card.apr.purchase_intro || card.apr.balance_transfer_intro) && (
-                    <div className={`bg-cyan-50 px-4 py-3 border-t border-cyan-100 ${
-                      !(card.rewards && card.rewards.length > 0) && !card.signup_bonus ? "rounded-t-lg" : ""
-                    }`}>
-                      <div className="text-sm font-medium text-cyan-900">
-                        {card.apr.balance_transfer_intro && (
-                          <p>
-                            <span className="font-bold">{card.apr.balance_transfer_intro.rate}% Intro APR</span> for {card.apr.balance_transfer_intro.months} months on balance transfers
-                          </p>
-                        )}
-                        {card.apr.purchase_intro && (
-                          <p className={card.apr.balance_transfer_intro ? "mt-1" : ""}>
-                            <span className="font-bold">{card.apr.purchase_intro.rate}% Intro APR</span> for {card.apr.purchase_intro.months} months on purchases
-                          </p>
+                  {card.reward_type && (
+                    <>
+                      <span className="text-gray-300">&middot;</span>
+                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${
+                        card.reward_type === 'cashback'
+                          ? "border-green-200 text-green-700 bg-green-50/50"
+                          : card.reward_type === 'points'
+                            ? "border-blue-200 text-blue-700 bg-blue-50/50"
+                            : "border-purple-200 text-purple-700 bg-purple-50/50"
+                      }`}>
+                        {card.reward_type === 'cashback' ? 'Cashback' : card.reward_type === 'points' ? 'Points' : 'Miles'}
+                      </span>
+                    </>
+                  )}
+                </div>
+
+                {/* Rewards Section - 2-column grid, sorted highest first */}
+                {card.rewards && card.rewards.length > 0 && (() => {
+                  // Sort rewards by value descending
+                  const sorted = [...card.rewards].sort((a, b) => b.value - a.value);
+                  // Split into 2 columns (column-major: fill left column top-down, then right)
+                  const mid = Math.ceil(sorted.length / 2);
+                  const leftCol = sorted.slice(0, mid);
+                  const rightCol = sorted.slice(mid);
+
+                  const rewardTypeLabel = card.reward_type === 'cashback' ? 'Cashback' : card.reward_type === 'miles' ? 'Miles' : 'Points';
+
+                  const renderReward = (reward: Reward) => {
+                    const label = reward.category === "rotating" && reward.mode
+                      ? reward.mode === "quarterly_rotating"
+                        ? "Rotating Categories"
+                        : reward.mode === "user_choice"
+                          ? `Choose ${reward.choices || ''} Categories`
+                          : reward.mode === "auto_top_spend"
+                            ? "Top Spend Category"
+                            : categoryLabels[reward.category] || reward.category
+                      : categoryLabels[reward.category] || reward.category;
+
+                    return (
+                      <div key={reward.category} className="flex items-center gap-2.5 py-1.5">
+                        <span className={`flex-shrink-0 ${
+                          reward.category === "everything_else" ? "text-gray-300" : "text-indigo-500"
+                        }`}>
+                          <CategoryIcon category={reward.category} className="h-5 w-5" />
+                        </span>
+                        <span className={`text-base font-bold flex-shrink-0 tabular-nums ${
+                          reward.category === "everything_else" ? "text-gray-400" : "text-indigo-600"
+                        }`}>
+                          {formatRewardValue(reward)}
+                        </span>
+                        <span className={`text-sm text-gray-400 flex-shrink-0`}>
+                          {reward.unit === "percent" ? "Cashback" : rewardTypeLabel}
+                        </span>
+                        <span className={`text-sm leading-tight ${
+                          reward.category === "everything_else" ? "text-gray-500" : "text-gray-700"
+                        }`}>
+                          {label}
+                        </span>
+                        {reward.note && (
+                          <span className="relative group">
+                            <InformationCircleIcon className="h-3.5 w-3.5 text-gray-300 hover:text-gray-500 cursor-help" />
+                            <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 bg-gray-800 text-white text-xs rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                              {reward.note}
+                            </span>
+                          </span>
                         )}
                       </div>
-                      {card.apr.regular && (
-                        <p className="text-xs text-cyan-600 mt-1">
-                          Then {card.apr.regular.min}%&ndash;{card.apr.regular.max}% variable APR
+                    );
+                  };
+
+                  return (
+                    <div className="mt-6">
+                      <p className="text-xs uppercase text-gray-400 font-semibold tracking-wider mb-2">Rewards</p>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6">
+                        <div>{leftCol.map(renderReward)}</div>
+                        <div>{rightCol.map(renderReward)}</div>
+                      </div>
+                      {/* Rotating category details */}
+                      {card.rewards.filter(r => r.category === "rotating" && r.mode).map((reward) => (
+                        <div key={`${reward.category}-detail`} className="text-xs text-gray-400 mt-2 pl-[2.875rem]">
+                          {reward.mode === "quarterly_rotating" && reward.current_categories && reward.current_period && (
+                            <span>
+                              {reward.current_period}: {reward.current_categories.map(c => categoryLabels[c] || c).join(', ')}
+                            </span>
+                          )}
+                          {(reward.mode === "user_choice" || reward.mode === "auto_top_spend") && reward.eligible_categories && (
+                            <span>
+                              Eligible: {reward.eligible_categories.map(c => categoryLabels[c] || c).join(', ')}
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })()}
+
+                {/* Intro APR Section */}
+                {card.apr && (card.apr.purchase_intro || card.apr.balance_transfer_intro) && (
+                  <div className="mt-6 bg-cyan-50/50 border border-cyan-100 rounded-xl px-5 py-4">
+                    <p className="text-xs uppercase text-cyan-600 font-semibold tracking-wider mb-2">Intro APR</p>
+                    <div className="text-sm text-cyan-900">
+                      {card.apr.balance_transfer_intro && (
+                        <p>
+                          <span className="font-bold">{card.apr.balance_transfer_intro.rate}%</span> for {card.apr.balance_transfer_intro.months} months on balance transfers
+                        </p>
+                      )}
+                      {card.apr.purchase_intro && (
+                        <p className={card.apr.balance_transfer_intro ? "mt-1" : ""}>
+                          <span className="font-bold">{card.apr.purchase_intro.rate}%</span> for {card.apr.purchase_intro.months} months on purchases
                         </p>
                       )}
                     </div>
-                  )}
-                </div>
-              )}
+                    {card.apr.regular && (
+                      <p className="text-xs text-cyan-500 mt-2">
+                        Then {card.apr.regular.min}%&ndash;{card.apr.regular.max}% variable APR
+                      </p>
+                    )}
+                  </div>
+                )}
 
-              {/* Stats Section */}
-              <div className="mt-6">
-              <div className="items-stretch">
-                {(card.approved_count || 0) > 0 ? (
-                  <>
-                    <h3 className="text-lg leading-6 font-medium text-gray-900 text-center sm:text-left mb-4">
-                      The median applicant who got <b>accepted</b> for the card had...
-                    </h3>
-
-                    <div className="bg-white shadow rounded-lg overflow-hidden">
-                      <dl className="grid grid-cols-3 divide-x divide-gray-200">
-                        <div className="px-2 py-3 sm:px-4 sm:py-5 text-center">
-                          <dt className="text-xs sm:text-sm font-medium text-gray-500">Credit Score</dt>
-                          <dd className="mt-1 text-xl sm:text-3xl font-semibold text-gray-900">
-                            {card.approved_median_credit_score}
-                          </dd>
-                        </div>
-                        <div className="px-2 py-3 sm:px-4 sm:py-5 text-center">
-                          <dt className="text-xs sm:text-sm font-medium text-gray-500">Income</dt>
-                          <dd className="mt-1 text-xl sm:text-3xl font-semibold text-gray-900">
-                            ${card.approved_median_income?.toLocaleString()}
-                          </dd>
-                        </div>
-                        <div className="px-2 py-3 sm:px-4 sm:py-5 text-center">
-                          <dt className="text-xs sm:text-sm font-medium text-gray-500">Credit Length</dt>
-                          <dd className="mt-1 text-xl sm:text-3xl font-semibold text-gray-900">
-                            {card.approved_median_length_credit}
-                          </dd>
-                        </div>
-                      </dl>
+                {/* Acceptance Odds Dashboard - inside right column */}
+                {(card.approved_count || 0) > 0 && (
+                  <div className="mt-6 bg-slate-50 border border-slate-200/80 rounded-xl p-5">
+                    <div className="flex items-center justify-between mb-4">
+                      <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                        Median Accepted Applicant
+                      </h3>
+                      <span className="relative group">
+                        <InformationCircleIcon className="h-4 w-4 text-gray-300 hover:text-gray-500 cursor-help" />
+                        <span className="absolute bottom-full right-0 mb-2 px-3 py-1.5 bg-gray-800 text-white text-xs rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                          Based on {(card.rejected_count || 0) + (card.approved_count || 0)} records
+                          — {card.approved_count} approved, {card.rejected_count || 0} rejected
+                        </span>
+                      </span>
                     </div>
-                    <p className="mt-3 text-center sm:text-left text-xs text-gray-400">
-                      Median based on {(card.rejected_count || 0) + (card.approved_count || 0)} records
-                      with <span className="text-green-600">{card.approved_count} approved</span> and <span className="text-red-600">{card.rejected_count} rejected</span>
-                    </p>
-                  </>
-                ) : null}
+                    <dl className="grid grid-cols-3 divide-x divide-slate-200">
+                      <div className="text-center px-2">
+                        <dt className="text-xs font-medium text-gray-400 mb-1">Credit Score</dt>
+                        <dd className="text-2xl sm:text-3xl font-bold text-gray-900">
+                          {card.approved_median_credit_score}
+                        </dd>
+                      </div>
+                      <div className="text-center px-2">
+                        <dt className="text-xs font-medium text-gray-400 mb-1">Income</dt>
+                        <dd className="text-2xl sm:text-3xl font-bold text-gray-900">
+                          ${card.approved_median_income?.toLocaleString()}
+                        </dd>
+                      </div>
+                      <div className="text-center px-2">
+                        <dt className="text-xs font-medium text-gray-400 mb-1">Credit History</dt>
+                        <dd className="text-2xl sm:text-3xl font-bold text-gray-900">
+                          {creditLength.number}
+                        </dd>
+                        {creditLength.unit && (
+                          <dd className="text-xs text-gray-400 font-medium -mt-0.5">{creditLength.unit}</dd>
+                        )}
+                      </div>
+                    </dl>
+                  </div>
+                )}
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
 
       {/* CTA Section - only show for cards accepting applications */}
       {card.accepting_applications && (

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-28T20:37:27.743Z",
+  "generated_at": "2026-03-01T00:10:28.159Z",
   "count": 142,
   "categories": [
     {
@@ -1161,6 +1161,20 @@
         "type": "cash",
         "spend_requirement": 500,
         "timeframe_months": 3
+      },
+      "apr": {
+        "purchase_intro": {
+          "rate": 0,
+          "months": 15
+        },
+        "balance_transfer_intro": {
+          "rate": 0,
+          "months": 15
+        },
+        "regular": {
+          "min": 18.24,
+          "max": 27.74
+        }
       },
       "card_id": "chase-freedom-unlimited",
       "card_name": "Chase Freedom Unlimited"

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -27,3 +27,13 @@ signup_bonus:
   type: cash
   spend_requirement: 500
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 18.24
+    max: 27.74


### PR DESCRIPTION
## Summary
- Redesigned card detail page with a modern two-column layout inside a white card container
- Left column: card image with drop shadow, signup bonus card, and apply buttons
- Right column: title, metadata badges, rewards in sorted 2-column grid (icon → multiplier → type → category), intro APR section, and median accepted applicant stats dashboard
- Added intro APR data for Chase Freedom Unlimited (0% for 15 months, then 18.24%–27.74%)

## Test plan
- [ ] Visit `/card/chase-sapphire-preferred` — verify two-column layout, rewards grid, stats dashboard
- [ ] Visit `/card/chase-freedom-unlimited` — verify intro APR section displays correctly
- [ ] Check mobile responsiveness — layout should stack vertically on small screens
- [ ] Verify signup bonus, apply buttons, and referral links still work
- [ ] Check a card without rewards/stats (e.g., archived card) renders gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)