### PR TITLE
Update card data for 115 cards — bonuses, rewards, and APR

### DIFF
--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -5,3 +5,30 @@ accepting_applications: true
 image: "aer-lingus.png"
 annual_fee: 95
 reward_type: "miles"
+tags:
+  - airline
+  - travel
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "Aer Lingus, British Airways, and Iberia flights"
+  - category: hotels
+    value: 2
+    unit: points_per_dollar
+    note: "Hotels booked directly"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 75000
+  type: miles
+  spend_requirement: 5000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/amazon-business-prime-american-express-card.yaml
+++ b/data/cards/amazon-business-prime-american-express-card.yaml
@@ -6,3 +6,32 @@ category: "business"
 annual_fee: 0
 reward_type: "cashback"
 image: "amazon-business-prime.png"
+rewards:
+  - category: amazon
+    value: 5
+    unit: percent
+    note: "U.S. purchases at Amazon.com, Amazon Business, AWS, and Whole Foods Market, on first $120,000/year then 1%"
+  - category: dining
+    value: 2
+    unit: percent
+    note: "U.S. restaurants"
+  - category: gas
+    value: 2
+    unit: percent
+    note: "U.S. gas stations"
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 125
+  type: cash
+  spend_requirement: 0
+  timeframe_months: 0
+apr:
+  regular:
+    min: 18.24
+    max: 26.24
+tags:
+  - business
+  - cashback
+  - shopping

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -20,6 +20,19 @@ rewards:
   - category: "gas"
     value: 2
     unit: "percent"
+  - category: "transit"
+    value: 2
+    unit: "percent"
+    note: "Local transit, commuting, and rideshare"
   - category: "everything_else"
     value: 1
     unit: "percent"
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 0
+  timeframe_months: 0
+apr:
+  regular:
+    min: 18.74
+    max: 27.49

--- a/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
+++ b/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
@@ -5,8 +5,25 @@ accepting_applications: true
 image: "american-aadvantage.jpeg"
 annual_fee: 0
 reward_type: "miles"
+tags:
+  - airlines
+rewards:
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+    note: "On eligible American Airlines purchases"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 15000
   type: miles
-  spend_requirement: 500
+  spend_requirement: 1000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 29.49

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -6,6 +6,20 @@ category: "business"
 image: "american-express-business-gold.png"
 annual_fee: 375
 reward_type: "points"
+rewards:
+  - category: everything_else
+    value: 4
+    unit: points_per_dollar
+    note: "4x on top 2 categories where you spend the most each billing cycle (from 6 eligible categories), on first $150,000/year"
+  - category: travel_portal
+    value: 3
+    unit: points_per_dollar
+    note: "Flights and prepaid hotels booked via AmexTravel.com"
+signup_bonus:
+  value: 100000
+  type: points
+  spend_requirement: 15000
+  timeframe_months: 3
 tags:
   - business
   - rewards

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -5,6 +5,24 @@ image: "amex_green_card.png"
 accepting_applications: true
 annual_fee: 150
 reward_type: "points"
+rewards:
+  - category: travel
+    value: 3
+    unit: points_per_dollar
+  - category: transit
+    value: 3
+    unit: points_per_dollar
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 40000
+  type: points
+  spend_requirement: 3000
+  timeframe_months: 6
 tags:
   - travel
   - dining

--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -6,13 +6,10 @@ accepting_applications: true
 annual_fee: 0
 reward_type: cashback
 rewards:
-  - category: everything_else
-    value: 1
-    unit: percent
   - category: online_shopping
     value: 3
     unit: percent
-    note: "Apple purchases"
+    note: "Apple purchases and select merchants"
   - category: dining
     value: 2
     unit: percent
@@ -25,5 +22,12 @@ rewards:
     value: 2
     unit: percent
     note: "Via Apple Pay"
+  - category: everything_else
+    value: 1
+    unit: percent
 tags:
   - cashback
+apr:
+  regular:
+    min: 17.49
+    max: 27.74

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -6,3 +6,24 @@ category: "secured"
 image: "bank-of-america-customized-cash-secured.png"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - secured
+  - cashback
+rewards:
+  - category: rotating
+    value: 3
+    unit: percent
+    mode: user_choice
+    choices: 1
+    note: "3% in choice category, up to $2,500/quarter"
+  - category: groceries
+    value: 2
+    unit: percent
+    note: "Also includes wholesale clubs, up to $2,500/quarter combined"
+  - category: everything_else
+    value: 1
+    unit: percent
+apr:
+  regular:
+    min: 27.49
+    max: 27.49

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -6,3 +6,35 @@ image: "customized-cash-rewards.png"
 category: "cashback"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+rewards:
+  - category: rotating
+    value: 3
+    unit: percent
+    mode: user_choice
+    choices: 1
+    note: "3% in choice category (gas, online shopping, dining, travel, drugstores, home improvement), up to $2,500/quarter"
+  - category: groceries
+    value: 2
+    unit: percent
+    note: "Also includes wholesale clubs, up to $2,500/quarter combined with choice category"
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 1000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 27.49

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -6,3 +6,26 @@ image: "premium-rewards.png"
 category: "travel"
 annual_fee: 550
 reward_type: "points"
+tags:
+  - travel
+  - rewards
+  - premium
+rewards:
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1.5
+    unit: points_per_dollar
+signup_bonus:
+  value: 75000
+  type: points
+  spend_requirement: 5000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 27.49

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -6,3 +6,25 @@ accepting_applications: true
 category: "travel"
 annual_fee: 95
 reward_type: "points"
+tags:
+  - travel
+  - rewards
+rewards:
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1.5
+    unit: points_per_dollar
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 4000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 27.49

--- a/data/cards/bank-of-america-travel-rewards.yaml
+++ b/data/cards/bank-of-america-travel-rewards.yaml
@@ -15,3 +15,13 @@ rewards:
   - category: "everything_else"
     value: 1.5
     unit: "points_per_dollar"
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 27.49

--- a/data/cards/bank-of-america-unlimited-cash-rewards.yaml
+++ b/data/cards/bank-of-america-unlimited-cash-rewards.yaml
@@ -6,8 +6,25 @@ category: "cashback"
 image: "unlimited-cash-rewards.png"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+rewards:
+  - category: everything_else
+    value: 1.5
+    unit: percent
 signup_bonus:
   value: 200
-  type: "cashback"
+  type: cash
   spend_requirement: 1000
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 27.49

--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -5,13 +5,15 @@ accepting_applications: true
 image: "bankamericard.png"
 category: "other"
 annual_fee: 0
+tags:
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0
-    months: 21
+    months: 18
   balance_transfer_intro:
     rate: 0
-    months: 21
+    months: 18
   regular:
-    min: 16.24
-    max: 26.24
+    min: 14.49
+    max: 24.49

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -9,3 +9,8 @@ release_date: "2025-01-15"
 tags:
   - rewards
   - travel
+rewards:
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+    note: "Also earns 4% Bilt Cash on everyday purchases"

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -10,3 +10,15 @@ tags:
   - rewards
   - travel
   - premium
