### PR TITLE
Add admin graphs with DAU and time range picker

### DIFF
--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -648,6 +648,90 @@ exports.AdminUserLookupHandler = async (event) => {
   }
 };
 
+// ============ GRAPHS HANDLER ============
+exports.AdminGraphsHandler = async (event) => {
+  console.info("AdminGraphs received:", event);
+
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 200, headers: responseHeaders, body: JSON.stringify({ statusText: "OK" }) };
+  }
+
+  if (!isAdmin(event)) {
+    return {
+      statusCode: 403,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: "Forbidden: Admin access required" }),
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return { statusCode: 405, headers: responseHeaders, body: JSON.stringify({ error: "Method not allowed" }) };
+  }
+
+  try {
+    const days = Math.min(parseInt(event.queryStringParameters?.days) || 30, 365);
+
+    const [recordsDaily, searchesDaily, referralsDaily, dauDaily] = await Promise.all([
+      mysql.query(`
+        SELECT DATE(submit_datetime) as date, COUNT(*) as count
+        FROM records
+        WHERE submit_datetime >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+        GROUP BY DATE(submit_datetime)
+        ORDER BY date ASC
+      `, [days]),
+      mysql.query(`
+        SELECT DATE(created_at) as date, COUNT(*) as count
+        FROM approval_searches
+        WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+        GROUP BY DATE(created_at)
+        ORDER BY date ASC
+      `, [days]),
+      mysql.query(`
+        SELECT DATE(submit_datetime) as date, COUNT(*) as count
+        FROM referrals
+        WHERE submit_datetime >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+        GROUP BY DATE(submit_datetime)
+        ORDER BY date ASC
+      `, [days]),
+      mysql.query(`
+        SELECT date, SUM(unique_users) as count FROM (
+          SELECT DATE(submit_datetime) as date, COUNT(DISTINCT submitter_id) as unique_users
+          FROM records
+          WHERE submit_datetime >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+          GROUP BY DATE(submit_datetime)
+          UNION ALL
+          SELECT DATE(created_at) as date, COUNT(DISTINCT user_id) as unique_users
+          FROM approval_searches
+          WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)
+          GROUP BY DATE(created_at)
+        ) combined
+        GROUP BY date
+        ORDER BY date ASC
+      `, [days, days]),
+    ]);
+
+    await mysql.end();
+
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({
+        records_daily: recordsDaily,
+        searches_daily: searchesDaily,
+        referrals_daily: referralsDaily,
+        dau_daily: dauDaily,
+      }),
+    };
+  } catch (error) {
+    console.error("Error fetching graphs:", error);
+    return {
+      statusCode: 500,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: `Failed to fetch graphs: ${error.message}` }),
+    };
+  }
+};
+
 // ============ AUDIT LOG HANDLER ============
 exports.AdminAuditHandler = async (event) => {
   console.info("AdminAudit received:", event);

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -627,6 +627,38 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  AdminGraphsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/admin.AdminGraphsHandler
+      Runtime: nodejs18.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Admin graphs endpoint for time-series data
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetGraphs:
+          Type: Api
+          Properties:
+            Path: /admin/graphs
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        GraphsOptions:
+          Type: Api
+          Properties:
+            Path: /admin/graphs
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
   AdminSearchesFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -11,6 +11,7 @@ import {
   getAdminAuditLog,
   getAdminSearches,
   getAdminUser,
+  getAdminGraphs,
   deleteAdminRecord,
   deleteAdminReferral,
   updateReferralApproval,
@@ -21,8 +22,12 @@ import {
   AdminSearch,
   AdminUserData,
   AuditLogEntry,
+  AdminGraphsData,
   Card
 } from "@/lib/api";
+import dynamic from "next/dynamic";
+
+const TimeSeriesChart = dynamic(() => import("@/components/charts/TimeSeriesChart"), { ssr: false });
 import { NumericFormat } from "react-number-format";
 import {
   CheckIcon,
@@ -60,6 +65,8 @@ export default function AdminPage() {
   const [auditTotal, setAuditTotal] = useState(0);
   const [searches, setSearches] = useState<AdminSearch[]>([]);
   const [searchesTotal, setSearchesTotal] = useState(0);
+  const [graphData, setGraphData] = useState<AdminGraphsData | null>(null);
+  const [graphDays, setGraphDays] = useState(30);
   const [userLookupId, setUserLookupId] = useState('');
 
   // Processing states
@@ -83,6 +90,22 @@ export default function AdminPage() {
     }
   }, [authState.isAuthenticated, authState.isLoading, isAdmin, router]);
 
+  const loadGraphs = async (days: number) => {
+    try {
+      const token = await getToken();
+      if (!token) return;
+      const data = await getAdminGraphs(token, days).catch(() => null);
+      setGraphData(data);
+    } catch (err) {
+      console.error("Error loading graphs:", err);
+    }
+  };
+
+  const handleGraphDaysChange = (days: number) => {
+    setGraphDays(days);
+    loadGraphs(days);
+  };
+
   const loadData = async () => {
     setLoading(true);
     setError(null);
@@ -94,12 +117,13 @@ export default function AdminPage() {
       }
 
       // Load all data in parallel
-      const [statsData, recordsData, referralsData, auditData, searchesData] = await Promise.all([
+      const [statsData, recordsData, referralsData, auditData, searchesData, graphsData] = await Promise.all([
         getAdminStats(token),
         getAdminRecords(token),
         getAdminReferrals(token),
         getAdminAuditLog(token),
-        getAdminSearches(token)
+        getAdminSearches(token),
+        getAdminGraphs(token, graphDays).catch(() => null)
       ]);
 
       setStats(statsData);
@@ -111,6 +135,7 @@ export default function AdminPage() {
       setAuditTotal(auditData.total);
       setSearches(searchesData.searches);
       setSearchesTotal(searchesData.total);
+      setGraphData(graphsData);
     } catch (err) {
       console.error("Error loading admin data:", err);
       setError(err instanceof Error ? err.message : "Failed to load data");
@@ -287,7 +312,14 @@ export default function AdminPage() {
         </div>
 
         {/* Tab Content */}
-        {activeTab === 'stats' && stats && <StatsTab stats={stats} />}
+        {activeTab === 'stats' && stats && (
+          <StatsTab
+            stats={stats}
+            graphData={graphData}
+            graphDays={graphDays}
+            onGraphDaysChange={handleGraphDaysChange}
+          />
+        )}
         {activeTab === 'records' && (
           <RecordsTab
             records={records}
@@ -327,7 +359,25 @@ export default function AdminPage() {
 }
 
 // ============ STATS TAB ============
-function StatsTab({ stats }: { stats: AdminStats }) {
+function toTimeSeries(data: { date: string; count: number }[]): [number, number][] {
+  return data.map(d => [new Date(d.date).getTime(), d.count]);
+}
+
+const GRAPH_RANGES = [
+  { label: '30d', days: 30 },
+  { label: '90d', days: 90 },
+  { label: '180d', days: 180 },
+  { label: '1y', days: 365 },
+];
+
+function StatsTab({ stats, graphData, graphDays, onGraphDaysChange }: {
+  stats: AdminStats;
+  graphData: AdminGraphsData | null;
+  graphDays: number;
+  onGraphDaysChange: (days: number) => void;
+}) {
+  const rangeLabel = GRAPH_RANGES.find(r => r.days === graphDays)?.label || `${graphDays}d`;
+
   return (
     <div className="space-y-6">
       {/* Stats Grid */}
@@ -338,6 +388,69 @@ function StatsTab({ stats }: { stats: AdminStats }) {
         <StatCard title="Pending Referrals" value={stats.pending_referrals} highlight={stats.pending_referrals > 0} />
         <StatCard title="Records Today" value={stats.records_today} />
         <StatCard title="Records This Week" value={stats.records_this_week} />
+      </div>
+
+      {/* Time Range Picker + Charts */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-medium text-gray-900">Activity Charts</h3>
+          <div className="flex gap-1 bg-gray-100 rounded-lg p-1">
+            {GRAPH_RANGES.map(range => (
+              <button
+                key={range.days}
+                onClick={() => onGraphDaysChange(range.days)}
+                className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                  graphDays === range.days
+                    ? 'bg-white text-indigo-600 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                {range.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {graphData && (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <TimeSeriesChart
+              title={`Daily Active Users (Last ${rangeLabel})`}
+              series={[{
+                name: "DAU",
+                color: "#10b981",
+                data: toTimeSeries(graphData.dau_daily),
+              }]}
+              yAxisTitle="Users"
+            />
+            <TimeSeriesChart
+              title={`Records per Day (Last ${rangeLabel})`}
+              series={[{
+                name: "Records",
+                color: "#6366f1",
+                data: toTimeSeries(graphData.records_daily),
+              }]}
+              yAxisTitle="Records"
+            />
+            <TimeSeriesChart
+              title={`Searches per Day (Last ${rangeLabel})`}
+              series={[{
+                name: "Searches",
+                color: "#8b5cf6",
+                data: toTimeSeries(graphData.searches_daily),
+              }]}
+              yAxisTitle="Searches"
+            />
+            <TimeSeriesChart
+              title={`Referrals per Day (Last ${rangeLabel})`}
+              series={[{
+                name: "Referrals",
+                color: "#ec4899",
+                data: toTimeSeries(graphData.referrals_daily),
+              }]}
+              yAxisTitle="Referrals"
+            />
+          </div>
+        )}
       </div>
 
       {/* Top Cards */}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -427,6 +427,26 @@ export async function getApprovalSearches(token: string): Promise<ApprovalSearch
 
 // ============ ADMIN API FUNCTIONS ============
 
+// Admin Graphs
+export interface AdminGraphsData {
+  records_daily: { date: string; count: number }[];
+  searches_daily: { date: string; count: number }[];
+  referrals_daily: { date: string; count: number }[];
+  dau_daily: { date: string; count: number }[];
+}
+
+export async function getAdminGraphs(token: string, days = 30): Promise<AdminGraphsData> {
+  const res = await fetch(`${API_BASE}/admin/graphs?days=${days}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to fetch admin graphs: ${res.status} ${errorText}`);
+  }
+  return res.json();
+}
+
 // Admin Stats
 export interface AdminStats {
   total_records: number;


### PR DESCRIPTION
## Summary
- New `/admin/graphs` Lambda endpoint returning daily time-series data (records, searches, referrals, DAU) with configurable `?days=` param (max 365)
- DAU computed from unique submitter_ids (records) + unique user_ids (searches) per day
- Admin Stats tab now shows 4 Highcharts area charts in a 2x2 grid with a 30d/90d/180d/1y range picker

## Test plan
- [ ] Visit admin dashboard Overview tab — verify 4 charts render with data
- [ ] Click each time range button (30d, 90d, 180d, 1y) — verify charts update
- [ ] Verify DAU chart shows reasonable unique user counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)