### PR TITLE
Add entertainment and credit_builder tags

### DIFF
--- a/data/cards/capital-one-platinum-secured.yaml
+++ b/data/cards/capital-one-platinum-secured.yaml
@@ -7,6 +7,7 @@ category: "secured"
 annual_fee: 0
 tags:
   - secured
+  - credit_builder
 apr:
   regular:
     min: 28.99

--- a/data/cards/capital-one-platinum.yaml
+++ b/data/cards/capital-one-platinum.yaml
@@ -6,7 +6,7 @@ accepting_applications: true
 category: "other"
 annual_fee: 0
 tags:
-  - secured
+  - credit_builder
 apr:
   regular:
     min: 28.99

--- a/data/cards/capital-one-savor-student.yaml
+++ b/data/cards/capital-one-savor-student.yaml
@@ -10,6 +10,7 @@ tags:
   - student
   - cashback
   - dining
+  - entertainment
 rewards:
   - category: dining
     value: 3

--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -9,6 +9,7 @@ reward_type: "cashback"
 tags:
   - cashback
   - dining
+  - entertainment
   - rewards
 rewards:
   - category: entertainment

--- a/data/cards/capital-one-savorone.yaml
+++ b/data/cards/capital-one-savorone.yaml
@@ -8,6 +8,7 @@ annual_fee: 0
 tags:
   - cashback
   - dining
+  - entertainment
   - rewards
 reward_type: "cashback"
 rewards:

--- a/data/cards/citi-secured-mastercard.yaml
+++ b/data/cards/citi-secured-mastercard.yaml
@@ -6,6 +6,7 @@ image: "citi-secured.png"
 annual_fee: 0
 tags:
   - secured
+  - credit_builder
 apr:
   regular:
     min: 26.74

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -43,7 +43,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["travel", "cashback", "hotel", "shopping", "student", "secured", "premium", "business", "rewards", "airline", "dining", "balance_transfer"]
+        "enum": ["travel", "cashback", "hotel", "shopping", "student", "secured", "premium", "business", "rewards", "airline", "dining", "balance_transfer", "entertainment", "credit_builder"]
       },
       "description": "Card tags for categorization and filtering (optional)"
     },

--- a/data/cards/us-bank-secured.yaml
+++ b/data/cards/us-bank-secured.yaml
@@ -7,6 +7,7 @@ annual_fee: 0
 category: "secured"
 tags:
   - secured
+  - credit_builder
 apr:
   regular:
     min: 27.49


### PR DESCRIPTION
## Summary

Two new tags that fill real gaps exposed by the card data audit:

**`entertainment`** — already a reward category in `categories.yaml` but wasn't a valid tag. Applied to:
- Capital One Savor
- Capital One SavorOne  
- Capital One Savor Student

**`credit_builder`** — distinct from `secured`. Capital One Platinum is an *unsecured* credit builder that was incorrectly tagged `secured`. Applied to:
- Capital One Platinum (replaces `secured` — this card is unsecured)
- Capital One Platinum Secured (added alongside `secured`)
- Citi Secured Mastercard (added alongside `secured`)
- US Bank Secured (added alongside `secured`)

## Test plan
- [x] Schema updated
- [x] All affected cards tagged
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)