+rewards:
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+    note: "Choose dining or groceries, up to $25,000/year"
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+    note: "Also earns 4% Bilt Cash on everyday purchases"

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -11,6 +11,18 @@ tags:
   - travel
   - premium
   - dining
+rewards:
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+    note: "Choose dining or groceries, up to $25,000/year"
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+    note: "Also earns 4% Bilt Cash on everyday purchases"
 signup_bonus:
   value: 50000
   type: "points"

--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -6,6 +6,23 @@ category: "business"
 annual_fee: 0
 reward_type: "cashback"
 image: "blue-business-cash.png"
+rewards:
+  - category: everything_else
+    value: 2
+    unit: percent
+    note: "On first $50,000 in purchases per calendar year, then 1%"
+signup_bonus:
+  value: 250
+  type: cash
+  spend_requirement: 15000
+  timeframe_months: 12
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 26.49
 tags:
   - business
   - cashback

--- a/data/cards/blue-business-plus-credit-card-from-american-express.yaml
+++ b/data/cards/blue-business-plus-credit-card-from-american-express.yaml
@@ -6,6 +6,23 @@ category: "business"
 image: "blue-business-plus.png"
 annual_fee: 0
 reward_type: "points"
+rewards:
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+    note: "On first $50,000 in purchases per calendar year, then 1x"
+signup_bonus:
+  value: 15000
+  type: points
+  spend_requirement: 3000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 17.49
+    max: 25.49
 tags:
   - business
   - rewards

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -21,8 +21,18 @@ rewards:
     value: 3
     unit: "percent"
     note: "U.S. online retail purchases, up to $6,000 per year then 1%"
+  - category: "everything_else"
+    value: 1
+    unit: "percent"
 signup_bonus:
   value: 200
-  type: "cashback"
+  type: "cash"
   spend_requirement: 2000
   timeframe_months: 6
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 19.49
+    max: 28.49

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -5,6 +5,38 @@ image: "amex_blue_cash_preferred.png"
 accepting_applications: true
 annual_fee: 95
 reward_type: "cashback"
+rewards:
+  - category: groceries
+    value: 6
+    unit: percent
+    note: "U.S. supermarkets, up to $6,000 per year then 1%"
+  - category: streaming
+    value: 6
+    unit: percent
+    note: "Select U.S. streaming subscriptions"
+  - category: transit
+    value: 3
+    unit: percent
+    note: "Including taxis, rideshare, parking, tolls, trains, buses"
+  - category: gas
+    value: 3
+    unit: percent
+    note: "U.S. gas stations"
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 250
+  type: cash
+  spend_requirement: 3000
+  timeframe_months: 6
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 19.49
+    max: 28.49
 tags:
   - cashback
   - shopping

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -5,3 +5,27 @@ accepting_applications: true
 image: "british-airways.png"
 annual_fee: 95
 reward_type: "miles"
+tags:
+  - airline
+  - travel
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "British Airways, Aer Lingus, and Iberia flights"
+  - category: hotels
+    value: 2
+    unit: points_per_dollar
+    note: "Hotels booked directly"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 75000
+  type: miles
+  spend_requirement: 5000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 29.99

--- a/data/cards/capital-one-platinum-secured.yaml
+++ b/data/cards/capital-one-platinum-secured.yaml
@@ -7,3 +7,8 @@ category: "secured"
 annual_fee: 0
 tags:
   - secured
+  - credit_builder
+apr:
+  regular:
+    min: 28.99
+    max: 28.99

--- a/data/cards/capital-one-platinum.yaml
+++ b/data/cards/capital-one-platinum.yaml
@@ -3,5 +3,11 @@ bank: "Capital One"
 slug: "capital-one-platinum"
 image: "capital_one_platinum.png"
 accepting_applications: true
-category: "rewards"
+category: "other"
 annual_fee: 0
+tags:
+  - credit_builder
+apr:
+  regular:
+    min: 28.99
+    max: 28.99

--- a/data/cards/capital-one-quicksilver-secured.yaml
+++ b/data/cards/capital-one-quicksilver-secured.yaml
@@ -9,3 +9,17 @@ reward_type: "cashback"
 tags:
   - secured
   - cashback
+rewards:
+  - category: hotels_car_portal
+    value: 5
+    unit: percent
+  - category: everything_else
+    value: 1.5
+    unit: percent
+apr:
+  balance_transfer_intro:
+    rate: 10.99
+    months: 6
+  regular:
+    min: 26.49
+    max: 26.49

--- a/data/cards/capital-one-quicksilver.yaml
+++ b/data/cards/capital-one-quicksilver.yaml
@@ -9,3 +9,25 @@ reward_type: "cashback"
 tags:
   - cashback
   - rewards
+rewards:
+  - category: hotels_car_portal
+    value: 5
+    unit: percent
+  - category: everything_else
+    value: 1.5
+    unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 500
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/capital-one-quicksilverone.yaml
+++ b/data/cards/capital-one-quicksilverone.yaml
@@ -13,3 +13,7 @@ rewards:
   - category: "everything_else"
     value: 1.5
     unit: "percent"
+apr:
+  regular:
+    min: 28.99
+    max: 28.99

--- a/data/cards/capital-one-savor-student.yaml
+++ b/data/cards/capital-one-savor-student.yaml
@@ -6,8 +6,35 @@ image: "capital-one-savor-student.png"
 category: "student"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - student
+  - cashback
+  - dining
+rewards:
+  - category: dining
+    value: 3
+    unit: percent
+  - category: entertainment
+    value: 3
+    unit: percent
+  - category: streaming
+    value: 3
+    unit: percent
+  - category: groceries
+    value: 3
+    unit: percent
+  - category: hotels_car_portal
+    value: 5
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent
 signup_bonus:
   value: 50
-  type: "cashback"
+  type: cash
   spend_requirement: 100
   timeframe_months: 3
+apr:
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -10,3 +10,38 @@ tags:
   - cashback
   - dining
   - rewards
+rewards:
+  - category: entertainment
+    value: 3
+    unit: percent
+    note: "Also 8% on Capital One Entertainment"
+  - category: dining
+    value: 3
+    unit: percent
+  - category: groceries
+    value: 3
+    unit: percent
+  - category: streaming
+    value: 3
+    unit: percent
+  - category: hotels_car_portal
+    value: 5
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 500
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/capital-one-savorone.yaml
+++ b/data/cards/capital-one-savorone.yaml
@@ -31,3 +31,13 @@ signup_bonus:
   type: cash
   spend_requirement: 500
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -9,3 +9,19 @@ reward_type: "miles"
 tags:
   - travel
   - rewards
+rewards:
+  - category: hotels_car_portal
+    value: 5
+    unit: points_per_dollar
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+signup_bonus:
+  value: 75000
+  type: miles
+  spend_requirement: 4000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 28.49

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -25,3 +25,7 @@ signup_bonus:
   type: miles
   spend_requirement: 4000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 28.49

--- a/data/cards/capital-one-ventureone-rewards.yaml
+++ b/data/cards/capital-one-ventureone-rewards.yaml
@@ -6,3 +6,25 @@ accepting_applications: true
 category: "travel"
 annual_fee: 0
 reward_type: "miles"
