### PR TITLE
Fix OG image bugs and simplify card layout

### DIFF
--- a/apps/web-next/src/app/articles/[slug]/opengraph-image.tsx
+++ b/apps/web-next/src/app/articles/[slug]/opengraph-image.tsx
@@ -9,8 +9,6 @@ export const size = {
 
 export const contentType = 'image/png';
 
-export const runtime = 'edge';
-
 interface Props {
   params: Promise<{ slug: string }>;
 }

--- a/apps/web-next/src/app/card/[name]/opengraph-image.tsx
+++ b/apps/web-next/src/app/card/[name]/opengraph-image.tsx
@@ -37,8 +37,8 @@ export default async function OGImage({ params }: Props) {
               color: 'white',
             }}
           >
-            <div style={{ fontSize: 64, fontWeight: 'bold' }}>CreditOdds</div>
-            <div style={{ fontSize: 32, marginTop: 16, opacity: 0.9 }}>Card Not Found</div>
+            <div style={{ display: 'flex', fontSize: 64, fontWeight: 'bold' }}>CreditOdds</div>
+            <div style={{ display: 'flex', fontSize: 32, marginTop: 16, opacity: 0.9 }}>Card Not Found</div>
           </div>
         </OGBackground>
       ),
@@ -50,139 +50,27 @@ export default async function OGImage({ params }: Props) {
     ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
     : null;
 
-  const totalRecords = card.total_records || 0;
-  const approvedCount = card.approved_count || 0;
-  const approvalRate = totalRecords > 0 ? Math.round((approvedCount / totalRecords) * 100) : 0;
-  const medianScore = card.approved_median_credit_score || 0;
-  const hasStats = totalRecords > 0;
-
   return new ImageResponse(
     (
       <OGBackground>
-        {/* Main content — two-column layout */}
+        {/* Main content */}
         <div
           style={{
             display: 'flex',
             width: '100%',
             height: '100%',
             alignItems: 'center',
-            padding: '60px 70px',
+            justifyContent: 'center',
+            padding: 60,
           }}
         >
-          {/* Left side: text + stats */}
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              flex: 1,
-              paddingRight: cardImageUrl ? 40 : 0,
-            }}
-          >
-            {/* Bank */}
-            <div
-              style={{
-                color: 'rgba(255,255,255,0.7)',
-                fontSize: 22,
-                marginBottom: 12,
-              }}
-            >
-              {card.bank}
-            </div>
-
-            {/* Card name */}
-            <div
-              style={{
-                color: 'white',
-                fontSize: card.card_name.length > 30 ? 36 : 44,
-                fontWeight: 'bold',
-                letterSpacing: -1,
-                lineHeight: 1.15,
-                maxWidth: 580,
-                marginBottom: hasStats ? 32 : 0,
-              }}
-            >
-              {card.card_name}
-            </div>
-
-            {/* Stats boxes */}
-            {hasStats && (
-              <div style={{ display: 'flex', gap: 16 }}>
-                {/* Approval Rate */}
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    padding: '16px 20px',
-                    background: 'rgba(255,255,255,0.12)',
-                    backdropFilter: 'blur(10px)',
-                    borderRadius: 14,
-                    border: '1px solid rgba(255,255,255,0.15)',
-                    minWidth: 130,
-                  }}
-                >
-                  <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: 14, marginBottom: 6 }}>
-                    Approval Rate
-                  </div>
-                  <div style={{ color: 'white', fontSize: 32, fontWeight: 'bold' }}>
-                    {approvalRate}%
-                  </div>
-                </div>
-
-                {/* Median Score */}
-                {medianScore > 0 && (
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      padding: '16px 20px',
-                      background: 'rgba(255,255,255,0.12)',
-                      backdropFilter: 'blur(10px)',
-                      borderRadius: 14,
-                      border: '1px solid rgba(255,255,255,0.15)',
-                      minWidth: 130,
-                    }}
-                  >
-                    <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: 14, marginBottom: 6 }}>
-                      Median Score
-                    </div>
-                    <div style={{ color: 'white', fontSize: 32, fontWeight: 'bold' }}>
-                      {medianScore}
-                    </div>
-                  </div>
-                )}
-
-                {/* Data Points */}
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    padding: '16px 20px',
-                    background: 'rgba(255,255,255,0.12)',
-                    backdropFilter: 'blur(10px)',
-                    borderRadius: 14,
-                    border: '1px solid rgba(255,255,255,0.15)',
-                    minWidth: 130,
-                  }}
-                >
-                  <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: 14, marginBottom: 6 }}>
-                    Data Points
-                  </div>
-                  <div style={{ color: 'white', fontSize: 32, fontWeight: 'bold' }}>
-                    {totalRecords}
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Right side: card image (slightly rotated) */}
+          {/* Card image or placeholder */}
           {cardImageUrl ? (
             <div
               style={{
                 display: 'flex',
-                flexShrink: 0,
-                transform: 'rotate(3deg)',
+                flexDirection: 'column',
+                alignItems: 'center',
               }}
             >
               <div
@@ -196,29 +84,63 @@ export default async function OGImage({ params }: Props) {
                 <img
                   src={cardImageUrl}
                   alt={card.card_name}
-                  width={420}
-                  height={265}
+                  width={480}
+                  height={303}
                   style={{ borderRadius: 16 }}
                 />
+              </div>
+
+              {/* Card name below */}
+              <div
+                style={{
+                  display: 'flex',
+                  marginTop: 36,
+                  color: 'white',
+                  fontSize: card.card_name.length > 30 ? 36 : 44,
+                  fontWeight: 'bold',
+                  textAlign: 'center',
+                  maxWidth: 900,
+                }}
+              >
+                {card.card_name}
               </div>
             </div>
           ) : (
             <div
               style={{
                 display: 'flex',
-                flexShrink: 0,
-                width: 350,
-                height: 220,
-                background: 'linear-gradient(145deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.05) 100%)',
-                borderRadius: 16,
+                flexDirection: 'column',
                 alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 64,
-                boxShadow: '0 25px 80px rgba(0,0,0,0.3)',
-                transform: 'rotate(3deg)',
+                color: 'white',
               }}
             >
-              💳
+              <div
+                style={{
+                  display: 'flex',
+                  width: 400,
+                  height: 252,
+                  background: 'linear-gradient(145deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.05) 100%)',
+                  borderRadius: 16,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 48,
+                  boxShadow: '0 25px 80px rgba(0,0,0,0.3)',
+                }}
+              >
+                💳
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  marginTop: 36,
+                  fontSize: card.card_name.length > 30 ? 36 : 44,
+                  fontWeight: 'bold',
+                  textAlign: 'center',
+                  maxWidth: 900,
+                }}
+              >
+                {card.card_name}
+              </div>
             </div>
           )}
         </div>
