### PR TITLE
Update Best Cards rankings with corrected data and reasoning

### DIFF
--- a/data/best/best-0-apr-cards.yaml
+++ b/data/best/best-0-apr-cards.yaml
@@ -2,20 +2,19 @@ id: best-0-apr-cards
 slug: best-0-apr-cards
 title: Best 0% APR Credit Cards
 description: The best 0% intro APR credit cards for purchases and balance transfers, all with no annual fee.
-date: "2026-02-28"
+date: "2026-03-01"
 seo_title: Best 0% APR Credit Cards of 2026
-seo_description: Compare the best 0% intro APR credit cards of 2026. Up to 21 months of 0% APR on purchases and balance transfers.
+seo_description: Compare the best 0% intro APR credit cards of 2026. Up to 24 months of 0% APR on purchases and balance transfers.
 intro: |
-  A 0% intro APR card lets you make purchases or transfer balances and pay no interest for an extended period — typically 12 to 21 months. These cards are ideal for financing a large purchase over time or consolidating existing credit card debt. Every card on this list has a $0 annual fee.
+  A 0% intro APR card lets you make purchases or transfer balances and pay no interest for an extended period — typically 12 to 24 months. These cards are ideal for financing a large purchase over time or consolidating existing credit card debt. Every card on this list has a $0 annual fee.
 
 cards:
-  - slug: wells-fargo-reflect
+  - slug: us-bank-shield
     badge: Best Overall
-    highlight: 21 months of 0% APR on both purchases and balance transfers — the longest intro period available. No rewards, but as a pure interest-saving tool it's hard to beat.
+    highlight: 24 months of 0% APR on both purchases and balance transfers — the longest intro period available. No rewards, but nearly two full years of interest-free financing is unmatched.
 
-  - slug: bankamericard
-    badge: Longest 0% Period
-    highlight: 21 months of 0% APR on both purchases and balance transfers, matching the longest periods on the market. A straightforward no-frills card focused entirely on interest savings.
+  - slug: wells-fargo-reflect
+    highlight: 21 months of 0% APR on both purchases and balance transfers. No rewards, but as a pure interest-saving tool with a long dual intro period, it's one of the best options available.
 
   - slug: citi-simplicity-card
     badge: No Late Fees
@@ -27,5 +26,5 @@ cards:
   - slug: chase-slate-edge
     highlight: 21 months of 0% APR on balance transfers. Chase also offers an automatic APR reduction if you pay on time and keep utilization under 30% — a unique perk for long-term cardholders.
 
-  - slug: us-bank-shield
-    highlight: 15 months of 0% APR on both purchases and balance transfers. Shorter than the top picks but still a generous window for interest-free financing.
+  - slug: bankamericard
+    highlight: 18 months of 0% APR on both purchases and balance transfers. Shorter than the top picks but still offers a generous interest-free window on both new purchases and transferred balances.

--- a/data/best/best-airline-cards.yaml
+++ b/data/best/best-airline-cards.yaml
@@ -2,9 +2,9 @@ id: best-airline-cards
 slug: best-airline-cards
 title: Best Airline Credit Cards
 description: The top co-branded airline credit cards ranked by signup bonuses, earning rates, and travel perks.
-date: "2026-02-28"
+date: "2026-03-01"
 seo_title: Best Airline Credit Cards of 2026
-seo_description: Compare the best airline credit cards of 2026. Delta, United, Southwest, JetBlue, and more — ranked by value.
+seo_description: Compare the best airline credit cards of 2026. Delta, United, American, Southwest, JetBlue, and more — ranked by value.
 intro: |
   Airline credit cards earn miles in a specific loyalty program and come with perks like free checked bags, priority boarding, and lounge access. They're best for travelers loyal to one airline or alliance. We've ranked these by overall value — factoring in signup bonuses, earning rates, annual fees, and travel benefits.
 
@@ -13,46 +13,59 @@ cards:
     badge: Best Premium
     highlight: 125,000 SkyMiles signup bonus, Delta Sky Club access, and a companion certificate. The ultimate Delta card for frequent flyers willing to pay the $650 annual fee.
 
+  - slug: citi-aadvantage-platinum-select-world-elite-m
+    badge: Best Value
+    highlight: 80,000 AAdvantage miles signup bonus for just $99/year. Includes a free first checked bag, preferred boarding, and 2x miles on AA purchases, dining, and gas. The best overall value among airline cards.
+
   - slug: delta-skymiles-platinum-american-express-card
     badge: Best Delta Value
-    highlight: 100,000 SkyMiles with a companion certificate and solid travel protections. A strong step up from the Gold at $350/year without the Reserve's premium price.
+    highlight: 100,000 SkyMiles with a companion certificate and solid travel protections. 3x on Delta and hotels, 2x on dining and groceries. A strong step up from the Gold at $350/year.
 
   - slug: delta-skymiles-gold-american-express-card
     badge: Best Mid-Tier
     highlight: 90,000 SkyMiles signup bonus with a $150 annual fee. Includes a free first checked bag and 2x earning on dining, groceries, and Delta purchases.
 
