### PR TITLE
Add card compare page

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -14,17 +14,8 @@ import {
   NewspaperIcon,
   XMarkIcon,
   InformationCircleIcon,
-  GlobeAltIcon,
-  ShoppingBagIcon,
-  TruckIcon,
-  SparklesIcon,
   BanknotesIcon,
-  FireIcon,
-  HomeModernIcon,
-  FilmIcon,
-  ComputerDesktopIcon,
-  TicketIcon,
-  CreditCardIcon,
+  ScaleIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
 import { Card, GraphData, Reward, trackReferralEvent, getRecords } from "@/lib/api";
@@ -33,6 +24,7 @@ import { Article, tagLabels as articleTagLabels, tagColors as articleTagColors }
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
 import { CreditCardSchema, BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { categoryLabels, CategoryIcon } from "@/lib/cardDisplayUtils";
 
 // Dynamic import for Highcharts (client-side only)
 const ScatterPlot = dynamic(() => import("@/components/charts/ScatterPlot"), {
@@ -47,85 +39,6 @@ function ChartErrorFallback() {
       <p className="text-gray-500">Unable to load chart. Please refresh the page.</p>
     </div>
   );
-}
-
-const categoryLabels: Record<string, string> = {
-  dining: "Dining",
-  groceries: "Groceries",
-  travel: "Travel",
-  gas: "Gas",
-  streaming: "Streaming",
-  transit: "Transit",
-  drugstores: "Drugstores",
-  home_improvement: "Home Improvement",
-  online_shopping: "Online Shopping",
-  hotels: "Hotels",
-  airlines: "Airlines",
-  car_rentals: "Car Rentals",
-  entertainment: "Entertainment",
-  rotating: "Rotating Categories",
-  travel_portal: "Travel (via Portal)",
-  hotels_portal: "Hotels (via Portal)",
-  flights_portal: "Flights (via Portal)",
-  hotels_car_portal: "Hotels & Car Rentals (via Portal)",
-  amazon: "Amazon.com",
-  everything_else: "Everything Else",
-};
-
-// Map category to icon component
-function CategoryIcon({ category, className }: { category: string; className?: string }) {
-  const iconClass = className || "h-5 w-5";
-  switch (category) {
-    case "dining":
-      return (
-        <svg className={iconClass} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M7 3v7a3 3 0 003 3v0a3 3 0 003-3V3M7 3H5m2 0h2m0 0h2m0 0h2M10 13v8m0 0H8m2 0h2M17 3v4a2 2 0 01-2 2v0a2 2 0 01-2-2V3m2 18V9" />
-        </svg>
-      );
-    case "groceries":
-      return <ShoppingBagIcon className={iconClass} />;
-    case "travel":
-    case "travel_portal":
-      return (
-        <svg className={iconClass} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L10.93 3.555a1.126 1.126 0 00-1.006 0L2.547 7.242A1.125 1.125 0 002 8.185v11.264c0 .756.794 1.245 1.473.89l4.23-2.21a1.126 1.126 0 011.006 0l3.86 2.02a1.126 1.126 0 001.006 0l2.928-1.533z" />
-        </svg>
-      );
-    case "gas":
-      return <FireIcon className={iconClass} />;
-    case "streaming":
-      return <ComputerDesktopIcon className={iconClass} />;
-    case "transit":
-      return <TruckIcon className={iconClass} />;
-    case "drugstores":
-      return <BuildingLibraryIcon className={iconClass} />;
-    case "home_improvement":
-      return <HomeModernIcon className={iconClass} />;
-    case "online_shopping":
-    case "amazon":
-      return <ShoppingBagIcon className={iconClass} />;
-    case "hotels":
-    case "hotels_portal":
-    case "hotels_car_portal":
-      return <HomeModernIcon className={iconClass} />;
-    case "airlines":
-    case "flights_portal":
-      return (
-        <svg className={iconClass} viewBox="0 0 24 24" fill="currentColor">
-          <path d="M21 16v-2l-8-5V3.5A1.5 1.5 0 0011.5 2 1.5 1.5 0 0010 3.5V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z" />
-        </svg>
-      );
-    case "car_rentals":
-      return <TruckIcon className={iconClass} />;
-    case "entertainment":
-      return <FilmIcon className={iconClass} />;
-    case "rotating":
-      return <SparklesIcon className={iconClass} />;
-    case "everything_else":
-      return <GlobeAltIcon className={iconClass} />;
-    default:
-      return <CreditCardIcon className={iconClass} />;
-  }
 }
 
 function formatRewardValue(reward: Reward): string {
@@ -343,6 +256,16 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
         <div className="bg-white rounded-2xl shadow-[0_4px_40px_rgba(0,0,0,0.08)] overflow-hidden">
           <div className="p-6 sm:p-10">
+            {/* Compare link */}
+            <div className="flex justify-end mb-4">
+              <Link
+                href={`/compare?cards=${card.slug}`}
+                className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-indigo-600 transition-colors"
+              >
+                <ScaleIcon className="h-4 w-4" />
+                Compare
+              </Link>
+            </div>
             {/* Two-column layout */}
             <div className="lg:grid lg:grid-cols-12 lg:gap-12">
 

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -1,0 +1,633 @@
+'use client';
+
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+import Downshift from 'downshift';
+import {
+  MagnifyingGlassIcon,
+  XMarkIcon,
+  ScaleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline';
+import { Card, Reward } from '@/lib/api';
+import { cardMatchesSearch } from '@/lib/searchAliases';
+import {
+  categoryLabels,
+  CategoryIcon,
+  formatBonusValue,
+  formatEstimatedValue,
+  formatBonusRequirement,
+  formatAnnualFee,
+  RewardTypeBadge,
+} from '@/lib/cardDisplayUtils';
+
+interface CompareClientProps {
+  allCards: Card[];
+}
+
+function CardPicker({
+  allCards,
+  selectedCard,
+  excludeSlugs,
+  onSelect,
+  onClear,
+  slotIndex,
+}: {
+  allCards: Card[];
+  selectedCard: Card | null;
+  excludeSlugs: string[];
+  onSelect: (card: Card) => void;
+  onClear: () => void;
+  slotIndex: number;
+}) {
+  const [inputValue, setInputValue] = useState('');
+
+  if (selectedCard) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-3 flex items-center gap-3">
+        <div className="flex-shrink-0 h-10 w-16 relative">
+          <Image
+            src={selectedCard.card_image_link
+              ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${selectedCard.card_image_link}`
+              : '/assets/generic-card.svg'}
+            alt={selectedCard.card_name}
+            fill
+            className="object-contain rounded"
+            sizes="64px"
+          />
+        </div>
+        <div className="flex-1 min-w-0">
+          <Link href={`/card/${selectedCard.slug}`} className="text-sm font-semibold text-gray-900 hover:text-indigo-600 truncate block">
+            {selectedCard.card_name}
+          </Link>
+          <p className="text-xs text-gray-500 truncate">{selectedCard.bank}</p>
+        </div>
+        <button
+          onClick={onClear}
+          className="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label={`Remove ${selectedCard.card_name}`}
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+      </div>
+    );
+  }
+
+  const filteredCards = allCards
+    .filter((item) => {
+      if (excludeSlugs.includes(item.slug)) return false;
+      return cardMatchesSearch(item.card_name, item.bank, inputValue || '');
+    })
+    .sort((a, b) => {
+      if (a.accepting_applications !== b.accepting_applications) {
+        return a.accepting_applications ? -1 : 1;
+      }
+      const aIsBusiness = /business/i.test(a.card_name);
+      const bIsBusiness = /business/i.test(b.card_name);
+      if (aIsBusiness !== bIsBusiness) {
+        return aIsBusiness ? 1 : -1;
+      }
+      return 0;
+    });
+
+  return (
+    <Downshift<Card>
+      id={`compare-picker-${slotIndex}`}
+      onChange={(selection) => {
+        if (selection) {
+          onSelect(selection);
+          setInputValue('');
+        }
+      }}
+      inputValue={inputValue}
+      itemToString={(item) => (item ? item.card_name : '')}
+      selectedItem={null}
+    >
+      {({
+        getInputProps,
+        getItemProps,
+        getMenuProps,
+        isOpen,
+        highlightedIndex,
+        getRootProps,
+      }) => (
+        <div className="relative">
+          <div {...getRootProps({}, { suppressRefError: true })}>
+            <div className="relative">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <MagnifyingGlassIcon className="h-4 w-4 text-gray-400" aria-hidden="true" />
+              </div>
+              <input
+                {...getInputProps({
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) => setInputValue(e.target.value),
+                })}
+                className="block w-full pl-9 pr-3 py-2.5 text-sm border border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500 bg-white"
+                placeholder={`Card ${slotIndex + 1}...`}
+                type="search"
+                autoComplete="off"
+              />
+            </div>
+            <ul
+              {...getMenuProps()}
+              className={`absolute z-20 mt-1 w-full bg-white shadow-lg max-h-60 rounded-lg py-1 text-sm ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none ${
+                isOpen && inputValue && filteredCards.length > 0 ? '' : 'hidden'
+              }`}
+            >
+              {filteredCards.slice(0, 20).map((item, index) => {
+                const isArchived = !item.accepting_applications;
+                return (
+                  <li
+                    key={item.slug}
+                    className={`cursor-pointer select-none relative py-2 pl-3 pr-4 ${
+                      highlightedIndex === index
+                        ? 'bg-indigo-50 text-indigo-900'
+                        : isArchived
+                        ? 'text-gray-400'
+                        : 'text-gray-900'
+                    }`}
+                    {...getItemProps({ index, item })}
+                  >
+                    <div className={`flex items-center gap-2 ${isArchived ? 'opacity-60' : ''}`}>
+                      <div className={`flex-shrink-0 h-6 w-10 relative ${isArchived ? 'grayscale' : ''}`}>
+                        <Image
+                          src={item.card_image_link
+                            ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${item.card_image_link}`
+                            : '/assets/generic-card.svg'}
+                          alt=""
+                          fill
+                          className="object-contain"
+                          sizes="40px"
+                        />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm truncate font-medium">{item.card_name}</p>
+                        <p className="text-xs text-gray-500 truncate">
+                          {item.bank}
+                          {isArchived && <span className="ml-1">(Archived)</span>}
+                        </p>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+              {filteredCards.length === 0 && inputValue && (
+                <li className="px-3 py-3 text-sm text-gray-500 text-center">
+                  No cards found
+                </li>
+              )}
+            </ul>
+          </div>
+        </div>
+      )}
+    </Downshift>
+  );
+}
+
+function formatRewardCellValue(reward: Reward | undefined): string {
+  if (!reward) return '\u2014';
+  if (reward.unit === 'percent') return `${reward.value}%`;
+  return `${reward.value}x`;
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
+
+export default function CompareClient({ allCards }: CompareClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Initialize from URL query params
+  const [slots, setSlots] = useState<(string | null)[]>(() => {
+    const cardsParam = searchParams.get('cards');
+    if (cardsParam) {
+      const slugs = cardsParam.split(',').filter(Boolean).slice(0, 3);
+      const validSlugs = slugs.filter(slug => allCards.some(c => c.slug === slug));
+      const result: (string | null)[] = [...validSlugs];
+      while (result.length < 3) result.push(null);
+      return result;
+    }
+    return [null, null, null];
+  });
+
+  // Detailed card data fetched from individual card endpoint (has median stats)
+  const [cardDetails, setCardDetails] = useState<Record<string, Card>>({});
+
+  // Fetch detailed card data when slots change
+  useEffect(() => {
+    const activeSlugs = slots.filter((s): s is string => s !== null);
+    const slugsToFetch = activeSlugs.filter(slug => !cardDetails[slug]);
+    if (slugsToFetch.length === 0) return;
+
+    let cancelled = false;
+    (async () => {
+      for (const slug of slugsToFetch) {
+        const cdnCard = allCards.find(c => c.slug === slug);
+        if (!cdnCard) continue;
+        try {
+          const res = await fetch(`${API_BASE}/card?card_name=${encodeURIComponent(cdnCard.card_name)}`);
+          if (!res.ok) continue;
+          const detail: Card = await res.json();
+          if (cancelled) return;
+          setCardDetails(prev => ({ ...prev, [slug]: detail }));
+        } catch {
+          // Silently fail — table will show dashes for missing stats
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [slots, allCards, cardDetails]);
+
+  // Sync URL when slots change
+  const isInitialMount = useRef(true);
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    const activeSlugs = slots.filter(Boolean);
+    if (activeSlugs.length > 0) {
+      router.replace(`/compare?cards=${activeSlugs.join(',')}`, { scroll: false });
+    } else {
+      router.replace('/compare', { scroll: false });
+    }
+  }, [slots, router]);
+
+  // Merge CDN card data with detailed card data (which has median stats)
+  const selectedCards = useMemo(() => {
+    return slots.map(slug => {
+      if (!slug) return null;
+      const cdnCard = allCards.find(c => c.slug === slug);
+      if (!cdnCard) return null;
+      const detail = cardDetails[slug];
+      if (detail) return { ...cdnCard, ...detail, slug: cdnCard.slug };
+      return cdnCard;
+    });
+  }, [slots, allCards, cardDetails]);
+
+  const activeCards = useMemo(() => {
+    return selectedCards.filter((c): c is Card => c !== null);
+  }, [selectedCards]);
+
+  const excludeSlugs = useMemo(() => {
+    return slots.filter((s): s is string => s !== null);
+  }, [slots]);
+
+  const handleSelect = useCallback((index: number, card: Card) => {
+    setSlots(prev => {
+      const next = [...prev];
+      next[index] = card.slug;
+      return next;
+    });
+  }, []);
+
+  const handleClear = useCallback((index: number) => {
+    setSlots(prev => {
+      const next = [...prev];
+      next[index] = null;
+      return next;
+    });
+  }, []);
+
+  // Build unified reward categories across all selected cards
+  const unifiedCategories = useMemo(() => {
+    if (activeCards.length < 2) return [];
+
+    const categorySet = new Set<string>();
+    for (const card of activeCards) {
+      if (card.rewards) {
+        for (const r of card.rewards) {
+          categorySet.add(r.category);
+        }
+      }
+    }
+
+    const categories = Array.from(categorySet);
+
+    // Sort by max value across all cards (descending), everything_else last
+    categories.sort((a, b) => {
+      if (a === 'everything_else') return 1;
+      if (b === 'everything_else') return -1;
+
+      const maxA = Math.max(...activeCards.map(card => {
+        const r = card.rewards?.find(rw => rw.category === a);
+        return r ? r.value : 0;
+      }));
+      const maxB = Math.max(...activeCards.map(card => {
+        const r = card.rewards?.find(rw => rw.category === b);
+        return r ? r.value : 0;
+      }));
+      return maxB - maxA;
+    });
+
+    return categories;
+  }, [activeCards]);
+
+  // Helper: find all indices that tie for best value
+  const getBestIndices = useCallback((values: (number | null | undefined)[], mode: 'min' | 'max'): Set<number> => {
+    let bestVal: number | null = null;
+    values.forEach((v) => {
+      if (v === null || v === undefined) return;
+      if (bestVal === null ||
+        (mode === 'min' && v < bestVal) ||
+        (mode === 'max' && v > bestVal)) {
+        bestVal = v;
+      }
+    });
+    if (bestVal === null) return new Set();
+    const indices = new Set<number>();
+    values.forEach((v, i) => {
+      if (v === bestVal) indices.add(i);
+    });
+    return indices;
+  }, []);
+
+  return (
+    <div className="mt-6">
+      {/* Card Pickers */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {[0, 1, 2].map((i) => (
+          <CardPicker
+            key={i}
+            allCards={allCards}
+            selectedCard={selectedCards[i]}
+            excludeSlugs={excludeSlugs}
+            onSelect={(card) => handleSelect(i, card)}
+            onClear={() => handleClear(i)}
+            slotIndex={i}
+          />
+        ))}
+      </div>
+
+      {/* Comparison Table or Empty State */}
+      {activeCards.length < 2 ? (
+        <div className="mt-16 text-center">
+          <ScaleIcon className="mx-auto h-12 w-12 text-gray-300" />
+          <h3 className="mt-4 text-lg font-medium text-gray-900">Compare Cards</h3>
+          <p className="mt-2 text-sm text-gray-500">
+            Select 2 or 3 cards above to compare them side-by-side.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-8 overflow-x-auto -mx-4 sm:mx-0">
+          <table className="min-w-[640px] w-full border-collapse">
+            <thead>
+              <tr>
+                <th className="sticky left-0 z-10 bg-gray-50 w-40 sm:w-48" />
+                {activeCards.map((card) => (
+                  <th key={card.slug} className="px-4 py-3 text-center font-semibold text-sm text-gray-900 bg-gray-50 border-b border-gray-200">
+                    <Link href={`/card/${card.slug}`} className="hover:text-indigo-600 transition-colors">
+                      {card.card_name}
+                    </Link>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {/* Card Image */}
+              <tr>
+                <td className="sticky left-0 z-10 bg-white px-4 py-3 text-sm font-medium text-gray-500">Card</td>
+                {activeCards.map((card) => (
+                  <td key={card.slug} className="px-4 py-3 text-center">
+                    <div className="mx-auto w-32 h-20 relative">
+                      <Image
+                        src={card.card_image_link
+                          ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                          : '/assets/generic-card.svg'}
+                        alt={card.card_name}
+                        fill
+                        className="object-contain rounded-lg"
+                        sizes="128px"
+                      />
+                    </div>
+                  </td>
+                ))}
+              </tr>
+
+              {/* Bank */}
+              <tr className="bg-gray-50/50">
+                <td className="sticky left-0 z-10 bg-gray-50/50 px-4 py-3 text-sm font-medium text-gray-500">Bank</td>
+                {activeCards.map((card) => (
+                  <td key={card.slug} className="px-4 py-3 text-center text-sm text-gray-900">
+                    <Link href={`/bank/${encodeURIComponent(card.bank)}`} className="hover:text-indigo-600">
+                      {card.bank}
+                    </Link>
+                  </td>
+                ))}
+              </tr>
+
+              {/* Annual Fee */}
+              {(() => {
+                const fees = activeCards.map(c => c.annual_fee);
+                const bestSet = getBestIndices(fees, 'min');
+                return (
+                  <tr>
+                    <td className="sticky left-0 z-10 bg-white px-4 py-3 text-sm font-medium text-gray-500">Annual Fee</td>
+                    {activeCards.map((card, i) => (
+                      <td key={card.slug} className={`px-4 py-3 text-center text-sm font-medium ${bestSet.has(i) ? 'text-green-700 bg-green-50' : 'text-gray-900'}`}>
+                        {formatAnnualFee(card.annual_fee)}/yr
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })()}
+
+              {/* Reward Type */}
+              <tr className="bg-gray-50/50">
+                <td className="sticky left-0 z-10 bg-gray-50/50 px-4 py-3 text-sm font-medium text-gray-500">Reward Type</td>
+                {activeCards.map((card) => (
+                  <td key={card.slug} className="px-4 py-3 text-center">
+                    <RewardTypeBadge type={card.reward_type} />
+                  </td>
+                ))}
+              </tr>
+
+              {/* Signup Bonus */}
+              {(() => {
+                const bonusValues = activeCards.map(c => {
+                  if (!c.signup_bonus) return null;
+                  if (c.signup_bonus.type === 'cash' || c.signup_bonus.type === 'cashback') {
+                    return c.signup_bonus.value;
+                  }
+                  const est = formatEstimatedValue(c);
+                  if (est) return parseInt(est.replace(/[~$,]/g, ''));
+                  return c.signup_bonus.value;
+                });
+                const bestSet = getBestIndices(bonusValues, 'max');
+                return (
+                  <tr>
+                    <td className="sticky left-0 z-10 bg-white px-4 py-3 text-sm font-medium text-gray-500">Signup Bonus</td>
+                    {activeCards.map((card, i) => (
+                      <td key={card.slug} className={`px-4 py-3 text-center text-sm ${bestSet.has(i) && card.signup_bonus ? 'bg-green-50' : ''}`}>
+                        {card.signup_bonus ? (
+                          <div>
+                            <span className={`font-semibold ${bestSet.has(i) ? 'text-green-700' : 'text-gray-900'}`}>
+                              {formatBonusValue(card)}
+                            </span>
+                            {formatEstimatedValue(card) && (
+                              <span className="text-gray-500 text-xs ml-1">({formatEstimatedValue(card)})</span>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-gray-400">{'\u2014'}</span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })()}
+
+              {/* Spend Requirement */}
+              <tr className="bg-gray-50/50">
+                <td className="sticky left-0 z-10 bg-gray-50/50 px-4 py-3 text-sm font-medium text-gray-500">Spend Requirement</td>
+                {activeCards.map((card) => (
+                  <td key={card.slug} className="px-4 py-3 text-center text-sm text-gray-900">
+                    {card.signup_bonus ? (
+                      <span>
+                        ${card.signup_bonus.spend_requirement.toLocaleString()} in {card.signup_bonus.timeframe_months} mo
+                      </span>
+                    ) : (
+                      <span className="text-gray-400">{'\u2014'}</span>
+                    )}
+                  </td>
+                ))}
+              </tr>
+
+              {/* Reward Categories (unified) */}
+              {unifiedCategories.map((cat, catIdx) => {
+                // For each card, find the specific reward or fall back to everything_else
+                const rewardsPerCard = activeCards.map(card => {
+                  const specific = card.rewards?.find(rw => rw.category === cat);
+                  if (specific) return { reward: specific, isFallback: false };
+                  if (cat !== 'everything_else') {
+                    const fallback = card.rewards?.find(rw => rw.category === 'everything_else');
+                    if (fallback) return { reward: fallback, isFallback: true };
+                  }
+                  return { reward: undefined, isFallback: false };
+                });
+
+                const values = rewardsPerCard.map(r => r.reward ? r.reward.value : null);
+                const bestSet = cat !== 'everything_else' ? getBestIndices(values, 'max') : new Set<number>();
+                const isEven = catIdx % 2 === 0;
+
+                return (
+                  <tr key={cat} className={isEven ? '' : 'bg-gray-50/50'}>
+                    <td className={`sticky left-0 z-10 ${isEven ? 'bg-white' : 'bg-gray-50/50'} px-4 py-2.5 text-sm font-medium text-gray-500`}>
+                      <div className="flex items-center gap-2">
+                        <span className="text-gray-400">
+                          <CategoryIcon category={cat} className="h-4 w-4" />
+                        </span>
+                        <span className="truncate">{categoryLabels[cat] || cat}</span>
+                      </div>
+                    </td>
+                    {activeCards.map((card, i) => {
+                      const { reward, isFallback } = rewardsPerCard[i];
+                      const isBest = bestSet.has(i) && reward !== undefined;
+                      return (
+                        <td key={card.slug} className={`px-4 py-2.5 text-center text-sm ${isBest && !isFallback ? 'text-green-700 font-semibold bg-green-50' : reward && !isFallback ? 'text-gray-900' : 'text-gray-400'} ${isFallback ? 'italic' : ''}`}>
+                          <span className="inline-flex items-center gap-1 justify-center">
+                            {formatRewardCellValue(reward)}
+                            {reward?.note && !isFallback && (
+                              <span className="relative group">
+                                <InformationCircleIcon className="h-3.5 w-3.5 text-gray-300 hover:text-gray-500 cursor-help" />
+                                <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 bg-gray-800 text-white text-xs rounded-md w-48 text-left opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-20">
+                                  {reward.note}
+                                </span>
+                              </span>
+                            )}
+                          </span>
+                          {!isFallback && reward?.mode === 'quarterly_rotating' && (
+                            <div className="text-xs text-gray-400 mt-0.5">Rotating</div>
+                          )}
+                          {!isFallback && reward?.mode === 'user_choice' && (
+                            <div className="text-xs text-gray-400 mt-0.5">You choose{reward.choices ? ` ${reward.choices}` : ''}</div>
+                          )}
+                          {!isFallback && reward?.mode === 'auto_top_spend' && (
+                            <div className="text-xs text-gray-400 mt-0.5">Auto top spend</div>
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+
+              {/* Purchase Intro APR */}
+              <tr className={unifiedCategories.length % 2 === 0 ? '' : 'bg-gray-50/50'}>
+                <td className={`sticky left-0 z-10 ${unifiedCategories.length % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'} px-4 py-3 text-sm font-medium text-gray-500`}>Purchase Intro APR</td>
+                {activeCards.map((card) => (
+                  <td key={card.slug} className="px-4 py-3 text-center text-sm text-gray-900">
+                    {card.apr?.purchase_intro ? (
+                      <span>{card.apr.purchase_intro.rate}% for {card.apr.purchase_intro.months} mo</span>
+                    ) : (
+                      <span className="text-gray-400">{'\u2014'}</span>
+                    )}
+                  </td>
+                ))}
+              </tr>
+
+              {/* Balance Transfer Intro APR */}
+              <tr className={unifiedCategories.length % 2 === 0 ? 'bg-gray-50/50' : ''}>
+                <td className={`sticky left-0 z-10 ${unifiedCategories.length % 2 === 0 ? 'bg-gray-50/50' : 'bg-white'} px-4 py-3 text-sm font-medium text-gray-500`}>BT Intro APR</td>
+                {activeCards.map((card) => (
+                  <td key={card.slug} className="px-4 py-3 text-center text-sm text-gray-900">
+                    {card.apr?.balance_transfer_intro ? (
+                      <span>{card.apr.balance_transfer_intro.rate}% for {card.apr.balance_transfer_intro.months} mo</span>
+                    ) : (
+                      <span className="text-gray-400">{'\u2014'}</span>
+                    )}
+                  </td>
+                ))}
+              </tr>
+
+              {/* Regular APR */}
+              <tr>
+                <td className="sticky left-0 z-10 bg-white px-4 py-3 text-sm font-medium text-gray-500">Regular APR</td>
+                {activeCards.map((card) => (
+                  <td key={card.slug} className="px-4 py-3 text-center text-sm text-gray-900">
+                    {card.apr?.regular ? (
+                      <span>{card.apr.regular.min}%&ndash;{card.apr.regular.max}%</span>
+                    ) : (
+                      <span className="text-gray-400">{'\u2014'}</span>
+                    )}
+                  </td>
+                ))}
+              </tr>
+
+              {/* Median Credit Score */}
+              {(() => {
+                const scores = activeCards.map(c => c.approved_median_credit_score ?? null);
+                const bestSet = getBestIndices(scores, 'min');
+                return (
+                  <tr className="bg-gray-50/50">
+                    <td className="sticky left-0 z-10 bg-gray-50/50 px-4 py-3 text-sm font-medium text-gray-500">Median Credit Score</td>
+                    {activeCards.map((card, i) => (
+                      <td key={card.slug} className={`px-4 py-3 text-center text-sm font-medium ${bestSet.has(i) && card.approved_median_credit_score ? 'text-green-700 bg-green-50' : 'text-gray-900'}`}>
+                        {card.approved_median_credit_score ?? <span className="text-gray-400">{'\u2014'}</span>}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })()}
+
+              {/* Median Income */}
+              <tr>
+                <td className="sticky left-0 z-10 bg-white px-4 py-3 text-sm font-medium text-gray-500">Median Income</td>
+                {activeCards.map((card) => (
+                  <td key={card.slug} className="px-4 py-3 text-center text-sm text-gray-900">
+                    {card.approved_median_income ? (
+                      <span>${card.approved_median_income.toLocaleString()}</span>
+                    ) : (
+                      <span className="text-gray-400">{'\u2014'}</span>
+                    )}
+                  </td>
+                ))}
+              </tr>
+
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web-next/src/app/compare/page.tsx
+++ b/apps/web-next/src/app/compare/page.tsx
@@ -1,0 +1,59 @@
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { getAllCards } from '@/lib/api';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import CompareClient from './CompareClient';
+
+export const revalidate = 300;
+
+export const metadata = {
+  title: 'Compare Credit Cards | CreditOdds',
+  description: 'Compare up to 3 credit cards side-by-side. See rewards, signup bonuses, APR, annual fees, and approval odds all in one place.',
+};
+
+export default async function ComparePage() {
+  const cards = await getAllCards();
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Compare Cards', url: 'https://creditodds.com/compare' },
+      ]} />
+
+      {/* Breadcrumbs */}
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">
+                Home
+              </Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Compare Cards</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-3xl font-extrabold text-gray-900 tracking-tight">
+          Compare Credit Cards
+        </h1>
+        <p className="mt-2 text-gray-600">
+          Select up to 3 cards to compare side-by-side.
+        </p>
+
+        <Suspense fallback={<div className="mt-8 text-gray-500">Loading...</div>}>
+          <CompareClient allCards={cards} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/best/BestCardList.tsx
+++ b/apps/web-next/src/components/best/BestCardList.tsx
@@ -3,6 +3,14 @@ import Link from 'next/link';
 import { Card } from '@/lib/api';
 import { BestPageCard } from '@/lib/best';
 import { ApplyButtons } from './ApplyButtons';
+import {
+  getCentsPerPoint,
+  formatEstimatedValue,
+  formatBonusValue,
+  formatBonusRequirement,
+  formatAnnualFee,
+  RewardTypeBadge,
+} from '@/lib/cardDisplayUtils';
 
 interface EnrichedCard extends BestPageCard {
   card: Card;
@@ -10,81 +18,6 @@ interface EnrichedCard extends BestPageCard {
 
 interface BestCardListProps {
   cards: EnrichedCard[];
-}
-
-// Cents-per-point estimates by program (conservative baseline values)
-function getCentsPerPoint(card: Card): number | null {
-  if (!card.signup_bonus) return null;
-  const { type } = card.signup_bonus;
-  if (type === 'cash' || type === 'cashback') return null; // Already in dollars
-
-  const name = card.card_name.toLowerCase();
-  // Points programs
-  if (name.includes('chase sapphire') || name.includes('freedom')) return 1.25; // Chase Ultimate Rewards
-  if (name.includes('amex') || name.includes('american express') || name.includes('gold card') || name.includes('platinum card')) {
-    if (name.includes('delta') || name.includes('skymiles')) return 1.1; // Delta SkyMiles
-    if (name.includes('hilton')) return 0.5; // Hilton Honors
-    return 1.2; // Amex Membership Rewards
-  }
-  if (name.includes('capital one')) return 1.0; // Capital One miles
-  if (name.includes('hyatt')) return 2.0; // World of Hyatt
-  if (name.includes('ihg')) return 0.5; // IHG Rewards
-  if (name.includes('marriott') || name.includes('bonvoy')) return 0.7; // Marriott Bonvoy
-  if (name.includes('atmos')) return 1.0; // Atmos (newer program, ~1cpp estimate)
-  if (name.includes('bilt')) return 1.5; // Bilt transfer partners
-  if (name.includes('citi')) return 1.0; // Citi ThankYou
-  if (name.includes('wells fargo')) return 1.0; // Wells Fargo Rewards
-
-  // Default for unknown points/miles
-  return 1.0;
-}
-
-function formatEstimatedValue(card: Card): string | null {
-  if (!card.signup_bonus) return null;
-  const cpp = getCentsPerPoint(card);
-  if (cpp === null) return null;
-  const value = Math.round((card.signup_bonus.value * cpp) / 100);
-  return `~$${value.toLocaleString()}`;
-}
-
-function formatBonusValue(card: Card): string {
-  if (!card.signup_bonus) return '';
-  const { value, type } = card.signup_bonus;
-  if (type === 'cash' || type === 'cashback') {
-    return `$${value.toLocaleString()}`;
-  }
-  return `${value.toLocaleString()} ${type}`;
-}
-
-function formatBonusRequirement(card: Card): string {
-  if (!card.signup_bonus) return '';
-  const { spend_requirement, timeframe_months } = card.signup_bonus;
-  return `after $${spend_requirement.toLocaleString()} in ${timeframe_months} month${timeframe_months !== 1 ? 's' : ''}`;
-}
-
-function formatAnnualFee(fee: number | undefined): string {
-  if (fee === undefined || fee === null) return 'N/A';
-  if (fee === 0) return '$0';
-  return `$${fee}`;
-}
-
-function RewardTypeBadge({ type }: { type?: string }) {
-  if (!type) return null;
-  const colors: Record<string, string> = {
-    cashback: 'bg-green-100 text-green-800',
-    points: 'bg-blue-100 text-blue-800',
-    miles: 'bg-purple-100 text-purple-800',
-  };
-  const labels: Record<string, string> = {
-    cashback: 'Cash Back',
-    points: 'Points',
-    miles: 'Miles',
-  };
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors[type] || 'bg-gray-100 text-gray-800'}`}>
-      {labels[type] || type}
-    </span>
-  );
 }
 
 export function BestCardList({ cards }: BestCardListProps) {

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -1,0 +1,163 @@
+import {
+  GlobeAltIcon,
+  ShoppingBagIcon,
+  TruckIcon,
+  SparklesIcon,
+  FireIcon,
+  HomeModernIcon,
+  FilmIcon,
+  ComputerDesktopIcon,
+  CreditCardIcon,
+} from "@heroicons/react/24/outline";
+import { Card } from "@/lib/api";
+
+export const categoryLabels: Record<string, string> = {
+  dining: "Dining",
+  groceries: "Groceries",
+  travel: "Travel",
+  gas: "Gas",
+  streaming: "Streaming",
+  transit: "Transit",
+  drugstores: "Drugstores",
+  home_improvement: "Home Improvement",
+  online_shopping: "Online Shopping",
+  hotels: "Hotels",
+  airlines: "Airlines",
+  car_rentals: "Car Rentals",
+  entertainment: "Entertainment",
+  rotating: "Rotating Categories",
+  travel_portal: "Travel (via Portal)",
+  hotels_portal: "Hotels (via Portal)",
+  flights_portal: "Flights (via Portal)",
+  hotels_car_portal: "Hotels & Car Rentals (via Portal)",
+  amazon: "Amazon.com",
+  everything_else: "Everything Else",
+};
+
+export function CategoryIcon({ category, className }: { category: string; className?: string }) {
+  const iconClass = className || "h-5 w-5";
+  switch (category) {
+    case "dining":
+      return (
+        <svg className={iconClass} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M7 3v7a3 3 0 003 3v0a3 3 0 003-3V3M7 3H5m2 0h2m0 0h2m0 0h2M10 13v8m0 0H8m2 0h2M17 3v4a2 2 0 01-2 2v0a2 2 0 01-2-2V3m2 18V9" />
+        </svg>
+      );
+    case "groceries":
+      return <ShoppingBagIcon className={iconClass} />;
+    case "travel":
+    case "travel_portal":
+      return (
+        <svg className={iconClass} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L10.93 3.555a1.126 1.126 0 00-1.006 0L2.547 7.242A1.125 1.125 0 002 8.185v11.264c0 .756.794 1.245 1.473.89l4.23-2.21a1.126 1.126 0 011.006 0l3.86 2.02a1.126 1.126 0 001.006 0l2.928-1.533z" />
+        </svg>
+      );
+    case "gas":
+      return <FireIcon className={iconClass} />;
+    case "streaming":
+      return <ComputerDesktopIcon className={iconClass} />;
+    case "transit":
+      return <TruckIcon className={iconClass} />;
+    case "drugstores":
+      return <CreditCardIcon className={iconClass} />;
+    case "home_improvement":
+      return <HomeModernIcon className={iconClass} />;
+    case "online_shopping":
+    case "amazon":
+      return <ShoppingBagIcon className={iconClass} />;
+    case "hotels":
+    case "hotels_portal":
+    case "hotels_car_portal":
+      return <HomeModernIcon className={iconClass} />;
+    case "airlines":
+    case "flights_portal":
+      return (
+        <svg className={iconClass} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M21 16v-2l-8-5V3.5A1.5 1.5 0 0011.5 2 1.5 1.5 0 0010 3.5V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z" />
+        </svg>
+      );
+    case "car_rentals":
+      return <TruckIcon className={iconClass} />;
+    case "entertainment":
+      return <FilmIcon className={iconClass} />;
+    case "rotating":
+      return <SparklesIcon className={iconClass} />;
+    case "everything_else":
+      return <GlobeAltIcon className={iconClass} />;
+    default:
+      return <CreditCardIcon className={iconClass} />;
+  }
+}
+
+// Cents-per-point estimates by program (conservative baseline values)
+export function getCentsPerPoint(card: Card): number | null {
+  if (!card.signup_bonus) return null;
+  const { type } = card.signup_bonus;
+  if (type === 'cash' || type === 'cashback') return null;
+
+  const name = card.card_name.toLowerCase();
+  if (name.includes('chase sapphire') || name.includes('freedom')) return 1.25;
+  if (name.includes('amex') || name.includes('american express') || name.includes('gold card') || name.includes('platinum card')) {
+    if (name.includes('delta') || name.includes('skymiles')) return 1.1;
+    if (name.includes('hilton')) return 0.5;
+    return 1.2;
+  }
+  if (name.includes('capital one')) return 1.0;
+  if (name.includes('hyatt')) return 2.0;
+  if (name.includes('ihg')) return 0.5;
+  if (name.includes('marriott') || name.includes('bonvoy')) return 0.7;
+  if (name.includes('atmos')) return 1.0;
+  if (name.includes('bilt')) return 1.5;
+  if (name.includes('citi')) return 1.0;
+  if (name.includes('wells fargo')) return 1.0;
+
+  return 1.0;
+}
+
+export function formatEstimatedValue(card: Card): string | null {
+  if (!card.signup_bonus) return null;
+  const cpp = getCentsPerPoint(card);
+  if (cpp === null) return null;
+  const value = Math.round((card.signup_bonus.value * cpp) / 100);
+  return `~$${value.toLocaleString()}`;
+}
+
+export function formatBonusValue(card: Card): string {
+  if (!card.signup_bonus) return '';
+  const { value, type } = card.signup_bonus;
+  if (type === 'cash' || type === 'cashback') {
+    return `$${value.toLocaleString()}`;
+  }
+  return `${value.toLocaleString()} ${type}`;
+}
+
+export function formatBonusRequirement(card: Card): string {
+  if (!card.signup_bonus) return '';
+  const { spend_requirement, timeframe_months } = card.signup_bonus;
+  return `after $${spend_requirement.toLocaleString()} in ${timeframe_months} month${timeframe_months !== 1 ? 's' : ''}`;
+}
+
+export function formatAnnualFee(fee: number | undefined): string {
+  if (fee === undefined || fee === null) return 'N/A';
+  if (fee === 0) return '$0';
+  return `$${fee}`;
+}
+
+export function RewardTypeBadge({ type }: { type?: string }) {
+  if (!type) return null;
+  const colors: Record<string, string> = {
+    cashback: 'bg-green-100 text-green-800',
+    points: 'bg-blue-100 text-blue-800',
+    miles: 'bg-purple-100 text-purple-800',
+  };
+  const labels: Record<string, string> = {
+    cashback: 'Cash Back',
+    points: 'Points',
+    miles: 'Miles',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors[type] || 'bg-gray-100 text-gray-800'}`}>
+      {labels[type] || type}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds unlisted `/compare` page for side-by-side comparison of up to 3 credit cards
- Shareable URLs via `?cards=slug1,slug2,slug3` query params
- Comparison table covers rewards (unified categories), signup bonus, APR, annual fee, and median approval stats
- Extracts shared display utilities (`categoryLabels`, `CategoryIcon`, format helpers) into `cardDisplayUtils.tsx` to deduplicate code across CardClient, BestCardList, and CompareClient
- Adds "Compare" link on individual card pages that preloads the card

## Details
- Everything_else reward used as italic fallback for categories a card doesn't have a specific bonus for
- Green highlighting for best values with tie support (all matching cards highlighted)
- Reward notes shown as hover tooltips instead of inline text to prevent column distortion
- Fetches individual card details client-side for median credit score/income (not in `/cards` CDN endpoint)

## Test plan
- [ ] Visit `/compare` — shows empty state with 3 pickers
- [ ] Select 2+ cards — table appears with side-by-side data
- [ ] URL updates with card slugs — copy/paste URL loads same cards
- [ ] Click X on a card — removed from comparison and URL
- [ ] Duplicate card selection prevented
- [ ] Mobile: horizontal scroll with sticky label column
- [ ] `/card/[name]` pages show "Compare" link, renders correctly
- [ ] `/best/[slug]` pages render correctly (no regression from shared utils)

🤖 Generated with [Claude Code](https://claude.com/claude-code)