### PR TITLE
Add 10 new points/miles converter tools with OG images

### DIFF
--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('amex-membership-rewards')?.cpp ?? 1.2;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          Amex Membership Rewards Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#11088;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 44, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Amex Membership Rewards to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Amex MR points to dollars &bull; 1.2&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
@@ -1,0 +1,132 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Amex Membership Rewards to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Amex Membership Rewards points to their estimated USD value. Free calculator using the standard 1.2 cents per point valuation.',
+};
+
+export default async function AmexMRToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const exclude = ['delta', 'hilton', 'blue cash'];
+  const cards = allCards.filter(c => {
+    const name = c.card_name.toLowerCase();
+    if (exclude.some(ex => name.includes(ex))) return false;
+    return (name.includes('american express') || name.includes('amex') || name.includes('gold card') || name.includes('platinum card')) && c.accepting_applications;
+  });
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('amex') || text.includes('membership rewards') || text.includes('american express');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Amex Membership Rewards to USD', url: 'https://creditodds.com/tools/amex-membership-rewards-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Amex Membership Rewards to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Amex Membership Rewards to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Amex Membership Rewards points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Amex Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Amex News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('bilt-rewards')?.cpp ?? 1.5;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          Bilt Rewards Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#11088;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 48, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Bilt Rewards Points to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Bilt Rewards points to dollars &bull; 1.5&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
@@ -1,0 +1,129 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Bilt Rewards Points to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Bilt Rewards points to their estimated USD value. Free calculator using the standard 1.5 cents per point valuation.',
+};
+
+export default async function BiltToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('bilt') && c.accepting_applications
+  );
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('bilt');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Bilt Rewards Points to USD', url: 'https://creditodds.com/tools/bilt-rewards-points-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Bilt Rewards Points to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Bilt Rewards Points to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Bilt Rewards points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Bilt Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Bilt News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_MILE = getValuationBySlug('capital-one-miles')?.cpp ?? 1.0;
+const RATE = CENTS_PER_MILE / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [miles, setMiles] = useState('');
+
+  const milesValue = parseNumber(miles);
+  const usdValue = milesValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="miles" className="block text-sm font-medium text-gray-700">
+          Capital One Miles
+        </label>
+        <div className="mt-1">
+          <input
+            id="miles"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={miles}
+            onChange={(e) => setMiles(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {milesValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(milesValue))} miles &times; {CENTS_PER_MILE}&cent; per mile
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_MILE} cents per mile. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#9992;&#65039;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 48, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Capital One Miles to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Capital One miles to dollars &bull; 1.0&cent; per mile
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
@@ -1,0 +1,129 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Capital One Miles to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Capital One miles to their estimated USD value. Free calculator using the standard 1.0 cents per mile valuation.',
+};
+
+export default async function CapitalOneMilesToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('capital one') && c.accepting_applications
+  );
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('capital one');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Capital One Miles to USD', url: 'https://creditodds.com/tools/capital-one-miles-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Capital One Miles to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Capital One Miles to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Capital One miles.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Capital One Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Capital One News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('chase-ultimate-rewards')?.cpp ?? 1.25;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          Chase Ultimate Rewards Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#11088;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 48, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Chase Ultimate Rewards to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Chase UR points to dollars &bull; 1.25&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
@@ -1,0 +1,130 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Chase Ultimate Rewards to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Chase Ultimate Rewards points to their estimated USD value. Free calculator using the standard 1.25 cents per point valuation.',
+};
+
+export default async function ChaseURToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c => {
+    const name = c.card_name.toLowerCase();
+    return (name.includes('chase sapphire') || name.includes('freedom')) && c.accepting_applications;
+  });
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('chase') || text.includes('ultimate rewards');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Chase Ultimate Rewards to USD', url: 'https://creditodds.com/tools/chase-ultimate-rewards-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Chase Ultimate Rewards to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Chase Ultimate Rewards to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Chase Ultimate Rewards points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Chase Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Chase News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('citi-thankyou')?.cpp ?? 1.0;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          Citi ThankYou Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#11088;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 48, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Citi ThankYou Points to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Citi ThankYou points to dollars &bull; 1.0&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
@@ -1,0 +1,129 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Citi ThankYou Points to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Citi ThankYou points to their estimated USD value. Free calculator using the standard 1.0 cents per point valuation.',
+};
+
+export default async function CitiThankYouToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('citi') && c.accepting_applications
+  );
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('citi') || text.includes('thankyou');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Citi ThankYou Points to USD', url: 'https://creditodds.com/tools/citi-thankyou-points-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Citi ThankYou Points to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Citi ThankYou Points to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Citi ThankYou points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Citi Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Citi News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#9992;&#65039;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 52, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Delta SkyMiles to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Delta SkyMiles to dollars &bull; 1.1&cent; per mile
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('hilton-honors')?.cpp ?? 0.5;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          Hilton Honors Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#127976;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 48, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Hilton Honors Points to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Hilton Honors points to dollars &bull; 0.5&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
@@ -1,0 +1,129 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Hilton Honors Points to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Hilton Honors points to their estimated USD value. Free calculator using the standard 0.5 cents per point valuation.',
+};
+
+export default async function HiltonHonorsToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('hilton') && c.accepting_applications
+  );
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('hilton');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Hilton Honors Points to USD', url: 'https://creditodds.com/tools/hilton-honors-points-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Hilton Honors Points to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Hilton Honors Points to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Hilton Honors points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Hilton Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Hilton News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('ihg-one-rewards')?.cpp ?? 0.5;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          IHG One Rewards Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#127976;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 44, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            IHG One Rewards Points to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert IHG One Rewards points to dollars &bull; 0.5&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
@@ -1,0 +1,129 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'IHG One Rewards Points to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert IHG One Rewards points to their estimated USD value. Free calculator using the standard 0.5 cents per point valuation.',
+};
+
+export default async function IHGToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('ihg') && c.accepting_applications
+  );
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('ihg');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'IHG One Rewards Points to USD', url: 'https://creditodds.com/tools/ihg-one-rewards-points-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">IHG One Rewards Points to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">IHG One Rewards Points to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your IHG One Rewards points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">IHG Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">IHG News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('marriott-bonvoy')?.cpp ?? 0.7;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          Marriott Bonvoy Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#127976;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 48, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Marriott Bonvoy Points to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Marriott Bonvoy points to dollars &bull; 0.7&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
@@ -1,0 +1,130 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Marriott Bonvoy Points to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Marriott Bonvoy points to their estimated USD value. Free calculator using the standard 0.7 cents per point valuation.',
+};
+
+export default async function MarriottBonvoyToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c => {
+    const name = c.card_name.toLowerCase();
+    return (name.includes('marriott') || name.includes('bonvoy')) && c.accepting_applications;
+  });
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('marriott') || text.includes('bonvoy');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Marriott Bonvoy Points to USD', url: 'https://creditodds.com/tools/marriott-bonvoy-points-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Marriott Bonvoy Points to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Marriott Bonvoy Points to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Marriott Bonvoy points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Marriott Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Marriott News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/opengraph-image.tsx
@@ -1,0 +1,34 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#128736;&#65039;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 56, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Credit Card Tools
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Free calculators to convert miles and points to their dollar value
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/page.tsx
+++ b/apps/web-next/src/app/tools/page.tsx
@@ -4,29 +4,75 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 
 export const metadata: Metadata = {
   title: 'Tools | CreditOdds',
-  description: 'Free credit card tools and calculators. Convert miles to dollars, estimate point values, and more.',
+  description: 'Free credit card tools and calculators. Convert miles and points to dollars for Chase, Amex, Delta, United, Southwest, Capital One, Marriott, Hilton, Hyatt, IHG, Bilt, and Citi.',
 };
