### PR TITLE
Fix Choice Privileges card image filenames

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-06T19:13:56.467Z",
+  "generated_at": "2026-03-06T19:21:40.289Z",
   "count": 146,
   "categories": [
     {
@@ -5804,7 +5804,7 @@
       "name": "Wells Fargo Choice Privileges Mastercard",
       "bank": "Wells Fargo",
       "slug": "wells-fargo-choice-privileges-mastercard",
-      "image": "wells-fargo-choice-privileges-mastercard.png",
+      "image": "choice-privileges.png",
       "accepting_applications": true,
       "category": "travel",
       "annual_fee": 0,
@@ -5866,7 +5866,7 @@
       "name": "Wells Fargo Choice Privileges Select Mastercard",
       "bank": "Wells Fargo",
       "slug": "wells-fargo-choice-privileges-select-mastercard",
-      "image": "wells-fargo-choice-privileges-select-mastercard.png",
+      "image": "choice-privileges-select.png",
       "accepting_applications": true,
       "category": "travel",
       "annual_fee": 95,

--- a/data/cards/wells-fargo-choice-privileges-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-mastercard.yaml
@@ -1,7 +1,7 @@
 name: "Wells Fargo Choice Privileges Mastercard"
 bank: "Wells Fargo"
 slug: "wells-fargo-choice-privileges-mastercard"
-image: "wells-fargo-choice-privileges-mastercard.png"
+image: "choice-privileges.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 0

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -1,7 +1,7 @@
 name: "Wells Fargo Choice Privileges Select Mastercard"
 bank: "Wells Fargo"
 slug: "wells-fargo-choice-privileges-select-mastercard"
-image: "wells-fargo-choice-privileges-select-mastercard.png"
+image: "choice-privileges-select.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 95


### PR DESCRIPTION
## Summary
- Updates card image references to match actual CDN filenames
- Choice Privileges Mastercard: `choice-privileges.png`
- Choice Privileges Select Mastercard: `choice-privileges-select.png`

## Test plan
- [ ] Verify card images load correctly on card pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)