### PR TITLE
Refine OG images: metallic border, card CTA, new pages

### DIFF
--- a/apps/web-next/src/app/best/[slug]/opengraph-image.tsx
+++ b/apps/web-next/src/app/best/[slug]/opengraph-image.tsx
@@ -1,0 +1,147 @@
+import { ImageResponse } from 'next/og';
+import { getBestPage } from '@/lib/best';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function OGImage({ params }: Props) {
+  const { slug } = await params;
+  const page = await getBestPage(slug);
+  const fonts = await loadInterFonts();
+
+  if (!page) {
+    return new ImageResponse(
+      (
+        <OGBackground>
+          <div
+            style={{
+              display: 'flex',
+              width: '100%',
+              height: '100%',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'white',
+            }}
+          >
+            <div style={{ display: 'flex', fontSize: 64, fontWeight: 'bold' }}>CreditOdds</div>
+            <div style={{ display: 'flex', fontSize: 32, marginTop: 16, opacity: 0.9 }}>Page Not Found</div>
+          </div>
+        </OGBackground>
+      ),
+      { ...size, fonts }
+    );
+  }
+
+  const titleLen = page.title.length;
+  const titleSize = titleLen > 40 ? 42 : 52;
+  const cardCount = page.cards?.length || 0;
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        {/* Main content */}
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 60,
+          }}
+        >
+          {/* Icon */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 120,
+              height: 120,
+              background: 'rgba(255,255,255,0.15)',
+              borderRadius: 24,
+              marginBottom: 36,
+              boxShadow: '0 20px 50px rgba(0,0,0,0.2)',
+            }}
+          >
+            <span style={{ fontSize: 60 }}>🏆</span>
+          </div>
+
+          {/* Title */}
+          <div
+            style={{
+              color: 'white',
+              fontSize: titleSize,
+              fontWeight: 'bold',
+              letterSpacing: -1,
+              marginBottom: 16,
+              textAlign: 'center',
+              maxWidth: 1000,
+            }}
+          >
+            {page.title}
+          </div>
+
+          {/* Description */}
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.9)',
+              fontSize: 26,
+              textAlign: 'center',
+              maxWidth: 800,
+              lineHeight: 1.4,
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {page.description}
+          </div>
+
+          {/* Card count pill */}
+          {cardCount > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                marginTop: 36,
+                alignItems: 'center',
+                padding: '10px 24px',
+                background: 'rgba(255,255,255,0.15)',
+                borderRadius: 50,
+                color: 'white',
+                fontSize: 20,
+              }}
+            >
+              {`${cardCount} Cards Ranked`}
+            </div>
+          )}
+        </div>
+
+        {/* Logo in bottom left */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/best/[slug]/twitter-image.tsx
+++ b/apps/web-next/src/app/best/[slug]/twitter-image.tsx
@@ -1,0 +1,2 @@
+// Re-export the OpenGraph image for Twitter cards
+export { default, size, contentType } from './opengraph-image';

--- a/apps/web-next/src/app/best/opengraph-image.tsx
+++ b/apps/web-next/src/app/best/opengraph-image.tsx
@@ -1,0 +1,115 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        {/* Main content */}
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 60,
+          }}
+        >
+          {/* Icon */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 140,
+              height: 140,
+              background: 'rgba(255,255,255,0.15)',
+              borderRadius: 28,
+              marginBottom: 40,
+              boxShadow: '0 20px 50px rgba(0,0,0,0.2)',
+            }}
+          >
+            <span style={{ fontSize: 72 }}>🏆</span>
+          </div>
+
+          {/* Title */}
+          <div
+            style={{
+              color: 'white',
+              fontSize: 56,
+              fontWeight: 'bold',
+              letterSpacing: -1,
+              marginBottom: 16,
+            }}
+          >
+            Best Credit Cards of 2026
+          </div>
+
+          {/* Subtitle */}
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.9)',
+              fontSize: 28,
+              textAlign: 'center',
+              maxWidth: 800,
+            }}
+          >
+            Data-driven rankings updated with live approval odds and bonus values
+          </div>
+
+          {/* Feature tags */}
+          <div
+            style={{
+              display: 'flex',
+              marginTop: 40,
+              gap: 16,
+            }}
+          >
+            {['Top Picks', 'Cash Back', 'Travel', 'Sign-Up Bonuses'].map((label) => (
+              <div
+                key={label}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '10px 20px',
+                  background: 'rgba(255,255,255,0.15)',
+                  borderRadius: 50,
+                  color: 'white',
+                  fontSize: 18,
+                }}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Logo in bottom left */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/best/twitter-image.tsx
+++ b/apps/web-next/src/app/best/twitter-image.tsx
@@ -1,0 +1,2 @@
+// Re-export the OpenGraph image for Twitter cards
+export { default, size, contentType } from './opengraph-image';

--- a/apps/web-next/src/app/card/[name]/opengraph-image.tsx
+++ b/apps/web-next/src/app/card/[name]/opengraph-image.tsx
@@ -61,7 +61,10 @@ export default async function OGImage({ params }: Props) {
             height: '100%',
             alignItems: 'center',
             justifyContent: 'center',
-            padding: 60,
+            paddingLeft: 50,
+            paddingRight: 280,
+            paddingTop: 60,
+            paddingBottom: 60,
           }}
         >
           {/* Card image or placeholder */}