+tags:
+  - travel
+  - rewards
+rewards:
+  - category: hotels_car_portal
+    value: 5
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1.25
+    unit: points_per_dollar
+signup_bonus:
+  value: 20000
+  type: miles
+  spend_requirement: 500
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/cash-magnet-card.yaml
+++ b/data/cards/cash-magnet-card.yaml
@@ -2,6 +2,6 @@ name: "Cash Magnet"
 bank: "American Express"
 slug: "cash-magnet-card"
 image: "amex_cash_magnet.png"
-accepting_applications: true
+accepting_applications: false
 annual_fee: 0
 reward_type: "cashback"

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -32,3 +32,13 @@ signup_bonus:
   type: cash
   spend_requirement: 500
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 18.24
+    max: 27.74

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -10,3 +10,7 @@ rewards:
   - category: everything_else
     value: 1.5
     unit: percent
+apr:
+  regular:
+    min: 25.24
+    max: 25.24

--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -9,8 +9,30 @@ tags:
   - hotel
   - travel
   - rewards
+rewards:
+  - category: hotels
+    value: 26
+    unit: points_per_dollar
+    note: "Up to 26x total points at IHG hotels"
+  - category: travel
+    value: 5
+    unit: points_per_dollar
+    note: "Travel, gas stations, select advertising, and restaurants"
+  - category: gas
+    value: 5
+    unit: points_per_dollar
+  - category: dining
+    value: 5
+    unit: points_per_dollar
+  - category: everything_else
+    value: 3
+    unit: points_per_dollar
 signup_bonus:
   value: 140000
   type: "points"
   spend_requirement: 4000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 29.99

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -9,3 +9,31 @@ reward_type: "cashback"
 tags:
   - business
   - cashback
+rewards:
+  - category: online_shopping
+    value: 5
+    unit: percent
+    note: "Office supply stores, internet, cable, and phone services (first $25,000/year)"
+  - category: gas
+    value: 2
+    unit: percent
+    note: "Gas stations and restaurants (first $25,000/year)"
+  - category: dining
+    value: 2
+    unit: percent
+    note: "Gas stations and restaurants (first $25,000/year)"
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 750
+  type: cash
+  spend_requirement: 6000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 16.74
+    max: 24.74

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -10,3 +10,20 @@ tags:
   - business
   - travel
   - rewards
+rewards:
+  - category: travel
+    value: 3
+    unit: points_per_dollar
+    note: "Travel, shipping, internet/cable/phone, advertising on search engines and social media (first $150,000/year combined)"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 100000
+  type: points
+  spend_requirement: 8000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 29.99

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -9,3 +9,19 @@ reward_type: "points"
 tags:
   - business
   - cashback
+rewards:
+  - category: everything_else
+    value: 1.5
+    unit: percent
+signup_bonus:
+  value: 750
+  type: cash
+  spend_requirement: 6000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 16.74
+    max: 24.74

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -31,7 +31,11 @@ rewards:
     value: 1
     unit: "points_per_dollar"
 signup_bonus:
-  value: 60000
+  value: 75000
   type: points
-  spend_requirement: 4000
+  spend_requirement: 5000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 27.49

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -10,23 +10,25 @@ tags:
   - dining
 reward_type: "points"
 rewards:
-  - category: hotels_car_portal
-    value: 10
-    unit: points_per_dollar
-  - category: flights_portal
-    value: 5
-    unit: points_per_dollar
-  - category: dining
-    value: 3
+  - category: travel_portal
+    value: 8
     unit: points_per_dollar
   - category: travel
+    value: 4
+    unit: points_per_dollar
+    note: "Hotels and flights booked directly"
+  - category: dining
     value: 3
     unit: points_per_dollar
   - category: everything_else
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 60000
+  value: 125000
   type: points
-  spend_requirement: 4000
+  spend_requirement: 6000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 27.99

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -5,3 +5,28 @@ accepting_applications: true
 annual_fee: 595
 reward_type: "miles"
 image: "citi-aadvantage-executive-world-elite.png"
+tags:
+  - travel
+  - airlines
+  - premium
+rewards:
+  - category: hotels_car_portal
+    value: 10
+    unit: points_per_dollar
+    note: "On eligible hotels and car rentals booked through AA portals"
+  - category: airlines
+    value: 4
+    unit: points_per_dollar
+    note: "On eligible American Airlines purchases"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 100000
+  type: miles
+  spend_requirement: 10000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 29.49

--- a/data/cards/citi-aadvantage-globe.yaml
+++ b/data/cards/citi-aadvantage-globe.yaml
@@ -5,3 +5,34 @@ accepting_applications: true
 annual_fee: 350
 reward_type: "miles"
 image: "citi-aadvantage-globe.png"
+tags:
+  - travel
+  - airlines
+rewards:
+  - category: hotels_portal
+    value: 6
+    unit: points_per_dollar
+    note: "On eligible hotels booked through aadvantagehotels.com"
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "On eligible American Airlines purchases"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: transit
+    value: 2
+    unit: points_per_dollar
+    note: "Rides and Rails including taxis, rideshares, and public transit"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 90000
+  type: miles
+  spend_requirement: 5000
+  timeframe_months: 4
+apr:
+  regular:
+    min: 19.49
+    max: 29.49

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -5,3 +5,29 @@ accepting_applications: true
 annual_fee: 99
 reward_type: "miles"
 image: "citi-aadvantage-platinum-select-world-elite.png"
+tags:
+  - travel
+  - airlines
+rewards:
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+    note: "On eligible American Airlines purchases"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 80000
+  type: miles
+  spend_requirement: 3500
+  timeframe_months: 4
+apr:
+  regular:
+    min: 19.49
+    max: 29.49

--- a/data/cards/citi-custom-cash.yaml
+++ b/data/cards/citi-custom-cash.yaml
@@ -18,3 +18,18 @@ rewards:
   - category: everything_else
     value: 1
     unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 1500
+  timeframe_months: 6
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 27.49

--- a/data/cards/citi-diamond-preferred.yaml
+++ b/data/cards/citi-diamond-preferred.yaml
@@ -4,6 +4,9 @@ slug: "citi-diamond-preferred"
 image: "citi_diamond_preferred.png"
 accepting_applications: true
 annual_fee: 0
+category: "balance_transfer"
+tags:
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0
@@ -12,5 +15,5 @@ apr:
     rate: 0
     months: 21
   regular:
-    min: 18.24
-    max: 29.24
+    min: 16.49
+    max: 27.24

--- a/data/cards/citi-double-cash.yaml
+++ b/data/cards/citi-double-cash.yaml
@@ -12,8 +12,16 @@ rewards:
   - category: everything_else
     value: 2
     unit: percent
+    note: "1% when you buy, 1% when you pay"
 signup_bonus:
   value: 200
   type: cash
   spend_requirement: 1500
   timeframe_months: 6
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 18
+  regular:
+    min: 17.49
+    max: 27.49

--- a/data/cards/citi-secured-mastercard.yaml
+++ b/data/cards/citi-secured-mastercard.yaml
@@ -6,3 +6,7 @@ image: "citi-secured.png"
 annual_fee: 0
 tags:
   - secured
+apr:
+  regular:
+    min: 26.74
+    max: 26.74