+
+const dollarIcon = (
+  <svg className="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+  </svg>
+);
 
 const tools = [
   {
+    name: 'Chase Ultimate Rewards to USD',
+    description: 'Convert Chase UR points to dollars. 1.25¢/point.',
+    href: '/tools/chase-ultimate-rewards-to-usd',
+  },
+  {
+    name: 'Amex Membership Rewards to USD',
+    description: 'Convert Amex MR points to dollars. 1.2¢/point.',
+    href: '/tools/amex-membership-rewards-to-usd',
+  },
+  {
     name: 'United Miles to USD',
-    description: 'Convert United MileagePlus miles to their estimated dollar value.',
+    description: 'Convert United MileagePlus miles to dollars. 1.2¢/mile.',
     href: '/tools/united-miles-to-usd',
-    icon: (
-      <svg className="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-      </svg>
-    ),
   },
   {
     name: 'Delta SkyMiles to USD',
-    description: 'Convert Delta SkyMiles to their estimated dollar value.',
+    description: 'Convert Delta SkyMiles to dollars. 1.1¢/mile.',
     href: '/tools/delta-skymiles-to-usd',
-    icon: (
-      <svg className="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-      </svg>
-    ),
+  },
+  {
+    name: 'Southwest Rapid Rewards to USD',
+    description: 'Convert Southwest points to dollars. 1.4¢/point.',
+    href: '/tools/southwest-rapid-rewards-to-usd',
+  },
+  {
+    name: 'Capital One Miles to USD',
+    description: 'Convert Capital One miles to dollars. 1.0¢/mile.',
+    href: '/tools/capital-one-miles-to-usd',
+  },
+  {
+    name: 'Marriott Bonvoy Points to USD',
+    description: 'Convert Marriott Bonvoy points to dollars. 0.7¢/point.',
+    href: '/tools/marriott-bonvoy-points-to-usd',
+  },
+  {
+    name: 'Hilton Honors Points to USD',
+    description: 'Convert Hilton Honors points to dollars. 0.5¢/point.',
+    href: '/tools/hilton-honors-points-to-usd',
+  },
+  {
+    name: 'World of Hyatt Points to USD',
+    description: 'Convert World of Hyatt points to dollars. 2.0¢/point.',
+    href: '/tools/world-of-hyatt-points-to-usd',
+  },
+  {
+    name: 'IHG One Rewards Points to USD',
+    description: 'Convert IHG One Rewards points to dollars. 0.5¢/point.',
+    href: '/tools/ihg-one-rewards-points-to-usd',
+  },
+  {
+    name: 'Bilt Rewards Points to USD',
+    description: 'Convert Bilt Rewards points to dollars. 1.5¢/point.',
+    href: '/tools/bilt-rewards-points-to-usd',
+  },
+  {
+    name: 'Citi ThankYou Points to USD',
+    description: 'Convert Citi ThankYou points to dollars. 1.0¢/point.',
+    href: '/tools/citi-thankyou-points-to-usd',
   },
 ];
 