@@ -73,10 +76,25 @@ export default async function OGImage({ params }: Props) {
                 alignItems: 'center',
               }}
             >
+              {/* Card name on top */}
               <div
                 style={{
                   display: 'flex',
-                  borderRadius: 20,
+                  marginBottom: 28,
+                  color: 'white',
+                  fontSize: card.card_name.length > 30 ? 34 : 42,
+                  fontWeight: 'bold',
+                  textAlign: 'center',
+                  maxWidth: 900,
+                }}
+              >
+                {card.card_name}
+              </div>
+
+              <div
+                style={{
+                  display: 'flex',
+                  borderRadius: 16,
                   boxShadow: '0 25px 80px rgba(0,0,0,0.4), 0 10px 30px rgba(0,0,0,0.3)',
                 }}
               >
@@ -84,25 +102,10 @@ export default async function OGImage({ params }: Props) {
                 <img
                   src={cardImageUrl}
                   alt={card.card_name}
-                  width={480}
-                  height={303}
+                  width={420}
+                  height={265}
                   style={{ borderRadius: 16 }}
                 />
-              </div>
-
-              {/* Card name below */}
-              <div
-                style={{
-                  display: 'flex',
-                  marginTop: 36,
-                  color: 'white',
-                  fontSize: card.card_name.length > 30 ? 36 : 44,
-                  fontWeight: 'bold',
-                  textAlign: 'center',
-                  maxWidth: 900,
-                }}
-              >
-                {card.card_name}
               </div>
             </div>
           ) : (
@@ -114,11 +117,25 @@ export default async function OGImage({ params }: Props) {
                 color: 'white',
               }}
             >
+              {/* Card name on top */}
               <div
                 style={{
                   display: 'flex',
-                  width: 400,
-                  height: 252,
+                  marginBottom: 28,
+                  fontSize: card.card_name.length > 30 ? 34 : 42,
+                  fontWeight: 'bold',
+                  textAlign: 'center',
+                  maxWidth: 900,
+                }}
+              >
+                {card.card_name}
+              </div>
+
+              <div
+                style={{
+                  display: 'flex',
+                  width: 380,
+                  height: 240,
                   background: 'linear-gradient(145deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.05) 100%)',
                   borderRadius: 16,
                   alignItems: 'center',
@@ -128,18 +145,6 @@ export default async function OGImage({ params }: Props) {
                 }}
               >
                 💳
-              </div>
-              <div
-                style={{
-                  display: 'flex',
-                  marginTop: 36,
-                  fontSize: card.card_name.length > 30 ? 36 : 44,
-                  fontWeight: 'bold',
-                  textAlign: 'center',
-                  maxWidth: 900,
-                }}
-              >
-                {card.card_name}
               </div>
             </div>
           )}
@@ -157,18 +162,59 @@ export default async function OGImage({ params }: Props) {
           <OGLogo size={40} />
         </div>
 
-        {/* Bank name in bottom right */}
+        {/* "Check Your Odds" text on the right */}
         <div
           style={{
             position: 'absolute',
-            bottom: 35,
+            right: 50,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-end',
+            gap: 10,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              color: 'white',
+              fontSize: 34,
+              fontWeight: 'bold',
+              letterSpacing: -0.5,
+            }}
+          >
+            Check Your
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              color: 'white',
+              fontSize: 34,
+              fontWeight: 'bold',
+              letterSpacing: -0.5,
+            }}
+          >
+            Odds →
+          </div>
+        </div>
+
+        {/* Bank name bottom right */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
             right: 50,
             display: 'flex',
             alignItems: 'center',
-            color: 'rgba(255,255,255,0.8)',
-            fontSize: 24,
+            gap: 8,
+            color: 'rgba(255,255,255,0.7)',
+            fontSize: 20,
           }}
         >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <path d="M3 21h18v-2H3v2zm0-4h18v-6H3v6zm0-8h18V7l-9-4-9 4v2z" fill="rgba(255,255,255,0.7)" />
+          </svg>
           {card.bank}
         </div>
       </OGBackground>