--- a/data/cards/citi-simplicity-card.yaml
+++ b/data/cards/citi-simplicity-card.yaml
@@ -4,6 +4,9 @@ slug: "citi-simplicity-card"
 accepting_applications: true
 image: "citi-simplicity.png"
 annual_fee: 0
+category: "balance_transfer"
+tags:
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0
@@ -12,5 +15,5 @@ apr:
     rate: 0
     months: 21
   regular:
-    min: 19.24
-    max: 29.99
+    min: 17.49
+    max: 28.24

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -6,3 +6,32 @@ category: "travel"
 image: "citi-strata-elite.png"
 annual_fee: 595
 reward_type: "points"
+tags:
+  - travel
+  - rewards
+  - premium
+rewards:
+  - category: hotels_car_portal
+    value: 12
+    unit: points_per_dollar
+    note: "On hotels, car rentals, and attractions booked through Citi Travel"
+  - category: flights_portal
+    value: 6
+    unit: points_per_dollar
+    note: "On air travel booked through Citi Travel"
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+    note: "6x on Citi Nights (Fri-Sat 6PM-6AM ET)"
+  - category: everything_else
+    value: 1.5
+    unit: points_per_dollar
+signup_bonus:
+  value: 75000
+  type: points
+  spend_requirement: 6000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 21.24
+    max: 29.24

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -6,3 +6,40 @@ accepting_applications: true
 category: "travel"
 annual_fee: 95
 reward_type: "points"
+tags:
+  - travel
+  - rewards
+rewards:
+  - category: hotels_car_portal
+    value: 10
+    unit: points_per_dollar
+    note: "On hotels, car rentals, and attractions booked through Citi Travel"
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+  - category: hotels
+    value: 3
+    unit: points_per_dollar
+    note: "On hotels booked directly"
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+  - category: groceries
+    value: 3
+    unit: points_per_dollar
+  - category: gas
+    value: 3
+    unit: points_per_dollar
+    note: "Includes EV charging stations"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 4000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 20.24
+    max: 28.24

--- a/data/cards/citi-strata.yaml
+++ b/data/cards/citi-strata.yaml
@@ -6,3 +6,48 @@ category: "travel"
 image: "citi-strata.png"
 annual_fee: 0
 reward_type: "points"
+tags:
+  - travel
+  - rewards
+rewards:
+  - category: hotels_car_portal
+    value: 5
+    unit: points_per_dollar
+    note: "On hotels, car rentals, and attractions booked through Citi Travel"
+  - category: groceries
+    value: 3
+    unit: points_per_dollar
+  - category: transit
+    value: 3
+    unit: points_per_dollar
+  - category: gas
+    value: 3
+    unit: points_per_dollar
+    note: "Includes EV charging stations"
+  - category: rotating
+    value: 3
+    unit: points_per_dollar
+    mode: user_choice
+    choices: 1
+    note: "3x on one eligible self-select category of your choice"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 20000
+  type: points
+  spend_requirement: 1000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -5,3 +5,30 @@ accepting_applications: true
 image: "citi-business-aadvantage-platinum-select.png"
 annual_fee: 99
 reward_type: "miles"
+tags:
+  - travel
+  - airlines
+  - business
+rewards:
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+    note: "On eligible American Airlines purchases"
+  - category: car_rentals
+    value: 2
+    unit: points_per_dollar
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 65000
+  type: miles
+  spend_requirement: 4000
+  timeframe_months: 4
+apr:
+  regular:
+    min: 21.24
+    max: 29.99

--- a/data/cards/coinbase-one.yaml
+++ b/data/cards/coinbase-one.yaml
@@ -10,3 +10,8 @@ reward_type: "cashback"
 tags:
   - rewards
   - crypto
+rewards:
+  - category: everything_else
+    value: 2
+    unit: percent
+    note: "Up to 4% with higher crypto balances on Coinbase; requires Coinbase One membership"

--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -5,3 +5,27 @@ accepting_applications: true
 image: "citi-costco-anywhere-business.png"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+  - business
+rewards:
+  - category: gas
+    value: 4
+    unit: percent
+    note: "On eligible gas and EV charging worldwide, first $7,000/year combined"
+  - category: dining
+    value: 3
+    unit: percent
+  - category: travel
+    value: 3
+    unit: percent
+    note: "Includes Costco Travel"
+  - category: everything_else
+    value: 1
+    unit: percent
+    note: "2% on purchases at Costco and Costco.com"
+apr:
+  regular:
+    min: 18.74
+    max: 26.74

--- a/data/cards/costco-anywhere-visa-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-card-by-citi.yaml
@@ -5,3 +5,26 @@ accepting_applications: true
 image: "citi-costco-anywhere.png"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+rewards:
+  - category: gas
+    value: 4
+    unit: percent
+    note: "On eligible gas and EV charging worldwide, first $7,000/year combined. 5% at Costco gas stations."
+  - category: dining
+    value: 3
+    unit: percent
+  - category: travel
+    value: 3
+    unit: percent
+    note: "Includes Costco Travel"
+  - category: everything_else
+    value: 1
+    unit: percent
+    note: "2% on purchases at Costco and Costco.com"
+apr:
+  regular:
+    min: 18.74
+    max: 26.74

--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -24,3 +24,7 @@ signup_bonus:
   type: miles
   spend_requirement: 1000
   timeframe_months: 6
+apr:
+  regular:
+    min: 19.49
+    max: 28.49

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -29,4 +29,7 @@ signup_bonus:
   type: miles
   spend_requirement: 5000
   timeframe_months: 6
-  note: "70k after $3k spend + 20k after additional $2k spend"
+apr:
+  regular:
+    min: 19.49
+    max: 28.49

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -33,4 +33,7 @@ signup_bonus:
   type: miles
   spend_requirement: 6000
   timeframe_months: 6
-  note: "80k after $4k spend + 20k after additional $2k spend"
+apr:
+  regular:
+    min: 19.49
+    max: 28.49

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -22,4 +22,7 @@ signup_bonus:
   type: miles
   spend_requirement: 9000
   timeframe_months: 6
-  note: "100k after $6k spend + 25k after additional $3k spend"
+apr:
+  regular:
+    min: 19.49
+    max: 28.49

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -15,6 +15,17 @@ rewards:
     mode: quarterly_rotating
     current_categories: [groceries, online_shopping]
     current_period: "Q1 2026"
+    note: "Up to $1,500/quarter when activated"
   - category: everything_else
     value: 1
     unit: percent
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 26.49

--- a/data/cards/discover-it-for-students-card.yaml
+++ b/data/cards/discover-it-for-students-card.yaml
@@ -4,7 +4,24 @@ slug: "discover-it-for-students-card"
 accepting_applications: true
 image: "discover-it-student-cash-back.png"
 annual_fee: 0
+category: "student"
 reward_type: "cashback"
 tags:
   - student
   - cashback
+rewards:
+  - category: rotating
+    value: 5
+    unit: percent
+    mode: quarterly_rotating
+    note: "Up to $1,500/quarter when activated"
+  - category: everything_else
+    value: 1
+    unit: percent
+apr:
+  purchase_intro:
+    rate: 0
+    months: 6
+  regular:
+    min: 16.49
+    max: 25.49