-  - slug: united-explorer
-    highlight: A well-rounded United card with a free first checked bag, two United Club one-time passes, and expanded award availability. Good for occasional to moderate United flyers.
+  - slug: united-club-infinite
+    highlight: United Club lounge access, 90,000-mile signup bonus, and the strongest United earning structure at 4x on United and 1.5x on everything else. Worth the $695 fee if you fly United frequently.
+
+  - slug: citi-aadvantage-executive-world-elite-masterc
+    highlight: 100,000 AAdvantage miles signup bonus and Admirals Club lounge access. 4x on AA purchases and 10x on hotels and car rentals booked through AA portals. The premium pick for AA loyalists at $595/year.
 
   - slug: united-quest
-    highlight: Premium United card with up to $250 in annual travel credits. 3x miles on United purchases and a stronger earning structure than the Explorer.
+    highlight: 80,000-mile signup bonus with up to $250 in annual travel credits. 3x on United purchases, 5x on Renowned Hotels, and 2x on travel, dining, and streaming. Strong value at $350/year.
 
-  - slug: united-club-infinite
-    highlight: United Club lounge access, Premier 1K-level upgrades, and the strongest United earning structure. Worth it if you fly United frequently and value lounge access.
+  - slug: citi-aadvantage-globe
+    highlight: 90,000 AAdvantage miles signup bonus. 3x on AA purchases, 6x on hotels through the AA portal, and 2x on dining and transit. A solid mid-tier AA option at $350/year.
+
+  - slug: united-explorer
+    highlight: 70,000-mile signup bonus. A well-rounded United card with 2x on United, dining, and hotels, plus a free first checked bag and two United Club one-time passes. Good value at $150/year.
+
+  - slug: british-airways-visa-signature-card
+    highlight: 75,000 Avios signup bonus for just $95/year. 3x on British Airways, Aer Lingus, and Iberia flights. Avios are highly valuable for short-haul redemptions on American Airlines and oneworld partners.
 
   - slug: southwest-rapid-rewards-priority-credit-card
-    highlight: $75 annual travel credit, 4 upgraded boardings per year, and 7,500 anniversary points. The best Southwest card for earning toward the Companion Pass.
+    highlight: $75 annual travel credit, 4x on Southwest, 4 upgraded boardings per year, and 7,500 anniversary points. The best Southwest card for earning toward the Companion Pass at $229/year.
 
   - slug: southwest-rapid-rewards-premier-credit-card
-    highlight: Solid mid-tier Southwest option with 2x on Southwest and Rapid Rewards hotel/car purchases. Lower annual fee than the Priority with core travel benefits.
-
-  - slug: southwest-rapid-rewards-plus-credit-card
-    highlight: The entry-level Southwest card at $99/year. 2x on Southwest purchases and 1x on everything else, plus anniversary points toward the Companion Pass.
-
-  - slug: delta-skymiles-blue-american-express-card
-    highlight: No annual fee entry point into the Delta ecosystem. 2x miles on dining and Delta purchases. A great starter airline card.
-
-  - slug: united-gateway
-    highlight: No annual fee United card. A free first checked bag on United and basic miles earning. Best for infrequent United travelers who want the checked bag perk.
+    highlight: Solid mid-tier Southwest option with 3x on Southwest and 2x on groceries and dining. Lower annual fee than the Priority at $149/year with core travel benefits.
 
   - slug: jetblue-plus-card
-    highlight: 6x points on JetBlue, a free first checked bag, and 50% savings on inflight purchases. A solid co-brand for Northeast and Florida travelers.
+    highlight: 70,000-point signup bonus and 6x points on JetBlue purchases. Includes a free first checked bag and 50% savings on inflight purchases. A great value at $99/year for Northeast and Florida travelers.
+
+  - slug: southwest-rapid-rewards-plus-credit-card
+    highlight: The entry-level Southwest card at $99/year. 2x on Southwest, gas, and grocery purchases, plus anniversary points toward the Companion Pass.
+
+  - slug: hawaiian-airlines-world-elite-mastercard
+    highlight: 50,000-mile signup bonus. 3x miles on Hawaiian Airlines, 2x on dining, gas, and groceries. Includes a companion fare discount and no foreign transaction fees — ideal for Hawaii-bound travelers.
+
+  - slug: united-gateway
+    highlight: 30,000-mile signup bonus with no annual fee. 2x miles on United, gas, and transit. A free first checked bag on United makes this the best no-fee airline card for United travelers.
+
+  - slug: delta-skymiles-blue-american-express-card
+    highlight: No annual fee entry point into the Delta ecosystem. 2x miles on dining and Delta purchases. A solid starter airline card with a 10,000-mile signup bonus.
+
+  - slug: american-airlines-aadvantage-mileu-mastercard
+    highlight: No annual fee American Airlines card with a 15,000-mile signup bonus. Earns 2x on eligible AA purchases and groceries. A free entry into the AAdvantage program.
 
   - slug: jetblue-card
     highlight: No annual fee JetBlue card with 3x on JetBlue purchases and 2x on dining and groceries. Good for casual JetBlue flyers.
