### PR TITLE
Remove inquiries and make credit length optional

### DIFF
--- a/apps/web-next/src/components/forms/SubmitRecordModal.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordModal.tsx
@@ -131,9 +131,6 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess }
     result: true,
     starting_credit_limit: undefined as number | undefined,
     reason_denied: "",
-    inquiries_3: undefined as number | undefined,
-    inquiries_12: undefined as number | undefined,
-    inquiries_24: undefined as number | undefined,
   };
 
   const formik = useFormik({
@@ -157,20 +154,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess }
       length_credit: Yup.number()
         .integer("Length of credit must be a whole number")
         .min(0, "Length of credit must be a positive number")
-        .max(50, "Length of credit cannot be greater than 50 years")
-        .required("Required"),
-      inquiries_3: Yup.number()
-        .integer("Inquiries must be a whole number")
-        .min(0, "Inquiries must be a positive number")
-        .max(50, "Inquiries cannot be higher than 50"),
-      inquiries_12: Yup.number()
-        .integer("Inquiries must be a whole number")
-        .min(0, "Inquiries must be a positive number")
-        .max(50, "Inquiries cannot be higher than 50"),
-      inquiries_24: Yup.number()
-        .integer("Inquiries must be a whole number")
-        .min(0, "Inquiries must be a positive number")
-        .max(50, "Inquiries cannot be higher than 50"),
+        .max(50, "Length of credit cannot be greater than 50 years"),
     }),
     onSubmit: async (values) => {
       setSubmitting(true);
@@ -415,7 +399,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess }
                           {/* Length of Credit */}
                           <div>
                             <label htmlFor="length_credit" className="block text-sm font-medium text-gray-700">
-                              Age of Oldest Account
+                              Age of Oldest Account <span className="text-gray-400 font-normal">(optional)</span>
                             </label>
                             <div className="mt-1 relative rounded-md shadow-sm">
                               <input
@@ -462,57 +446,6 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess }
                                 )}
                               />
                             </Switch>
-                          </div>
-
-                          {/* Inquiries */}
-                          <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-2">
-                              Number of Credit Inquiries in the last
-                            </label>
-                            <div className="space-y-2">
-                              <div className="flex rounded-md shadow-sm">
-                                <span className="inline-flex w-28 items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
-                                  3 months
-                                </span>
-                                <input
-                                  name="inquiries_3"
-                                  id="inquiries_3"
-                                  type="number"
-                                  onChange={formik.handleChange}
-                                  onBlur={formik.handleBlur}
-                                  value={formik.values.inquiries_3 ?? ""}
-                                  className="flex-1 min-w-0 block w-full px-3 py-2 rounded-none rounded-r-md border-gray-300 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                                />
-                              </div>
-                              <div className="flex rounded-md shadow-sm">
-                                <span className="inline-flex w-28 items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
-                                  12 months
-                                </span>
-                                <input
-                                  name="inquiries_12"
-                                  id="inquiries_12"
-                                  type="number"
-                                  onChange={formik.handleChange}
-                                  onBlur={formik.handleBlur}
-                                  value={formik.values.inquiries_12 ?? ""}
-                                  className="flex-1 min-w-0 block w-full px-3 py-2 rounded-none rounded-r-md border-gray-300 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                                />
-                              </div>
-                              <div className="flex rounded-md shadow-sm">
-                                <span className="inline-flex w-28 items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
-                                  24 months
-                                </span>
-                                <input
-                                  name="inquiries_24"
-                                  id="inquiries_24"
-                                  type="number"
-                                  onChange={formik.handleChange}
-                                  onBlur={formik.handleBlur}
-                                  value={formik.values.inquiries_24 ?? ""}
-                                  className="flex-1 min-w-0 block w-full px-3 py-2 rounded-none rounded-r-md border-gray-300 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                                />
-                              </div>
-                            </div>
                           </div>
 
                           {/* Approved/Rejected Toggle */}

--- a/packages/shared/validation.js
+++ b/packages/shared/validation.js
@@ -6,7 +6,7 @@ const recordSchema = yup.object().shape({
   credit_score_source: yup.number().integer().min(0).max(4).required(),
   result: yup.boolean().required(),
   listed_income: yup.number().integer().min(0).max(1000000).required(),
-  length_credit: yup.number().integer().min(0).max(100).required(),
+  length_credit: yup.number().integer().min(0).max(100),
   starting_credit_limit: yup.number().integer().min(0).max(1000000),
   reason_denied: yup.string().max(254),
   date_applied: yup.date().required(),


### PR DESCRIPTION
## Summary
- Removed the "Number of Credit Inquiries in the last 3/12/24 months" question from the submit form — users were dropping off at this step
- Made "Age of Oldest Account" optional (removed `.required()` from both frontend and shared backend validation)
- Added "(optional)" label to the field so users know they can skip it

## Test plan
- [ ] Submit form no longer shows the inquiries fields
- [ ] "Age of Oldest Account" shows "(optional)" label
- [ ] Form submits successfully without filling in age of oldest account
- [ ] Form still submits successfully with age of oldest account filled in
- [ ] Backend accepts submissions without `length_credit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)