### PR TITLE
Overhaul OG images with richer backgrounds and dynamic data

### DIFF
--- a/apps/web-next/src/app/articles/[slug]/opengraph-image.tsx
+++ b/apps/web-next/src/app/articles/[slug]/opengraph-image.tsx
@@ -1,0 +1,188 @@
+import { ImageResponse } from 'next/og';
+import { getArticle } from '@/lib/articles';
+import { OGBackground, OGLogo, loadInterFonts, ARTICLE_TAG_COLORS, ARTICLE_TAG_LABELS } from '@/components/og/og-utils';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'edge';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function OGImage({ params }: Props) {
+  const { slug } = await params;
+  const article = await getArticle(slug);
+  const fonts = await loadInterFonts();
+
+  if (!article) {
+    return new ImageResponse(
+      (
+        <OGBackground>
+          <div
+            style={{
+              display: 'flex',
+              width: '100%',
+              height: '100%',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'white',
+            }}
+          >
+            <div style={{ fontSize: 64, fontWeight: 'bold' }}>CreditOdds</div>
+            <div style={{ fontSize: 32, marginTop: 16, opacity: 0.9 }}>Article Not Found</div>
+          </div>
+        </OGBackground>
+      ),
+      { ...size, fonts }
+    );
+  }
+
+  const firstTag = article.tags?.[0];
+  const tagColor = firstTag ? ARTICLE_TAG_COLORS[firstTag] : null;
+  const tagLabel = firstTag ? ARTICLE_TAG_LABELS[firstTag] : null;
+  const accentColor = tagColor?.accent;
+
+  const articleImageUrl = article.image
+    ? `https://d2hxvzw7msbtvt.cloudfront.net/article_images/${article.image}`
+    : null;
+
+  // Scale title font size based on length and image presence
+  const titleLen = article.title.length;
+  let titleSize: number;
+  if (articleImageUrl) {
+    titleSize = titleLen > 80 ? 30 : titleLen > 50 ? 36 : 42;
+  } else {
+    titleSize = titleLen > 80 ? 38 : titleLen > 50 ? 44 : 52;
+  }
+
+  const date = new Date(article.date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return new ImageResponse(
+    (
+      <OGBackground accentColor={accentColor}>
+        {/* Main content */}
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            alignItems: 'center',
+            padding: '60px 70px',
+          }}
+        >
+          {/* Left side: text */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              flex: 1,
+              paddingRight: articleImageUrl ? 40 : 0,
+            }}
+          >
+            {/* Tag badge */}
+            {tagColor && tagLabel && (
+              <div style={{ display: 'flex', marginBottom: 16 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    padding: '6px 16px',
+                    background: tagColor.bg,
+                    borderRadius: 50,
+                    color: tagColor.text,
+                    fontSize: 16,
+                    fontWeight: 'bold',
+                  }}
+                >
+                  {tagLabel}
+                </div>
+              </div>
+            )}
+
+            {/* Title */}
+            <div
+              style={{
+                color: 'white',
+                fontSize: titleSize,
+                fontWeight: 'bold',
+                letterSpacing: -1,
+                lineHeight: 1.2,
+                maxWidth: articleImageUrl ? 600 : 1000,
+                overflow: 'hidden',
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+              }}
+            >
+              {article.title}
+            </div>
+
+            {/* Author + reading time */}
+            <div
+              style={{
+                display: 'flex',
+                marginTop: 20,
+                gap: 20,
+                color: 'rgba(255,255,255,0.7)',
+                fontSize: 20,
+              }}
+            >
+              <span>{article.author}</span>
+              <span>·</span>
+              <span>{date}</span>
+              <span>·</span>
+              <span>{article.reading_time} min read</span>
+            </div>
+          </div>
+
+          {/* Right side: article image */}
+          {articleImageUrl && (
+            <div
+              style={{
+                display: 'flex',
+                flexShrink: 0,
+                borderRadius: 16,
+                boxShadow: '0 25px 80px rgba(0,0,0,0.4), 0 10px 30px rgba(0,0,0,0.3)',
+                overflow: 'hidden',
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={articleImageUrl}
+                alt={article.title}
+                width={420}
+                height={280}
+                style={{ objectFit: 'cover' }}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Logo in bottom left */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -46,10 +46,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const openGraphImages = article.image
-    ? [{ url: `https://d2hxvzw7msbtvt.cloudfront.net/article_images/${article.image}` }]
-    : undefined;
-
   return {
     title: article.seo_title || `${article.title} | CreditOdds`,
     description: article.seo_description || article.summary,
@@ -61,7 +57,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       publishedTime: article.date,
       modifiedTime: article.updated_at || article.date,
       authors: [article.author],
-      images: openGraphImages,
     },
     alternates: {
       canonical: `https://creditodds.com/articles/${article.slug}`,

--- a/apps/web-next/src/app/articles/[slug]/twitter-image.tsx
+++ b/apps/web-next/src/app/articles/[slug]/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, size, contentType } from './opengraph-image';

--- a/apps/web-next/src/app/card/[name]/opengraph-image.tsx
+++ b/apps/web-next/src/app/card/[name]/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
 import { getCard } from '@/lib/api';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
 
-// Image dimensions for OG images
 export const size = {
   width: 1200,
   height: 630,
@@ -9,7 +9,6 @@ export const size = {
 
 export const contentType = 'image/png';
 
-// Allow dynamic generation
 export const runtime = 'edge';
 
 interface Props {
@@ -18,39 +17,32 @@ interface Props {
 
 export default async function OGImage({ params }: Props) {
   const { name: slug } = await params;
+  const fonts = await loadInterFonts();
 
   let card;
   try {
     card = await getCard(slug);
   } catch {
-    // Return a default image if card not found
     return new ImageResponse(
       (
-        <div
-          style={{
-            width: '100%',
-            height: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
-            fontFamily: 'system-ui, sans-serif',
-          }}
-        >
+        <OGBackground>
           <div
             style={{
               display: 'flex',
+              width: '100%',
+              height: '100%',
               flexDirection: 'column',
               alignItems: 'center',
+              justifyContent: 'center',
               color: 'white',
             }}
           >
             <div style={{ fontSize: 64, fontWeight: 'bold' }}>CreditOdds</div>
             <div style={{ fontSize: 32, marginTop: 16, opacity: 0.9 }}>Card Not Found</div>
           </div>
-        </div>
+        </OGBackground>
       ),
-      { ...size }
+      { ...size, fonts }
     );
   }
 
@@ -58,56 +50,145 @@ export default async function OGImage({ params }: Props) {
     ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
     : null;
 
+  const totalRecords = card.total_records || 0;
+  const approvedCount = card.approved_count || 0;
+  const approvalRate = totalRecords > 0 ? Math.round((approvedCount / totalRecords) * 100) : 0;
+  const medianScore = card.approved_median_credit_score || 0;
+  const hasStats = totalRecords > 0;
+
   return new ImageResponse(
     (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          position: 'relative',
-          background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
-          fontFamily: 'system-ui, sans-serif',
-        }}
-      >
-        {/* Background pattern overlay */}
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundImage: 'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.1) 0%, transparent 50%)',
-            display: 'flex',
-          }}
-        />
-
-        {/* Main content */}
+      <OGBackground>
+        {/* Main content — two-column layout */}
         <div
           style={{
             display: 'flex',
             width: '100%',
             height: '100%',
             alignItems: 'center',
-            justifyContent: 'center',
-            padding: 60,
+            padding: '60px 70px',
           }}
         >
-          {/* Card image or placeholder */}
+          {/* Left side: text + stats */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              flex: 1,
+              paddingRight: cardImageUrl ? 40 : 0,
+            }}
+          >
+            {/* Bank */}
+            <div
+              style={{
+                color: 'rgba(255,255,255,0.7)',
+                fontSize: 22,
+                marginBottom: 12,
+              }}
+            >
+              {card.bank}
+            </div>
+
+            {/* Card name */}
+            <div
+              style={{
+                color: 'white',
+                fontSize: card.card_name.length > 30 ? 36 : 44,
+                fontWeight: 'bold',
+                letterSpacing: -1,
+                lineHeight: 1.15,
+                maxWidth: 580,
+                marginBottom: hasStats ? 32 : 0,
+              }}
+            >
+              {card.card_name}
+            </div>
+
+            {/* Stats boxes */}
+            {hasStats && (
+              <div style={{ display: 'flex', gap: 16 }}>
+                {/* Approval Rate */}
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    padding: '16px 20px',
+                    background: 'rgba(255,255,255,0.12)',
+                    backdropFilter: 'blur(10px)',
+                    borderRadius: 14,
+                    border: '1px solid rgba(255,255,255,0.15)',
+                    minWidth: 130,
+                  }}
+                >
+                  <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: 14, marginBottom: 6 }}>
+                    Approval Rate
+                  </div>
+                  <div style={{ color: 'white', fontSize: 32, fontWeight: 'bold' }}>
+                    {approvalRate}%
+                  </div>
+                </div>
+
+                {/* Median Score */}
+                {medianScore > 0 && (
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      padding: '16px 20px',
+                      background: 'rgba(255,255,255,0.12)',
+                      backdropFilter: 'blur(10px)',
+                      borderRadius: 14,
+                      border: '1px solid rgba(255,255,255,0.15)',
+                      minWidth: 130,
+                    }}
+                  >
+                    <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: 14, marginBottom: 6 }}>
+                      Median Score
+                    </div>
+                    <div style={{ color: 'white', fontSize: 32, fontWeight: 'bold' }}>
+                      {medianScore}
+                    </div>
+                  </div>
+                )}
+
+                {/* Data Points */}
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    padding: '16px 20px',
+                    background: 'rgba(255,255,255,0.12)',
+                    backdropFilter: 'blur(10px)',
+                    borderRadius: 14,
+                    border: '1px solid rgba(255,255,255,0.15)',
+                    minWidth: 130,
+                  }}
+                >
+                  <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: 14, marginBottom: 6 }}>
+                    Data Points
+                  </div>
+                  <div style={{ color: 'white', fontSize: 32, fontWeight: 'bold' }}>
+                    {totalRecords}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Right side: card image (slightly rotated) */}
           {cardImageUrl ? (
             <div
               style={{
                 display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
+                flexShrink: 0,
+                transform: 'rotate(3deg)',
               }}
             >
-              {/* Card with shadow effect */}
               <div
                 style={{
                   display: 'flex',
-                  borderRadius: 24,
+                  borderRadius: 20,
                   boxShadow: '0 25px 80px rgba(0,0,0,0.4), 0 10px 30px rgba(0,0,0,0.3)',
                 }}
               >
@@ -115,119 +196,46 @@ export default async function OGImage({ params }: Props) {
                 <img
                   src={cardImageUrl}
                   alt={card.card_name}
-                  width={500}
-                  height={315}
-                  style={{
-                    borderRadius: 16,
-                  }}
+                  width={420}
+                  height={265}
+                  style={{ borderRadius: 16 }}
                 />
-              </div>
-
-              {/* Card name below */}
-              <div
-                style={{
-                  marginTop: 40,
-                  color: 'white',
-                  fontSize: 42,
-                  fontWeight: 'bold',
-                  textAlign: 'center',
-                  maxWidth: 900,
-                }}
-              >
-                {card.card_name}
               </div>
             </div>
           ) : (
             <div
               style={{
                 display: 'flex',
-                flexDirection: 'column',
+                flexShrink: 0,
+                width: 350,
+                height: 220,
+                background: 'linear-gradient(145deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.05) 100%)',
+                borderRadius: 16,
                 alignItems: 'center',
-                color: 'white',
+                justifyContent: 'center',
+                fontSize: 64,
+                boxShadow: '0 25px 80px rgba(0,0,0,0.3)',
+                transform: 'rotate(3deg)',
               }}
             >
-              <div
-                style={{
-                  width: 400,
-                  height: 252,
-                  background: 'linear-gradient(145deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.05) 100%)',
-                  borderRadius: 16,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: 48,
-                  boxShadow: '0 25px 80px rgba(0,0,0,0.3)',
-                }}
-              >
-                💳
-              </div>
-              <div
-                style={{
-                  marginTop: 40,
-                  fontSize: 42,
-                  fontWeight: 'bold',
-                  textAlign: 'center',
-                  maxWidth: 900,
-                }}
-              >
-                {card.card_name}
-              </div>
+              💳
             </div>
           )}
         </div>
 
-        {/* Logo in bottom left corner */}
+        {/* Logo in bottom left */}
         <div
           style={{
             position: 'absolute',
-            bottom: 40,
-            left: 50,
+            bottom: 30,
+            left: 40,
             display: 'flex',
-            alignItems: 'center',
-            color: 'white',
           }}
         >
-          {/* Logo icon */}
-          <svg
-            width="48"
-            height="48"
-            viewBox="0 0 180 180"
-            style={{ marginRight: 12 }}
-          >
-            <ellipse cx="138.19" cy="63.59" rx="9" ry="10.38" fill="white" />
-            <ellipse cx="161.11" cy="68.38" rx="7.02" ry="8.09" fill="white" />
-            <ellipse cx="138.71" cy="97.12" rx="9" ry="10.38" fill="white" />
-            <ellipse cx="161.63" cy="101.92" rx="7.02" ry="8.09" fill="white" />
-            <path
-              d="M114.57,53.6V33.17c0-4.47-3.53-7.45-6.66-5.63l-42.9,24.98c-1.7,0.99-2.8,3.2-2.8,5.63v17.29L114.57,53.6z"
-              fill="white"
-            />
-            <path
-              d="M62.22,91.14v30.3c0,3.41,2.12,6.17,4.73,6.17h42.9c2.61,0,4.73-2.76,4.73-6.17V74.71L62.22,91.14z"
-              fill="white"
-            />
-          </svg>
-          <span style={{ fontSize: 32, fontWeight: 'bold', letterSpacing: -0.5 }}>
-            CreditOdds
-          </span>
+          <OGLogo size={40} />
         </div>
-
-        {/* Bank name in bottom right */}
-        <div
-          style={{
-            position: 'absolute',
-            bottom: 45,
-            right: 50,
-            display: 'flex',
-            alignItems: 'center',
-            color: 'rgba(255,255,255,0.8)',
-            fontSize: 24,
-          }}
-        >
-          {card.bank}
-        </div>
-      </div>
+      </OGBackground>
     ),