-
-  - slug: american-airlines-aadvantage-mileu-mastercard
-    highlight: No annual fee American Airlines card. Earns 2x on eligible AA purchases and is the only free entry into the AAdvantage program via a credit card.
-
-  - slug: hawaiian-airlines-world-elite-mastercard
-    highlight: 3x miles on Hawaiian Airlines, 2x on dining and gas. Includes a companion fare discount and no foreign transaction fees — ideal for Hawaii-bound travelers.

--- a/data/best/best-cash-back-cards.yaml
+++ b/data/best/best-cash-back-cards.yaml
@@ -2,7 +2,7 @@ id: best-cash-back-cards
 slug: best-cash-back-cards
 title: Best Cash Back Credit Cards
 description: The top cash back credit cards ranked by earning rates, bonus categories, and signup offers — all with no annual fee unless noted.
-date: "2026-02-28"
+date: "2026-03-01"
 seo_title: Best Cash Back Credit Cards of 2026
 seo_description: Compare the best cash back credit cards of 2026. Flat-rate 2% cards, 5% rotating categories, and the best signup bonuses.
 intro: |
@@ -52,4 +52,4 @@ cards:
     highlight: 3x points on dining, travel, gas, transit, and streaming with no annual fee. While technically a points card, rewards redeem at 1 cent each — making it effectively a multi-category 3% cash back card.
 
   - slug: wells-fargo-attune
-    highlight: 4% on select categories you choose and 2% on everyday spending. A newer Wells Fargo card with a customizable rewards structure and $100 signup bonus.
+    highlight: 4% back on lifestyle categories like fitness, wellness, sports, live events, pet supplies, transit, and EV charging. 1% on everything else with no annual fee. A niche pick with a $100 signup bonus after $500 in spending.

--- a/data/best/best-dining-grocery-cards.yaml
+++ b/data/best/best-dining-grocery-cards.yaml
@@ -2,7 +2,7 @@ id: best-dining-grocery-cards
 slug: best-dining-grocery-cards
 title: Best Credit Cards for Dining and Groceries
 description: The top credit cards for earning rewards on restaurants and grocery store purchases, from premium to no-annual-fee options.
-date: "2026-02-28"
+date: "2026-03-01"
 seo_title: Best Credit Cards for Dining and Groceries of 2026
 seo_description: Compare the best dining and grocery credit cards of 2026. Earn 3-4x points or up to 6% cash back on food spending.
 intro: |
@@ -11,38 +11,43 @@ intro: |
 cards:
   - slug: american-express-gold-card
     badge: Best Overall
-    highlight: 4x Membership Rewards points on dining and groceries is the highest ongoing earn rate in both categories from a single card. The $325 annual fee is offset by monthly dining and Uber credits.
+    highlight: 4x Membership Rewards points on both dining and groceries is the highest ongoing earn rate in both categories from a single card. The $325 annual fee is offset by monthly dining and Uber credits.
+
+  - slug: blue-cash-preferred-card
+    badge: Best for Groceries
+    highlight: 6% cash back at U.S. supermarkets (up to $6,000/year) is the highest grocery earn rate of any card. Also earns 6% on streaming and 3% on transit and gas for a $95 annual fee.
+
+  - slug: us-bank-altitude-go-visa-signature
+    badge: Best No-Fee Dining
+    highlight: 4x points on dining (up to $2,000/quarter) with no annual fee is the highest no-fee dining rate available. Also earns 2x on groceries, gas, and streaming.
 
   - slug: capital-one-savorone
-    badge: Best No-Fee Card
-    highlight: 3% cash back on dining, groceries, entertainment, and streaming with no annual fee. The best all-around no-fee card for food spending.
+    badge: Best No-Fee All-Around
+    highlight: 3% cash back on dining, groceries, entertainment, and streaming with no annual fee. The best all-around no-fee card for food spending across both categories.
+
+  - slug: citi-strata-premier
+    highlight: 3x points on both dining and groceries plus 3x on airlines, hotels, and gas for a $95 annual fee. One of the few mid-tier cards with elevated earning in both food categories.
 
   - slug: chase-sapphire-preferred
-    highlight: 3x points on dining make this a strong everyday earner. Points transfer to Hyatt, United, and other partners, giving you outsized value for a $95 annual fee.
+    highlight: 3x points on dining and 3x on online grocery purchases make this a strong everyday earner. Points transfer to Hyatt, United, and other partners, giving you outsized value for a $95 annual fee.
+
+  - slug: citi-custom-cash
+    highlight: Automatically earns 5% on your top spending category each billing cycle, including dining or groceries (up to $500/month). No annual fee makes this a great targeted card for your biggest food expense.
 
   - slug: chase-sapphire-reserve
