### PR TITLE
Add UTM tracking params to social media URLs

### DIFF
--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -47,13 +47,19 @@ function parseArgs() {
 }
 
 /**
- * Build the public URL for a news item or article.
+ * Build the public URL for a news item or article with UTM tracking params.
  */
 function buildUrl(type, item) {
-  if (type === 'news') {
-    return `https://creditodds.com/news/${item.id}`;
-  }
-  return `https://creditodds.com/articles/${item.slug}`;
+  const base = type === 'news'
+    ? `https://creditodds.com/news/${item.id}`
+    : `https://creditodds.com/articles/${item.slug}`;
+  const params = new URLSearchParams({
+    utm_source: 'twitter',
+    utm_medium: 'social',
+    utm_campaign: `auto-${type}`,
+    utm_content: type === 'news' ? item.id : item.slug,
+  });
+  return `${base}?${params}`;
 }
 
 /**

--- a/scripts/queue-social.js
+++ b/scripts/queue-social.js
@@ -60,11 +60,17 @@ function parseArgs() {
   return { type, files };
 }
 
-function buildUrl(type, item) {
-  if (type === 'news') {
-    return `https://creditodds.com/news/${item.id}`;
-  }
-  return `https://creditodds.com/articles/${item.slug}`;
+function buildUrl(type, item, source = 'twitter') {
+  const base = type === 'news'
+    ? `https://creditodds.com/news/${item.id}`
+    : `https://creditodds.com/articles/${item.slug}`;
+  const params = new URLSearchParams({
+    utm_source: source,
+    utm_medium: 'social',
+    utm_campaign: `auto-${type}`,
+    utm_content: type === 'news' ? item.id : item.slug,
+  });
+  return `${base}?${params}`;
 }
 
 async function generatePost(type, item) {


### PR DESCRIPTION
## Summary
- All URLs in social posts now include UTM parameters for analytics tracking
- Format: `?utm_source=twitter&utm_medium=social&utm_campaign=auto-news&utm_content={id}`
- Applied to both `post-social.js` (direct Twitter) and `queue-social.js` (social posting service)
- `queue-social.js` accepts a `source` parameter for future platforms (reddit, linkedin, etc.)

## Example
`https://creditodds.com/news/some-news-id?utm_source=twitter&utm_medium=social&utm_campaign=auto-news&utm_content=some-news-id`

## Test plan
- [ ] Next auto-news/article post should include UTM params in the URL
- [ ] Verify URLs render correctly in tweets (Twitter unfurls ignore query params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)