-    { ...size }
+    { ...size, fonts }
   );
 }

--- a/apps/web-next/src/app/explore/opengraph-image.tsx
+++ b/apps/web-next/src/app/explore/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
 
-// Image dimensions for OG images
 export const size = {
   width: 1200,
   height: 630,
@@ -11,31 +11,11 @@ export const contentType = 'image/png';
 export const runtime = 'edge';
 
 export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
   return new ImageResponse(
     (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          position: 'relative',
-          background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
-          fontFamily: 'system-ui, sans-serif',
-        }}
-      >
-        {/* Background pattern overlay */}
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundImage: 'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.1) 0%, transparent 50%)',
-            display: 'flex',
-          }}
-        />
-
+      <OGBackground>
         {/* Main content */}
         <div
           style={{
@@ -135,42 +115,19 @@ export default async function OGImage() {
           </div>
         </div>
 
-        {/* Logo in bottom left corner */}
+        {/* Logo in bottom left */}
         <div
           style={{
             position: 'absolute',
-            bottom: 40,
-            left: 50,
+            bottom: 30,
+            left: 40,
             display: 'flex',
-            alignItems: 'center',
-            color: 'white',
           }}
         >
-          <svg
-            width="48"
-            height="48"
-            viewBox="0 0 180 180"
-            style={{ marginRight: 12 }}
-          >
-            <ellipse cx="138.19" cy="63.59" rx="9" ry="10.38" fill="white" />
-            <ellipse cx="161.11" cy="68.38" rx="7.02" ry="8.09" fill="white" />
-            <ellipse cx="138.71" cy="97.12" rx="9" ry="10.38" fill="white" />
-            <ellipse cx="161.63" cy="101.92" rx="7.02" ry="8.09" fill="white" />
-            <path
-              d="M114.57,53.6V33.17c0-4.47-3.53-7.45-6.66-5.63l-42.9,24.98c-1.7,0.99-2.8,3.2-2.8,5.63v17.29L114.57,53.6z"
-              fill="white"
-            />
-            <path
-              d="M62.22,91.14v30.3c0,3.41,2.12,6.17,4.73,6.17h42.9c2.61,0,4.73-2.76,4.73-6.17V74.71L62.22,91.14z"
-              fill="white"
-            />
-          </svg>
-          <span style={{ fontSize: 32, fontWeight: 'bold', letterSpacing: -0.5 }}>
-            CreditOdds
-          </span>
+          <OGLogo size={40} />
         </div>
-      </div>
+      </OGBackground>
     ),
-    { ...size }
+    { ...size, fonts }
   );
 }