-    highlight: 3x on dining with a $300 travel credit and 50% bonus when redeeming through Chase Travel. The premium option for frequent travelers who also dine out a lot.
+    highlight: 3x on dining with a $300 travel credit and 50% point bonus when redeeming through Chase Travel. The premium option for frequent travelers who also dine out a lot, though the $795 annual fee is steep.
 
   - slug: chase-freedom-flex
-    highlight: 3% back on dining at restaurants with no annual fee, plus 5% rotating categories that sometimes include grocery stores. A great starter or pairing card.
+    highlight: 3% back on dining with no annual fee, plus 5% rotating categories that sometimes include grocery stores. A great starter or pairing card with a Sapphire card for point transfers.
 
   - slug: chase-freedom-unlimited
     highlight: 3% on dining plus 1.5% on everything else, no annual fee. Pairs perfectly with a Sapphire card to transfer points to travel partners.
 
-  - slug: wells-fargo-autograph
-    highlight: 3x points on dining with no annual fee. Also earns 3x on travel, gas, transit, and streaming — a versatile everyday card.
-
   - slug: blue-cash-everyday-card
-    highlight: 3% cash back at U.S. supermarkets (up to $6,000/year) with no annual fee. One of the best standalone grocery cards for most households.
+    highlight: 3% cash back at U.S. supermarkets (up to $6,000/year) with no annual fee. A strong no-fee grocery card that also earns 3% on gas and online shopping.
 
-  - slug: atmos-rewards-summit
-    highlight: 3x points on dining plus a strong rewards structure across travel and everyday categories. A newer card with competitive earning rates.
+  - slug: wells-fargo-autograph
+    highlight: 3x points on dining with no annual fee. Also earns 3x on travel, gas, transit, and streaming, though it has no grocery bonus.
 
   - slug: delta-skymiles-gold-american-express-card
-    highlight: 2x miles on dining and U.S. supermarkets. A strong pick if you fly Delta — the dining and grocery earnings fuel your miles balance between flights.
-
-  - slug: rakuten-american-express
-    highlight: 2% back on dining and groceries with no annual fee. Also earns elevated rates on Rakuten shopping portal purchases — a solid secondary card.
-
-  - slug: atmos-rewards-ascent
-    highlight: 3x on dining with a lower annual fee than the Summit. A good mid-tier option if you want elevated dining rewards without the premium price tag.
+    highlight: 2x miles on dining and U.S. supermarkets. A strong pick if you fly Delta regularly, as the dining and grocery earnings fuel your miles balance between flights.

--- a/data/best/best-secured-cards.yaml
+++ b/data/best/best-secured-cards.yaml
@@ -2,7 +2,7 @@ id: best-secured-cards
 slug: best-secured-cards
 title: Best Secured Credit Cards
 description: The best secured credit cards for building or rebuilding credit, all with no annual fee.
-date: "2026-02-28"
+date: "2026-03-01"
 seo_title: Best Secured Credit Cards of 2026
 seo_description: Compare the best secured credit cards of 2026 for building credit. All have $0 annual fees and report to all three bureaus.
 intro: |
@@ -15,10 +15,10 @@ cards:
 
   - slug: capital-one-quicksilver-secured
     badge: Best for Rewards
-    highlight: Earns 1.5% cash back on every purchase with no annual fee. One of the few secured cards with a flat-rate rewards structure, making it feel like a regular credit card.
+    highlight: Earns 1.5% cash back on every purchase — or 5% on hotels and car rentals booked through Capital One Travel. One of the few secured cards with a flat-rate rewards structure, making it feel like a regular credit card.
 
   - slug: bank-of-america-cash-rewards-secured
-    highlight: Earns cash back in a category of your choice (gas, online shopping, dining, travel, drug stores, or home improvement). A good pick if your spending is concentrated in one area.
+    highlight: Earns 3% cash back in a category of your choice, 2% at grocery stores and wholesale clubs, and 1% on everything else. A good pick if your spending is concentrated in one area.
 
   - slug: capital-one-platinum-secured
     badge: Easiest Approval

--- a/data/best/best-signup-bonuses.yaml
+++ b/data/best/best-signup-bonuses.yaml
@@ -2,49 +2,59 @@ id: best-signup-bonuses
 slug: best-signup-bonuses
 title: Best Credit Card Signup Bonuses
 description: The most valuable credit card signup bonuses available right now, ranked by bonus value and overall appeal.
-date: "2026-02-28"
+date: "2026-03-01"
 seo_title: Best Credit Card Signup Bonuses of 2026
-seo_description: Compare the best credit card signup bonuses of 2026. Ranked by value — from 140k points to $200 cash back.
+seo_description: Compare the best credit card signup bonuses of 2026. Ranked by value — from 175k points to $200 cash back.
 intro: |
   Signup bonuses are the fastest way to earn a big chunk of rewards from a new credit card. We've ranked the best offers available right now based on bonus value, ease of earning, and overall card quality. All data is pulled live from our card database so bonus values, annual fees, and apply links are always current.
 
 cards:
-  - slug: ihg-rewards-premier-business
+  - slug: the-platinum-card
     badge: Best Overall
-    highlight: The highest signup bonus available right now — 140,000 IHG points after $4,000 in 3 months. IHG points are worth around 0.5 cents each, making this worth roughly $700 in hotel stays.
+    highlight: 175,000 Membership Rewards points after $12,000 in 6 months — worth roughly $3,500 when transferred to airline and hotel partners. The highest-value signup bonus available right now by a wide margin.
+
+  - slug: ihg-rewards-club-premier-credit-card
+    badge: Best Hotel Bonus
+    highlight: 175,000 IHG points after $5,000 in 3 months. IHG points are worth around 0.5 cents each, making this worth roughly $875 in hotel stays — the highest raw point count on the list.
+
+  - slug: ihg-rewards-premier-business
+    highlight: 140,000 IHG points after $4,000 in 3 months. A lower spend requirement than the personal IHG Premier, with the same strong earning rates at IHG properties.
+
+  - slug: chase-sapphire-reserve
+    badge: Best Premium Travel
+    highlight: 125,000 Ultimate Rewards points after $6,000 in 3 months — worth up to $1,875 through Chase Travel. Also includes a $300 annual travel credit that offsets much of the $795 annual fee.
 
   - slug: delta-skymiles-reserve-american-express-card
-    badge: Best for Premium Travel
-    highlight: 125,000 Delta SkyMiles is an enormous haul. The Reserve card also includes Delta Sky Club access and a companion certificate — ideal for frequent Delta flyers.
+    badge: Best for Delta Flyers
+    highlight: 125,000 Delta SkyMiles after $9,000 in 6 months. The Reserve also includes Delta Sky Club access and a companion certificate — ideal for frequent Delta flyers.
+
+  - slug: chase-ink-business-preferred
+    badge: Best Business Card
+    highlight: 100,000 Ultimate Rewards points after $8,000 in 3 months — worth up to $1,500 through Chase Travel or transfer partners. One of the best business card bonuses available at just $95/year.
 
   - slug: delta-skymiles-platinum-american-express-card
-    badge: Best Delta Value
-    highlight: 100,000 SkyMiles for a lower annual fee than the Reserve. You still get a companion certificate and solid travel perks without the ultra-premium price tag.
+    highlight: 100,000 SkyMiles after $6,000 in 6 months. You still get a companion certificate and solid travel perks without the ultra-premium price tag of the Reserve.
 
   - slug: delta-skymiles-gold-american-express-card
-    highlight: 90,000 SkyMiles is a top-tier bonus for a mid-tier card. Great entry point into the Delta ecosystem with a reasonable $150 annual fee.
+    highlight: 90,000 SkyMiles after $5,000 in 6 months. A top-tier bonus for a mid-tier card and a great entry point into the Delta ecosystem at just $150/year.
 
-  - slug: atmos-rewards-summit
-    highlight: 80,000 Atmos points with a $4,000 spend requirement. Atmos is a newer player but their redemption rates are competitive with major programs.
-
-  - slug: capital-one-venture-x
-    badge: Best Travel Card
-    highlight: 75,000 miles after $4,000 in 3 months. The Venture X also comes with a $300 travel credit and 10,000 anniversary miles, effectively making the $395 annual fee very manageable.
-
-  - slug: atmos-rewards-ascent
-    highlight: 70,000 Atmos points with only $3,000 in spending required. A lower spend threshold makes this one of the easier big bonuses to earn.
+  - slug: united-quest
+    highlight: 80,000 United miles after $4,000 in 3 months. United miles are worth around 1.3 cents each, putting this bonus value over $1,000. Also includes two free checked bags and 25% back on United award flights.
 
   - slug: chase-sapphire-preferred
-    highlight: 60,000 Ultimate Rewards points are worth at least $750 when redeemed through Chase Travel. One of the most versatile points currencies available.
+    badge: Best Mid-Tier Travel
+    highlight: 75,000 Ultimate Rewards points after $5,000 in 3 months — worth at least $937 through Chase Travel. One of the most versatile points currencies available, all for a $95 annual fee.
+
+  - slug: capital-one-venture-x
+    badge: Best Travel Card Value
+    highlight: 75,000 miles after $4,000 in 3 months. The Venture X also comes with a $300 travel credit and 10,000 anniversary miles, effectively making the $395 annual fee very manageable.
+
+  - slug: world-of-hyatt-business-credit-card
+    badge: Best Hotel Value
+    highlight: 60,000 World of Hyatt points can easily be worth $1,200+ in hotel stays. Hyatt consistently offers the best value among hotel loyalty programs at roughly 2 cents per point.
 
   - slug: american-express-gold-card
     highlight: 60,000 Membership Rewards points after $6,000 in 6 months. The Gold Card is a powerhouse for dining and groceries with 4x earning in both categories.
