### PR TITLE
Fix misleading REI Mastercard 5% category labeling

### DIFF
--- a/apps/web-next/src/components/wallet/BestCardByCategory.tsx
+++ b/apps/web-next/src/components/wallet/BestCardByCategory.tsx
@@ -24,6 +24,7 @@ const categoryLabels: Record<string, string> = {
   flights_portal: "Flights (via Portal)",
   hotels_car_portal: "Hotels & Car Rentals (via Portal)",
   amazon: "Amazon.com",
+  rei: "REI",
 };
 
 const canonicalOrder = Object.keys(categoryLabels);

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -32,6 +32,7 @@ export const categoryLabels: Record<string, string> = {
   flights_portal: "Flights (via Portal)",
   hotels_car_portal: "Hotels & Car Rentals (via Portal)",
   amazon: "Amazon.com",
+  rei: "REI",
   everything_else: "Everything Else",
 };
 
@@ -65,6 +66,7 @@ export function CategoryIcon({ category, className }: { category: string; classN
       return <HomeModernIcon className={iconClass} />;
     case "online_shopping":
     case "amazon":
+    case "rei":
       return <ShoppingBagIcon className={iconClass} />;
     case "hotels":
     case "hotels_portal":

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-03-06T19:21:40.289Z",
-  "count": 146,
+  "count": 147,
   "categories": [
     {
       "id": "dining",
@@ -77,6 +77,10 @@
     {
       "id": "amazon",
       "label": "Amazon.com"
+    },
+    {
+      "id": "rei",
+      "label": "REI"
     },
     {
       "id": "rakuten",
@@ -4646,6 +4650,47 @@
       },
       "card_id": "rakuten-american-express",
       "card_name": "Rakuten American Express"
+    },
+    {
+      "name": "REI Co-op Mastercard",
+      "bank": "Capital One",
+      "slug": "rei-co-op-mastercard",
+      "image": "rei-coop.png",
+      "accepting_applications": true,
+      "annual_fee": 0,
+      "reward_type": "cashback",
+      "tags": [
+        "cashback",
+        "rewards"
+      ],
+      "rewards": [
+        {
+          "category": "rei",
+          "value": 5,
+          "unit": "percent",
+          "note": "At REI retail locations and REI.com"
+        },
+        {
+          "category": "everything_else",
+          "value": 1.5,
+          "unit": "percent"
+        }
+      ],
+      "signup_bonus": {
+        "value": 100,
+        "type": "cash",
+        "spend_requirement": 0,
+        "timeframe_months": 2,
+        "note": "$100 REI gift card after first purchase outside REI within 60 days"
+      },
+      "apr": {
+        "regular": {
+          "min": 17.49,
+          "max": 28.49
+        }
+      },
+      "card_id": "rei-co-op-mastercard",
+      "card_name": "REI Co-op Mastercard"
     },
     {
       "name": "Robinhood Platinum",

--- a/data/cards/rei-co-op-mastercard.yaml
+++ b/data/cards/rei-co-op-mastercard.yaml
@@ -9,7 +9,7 @@ tags:
   - cashback
   - rewards
 rewards:
-  - category: everything_else
+  - category: rei
     value: 5
     unit: percent
     note: "At REI retail locations and REI.com"

--- a/data/categories.yaml
+++ b/data/categories.yaml
@@ -37,6 +37,8 @@ categories:
     label: Hotels & Car Rentals (via Portal)
   - id: amazon
     label: Amazon.com
+  - id: rei
+    label: REI
   - id: rakuten
     label: Rakuten.com
   - id: rakuten_dining


### PR DESCRIPTION
## Summary
- replace the REI Co-op Mastercard 5% reward category from everything_else to a dedicated rei category
- add rei to category definitions and frontend category label mappings
- update data/cards.json so generated card/category data includes the REI category and REI card entry

## Why
The previous data made the card appear as "5% Everything Else" with a note, which is misleading. This change makes the UI explicitly show REI as the 5% category and keeps 1.5% as the true everything-else base rate.

## Testing
- verified updated YAML/JSON diffs for REI category and rewards structure
