### PR TITLE
Add balance_transfer as a card category and tag

### DIFF
--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -3,10 +3,10 @@ bank: "Bank of America"
 slug: "bankamericard"
 accepting_applications: true
 image: "bankamericard.png"
-category: "other"
+category: "balance_transfer"
 annual_fee: 0
 tags:
-  - cashback
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0

--- a/data/cards/chase-slate-edge.yaml
+++ b/data/cards/chase-slate-edge.yaml
@@ -3,7 +3,9 @@ bank: "Chase"
 slug: "chase-slate-edge"
 image: "chase-slate-edge.png"
 accepting_applications: true
-category: "other"
+category: "balance_transfer"
+tags:
+  - balance_transfer
 annual_fee: 0
 apr:
   balance_transfer_intro:

--- a/data/cards/citi-diamond-preferred.yaml
+++ b/data/cards/citi-diamond-preferred.yaml
@@ -4,9 +4,9 @@ slug: "citi-diamond-preferred"
 image: "citi_diamond_preferred.png"
 accepting_applications: true
 annual_fee: 0
-category: "other"
+category: "balance_transfer"
 tags:
-  - cashback
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0

--- a/data/cards/citi-simplicity-card.yaml
+++ b/data/cards/citi-simplicity-card.yaml
@@ -4,9 +4,9 @@ slug: "citi-simplicity-card"
 accepting_applications: true
 image: "citi-simplicity.png"
 annual_fee: 0
-category: "other"
+category: "balance_transfer"
 tags:
-  - cashback
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -26,7 +26,7 @@
     },
     "category": {
       "type": "string",
-      "enum": ["travel", "cashback", "business", "student", "secured", "rewards", "other"],
+      "enum": ["travel", "cashback", "business", "student", "secured", "rewards", "balance_transfer", "other"],
       "description": "Card category (optional)"
     },
     "annual_fee": {
@@ -43,7 +43,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["travel", "cashback", "hotel", "shopping", "student", "secured", "premium", "business", "rewards", "airline", "dining"]
+        "enum": ["travel", "cashback", "hotel", "shopping", "student", "secured", "premium", "business", "rewards", "airline", "dining", "balance_transfer"]
       },
       "description": "Card tags for categorization and filtering (optional)"
     },

--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -4,9 +4,9 @@ slug: "us-bank-shield"
 image: "us-bank-shield.png"
 accepting_applications: true
 annual_fee: 0
-category: "other"
+category: "balance_transfer"
 tags:
-  - cashback
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0

--- a/data/cards/wells-fargo-platinum.yaml
+++ b/data/cards/wells-fargo-platinum.yaml
@@ -4,6 +4,6 @@ slug: "wells-fargo-platinum"
 image: "wells_fargo_platinum.png"
 accepting_applications: false
 annual_fee: 0
-category: "other"
+category: "balance_transfer"
 tags:
-  - cashback
+  - balance_transfer

--- a/data/cards/wells-fargo-reflect.yaml
+++ b/data/cards/wells-fargo-reflect.yaml
@@ -3,10 +3,10 @@ bank: "Wells Fargo"
 slug: "wells-fargo-reflect"
 image: "wells_fargo_reflect.png"
 accepting_applications: true
-category: "other"
+category: "balance_transfer"
 annual_fee: 0
 tags:
-  - cashback
+  - balance_transfer
 apr:
   purchase_intro:
     rate: 0


### PR DESCRIPTION
## Summary

BT cards are a distinct product type whose primary value is long 0% intro APR, not rewards. Having them in `"other"` loses that signal.

- Add `balance_transfer` to `category` and `tags` enums in `schema.json`
- Re-tag 7 balance transfer cards:
  - Citi Diamond Preferred
  - Citi Simplicity
  - BankAmericard
  - Chase Slate Edge
  - Wells Fargo Reflect
  - Wells Fargo Platinum (discontinued)
  - US Bank Shield

## Test plan
- [x] Schema updated with new enum value
- [x] All 7 BT cards tagged correctly
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)