-
-  - slug: chase-sapphire-reserve
-    highlight: 60,000 Ultimate Rewards points plus a $300 annual travel credit. Points are worth 50% more through Chase Travel, making this bonus worth up to $900.
-
-  - slug: world-of-hyatt-business-credit-card
-    highlight: 60,000 World of Hyatt points can easily be worth $1,200+ in hotel stays. Hyatt consistently offers the best value among hotel loyalty programs.
 
   - slug: wells-fargo-signify-business-cash
     badge: Best Cash Back
@@ -54,7 +64,7 @@ cards:
     highlight: $200 cash back after just $500 in spending — one of the easiest bonuses to earn. Plus 5% rotating categories and a strong everyday rewards structure.
 
   - slug: wells-fargo-active-cash
-    highlight: $200 cash back with a low $500 spend requirement. Pairs well with the 2% flat cash back on everything, making it a solid daily driver.
+    highlight: $200 cash back with a $500 spend requirement. Pairs well with the 2% flat cash back on everything, making it a solid daily driver.
 
   - slug: capital-one-savorone
     highlight: $200 cash back after $500 in 3 months. The SavorOne also earns 3% on dining, entertainment, groceries, and streaming — a great all-around no-annual-fee card.

--- a/data/best/best-travel-cards.yaml
+++ b/data/best/best-travel-cards.yaml
@@ -1,8 +1,98 @@
+# ============================================================
+# Best Travel Credit Cards — Ranking Reasoning (2026-03-01)
+# ============================================================
+#
+# #1 Chase Sapphire Reserve (Best Premium)
+#   - The gold standard for premium travel cards. 8x through Chase Travel portal
+#     (marketed as 10x hotels/car, 5x flights with bonus structure), 3x dining,
+#     Priority Pass lounge access, $300 annual travel credit, and 50% point boost
+#     through Chase Travel. 125,000-point signup bonus is industry-leading.
+#     The $795 fee is steep but offset by credits and perks for frequent travelers.
+#
+# #2 Capital One Venture X (Best Value Premium)
+#   - Best value in premium travel cards. 10x hotels/car and 5x flights through
+#     Capital One portal, 2x on everything else. The $300 travel credit + 10,000
+#     anniversary miles bring the effective fee near $0 on a $395 card. Capital One
+#     Lounges and Priority Pass included. 75,000-mile signup bonus.
+#
+# #3 Chase Sapphire Preferred (Best Mid-Tier)
+#   - The most popular mid-tier travel card. 5x Chase Travel, 3x dining/streaming/
+#     online groceries, 2x other travel. 75,000-point signup bonus (worth $937+)
+#     is exceptional for a $95 card. Chase transfer partners (Hyatt, United, etc.)
+#     provide outsized redemption value.
+#
+# #4 American Express Gold
+#   - Top card for dining and grocery spenders who travel. 4x dining and groceries,
+#     3x flights. Monthly dining ($10) and Uber ($10) credits offset part of the
+#     $325 fee. Membership Rewards has the broadest set of transfer partners.
+#     60,000-point signup bonus.
+#
+# #5 Citi Strata Premier
+#   - Underrated powerhouse at $95/year. 10x through Citi Travel portal, 3x on
+#     airlines, hotels (direct), dining, groceries, AND gas — the widest 3x
+#     category coverage of any mid-tier card. 60,000-point signup bonus. ThankYou
+#     points transfer to partners. Moved up from #12 because its earning breadth
+#     rivals or beats the Sapphire Preferred.
+#
+# #6 Capital One Venture Rewards
+#   - Simple, strong mid-tier option. 5x hotels/car through portal, 2x on
+#     everything else with no category tracking. 75,000-mile signup bonus is
+#     outstanding for $95/year. Miles transfer to partners or erase travel
+#     purchases. The simplicity appeals to travelers who don't want to optimize.
+#
+# #7 Wells Fargo Autograph (Best No-Fee)
+#   - Best no-annual-fee travel card. 3x on dining, travel, gas, transit, and
+#     streaming — five bonus categories with no fee. 20,000-point signup bonus.
+#     Hard to find this many 3x categories without paying an annual fee.
+#
+# #8 Bank of America Travel Rewards
+#   - Simplest no-fee travel card. 1.5x on everything, no foreign transaction
+#     fees, 25,000-point signup bonus. No category tracking needed. Good for
+#     occasional travelers or as a backup card abroad.
+#
+# #9 Bilt Palladium
+#   - The only card that earns points on rent with no transaction fees — unique
+#     value proposition for renters. 3x dining, 2x travel, 2x everything else.
+#     Points transfer to Hyatt, AA, United, and more. The $495 fee is high, but
+#     renters paying $2,000+/month in rent earn significant value.
+#
+# #10 World of Hyatt Business (Best Hotel Card)
+#   - Best hotel card for outsized value. 60,000 Hyatt points (worth $1,200+ in
+#     stays) at the best cents-per-point hotel program. 4x at Hyatt (up to 9x
+#     with membership), 2x dining. $199 fee. Discoverist status included.
+#     Ranked as a niche pick for hotel-focused travelers.
+#
+# #11 Citi Strata Elite
+#   - Citi's premium flagship. 12x hotels/car portal, 6x flights portal, 3x
+#     dining (6x on Citi Nights), 1.5x everything else. 75,000-point bonus.
+#     At $595/year, it offers strong portal multipliers but lacks the transfer
+#     partner depth and lounge network of CSR/Venture X. A solid alternative
+#     for Citi loyalists.
+#
+# #12 Atmos Rewards Summit
+#   - Newer premium entrant from Bank of America. 80,000-point signup bonus,
+#     3x on airlines, dining, and foreign transactions. $395/year. Still
+#     building its reputation — the signup bonus is strong but the ongoing
+#     rewards structure and redemption ecosystem trail established competitors.
+#
+# #13 Atmos Rewards Ascent
+#   - Lower-fee companion to the Summit. 70,000-point signup bonus with only
+#     $3,000 spend required — the lowest threshold on the list. 3x airlines,
+#     2x gas/streaming/transit. $95/year. Strong for a sign-up bonus play.
+#
+# #14 US Bank Altitude Go Visa Signature
+#   - No-fee card with 4x dining and 2x on groceries, gas, and streaming.
+#     Not a pure travel card, but the dining rewards are strong and points
+#     can be redeemed for travel. Best for diners who want a no-fee option
+#     with travel-adjacent rewards.
+#
+# ============================================================
+
 id: best-travel-cards
 slug: best-travel-cards
 title: Best Travel Credit Cards
 description: The top travel credit cards ranked by rewards, travel perks, and overall value — from premium to no-annual-fee options.
