### PR TITLE
Add Reddit listener for auto-collecting data points

### DIFF
--- a/apps/api/migrations/008_add_record_source.sql
+++ b/apps/api/migrations/008_add_record_source.sql
@@ -1,0 +1,9 @@
+-- Add source tracking to records table for Reddit listener and future integrations
+-- source: 'user' (default, existing records), 'reddit', 'admin'
+-- source_url: URL to the original Reddit post (or other source)
+
+ALTER TABLE records ADD COLUMN source VARCHAR(20) DEFAULT 'user' AFTER admin_review;
+ALTER TABLE records ADD COLUMN source_url VARCHAR(500) DEFAULT NULL AFTER source;
+
+-- Index for filtering pending Reddit records in admin console
+CREATE INDEX idx_records_source_review ON records (source, admin_review);

--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -144,6 +144,19 @@ exports.AdminRecordsHandler = async (event) => {
         const limit = parseInt(event.queryStringParameters?.limit) || 100;
         const offset = parseInt(event.queryStringParameters?.offset) || 0;
 
+        const source = event.queryStringParameters?.source;
+        const pendingOnly = event.queryStringParameters?.pending === 'true';
+
+        let whereClause = 'WHERE 1=1';
+        const queryParams = [];
+        if (source) {
+          whereClause += ' AND r.source = ?';
+          queryParams.push(source);
+        }
+        if (pendingOnly) {
+          whereClause += ' AND r.admin_review = 0';
+        }
+
         const results = await mysql.query(`
           SELECT
             r.record_id,
@@ -156,16 +169,28 @@ exports.AdminRecordsHandler = async (event) => {
             r.date_applied,
             r.submitter_id,
             r.submitter_ip_address,
+            r.source,
+            r.source_url,
+            r.admin_review,
+            r.starting_credit_limit,
+            r.bank_customer,
+            r.inquiries_3,
+            r.inquiries_12,
+            r.inquiries_24,
             c.card_name,
             c.card_image_link,
             c.bank
           FROM records r
           JOIN cards c ON r.card_id = c.card_id
+          ${whereClause}
           ORDER BY r.submit_datetime DESC
           LIMIT ? OFFSET ?
-        `, [limit, offset]);
+        `, [...queryParams, limit, offset]);
 
-        const countResult = await mysql.query("SELECT COUNT(*) as total FROM records");
+        const countResult = await mysql.query(
+          `SELECT COUNT(*) as total FROM records r ${whereClause}`,
+          queryParams
+        );
         await mysql.end();
 
         return {
@@ -265,6 +290,52 @@ exports.AdminRecordsHandler = async (event) => {
           statusCode: 500,
           headers: responseHeaders,
           body: JSON.stringify({ error: `Failed to create record: ${error.message}` }),
+        };
+      }
+
+    case "PUT":
+      try {
+        const body = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
+        const { record_id, approved } = body;
+
+        if (!record_id || approved === undefined) {
+          return {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "record_id and approved are required" }),
+          };
+        }
+
+        const record = await mysql.query("SELECT * FROM records WHERE record_id = ?", [record_id]);
+        if (record.length === 0) {
+          return {
+            statusCode: 404,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "Record not found" }),
+          };
+        }
+
+        await mysql.query(
+          "UPDATE records SET admin_review = ? WHERE record_id = ?",
+          [approved ? 1 : 0, record_id]
+        );
+        await logAuditAction(userId, approved ? 'APPROVE' : 'REJECT', 'record', record_id, record[0]);
+        await mysql.end();
+
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({
+            message: approved ? "Record approved" : "Record rejected",
+            record_id,
+          }),
+        };
+      } catch (error) {
+        console.error("Error updating record:", error);
+        return {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: `Failed to update record: ${error.message}` }),
         };
       }
 

--- a/apps/api/src/handlers/reddit-listener.js
+++ b/apps/api/src/handlers/reddit-listener.js
@@ -1,0 +1,352 @@
+/**
+ * Reddit Listener Lambda Handler
+ *
+ * Scheduled via EventBridge to poll r/creditcards for approval/denial data points.
+ * Uses Claude Haiku to extract structured data from Reddit posts, then inserts
+ * qualifying records into the DB with admin_review = 0 for manual approval.
+ */
+
+const mysql = require("serverless-mysql")({
+  config: {
+    host: process.env.ENDPOINT,
+    database: process.env.DATABASE,
+    user: process.env.USERNAME,
+    password: process.env.PASSWORD,
+  },
+});
+
+// Reddit API configuration
+const REDDIT_CLIENT_ID = process.env.REDDIT_CLIENT_ID;
+const REDDIT_CLIENT_SECRET = process.env.REDDIT_CLIENT_SECRET;
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+const SUBREDDITS = ['CreditCards'];
+const MAX_POSTS_PER_RUN = 50;
+const MAX_INSERTS_PER_RUN = 20;
+
+/**
+ * Get Reddit OAuth token using client credentials (app-only, read-only access)
+ */
+async function getRedditToken() {
+  const credentials = Buffer.from(`${REDDIT_CLIENT_ID}:${REDDIT_CLIENT_SECRET}`).toString('base64');
+
+  const response = await fetch('https://www.reddit.com/api/v1/access_token', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Basic ${credentials}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'CreditOdds-RedditListener/1.0',
+    },
+    body: 'grant_type=client_credentials',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Reddit auth failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+
+/**
+ * Fetch recent posts from a subreddit
+ */
+async function fetchSubredditPosts(token, subreddit) {
+  const response = await fetch(
+    `https://oauth.reddit.com/r/${subreddit}/new?limit=${MAX_POSTS_PER_RUN}&t=day`,
+    {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'User-Agent': 'CreditOdds-RedditListener/1.0',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Reddit API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.data?.children?.map(c => c.data) || [];
+}
+
+/**
+ * Filter posts that likely contain approval/denial data points
+ */
+function filterRelevantPosts(posts) {
+  const keywords = [
+    'approved', 'denied', 'approval', 'denial',
+    'data point', 'dp:', 'got the', 'was approved', 'was denied',
+    'instant approval', 'instantly approved', 'credit limit',
+    'fico', 'credit score', 'vantage',
+  ];
+
+  return posts.filter(post => {
+    const text = `${post.title} ${post.selftext || ''}`.toLowerCase();
+    return keywords.some(kw => text.includes(kw));
+  });
+}
+
+/**
+ * Load cards from the database for card name matching
+ */
+async function loadCards() {
+  const cards = await mysql.query(
+    "SELECT card_id, card_name, bank FROM cards WHERE active = 1"
+  );
+  return cards;
+}
+
+/**
+ * Get already-processed Reddit post URLs to avoid duplicates
+ */
+async function getProcessedUrls() {
+  const results = await mysql.query(
+    "SELECT source_url FROM records WHERE source = 'reddit' AND source_url IS NOT NULL"
+  );
+  return new Set(results.map(r => r.source_url));
+}
+
+/**
+ * Use Claude to extract structured data from a Reddit post
+ */
+async function extractDataPoint(post, cardsList) {
+  const cardsRef = cardsList
+    .map(c => `- ${c.card_name} (bank: ${c.bank}, card_id: ${c.card_id})`)
+    .join('\n');
+
+  const postText = `Title: ${post.title}\n\nBody: ${post.selftext || '(no body)'}`;
+
+  const prompt = `You are a data extraction system for credit card approval/denial reports. Extract structured data from this Reddit post.
+
+## Reddit Post
+${postText}
+
+## Card Database (match card names to these)
+${cardsRef}
+
+## Instructions
+Extract ALL data points from this post. A single post may contain multiple data points (e.g., someone reporting approvals for multiple cards).
+
+For each data point, extract:
+- card_id (REQUIRED): Must match a card_id from the database above. If the card isn't in our database, skip it.
+- result (REQUIRED): true = approved, false = denied
+- credit_score (REQUIRED): 300-850 range. If not mentioned, skip this data point.
+- credit_score_source: 0=Unknown, 1=FICO, 2=VantageScore, 3=Experian, 4=TransUnion. Default 0.
+- listed_income: Annual income in dollars. Only include if explicitly stated.
+- length_credit: Years of credit history. Only include if explicitly stated.
+- starting_credit_limit: Credit limit received (approvals only). Only include if stated.
+- bank_customer: true/false - whether they mentioned being an existing customer of the bank. Default false.
+- inquiries_3: Hard inquiries in last 3 months (if mentioned)
+- inquiries_12: Hard inquiries in last 12 months (if mentioned)
+- inquiries_24: Hard inquiries in last 24 months (if mentioned)
+
+## Output Format
+Return a JSON array of extracted data points. If no valid data points can be extracted (missing required fields or card not in database), return an empty array [].
+
+CRITICAL: Only extract data that is explicitly stated in the post. Do NOT guess or infer values. If credit_score is not mentioned, do not include that data point. If income is not mentioned, omit the listed_income field entirely.
+
+Output raw JSON only, no markdown fences.`;
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 2048,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.warn(`Claude API error: ${response.status} - ${errorText}`);
+    return [];
+  }
+
+  const data = await response.json();
+  const text = data.content[0]?.text || '';
+
+  try {
+    const jsonMatch = text.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) return [];
+    return JSON.parse(jsonMatch[0]);
+  } catch (err) {
+    console.warn(`Failed to parse Claude response: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Validate an extracted data point
+ */
+function validateDataPoint(dp, validCardIds) {
+  if (!dp.card_id || !validCardIds.has(dp.card_id)) return null;
+  if (typeof dp.result !== 'boolean') return null;
+  if (!dp.credit_score || dp.credit_score < 300 || dp.credit_score > 850) return null;
+
+  return {
+    card_id: dp.card_id,
+    result: dp.result,
+    credit_score: dp.credit_score,
+    credit_score_source: [0, 1, 2, 3, 4].includes(dp.credit_score_source) ? dp.credit_score_source : 0,
+    listed_income: dp.listed_income && dp.listed_income >= 0 && dp.listed_income <= 1000000 ? dp.listed_income : null,
+    length_credit: dp.length_credit && dp.length_credit >= 0 && dp.length_credit <= 100 ? dp.length_credit : null,
+    starting_credit_limit: dp.result && dp.starting_credit_limit && dp.starting_credit_limit >= 0 ? dp.starting_credit_limit : null,
+    bank_customer: dp.bank_customer === true,
+    reason_denied: !dp.result ? (dp.reason_denied || null) : null,
+    inquiries_3: dp.inquiries_3 >= 0 && dp.inquiries_3 <= 50 ? dp.inquiries_3 : null,
+    inquiries_12: dp.inquiries_12 >= 0 && dp.inquiries_12 <= 50 ? dp.inquiries_12 : null,
+    inquiries_24: dp.inquiries_24 >= 0 && dp.inquiries_24 <= 50 ? dp.inquiries_24 : null,
+  };
+}
+
+/**
+ * Insert a record into the database with admin_review = 0
+ */
+async function insertPendingRecord(dp, redditUsername, postUrl, postDate) {
+  const result = await mysql.query("INSERT INTO records SET ?", {
+    card_id: dp.card_id,
+    result: dp.result,
+    credit_score: dp.credit_score,
+    credit_score_source: dp.credit_score_source,
+    listed_income: dp.listed_income,
+    date_applied: postDate,
+    length_credit: dp.length_credit,
+    starting_credit_limit: dp.starting_credit_limit,
+    submitter_id: `reddit:u/${redditUsername}`,
+    submitter_ip_address: null,
+    submit_datetime: new Date(),
+    bank_customer: dp.bank_customer,
+    reason_denied: dp.reason_denied,
+    inquiries_3: dp.inquiries_3,
+    inquiries_12: dp.inquiries_12,
+    inquiries_24: dp.inquiries_24,
+    admin_review: 0,
+    source: 'reddit',
+    source_url: postUrl,
+  });
+  return result.insertId;
+}
+
+/**
+ * Main Lambda handler — triggered by EventBridge schedule
+ */
+exports.RedditListenerHandler = async (event) => {
+  console.log('=== Reddit Listener ===');
+  console.log('Event:', JSON.stringify(event));
+
+  if (!REDDIT_CLIENT_ID || !REDDIT_CLIENT_SECRET) {
+    console.error('Missing Reddit API credentials');
+    return { statusCode: 500, body: 'Missing Reddit credentials' };
+  }
+  if (!ANTHROPIC_API_KEY) {
+    console.error('Missing ANTHROPIC_API_KEY');
+    return { statusCode: 500, body: 'Missing Anthropic API key' };
+  }
+
+  try {
+    // 1. Authenticate with Reddit
+    console.log('Authenticating with Reddit...');
+    const redditToken = await getRedditToken();
+
+    // 2. Load cards and processed URLs
+    console.log('Loading cards and processed URLs...');
+    const [cards, processedUrls] = await Promise.all([
+      loadCards(),
+      getProcessedUrls(),
+    ]);
+    const validCardIds = new Set(cards.map(c => c.card_id));
+    console.log(`Loaded ${cards.length} cards, ${processedUrls.size} processed URLs`);
+
+    // 3. Fetch posts from subreddits
+    let allPosts = [];
+    for (const sub of SUBREDDITS) {
+      console.log(`Fetching posts from r/${sub}...`);
+      const posts = await fetchSubredditPosts(redditToken, sub);
+      console.log(`  Found ${posts.length} posts`);
+      allPosts = allPosts.concat(posts);
+    }
+
+    // 4. Filter relevant posts and skip already-processed
+    const relevantPosts = filterRelevantPosts(allPosts);
+    console.log(`${relevantPosts.length} posts match approval/denial keywords`);
+
+    const newPosts = relevantPosts.filter(post => {
+      const url = `https://reddit.com${post.permalink}`;
+      return !processedUrls.has(url);
+    });
+    console.log(`${newPosts.length} posts are new (not yet processed)`);
+
+    if (newPosts.length === 0) {
+      console.log('No new posts to process');
+      await mysql.end();
+      return { statusCode: 200, body: 'No new posts' };
+    }
+
+    // 5. Extract data points from each post
+    let totalInserted = 0;
+
+    for (const post of newPosts) {
+      if (totalInserted >= MAX_INSERTS_PER_RUN) {
+        console.log(`Reached max inserts (${MAX_INSERTS_PER_RUN}), stopping`);
+        break;
+      }
+
+      const postUrl = `https://reddit.com${post.permalink}`;
+      const postDate = new Date(post.created_utc * 1000);
+      console.log(`\nProcessing: "${post.title}" by u/${post.author}`);
+
+      const dataPoints = await extractDataPoint(post, cards);
+      console.log(`  Extracted ${dataPoints.length} potential data point(s)`);
+
+      for (const dp of dataPoints) {
+        if (totalInserted >= MAX_INSERTS_PER_RUN) break;
+
+        const validated = validateDataPoint(dp, validCardIds);
+        if (!validated) {
+          console.log(`  Skipping invalid data point (card_id: ${dp.card_id})`);
+          continue;
+        }
+
+        // Check for duplicate: same card, source_url, result
+        const existing = await mysql.query(
+          `SELECT record_id FROM records
+           WHERE source = 'reddit' AND source_url = ? AND card_id = ? AND result = ?
+           LIMIT 1`,
+          [postUrl, validated.card_id, validated.result]
+        );
+
+        if (existing.length > 0) {
+          console.log(`  Skipping duplicate for card_id ${validated.card_id}`);
+          continue;
+        }
+
+        const recordId = await insertPendingRecord(validated, post.author, postUrl, postDate);
+        console.log(`  Inserted record ${recordId} (card_id: ${validated.card_id}, ${validated.result ? 'approved' : 'denied'})`);
+        totalInserted++;
+      }
+
+      // Rate limit between Claude API calls
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+
+    await mysql.end();
+
+    console.log(`\n=== Complete: Inserted ${totalInserted} pending record(s) ===`);
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ inserted: totalInserted }),
+    };
+  } catch (error) {
+    console.error('Reddit listener error:', error);
+    await mysql.end();
+    return {
+      statusCode: 500,
+      body: `Error: ${error.message}`,
+    };
+  }
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -32,7 +32,22 @@ Parameters:
   CardsJsonUrl:
     Type: String
     Description: CloudFront URL for cards.json