--- a/data/cards/discover-it-miles.yaml
+++ b/data/cards/discover-it-miles.yaml
@@ -4,7 +4,21 @@ slug: "discover-it-miles"
 accepting_applications: true
 image: "discover-it-miles.png"
 annual_fee: 0
-reward_type: "cashback"
+reward_type: "miles"
 tags:
   - travel
   - rewards
+rewards:
+  - category: everything_else
+    value: 1.5
+    unit: points_per_dollar
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 26.49

--- a/data/cards/discover-it-secured-credit-card.yaml
+++ b/data/cards/discover-it-secured-credit-card.yaml
@@ -8,3 +8,22 @@ reward_type: "cashback"
 tags:
   - secured
   - cashback
+rewards:
+  - category: gas
+    value: 2
+    unit: percent
+    note: "Up to $1,000/quarter combined with dining"
+  - category: dining
+    value: 2
+    unit: percent
+    note: "Up to $1,000/quarter combined with gas"
+  - category: everything_else
+    value: 1
+    unit: percent
+apr:
+  balance_transfer_intro:
+    rate: 10.99
+    months: 6
+  regular:
+    min: 26.49
+    max: 26.49

--- a/data/cards/discover-it-student-chrome-card.yaml
+++ b/data/cards/discover-it-student-chrome-card.yaml
@@ -4,4 +4,30 @@ slug: "discover-it-student-chrome-card"
 accepting_applications: true
 image: "discover-it-student-chrome.png"
 annual_fee: 0
+category: "student"
 reward_type: "cashback"
+tags:
+  - student
+  - cashback
+rewards:
+  - category: gas
+    value: 2
+    unit: percent
+    note: "Up to $1,000/quarter combined with dining"
+  - category: dining
+    value: 2
+    unit: percent
+    note: "Up to $1,000/quarter combined with gas"
+  - category: everything_else
+    value: 1
+    unit: percent
+apr:
+  purchase_intro:
+    rate: 0
+    months: 6
+  balance_transfer_intro:
+    rate: 0
+    months: 18
+  regular:
+    min: 16.49
+    max: 25.49

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -10,3 +10,33 @@ tags:
   - rewards
   - disney
   - entertainment
+rewards:
+  - category: streaming
+    value: 10
+    unit: percent
+    note: "Disney+, Hulu, and ESPN+ purchases"
+  - category: gas
+    value: 3
+    unit: percent
+  - category: entertainment
+    value: 3
+    unit: percent
+    note: "Most U.S. Disney locations"
+  - category: groceries
+    value: 2
+    unit: percent
+  - category: dining
+    value: 2
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 300
+  type: cash
+  spend_requirement: 1000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 18.24
+    max: 27.74

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -5,3 +5,30 @@ accepting_applications: true
 image: "chase-disney-premier.png"
 annual_fee: 49
 reward_type: "cashback"
+rewards:
+  - category: streaming
+    value: 5
+    unit: percent
+    note: "Disney+, Hulu, and ESPN+ purchases"
+  - category: entertainment
+    value: 2
+    unit: percent
+    note: "Select Disney purchases, gas stations, and grocery stores"
+  - category: gas
+    value: 2
+    unit: percent
+  - category: groceries
+    value: 2
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 100
+  type: cash
+  spend_requirement: 500
+  timeframe_months: 3
+apr:
+  regular:
+    min: 18.24
+    max: 27.74

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -5,3 +5,17 @@ accepting_applications: true
 image: "chase-disney.png"
 annual_fee: 0
 reward_type: "cashback"
+rewards:
+  - category: everything_else
+    value: 1
+    unit: percent
+    note: "1% in Disney Rewards Dollars on all purchases"
+signup_bonus:
+  value: 50
+  type: cash
+  spend_requirement: 500
+  timeframe_months: 3
+apr:
+  regular:
+    min: 18.24
+    max: 29.99

--- a/data/cards/gemini-credit.yaml
+++ b/data/cards/gemini-credit.yaml
@@ -10,3 +10,21 @@ reward_type: "cashback"
 tags:
   - rewards
   - crypto
+rewards:
+  - category: gas
+    value: 4
+    unit: percent
+    note: "First $300/month on gas and EV charging"
+  - category: dining
+    value: 3
+    unit: percent
+  - category: groceries
+    value: 2
+    unit: percent
+  - category: everything_else
+    value: 1
+    unit: percent
+apr:
+  regular:
+    min: 18.99
+    max: 34.99

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -6,8 +6,36 @@ category: "travel"
 image: "barclays-hawaiian.png"
 annual_fee: 99
 reward_type: "miles"
+tags:
+  - travel
+  - airlines
+  - rewards
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "Hawaiian Airlines purchases"
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 50000
   type: miles
   spend_requirement: 2000
   timeframe_months: 3
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 20.24
+    max: 29.99

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -5,6 +5,35 @@ image: "amex_hilton_honors_aspire.png"
 accepting_applications: true
 annual_fee: 550
 reward_type: "points"
+rewards:
+  - category: hotels
+    value: 14
+    unit: points_per_dollar
+    note: "Eligible purchases at Hilton hotels and resorts"
+  - category: airlines
+    value: 7
+    unit: points_per_dollar
+    note: "Flights booked directly with airlines or through AmexTravel.com"
+  - category: car_rentals
+    value: 7
+    unit: points_per_dollar
+    note: "Booked directly with select car rental companies"
+  - category: dining
+    value: 7
+    unit: points_per_dollar
+    note: "U.S. restaurants"
+  - category: everything_else
+    value: 3
+    unit: points_per_dollar
+signup_bonus:
+  value: 175000
+  type: points
+  spend_requirement: 6000
+  timeframe_months: 6
+apr:
+  regular:
+    min: 19.49
+    max: 28.49
 tags:
   - hotel
   - travel

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -5,6 +5,42 @@ image: "amex_hilton_honors_surpass.png"
 accepting_applications: true
 annual_fee: 150
 reward_type: "points"
+rewards:
+  - category: hotels
+    value: 12
+    unit: points_per_dollar
+    note: "Eligible purchases at Hilton hotels and resorts"
+  - category: dining
+    value: 6
+    unit: points_per_dollar
+    note: "U.S. restaurants"
+  - category: groceries
+    value: 6
+    unit: points_per_dollar
+    note: "U.S. supermarkets"
+  - category: gas
+    value: 6
+    unit: points_per_dollar
+    note: "U.S. gas stations"
+  - category: online_shopping
+    value: 4
+    unit: points_per_dollar
+    note: "U.S. online retail purchases"
+  - category: everything_else
+    value: 3
+    unit: points_per_dollar
+signup_bonus:
+  value: 130000
+  type: points
+  spend_requirement: 3000
+  timeframe_months: 6
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 27.49
 tags:
   - hotel
   - travel

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -6,6 +6,35 @@ accepting_applications: true
 card_referral_link: "https://www.americanexpress.com/en-us/credit-cards/referral/prospect/hilton-honors/personal?ref="
 annual_fee: 0
 reward_type: "points"