-date: "2026-02-28"
+date: "2026-03-01"
 seo_title: Best Travel Credit Cards of 2026
 seo_description: Compare the best travel credit cards of 2026. From Chase Sapphire Reserve to no-fee options — ranked by rewards and perks.
 intro: |
@@ -11,7 +101,7 @@ intro: |
 cards:
   - slug: chase-sapphire-reserve
     badge: Best Premium
-    highlight: 10x on hotels and car rentals through Chase Travel, 5x on flights, 3x on dining and travel. The $300 annual travel credit and Priority Pass lounge access help offset the $795 fee. Points are worth 50% more through Chase Travel.
+    highlight: 8x on all travel through Chase Travel portal, 3x on dining and travel booked directly. The $300 annual travel credit and Priority Pass lounge access help offset the $795 fee. A 125,000-point signup bonus and points worth 50% more through Chase Travel.
 
   - slug: capital-one-venture-x
     badge: Best Value Premium
@@ -19,13 +109,16 @@ cards:
 
   - slug: chase-sapphire-preferred
     badge: Best Mid-Tier
-    highlight: 5x on Chase Travel, 3x on dining, streaming, and online groceries, 2x on other travel. The 60,000-point signup bonus is worth at least $750. The most popular travel card for good reason.
+    highlight: 5x on Chase Travel, 3x on dining, streaming, and online groceries, 2x on other travel. The 75,000-point signup bonus is worth at least $937. The most popular travel card for good reason at just $95/year.
 
   - slug: american-express-gold-card
-    highlight: 4x on dining and groceries, 3x on flights. Monthly dining and Uber credits help offset the $325 fee. Membership Rewards points transfer to a huge list of airline and hotel partners.
+    highlight: 4x on dining and groceries, 3x on flights. Monthly dining and Uber credits help offset the $325 fee. Membership Rewards points transfer to a huge list of airline and hotel partners. 60,000-point signup bonus.
+
+  - slug: citi-strata-premier
+    highlight: 10x on hotels and car rentals through Citi Travel, 3x on airlines, hotels, dining, groceries, and gas — the widest 3x coverage of any mid-tier card. 60,000-point signup bonus. ThankYou points transfer to airline partners. All for $95/year.
 
   - slug: capital-one-venture-rewards
-    highlight: 2x miles on every purchase with no category tracking needed. Miles can be transferred to partners or used to erase travel purchases. A solid mid-tier option at $95/year.
+    highlight: 5x on hotels and car rentals through the portal, 2x miles on every other purchase with no category tracking. A 75,000-mile signup bonus after $4,000 spend makes this one of the best mid-tier values at $95/year. Miles transfer to partners or erase travel purchases.
 
   - slug: wells-fargo-autograph
     badge: Best No-Fee
@@ -35,20 +128,20 @@ cards:
     highlight: 1.5x points on everything with no annual fee and no foreign transaction fees. A 25,000-point signup bonus after $1,000 spend. Simple and effective for occasional travelers.
 
   - slug: bilt-palladium
