### PR TITLE
Fix Robinhood Platinum card category

### DIFF
--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -4,7 +4,7 @@ slug: "robinhood-platinum"
 accepting_applications: true
 image: "robinhood-platinum.png"
 release_date: "2026-03-05"
-category: "premium"
+category: "travel"
 annual_fee: 695
 tags:
   - premium


### PR DESCRIPTION
## Summary
- Changed category from `premium` to `travel` — `premium` is not in the schema enum
- This fixes the Build and Deploy Cards workflow failure from PR #195

## Test plan
- [x] `node scripts/build-cards.js` passes locally (143 cards built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)