--- a/apps/web-next/src/app/news/[id]/opengraph-image.tsx
+++ b/apps/web-next/src/app/news/[id]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { getNewsItem } from '@/lib/news';
+import { OGBackground, OGLogo, loadInterFonts, NEWS_TAG_COLORS, NEWS_TAG_LABELS } from '@/components/og/og-utils';
 
 export const size = {
   width: 1200,
@@ -13,11 +14,17 @@ export const runtime = 'edge';
 export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const item = await getNewsItem(id);
+  const fonts = await loadInterFonts();
 
   const title = item?.title || 'Card News';
   const date = item?.date
     ? new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
     : '';
+
+  // Tag color
+  const firstTag = item?.tags?.[0] || 'general';
+  const tagColor = NEWS_TAG_COLORS[firstTag] || NEWS_TAG_COLORS['general'];
+  const tagLabel = NEWS_TAG_LABELS[firstTag] || 'News';
 
   // Single card referenced — show card image
   const hasSingleCard = item?.card_slugs?.length === 1 && item?.card_image_links?.[0];
@@ -28,25 +35,16 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
 
   return new ImageResponse(
     (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          position: 'relative',
-          background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
-          fontFamily: 'system-ui, sans-serif',
-        }}
-      >
-        {/* Background pattern overlay */}
+      <OGBackground accentColor={tagColor.accent}>
+        {/* Color-coded accent bar at top */}
         <div
           style={{
             position: 'absolute',
             top: 0,
             left: 0,
             right: 0,
-            bottom: 0,
-            backgroundImage: 'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.1) 0%, transparent 50%)',
+            height: 5,
+            background: tagColor.accent,
             display: 'flex',
           }}
         />
@@ -58,7 +56,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
             width: '100%',
             height: '100%',
             alignItems: 'center',
-            padding: '60px 80px',
+            padding: '60px 70px',
           }}
         >
           {/* Left side: text */}
