### PR TITLE
Dismiss nudge banner after submitting a record

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -143,6 +143,7 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
 
   // Refresh page data after successful submission (#8)
   const handleSubmitSuccess = () => {
+    setHasSubmittedForCard(true);
     router.refresh();
   };
 


### PR DESCRIPTION
## Summary
- Set `hasSubmittedForCard = true` in `handleSubmitSuccess` so the "You haven't shared your result" banner disappears immediately after submission

## Test plan
- [ ] Go to a card page while logged in (for a card you haven't submitted for)
- [ ] Verify the amber nudge banner appears
- [ ] Submit a data point via the modal
- [ ] Verify the banner disappears after successful submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)