### PR TITLE
Add signup bonus to Marriott Bonvoy Boundless

### DIFF
--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -29,6 +29,11 @@ rewards:
   - category: everything_else
     value: 2
     unit: points_per_dollar
+signup_bonus:
+  value: "5 Free Night Awards"
+  type: free_nights
+  spend_requirement: 3000
+  timeframe_months: 3
 apr:
   regular:
     min: 20.49


### PR DESCRIPTION
## Summary
- Adds signup bonus: 5 Free Night Awards after $3,000 spend in 3 months

## Test plan
- [ ] Run `npm run build:cards` to verify YAML parses correctly
- [ ] Verify bonus displays on card page

🤖 Generated with [Claude Code](https://claude.com/claude-code)