### PR TITLE
Add PATCH route for /referrals to API Gateway

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -225,6 +225,13 @@ Resources:
             Method: POST
             RestApiId:
               Ref: CreditCardOddsAPI
+        PATCHCreditCardOddsAPI:
+          Type: Api
+          Properties:
+            Path: /referrals
+            Method: PATCH
+            RestApiId:
+              Ref: CreditCardOddsAPI
         DELETECreditCardOddsAPI:
           Type: Api
           Properties:


### PR DESCRIPTION
## Summary
- Add missing PATCH method route for `/referrals` in SAM template
- Required for the referral archive feature to work

Already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)