@@ -71,13 +69,31 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
               paddingRight: cardImageUrl ? 40 : 0,
             }}
           >
+            {/* Tag badge */}
+            <div style={{ display: 'flex', marginBottom: 16 }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '6px 16px',
+                  background: tagColor.bg,
+                  borderRadius: 50,
+                  color: tagColor.text,
+                  fontSize: 16,
+                  fontWeight: 'bold',
+                }}
+              >
+                {tagLabel}
+              </div>
+            </div>
+
             {/* Date */}
             {date && (
               <div
                 style={{
                   color: 'rgba(255,255,255,0.7)',
-                  fontSize: 24,
-                  marginBottom: 16,
+                  fontSize: 22,
+                  marginBottom: 14,
                 }}
               >
                 {date}
@@ -94,7 +110,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
                 fontWeight: 'bold',
                 letterSpacing: -1,
                 lineHeight: 1.2,
-                maxWidth: cardImageUrl ? 650 : 1000,
+                maxWidth: cardImageUrl ? 620 : 1000,
                 overflow: 'hidden',
                 display: '-webkit-box',
                 WebkitLineClamp: 3,
@@ -103,32 +119,9 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
             >
               {title}
             </div>
-
-            {/* Tag line */}
-            <div
-              style={{
-                display: 'flex',
-                marginTop: 24,
-                gap: 12,
-              }}
-            >
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  padding: '8px 20px',
-                  background: 'rgba(255,255,255,0.15)',
-                  borderRadius: 50,
-                  color: 'white',
-                  fontSize: 18,
-                }}
-              >
-                Card News
-              </div>
-            </div>
           </div>
 