+rewards:
+  - category: hotels
+    value: 7
+    unit: points_per_dollar
+    note: "Eligible purchases at Hilton hotels and resorts"
+  - category: dining
+    value: 5
+    unit: points_per_dollar
+    note: "U.S. restaurants"
+  - category: groceries
+    value: 5
+    unit: points_per_dollar
+    note: "U.S. supermarkets"
+  - category: gas
+    value: 5
+    unit: points_per_dollar
+    note: "U.S. gas stations"
+  - category: everything_else
+    value: 3
+    unit: points_per_dollar
+signup_bonus:
+  value: 70000
+  type: points
+  spend_requirement: 2000
+  timeframe_months: 6
+apr:
+  regular:
+    min: 19.49
+    max: 28.49
 tags:
   - hotel
   - travel

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -5,3 +5,27 @@ accepting_applications: true
 image: "iberia-plus.png"
 annual_fee: 95
 reward_type: "miles"
+tags:
+  - airline
+  - travel
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "Iberia, British Airways, and Aer Lingus flights"
+  - category: hotels
+    value: 2
+    unit: points_per_dollar
+    note: "Hotels booked directly"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 75000
+  type: miles
+  spend_requirement: 5000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 29.99

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -9,3 +9,29 @@ tags:
   - hotel
   - travel
   - rewards
+rewards:
+  - category: hotels
+    value: 26
+    unit: points_per_dollar
+    note: "Up to 26x total points at IHG hotels"
+  - category: travel
+    value: 5
+    unit: points_per_dollar
+  - category: gas
+    value: 5
+    unit: points_per_dollar
+  - category: dining
+    value: 5
+    unit: points_per_dollar
+  - category: everything_else
+    value: 3
+    unit: points_per_dollar
+signup_bonus:
+  value: 175000
+  type: points
+  spend_requirement: 5000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 29.99

--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -9,3 +9,30 @@ tags:
   - hotel
   - travel
   - rewards
+rewards:
+  - category: hotels
+    value: 17
+    unit: points_per_dollar
+    note: "Up to 17x total points at IHG hotels"
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+  - category: gas
+    value: 3
+    unit: points_per_dollar
+  - category: streaming
+    value: 3
+    unit: points_per_dollar
+    note: "Utilities, internet, cable, phone, and select streaming"
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+signup_bonus:
+  value: 90000
+  type: points
+  spend_requirement: 2000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 29.99

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -6,8 +6,29 @@ category: "business"
 image: "barclays-jetblue-business.png"
 annual_fee: 99
 reward_type: "points"
+tags:
+  - travel
+  - airlines
+  - business
+  - rewards
+rewards:
+  - category: airlines
+    value: 6
+    unit: points_per_dollar
+    note: "JetBlue purchases"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+    note: "2x on office supply stores"
 signup_bonus:
-  value: 60000
+  value: 50000
   type: points
   spend_requirement: 2000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 29.49

--- a/data/cards/jetblue-card.yaml
+++ b/data/cards/jetblue-card.yaml
@@ -6,8 +6,33 @@ category: "travel"
 image: "barclays-jetblue.png"
 annual_fee: 0
 reward_type: "points"
+tags:
+  - travel
+  - airlines
+  - rewards
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "JetBlue purchases"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 10000
   type: points
   spend_requirement: 1000
   timeframe_months: 3
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 19.74
+    max: 29.74

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -6,8 +6,33 @@ category: "travel"
 image: "barclays-jetblue-plus.png"
 annual_fee: 99
 reward_type: "points"
+tags:
+  - travel
+  - airlines
+  - rewards
+rewards:
+  - category: airlines
+    value: 6
+    unit: points_per_dollar
+    note: "JetBlue purchases"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 70000
   type: points
   spend_requirement: 1000
   timeframe_months: 3
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 20.24
+    max: 29.99

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -8,3 +8,27 @@ reward_type: "points"
 tags:
   - hotel
   - travel
+rewards:
+  - category: hotels
+    value: 6
+    unit: points_per_dollar
+    note: "Marriott Bonvoy hotels"
+  - category: groceries
+    value: 3
+    unit: points_per_dollar
+    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+  - category: gas
+    value: 3
+    unit: points_per_dollar
+    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+apr:
+  regular:
+    min: 19.24
+    max: 27.74

--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -9,3 +9,27 @@ tags:
   - hotel
   - travel
   - rewards
+rewards:
+  - category: hotels
+    value: 6
+    unit: points_per_dollar
+    note: "Marriott Bonvoy hotels"
+  - category: groceries
+    value: 3
+    unit: points_per_dollar
+    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+  - category: gas
+    value: 3
+    unit: points_per_dollar
+    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+apr:
+  regular:
+    min: 20.49
+    max: 27.49

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -5,6 +5,31 @@ image: "amex_marriott_bonvoy_brilliant.png"
 accepting_applications: true
 annual_fee: 650
 reward_type: "points"
+rewards:
+  - category: hotels
+    value: 6
+    unit: points_per_dollar
+    note: "Hotels participating in Marriott Bonvoy"
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+    note: "Restaurants worldwide"
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "Flights booked directly with airlines"
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+signup_bonus:
+  value: 100000
+  type: points
+  spend_requirement: 6000
+  timeframe_months: 6
+apr:
+  regular:
+    min: 19.49
+    max: 28.49
 tags:
   - hotel
   - travel

--- a/data/cards/nhl-discover-it.yaml
+++ b/data/cards/nhl-discover-it.yaml
@@ -5,3 +5,25 @@ accepting_applications: true
 image: "discover-it-nhl.png"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+rewards:
+  - category: rotating
+    value: 5
+    unit: percent
+    mode: quarterly_rotating
+    note: "Up to $1,500/quarter when activated"
+  - category: everything_else
+    value: 1
+    unit: percent
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 18.24
+    max: 28.24

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -6,3 +6,23 @@ category: "travel"
 image: "barclays-princess.png"
 annual_fee: 0
 reward_type: "points"
+rewards:
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+    note: "Princess Cruises purchases"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 20000
+  type: points
+  spend_requirement: 500
+  timeframe_months: 3
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 18.49
+    max: 29.49

--- a/data/cards/rakuten-american-express.yaml
+++ b/data/cards/rakuten-american-express.yaml
@@ -30,7 +30,14 @@ rewards:
     value: 1
     unit: "percent"
 signup_bonus:
-  value: 25
+  value: 75
   type: "cash"
-  spend_requirement: 500
+  spend_requirement: 2000
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 19.49
+    max: 28.49

--- a/data/cards/robinhood-gold-card.yaml
+++ b/data/cards/robinhood-gold-card.yaml
@@ -10,6 +10,14 @@ tags:
   - rewards
 reward_type: "cashback"
 rewards:
+  - category: travel_portal
+    value: 5
+    unit: percent
+    note: "Travel booked through Robinhood travel portal"
   - category: everything_else
     value: 3
     unit: percent
+apr:
+  regular:
+    min: 29.99
+    max: 29.99

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -4,11 +4,31 @@ slug: "southwest-rapid-rewards-plus-credit-card"
 accepting_applications: true
 annual_fee: 99
 reward_type: "points"
