### PR TITLE
Show estimated USD value next to signup bonus

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -8,6 +8,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   BuildingLibraryIcon,
 } from "@heroicons/react/24/solid";
+import { getValuation } from "@/lib/valuations";
 import {
   ExclamationTriangleIcon,
   PencilSquareIcon,
@@ -300,6 +301,11 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
                           {card.signup_bonus.type === "cash"
                             ? `$${card.signup_bonus.value.toLocaleString()}`
                             : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type.charAt(0).toUpperCase() + card.signup_bonus.type.slice(1)}`}
+                          {card.signup_bonus.type !== "cash" && (
+                            <span className="text-sm font-medium text-amber-700/70 ml-1.5">
+                              (~${(card.signup_bonus.value * getValuation(card.card_name) / 100).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })})
+                            </span>
+                          )}
                         </p>
                         <p className="text-sm text-amber-800/70 mt-1">
                           After spending ${card.signup_bonus.spend_requirement.toLocaleString()} in{" "}


### PR DESCRIPTION
## Summary
- Displays estimated USD value next to non-cash signup bonuses on card pages
- Uses the card's point/mile valuation from `valuations.ts`
- Shown as `(~$X)` in a lighter, smaller font next to the bonus amount

### Examples
- Chase Sapphire Reserve: **130,000 Points** (~$1,625)
- Amex Gold: **80,000 Points** (~$960)
- Delta SkyMiles Gold: **90,000 Miles** (~$990)
- Cash bonuses are unchanged (already shown as $X)

## Test plan
- [ ] Verify USD estimate shows on cards with points/miles bonuses
- [ ] Verify cash bonus cards don't show duplicate dollar amounts
- [ ] Verify valuations are correct per program

🤖 Generated with [Claude Code](https://claude.com/claude-code)