-          {/* Right side: card image (single card only) */}
+          {/* Right side: card image (tilted) */}
           {cardImageUrl && (
             <div
               style={{
@@ -136,6 +129,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
                 flexDirection: 'column',
                 alignItems: 'center',
                 flexShrink: 0,
+                transform: 'rotate(-3deg)',
               }}
             >
               <div
@@ -151,9 +145,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
                   alt={cardName || ''}
                   width={380}
                   height={240}
-                  style={{
-                    borderRadius: 16,
-                  }}
+                  style={{ borderRadius: 16 }}
                 />
               </div>
               {cardName && (
@@ -161,7 +153,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
                   style={{
                     marginTop: 16,
                     color: 'rgba(255,255,255,0.8)',
-                    fontSize: 20,
+                    fontSize: 18,
                     textAlign: 'center',
                     maxWidth: 380,
                   }}
@@ -173,42 +165,19 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
           )}
         </div>
 
-        {/* Logo in bottom left corner */}
+        {/* Logo in bottom left */}
         <div
           style={{
             position: 'absolute',
-            bottom: 40,
-            left: 50,
+            bottom: 30,
+            left: 40,
             display: 'flex',
-            alignItems: 'center',
-            color: 'white',
           }}
         >
-          <svg
-            width="48"
-            height="48"
-            viewBox="0 0 180 180"
-            style={{ marginRight: 12 }}
-          >
-            <ellipse cx="138.19" cy="63.59" rx="9" ry="10.38" fill="white" />
-            <ellipse cx="161.11" cy="68.38" rx="7.02" ry="8.09" fill="white" />
-            <ellipse cx="138.71" cy="97.12" rx="9" ry="10.38" fill="white" />
-            <ellipse cx="161.63" cy="101.92" rx="7.02" ry="8.09" fill="white" />
-            <path
-              d="M114.57,53.6V33.17c0-4.47-3.53-7.45-6.66-5.63l-42.9,24.98c-1.7,0.99-2.8,3.2-2.8,5.63v17.29L114.57,53.6z"
-              fill="white"
-            />
-            <path
-              d="M62.22,91.14v30.3c0,3.41,2.12,6.17,4.73,6.17h42.9c2.61,0,4.73-2.76,4.73-6.17V74.71L62.22,91.14z"
-              fill="white"
-            />
-          </svg>
-          <span style={{ fontSize: 32, fontWeight: 'bold', letterSpacing: -0.5 }}>
-            CreditOdds
-          </span>
+          <OGLogo size={40} />
         </div>
-      </div>
+      </OGBackground>
     ),
-    { ...size }
+    { ...size, fonts }
   );
 }

--- a/apps/web-next/src/app/news/opengraph-image.tsx
+++ b/apps/web-next/src/app/news/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
 
-// Image dimensions for OG images
 export const size = {
   width: 1200,
   height: 630,
@@ -11,31 +11,11 @@ export const contentType = 'image/png';
 export const runtime = 'edge';
 
 export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
   return new ImageResponse(
     (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          position: 'relative',
-          background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
-          fontFamily: 'system-ui, sans-serif',
-        }}
-      >
-        {/* Background pattern overlay */}
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundImage: 'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.1) 0%, transparent 50%)',
-            display: 'flex',
-          }}
-        />
-
+      <OGBackground>
         {/* Main content */}
         <div
           style={{
@@ -98,84 +78,38 @@ export default async function OGImage() {
               gap: 16,
             }}
           >
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '10px 20px',
-                background: 'rgba(255,255,255,0.15)',
-                borderRadius: 50,
-                color: 'white',
-                fontSize: 18,
-              }}
-            >
-              New Cards
-            </div>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '10px 20px',
-                background: 'rgba(255,255,255,0.15)',
-                borderRadius: 50,
-                color: 'white',
-                fontSize: 18,
-              }}
-            >
-              Bonus Updates
-            </div>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '10px 20px',
-                background: 'rgba(255,255,255,0.15)',
-                borderRadius: 50,
-                color: 'white',
-                fontSize: 18,
-              }}
-            >
-              Industry News
-            </div>
+            {['New Cards', 'Bonus Updates', 'Industry News'].map((label) => (
+              <div
+                key={label}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '10px 20px',
+                  background: 'rgba(255,255,255,0.15)',
+                  borderRadius: 50,
+                  color: 'white',
+                  fontSize: 18,
+                }}
+              >
+                {label}
+              </div>
+            ))}
           </div>
         </div>
 