+rewards:
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+    note: "Southwest Airlines purchases"
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+    note: "Gas stations and grocery stores (first $5,000/year)"
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+    note: "Gas stations and grocery stores (first $5,000/year)"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 20000
   type: points
   spend_requirement: 3000
   timeframe_months: 3
+apr:
+  regular:
+    min: 20.49
+    max: 27.49
 image: "chase-southwest-rapid-rewards-plus.png"
 tags:
   - airline

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -5,11 +5,31 @@ accepting_applications: true
 image: "chase-southwest-rapid-rewards-premier.png"
 annual_fee: 149
 reward_type: "points"
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "Southwest Airlines purchases"
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+    note: "Grocery stores and restaurants (first $8,000/year)"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+    note: "Grocery stores and restaurants (first $8,000/year)"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 30000
   type: points
   spend_requirement: 4000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 27.74
 tags:
   - airline
   - travel

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -5,11 +5,29 @@ image: "southwest_priority.png"
 accepting_applications: true
 annual_fee: 229
 reward_type: "points"
+rewards:
+  - category: airlines
+    value: 4
+    unit: points_per_dollar
+    note: "Southwest Airlines purchases (flights, in-flight, gift cards)"
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 40000
   type: points
   spend_requirement: 5000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 27.74
 tags:
   - airline
   - travel

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -6,6 +6,24 @@ category: "business"
 image: "business-platinum.png"
 annual_fee: 895
 reward_type: "points"
+rewards:
+  - category: flights_portal
+    value: 5
+    unit: points_per_dollar
+    note: "Flights booked through Amex Travel"
+  - category: hotels_portal
+    value: 5
+    unit: points_per_dollar
+    note: "Prepaid hotels booked through Amex Travel"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+    note: "2x on purchases of $5,000 or more (up to $2M/year)"
+signup_bonus:
+  value: 200000
+  type: points
+  spend_requirement: 20000
+  timeframe_months: 3
 tags:
   - business
   - travel

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -18,6 +18,11 @@ rewards:
   - category: everything_else
     value: 1
     unit: points_per_dollar
+signup_bonus:
+  value: 175000
+  type: points
+  spend_requirement: 12000
+  timeframe_months: 6
 tags:
   - travel
   - premium

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -5,11 +5,29 @@ image: "united_club_infinite.png"
 accepting_applications: true
 annual_fee: 695
 reward_type: "miles"
+rewards:
+  - category: airlines
+    value: 4
+    unit: points_per_dollar
+    note: "United purchases"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1.5
+    unit: points_per_dollar
 signup_bonus:
   value: 90000
   type: miles
   spend_requirement: 5000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.74
+    max: 28.24
 tags:
   - airline
   - travel

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -5,11 +5,29 @@ image: "united_explorer.png"
 accepting_applications: true
 annual_fee: 150
 reward_type: "miles"
+rewards:
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+    note: "United purchases, dining, and hotel stays"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: hotels
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 70000
   type: miles
   spend_requirement: 3000
   timeframe_months: 3
+apr:
+  regular:
+    min: 19.74
+    max: 28.24
 tags:
   - airline
   - travel

--- a/data/cards/united-gateway.yaml
+++ b/data/cards/united-gateway.yaml
@@ -5,11 +5,32 @@ image: "united_gateway.png"
 accepting_applications: true
 annual_fee: 0
 reward_type: "miles"
+rewards:
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+    note: "United purchases"
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+  - category: transit
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 30000
   type: miles
   spend_requirement: 1000
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 20.24
+    max: 28.74
 tags:
   - airline
   - travel

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -5,11 +5,37 @@ image: "united_quest.png"
 accepting_applications: true
 annual_fee: 350
 reward_type: "miles"
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    note: "United purchases"
+  - category: hotels
+    value: 5
+    unit: points_per_dollar
+    note: "Hotels prepaid through Renowned Hotels and Resorts for United Cardmembers"
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: streaming
+    value: 2
+    unit: points_per_dollar
+    note: "Select streaming services"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
 signup_bonus:
   value: 80000
   type: miles
   spend_requirement: 4000
   timeframe_months: 3
+apr:
+  regular:
+    min: 21.24
+    max: 28.24
 tags:
   - airline
   - travel

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -3,5 +3,44 @@ bank: "U.S. Bank"
 slug: "us-bank-altitude-connect"
 image: "altitude-connect.png"
 accepting_applications: true
+category: "travel"
 annual_fee: 0
 reward_type: "points"
+tags:
+  - travel
+  - rewards
+rewards:
+  - category: hotels_car_portal
+    value: 5
+    unit: points_per_dollar
+  - category: travel
+    value: 4
+    unit: points_per_dollar
+    note: "Also gas stations and EV charging, up to $1,000/quarter"
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: streaming
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 20000
+  type: points
+  spend_requirement: 1000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 27.49

--- a/data/cards/us-bank-altitude-go-visa-signature.yaml
+++ b/data/cards/us-bank-altitude-go-visa-signature.yaml
@@ -2,7 +2,39 @@ name: "U.S. Bank Altitude Go Visa Signature"
 bank: "U.S. Bank"
 slug: "us-bank-altitude-go-visa-signature"
 accepting_applications: true
-category: "travel"
+category: "dining"
 image: "us-bank-altitude-go.png"
 annual_fee: 0
 reward_type: "points"
+tags:
+  - dining
+  - rewards
+rewards:
+  - category: dining
+    value: 4
+    unit: points_per_dollar
+    note: "Up to $2,000/quarter"
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+  - category: streaming
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 20000
+  type: points
+  spend_requirement: 1000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.49
+    max: 27.49

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -16,6 +16,26 @@ rewards:
     choices: 2
     eligible_categories: [gas, groceries, online_shopping, streaming, transit, home_improvement, entertainment]
     note: "Choose 2 categories each quarter, up to $2,000 combined"
+  - category: dining
+    value: 2
+    unit: percent
+    note: "Choose 1 everyday category: gas, grocery, or restaurants"
+    mode: user_choice
   - category: everything_else
     value: 1
     unit: percent
+signup_bonus:
+  value: 200
+  type: cash
+  spend_requirement: 1000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 17.74
+    max: 27.99

--- a/data/cards/us-bank-secured.yaml
+++ b/data/cards/us-bank-secured.yaml
@@ -4,3 +4,11 @@ slug: "us-bank-secured"
 image: "us-bank-secured.png"
 accepting_applications: true
 annual_fee: 0
+category: "secured"
+tags:
+  - secured
+  - credit_builder
+apr:
+  regular:
+    min: 27.49
+    max: 27.49

--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -4,10 +4,16 @@ slug: "us-bank-shield"
 image: "us-bank-shield.png"
 accepting_applications: true
 annual_fee: 0
+category: "other"
+tags:
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0
-    months: 15
+    months: 24
   balance_transfer_intro:
     rate: 0
-    months: 15
+    months: 24
+  regular:
+    min: 16.99
+    max: 27.99

--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -35,3 +35,7 @@ signup_bonus:
   type: cash
   spend_requirement: 2000
   timeframe_months: 4
+apr:
+  regular:
+    min: 18.74
+    max: 28.74

