### PR TITLE
Add Robinhood Platinum card and launch news

### DIFF
--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -1,0 +1,13 @@
+name: "Robinhood Platinum"
+bank: "Robinhood"
+slug: "robinhood-platinum"
+accepting_applications: true
+image: "robinhood-platinum.png"
+release_date: "2026-03-05"
+category: "premium"
+annual_fee: 695
+tags:
+  - premium
+  - travel
+  - rewards
+reward_type: "cashback"

--- a/data/news/2026-03-05-robinhood-platinum-card-launch.yaml
+++ b/data/news/2026-03-05-robinhood-platinum-card-launch.yaml
@@ -1,0 +1,43 @@
+id: "robinhood-platinum-card-launch"
+date: "2026-03-05"
+title: "Robinhood Launches Premium Platinum Card with $695 Annual Fee"
+summary: "Robinhood announced the Robinhood Platinum Card, a premium credit card with a $695 annual fee designed to compete directly with the American Express Platinum Card. The new card expands Robinhood's credit card lineup beyond its existing Gold Card."
+tags:
+  - "new-card"
+bank: "Robinhood"
+card_slug: "robinhood-platinum"
+card_name: "Robinhood Platinum"
+source: "Yahoo Finance"
+source_url: "https://finance.yahoo.com/personal-finance/credit-cards/article/robinhood-platinum-card-launch-004511514.html"
+body: |
+  Robinhood has entered the premium credit card market with the launch of the **Robinhood Platinum Card**, a new offering carrying a **$695 annual fee** that puts it in direct competition with the American Express Platinum Card and other high-end travel rewards products.
+
+  ## A Bold Move Into Premium Cards
+
+  The Robinhood Platinum represents a significant step up from the company's existing Gold Card, which has no annual fee (beyond the Robinhood Gold membership) and offers a flat 3% cash back on all purchases. By introducing a premium-tier product at $695, Robinhood is signaling its ambition to compete with established players in the luxury credit card segment.
+
+  The move follows Robinhood's broader strategy of expanding its financial services beyond stock trading into banking, credit cards, and wealth management. The Gold Card, which launched in March 2024, has been one of Robinhood's most successful product launches, attracting hundreds of thousands of cardholders with its competitive rewards structure.
+
+  ## Competing With the Amex Platinum
+
+  The $695 annual fee places the Robinhood Platinum squarely against the American Express Platinum Card ($695 annual fee), the Chase Sapphire Reserve ($550 annual fee), and the Capital One Venture X ($395 annual fee). These premium cards typically justify their fees through a combination of travel credits, airport lounge access, elite hotel status, and elevated earning rates on travel and dining.
+
+  Robinhood has historically differentiated itself by offering simpler, more transparent product structures compared to traditional financial institutions. If the Platinum Card follows this philosophy, it could appeal to consumers who find the complex credit and offset structures of traditional premium cards confusing or difficult to maximize.
+
+  ## What We Know So Far
+
+  The card was announced on March 5, 2026, and full details about rewards rates, sign-up bonuses, travel credits, and specific benefits are still emerging. The existing Gold Card is issued by Coastal Community Bank on the Visa network, and the Platinum Card is expected to follow a similar arrangement.
+
+  Given Robinhood's track record with the Gold Card — which disrupted the cash-back market with its 3% flat rate — industry observers expect the Platinum Card to offer competitive rewards that challenge the traditional premium card value proposition.
+
+  ## Market Context
+
+  The premium credit card market has become increasingly competitive in recent years, with issuers continually adding benefits and credits to justify annual fees that have risen significantly. The entry of a fintech player like Robinhood could pressure established issuers to improve their offerings, similar to how the Gold Card's 3% flat rate pushed competitors to enhance their no-annual-fee products.
+
+  For existing Robinhood Gold Card holders, the Platinum Card may present an upgrade opportunity, though the jump from an effectively $50 annual cost (Gold membership) to $695 is substantial. The card will need to deliver clear value above and beyond the Gold Card's already-competitive 3% earning rate to justify the premium.
+
+  ## Looking Ahead
+
+  As more details emerge about the Robinhood Platinum Card's full benefits package, potential applicants should compare its value proposition against established premium cards. Key factors to evaluate will include the rewards structure, travel credits, lounge access, insurance benefits, and any unique perks that differentiate it from competitors.
+
+  CreditOdds will update this article as additional details about rewards rates, sign-up bonuses, and card benefits become available.


### PR DESCRIPTION
## Summary
- Added new card definition for the Robinhood Platinum ($695 annual fee, announced March 5, 2026)
- Added news article covering the launch and competitive positioning vs Amex Platinum
- Card details are minimal since it was just announced — will update rewards/benefits/APR as details emerge
- News article is linked to the card via `card_slug: robinhood-platinum`

## Notes
- Card image placeholder: `robinhood-platinum.png` — will be uploaded separately
- Card YAML intentionally sparse (no rewards breakdown, no signup bonus) since full details aren't public yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)