-        {/* Logo in bottom left corner */}
+        {/* Logo in bottom left */}
         <div
           style={{
             position: 'absolute',
-            bottom: 40,
-            left: 50,
+            bottom: 30,
+            left: 40,
             display: 'flex',
-            alignItems: 'center',
-            color: 'white',
           }}
         >
-          <svg
-            width="48"
-            height="48"
-            viewBox="0 0 180 180"
-            style={{ marginRight: 12 }}
-          >
-            <ellipse cx="138.19" cy="63.59" rx="9" ry="10.38" fill="white" />
-            <ellipse cx="161.11" cy="68.38" rx="7.02" ry="8.09" fill="white" />
-            <ellipse cx="138.71" cy="97.12" rx="9" ry="10.38" fill="white" />
-            <ellipse cx="161.63" cy="101.92" rx="7.02" ry="8.09" fill="white" />
-            <path
-              d="M114.57,53.6V33.17c0-4.47-3.53-7.45-6.66-5.63l-42.9,24.98c-1.7,0.99-2.8,3.2-2.8,5.63v17.29L114.57,53.6z"
-              fill="white"
-            />
-            <path
-              d="M62.22,91.14v30.3c0,3.41,2.12,6.17,4.73,6.17h42.9c2.61,0,4.73-2.76,4.73-6.17V74.71L62.22,91.14z"
-              fill="white"
-            />
-          </svg>
-          <span style={{ fontSize: 32, fontWeight: 'bold', letterSpacing: -0.5 }}>
-            CreditOdds
-          </span>
+          <OGLogo size={40} />
         </div>
-      </div>
+      </OGBackground>
     ),
-    { ...size }
+    { ...size, fonts }
   );
 }

--- a/apps/web-next/src/app/opengraph-image.tsx
+++ b/apps/web-next/src/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts, formatStatNumber } from '@/components/og/og-utils';
 
-// Image dimensions for OG images
 export const size = {
   width: 1200,
   height: 630,
@@ -10,33 +10,44 @@ export const contentType = 'image/png';
 
 export const runtime = 'edge';
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
+
 export default async function OGImage() {
+  let totalRecords = 0;
+  let totalContributors = 0;
+  let cardCount = 0;
+
+  try {
+    const [leaderboardRes, cardsRes] = await Promise.all([
+      fetch(`${API_BASE}/leaderboard?limit=1`, { next: { revalidate: 300 } }),
+      fetch(`${API_BASE}/cards`, { next: { revalidate: 300 } }),
+    ]);
+
+    if (leaderboardRes.ok) {
+      const data = await leaderboardRes.json();
+      totalRecords = data.stats?.total_records || 0;
+      totalContributors = data.stats?.total_contributors || 0;
+    }
+
+    if (cardsRes.ok) {
+      const cards = await cardsRes.json();
+      cardCount = Array.isArray(cards) ? cards.length : 0;
+    }
+  } catch {
+    // Graceful fallback — use zeros
+  }
+
+  const fonts = await loadInterFonts();
+
+  const pills = [
+    totalRecords > 0 ? `${formatStatNumber(totalRecords)} Data Points` : 'Real Data Points',
+    totalContributors > 0 ? `${formatStatNumber(totalContributors)} Users` : 'Community Powered',
+    cardCount > 0 ? `${formatStatNumber(cardCount)} Cards Tracked` : '100% Free',
+  ];
+
   return new ImageResponse(
     (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          position: 'relative',
-          background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
-          fontFamily: 'system-ui, sans-serif',
-        }}
-      >
-        {/* Background pattern overlay */}
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundImage: 'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.1) 0%, transparent 50%)',
-            display: 'flex',
-          }}
-        />
-
-        {/* Main content */}
+      <OGBackground>
         <div
           style={{
             display: 'flex',
@@ -48,7 +59,7 @@ export default async function OGImage() {
             padding: 60,
           }}
         >
-          {/* Logo */}
+          {/* Logo icon */}
           <svg
             width="120"
             height="120"
@@ -94,7 +105,7 @@ export default async function OGImage() {
             Discover Your Credit Card Approval Odds
           </div>
 
-          {/* Feature pills */}
+          {/* Dynamic stat pills */}
           <div
             style={{
               display: 'flex',
@@ -102,49 +113,29 @@ export default async function OGImage() {
               gap: 20,
             }}
           >
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '12px 24px',
-                background: 'rgba(255,255,255,0.15)',
-                borderRadius: 50,
-                color: 'white',
-                fontSize: 20,
-              }}
-            >
-              Real Data Points
-            </div>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '12px 24px',
-                background: 'rgba(255,255,255,0.15)',
-                borderRadius: 50,
-                color: 'white',
-                fontSize: 20,
-              }}
-            >
-              Community Powered
-            </div>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '12px 24px',
-                background: 'rgba(255,255,255,0.15)',
-                borderRadius: 50,
-                color: 'white',
-                fontSize: 20,
-              }}
-            >
-              100% Free
-            </div>
+            {pills.map((pill) => (
+              <div
+                key={pill}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '12px 24px',
+                  background: 'rgba(255,255,255,0.15)',
+                  borderRadius: 50,
+                  color: 'white',
+                  fontSize: 20,
+                }}
+              >
+                {pill}
+              </div>
+            ))}
           </div>
         </div>
