### PR TITLE
Add Wells Fargo Choice Privileges Mastercard cards

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-03-06T18:43:19.387Z",
-  "count": 144,
+  "generated_at": "2026-03-06T19:13:56.467Z",
+  "count": 146,
   "categories": [
     {
       "id": "dining",
@@ -5799,6 +5799,130 @@
       "reward_type": "cashback",
       "card_id": "wells-fargo-cash-wise-visa",
       "card_name": "Wells Fargo Cash Wise Visa"
+    },
+    {
+      "name": "Wells Fargo Choice Privileges Mastercard",
+      "bank": "Wells Fargo",
+      "slug": "wells-fargo-choice-privileges-mastercard",
+      "image": "wells-fargo-choice-privileges-mastercard.png",
+      "accepting_applications": true,
+      "category": "travel",
+      "annual_fee": 0,
+      "reward_type": "points",
+      "tags": [
+        "travel",
+        "hotel",
+        "rewards"
+      ],
+      "rewards": [
+        {
+          "category": "hotels",
+          "value": 5,
+          "unit": "points_per_dollar",
+          "note": "At participating Choice Hotels properties"
+        },
+        {
+          "category": "gas",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "groceries",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "home_improvement",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "phone",
+          "value": 3,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "points_per_dollar"
+        }
+      ],
+      "signup_bonus": {
+        "value": 60000,
+        "type": "points",
+        "spend_requirement": 1000,
+        "timeframe_months": 3
+      },
+      "apr": {
+        "regular": {
+          "min": 19.99,
+          "max": 28.74
+        }
+      },
+      "card_id": "wells-fargo-choice-privileges-mastercard",
+      "card_name": "Wells Fargo Choice Privileges Mastercard"
+    },
+    {
+      "name": "Wells Fargo Choice Privileges Select Mastercard",
+      "bank": "Wells Fargo",
+      "slug": "wells-fargo-choice-privileges-select-mastercard",
+      "image": "wells-fargo-choice-privileges-select-mastercard.png",
+      "accepting_applications": true,
+      "category": "travel",
+      "annual_fee": 95,
+      "reward_type": "points",
+      "tags": [
+        "travel",
+        "hotel",
+        "rewards"
+      ],
+      "rewards": [
+        {
+          "category": "hotels",
+          "value": 10,
+          "unit": "points_per_dollar",
+          "note": "At participating Choice Hotels properties"
+        },
+        {
+          "category": "gas",
+          "value": 5,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "groceries",
+          "value": 5,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "home_improvement",
+          "value": 5,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "phone",
+          "value": 5,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "points_per_dollar"
+        }
+      ],
+      "signup_bonus": {
+        "value": 60000,
+        "type": "points",
+        "spend_requirement": 3000,
+        "timeframe_months": 3
+      },
+      "apr": {
+        "regular": {
+          "min": 19.74,
+          "max": 28.49
+        }
+      },
+      "card_id": "wells-fargo-choice-privileges-select-mastercard",
+      "card_name": "Wells Fargo Choice Privileges Select Mastercard"
     },
     {
       "name": "Wells Fargo Platinum",

--- a/data/cards/wells-fargo-choice-privileges-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-mastercard.yaml
@@ -1,0 +1,41 @@
+name: "Wells Fargo Choice Privileges Mastercard"
+bank: "Wells Fargo"
+slug: "wells-fargo-choice-privileges-mastercard"
+image: "wells-fargo-choice-privileges-mastercard.png"
+accepting_applications: true
+category: "travel"
+annual_fee: 0
+reward_type: "points"
+tags:
+  - travel
+  - hotel
+  - rewards
+rewards:
+  - category: hotels
+    value: 5
+    unit: points_per_dollar
+    note: "At participating Choice Hotels properties"
+  - category: gas
+    value: 3
+    unit: points_per_dollar
+  - category: groceries
+    value: 3
+    unit: points_per_dollar
+  - category: home_improvement
+    value: 3
+    unit: points_per_dollar
+  - category: phone
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 1000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.99
+    max: 28.74

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -1,0 +1,41 @@
+name: "Wells Fargo Choice Privileges Select Mastercard"
+bank: "Wells Fargo"
+slug: "wells-fargo-choice-privileges-select-mastercard"
+image: "wells-fargo-choice-privileges-select-mastercard.png"
+accepting_applications: true
+category: "travel"
+annual_fee: 95
+reward_type: "points"
+tags:
+  - travel
+  - hotel
+  - rewards
+rewards:
+  - category: hotels
+    value: 10
+    unit: points_per_dollar
+    note: "At participating Choice Hotels properties"
+  - category: gas
+    value: 5
+    unit: points_per_dollar
+  - category: groceries
+    value: 5
+    unit: points_per_dollar
+  - category: home_improvement
+    value: 5
+    unit: points_per_dollar
+  - category: phone
+    value: 5
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 60000
+  type: points
+  spend_requirement: 3000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 19.74
+    max: 28.49


### PR DESCRIPTION
## Summary
- Adds two new Wells Fargo Choice Hotels co-branded cards

### Choice Privileges Mastercard (no annual fee)
| Detail | Value |
|--------|-------|
| Annual Fee | $0 |
| Rewards | 5x Choice Hotels, 3x gas/groceries/home improvement/phone, 1x everything else |
| Signup Bonus | 60,000 points ($1,000 spend / 3 months) |
| APR | 19.99% - 28.74% variable |
| FTF | None |
| Elite Status | Gold |

### Choice Privileges Select Mastercard ($95/yr)
| Detail | Value |
|--------|-------|
| Annual Fee | $95 |
| Rewards | 10x Choice Hotels, 5x gas/groceries/home improvement/phone, 1x everything else |
| Signup Bonus | 60,000 points ($3,000 spend / 3 months) |
| Anniversary | 30,000 points |
| APR | 19.74% - 28.49% variable |
| FTF | None |
| Elite Status | Platinum |

## Test plan
- [ ] Verify both cards appear on explore page
- [ ] Verify card detail pages render correctly
- [ ] Upload card images to CDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)