### PR TITLE
Add referral archive to preserve stats when replacing links

### DIFF
--- a/apps/api/migrations/009_add_referral_archived_at.sql
+++ b/apps/api/migrations/009_add_referral_archived_at.sql
@@ -1,0 +1,4 @@
+-- Add archived_at column to referrals table
+-- When set, the referral link is inactive but stats are preserved
+ALTER TABLE referrals ADD COLUMN archived_at TIMESTAMP NULL DEFAULT NULL;
+CREATE INDEX idx_referrals_archived_at ON referrals (archived_at);

--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -352,6 +352,7 @@ exports.AdminReferralsHandler = async (event) => {
             r.submitter_id,
             r.submit_datetime,
             r.admin_approved,
+            r.archived_at,
             c.card_name,
             c.card_image_link,
             c.bank,
@@ -400,13 +401,13 @@ exports.AdminReferralsHandler = async (event) => {
     case "PUT":
       try {
         const body = JSON.parse(event.body);
-        const { referral_id, approved, referral_link } = body;
+        const { referral_id, approved, referral_link, archived } = body;
 
-        if (!referral_id || approved === undefined) {
+        if (!referral_id) {
           return {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "referral_id and approved are required" }),
+            body: JSON.stringify({ error: "referral_id is required" }),
           };
         }
 
@@ -420,21 +421,33 @@ exports.AdminReferralsHandler = async (event) => {
           };
         }
 
-        if (referral_link) {
+        // Handle archive/unarchive
+        if (archived !== undefined) {
           await mysql.query(
-            "UPDATE referrals SET admin_approved = ?, referral_link = ? WHERE referral_id = ?",
-            [approved ? 1 : 0, referral_link, referral_id]
+            "UPDATE referrals SET archived_at = ? WHERE referral_id = ?",
+            [archived ? new Date() : null, referral_id]
           );
-        } else {
-          await mysql.query(
-            "UPDATE referrals SET admin_approved = ? WHERE referral_id = ?",
-            [approved ? 1 : 0, referral_id]
-          );
+          await logAuditAction(userId, archived ? 'ARCHIVE' : 'UNARCHIVE', 'referral', referral_id, referral[0]);
         }
-        const auditDetails = referral_link
-          ? { ...referral[0], updated_referral_link: referral_link }
-          : referral[0];
-        await logAuditAction(userId, approved ? 'APPROVE' : 'UNAPPROVE', 'referral', referral_id, auditDetails);
+
+        // Handle approval and link update
+        if (approved !== undefined) {
+          if (referral_link) {
+            await mysql.query(
+              "UPDATE referrals SET admin_approved = ?, referral_link = ? WHERE referral_id = ?",
+              [approved ? 1 : 0, referral_link, referral_id]
+            );
+          } else {
+            await mysql.query(
+              "UPDATE referrals SET admin_approved = ? WHERE referral_id = ?",
+              [approved ? 1 : 0, referral_id]
+            );
+          }
+          const auditDetails = referral_link
+            ? { ...referral[0], updated_referral_link: referral_link }
+            : referral[0];
+          await logAuditAction(userId, approved ? 'APPROVE' : 'UNAPPROVE', 'referral', referral_id, auditDetails);
+        }
         await mysql.end();
 
         return {

--- a/apps/api/src/handlers/card-by-id.js
+++ b/apps/api/src/handlers/card-by-id.js
@@ -95,7 +95,7 @@ async function fetchCardFromDB(cardName) {
       mysql.query(`
         SELECT referral_id, referral_link
         FROM referrals
-        WHERE card_id = ? AND admin_approved = 1
+        WHERE card_id = ? AND admin_approved = 1 AND archived_at IS NULL
       `, [dbCard.card_id])
     ]);
 

--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -48,13 +48,13 @@ exports.UserReferralsHandler = async (event) => {
           return element.referral_link == null;
         });
 
-        // Get impression/click counts and card_referral_link for submitted referrals
+        // Get impression/click counts, card_referral_link, and archived status for submitted referrals
         if (submitted.length > 0) {
           const referralIds = submitted.map(r => r.referral_id).filter(id => id);
           const cardIds = submitted.map(r => r.card_id).filter(id => id);
 
-          // Fetch stats and card referral links in parallel
-          const [statsResults, cardResults] = await Promise.all([
+          // Fetch stats, card referral links, and archived status in parallel
+          const [statsResults, cardResults, archivedResults] = await Promise.all([
             referralIds.length > 0 ? mysql.query(`
               SELECT
                 referral_id,
@@ -68,7 +68,12 @@ exports.UserReferralsHandler = async (event) => {
               SELECT card_id, card_referral_link
               FROM cards
               WHERE card_id IN (?)
-            `, [cardIds]) : []
+            `, [cardIds]) : [],
+            referralIds.length > 0 ? mysql.query(`
+              SELECT referral_id, archived_at
+              FROM referrals
+              WHERE referral_id IN (?)
+            `, [referralIds]) : []
           ]);
 
           // Create a map of stats by referral_id
@@ -86,12 +91,40 @@ exports.UserReferralsHandler = async (event) => {
             cardLinkMap[card.card_id] = card.card_referral_link;
           }
 
-          // Add stats and card_referral_link to submitted referrals
+          // Create a map of archived_at by referral_id
+          const archivedMap = {};
+          for (const row of archivedResults) {
+            archivedMap[row.referral_id] = row.archived_at;
+          }
+
+          // Add stats, card_referral_link, and archived_at to submitted referrals
           for (const referral of submitted) {
             const stats = statsMap[referral.referral_id] || { impressions: 0, clicks: 0 };
             referral.impressions = stats.impressions;
             referral.clicks = stats.clicks;
             referral.card_referral_link = cardLinkMap[referral.card_id] || null;
+            referral.archived_at = archivedMap[referral.referral_id] || null;
+          }
+        }
+
+        // Also include cards with only archived referrals in the "open" list
+        const archivedCardIds = new Set(
+          submitted.filter(r => r.archived_at).map(r => r.card_id)
+        );
+        const activeCardIds = new Set(
+          submitted.filter(r => !r.archived_at).map(r => r.card_id)
+        );
+        // Cards that only have archived referrals (no active one) should appear in open
+        for (const cardId of archivedCardIds) {
+          if (!activeCardIds.has(cardId)) {
+            const archivedRef = submitted.find(r => r.card_id === cardId && r.archived_at);
+            if (archivedRef && !open.some(o => o.card_id === cardId)) {
+              open.push({
+                card_id: archivedRef.card_id,
+                card_name: archivedRef.card_name,
+                card_image_link: archivedRef.card_image_link,
+              });
+            }
           }
         }
 
@@ -113,28 +146,31 @@ exports.UserReferralsHandler = async (event) => {
       break;
     case "POST":
       try {
-        console.log(JSON.parse(event.body).card_id);
-        console.log(JSON.parse(event.body).referral_link);
-        let count = await mysql.query("call creditodds.check_referral(?,?,?)", [
-          JSON.parse(event.body).card_id,
-          event.requestContext.authorizer.sub,
-          JSON.parse(event.body).referral_link,
-        ]);
-        await mysql.end();
-        console.log(count);
-        count = JSON.parse(JSON.stringify(count))[0][0]["count"];
-        console.log(count);
+        const postBody = JSON.parse(event.body);
+        const userId = event.requestContext.authorizer.sub;
 
-        if (count > 0) {
-          throw new Error(
-            `User has already submitted a referral for this card or this referral link has been used by another account.`
-          );
+        // Check for existing active (non-archived) referral for this card by this user
+        const existingActive = await mysql.query(
+          "SELECT referral_id FROM referrals WHERE card_id = ? AND submitter_id = ? AND archived_at IS NULL",
+          [postBody.card_id, userId]
+        );
+        if (existingActive.length > 0) {
+          throw new Error("User has already submitted an active referral for this card.");
+        }
+
+        // Check if this exact link is used by another account (active only)
+        const existingLink = await mysql.query(
+          "SELECT referral_id FROM referrals WHERE referral_link = ? AND submitter_id != ? AND archived_at IS NULL",
+          [postBody.referral_link, userId]
+        );
+        if (existingLink.length > 0) {
+          throw new Error("This referral link has been used by another account.");
         }
 
         const referral = await mysql.query("INSERT INTO referrals SET ?", {
-          card_id: JSON.parse(event.body).card_id,
-          referral_link: JSON.parse(event.body).referral_link,
-          submitter_id: event.requestContext.authorizer.sub,
+          card_id: postBody.card_id,
+          referral_link: postBody.referral_link,
+          submitter_id: userId,
           submitter_ip_address: event.requestContext.identity.sourceIp,
           submit_datetime: new Date(),
         });
@@ -149,6 +185,48 @@ exports.UserReferralsHandler = async (event) => {
         response = {
           statusCode: 500,
           body: `There was an error with the query: ${error}`,
+          headers: responseHeaders,
+        };
+      }
+      break;
+    case "PATCH":
+      try {
+        const patchBody = JSON.parse(event.body);
+        const patchUserId = event.requestContext.authorizer.sub;
+
+        if (!patchBody.referral_id) {
+          throw new Error("referral_id is required");
+        }
+
+        // Verify the referral belongs to this user
+        const referralToArchive = await mysql.query(
+          "SELECT referral_id, archived_at FROM referrals WHERE referral_id = ? AND submitter_id = ?",
+          [patchBody.referral_id, patchUserId]
+        );
+
+        if (referralToArchive.length === 0) {
+          throw new Error("Referral not found or you don't have permission to archive it");
+        }
+
+        if (referralToArchive[0].archived_at) {
+          throw new Error("Referral is already archived");
+        }
+
+        await mysql.query(
+          "UPDATE referrals SET archived_at = NOW() WHERE referral_id = ?",
+          [patchBody.referral_id]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ message: "Referral archived successfully" }),
+        };
+      } catch (error) {
+        response = {
+          statusCode: 500,
+          body: `There was an error archiving the referral: ${error}`,
           headers: responseHeaders,
         };
       }
@@ -194,7 +272,7 @@ exports.UserReferralsHandler = async (event) => {
       //Throw an error if the request method is not GET
       response = {
         statusCode: 405,
-        body: `UserReferrals only accepts GET, POST, and DELETE methods, you tried: ${event.httpMethod}`,
+        body: `UserReferrals only accepts GET, POST, PATCH, and DELETE methods, you tried: ${event.httpMethod}`,
         headers: responseHeaders,
       };
       break;

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -697,11 +697,18 @@ function ReferralsTab({
                   )}
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap">
-                  <span className={`px-2 py-1 text-xs font-medium rounded-full ${
-                    referral.admin_approved ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
-                  }`}>
-                    {referral.admin_approved ? 'Approved' : 'Pending'}
-                  </span>
+                  <div className="flex flex-col gap-1">
+                    <span className={`px-2 py-1 text-xs font-medium rounded-full inline-block w-fit ${
+                      referral.admin_approved ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
+                    }`}>
+                      {referral.admin_approved ? 'Approved' : 'Pending'}
+                    </span>
+                    {referral.archived_at && (
+                      <span className="px-2 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-600 inline-block w-fit">
+                        Archived
+                      </span>
+                    )}
+                  </div>
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
                   <div>{referral.impressions} views</div>
@@ -1099,11 +1106,18 @@ function UserLookupTab({
                           </a>
                         </td>
                         <td className="px-4 py-3 whitespace-nowrap">
-                          <span className={`px-2 py-1 text-xs font-medium rounded-full ${
-                            referral.admin_approved ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
-                          }`}>
-                            {referral.admin_approved ? 'Approved' : 'Pending'}
-                          </span>
+                          <div className="flex flex-col gap-1">
+                            <span className={`px-2 py-1 text-xs font-medium rounded-full inline-block w-fit ${
+                              referral.admin_approved ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
+                            }`}>
+                              {referral.admin_approved ? 'Approved' : 'Pending'}
+                            </span>
+                            {referral.archived_at && (
+                              <span className="px-2 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-600 inline-block w-fit">
+                                Archived
+                              </span>
+                            )}
+                          </div>
                         </td>
                         <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
                           <div>{referral.impressions} views</div>

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -6,10 +6,10 @@ import Image from "next/image";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useAuth } from "@/auth/AuthProvider";
-import { getAllCards, getProfile, getRecords, getReferrals, deleteRecord, deleteReferral, getWallet, deleteAccount, WalletCard, Card } from "@/lib/api";
+import { getAllCards, getProfile, getRecords, getReferrals, deleteRecord, deleteReferral, archiveReferral, getWallet, deleteAccount, WalletCard, Card } from "@/lib/api";
 import { getNews, NewsItem, tagLabels, tagColors, NewsTag } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
-import { PlusIcon, WalletIcon, TrashIcon, DocumentTextIcon, LinkIcon, NewspaperIcon, ChartBarIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { PlusIcon, WalletIcon, TrashIcon, DocumentTextIcon, LinkIcon, NewspaperIcon, ChartBarIcon, ExclamationTriangleIcon, ArchiveBoxIcon } from "@heroicons/react/24/outline";
 import { calculateApplicationRules, countCardsMissingDates } from "@/lib/applicationRules";
 
 // Lazy load modals - only loaded when user opens them
@@ -68,6 +68,7 @@ interface Referral {
   referral_link: string;
   card_referral_link?: string;
   admin_approved: boolean;
+  archived_at?: string | null;
   impressions?: number;
   clicks?: number;
 }
@@ -104,6 +105,7 @@ export default function ProfileClient() {
   const [showWalletModal, setShowWalletModal] = useState(false);
   const [deletingRecordId, setDeletingRecordId] = useState<number | null>(null);
   const [deletingReferralId, setDeletingReferralId] = useState<number | null>(null);
+  const [archivingReferralId, setArchivingReferralId] = useState<number | null>(null);
   const [deletingAccount, setDeletingAccount] = useState(false);
   const [showInactiveCards, setShowInactiveCards] = useState(false);
   const [activeTab, setActiveTab] = useState<'wallet' | 'records' | 'referrals' | 'advanced'>('wallet');
@@ -318,8 +320,29 @@ export default function ProfileClient() {
     }
   };
 
+  const handleArchiveReferral = async (referralId: number) => {
+    if (!confirm("Archive this referral? It will stop being shown to visitors but stats will be preserved.")) {
+      return;
+    }
+
+    setArchivingReferralId(referralId);
+    try {
+      const token = await getToken();
+      if (!token) return;
+      await archiveReferral(referralId, token);
+      setReferrals(referrals.map(r =>
+        r.referral_id === referralId ? { ...r, archived_at: new Date().toISOString() } : r
+      ));
+    } catch (error) {
+      console.error("Error archiving referral:", error);
+      alert("Failed to archive referral. Please try again.");
+    } finally {
+      setArchivingReferralId(null);
+    }
+  };
+
   const handleDeleteReferral = async (referralId: number) => {
-    if (!confirm("Are you sure you want to delete this referral?")) {
+    if (!confirm("Permanently delete this referral and all its stats? This cannot be undone.")) {
       return;
     }
 
@@ -331,7 +354,6 @@ export default function ProfileClient() {
         return;
       }
       await deleteReferral(referralId, token);
-      // Remove the referral from local state
       setReferrals(referrals.filter(r => r.referral_id !== referralId));
     } catch (error) {
       console.error("Error deleting referral:", error);
@@ -799,167 +821,207 @@ export default function ProfileClient() {
               Submit your full referral URL for any card in your wallet or with a submitted record.
             </p>
           </div>
-          {referrals.length > 0 ? (
-            <div className="border-t border-gray-200">
-              {/* Mobile: Card layout */}
-              <div className="sm:hidden divide-y divide-gray-200">
-                {referrals.map((referral, index) => (
-                  <div key={referral.referral_id || index} className="p-4">
-                    <div className="flex items-start gap-3">
-                      {referral.card_image_link && (
-                        <div className="flex-shrink-0 h-12 w-20 relative">
-                          <Image
-                            className="object-contain"
-                            src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
-                            alt={referral.card_name}
-                            fill
-                            sizes="80px"
-                          />
-                        </div>
+          {(() => {
+            const activeReferrals = referrals.filter(r => !r.archived_at);
+            const archivedReferrals = referrals.filter(r => r.archived_at);
+
+            const renderReferralRow = (referral: Referral, isArchived: boolean) => (
+              <tr key={referral.referral_id} className={isArchived ? 'opacity-60' : ''}>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <div className="flex items-center">
+                    {referral.card_image_link && (
+                      <div className={`flex-shrink-0 h-8 w-12 relative ${isArchived ? 'grayscale' : ''}`}>
+                        <Image
+                          className="object-contain"
+                          src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
+                          alt={referral.card_name}
+                          fill
+                          sizes="48px"
+                        />
+                      </div>
+                    )}
+                    <div className="ml-3">
+                      <div className="text-sm font-medium text-gray-900">{referral.card_name}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <a href={referral.referral_link} target="_blank" rel="noreferrer"
+                    className="text-sm text-indigo-600 hover:text-indigo-900 truncate block max-w-[200px]">
+                    {referral.referral_link}
+                  </a>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  {isArchived ? (
+                    <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-600">
+                      Archived
+                    </span>
+                  ) : referral.admin_approved ? (
+                    <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                      Approved
+                    </span>
+                  ) : (
+                    <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                      Pending
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                  <div>{referral.impressions ?? 0} views</div>
+                  <div>{referral.clicks ?? 0} clicks</div>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-right text-sm font-medium">
+                  {!isArchived && (
+                    <button
+                      onClick={() => handleArchiveReferral(referral.referral_id)}
+                      disabled={archivingReferralId === referral.referral_id}
+                      className="text-gray-500 hover:text-gray-700 disabled:opacity-50 mr-3"
+                      title="Archive"
+                    >
+                      {archivingReferralId === referral.referral_id ? "..." : <ArchiveBoxIcon className="h-4 w-4 inline" />}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleDeleteReferral(referral.referral_id)}
+                    disabled={deletingReferralId === referral.referral_id}
+                    className="text-red-600 hover:text-red-900 disabled:opacity-50"
+                    title="Delete permanently"
+                  >
+                    {deletingReferralId === referral.referral_id ? "..." : <TrashIcon className="h-4 w-4 inline" />}
+                  </button>
+                </td>
+              </tr>
+            );
+
+            const renderReferralMobileCard = (referral: Referral, isArchived: boolean) => (
+              <div key={referral.referral_id} className={`p-4 ${isArchived ? 'opacity-60' : ''}`}>
+                <div className="flex items-start gap-3">
+                  {referral.card_image_link && (
+                    <div className={`flex-shrink-0 h-12 w-20 relative ${isArchived ? 'grayscale' : ''}`}>
+                      <Image
+                        className="object-contain"
+                        src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
+                        alt={referral.card_name}
+                        fill
+                        sizes="80px"
+                      />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between">
+                      <p className="text-sm font-medium text-gray-900 truncate">{referral.card_name}</p>
+                      {isArchived ? (
+                        <span className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-600">
+                          Archived
+                        </span>
+                      ) : referral.admin_approved ? (
+                        <span className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                          Approved
+                        </span>
+                      ) : (
+                        <span className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                          Pending
+                        </span>
                       )}
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-start justify-between">
-                          <p className="text-sm font-medium text-gray-900 truncate">{referral.card_name}</p>
-                          {referral.admin_approved ? (
-                            <span className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                              Approved
-                            </span>
-                          ) : (
-                            <span className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                              Pending
-                            </span>
-                          )}
-                        </div>
-                        <a
-                          href={referral.referral_link}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="mt-1 text-xs text-indigo-600 hover:text-indigo-900 truncate block"
-                        >
-                          {referral.referral_link}
-                        </a>
-                        <div className="mt-1 flex items-center justify-between">
-                          <div className="flex gap-3 text-xs text-gray-500">
-                            <span>{referral.impressions ?? 0} views</span>
-                            <span>{referral.clicks ?? 0} clicks</span>
-                          </div>
+                    </div>
+                    <a href={referral.referral_link} target="_blank" rel="noreferrer"
+                      className="mt-1 text-xs text-indigo-600 hover:text-indigo-900 truncate block">
+                      {referral.referral_link}
+                    </a>
+                    <div className="mt-1 flex items-center justify-between">
+                      <div className="flex gap-3 text-xs text-gray-500">
+                        <span>{referral.impressions ?? 0} views</span>
+                        <span>{referral.clicks ?? 0} clicks</span>
+                      </div>
+                      <div className="flex gap-2">
+                        {!isArchived && (
                           <button
-                            onClick={() => handleDeleteReferral(referral.referral_id)}
-                            disabled={deletingReferralId === referral.referral_id}
-                            className="text-xs text-red-600 hover:text-red-900 disabled:opacity-50"
+                            onClick={() => handleArchiveReferral(referral.referral_id)}
+                            disabled={archivingReferralId === referral.referral_id}
+                            className="text-xs text-gray-500 hover:text-gray-700 disabled:opacity-50"
                           >
-                            {deletingReferralId === referral.referral_id ? "Deleting..." : "Delete"}
+                            {archivingReferralId === referral.referral_id ? "..." : "Archive"}
                           </button>
-                        </div>
+                        )}
+                        <button
+                          onClick={() => handleDeleteReferral(referral.referral_id)}
+                          disabled={deletingReferralId === referral.referral_id}
+                          className="text-xs text-red-600 hover:text-red-900 disabled:opacity-50"
+                        >
+                          {deletingReferralId === referral.referral_id ? "..." : "Delete"}
+                        </button>
                       </div>
                     </div>
                   </div>
-                ))}
+                </div>
               </div>
-              {/* Desktop: Table layout */}
-              <div className="hidden sm:block">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Card
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Referral Link
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Status
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Stats
-                      </th>
-                      <th className="relative px-4 py-3">
-                        <span className="sr-only">Delete</span>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
-                    {referrals.map((referral, index) => (
-                      <tr key={referral.referral_id || index}>
-                        <td className="px-4 py-3 whitespace-nowrap">
-                          <div className="flex items-center">
-                            {referral.card_image_link && (
-                              <div className="flex-shrink-0 h-8 w-12 relative">
-                                <Image
-                                  className="object-contain"
-                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
-                                  alt={referral.card_name}
-                                  fill
-                                  sizes="48px"
-                                />
-                              </div>
-                            )}
-                            <div className="ml-3">
-                              <div className="text-sm font-medium text-gray-900">
-                                {referral.card_name}
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3">
-                          <a
-                            href={referral.referral_link}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="text-sm text-indigo-600 hover:text-indigo-900 truncate block max-w-[200px]"
-                          >
-                            {referral.referral_link}
-                          </a>
-                        </td>
-                        <td className="px-4 py-3 whitespace-nowrap">
-                          {referral.admin_approved ? (
-                            <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                              Approved
-                            </span>
-                          ) : (
-                            <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                              Pending
-                            </span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
-                          <div>{referral.impressions ?? 0} views</div>
-                          <div>{referral.clicks ?? 0} clicks</div>
-                        </td>
-                        <td className="px-4 py-3 whitespace-nowrap text-right text-sm font-medium">
-                          <button
-                            onClick={() => handleDeleteReferral(referral.referral_id)}
-                            disabled={deletingReferralId === referral.referral_id}
-                            className="text-red-600 hover:text-red-900 disabled:opacity-50"
-                          >
-                            {deletingReferralId === referral.referral_id ? "..." : "Delete"}
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          ) : (
-            <div className="border-t border-gray-200 px-4 py-5 sm:px-6">
-              <p className="text-gray-500">No referrals submitted yet.</p>
-            </div>
-          )}
-          <div className="border-t border-gray-200">
-            {eligibleReferralCards.length > 0 ? (
-              <button
-                onClick={() => setShowReferralModal(true)}
-                className="block w-full bg-gray-50 text-sm font-medium text-gray-500 text-center px-4 py-4 hover:text-gray-700 sm:rounded-b-lg cursor-pointer"
-              >
-                Submit a referral
-              </button>
-            ) : (
-              <div className="bg-gray-50 text-sm text-gray-400 text-center px-4 py-4 sm:rounded-b-lg">
-                Add a card to your wallet or submit a data point to add your referral link
-              </div>
-            )}
-            </div>
+            );
+
+            return (
+              <>
+                {activeReferrals.length > 0 ? (
+                  <div className="border-t border-gray-200">
+                    <div className="sm:hidden divide-y divide-gray-200">
+                      {activeReferrals.map(r => renderReferralMobileCard(r, false))}
+                    </div>
+                    <div className="hidden sm:block">
+                      <table className="min-w-full divide-y divide-gray-200">
+                        <thead className="bg-gray-50">
+                          <tr>
+                            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Card</th>
+                            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Referral Link</th>
+                            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Stats</th>
+                            <th className="relative px-4 py-3"><span className="sr-only">Actions</span></th>
+                          </tr>
+                        </thead>
+                        <tbody className="bg-white divide-y divide-gray-200">
+                          {activeReferrals.map(r => renderReferralRow(r, false))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="border-t border-gray-200 px-4 py-5 sm:px-6">
+                    <p className="text-gray-500">No active referrals.</p>
+                  </div>
+                )}
+
+                {archivedReferrals.length > 0 && (
+                  <div className="border-t border-gray-200">
+                    <div className="px-4 py-3 sm:px-6 bg-gray-50">
+                      <h3 className="text-sm font-medium text-gray-500">Archived ({archivedReferrals.length})</h3>
+                    </div>
+                    <div className="sm:hidden divide-y divide-gray-200">
+                      {archivedReferrals.map(r => renderReferralMobileCard(r, true))}
+                    </div>
+                    <div className="hidden sm:block">
+                      <table className="min-w-full divide-y divide-gray-200">
+                        <tbody className="bg-white divide-y divide-gray-200">
+                          {archivedReferrals.map(r => renderReferralRow(r, true))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )}
+
+                <div className="border-t border-gray-200">
+                  {eligibleReferralCards.length > 0 ? (
+                    <button
+                      onClick={() => setShowReferralModal(true)}
+                      className="block w-full bg-gray-50 text-sm font-medium text-gray-500 text-center px-4 py-4 hover:text-gray-700 sm:rounded-b-lg cursor-pointer"
+                    >
+                      Submit a referral
+                    </button>
+                  ) : (
+                    <div className="bg-gray-50 text-sm text-gray-400 text-center px-4 py-4 sm:rounded-b-lg">
+                      Add a card to your wallet or submit a data point to add your referral link
+                    </div>
+                  )}
+                </div>
+              </>
+            );
+          })()}
           </div>
           )
         )}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -189,6 +189,19 @@ export async function deleteReferral(referralId: number, token: string) {
   return res.json();
 }
 
+export async function archiveReferral(referralId: number, token: string) {
+  const res = await fetch(`${API_BASE}/referrals`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ referral_id: referralId }),
+  });
+  if (!res.ok) throw new Error('Failed to archive referral');
+  return res.json();
+}
+
 export async function getProfile(token: string) {
   const res = await fetch(`${API_BASE}/profile`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -601,6 +614,7 @@ export interface AdminReferral {
   submitter_email?: string;
   submit_datetime: string;
   admin_approved: number;
+  archived_at: string | null;
   impressions: number;
   clicks: number;
 }


### PR DESCRIPTION
## Summary
- Users can **archive** a referral link when it stops working, preserving all view/click stats
- After archiving, they can submit a **new referral** for the same card (starts fresh stats)
- Archived referrals are **hidden from visitors** on card pages but visible to the user in a grayed "Archived" section
- Admin page shows archived badge on referrals

## Changes
- **Migration** (`009`): Adds `archived_at TIMESTAMP NULL` to referrals table
- **card-by-id**: Filters out archived referrals from public API
- **user-referrals**: New `PATCH` method for archiving; `POST` allows new referral when existing is archived; `GET` returns `archived_at`
- **admin**: Shows archived status badge
- **Profile UI**: Active/archived split, archive button with confirmation
- **api.ts**: New `archiveReferral()` function, `archived_at` on types

## Deploy steps
1. Run migration `009_add_referral_archived_at.sql`
2. Deploy API: `cd apps/api && sam build && sam deploy`
3. Frontend auto-deploys via Amplify

## Test plan
- [ ] Run migration on DB
- [ ] Archive a referral → verify it disappears from card page but stats are preserved in profile
- [ ] Submit a new referral for the same card → verify it works
- [ ] Check admin page shows "Archived" badge
- [ ] Verify non-archived referrals still display normally on card pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)