--- a/data/cards/us-bank-smartly-visa-signature.yaml
+++ b/data/cards/us-bank-smartly-visa-signature.yaml
@@ -6,4 +6,21 @@ accepting_applications: true
 category: "cashback"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+rewards:
+  - category: everything_else
+    value: 2
+    unit: percent
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 17.74
+    max: 27.99
 

--- a/data/cards/us-bank-split.yaml
+++ b/data/cards/us-bank-split.yaml
@@ -4,3 +4,6 @@ slug: "us-bank-split"
 image: "us-bank-split.png"
 accepting_applications: true
 annual_fee: 0
+category: "other"
+tags:
+  - installment

--- a/data/cards/wells-fargo-active-cash.yaml
+++ b/data/cards/wells-fargo-active-cash.yaml
@@ -18,3 +18,13 @@ signup_bonus:
   type: cash
   spend_requirement: 500
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -6,8 +6,26 @@ category: "cashback"
 image: "wells-fargo-attune.png"
 annual_fee: 0
 reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+rewards:
+  - category: entertainment
+    value: 4
+    unit: percent
+    note: "Fitness, wellness, sports, recreation, live events, gardening, pet supplies, transit, EV charging, thrift stores"
+  - category: everything_else
+    value: 1
+    unit: percent
 signup_bonus:
   value: 100
-  type: "cashback"
+  type: cash
   spend_requirement: 500
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -6,3 +6,32 @@ image: "wells-fargo-autograph-journey.png"
 category: "travel"
 annual_fee: 95
 reward_type: "points"
+tags:
+  - travel
+  - rewards
+  - premium
+rewards:
+  - category: hotels
+    value: 5
+    unit: points_per_dollar
+  - category: airlines
+    value: 4
+    unit: points_per_dollar
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+  - category: travel
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 4000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/wells-fargo-autograph.yaml
+++ b/data/cards/wells-fargo-autograph.yaml
@@ -34,3 +34,10 @@ signup_bonus:
   type: points
   spend_requirement: 1000
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/wells-fargo-cash-back-college.yaml
+++ b/data/cards/wells-fargo-cash-back-college.yaml
@@ -2,6 +2,14 @@ name: "Wells Fargo Cash Back College"
 bank: "Wells Fargo"
 slug: "wells-fargo-cash-back-college"
 image: "wells_fargo_cash_back_college.png"
-accepting_applications: true
+accepting_applications: false
 annual_fee: 0
+category: "student"
 reward_type: "cashback"
+tags:
+  - student
+  - cashback
+rewards:
+  - category: everything_else
+    value: 1
+    unit: percent

--- a/data/cards/wells-fargo-platinum.yaml
+++ b/data/cards/wells-fargo-platinum.yaml
@@ -2,5 +2,8 @@ name: "Wells Fargo Platinum"
 bank: "Wells Fargo"
 slug: "wells-fargo-platinum"
 image: "wells_fargo_platinum.png"
-accepting_applications: true
+accepting_applications: false
 annual_fee: 0
+category: "other"
+tags:
+  - balance_transfer

--- a/data/cards/wells-fargo-reflect.yaml
+++ b/data/cards/wells-fargo-reflect.yaml
@@ -5,6 +5,8 @@ image: "wells_fargo_reflect.png"
 accepting_applications: true
 category: "other"
 annual_fee: 0
+tags:
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0
@@ -13,5 +15,5 @@ apr:
     rate: 0
     months: 21
   regular:
-    min: 24.49
-    max: 34.49
+    min: 17.49
+    max: 28.24

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -12,6 +12,13 @@ rewards:
     unit: "percent"
 signup_bonus:
   value: 500
-  type: "cashback"
+  type: cash
   spend_requirement: 5000
   timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 26.49

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -6,6 +6,23 @@ image: "chase-world-of-hyatt-business.png"
 category: "business"
 annual_fee: 199
 reward_type: "points"
+tags:
+  - hotel
+  - travel
+  - business
+  - rewards
+rewards:
+  - category: hotels
+    value: 4
+    unit: points_per_dollar
+    note: "At Hyatt hotels, up to 9x total with World of Hyatt membership"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+    note: "2x on top 3 spend categories each quarter"
 signup_bonus:
   value: 60000
   type: "points"

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -9,3 +9,30 @@ tags:
   - hotel
   - travel
   - rewards
+rewards:
+  - category: hotels
+    value: 4
+    unit: points_per_dollar
+    note: "At Hyatt hotels, up to 9x total with World of Hyatt membership"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+    note: "Purchased directly from airlines"
+  - category: transit
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 30000
+  type: points
+  spend_requirement: 3000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.24
+    max: 29.99

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -6,3 +6,28 @@ category: "business"
 image: "barclays-wyndham-earner-business.png"
 annual_fee: 95
 reward_type: "points"
+tags:
+  - hotel
+  - business
+  - rewards
+rewards:
+  - category: hotels
+    value: 8
+    unit: points_per_dollar
+    note: "At Wyndham hotels"
+  - category: gas
+    value: 8
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+    note: "5x on marketing, advertising, and utility purchases"
+signup_bonus:
+  value: 50000
+  type: points
+  spend_requirement: 4000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.49
+    max: 29.49


### PR DESCRIPTION
## Summary

Comprehensive audit and update of all active credit card YAML data files:

- **115 files changed**, 2,038 lines added
- Added missing **signup bonuses** for ~60 cards (e.g., CSP 60k→75k, CSR 60k→125k, Amex Platinum 175k, Citi Strata Premier 60k, Capital One Venture 75k)
- Added missing **reward category structures** for ~88 cards that previously had no rewards data
- Added missing **APR data** (regular + intro offers) for ~109 cards
- **Marked 3 cards as discontinued**: Amex Cash Magnet, Wells Fargo Platinum, Wells Fargo Cash Back College
- Updated outdated values (CSR rewards overhaul to 8x/4x/3x, Rakuten bonus update, BankAmericard intro period change, etc.)
- Fixed schema violations (removed invalid `card_type` and `signup_bonus.note` fields)

### Banks covered
Chase (29), Amex (20), Citi (15), Capital One (11), Wells Fargo (8), Bank of America (7), US Bank (8), Discover (6), Bilt (3), plus Hyatt, Wyndham, Hawaiian, JetBlue, Disney, United, Southwest, Marriott, Hilton, IHG, and others

### Cards intentionally left without signup_bonus
- Secured/credit-builder cards (no traditional bonus)
- Discover cards (Cashback Match is not a fixed bonus amount)
- Marriott Bold/Boundless (bonus is Free Night Awards, not expressible as points)
- Costco cards (no signup bonus, require membership)
- Apple Card, Robinhood Gold (no traditional bonus)

### Cards intentionally left without rewards
- Balance transfer cards (BankAmericard, Chase Slate Edge, Citi Simplicity/Diamond Preferred, Wells Fargo Reflect)
- Credit builder cards (Capital One Platinum, Citi Secured, US Bank Secured)

## Test plan
- [x] All 142 YAML files parse successfully
- [x] All files pass schema validation (only pre-existing issues in 2 legacy inactive cards)
- [ ] Verify cards.json builds correctly in CI
- [ ] Spot-check card pages on staging to confirm data renders correctly
- [ ] Verify compare page shows new reward categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)