### PR TITLE
Preserve data on account delete + Admin Searches & User Lookup

### DIFF
--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -503,6 +503,151 @@ exports.AdminReferralsHandler = async (event) => {
   }
 };
 
+// ============ SEARCHES HANDLER ============
+exports.AdminSearchesHandler = async (event) => {
+  console.info("AdminSearches received:", event);
+
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 200, headers: responseHeaders, body: JSON.stringify({ statusText: "OK" }) };
+  }
+
+  if (!isAdmin(event)) {
+    return {
+      statusCode: 403,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: "Forbidden: Admin access required" }),
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return { statusCode: 405, headers: responseHeaders, body: JSON.stringify({ error: "Method not allowed" }) };
+  }
+
+  try {
+    const limit = parseInt(event.queryStringParameters?.limit) || 100;
+    const offset = parseInt(event.queryStringParameters?.offset) || 0;
+
+    const results = await mysql.query(`
+      SELECT *
+      FROM approval_searches
+      ORDER BY created_at DESC
+      LIMIT ? OFFSET ?
+    `, [limit, offset]);
+
+    const countResult = await mysql.query("SELECT COUNT(*) as total FROM approval_searches");
+    await mysql.end();
+
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({
+        searches: results,
+        total: countResult[0].total,
+        limit,
+        offset
+      }),
+    };
+  } catch (error) {
+    console.error("Error fetching searches:", error);
+    return {
+      statusCode: 500,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: `Failed to fetch searches: ${error.message}` }),
+    };
+  }
+};
+
+// ============ USER LOOKUP HANDLER ============
+exports.AdminUserLookupHandler = async (event) => {
+  console.info("AdminUserLookup received:", event);
+
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 200, headers: responseHeaders, body: JSON.stringify({ statusText: "OK" }) };
+  }
+
+  if (!isAdmin(event)) {
+    return {
+      statusCode: 403,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: "Forbidden: Admin access required" }),
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return { statusCode: 405, headers: responseHeaders, body: JSON.stringify({ error: "Method not allowed" }) };
+  }
+
+  const userId = event.queryStringParameters?.user_id;
+  if (!userId) {
+    return {
+      statusCode: 400,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: "user_id query parameter is required" }),
+    };
+  }
+
+  try {
+    const [records, searches, wallet, referrals] = await Promise.all([
+      mysql.query(`
+        SELECT r.*, c.card_name, c.card_image_link, c.bank
+        FROM records r
+        JOIN cards c ON r.card_id = c.card_id
+        WHERE r.submitter_id = ?
+        ORDER BY r.submit_datetime DESC
+      `, [userId]),
+      mysql.query(`
+        SELECT * FROM approval_searches
+        WHERE user_id = ?
+        ORDER BY created_at DESC
+      `, [userId]),
+      mysql.query(`
+        SELECT uc.*, c.card_name, c.card_image_link, c.bank
+        FROM user_cards uc
+        JOIN cards c ON uc.card_id = c.card_id
+        WHERE uc.user_id = ?
+        ORDER BY uc.created_at DESC
+      `, [userId]),
+      mysql.query(`
+        SELECT r.*, c.card_name, c.card_image_link, c.bank,
+          COALESCE(stats.impressions, 0) as impressions,
+          COALESCE(stats.clicks, 0) as clicks
+        FROM referrals r
+        JOIN cards c ON r.card_id = c.card_id
+        LEFT JOIN (
+          SELECT referral_id,
+            SUM(CASE WHEN event_type = 'impression' THEN 1 ELSE 0 END) as impressions,
+            SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks
+          FROM referral_stats
+          GROUP BY referral_id
+        ) stats ON r.referral_id = stats.referral_id
+        WHERE r.submitter_id = ?
+        ORDER BY r.submit_datetime DESC
+      `, [userId]),
+    ]);
+
+    await mysql.end();
+
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({
+        user_id: userId,
+        records,
+        searches,
+        wallet,
+        referrals
+      }),
+    };
+  } catch (error) {
+    console.error("Error looking up user:", error);
+    return {
+      statusCode: 500,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: `Failed to look up user: ${error.message}` }),
+    };
+  }
+};
+
 // ============ AUDIT LOG HANDLER ============
 exports.AdminAuditHandler = async (event) => {
   console.info("AdminAudit received:", event);

--- a/apps/api/src/handlers/delete-account.js
+++ b/apps/api/src/handlers/delete-account.js
@@ -54,41 +54,19 @@ exports.DeleteAccountHandler = async (event) => {
   }
 
   try {
-    // 1. Get all referral IDs for this user (to delete stats)
-    const userReferrals = await mysql.query(
-      "SELECT referral_id FROM referrals WHERE submitter_id = ?",
-      [userId]
-    );
-
-    // 2. Delete referral stats for user's referrals
-    if (userReferrals.length > 0) {
-      const referralIds = userReferrals.map(r => r.referral_id);
-      await mysql.query(
-        `DELETE FROM referral_stats WHERE referral_id IN (?)`,
-        [referralIds]
-      );
-    }
-
-    // 3. Delete user's referrals
+    // 1. Anonymize referrals (keep rows + referral_stats intact, remove user association)
     await mysql.query(
-      "DELETE FROM referrals WHERE submitter_id = ?",
+      "UPDATE referrals SET submitter_id = NULL WHERE submitter_id = ?",
       [userId]
     );
 
-    // 4. Delete user's wallet entries
+    // 2. Delete user's wallet entries
     await mysql.query(
       "DELETE FROM user_cards WHERE user_id = ?",
       [userId]
     );
 
-    // 5. Delete user's approval searches
-    await mysql.query(
-      "DELETE FROM approval_searches WHERE user_id = ?",
-      [userId]
-    );
-
-    // 6. Anonymize records (keep data points but remove user association)
-    // Set submitter_id to NULL to preserve data integrity while removing PII
+    // 3. Anonymize records (keep data points but remove user association)
     await mysql.query(
       "UPDATE records SET submitter_id = NULL WHERE submitter_id = ?",
       [userId]
@@ -96,7 +74,7 @@ exports.DeleteAccountHandler = async (event) => {
 
     await mysql.end();
 
-    // 7. Delete Firebase user account
+    // 4. Delete Firebase user account
     try {
       await admin.auth().deleteUser(userId);
       console.info(`Firebase user ${userId} deleted successfully`);
@@ -112,8 +90,8 @@ exports.DeleteAccountHandler = async (event) => {
       body: JSON.stringify({
         message: "Account deleted successfully",
         deleted: {
-          referrals: userReferrals.length,
           wallet_entries: "all",
+          referrals_anonymized: "all",
           records_anonymized: "all"
         }
       }),

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -627,6 +627,70 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  AdminSearchesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/admin.AdminSearchesHandler
+      Runtime: nodejs18.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Admin approval searches endpoint
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetSearches:
+          Type: Api
+          Properties:
+            Path: /admin/searches
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        SearchesOptions:
+          Type: Api
+          Properties:
+            Path: /admin/searches
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
+  AdminUserLookupFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/admin.AdminUserLookupHandler
+      Runtime: nodejs18.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Admin user lookup endpoint
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetUser:
+          Type: Api
+          Properties:
+            Path: /admin/user
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        UserOptions:
+          Type: Api
+          Properties:
+            Path: /admin/user
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
   AdminAuditFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -9,6 +9,8 @@ import {
   getAdminRecords,
   getAdminReferrals,
   getAdminAuditLog,
+  getAdminSearches,
+  getAdminUser,
   deleteAdminRecord,
   deleteAdminReferral,
   updateReferralApproval,
@@ -16,6 +18,8 @@ import {
   AdminStats,
   AdminRecord,
   AdminReferral,
+  AdminSearch,
+  AdminUserData,
   AuditLogEntry,
   Card
 } from "@/lib/api";
@@ -29,13 +33,15 @@ import {
   LinkIcon,
   ClipboardDocumentListIcon,
   PencilIcon,
-  PlusCircleIcon
+  PlusCircleIcon,
+  MagnifyingGlassIcon,
+  UserIcon
 } from "@heroicons/react/24/outline";
 
 // Master admin user ID (Firebase UID)
 const ADMIN_USER_IDS = ['zXOyHmGl7HStyAqEdLsgXLA5inS2'];
 
-type TabType = 'stats' | 'records' | 'referrals' | 'audit' | 'submit';
+type TabType = 'stats' | 'records' | 'referrals' | 'searches' | 'user' | 'audit' | 'submit';
 
 export default function AdminPage() {
   const { authState, getToken } = useAuth();
@@ -52,6 +58,9 @@ export default function AdminPage() {
   const [referralsTotal, setReferralsTotal] = useState(0);
   const [auditLogs, setAuditLogs] = useState<AuditLogEntry[]>([]);
   const [auditTotal, setAuditTotal] = useState(0);
+  const [searches, setSearches] = useState<AdminSearch[]>([]);
+  const [searchesTotal, setSearchesTotal] = useState(0);
+  const [userLookupId, setUserLookupId] = useState('');
 
   // Processing states
   const [processingId, setProcessingId] = useState<number | null>(null);
@@ -85,11 +94,12 @@ export default function AdminPage() {
       }
 
       // Load all data in parallel
-      const [statsData, recordsData, referralsData, auditData] = await Promise.all([
+      const [statsData, recordsData, referralsData, auditData, searchesData] = await Promise.all([
         getAdminStats(token),
         getAdminRecords(token),
         getAdminReferrals(token),
-        getAdminAuditLog(token)
+        getAdminAuditLog(token),
+        getAdminSearches(token)
       ]);
 
       setStats(statsData);
@@ -99,6 +109,8 @@ export default function AdminPage() {
       setReferralsTotal(referralsData.total);
       setAuditLogs(auditData.logs);
       setAuditTotal(auditData.total);
+      setSearches(searchesData.searches);
+      setSearchesTotal(searchesData.total);
     } catch (err) {
       console.error("Error loading admin data:", err);
       setError(err instanceof Error ? err.message : "Failed to load data");
@@ -197,6 +209,11 @@ export default function AdminPage() {
     }
   };
 
+  const handleUserLookup = (userId: string) => {
+    setUserLookupId(userId);
+    setActiveTab('user');
+  };
+
   if (authState.isLoading || loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
@@ -213,6 +230,8 @@ export default function AdminPage() {
     { id: 'stats' as TabType, name: 'Overview', icon: ChartBarIcon },
     { id: 'records' as TabType, name: 'Records', icon: DocumentTextIcon, count: recordsTotal },
     { id: 'referrals' as TabType, name: 'Referrals', icon: LinkIcon, count: referralsTotal, badge: stats?.pending_referrals },
+    { id: 'searches' as TabType, name: 'Searches', icon: MagnifyingGlassIcon, count: searchesTotal },
+    { id: 'user' as TabType, name: 'User Lookup', icon: UserIcon },
     { id: 'audit' as TabType, name: 'Audit Log', icon: ClipboardDocumentListIcon },
     { id: 'submit' as TabType, name: 'Submit Record', icon: PlusCircleIcon },
   ];
@@ -285,6 +304,19 @@ export default function AdminPage() {
             onApprove={handleApproveReferral}
             onDelete={handleDeleteReferral}
             onEdit={handleEditReferral}
+          />
+        )}
+        {activeTab === 'searches' && (
+          <SearchesTab
+            searches={searches}
+            total={searchesTotal}
+            onUserClick={handleUserLookup}
+          />
+        )}
+        {activeTab === 'user' && (
+          <UserLookupTab
+            getToken={getToken}
+            initialUserId={userLookupId}
           />
         )}
         {activeTab === 'audit' && <AuditTab logs={auditLogs} total={auditTotal} />}
@@ -604,6 +636,378 @@ function ReferralsTab({
           </tbody>
         </table>
       </div>
+    </div>
+  );
+}
+
+// ============ SEARCHES TAB ============
+function SearchesTab({
+  searches,
+  total,
+  onUserClick
+}: {
+  searches: AdminSearch[];
+  total: number;
+  onUserClick: (userId: string) => void;
+}) {
+  return (
+    <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="px-4 py-5 sm:px-6 border-b border-gray-200">
+        <h3 className="text-lg font-medium text-gray-900">Approval Searches ({total})</h3>
+      </div>
+      {searches.length === 0 ? (
+        <div className="px-4 py-12 text-center text-gray-500">
+          No approval searches yet.
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">User ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Score</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Income</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Length</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {searches.map((search) => (
+                <tr key={search.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 whitespace-nowrap">
+                    <button
+                      onClick={() => onUserClick(search.user_id)}
+                      className="text-sm text-indigo-600 hover:text-indigo-800 font-mono"
+                    >
+                      {search.user_id}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">{search.credit_score}</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                    ${search.income?.toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                    {search.length_credit} years
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                    {new Date(search.created_at).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============ USER LOOKUP TAB ============
+function UserLookupTab({
+  getToken,
+  initialUserId
+}: {
+  getToken: () => Promise<string | null>;
+  initialUserId: string;
+}) {
+  const [userId, setUserId] = useState(initialUserId);
+  const [userData, setUserData] = useState<AdminUserData | null>(null);
+  const [lookupLoading, setLookupLoading] = useState(false);
+  const [lookupError, setLookupError] = useState('');
+
+  useEffect(() => {
+    if (initialUserId) {
+      setUserId(initialUserId);
+      doLookup(initialUserId);
+    }
+  }, [initialUserId]);
+
+  const doLookup = async (uid?: string) => {
+    const lookupId = uid || userId;
+    if (!lookupId.trim()) return;
+
+    setLookupLoading(true);
+    setLookupError('');
+    setUserData(null);
+
+    try {
+      const token = await getToken();
+      if (!token) {
+        setLookupError('No auth token');
+        return;
+      }
+      const data = await getAdminUser(lookupId.trim(), token);
+      setUserData(data);
+    } catch (err) {
+      setLookupError(err instanceof Error ? err.message : 'Failed to look up user');
+    } finally {
+      setLookupLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Search bar */}
+      <div className="bg-white shadow rounded-lg p-6">
+        <h3 className="text-lg font-medium text-gray-900 mb-4">Look Up User by Firebase UID</h3>
+        <div className="flex gap-3">
+          <input
+            type="text"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && doLookup()}
+            placeholder="Enter Firebase UID..."
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm font-mono focus:ring-indigo-500 focus:border-indigo-500"
+          />
+          <button
+            onClick={() => doLookup()}
+            disabled={lookupLoading || !userId.trim()}
+            className="bg-indigo-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {lookupLoading ? 'Loading...' : 'Look Up'}
+          </button>
+        </div>
+        {lookupError && (
+          <p className="mt-2 text-sm text-red-600">{lookupError}</p>
+        )}
+      </div>
+
+      {userData && (
+        <>
+          {/* Wallet */}
+          <div className="bg-white shadow rounded-lg overflow-hidden">
+            <div className="px-4 py-4 sm:px-6 border-b border-gray-200">
+              <h3 className="text-base font-medium text-gray-900">Wallet ({userData.wallet.length})</h3>
+            </div>
+            {userData.wallet.length === 0 ? (
+              <div className="px-4 py-8 text-center text-gray-500 text-sm">No cards in wallet.</div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Card</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Bank</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Acquired</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Added</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {userData.wallet.map((card) => (
+                      <tr key={card.id} className="hover:bg-gray-50">
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <div className="flex items-center">
+                            {card.card_image_link && (
+                              <div className="flex-shrink-0 h-8 w-12 relative mr-3">
+                                <Image
+                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
+                                  alt={card.card_name}
+                                  fill
+                                  className="object-contain"
+                                  sizes="48px"
+                                />
+                              </div>
+                            )}
+                            <span className="text-sm font-medium text-gray-900">{card.card_name}</span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">{card.bank}</td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                          {card.acquired_month && card.acquired_year
+                            ? `${card.acquired_month}/${card.acquired_year}`
+                            : '-'}
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                          {new Date(card.created_at).toLocaleDateString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          {/* Records */}
+          <div className="bg-white shadow rounded-lg overflow-hidden">
+            <div className="px-4 py-4 sm:px-6 border-b border-gray-200">
+              <h3 className="text-base font-medium text-gray-900">Records ({userData.records.length})</h3>
+            </div>
+            {userData.records.length === 0 ? (
+              <div className="px-4 py-8 text-center text-gray-500 text-sm">No records.</div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Card</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Score</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Income</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Result</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {userData.records.map((record) => (
+                      <tr key={record.record_id} className="hover:bg-gray-50">
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <div className="flex items-center">
+                            {record.card_image_link && (
+                              <div className="flex-shrink-0 h-8 w-12 relative mr-3">
+                                <Image
+                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${record.card_image_link}`}
+                                  alt={record.card_name}
+                                  fill
+                                  className="object-contain"
+                                  sizes="48px"
+                                />
+                              </div>
+                            )}
+                            <div>
+                              <div className="text-sm font-medium text-gray-900 truncate max-w-[200px]">
+                                {record.card_name}
+                              </div>
+                              <div className="text-xs text-gray-500">{record.bank}</div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">{record.credit_score}</td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                          ${record.listed_income?.toLocaleString()}
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className={`px-2 py-1 text-xs font-medium rounded-full ${
+                            record.result ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                          }`}>
+                            {record.result ? 'Approved' : 'Denied'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                          {new Date(record.submit_datetime).toLocaleDateString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          {/* Searches */}
+          <div className="bg-white shadow rounded-lg overflow-hidden">
+            <div className="px-4 py-4 sm:px-6 border-b border-gray-200">
+              <h3 className="text-base font-medium text-gray-900">Approval Searches ({userData.searches.length})</h3>
+            </div>
+            {userData.searches.length === 0 ? (
+              <div className="px-4 py-8 text-center text-gray-500 text-sm">No searches.</div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Score</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Income</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Length</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {userData.searches.map((search) => (
+                      <tr key={search.id} className="hover:bg-gray-50">
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">{search.credit_score}</td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                          ${search.income?.toLocaleString()}
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                          {search.length_credit} years
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                          {new Date(search.created_at).toLocaleString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          {/* Referrals */}
+          <div className="bg-white shadow rounded-lg overflow-hidden">
+            <div className="px-4 py-4 sm:px-6 border-b border-gray-200">
+              <h3 className="text-base font-medium text-gray-900">Referrals ({userData.referrals.length})</h3>
+            </div>
+            {userData.referrals.length === 0 ? (
+              <div className="px-4 py-8 text-center text-gray-500 text-sm">No referrals.</div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Card</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Link</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Stats</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {userData.referrals.map((referral) => (
+                      <tr key={referral.referral_id} className="hover:bg-gray-50">
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <div className="flex items-center">
+                            {referral.card_image_link && (
+                              <div className="flex-shrink-0 h-8 w-12 relative mr-3">
+                                <Image
+                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
+                                  alt={referral.card_name}
+                                  fill
+                                  className="object-contain"
+                                  sizes="48px"
+                                />
+                              </div>
+                            )}
+                            <div>
+                              <div className="text-sm font-medium text-gray-900 truncate max-w-[150px]">
+                                {referral.card_name}
+                              </div>
+                              <div className="text-xs text-gray-500">{referral.bank}</div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <a
+                            href={referral.referral_link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-sm text-indigo-600 hover:text-indigo-800 break-all max-w-[200px] block truncate"
+                          >
+                            {referral.referral_link}
+                          </a>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className={`px-2 py-1 text-xs font-medium rounded-full ${
+                            referral.admin_approved ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
+                          }`}>
+                            {referral.admin_approved ? 'Approved' : 'Pending'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                          <div>{referral.impressions} views</div>
+                          <div>{referral.clicks} clicks</div>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                          {new Date(referral.submit_datetime).toLocaleDateString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -606,6 +606,63 @@ export async function deleteAdminReferral(
   return res.json();
 }
 
+// Admin Searches
+export interface AdminSearch {
+  id: number;
+  user_id: string;
+  credit_score: number;
+  income: number;
+  length_credit: number;
+  created_at: string;
+}
+
+export interface AdminSearchesResponse {
+  searches: AdminSearch[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export async function getAdminSearches(
+  token: string,
+  limit = 100,
+  offset = 0
+): Promise<AdminSearchesResponse> {
+  const res = await fetch(`${API_BASE}/admin/searches?limit=${limit}&offset=${offset}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to fetch admin searches: ${res.status} ${errorText}`);
+  }
+  return res.json();
+}
+
+// Admin User Lookup
+export interface AdminUserData {
+  user_id: string;
+  records: AdminRecord[];
+  searches: AdminSearch[];
+  wallet: WalletCard[];
+  referrals: AdminReferral[];
+}
+
+export async function getAdminUser(
+  userId: string,
+  token: string
+): Promise<AdminUserData> {
+  const res = await fetch(`${API_BASE}/admin/user?user_id=${encodeURIComponent(userId)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to look up user: ${res.status} ${errorText}`);
+  }
+  return res.json();
+}
+
 // Admin Audit Log
 export interface AuditLogEntry {
   id: number;


### PR DESCRIPTION
## Summary
- **Preserve data on account delete**: Stop deleting `approval_searches` and `referral_stats` when a user deletes their account. Referrals are now anonymized (`submitter_id = NULL`) instead of deleted, keeping `referral_stats` intact via FK
- **Admin Searches tab**: New paginated view of all approval searches with clickable user IDs
- **Admin User Lookup tab**: Look up any user by Firebase UID to see their wallet, records, searches, and referrals in one place

## Test plan
- [ ] Delete account no longer removes approval_searches or referral_stats (referrals are anonymized)
- [ ] Admin dashboard Searches tab loads and displays paginated approval searches
- [ ] Clicking a user ID in Searches tab navigates to User Lookup with UID pre-filled
- [ ] User Lookup tab fetches and displays all data sections for a given Firebase UID
- [ ] Backend already deployed via `sam deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)