### PR TITLE
Add user card rating feature

### DIFF
--- a/apps/api/migrations/008_create_card_ratings.sql
+++ b/apps/api/migrations/008_create_card_ratings.sql
@@ -1,0 +1,11 @@
+CREATE TABLE card_ratings (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id VARCHAR(128) NOT NULL,
+  card_id INT NOT NULL,
+  rating TINYINT NOT NULL CHECK (rating >= 1 AND rating <= 4),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY unique_user_card (user_id, card_id),
+  KEY idx_card_id (card_id),
+  CONSTRAINT fk_rating_card FOREIGN KEY (card_id) REFERENCES cards(card_id)
+);

--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -1,0 +1,194 @@
+const mysql = require("serverless-mysql")({
+  config: {
+    host: process.env.ENDPOINT,
+    database: process.env.DATABASE,
+    user: process.env.USERNAME,
+    password: process.env.PASSWORD,
+  },
+});
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+// GET /ratings?card_id=123 — public, returns avg + count
+// GET /ratings/me?card_id=123 — authenticated, returns user's rating
+// POST /ratings — authenticated, upsert rating
+exports.CardRatingsHandler = async (event) => {
+  console.info("received:", event);
+
+  let response = {};
+
+  switch (event.httpMethod) {
+    case "OPTIONS":
+      response = {
+        statusCode: 200,
+        headers: responseHeaders,
+        body: JSON.stringify({ statusText: "OK" }),
+      };
+      break;
+
+    case "GET":
+      try {
+        const cardId = event.queryStringParameters?.card_id;
+        if (!cardId) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "card_id is required" }),
+          };
+          break;
+        }
+
+        const results = await mysql.query(
+          `SELECT COUNT(*) as count, AVG(rating) as average
+           FROM card_ratings WHERE card_id = ?`,
+          [cardId]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({
+            count: results[0].count,
+            average: results[0].average ? parseFloat(results[0].average.toFixed(2)) : null,
+          }),
+        };
+        break;
+      } catch (error) {
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: String(error) }),
+        };
+        break;
+      }
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: JSON.stringify({ error: `Method ${event.httpMethod} not allowed` }),
+      };
+      break;
+  }
+
+  console.info(`response from: ${event.path} statusCode: ${response.statusCode}`);
+  return response;
+};
+
+// Authenticated handler for user's own rating
+exports.CardRatingsUserHandler = async (event) => {
+  console.info("received:", event);
+
+  let response = {};
+  const userId = event.requestContext?.authorizer?.sub;
+
+  switch (event.httpMethod) {
+    case "OPTIONS":
+      response = {
+        statusCode: 200,
+        headers: responseHeaders,
+        body: JSON.stringify({ statusText: "OK" }),
+      };
+      break;
+
+    case "GET":
+      try {
+        const cardId = event.queryStringParameters?.card_id;
+        if (!cardId) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "card_id is required" }),
+          };
+          break;
+        }
+
+        const results = await mysql.query(
+          `SELECT rating FROM card_ratings WHERE user_id = ? AND card_id = ?`,
+          [userId, cardId]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({
+            rating: results.length > 0 ? results[0].rating : null,
+          }),
+        };
+        break;
+      } catch (error) {
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: String(error) }),
+        };
+        break;
+      }
+
+    case "POST":
+      try {
+        const body = typeof event.body === "string" ? JSON.parse(event.body) : event.body;
+        const { card_id, rating } = body;
+
+        if (!card_id || !rating) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "card_id and rating are required" }),
+          };
+          break;
+        }
+
+        if (rating < 1 || rating > 4 || !Number.isInteger(rating)) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "rating must be an integer between 1 and 4" }),
+          };
+          break;
+        }
+
+        // Upsert: insert or update on duplicate key
+        await mysql.query(
+          `INSERT INTO card_ratings (user_id, card_id, rating)
+           VALUES (?, ?, ?)
+           ON DUPLICATE KEY UPDATE rating = VALUES(rating), updated_at = NOW()`,
+          [userId, card_id, rating]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ success: true, rating }),
+        };
+        break;
+      } catch (error) {
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: String(error) }),
+        };
+        break;
+      }
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: JSON.stringify({ error: `Method ${event.httpMethod} not allowed` }),
+      };
+      break;
+  }
+
+  console.info(`response from: ${event.path} statusCode: ${response.statusCode}`);
+  return response;
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -754,3 +754,76 @@ Resources:
               Ref: CreditCardOddsAPI
             Auth:
               Authorizer: NONE
