### PR TITLE
Add OG images for compare page

### DIFF
--- a/apps/web-next/src/app/api/og/compare/route.tsx
+++ b/apps/web-next/src/app/api/og/compare/route.tsx
@@ -1,0 +1,201 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+import { getAllCards } from '@/lib/api';
+
+export const runtime = 'edge';
+
+const size = {
+  width: 1200,
+  height: 630,
+};
+
+const CDN_BASE = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const cardsParam = searchParams.get('cards');
+  const fonts = await loadInterFonts();
+
+  if (!cardsParam) {
+    return renderFallback(fonts);
+  }
+
+  const slugs = cardsParam.split(',').filter(Boolean).slice(0, 3);
+  if (slugs.length === 0) {
+    return renderFallback(fonts);
+  }
+
+  const allCards = await getAllCards();
+  const matchedCards = slugs
+    .map((slug) => allCards.find((c) => c.slug === slug))
+    .filter(Boolean);
+
+  if (matchedCards.length === 0) {
+    return renderFallback(fonts);
+  }
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '40px 60px',
+          }}
+        >
+          {/* Title */}
+          <div
+            style={{
+              color: 'white',
+              fontSize: 44,
+              fontWeight: 'bold',
+              letterSpacing: -1,
+              marginBottom: 40,
+            }}
+          >
+            Compare Credit Cards
+          </div>
+
+          {/* Cards side by side */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: matchedCards.length === 1 ? 0 : 48,
+            }}
+          >
+            {matchedCards.map((card, i) => (
+              <div
+                key={i}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 16,
+                }}
+              >
+                {/* Card image or placeholder */}
+                {card!.card_image_link ? (
+                  <img
+                    src={`${CDN_BASE}/${card!.card_image_link}`}
+                    width={280}
+                    height={176}
+                    style={{
+                      objectFit: 'contain',
+                      borderRadius: 12,
+                      boxShadow: '0 16px 40px rgba(0,0,0,0.3)',
+                    }}
+                  />
+                ) : (
+                  <div
+                    style={{
+                      width: 280,
+                      height: 176,
+                      background: 'linear-gradient(145deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.08) 100%)',
+                      borderRadius: 12,
+                      boxShadow: '0 16px 40px rgba(0,0,0,0.3)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <span style={{ fontSize: 48 }}>💳</span>
+                  </div>
+                )}
+                {/* Card name */}
+                <div
+                  style={{
+                    color: 'rgba(255,255,255,0.95)',
+                    fontSize: matchedCards.length >= 3 ? 18 : 22,
+                    fontWeight: 'bold',
+                    textAlign: 'center',
+                    maxWidth: 280,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {card!.card_name}
+                </div>
+              </div>
+            ))}
+
+            {/* VS badges between cards */}
+          </div>
+        </div>
+
+        {/* Logo in bottom left */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}
+
+function renderFallback(fonts: Awaited<ReturnType<typeof loadInterFonts>>) {
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 60,
+          }}
+        >
+          <div
+            style={{
+              color: 'white',
+              fontSize: 56,
+              fontWeight: 'bold',
+              letterSpacing: -1,
+              marginBottom: 16,
+            }}
+          >
+            Compare Credit Cards
+          </div>
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.9)',
+              fontSize: 28,
+              textAlign: 'center',
+              maxWidth: 800,
+            }}
+          >
+            Compare up to 3 cards side-by-side
+          </div>
+        </div>
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/compare/opengraph-image.tsx
+++ b/apps/web-next/src/app/compare/opengraph-image.tsx
@@ -1,0 +1,138 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        {/* Main content */}
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 60,
+          }}
+        >
+          {/* VS comparison visual - two cards with VS badge */}
+          <div
+            style={{
+              display: 'flex',
+              position: 'relative',
+              width: 440,
+              height: 200,
+              marginBottom: 40,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {/* Card 1 - left */}
+            <div
+              style={{
+                width: 240,
+                height: 150,
+                background: 'linear-gradient(145deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.08) 100%)',
+                borderRadius: 16,
+                boxShadow: '0 15px 40px rgba(0,0,0,0.25)',
+                transform: 'rotate(-6deg)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <span style={{ fontSize: 40 }}>💳</span>
+            </div>
+            {/* VS badge */}
+            <div
+              style={{
+                position: 'absolute',
+                left: '50%',
+                top: '50%',
+                transform: 'translate(-50%, -50%)',
+                width: 64,
+                height: 64,
+                borderRadius: 32,
+                background: 'linear-gradient(135deg, #f59e0b 0%, #ef4444 100%)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                boxShadow: '0 8px 24px rgba(0,0,0,0.3)',
+                zIndex: 10,
+              }}
+            >
+              <span style={{ color: 'white', fontSize: 24, fontWeight: 'bold' }}>VS</span>
+            </div>
+            {/* Card 2 - right */}
+            <div
+              style={{
+                width: 240,
+                height: 150,
+                background: 'linear-gradient(145deg, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0.1) 100%)',
+                borderRadius: 16,
+                boxShadow: '0 15px 40px rgba(0,0,0,0.25)',
+                transform: 'rotate(6deg)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <span style={{ fontSize: 40 }}>💳</span>
+            </div>
+          </div>
+
+          {/* Title */}
+          <div
+            style={{
+              color: 'white',
+              fontSize: 56,
+              fontWeight: 'bold',
+              letterSpacing: -1,
+              marginBottom: 16,
+            }}
+          >
+            Compare Credit Cards
+          </div>
+
+          {/* Subtitle */}
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.9)',
+              fontSize: 28,
+              textAlign: 'center',
+              maxWidth: 800,
+            }}
+          >
+            Compare up to 3 cards side-by-side
+          </div>
+        </div>
+
+        {/* Logo in bottom left */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/compare/page.tsx
+++ b/apps/web-next/src/app/compare/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import { Metadata } from 'next';
 import Link from 'next/link';
 import { getAllCards } from '@/lib/api';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
@@ -6,10 +7,52 @@ import CompareClient from './CompareClient';
 
 export const revalidate = 300;
 
-export const metadata = {
-  title: 'Compare Credit Cards | CreditOdds',
-  description: 'Compare up to 3 credit cards side-by-side. See rewards, signup bonuses, APR, annual fees, and approval odds all in one place.',
-};
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ cards?: string }>;
+}): Promise<Metadata> {
+  const params = await searchParams;
+  const baseTitle = 'Compare Credit Cards | CreditOdds';
+  const baseDescription = 'Compare up to 3 credit cards side-by-side. See rewards, signup bonuses, APR, annual fees, and approval odds all in one place.';
+
+  if (!params.cards) {
+    return { title: baseTitle, description: baseDescription };
+  }
+
+  const slugs = params.cards.split(',').filter(Boolean).slice(0, 3);
+  if (slugs.length === 0) {
+    return { title: baseTitle, description: baseDescription };
+  }
+
+  const allCards = await getAllCards();
+  const matchedCards = slugs
+    .map((slug) => allCards.find((c) => c.slug === slug))
+    .filter(Boolean);
+
+  if (matchedCards.length === 0) {
+    return { title: baseTitle, description: baseDescription };
+  }
+
+  const cardNames = matchedCards.map((c) => c!.card_name);
+  const title = `Compare ${cardNames.join(' vs ')} | CreditOdds`;
+
+  return {
+    title,
+    description: baseDescription,
+    openGraph: {
+      title,
+      description: baseDescription,
+      images: [`/api/og/compare?cards=${slugs.join(',')}`],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: baseDescription,
+      images: [`/api/og/compare?cards=${slugs.join(',')}`],
+    },
+  };
+}
 
 export default async function ComparePage() {
   const cards = await getAllCards();


### PR DESCRIPTION
## Summary
- Adds a static OG image for `/compare` with a VS card visual
- Adds a dynamic OG route handler at `/api/og/compare?cards=slug1,slug2,slug3` that renders 1-3 card images side-by-side with names
- Updates compare page to use `generateMetadata()` for dynamic titles and OG image URLs when cards are selected

## Test plan
- [ ] Visit `/compare` — static OG image renders
- [ ] Visit `/compare?cards=chase-sapphire-preferred` — dynamic OG with 1 card
- [ ] Visit `/compare?cards=chase-sapphire-preferred,amex-gold` — 2 cards side-by-side
- [ ] Visit `/compare?cards=chase-sapphire-preferred,amex-gold,capital-one-venture-x` — 3 cards
- [ ] Check page source for correct `og:image` meta tag URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)