### PR TITLE
Normalize reward rates to USD equivalents in Best/Compare

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -19,6 +19,7 @@ import {
   ScaleIcon,
   WalletIcon,
   CheckIcon,
+  ArrowRightOnRectangleIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
 import { Card, GraphData, Reward, trackReferralEvent, getRecords, getCardRatings, getUserCardRating, submitCardRating, getWallet, addToWallet } from "@/lib/api";
@@ -105,6 +106,7 @@ function CardRating({ cardName, dbCardId, isAuthenticated, getToken }: {
   const [showWalletPrompt, setShowWalletPrompt] = useState(false);
   const [addingToWallet, setAddingToWallet] = useState(false);
   const [walletAdded, setWalletAdded] = useState(false);
+  const [showSignInPrompt, setShowSignInPrompt] = useState(false);
 
   useEffect(() => {
     getCardRatings(cardName).then(setAggregate).catch(() => {});
@@ -168,12 +170,21 @@ function CardRating({ cardName, dbCardId, isAuthenticated, getToken }: {
   const displayRating = hoveredRating ?? userRating;
   const ratingStyle = displayRating ? RATING_COLORS[displayRating] : null;
 
+  const handleStarClick = (rating: number) => {
+    if (!isAuthenticated) {
+      setShowSignInPrompt(true);
+      return;
+    }
+    setShowSignInPrompt(false);
+    handleRate(rating);
+  };
+
   return (
-    <div className="mt-6 w-full bg-gray-50 border border-gray-200 rounded-xl px-5 py-4">
-      <div className="flex items-center justify-between mb-2">
-        <p className="text-xs uppercase text-gray-400 font-semibold tracking-wider">User Rating</p>
+    <div className="mt-6 w-full rounded-xl border border-gray-200 bg-white px-5 py-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">User Rating</p>
         {aggregate.count > 0 && aggregate.average !== null && (
-          <span className="text-sm text-gray-500">
+          <span className="text-sm text-gray-500 whitespace-nowrap">
             {aggregate.average.toFixed(1)}/4 from {aggregate.count} {aggregate.count === 1 ? 'rating' : 'ratings'}
           </span>
         )}
@@ -181,7 +192,7 @@ function CardRating({ cardName, dbCardId, isAuthenticated, getToken }: {
 
       {/* Star display for aggregate */}
       {aggregate.count > 0 && aggregate.average !== null && (
-        <div className="flex items-center gap-0.5 mb-3">
+        <div className="mb-4 flex items-center gap-0.5">
           {[1, 2, 3, 4].map((star) => {
             const filled = star <= Math.floor(aggregate.average!);
             const half = !filled && star === Math.ceil(aggregate.average!) && aggregate.average! % 1 >= 0.25;
@@ -197,75 +208,85 @@ function CardRating({ cardName, dbCardId, isAuthenticated, getToken }: {
         </div>
       )}
 
-      {/* Interactive rating for signed-in users */}
-      {isAuthenticated ? (
-        <div>
-          <p className="text-sm text-gray-600 mb-2">
-            {userRating ? 'Your rating (click to change):' : 'Rate this card:'}
+      <div className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-3">
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <p className="text-sm text-gray-700">
+            {isAuthenticated
+              ? (userRating ? 'Your rating (click to change):' : 'Rate this card:')
+              : 'Rate this card:'}
           </p>
-          <div className="flex items-center gap-1">
-            {[1, 2, 3, 4].map((star) => {
-              const active = (hoveredRating ?? userRating ?? 0) >= star;
-              const colors = RATING_COLORS[hoveredRating ?? userRating ?? star];
-              return (
-                <button
-                  key={star}
-                  onClick={() => handleRate(star)}
-                  onMouseEnter={() => setHoveredRating(star)}
-                  onMouseLeave={() => setHoveredRating(null)}
-                  disabled={submitting}
-                  className={`p-1.5 rounded-lg transition-colors ${
-                    active ? colors.bg : 'hover:bg-gray-100'
-                  } ${submitting ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-                  title={RATING_LABELS[star]}
-                >
-                  <StarIcon
-                    filled={active}
-                    className={`h-7 w-7 ${active ? colors.fill : 'text-gray-300'}`}
-                  />
-                </button>
-              );
-            })}
-            {displayRating && ratingStyle && (
-              <span className={`ml-2 text-sm font-medium ${ratingStyle.text}`}>
-                {RATING_LABELS[displayRating]}
-              </span>
-            )}
-          </div>
-
-          {/* Add to wallet prompt */}
-          {showWalletPrompt && dbCardId && (
-            <div className="mt-3 flex items-center gap-2 bg-indigo-50 border border-indigo-200 rounded-lg px-3 py-2">
-              <WalletIcon className="h-4 w-4 text-indigo-500 flex-shrink-0" />
-              <span className="text-sm text-indigo-700 flex-1">Add this card to your wallet?</span>
-              <button
-                onClick={handleAddToWallet}
-                disabled={addingToWallet}
-                className="text-xs font-semibold text-white bg-indigo-600 hover:bg-indigo-500 px-2.5 py-1 rounded-md disabled:opacity-50"
-              >
-                {addingToWallet ? 'Adding...' : 'Add'}
-              </button>
-              <button
-                onClick={() => setShowWalletPrompt(false)}
-                className="text-indigo-400 hover:text-indigo-600"
-              >
-                <XMarkIcon className="h-4 w-4" />
-              </button>
-            </div>
-          )}
-
-          {/* Wallet added confirmation */}
-          {walletAdded && (
-            <div className="mt-3 flex items-center gap-2 text-sm text-green-600">
-              <CheckIcon className="h-4 w-4" />
-              Added to your wallet
-            </div>
+          {displayRating && ratingStyle && (
+            <span className={`text-xs font-semibold ${ratingStyle.text}`}>
+              {RATING_LABELS[displayRating]}
+            </span>
           )}
         </div>
-      ) : (
-        <p className="text-sm text-gray-400">
-          Sign in to rate this card
-        </p>
+        <div className="flex items-center gap-1">
+          {[1, 2, 3, 4].map((star) => {
+            const active = (hoveredRating ?? userRating ?? 0) >= star;
+            const colors = RATING_COLORS[hoveredRating ?? userRating ?? star];
+            return (
+              <button
+                key={star}
+                onClick={() => handleStarClick(star)}
+                onMouseEnter={() => setHoveredRating(star)}
+                onMouseLeave={() => setHoveredRating(null)}
+                disabled={isAuthenticated && submitting}
+                className={`rounded-lg p-1.5 transition-colors ${
+                  active ? colors.bg : 'hover:bg-white'
+                } ${(isAuthenticated && submitting) ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+                title={RATING_LABELS[star]}
+              >
+                <StarIcon
+                  filled={active}
+                  className={`h-7 w-7 ${active ? colors.fill : 'text-gray-300'}`}
+                />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {!isAuthenticated && showSignInPrompt && (
+        <div className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2.5">
+          <span className="text-sm text-indigo-900">Sign in to submit your rating.</span>
+          <Link
+            href="/login"
+            className="inline-flex items-center gap-1 rounded-md bg-indigo-600 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-indigo-500"
+          >
+            Sign in
+            <ArrowRightOnRectangleIcon className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+      )}
+
+      {/* Add to wallet prompt */}
+      {isAuthenticated && showWalletPrompt && dbCardId && (
+        <div className="mt-3 flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2">
+          <WalletIcon className="h-4 w-4 flex-shrink-0 text-indigo-500" />
+          <span className="flex-1 text-sm text-indigo-700">Add this card to your wallet?</span>
+          <button
+            onClick={handleAddToWallet}
+            disabled={addingToWallet}
+            className="rounded-md bg-indigo-600 px-2.5 py-1 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            {addingToWallet ? 'Adding...' : 'Add'}
+          </button>
+          <button
+            onClick={() => setShowWalletPrompt(false)}
+            className="text-indigo-400 hover:text-indigo-600"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Wallet added confirmation */}
+      {isAuthenticated && walletAdded && (
+        <div className="mt-3 flex items-center gap-2 text-sm text-green-600">
+          <CheckIcon className="h-4 w-4" />
+          Added to your wallet
+        </div>
       )}
     </div>
   );

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -17,6 +17,7 @@ import {
   InformationCircleIcon,
   BanknotesIcon,
   ScaleIcon,
+  ShareIcon,
   WalletIcon,
   CheckIcon,
   ArrowRightOnRectangleIcon,
@@ -302,14 +303,21 @@ interface CardClientProps {
 export default function CardClient({ card, graphData, news, articles }: CardClientProps) {
   const [showModal, setShowModal] = useState(false);
   const [hasSubmittedForCard, setHasSubmittedForCard] = useState<boolean | null>(null);
+  const [showShareMenu, setShowShareMenu] = useState(false);
+  const [copiedShareLink, setCopiedShareLink] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(() => {
     if (typeof window === 'undefined') return false;
     const dismissed = localStorage.getItem('nudge_dismissed');
     return dismissed === new Date().toISOString().slice(0, 10);
   });
+  const shareMenuRef = useRef<HTMLDivElement | null>(null);
   const { authState, getToken } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const cardUrl = `https://creditodds.com/card/${card.slug}`;
+  const shareTitle = `${card.card_name} on CreditOdds`;
+  const encodedShareTitle = encodeURIComponent(shareTitle);
+  const encodedCardUrl = encodeURIComponent(cardUrl);
 
   // Auto-open submit modal when ?submit=true is present
   useEffect(() => {
@@ -318,6 +326,27 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
       router.replace(`/card/${card.slug}`, { scroll: false });
     }
   }, [searchParams, authState.isAuthenticated, card.slug, router]);
+
+  useEffect(() => {
+    if (!showShareMenu) return;
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (shareMenuRef.current && !shareMenuRef.current.contains(event.target as Node)) {
+        setShowShareMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, [showShareMenu]);
+
+  const handleCopyShareLink = async () => {
+    try {
+      await navigator.clipboard.writeText(cardUrl);
+      setCopiedShareLink(true);
+      setTimeout(() => setCopiedShareLink(false), 2000);
+    } catch {
+      // Silently fail
+    }
+  };
 
   // Check if user has already submitted a record for this card
   useEffect(() => {
@@ -501,16 +530,6 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
         <div className="bg-white rounded-2xl shadow-[0_4px_40px_rgba(0,0,0,0.08)] overflow-hidden">
           <div className="p-6 sm:p-10">
-            {/* Compare link */}
-            <div className="flex justify-end mb-4">
-              <Link
-                href={`/compare?cards=${card.slug}`}
-                className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-indigo-600 transition-colors"
-              >
-                <ScaleIcon className="h-4 w-4" />
-                Compare
-              </Link>
-            </div>
             {/* Two-column layout */}
             <div className="lg:grid lg:grid-cols-12 lg:gap-12">
 
@@ -601,9 +620,73 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
               {/* Right Column - Details */}
               <div className="lg:col-span-8 mt-8 lg:mt-0">
                 {/* Title */}
-                <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 tracking-tight text-center lg:text-left">
-                  {card.card_name}
-                </h1>
+                <div className="flex flex-col items-center gap-2 lg:flex-row lg:items-start lg:justify-between">
+                  <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 tracking-tight text-center lg:text-left">
+                    {card.card_name}
+                  </h1>
+                  <div className="relative lg:mt-1 lg:flex-shrink-0" ref={shareMenuRef}>
+                    <div className="flex items-center gap-3">
+                      <Link
+                        href={`/compare?cards=${card.slug}`}
+                        className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-indigo-600 transition-colors"
+                      >
+                        <ScaleIcon className="h-4 w-4" />
+                        Compare
+                      </Link>
+                      <button
+                        onClick={() => setShowShareMenu((prev) => !prev)}
+                        className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-indigo-600 transition-colors"
+                      >
+                        <ShareIcon className="h-4 w-4" />
+                        Share
+                      </button>
+                    </div>
+
+                    {showShareMenu && (
+                      <div className="absolute right-0 z-20 mt-2 w-52 rounded-lg border border-gray-200 bg-white p-1.5 shadow-lg">
+                        <a
+                          href={`https://twitter.com/intent/tweet?text=${encodedShareTitle}&url=${encodedCardUrl}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                        >
+                          Share on X
+                        </a>
+                        <a
+                          href={`https://www.facebook.com/sharer/sharer.php?u=${encodedCardUrl}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                        >
+                          Share on Facebook
+                        </a>
+                        <a
+                          href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedCardUrl}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                        >
+                          Share on LinkedIn
+                        </a>
+                        <a
+                          href={`https://www.reddit.com/submit?url=${encodedCardUrl}&title=${encodedShareTitle}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                        >
+                          Share on Reddit
+                        </a>
+                        <button
+                          onClick={handleCopyShareLink}
+                          className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                        >
+                          Copy link
+                          {copiedShareLink && <span className="text-xs font-semibold text-green-600">Copied</span>}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
 
                 {/* Metadata Row */}
                 <div className="flex flex-wrap items-center justify-center lg:justify-start gap-x-3 gap-y-2 mt-3">

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -20,6 +20,8 @@ import {
   formatEstimatedValue,
   formatBonusRequirement,
   formatAnnualFee,
+  formatRewardWithUsdEquivalent,
+  getRewardUsdRate,
   RewardTypeBadge,
 } from '@/lib/cardDisplayUtils';
 
@@ -185,10 +187,8 @@ function CardPicker({
   );
 }
 
-function formatRewardCellValue(reward: Reward | undefined): string {
-  if (!reward) return '\u2014';
-  if (reward.unit === 'percent') return `${reward.value}%`;
-  return `${reward.value}x`;
+function formatRewardCellValue(reward: Reward | undefined, card: Card): string {
+  return formatRewardWithUsdEquivalent(reward, card);
 }
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
@@ -311,11 +311,11 @@ export default function CompareClient({ allCards }: CompareClientProps) {
 
       const maxA = Math.max(...activeCards.map(card => {
         const r = card.rewards?.find(rw => rw.category === a);
-        return r ? r.value : 0;
+        return r ? getRewardUsdRate(r, card) : 0;
       }));
       const maxB = Math.max(...activeCards.map(card => {
         const r = card.rewards?.find(rw => rw.category === b);
-        return r ? r.value : 0;
+        return r ? getRewardUsdRate(r, card) : 0;
       }));
       return maxB - maxA;
     });
@@ -463,7 +463,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
 
                     const catValues = activeCards.map(c => {
                       const r = c.rewards?.find(rw => rw.category === cat);
-                      return r ? r.value : null;
+                      return r ? getRewardUsdRate(r, c) : null;
                     });
                     const catBest = cat !== 'everything_else' ? getBestIndices(catValues, 'max') : new Set<number>();
                     const isBest = catBest.has(cardIdx) && specific !== undefined;
@@ -475,7 +475,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                           {categoryLabels[cat] || cat}
                         </span>
                         <span className={`${isBest ? 'text-green-700 font-semibold' : isFallback ? 'text-gray-400 italic' : 'text-gray-900'}`}>
-                          {formatRewardCellValue(reward)}
+                          {formatRewardCellValue(reward, card)}
                           {reward?.note && !isFallback && (
                             <span className="text-gray-400 text-xs ml-1">*</span>
                           )}
@@ -669,7 +669,10 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                   return { reward: undefined, isFallback: false };
                 });
 
-                const values = rewardsPerCard.map(r => r.reward ? r.reward.value : null);
+                const values = rewardsPerCard.map((r, i) => {
+                  if (!r.reward) return null;
+                  return getRewardUsdRate(r.reward, activeCards[i]);
+                });
                 const bestSet = cat !== 'everything_else' ? getBestIndices(values, 'max') : new Set<number>();
                 const isEven = catIdx % 2 === 0;
 
@@ -689,7 +692,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                       return (
                         <td key={card.slug} className={`px-4 py-2.5 text-center text-sm ${isBest && !isFallback ? 'text-green-700 font-semibold bg-green-50' : reward && !isFallback ? 'text-gray-900' : 'text-gray-400'} ${isFallback ? 'italic' : ''}`}>
                           <span className="inline-flex items-center gap-1 justify-center">
-                            {formatRewardCellValue(reward)}
+                            {formatRewardCellValue(reward, card)}
                             {reward?.note && !isFallback && (
                               <span className="relative group">
                                 <InformationCircleIcon className="h-3.5 w-3.5 text-gray-300 hover:text-gray-500 cursor-help" />

--- a/apps/web-next/src/components/best/BestComparisonTable.tsx
+++ b/apps/web-next/src/components/best/BestComparisonTable.tsx
@@ -95,8 +95,8 @@ export function BestComparisonTable({ cards }: BestComparisonTableProps) {
                       {index + 1}
                     </span>
                   </td>
-                  <td className="px-4 py-3 whitespace-nowrap">
-                    <div className="flex items-center gap-3">
+                  <td className="px-4 py-3 align-top">
+                    <div className="flex items-start gap-3 min-w-0">
                       <Link href={`/card/${card.slug}`} className="flex-shrink-0">
                         {card.card_image_link ? (
                           <Image
@@ -110,12 +110,15 @@ export function BestComparisonTable({ cards }: BestComparisonTableProps) {
                           <div className="w-12 h-[30px] bg-gray-200 rounded" />
                         )}
                       </Link>
-                      <div>
-                        <Link href={`/card/${card.slug}`} className="text-sm font-medium text-indigo-600 hover:text-indigo-900">
+                      <div className="min-w-0">
+                        <Link
+                          href={`/card/${card.slug}`}
+                          className="block text-sm font-medium text-indigo-600 hover:text-indigo-900 break-words leading-snug"
+                        >
                           {card.card_name}
                         </Link>
                         {entry.badge && (
-                          <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 text-amber-800">
+                          <span className="mt-1 inline-flex max-w-full items-center rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-800 break-words leading-tight">
                             {entry.badge}
                           </span>
                         )}

--- a/apps/web-next/src/components/wallet/BestCardByCategory.tsx
+++ b/apps/web-next/src/components/wallet/BestCardByCategory.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import Image from 'next/image';
 import { Card, WalletCard, Reward } from '@/lib/api';
+import { formatRewardWithUsdEquivalent, getRewardUsdRate } from '@/lib/cardDisplayUtils';
 
 const categoryLabels: Record<string, string> = {
   dining: "Dining",
@@ -29,13 +30,6 @@ const categoryLabels: Record<string, string> = {
 
 const canonicalOrder = Object.keys(categoryLabels);
 
-function formatRewardValue(reward: Reward): string {
-  if (reward.unit === "percent") {
-    return `${reward.value}%`;
-  }
-  return `${reward.value}x`;
-}
-
 interface BestCardByCategoryProps {
   walletCards: WalletCard[];
   allCards: Card[];
@@ -60,15 +54,16 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
     if (walletCardData.length === 0) return [];
 
     // For each category, find the card with the highest reward value
-    const bestByCategory = new Map<string, { card: Card; reward: Reward }>();
+    const bestByCategory = new Map<string, { card: Card; reward: Reward; usdRate: number }>();
 
     for (const card of walletCardData) {
       for (const reward of card.rewards!) {
         if (reward.category === 'everything_else') continue;
+        const usdRate = getRewardUsdRate(reward, card);
 
         const existing = bestByCategory.get(reward.category);
-        if (!existing || reward.value > existing.reward.value) {
-          bestByCategory.set(reward.category, { card, reward });
+        if (!existing || usdRate > existing.usdRate) {
+          bestByCategory.set(reward.category, { card, reward, usdRate });
         }
       }
     }
@@ -152,7 +147,7 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
                       ? 'bg-green-100 text-green-800'
                       : 'bg-indigo-100 text-indigo-800'
                   }`}>
-                    {formatRewardValue(reward)}
+                    {formatRewardWithUsdEquivalent(reward, card)}
                   </span>
                 </td>
               </tr>
@@ -183,7 +178,7 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
                   ? 'bg-green-100 text-green-800'
                   : 'bg-indigo-100 text-indigo-800'
               }`}>
-                {formatRewardValue(reward)}
+                {formatRewardWithUsdEquivalent(reward, card)}
               </span>
             </div>
           </div>

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -9,7 +9,7 @@ import {
   ComputerDesktopIcon,
   CreditCardIcon,
 } from "@heroicons/react/24/outline";
-import { Card } from "@/lib/api";
+import { Card, Reward } from "@/lib/api";
 import { getValuation } from "@/lib/valuations";
 
 export const categoryLabels: Record<string, string> = {
@@ -127,6 +127,27 @@ export function formatAnnualFee(fee: number | undefined): string {
   if (fee === undefined || fee === null) return 'N/A';
   if (fee === 0) return '$0';
   return `$${fee}`;
+}
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value * 100) / 100;
+  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(2).replace(/\.?0+$/, '');
+}
+
+// Normalizes reward rate into cash-equivalent percentage (value per $1 spent).
+// Example: 5x points at 0.5 cpp => 2.5 (%)
+export function getRewardUsdRate(reward: Reward, card: Card): number {
+  if (reward.unit === 'percent') return reward.value;
+  const cpp = getValuation(card.card_name);
+  return reward.value * cpp;
+}
+
+export function formatRewardWithUsdEquivalent(reward: Reward | undefined, card: Card): string {
+  if (!reward) return '\u2014';
+  const raw = reward.unit === 'percent' ? `${reward.value}%` : `${reward.value}x`;
+  if (reward.unit === 'percent') return raw;
+  const usdRate = getRewardUsdRate(reward, card);
+  return `${raw} (~${formatPercent(usdRate)}%)`;
 }
 
 export function RewardTypeBadge({ type }: { type?: string }) {


### PR DESCRIPTION
## Summary
- add shared helper to convert reward rates into USD-equivalent percentages using existing valuation logic
- update Best Card by Category winner selection to compare cash-equivalent rates instead of raw multipliers
- update Compare category sorting and best highlighting to use cash-equivalent rates
- display non-cash rewards as raw multiplier plus equivalent percent (for example: 5x (~2.5%))

## Validation
- next dev compile clean
- npm run build:web-next passes