### PR TITLE
Add retry logic to queue-social.js

### DIFF
--- a/scripts/queue-social.js
+++ b/scripts/queue-social.js
@@ -13,6 +13,26 @@
 const fs = require('fs');
 const yaml = require('js-yaml');
 
+async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(url, options, { maxRetries = 3, baseDelay = 2000 } = {}) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, options);
+    if (response.ok || (response.status < 500 && response.status !== 429)) {
+      return response;
+    }
+    if (attempt < maxRetries) {
+      const delay = baseDelay * Math.pow(2, attempt);
+      console.log(`  Retrying in ${delay / 1000}s (attempt ${attempt + 1}/${maxRetries}, status ${response.status})...`);
+      await sleep(delay);
+    } else {
+      return response;
+    }
+  }
+}
+
 function parseArgs() {
   const args = process.argv.slice(2);
   let type = null;
@@ -70,7 +90,7 @@ Rules:
 - Do NOT include any URL
 - Do NOT use emojis excessively — 0-1 emoji max`;
 
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
+  const response = await fetchWithRetry('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -101,7 +121,7 @@ async function queuePost(textContent, linkUrl, sourceType, sourceId) {
 
   if (!apiUrl || !apiKey) throw new Error('SOCIAL_API_URL and SOCIAL_API_KEY are required');
 
-  const response = await fetch(`${apiUrl}/social/queue`, {
+  const response = await fetchWithRetry(`${apiUrl}/social/queue`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- The social post for #186 (Marriott Bonvoy Boundless news) failed due to a Claude API 529 overload error — no retry, so the post was silently dropped
- Adds `fetchWithRetry` with exponential backoff (3 retries at 2s/4s/8s) for 5xx and 429 errors on both the Claude API and queue API calls
- Re-triggered the workflow manually to queue the missed post

## Test plan
- [ ] Verify the re-triggered workflow successfully queued the Marriott post
- [ ] Confirm retry logic handles transient failures gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)