### PR TITLE
Make length_credit optional in API handler

### DIFF
--- a/apps/api/src/handlers/user-records.js
+++ b/apps/api/src/handlers/user-records.js
@@ -16,7 +16,7 @@ const recordSchema = yup.object().shape({
   credit_score_source: yup.number().integer().min(0).max(4).required(),
   result: yup.boolean().required(),
   listed_income: yup.number().integer().min(0).max(1000000).required(),
-  length_credit: yup.number().integer().min(0).max(100).required(),
+  length_credit: yup.number().integer().min(0).max(100),
   starting_credit_limit: yup.number().integer().min(0).max(1000000),
   reason_denied: yup.string().max(254),
   date_applied: yup.date().required(),


### PR DESCRIPTION
## Summary
- The `user-records.js` handler had its own validation schema (not using the shared package) with `length_credit` still marked as `.required()`
- Removed `.required()` to match the shared validation and frontend changes from PR #200
- Already deployed via `sam deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)