@@ -68,7 +114,7 @@ export default function ToolsPage() {
               className="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow group"
             >
               <div className="flex items-center gap-4">
-                {tool.icon}
+                {dollarIcon}
                 <div>
                   <h2 className="text-lg font-semibold text-gray-900 group-hover:text-indigo-600">
                     {tool.name}

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('southwest-rapid-rewards')?.cpp ?? 1.4;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          Southwest Rapid Rewards Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#9992;&#65039;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 44, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            Southwest Rapid Rewards to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert Southwest points to dollars &bull; 1.4&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
@@ -1,0 +1,129 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'Southwest Rapid Rewards to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert Southwest Rapid Rewards points to their estimated USD value. Free calculator using the standard 1.4 cents per point valuation.',
+};
+
+export default async function SouthwestRRToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('southwest') && c.accepting_applications
+  );
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('southwest') || text.includes('rapid rewards');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'Southwest Rapid Rewards to USD', url: 'https://creditodds.com/tools/southwest-rapid-rewards-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Southwest Rapid Rewards to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Southwest Rapid Rewards to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your Southwest Rapid Rewards points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Southwest Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Southwest News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/united-miles-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#9992;&#65039;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 52, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            United Miles to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert United MileagePlus miles to dollars &bull; 1.2&cent; per mile
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/ConverterClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { getValuationBySlug } from '@/lib/valuations';
+
+const CENTS_PER_POINT = getValuationBySlug('world-of-hyatt')?.cpp ?? 2.0;
+const RATE = CENTS_PER_POINT / 100;
+
+function formatNumber(value: string): string {
+  const num = value.replace(/[^0-9]/g, '');
+  if (!num) return '';
+  return Number(num).toLocaleString();
+}
+
+function parseNumber(formatted: string): number {
+  return Number(formatted.replace(/[^0-9]/g, '')) || 0;
+}
+
+export default function ConverterClient() {
+  const [points, setPoints] = useState('');
+
+  const pointsValue = parseNumber(points);
+  const usdValue = pointsValue * RATE;
+
+  return (
+    <div className="mt-6 max-w-lg">
+      <div className="bg-white rounded-lg shadow p-6">
+        <label htmlFor="points" className="block text-sm font-medium text-gray-700">
+          World of Hyatt Points
+        </label>
+        <div className="mt-1">
+          <input
+            id="points"
+            type="text"
+            inputMode="numeric"
+            placeholder="10,000"
+            value={points}
+            onChange={(e) => setPoints(formatNumber(e.target.value))}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {pointsValue > 0 && (
+          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
+            <p className="text-sm text-gray-600">Estimated Value</p>
+            <p className="text-3xl font-bold text-indigo-600">
+              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              {formatNumber(String(pointsValue))} points &times; {CENTS_PER_POINT}&cent; per point
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-4 text-xs text-gray-400">
+        Based on a valuation of {CENTS_PER_POINT} cents per point. Actual redemption value varies by booking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/opengraph-image.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div style={{ display: 'flex', width: '100%', height: '100%', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 24 }}>
+            <div style={{ display: 'flex', background: 'rgba(255,255,255,0.15)', borderRadius: 16, padding: '16px 24px', fontSize: 40 }}>
+              <span>&#127976;</span>
+              <span style={{ marginLeft: 12, marginRight: 12 }}>&#8594;</span>
+              <span>&#128176;</span>
+            </div>
+          </div>
+          <div style={{ color: 'white', fontSize: 48, fontWeight: 'bold', letterSpacing: -1, marginBottom: 16, textAlign: 'center' }}>
+            World of Hyatt Points to USD
+          </div>
+          <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 28, textAlign: 'center', maxWidth: 800 }}>
+            Convert World of Hyatt points to dollars &bull; 2.0&cent; per point
+          </div>
+        </div>
+        <div style={{ position: 'absolute', bottom: 30, left: 40, display: 'flex' }}>
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
@@ -1,0 +1,129 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { getAllCards } from '@/lib/api';
+import { getNews } from '@/lib/news';
+import ConverterClient from './ConverterClient';
+
+export const metadata: Metadata = {
+  title: 'World of Hyatt Points to USD (Converter/Calculator) | CreditOdds',
+  description: 'Convert World of Hyatt points to their estimated USD value. Free calculator using the standard 2.0 cents per point valuation.',
+};
+
+export default async function HyattToUsdPage() {
+  const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+
+  const cards = allCards.filter(c =>
+    c.card_name.toLowerCase().includes('hyatt') && c.accepting_applications
+  );
+  const news = allNews.filter(n => {
+    const text = `${n.title} ${n.summary}`.toLowerCase();
+    return text.includes('hyatt');
+  });
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Tools', url: 'https://creditodds.com/tools' },
+        { name: 'World of Hyatt Points to USD', url: 'https://creditodds.com/tools/world-of-hyatt-points-to-usd' },
+      ]} />
+
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">Home</Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <Link href="/tools" className="ml-4 text-sm font-medium text-gray-400 hover:text-gray-500">Tools</Link>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">World of Hyatt Points to USD</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">World of Hyatt Points to USD Converter</h1>
+        <p className="mt-2 text-gray-600">
+          Estimate the dollar value of your World of Hyatt points.
+        </p>
+
+        <ConverterClient />
+
+        {cards.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Hyatt Credit Cards</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cards.map(card => (
+                <Link
+                  key={card.slug}
+                  href={`/card/${card.slug}`}
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                >
+                  <div className="h-10 w-16 flex-shrink-0 relative">
+                    <Image
+                      src={card.card_image_link
+                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
+                        : '/assets/generic-card.svg'}
+                      alt={card.card_name}
+                      fill
+                      className="object-contain"
+                      sizes="64px"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                    <p className="text-xs text-gray-500">{card.bank}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {news.length > 0 && (
+          <div className="mt-12">
+            <h2 className="text-lg font-semibold text-gray-900">Hyatt News</h2>
+            <div className="mt-4 space-y-3">
+              {news.map(item => (
+                <div key={item.id} className="bg-white rounded-lg shadow p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-xs text-gray-500">
+                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                      </p>
+                      <p className="text-sm font-medium text-gray-900 mt-1">
+                        {item.body ? (
+                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                            {item.title}
+                          </Link>
+                        ) : (
+                          item.title
+                        )}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds 10 new points/miles-to-USD converter tools and OG images for all 12 tools (including 2 existing).

### New converters
| Tool | Valuation | Type |
|------|-----------|------|
| Chase Ultimate Rewards | 1.25 cpp | Points |
| Amex Membership Rewards | 1.2 cpp | Points |
| Southwest Rapid Rewards | 1.4 cpp | Points |
| Capital One Miles | 1.0 cpp | Miles |
| Marriott Bonvoy | 0.7 cpp | Points |
| Hilton Honors | 0.5 cpp | Points |
| World of Hyatt | 2.0 cpp | Points |
| IHG One Rewards | 0.5 cpp | Points |
| Bilt Rewards | 1.5 cpp | Points |
| Citi ThankYou | 1.0 cpp | Points |

### OG images added
- All 12 individual tool pages (airline = plane emoji, hotel = hotel emoji, bank = star emoji)
- Tools index page
- Existing United and Delta tools (previously had no OG images)

### SEO
- Each page has unique title with "(Converter/Calculator)" for search intent
- Unique meta descriptions with program name and valuation
- BreadcrumbSchema JSON-LD on every page
- Related cards and news sections for internal linking

### Other changes
- Updated /tools index page with all 12 tools listed
- Improved tools index meta description to include all program names

## Test plan
- [ ] Verify all 12 tool pages render correctly
- [ ] Verify converter calculations are accurate
- [ ] Verify OG images render on all tool pages
- [ ] Verify related cards/news sections populate correctly
- [ ] Test OG image unfurling on social media

🤖 Generated with [Claude Code](https://claude.com/claude-code)