-    highlight: Earn points on rent payments with no transaction fees — a unique feature no other card offers. Also earns on dining, travel, and everyday spending. Points transfer to Hyatt, AA, United, and more.
+    highlight: Earn points on rent payments with no transaction fees — a unique feature no other card offers. 3x on dining, 2x on travel and everything else. Points transfer to Hyatt, AA, United, and more. The $495 fee is steep but pays off for high-rent payers.
 
   - slug: world-of-hyatt-business-credit-card
     badge: Best Hotel Card
-    highlight: 60,000 World of Hyatt points can be worth $1,200+ in hotel stays. Hyatt offers the best cents-per-point value of any major hotel program. Automatic Discoverist status included.
+    highlight: 60,000 World of Hyatt points can be worth $1,200+ in hotel stays. Hyatt offers the best cents-per-point value of any major hotel program. 4x at Hyatt properties, 2x on dining. Automatic Discoverist status at $199/year.
+
+  - slug: citi-strata-elite
+    highlight: 12x on hotels and car rentals through Citi Travel, 6x on flights through the portal, 3x on dining. 75,000-point signup bonus. At $595/year, a strong premium option for travelers who book through Citi Travel.
 
   - slug: atmos-rewards-summit
-    highlight: 80,000-point signup bonus with 3x on dining and a competitive rewards structure. A newer entrant competing with the established premium travel cards.
+    highlight: 80,000-point signup bonus with 3x on airlines, dining, and foreign transactions. A newer premium entrant at $395/year competing with the established travel cards.
 
   - slug: atmos-rewards-ascent
-    highlight: 70,000-point signup bonus with only $3,000 in spending required. A lower-fee alternative to the Summit that still earns elevated rewards on dining and travel.
-
-  - slug: citi-strata-premier
-    highlight: A strong Citi travel card with competitive earning rates on travel and dining. ThankYou points transfer to a solid lineup of airline partners.
+    highlight: 70,000-point signup bonus with only $3,000 in spending required — one of the lowest thresholds on the list. 3x on airlines, 2x on gas, streaming, and transit. A solid option at $95/year.
 
   - slug: us-bank-altitude-go-visa-signature
     highlight: 4x points on dining and takeout, 2x on groceries, gas, and streaming with no annual fee. A strong no-fee option for diners who want travel-redeemable rewards.


### PR DESCRIPTION
## Summary

Reviews all 7 best card category pages against the updated card YAML data from the recent audit (PRs #175-#178). Fixes incorrect bonus amounts, outdated APR periods, and reranks based on current data.

### Best Travel Cards
- Fixed CSP bonus (60k→75k) and added CSR 125k bonus to highlights
- Promoted Citi Strata Premier from #12 to #5 (10x portal, 3x on 6 categories at $95/yr)
- Added Citi Strata Elite at #11 (premium Citi option)
- Added annual fee and specific reward rates to Bilt, Hyatt Business, Venture Rewards highlights
- Corrected Atmos Ascent highlight (was claiming dining bonus it doesn't have)

### Best Signup Bonuses
- Added Amex Platinum at #1 (175k MR, ~$3,500 value)
- Added IHG Premier personal at #2 (175k IHG)
- Added Chase Ink Business Preferred (100k UR) and United Quest (80k miles)
- Fixed CSP: 60k→75k points, CSR: 60k→125k points
- Removed Atmos Summit/Ascent (less established program, replaced with better-known alternatives)
- Expanded from 15 to 17 cards

### Best 0% APR Cards
- Promoted US Bank Shield to #1 (24 months, was incorrectly listed as 15)
- Corrected BankAmericard to 18 months (was incorrectly listed as 21)
- Updated SEO description and intro to reflect "up to 24 months"

### Best Dining & Grocery Cards
- Added Blue Cash Preferred at #2 (6% groceries)
- Added US Bank Altitude Go at #3 (4x dining, $0 fee)
- Added Citi Strata Premier and Citi Custom Cash
- Removed Atmos Ascent (no dining bonus) and Rakuten (too weak at 2%)
- Updated SavorOne badge to "Best No-Fee All-Around"

### Best Airline Cards
- Added 4 American Airlines cards: Citi AA Platinum Select (#2), Executive (#6), Globe (#8), British Airways Visa (#10)
- Fixed Southwest Premier earning rate (2x→3x)
- Added specific signup bonus amounts to United, JetBlue, Delta Blue, Hawaiian, AA MileUp highlights
- Expanded from 15 to 19 cards

### Best Cash Back Cards
- Fixed Wells Fargo Attune: was claiming 2% base (actually 1%), was claiming user-selectable categories (actually fixed lifestyle categories)

### Best Secured Cards  
- Added specific reward rates to Capital One Quicksilver Secured (5% portal) and BofA Cash Rewards Secured (3%/2%/1%) highlights
- No ranking changes needed

## Test plan
- [ ] Verify all card slugs resolve correctly on `/best/*` pages
- [ ] Check highlight text matches card detail pages
- [ ] Verify new cards (Blue Cash Preferred, Citi Strata Elite, AA cards, etc.) appear correctly
- [ ] Mobile: confirm comparison table renders properly on best pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)