-      </div>
+      </OGBackground>
     ),
-    { ...size }
+    {
+      ...size,
+      fonts,
+    }
   );
 }

--- a/apps/web-next/src/components/og/InfoPageOGImage.tsx
+++ b/apps/web-next/src/components/og/InfoPageOGImage.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
+import { OGBackground, loadInterFonts } from '@/components/og/og-utils';
 
-// Image dimensions for OG images
 export const size = {
   width: 1200,
   height: 630,
@@ -9,31 +9,11 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function InfoPageOGImage() {
+  const fonts = await loadInterFonts();
+
   return new ImageResponse(
     (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          position: 'relative',
-          background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
-          fontFamily: 'system-ui, sans-serif',
-        }}
-      >
-        {/* Background pattern overlay */}
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundImage: 'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.1) 0%, transparent 50%)',
-            display: 'flex',
-          }}
-        />
-
+      <OGBackground>
         {/* Main content */}
         <div
           style={{
@@ -108,8 +88,8 @@ export default async function InfoPageOGImage() {
             creditodds.com
           </div>
         </div>
-      </div>
+      </OGBackground>
     ),
-    { ...size }
+    { ...size, fonts }
   );
 }

--- a/apps/web-next/src/components/og/og-utils.tsx
+++ b/apps/web-next/src/components/og/og-utils.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+
+// ── Color constants for OG images (hex equivalents of Tailwind classes) ──
+
+export const NEWS_TAG_COLORS: Record<string, { bg: string; text: string; accent: string }> = {
+  'new-card':       { bg: '#ecfdf5', text: '#047857', accent: '#10b981' },
+  'discontinued':   { bg: '#fef2f2', text: '#b91c1c', accent: '#ef4444' },
+  'bonus-change':   { bg: '#eff6ff', text: '#1d4ed8', accent: '#3b82f6' },
+  'fee-change':     { bg: '#fffbeb', text: '#b45309', accent: '#f59e0b' },
+  'benefit-change': { bg: '#f5f3ff', text: '#6d28d9', accent: '#8b5cf6' },
+  'limited-time':   { bg: '#fff7ed', text: '#c2410c', accent: '#f97316' },
+  'policy-change':  { bg: '#f8fafc', text: '#334155', accent: '#64748b' },
+  'general':        { bg: '#eef2ff', text: '#4338ca', accent: '#6366f1' },
+};
+
+export const ARTICLE_TAG_COLORS: Record<string, { bg: string; text: string; accent: string }> = {
+  'strategy':      { bg: '#f3e8ff', text: '#6b21a8', accent: '#a855f7' },
+  'guide':         { bg: '#dbeafe', text: '#1e40af', accent: '#3b82f6' },
+  'analysis':      { bg: '#dcfce7', text: '#166534', accent: '#22c55e' },
+  'news-analysis': { bg: '#ffedd5', text: '#9a3412', accent: '#f97316' },
+  'beginner':      { bg: '#ccfbf1', text: '#115e59', accent: '#14b8a6' },
+};
+
+export const NEWS_TAG_LABELS: Record<string, string> = {
+  'new-card': 'New Card',
+  'discontinued': 'Discontinued',
+  'bonus-change': 'Bonus Change',
+  'fee-change': 'Fee Change',
+  'benefit-change': 'Benefit Change',
+  'limited-time': 'Limited Time',
+  'policy-change': 'Policy Change',
+  'general': 'General',
+};
+
+export const ARTICLE_TAG_LABELS: Record<string, string> = {
+  'strategy': 'Strategy',
+  'guide': 'Guide',
+  'analysis': 'Analysis',
+  'news-analysis': 'News Analysis',
+  'beginner': 'Beginner',
+};
+
+// ── Format numbers for display ──
+
+export function formatStatNumber(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    // Show one decimal if < 100k, otherwise round
+    const formatted = k >= 100 ? Math.round(k).toString() : k.toFixed(1).replace(/\.0$/, '');
+    return `${formatted}K+`;
+  }
+  return `${n}+`;
+}
+
+// ── Load Inter fonts from Google Fonts CDN ──
+
+export async function loadInterFonts(): Promise<{ name: string; data: ArrayBuffer; style: 'normal'; weight: 400 | 700 }[]> {
+  const [regular, bold] = await Promise.all([
+    fetch('https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZ9hjQ.woff2').then(r => r.arrayBuffer()),
+    fetch('https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYAZ9hjQ.woff2').then(r => r.arrayBuffer()),
+  ]);
+
+  return [
+    { name: 'Inter', data: regular, style: 'normal' as const, weight: 400 as const },
+    { name: 'Inter', data: bold, style: 'normal' as const, weight: 700 as const },
+  ];
+}
+
+// ── OGLogo component ──
+
+export function OGLogo({ size = 48 }: { size?: number }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 180 180"
+        style={{ marginRight: 12 }}
+      >
+        <ellipse cx="138.19" cy="63.59" rx="9" ry="10.38" fill="white" />
+        <ellipse cx="161.11" cy="68.38" rx="7.02" ry="8.09" fill="white" />
+        <ellipse cx="138.71" cy="97.12" rx="9" ry="10.38" fill="white" />
+        <ellipse cx="161.63" cy="101.92" rx="7.02" ry="8.09" fill="white" />
+        <path
+          d="M114.57,53.6V33.17c0-4.47-3.53-7.45-6.66-5.63l-42.9,24.98c-1.7,0.99-2.8,3.2-2.8,5.63v17.29L114.57,53.6z"
+          fill="white"
+        />
+        <path
+          d="M62.22,91.14v30.3c0,3.41,2.12,6.17,4.73,6.17h42.9c2.61,0,4.73-2.76,4.73-6.17V74.71L62.22,91.14z"
+          fill="white"
+        />
+      </svg>
+      <span style={{ fontSize: Math.round(size * 0.67), fontWeight: 'bold', letterSpacing: -0.5, color: 'white' }}>
+        CreditOdds
+      </span>
+    </div>
+  );
+}
+
+// ── OGBackground component ──
+
+export function OGBackground({
+  children,
+  accentColor,
+}: {
+  children: React.ReactNode;
+  accentColor?: string;
+}) {
+  const warmGlow = accentColor || '#f59e0b';
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        position: 'relative',
+        background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
+        fontFamily: 'Inter, system-ui, sans-serif',
+      }}
+    >
+      {/* Dot grid pattern overlay */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.12) 1px, transparent 1px)',
+          backgroundSize: '24px 24px',
+          display: 'flex',
+        }}
+      />
+
+      {/* Cool indigo glow — top left */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundImage: 'radial-gradient(circle at 15% 20%, rgba(99,102,241,0.4) 0%, transparent 50%)',
+          display: 'flex',
+        }}
+      />
+
+      {/* Warm accent glow — bottom right */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundImage: `radial-gradient(circle at 85% 80%, ${hexToRgba(warmGlow, 0.25)} 0%, transparent 50%)`,
+          display: 'flex',
+        }}
+      />
+
+      {/* Thin white inset border */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          left: 12,
+          right: 12,
+          bottom: 12,
+          border: '1px solid rgba(255,255,255,0.15)',
+          borderRadius: 16,
+          display: 'flex',
+        }}
+      />
+
+      {/* Content */}
+      {children}
+    </div>
+  );
+}
+
+// ── Helpers ──
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -59,6 +59,7 @@ export interface Card {
   approved_median_length_credit?: string | number;
   approved_count?: number;
   rejected_count?: number;
+  total_records?: number;
   release_date?: string;
   tags?: string[];
   category?: string;


### PR DESCRIPTION
## Summary
- Add shared `og-utils.tsx` with `OGBackground` (dot grid pattern, dual glows, inset border), `OGLogo`, Inter font loader, and tag color constants
- **Home page**: dynamic stat pills fetched from leaderboard + cards APIs
- **Card detail**: two-column layout with rotated card image and frosted-glass stat boxes (approval rate, median score, data points)
- **News detail**: color-coded 5px accent bar and tag badge based on news category, tilted card image
- **Articles**: new OG image with tag badge, title, author/date/reading time, optional article image
- **Static pages** (news, explore, about, how, terms, privacy): new background + Inter font
- Add `total_records` to Card TS interface; remove hardcoded OG images from article metadata

## Test plan
- [ ] Visit `/opengraph-image` — verify dynamic stats render
- [ ] Visit `/card/chase-sapphire-preferred/opengraph-image` — verify stat boxes and rotated card image
- [ ] Visit `/news/[any-id]/opengraph-image` — verify color accent bar and tag badge
- [ ] Visit `/explore/opengraph-image` — verify new background
- [ ] Visit `/articles/[any-slug]/opengraph-image` — verify new article OG image
- [ ] All images render at 1200x630 with Inter font, dot grid, dual glows, inset border
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)