-    Default: https://d2hxvzw7msbtvt.cloudfront.net/cards.json 
+    Default: https://d2hxvzw7msbtvt.cloudfront.net/cards.json
+  REDDIT_CLIENT_ID:
+    Type: String
+    Description: Reddit API client ID
+    NoEcho: true
+    Default: ''
+  REDDIT_CLIENT_SECRET:
+    Type: String
+    Description: Reddit API client secret
+    NoEcho: true
+    Default: ''
+  ANTHROPIC_API_KEY:
+    Type: String
+    Description: Anthropic API key for Claude
+    NoEcho: true
+    Default: ''
 
 # Resources declares the AWS resources that you want to include in the stack
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
@@ -524,6 +539,13 @@ Resources:
             Method: POST
             RestApiId:
               Ref: CreditCardOddsAPI
+        UpdateRecord:
+          Type: Api
+          Properties:
+            Path: /admin/records
+            Method: PUT
+            RestApiId:
+              Ref: CreditCardOddsAPI
         DeleteRecord:
           Type: Api
           Properties:
@@ -754,3 +776,29 @@ Resources:
               Ref: CreditCardOddsAPI
             Auth:
               Authorizer: NONE
+
+  # Reddit Listener - polls r/creditcards for approval/denial data points
+  RedditListenerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/reddit-listener.RedditListenerHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 300
+      Description: Polls Reddit for credit card approval/denial data points
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+          REDDIT_CLIENT_ID: !Ref REDDIT_CLIENT_ID
+          REDDIT_CLIENT_SECRET: !Ref REDDIT_CLIENT_SECRET
+          ANTHROPIC_API_KEY: !Ref ANTHROPIC_API_KEY
+      Events:
+        ScheduledRun:
+          Type: Schedule
+          Properties:
+            Schedule: rate(6 hours)
+            Description: Poll Reddit for new data points every 6 hours
+            Enabled: true

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -16,6 +16,7 @@ import {
   deleteAdminReferral,
   updateReferralApproval,
   createAdminRecord,
+  approveAdminRecord,
   AdminStats,
   AdminRecord,
   AdminReferral,
@@ -46,7 +47,7 @@ import {
 // Master admin user ID (Firebase UID)
 const ADMIN_USER_IDS = ['zXOyHmGl7HStyAqEdLsgXLA5inS2'];
 
-type TabType = 'stats' | 'records' | 'referrals' | 'searches' | 'user' | 'audit' | 'submit';
+type TabType = 'stats' | 'records' | 'reddit' | 'referrals' | 'searches' | 'user' | 'audit' | 'submit';
 
 export default function AdminPage() {
   const { authState, getToken } = useAuth();
@@ -68,6 +69,8 @@ export default function AdminPage() {
   const [graphData, setGraphData] = useState<AdminGraphsData | null>(null);
   const [graphDays, setGraphDays] = useState(30);
   const [userLookupId, setUserLookupId] = useState('');
+  const [redditRecords, setRedditRecords] = useState<AdminRecord[]>([]);
+  const [redditTotal, setRedditTotal] = useState(0);
 
   // Processing states
   const [processingId, setProcessingId] = useState<number | null>(null);
@@ -117,13 +120,14 @@ export default function AdminPage() {
       }
 
       // Load all data in parallel
-      const [statsData, recordsData, referralsData, auditData, searchesData, graphsData] = await Promise.all([
+      const [statsData, recordsData, referralsData, auditData, searchesData, graphsData, redditData] = await Promise.all([
         getAdminStats(token),
         getAdminRecords(token),
         getAdminReferrals(token),
         getAdminAuditLog(token),
         getAdminSearches(token),
-        getAdminGraphs(token, graphDays).catch(() => null)
+        getAdminGraphs(token, graphDays).catch(() => null),
+        getAdminRecords(token, 100, 0, { source: 'reddit', pending: true }).catch(() => ({ records: [], total: 0 })),
       ]);
 
       setStats(statsData);
@@ -136,6 +140,8 @@ export default function AdminPage() {
       setSearches(searchesData.searches);
       setSearchesTotal(searchesData.total);
       setGraphData(graphsData);
+      setRedditRecords(redditData.records);
+      setRedditTotal(redditData.total);
     } catch (err) {
       console.error("Error loading admin data:", err);
       setError(err instanceof Error ? err.message : "Failed to load data");
@@ -158,6 +164,28 @@ export default function AdminPage() {
       if (stats) setStats({ ...stats, total_records: stats.total_records - 1 });
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to delete record");
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  const handleApproveRecord = async (recordId: number, approve: boolean) => {
+    setProcessingId(recordId);
+    try {
+      const token = await getToken();
+      if (!token) return;
+
+      if (approve) {
+        await approveAdminRecord(recordId, true, token);
+        setRedditRecords(prev => prev.filter(r => r.record_id !== recordId));
+        setRedditTotal(prev => prev - 1);
+      } else {
+        await deleteAdminRecord(recordId, token);
+        setRedditRecords(prev => prev.filter(r => r.record_id !== recordId));
+        setRedditTotal(prev => prev - 1);
+      }
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update record");
     } finally {
       setProcessingId(null);
     }
@@ -254,6 +282,7 @@ export default function AdminPage() {
   const tabs = [
     { id: 'stats' as TabType, name: 'Overview', icon: ChartBarIcon },
     { id: 'records' as TabType, name: 'Records', icon: DocumentTextIcon, count: recordsTotal },
+    { id: 'reddit' as TabType, name: 'Reddit', icon: DocumentTextIcon, badge: redditTotal },
     { id: 'referrals' as TabType, name: 'Referrals', icon: LinkIcon, count: referralsTotal, badge: stats?.pending_referrals },
     { id: 'searches' as TabType, name: 'Searches', icon: MagnifyingGlassIcon, count: searchesTotal },
     { id: 'user' as TabType, name: 'User Lookup', icon: UserIcon },
@@ -326,6 +355,14 @@ export default function AdminPage() {
             total={recordsTotal}
             processingId={processingId}
             onDelete={handleDeleteRecord}
+          />
+        )}
+        {activeTab === 'reddit' && (
+          <RedditTab
+            records={redditRecords}
+            total={redditTotal}
+            processingId={processingId}
+            onApprove={handleApproveRecord}
           />
         )}
         {activeTab === 'referrals' && (
@@ -569,6 +606,125 @@ function RecordsTab({
           </tbody>
         </table>
       </div>
+    </div>
+  );
+}
+
+// ============ REDDIT TAB ============
+function RedditTab({
+  records,
+  total,
+  processingId,
+  onApprove,
+}: {
+  records: AdminRecord[];
+  total: number;
+  processingId: number | null;
+  onApprove: (id: number, approve: boolean) => void;
+}) {
+  return (
+    <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="px-4 py-5 sm:px-6 border-b border-gray-200">
+        <h3 className="text-lg font-medium text-gray-900">Reddit Data Points — Pending Approval ({total})</h3>
+        <p className="mt-1 text-sm text-gray-500">
+          Data points extracted from r/creditcards. Review and approve or reject each entry.
+        </p>
+      </div>
+      {records.length === 0 ? (
+        <div className="px-4 py-12 text-center text-gray-500">
+          No pending Reddit data points to review.
+        </div>
+      ) : (
+        <div className="divide-y divide-gray-200">
+          {records.map((record) => (
+            <div key={record.record_id} className="p-4 hover:bg-gray-50">
+              <div className="flex items-start justify-between">
+                <div className="flex items-start space-x-4 flex-1 min-w-0">
+                  {record.card_image_link && (
+                    <div className="flex-shrink-0 h-10 w-16 relative">
+                      <Image
+                        src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${record.card_image_link}`}
+                        alt={record.card_name}
+                        fill
+                        className="object-contain"
+                        sizes="64px"
+                      />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center space-x-2">
+                      <span className="text-sm font-medium text-gray-900">{record.card_name}</span>
+                      <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${
+                        record.result ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                      }`}>
+                        {record.result ? 'Approved' : 'Denied'}
+                      </span>
+                      <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-orange-100 text-orange-800">
+                        Reddit
+                      </span>
+                    </div>
+                    <div className="mt-1 text-sm text-gray-600">
+                      <span className="font-medium">Score:</span> {record.credit_score}
+                      {record.listed_income != null && (
+                        <> &middot; <span className="font-medium">Income:</span> ${record.listed_income.toLocaleString()}</>
+                      )}
+                      {record.length_credit != null && (
+                        <> &middot; <span className="font-medium">History:</span> {record.length_credit}yr</>
+                      )}
+                      {record.starting_credit_limit != null && (
+                        <> &middot; <span className="font-medium">Limit:</span> ${record.starting_credit_limit.toLocaleString()}</>
+                      )}
+                      {record.bank_customer && (
+                        <> &middot; <span className="font-medium">Existing customer</span></>
+                      )}
+                    </div>
+                    {(record.inquiries_3 != null || record.inquiries_12 != null || record.inquiries_24 != null) && (
+                      <div className="mt-0.5 text-sm text-gray-500">
+                        Inquiries:
+                        {record.inquiries_3 != null && <> {record.inquiries_3}/3mo</>}
+                        {record.inquiries_12 != null && <> {record.inquiries_12}/12mo</>}
+                        {record.inquiries_24 != null && <> {record.inquiries_24}/24mo</>}
+                      </div>
+                    )}
+                    <div className="mt-1 flex items-center space-x-3 text-xs text-gray-400">
+                      <span>{record.submitter_id?.replace('reddit:', '') || 'Unknown'}</span>
+                      <span>{new Date(record.submit_datetime).toLocaleDateString()}</span>
+                      {record.source_url && (
+                        <a
+                          href={record.source_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-indigo-500 hover:text-indigo-700 underline"
+                        >
+                          View Reddit Post
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center space-x-2 ml-4 flex-shrink-0">
+                  <button
+                    onClick={() => onApprove(record.record_id, true)}
+                    disabled={processingId === record.record_id}
+                    className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md bg-green-50 text-green-700 hover:bg-green-100 disabled:opacity-50"
+                  >
+                    <CheckIcon className="h-4 w-4 mr-1" />
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => onApprove(record.record_id, false)}
+                    disabled={processingId === record.record_id}
+                    className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md bg-red-50 text-red-700 hover:bg-red-100 disabled:opacity-50"
+                  >
+                    <XMarkIcon className="h-4 w-4 mr-1" />
+                    Reject
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -486,6 +486,14 @@ export interface AdminRecord {
   submitter_id: string;
   submitter_email?: string;
   submitter_ip_address?: string;
+  source?: string;
+  source_url?: string;
+  admin_review?: number;
+  starting_credit_limit?: number;
+  bank_customer?: boolean;
+  inquiries_3?: number;
+  inquiries_12?: number;
+  inquiries_24?: number;
 }
 
 export interface AdminRecordsResponse {
@@ -498,15 +506,39 @@ export interface AdminRecordsResponse {
 export async function getAdminRecords(
   token: string,
   limit = 100,
-  offset = 0
+  offset = 0,
+  options?: { source?: string; pending?: boolean }
 ): Promise<AdminRecordsResponse> {
-  const res = await fetch(`${API_BASE}/admin/records?limit=${limit}&offset=${offset}`, {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  if (options?.source) params.set('source', options.source);
+  if (options?.pending) params.set('pending', 'true');
+  const res = await fetch(`${API_BASE}/admin/records?${params}`, {
     headers: { Authorization: `Bearer ${token}` },
     cache: 'no-store',
   });
   if (!res.ok) {
     const errorText = await res.text().catch(() => 'Unknown error');
     throw new Error(`Failed to fetch admin records: ${res.status} ${errorText}`);
+  }
+  return res.json();
+}
+
+export async function approveAdminRecord(
+  recordId: number,
+  approved: boolean,
+  token: string
+): Promise<{ message: string }> {
+  const res = await fetch(`${API_BASE}/admin/records`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ record_id: recordId, approved }),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to update record: ${errorText}`);
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- **Scheduled Lambda** polls r/creditcards every 6 hours for approval/denial posts
- **Claude Haiku** extracts structured data (credit score, income, result, credit limit, etc.)
- Records inserted with `admin_review=0`, `source='reddit'`, Reddit username, and post URL
- **New "Reddit" tab** in admin console shows pending data points for approval
- Each entry shows the Reddit username, all extracted fields, and a link to the original post
- Admin can **approve** (sets `admin_review=1`, record becomes public) or **reject** (deletes it)

## New files
- `apps/api/migrations/008_add_record_source.sql` — adds `source` and `source_url` columns to records table
- `apps/api/src/handlers/reddit-listener.js` — Lambda handler for Reddit polling + extraction

## Modified files
- `apps/api/template.yml` — new Lambda + EventBridge schedule + Reddit/Anthropic API key params
- `apps/api/src/handlers/admin.js` — PUT handler for record approval, filtering by source/pending
- `apps/web-next/src/lib/api.ts` — new types/functions for Reddit records + approval
- `apps/web-next/src/app/admin/page.tsx` — new Reddit tab component

## Setup required
1. Run migration `008_add_record_source.sql`
2. Register a Reddit "script" app at https://www.reddit.com/prefs/apps
3. Add SAM parameters: `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `ANTHROPIC_API_KEY`
4. Deploy with `sam build && sam deploy`

## Test plan
- [ ] Run migration on DB
- [ ] Deploy Lambda and verify EventBridge schedule triggers
- [ ] Check CloudWatch logs for Reddit polling and extraction
- [ ] Verify pending records appear in admin console Reddit tab
- [ ] Test approve and reject buttons
- [ ] Confirm approved records show up in public card pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)