--- a/apps/web-next/src/app/check-odds/opengraph-image.tsx
+++ b/apps/web-next/src/app/check-odds/opengraph-image.tsx
@@ -1,0 +1,115 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        {/* Main content */}
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 60,
+          }}
+        >
+          {/* Icon */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 140,
+              height: 140,
+              background: 'rgba(255,255,255,0.15)',
+              borderRadius: 28,
+              marginBottom: 40,
+              boxShadow: '0 20px 50px rgba(0,0,0,0.2)',
+            }}
+          >
+            <span style={{ fontSize: 72 }}>🎯</span>
+          </div>
+
+          {/* Title */}
+          <div
+            style={{
+              color: 'white',
+              fontSize: 56,
+              fontWeight: 'bold',
+              letterSpacing: -1,
+              marginBottom: 16,
+            }}
+          >
+            Check Your Odds
+          </div>
+
+          {/* Subtitle */}
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.9)',
+              fontSize: 28,
+              textAlign: 'center',
+              maxWidth: 800,
+            }}
+          >
+            See your approval chances across all credit cards based on your profile
+          </div>
+
+          {/* Feature tags */}
+          <div
+            style={{
+              display: 'flex',
+              marginTop: 40,
+              gap: 16,
+            }}
+          >
+            {['Credit Score', 'Income', 'Approval Rate'].map((label) => (
+              <div
+                key={label}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '10px 20px',
+                  background: 'rgba(255,255,255,0.15)',
+                  borderRadius: 50,
+                  color: 'white',
+                  fontSize: 18,
+                }}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Logo in bottom left */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/check-odds/twitter-image.tsx
+++ b/apps/web-next/src/app/check-odds/twitter-image.tsx
@@ -1,0 +1,2 @@
+// Re-export the OpenGraph image for Twitter cards
+export { default, size, contentType } from './opengraph-image';

--- a/apps/web-next/src/components/og/og-utils.tsx
+++ b/apps/web-next/src/components/og/og-utils.tsx
@@ -115,67 +115,65 @@ export function OGBackground({
         width: '100%',
         height: '100%',
         display: 'flex',
-        position: 'relative',
-        background: 'linear-gradient(135deg, #3730A3 0%, #504DE1 30%, #7C3AED 60%, #4F46E5 100%)',
+        background: 'linear-gradient(115deg, #e8e8e8 0%, #9a9a9a 8%, #f0f0f0 16%, #858585 24%, #d8d8d8 32%, #a8a8a8 40%, #ececec 48%, #929292 56%, #dcdcdc 64%, #b0b0b0 72%, #f2f2f2 80%, #8e8e8e 88%, #d0d0d0 96%)',
         fontFamily: 'Inter, system-ui, sans-serif',
+        padding: 8,
       }}
     >
-      {/* Dot grid pattern overlay */}
+      {/* Inner rounded content area */}
       <div
         style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.12) 1px, transparent 1px)',
-          backgroundSize: '24px 24px',
           display: 'flex',
-        }}
-      />
-
-      {/* Cool indigo glow — top left */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundImage: 'radial-gradient(circle at 15% 20%, rgba(99,102,241,0.4) 0%, transparent 50%)',
-          display: 'flex',
-        }}
-      />
-
-      {/* Warm accent glow — bottom right */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundImage: `radial-gradient(circle at 85% 80%, ${hexToRgba(warmGlow, 0.25)} 0%, transparent 50%)`,
-          display: 'flex',
-        }}
-      />
-
-      {/* Thin white inset border */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 12,
-          left: 12,
-          right: 12,
-          bottom: 12,
-          border: '1px solid rgba(255,255,255,0.15)',
+          flex: 1,
+          position: 'relative',
           borderRadius: 16,
-          display: 'flex',
+          overflow: 'hidden',
+          background: 'linear-gradient(135deg, #3730A3 0%, #504DE1 30%, #7C3AED 60%, #4F46E5 100%)',
         }}
-      />
+      >
+        {/* Dot grid pattern overlay */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.12) 1px, transparent 1px)',
+            backgroundSize: '24px 24px',
+            display: 'flex',
+          }}
+        />
 
-      {/* Content */}
-      {children}
+        {/* Cool indigo glow — top left */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundImage: 'radial-gradient(circle at 15% 20%, rgba(99,102,241,0.4) 0%, transparent 50%)',
+            display: 'flex',
+          }}
+        />
+
+        {/* Warm accent glow — bottom right */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundImage: `radial-gradient(circle at 85% 80%, ${hexToRgba(warmGlow, 0.25)} 0%, transparent 50%)`,
+            display: 'flex',
+          }}
+        />
+
+        {/* Content */}
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **OGBackground**: Metallic shimmer gradient border (edge-to-edge with rounded interior), replacing flat white inset border
- **Card OG**: Card name on top, smaller image, "Check Your Odds →" CTA on right side, bank name with icon bottom-right
- **New**: OG + Twitter images for `/check-odds` page
- **New**: OG + Twitter images for `/best` listing page and all `/best/[slug]` category pages (dynamic title, description, card count)

## Test plan
- [ ] Verify card OG renders at `/card/chase-sapphire-preferred/opengraph-image`
- [ ] Verify check-odds OG renders at `/check-odds/opengraph-image`
- [ ] Verify best listing OG renders at `/best/opengraph-image`
- [ ] Verify best category OG renders at `/best/best-cash-back-cards/opengraph-image`
- [ ] Confirm metallic border appears on all OG images

🤖 Generated with [Claude Code](https://claude.com/claude-code)