@@ -233,6 +155,21 @@ export default async function OGImage({ params }: Props) {
           }}
         >
           <OGLogo size={40} />
+        </div>
+
+        {/* Bank name in bottom right */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 35,
+            right: 50,
+            display: 'flex',
+            alignItems: 'center',
+            color: 'rgba(255,255,255,0.8)',
+            fontSize: 24,
+          }}
+        >
+          {card.bank}
         </div>
       </OGBackground>
     ),

--- a/apps/web-next/src/app/news/[id]/opengraph-image.tsx
+++ b/apps/web-next/src/app/news/[id]/opengraph-image.tsx
@@ -9,8 +9,6 @@ export const size = {
 
 export const contentType = 'image/png';
 
-export const runtime = 'edge';
-
 export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const item = await getNewsItem(id);

--- a/apps/web-next/src/app/news/[id]/twitter-image.tsx
+++ b/apps/web-next/src/app/news/[id]/twitter-image.tsx
@@ -1,5 +1,2 @@
 // Re-export the OpenGraph image for Twitter cards
 export { default, size, contentType } from './opengraph-image';
-
-// Runtime must be defined directly, not re-exported
-export const runtime = 'edge';

--- a/apps/web-next/src/components/og/og-utils.tsx
+++ b/apps/web-next/src/components/og/og-utils.tsx
@@ -55,9 +55,10 @@ export function formatStatNumber(n: number): string {
 // ── Load Inter fonts from Google Fonts CDN ──
 
 export async function loadInterFonts(): Promise<{ name: string; data: ArrayBuffer; style: 'normal'; weight: 400 | 700 }[]> {
+  // Satori requires TTF format (not woff2)
   const [regular, bold] = await Promise.all([
-    fetch('https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZ9hjQ.woff2').then(r => r.arrayBuffer()),
-    fetch('https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYAZ9hjQ.woff2').then(r => r.arrayBuffer()),
+    fetch('https://fonts.gstatic.com/s/inter/v20/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf').then(r => r.arrayBuffer()),
+    fetch('https://fonts.gstatic.com/s/inter/v20/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYMZg.ttf').then(r => r.arrayBuffer()),
   ]);
 
   return [
@@ -115,7 +116,7 @@ export function OGBackground({
         height: '100%',
         display: 'flex',
         position: 'relative',
-        background: 'linear-gradient(135deg, #504DE1 0%, #7C3AED 50%, #4F46E5 100%)',
+        background: 'linear-gradient(135deg, #3730A3 0%, #504DE1 30%, #7C3AED 60%, #4F46E5 100%)',
         fontFamily: 'Inter, system-ui, sans-serif',
       }}
     >


### PR DESCRIPTION
## Summary
- Fix Inter font URLs: use TTF format (Satori rejects woff2) with correct v20 Google Fonts paths
- Darken OG background gradient with deeper indigo (#3730A3)
- Card OG: remove stats, center card image horizontally with name + bank
- Add `display: flex` to all divs for Satori compatibility
- Remove `runtime = 'edge'` from news detail and article OG (fixes `fs/promises` incompatibility)

## Test plan
- [ ] All OG images render at 1200x630 with Inter font
- [ ] Card OG shows centered card image with name below
- [ ] News detail OG shows tag badge, title, date, card image
- [ ] Article OG shows tag, title, author, reading time

🤖 Generated with [Claude Code](https://claude.com/claude-code)