+
+  CardRatingsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/card-ratings.CardRatingsHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Public card ratings aggregate endpoint
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetRatings:
+          Type: Api
+          Properties:
+            Path: /ratings
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+        RatingsOptions:
+          Type: Api
+          Properties:
+            Path: /ratings
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
+  CardRatingsUserFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/card-ratings.CardRatingsUserHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Authenticated user card rating endpoint
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetUserRating:
+          Type: Api
+          Properties:
+            Path: /ratings/me
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        PostUserRating:
+          Type: Api
+          Properties:
+            Path: /ratings/me
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        UserRatingOptions:
+          Type: Api
+          Properties:
+            Path: /ratings/me
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -19,7 +19,7 @@ import {
   ScaleIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
-import { Card, GraphData, Reward, trackReferralEvent, getRecords } from "@/lib/api";
+import { Card, GraphData, Reward, trackReferralEvent, getRecords, getCardRatings, getUserCardRating, submitCardRating } from "@/lib/api";
 import { NewsItem, tagLabels, tagColors } from "@/lib/news";
 import { Article, tagLabels as articleTagLabels, tagColors as articleTagColors } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -47,6 +47,168 @@ function formatRewardValue(reward: Reward): string {
     return `${reward.value}%`;
   }
   return `${reward.value}x`;
+}
+
+const RATING_LABELS: Record<number, string> = {
+  1: 'Very Bad',
+  2: 'Bad',
+  3: 'Good',
+  4: 'Very Good',
+};
+
+const RATING_COLORS: Record<number, { bg: string; text: string; fill: string }> = {
+  1: { bg: 'bg-red-100', text: 'text-red-700', fill: 'text-red-400' },
+  2: { bg: 'bg-orange-100', text: 'text-orange-700', fill: 'text-orange-400' },
+  3: { bg: 'bg-green-100', text: 'text-green-700', fill: 'text-green-400' },
+  4: { bg: 'bg-emerald-100', text: 'text-emerald-700', fill: 'text-emerald-500' },
+};
+
+function StarIcon({ filled, half, className }: { filled?: boolean; half?: boolean; className?: string }) {
+  if (half) {
+    return (
+      <svg className={className} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="halfGrad">
+            <stop offset="50%" stopColor="currentColor" />
+            <stop offset="50%" stopColor="transparent" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+          fill="url(#halfGrad)"
+          stroke="currentColor"
+          strokeWidth="1"
+        />
+      </svg>
+    );
+  }
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth={filled ? "0" : "1.5"} xmlns="http://www.w3.org/2000/svg">
+      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+    </svg>
+  );
+}
+
+function CardRating({ cardId, isAuthenticated, getToken }: {
+  cardId: number | undefined;
+  isAuthenticated: boolean;
+  getToken: () => Promise<string | null>;
+}) {
+  const [aggregate, setAggregate] = useState<{ count: number; average: number | null }>({ count: 0, average: null });
+  const [userRating, setUserRating] = useState<number | null>(null);
+  const [hoveredRating, setHoveredRating] = useState<number | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!cardId) return;
+    getCardRatings(cardId).then(setAggregate).catch(() => {});
+  }, [cardId]);
+
+  useEffect(() => {
+    if (!cardId || !isAuthenticated) return;
+    let cancelled = false;
+    (async () => {
+      const token = await getToken();
+      if (!token || cancelled) return;
+      const rating = await getUserCardRating(cardId, token);
+      if (!cancelled) setUserRating(rating);
+    })();
+    return () => { cancelled = true; };
+  }, [cardId, isAuthenticated, getToken]);
+
+  const handleRate = async (rating: number) => {
+    if (!cardId || !isAuthenticated || submitting) return;
+    setSubmitting(true);
+    try {
+      const token = await getToken();
+      if (!token) return;
+      await submitCardRating(cardId, rating, token);
+      setUserRating(rating);
+      // Refresh aggregate
+      const updated = await getCardRatings(cardId);
+      setAggregate(updated);
+    } catch {
+      // Silently fail
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const displayRating = hoveredRating ?? userRating;
+  const ratingStyle = displayRating ? RATING_COLORS[displayRating] : null;
+
+  return (
+    <div className="mt-5 bg-gray-50 border border-gray-200 rounded-xl px-5 py-4">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs uppercase text-gray-400 font-semibold tracking-wider">User Rating</p>
+        {aggregate.count > 0 && aggregate.average !== null && (
+          <span className="text-sm text-gray-500">
+            {aggregate.average.toFixed(1)}/4 from {aggregate.count} {aggregate.count === 1 ? 'rating' : 'ratings'}
+          </span>
+        )}
+      </div>
+
+      {/* Star display for aggregate */}
+      {aggregate.count > 0 && aggregate.average !== null && (
+        <div className="flex items-center gap-0.5 mb-3">
+          {[1, 2, 3, 4].map((star) => {
+            const filled = star <= Math.floor(aggregate.average!);
+            const half = !filled && star === Math.ceil(aggregate.average!) && aggregate.average! % 1 >= 0.25;
+            return (
+              <StarIcon
+                key={star}
+                filled={filled}
+                half={half}
+                className={`h-5 w-5 ${filled || half ? 'text-amber-400' : 'text-gray-300'}`}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {/* Interactive rating for signed-in users */}
+      {isAuthenticated ? (
+        <div>
+          <p className="text-sm text-gray-600 mb-2">
+            {userRating ? 'Your rating (click to change):' : 'Rate this card:'}
+          </p>
+          <div className="flex items-center gap-1">
+            {[1, 2, 3, 4].map((star) => {
+              const active = (hoveredRating ?? userRating ?? 0) >= star;
+              const colors = RATING_COLORS[hoveredRating ?? userRating ?? star];
+              return (
+                <button
+                  key={star}
+                  onClick={() => handleRate(star)}
+                  onMouseEnter={() => setHoveredRating(star)}
+                  onMouseLeave={() => setHoveredRating(null)}
+                  disabled={submitting}
+                  className={`p-1.5 rounded-lg transition-colors ${
+                    active ? colors.bg : 'hover:bg-gray-100'
+                  } ${submitting ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                  title={RATING_LABELS[star]}
+                >
+                  <StarIcon
+                    filled={active}
+                    className={`h-7 w-7 ${active ? colors.fill : 'text-gray-300'}`}
+                  />
+                </button>
+              );
+            })}
+            {displayRating && ratingStyle && (
+              <span className={`ml-2 text-sm font-medium ${ratingStyle.text}`}>
+                {RATING_LABELS[displayRating]}
+              </span>
+            )}
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-400">
+          Sign in to rate this card
+        </p>
+      )}
+    </div>
+  );
 }
 
 interface CardClientProps {
@@ -528,6 +690,13 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
                     </dl>
                   </div>
                 )}
+
+                {/* Card Rating */}
+                <CardRating
+                  cardId={card.db_card_id}
+                  isAuthenticated={authState.isAuthenticated}
+                  getToken={getToken}
+                />
               </div>
             </div>
           </div>

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -425,6 +425,49 @@ export async function getApprovalSearches(token: string): Promise<ApprovalSearch
   return res.json();
 }
 
+// Card Ratings
+export interface CardRatingAggregates {
+  count: number;
+  average: number | null;
+}
+
+export async function getCardRatings(cardId: number): Promise<CardRatingAggregates> {
+  const res = await fetch(`${API_BASE}/ratings?card_id=${cardId}`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) return { count: 0, average: null };
+  return res.json();
+}
+
+export async function getUserCardRating(cardId: number, token: string): Promise<number | null> {
+  const res = await fetch(`${API_BASE}/ratings/me?card_id=${cardId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.rating;
+}
+
+export async function submitCardRating(
+  cardId: number,
+  rating: number,
+  token: string
+): Promise<void> {
+  const res = await fetch(`${API_BASE}/ratings/me`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ card_id: cardId, rating }),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to submit rating: ${errorText}`);
+  }
+}
+
 // ============ ADMIN API FUNCTIONS ============
 
 // Admin Graphs


### PR DESCRIPTION
## Summary
- Adds a 1-4 star rating system for credit cards (Very Bad, Bad, Good, Very Good)
- Only signed-in users can rate; one rating per card, changeable from the card page
- Shows aggregate average + count publicly on every card page
- New DB migration (`008_create_card_ratings.sql`), two Lambda endpoints (public aggregates + authenticated user ratings), and interactive UI component

## Deployment Steps
1. Run migration `008_create_card_ratings.sql` against the database
2. Deploy API: `cd apps/api && sam build && sam deploy`
3. Frontend auto-deploys via Amplify on merge

## Test plan
- [ ] Verify card page shows "User Rating" section with "Sign in to rate" for logged-out users
- [ ] Sign in and rate a card — confirm star highlights and label appears
- [ ] Verify rating persists on page refresh
- [ ] Change rating and confirm it updates
- [ ] Check aggregate count/average updates after rating

Generated with [Claude Code](https://claude.com/claude-code)