### PR TITLE
Fix card ratings to use card_name lookup

### DIFF
--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -15,9 +15,16 @@ const responseHeaders = {
   "X-Requested-With": "*",
 };
 
-// GET /ratings?card_id=123 — public, returns avg + count
-// GET /ratings/me?card_id=123 — authenticated, returns user's rating
-// POST /ratings — authenticated, upsert rating
+// Resolve a card_name to its numeric card_id
+async function resolveCardId(cardName) {
+  const rows = await mysql.query(
+    `SELECT card_id FROM cards WHERE card_name = ? OR card_name = ? LIMIT 1`,
+    [cardName, cardName.replace(/ Card$/, '')]
+  );
+  return rows.length > 0 ? rows[0].card_id : null;
+}
+
+// GET /ratings?card_name=Chase+Sapphire+Preferred — public, returns avg + count
 exports.CardRatingsHandler = async (event) => {
   console.info("received:", event);
 
@@ -34,12 +41,23 @@ exports.CardRatingsHandler = async (event) => {
 
     case "GET":
       try {
-        const cardId = event.queryStringParameters?.card_id;
-        if (!cardId) {
+        const cardName = event.queryStringParameters?.card_name;
+        if (!cardName) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "card_id is required" }),
+            body: JSON.stringify({ error: "card_name is required" }),
+          };
+          break;
+        }
+
+        const cardId = await resolveCardId(cardName);
+        if (!cardId) {
+          await mysql.end();
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({ count: 0, average: null }),
           };
           break;
         }
@@ -61,6 +79,7 @@ exports.CardRatingsHandler = async (event) => {
         };
         break;
       } catch (error) {
+        await mysql.end();
         response = {
           statusCode: 500,
           headers: responseHeaders,
@@ -100,12 +119,23 @@ exports.CardRatingsUserHandler = async (event) => {
 
     case "GET":
       try {
-        const cardId = event.queryStringParameters?.card_id;
-        if (!cardId) {
+        const cardName = event.queryStringParameters?.card_name;
+        if (!cardName) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "card_id is required" }),
+            body: JSON.stringify({ error: "card_name is required" }),
+          };
+          break;
+        }
+
+        const cardId = await resolveCardId(cardName);
+        if (!cardId) {
+          await mysql.end();
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({ rating: null }),
           };
           break;
         }
@@ -125,6 +155,7 @@ exports.CardRatingsUserHandler = async (event) => {
         };
         break;
       } catch (error) {
+        await mysql.end();
         response = {
           statusCode: 500,
           headers: responseHeaders,
@@ -136,13 +167,13 @@ exports.CardRatingsUserHandler = async (event) => {
     case "POST":
       try {
         const body = typeof event.body === "string" ? JSON.parse(event.body) : event.body;
-        const { card_id, rating } = body;
+        const { card_name: cardName, rating } = body;
 
-        if (!card_id || !rating) {
+        if (!cardName || !rating) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "card_id and rating are required" }),
+            body: JSON.stringify({ error: "card_name and rating are required" }),
           };
           break;
         }
@@ -156,12 +187,23 @@ exports.CardRatingsUserHandler = async (event) => {
           break;
         }
 
+        const cardId = await resolveCardId(cardName);
+        if (!cardId) {
+          await mysql.end();
+          response = {
+            statusCode: 404,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "Card not found" }),
+          };
+          break;
+        }
+
         // Upsert: insert or update on duplicate key
         await mysql.query(
           `INSERT INTO card_ratings (user_id, card_id, rating)
            VALUES (?, ?, ?)
            ON DUPLICATE KEY UPDATE rating = VALUES(rating), updated_at = NOW()`,
-          [userId, card_id, rating]
+          [userId, cardId, rating]
         );
         await mysql.end();
 
@@ -172,6 +214,7 @@ exports.CardRatingsUserHandler = async (event) => {
         };
         break;
       } catch (error) {
+        await mysql.end();
         response = {
           statusCode: 500,
           headers: responseHeaders,

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -89,8 +89,8 @@ function StarIcon({ filled, half, className }: { filled?: boolean; half?: boolea
   );
 }
 
-function CardRating({ cardId, isAuthenticated, getToken }: {
-  cardId: number | undefined;
+function CardRating({ cardName, isAuthenticated, getToken }: {
+  cardName: string;
   isAuthenticated: boolean;
   getToken: () => Promise<string | null>;
 }) {
@@ -100,32 +100,31 @@ function CardRating({ cardId, isAuthenticated, getToken }: {
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
-    if (!cardId) return;
-    getCardRatings(cardId).then(setAggregate).catch(() => {});
-  }, [cardId]);
+    getCardRatings(cardName).then(setAggregate).catch(() => {});
+  }, [cardName]);
 
   useEffect(() => {
-    if (!cardId || !isAuthenticated) return;
+    if (!isAuthenticated) return;
     let cancelled = false;
     (async () => {
       const token = await getToken();
       if (!token || cancelled) return;
-      const rating = await getUserCardRating(cardId, token);
+      const rating = await getUserCardRating(cardName, token);
       if (!cancelled) setUserRating(rating);
     })();
     return () => { cancelled = true; };
-  }, [cardId, isAuthenticated, getToken]);
+  }, [cardName, isAuthenticated, getToken]);
 
   const handleRate = async (rating: number) => {
-    if (!cardId || !isAuthenticated || submitting) return;
+    if (!isAuthenticated || submitting) return;
     setSubmitting(true);
     try {
       const token = await getToken();
       if (!token) return;
-      await submitCardRating(cardId, rating, token);
+      await submitCardRating(cardName, rating, token);
       setUserRating(rating);
       // Refresh aggregate
-      const updated = await getCardRatings(cardId);
+      const updated = await getCardRatings(cardName);
       setAggregate(updated);
     } catch {
       // Silently fail
@@ -693,7 +692,7 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
 
                 {/* Card Rating */}
                 <CardRating
-                  cardId={card.db_card_id}
+                  cardName={card.card_name}
                   isAuthenticated={authState.isAuthenticated}
                   getToken={getToken}
                 />

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -431,16 +431,16 @@ export interface CardRatingAggregates {
   average: number | null;
 }
 
-export async function getCardRatings(cardId: number): Promise<CardRatingAggregates> {
-  const res = await fetch(`${API_BASE}/ratings?card_id=${cardId}`, {
+export async function getCardRatings(cardName: string): Promise<CardRatingAggregates> {
+  const res = await fetch(`${API_BASE}/ratings?card_name=${encodeURIComponent(cardName)}`, {
     cache: 'no-store',
   });
   if (!res.ok) return { count: 0, average: null };
   return res.json();
 }
 
-export async function getUserCardRating(cardId: number, token: string): Promise<number | null> {
-  const res = await fetch(`${API_BASE}/ratings/me?card_id=${cardId}`, {
+export async function getUserCardRating(cardName: string, token: string): Promise<number | null> {
+  const res = await fetch(`${API_BASE}/ratings/me?card_name=${encodeURIComponent(cardName)}`, {
     headers: { Authorization: `Bearer ${token}` },
     cache: 'no-store',
   });
@@ -450,7 +450,7 @@ export async function getUserCardRating(cardId: number, token: string): Promise<
 }
 
 export async function submitCardRating(
-  cardId: number,
+  cardName: string,
   rating: number,
   token: string
 ): Promise<void> {
@@ -460,7 +460,7 @@ export async function submitCardRating(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ card_id: cardId, rating }),
+    body: JSON.stringify({ card_name: cardName, rating }),
   });
   if (!res.ok) {
     const errorText = await res.text().catch(() => 'Unknown error');


### PR DESCRIPTION
## Summary
- The card ratings feature wasn't working because `db_card_id` isn't returned by the single-card API endpoint, so it was always `undefined`
- Changed the rating API to accept `card_name` instead of numeric ID, resolving it server-side
- Frontend now passes `card.card_name` which is always available

## Changes
- **API handler**: Accepts `card_name` query param, resolves to numeric `card_id` via DB lookup
- **Frontend API**: Functions now take `cardName: string` instead of `cardId: number`
- **CardRating component**: Passes `card.card_name` instead of `card.db_card_id`

## Already deployed
- API has been redeployed with the fix

Generated with [Claude Code](https://claude.com/claude-code)