### PR TITLE
Fix orphaned records from card name standardization

### DIFF
--- a/apps/api/migrations/010_merge_duplicate_cards.sql
+++ b/apps/api/migrations/010_merge_duplicate_cards.sql
@@ -1,0 +1,214 @@
+-- Merge duplicate cards created when CDN name changes ran before migration 006.
+-- The update-cards-github sync creates a NEW card when it can't find an exact
+-- card_name match, so after "Chase Sapphire Preferred Card" → "Chase Sapphire Preferred"
+-- in the CDN, a second card row was inserted. Old records are orphaned under the
+-- original card_id.
+--
+-- This migration handles TWO cases:
+--   A) Old name still exists alongside new name (migration 006 didn't run or ran after sync)
+--   B) Same name appears twice (migration 006 ran, then sync also created a new entry)
+
+-- ============================================================
+-- PHASE 1: Merge old-name cards into new-name cards
+-- These are the pairs from migration 006 where the old name
+-- may still exist as a separate row.
+-- ============================================================
+
+CREATE TEMPORARY TABLE name_mappings (
+  old_name VARCHAR(255),
+  new_name VARCHAR(255)
+);
+
+INSERT INTO name_mappings (old_name, new_name) VALUES
+('Aer Lingus Visa Signature card', 'Aer Lingus Visa Signature'),
+('Amazon Business Prime American Express Card', 'Amazon Business Prime American Express'),
+('Amazon Prime Rewards Visa Signature Card', 'Amazon Prime Rewards Visa Signature'),
+('American Express Business Gold Card', 'American Express Business Gold'),
+('American Express Gold Card', 'American Express Gold'),
+('American Express Green Card', 'American Express Green'),
+('Amex Everyday Credit Card', 'Amex Everyday'),
+('Amex Everyday Preferred Credit Card', 'Amex Everyday Preferred'),
+('AT&T Access Card From Citi', 'AT&T Access from Citi'),
+('Bank of America Cash Rewards Secured Credit Card', 'Bank of America Cash Rewards Secured'),
+('Bank of America Customized Cash Rewards Credit Card', 'Bank of America Customized Cash Rewards'),
+('Bank of America Premium Rewards Elite Credit Card', 'Bank of America Premium Rewards Elite'),
+('Bank of America Premium Rewards Credit Card', 'Bank of America Premium Rewards'),
+('Bank of America Travel Rewards Credit Card', 'Bank of America Travel Rewards'),
+('Bank of America Unlimited Cash Rewards Credit Card', 'Bank of America Unlimited Cash Rewards'),
+('BankAmericard Credit Card', 'BankAmericard'),
+('Blue Business Cash Card from American Express', 'Blue Business Cash from American Express'),
+('Blue Business Plus Credit Card from American Express', 'Blue Business Plus from American Express'),
+('Blue Cash Everyday Card', 'Blue Cash Everyday'),
+('Blue Cash Preferred Card', 'Blue Cash Preferred'),
+('British Airways Visa Signature card', 'British Airways Visa Signature'),
+('Capital One Platinum Secured Credit Card', 'Capital One Platinum Secured'),
+('Capital One Platinum Credit Card', 'Capital One Platinum'),
+('Capital One Quicksilver Secured Cash Rewards Credit Card', 'Capital One Quicksilver Secured Cash Rewards'),
+('Capital One Quicksilver Cash Rewards Credit Card', 'Capital One Quicksilver Cash Rewards'),
+('Capital One QuicksilverOne Cash Rewards Credit Card', 'Capital One QuicksilverOne Cash Rewards'),
+('Capital One Savor Student Cash Rewards Credit Card', 'Capital One Savor Student Cash Rewards'),
+('Capital One Savor Cash Rewards Credit Card', 'Capital One Savor Cash Rewards'),
+('Capital One SavorOne Cash Rewards Credit Card', 'Capital One SavorOne Cash Rewards'),
+('Capital One Venture Rewards Credit Card', 'Capital One Venture Rewards'),
+('Capital One Venture X Rewards Credit Card', 'Capital One Venture X Rewards'),
+('Capital One VentureOne Rewards Credit Card', 'Capital One VentureOne Rewards'),
+('Cash Magnet Card', 'Cash Magnet'),
+('IHG One Rewards Premier Business Credit Card', 'IHG One Rewards Premier Business'),
+('Ink Business Cash Credit Card', 'Ink Business Cash'),
+('Ink Business Preferred Credit Card', 'Ink Business Preferred'),
+('Ink Business Unlimited Credit Card', 'Ink Business Unlimited'),
+('Chase Sapphire Preferred Card', 'Chase Sapphire Preferred'),
+('Citi Strata Elite Card', 'Citi Strata Elite'),
+('Citi Strata Premier Card', 'Citi Strata Premier'),
+('Citi Strata Card', 'Citi Strata'),
+('Costco Anywhere Visa Business Card by Citi', 'Costco Anywhere Visa Business by Citi'),
+('Costco Anywhere Visa Card by Citi', 'Costco Anywhere Visa by Citi'),
+('Delta SkyMiles Blue American Express Card', 'Delta SkyMiles Blue American Express'),
+('Delta SkyMiles Gold American Express Card', 'Delta SkyMiles Gold American Express'),
+('Delta SkyMiles Platinum American Express Card', 'Delta SkyMiles Platinum American Express'),
+('Delta SkyMiles Reserve American Express Card', 'Delta SkyMiles Reserve American Express'),
+('Discover it for Students Card', 'Discover it for Students'),
+('Discover it Secured Credit Card', 'Discover it Secured'),
+('Discover it Student Chrome Card', 'Discover it Student Chrome'),
+('Disney Inspire Visa Card', 'Disney Inspire Visa'),
+('Disney Premier Visa Card', 'Disney Premier Visa'),
+('Disney Visa Card', 'Disney Visa'),
+('Expedia Rewards Card from Citi', 'Expedia Rewards from Citi'),
+('Expedia Rewards Voyager Card from Citi', 'Expedia Rewards Voyager from Citi'),
+('Hilton Honors American Express Aspire Card', 'Hilton Honors American Express Aspire'),
+('Hilton Honors American Express Surpass Card', 'Hilton Honors American Express Surpass'),
+('Hilton Honors Card', 'Hilton Honors'),
+('Iberia Visa Signature card', 'Iberia Visa Signature'),
+('IHG One Rewards Premier Credit Card', 'IHG One Rewards Premier'),
+('IHG Rewards Club Traveler Credit Card', 'IHG Rewards Club Traveler'),
+('JetBlue Business Card', 'JetBlue Business'),
+('JetBlue Card', 'JetBlue'),
+('JetBlue Plus Card', 'JetBlue Plus'),
+('Marriott Bonvoy Bold Credit Card', 'Marriott Bonvoy Bold'),
+('Marriott Bonvoy Boundless credit card', 'Marriott Bonvoy Boundless'),
+('Princess Cruises Rewards Visa Card', 'Princess Cruises Rewards Visa'),
+('Southwest Rapid Rewards Plus Credit Card', 'Southwest Rapid Rewards Plus'),
+('Southwest Rapid Rewards Premier Credit Card', 'Southwest Rapid Rewards Premier'),
+('Southwest Rapid Rewards Priority Credit Card', 'Southwest Rapid Rewards Priority'),
+('Starbucks Rewards Visa Card', 'Starbucks Rewards Visa'),
+('U.S. Bank Altitude Go Visa Signature Card', 'U.S. Bank Altitude Go Visa Signature'),
+('U.S. Bank Altitude Reserve Visa Infinite Card', 'U.S. Bank Altitude Reserve Visa Infinite'),
+('U.S. Bank Cash+ Visa Signature Card', 'U.S. Bank Cash+ Visa Signature'),
+('Smartly Visa Signature Card', 'Smartly Visa Signature'),
+('Wells Fargo Active Cash Card', 'Wells Fargo Active Cash'),
+('Wells Fargo Attune Card', 'Wells Fargo Attune'),
+('Wells Fargo Autograph Journey Card', 'Wells Fargo Autograph Journey'),
+('Wells Fargo Autograph Card', 'Wells Fargo Autograph'),
+('Wells Fargo Reflect Card', 'Wells Fargo Reflect'),
+('Wells Fargo Signify Business Cash Card', 'Wells Fargo Signify Business Cash'),
+('World of Hyatt Business Credit Card', 'World of Hyatt Business'),
+('World of Hyatt Credit Card', 'World of Hyatt'),
+('Wyndham Rewards Earner Business Card', 'Wyndham Rewards Earner Business'),
+('Wyndham Rewards Earner Card', 'Wyndham Rewards Earner'),
+('Wyndham Rewards Earner Plus Card', 'Wyndham Rewards Earner Plus');
+
+-- Move records from old-name card to new-name card (only where both exist)
+UPDATE records r
+INNER JOIN cards c_old ON r.card_id = c_old.card_id
+INNER JOIN name_mappings nm ON c_old.card_name = nm.old_name
+INNER JOIN cards c_new ON c_new.card_name = nm.new_name
+SET r.card_id = c_new.card_id;
+
+-- Move referrals from old-name card to new-name card
+UPDATE referrals ref
+INNER JOIN cards c_old ON ref.card_id = c_old.card_id
+INNER JOIN name_mappings nm ON c_old.card_name = nm.old_name
+INNER JOIN cards c_new ON c_new.card_name = nm.new_name
+SET ref.card_id = c_new.card_id;
+
+-- Handle user_cards: delete old entries where user already has the new card
+DELETE uc_old FROM user_cards uc_old
+INNER JOIN cards c_old ON uc_old.card_id = c_old.card_id
+INNER JOIN name_mappings nm ON c_old.card_name = nm.old_name
+INNER JOIN cards c_new ON c_new.card_name = nm.new_name
+INNER JOIN user_cards uc_new ON uc_old.user_id = uc_new.user_id AND uc_new.card_id = c_new.card_id;
+
+-- Move remaining user_cards from old to new
+UPDATE user_cards uc
+INNER JOIN cards c_old ON uc.card_id = c_old.card_id
+INNER JOIN name_mappings nm ON c_old.card_name = nm.old_name
+INNER JOIN cards c_new ON c_new.card_name = nm.new_name
+SET uc.card_id = c_new.card_id;
+
+-- Delete old-name card entries (only where new-name card exists)
+DELETE c_old FROM cards c_old
+INNER JOIN name_mappings nm ON c_old.card_name = nm.old_name
+WHERE EXISTS (
+  SELECT 1 FROM cards c_new WHERE c_new.card_name = nm.new_name AND c_new.card_id != c_old.card_id
+);
+
+-- If old name exists but new name doesn't, just rename the card
+UPDATE cards c
+INNER JOIN name_mappings nm ON c.card_name = nm.old_name
+SET c.card_name = nm.new_name
+WHERE NOT EXISTS (
+  SELECT 1 FROM cards c2 WHERE c2.card_name = nm.new_name
+);
+
+DROP TEMPORARY TABLE name_mappings;
+
+-- ============================================================
+-- PHASE 2: Merge exact-name duplicates
+-- If migration 006 ran AND the sync also created a new entry,
+-- there will be two rows with the same card_name. Keep the one
+-- with more records and merge the other into it.
+-- ============================================================
+
+-- Find duplicate card_names and merge records to the card_id with the most records.
+-- We keep the card_id with the highest record count (the "primary").
+
+CREATE TEMPORARY TABLE dup_cards AS
+SELECT c.card_id, c.card_name,
+  COALESCE((SELECT COUNT(*) FROM records r WHERE r.card_id = c.card_id), 0) AS rec_count
+FROM cards c
+WHERE c.card_name IN (
+  SELECT card_name FROM cards GROUP BY card_name HAVING COUNT(*) > 1
+);
+
+-- For each duplicate group, identify the primary (most records, ties broken by lowest card_id)
+CREATE TEMPORARY TABLE dup_primary AS
+SELECT d1.card_id, d1.card_name
+FROM dup_cards d1
+WHERE d1.rec_count = (
+  SELECT MAX(d2.rec_count) FROM dup_cards d2 WHERE d2.card_name = d1.card_name
+)
+AND d1.card_id = (
+  SELECT MIN(d3.card_id) FROM dup_cards d3
+  WHERE d3.card_name = d1.card_name AND d3.rec_count = d1.rec_count
+);
+
+-- Move records from non-primary duplicates to primary
+UPDATE records r
+INNER JOIN dup_cards dc ON r.card_id = dc.card_id
+INNER JOIN dup_primary dp ON dc.card_name = dp.card_name AND dc.card_id != dp.card_id
+SET r.card_id = dp.card_id;
+
+-- Move referrals from non-primary duplicates to primary
+UPDATE referrals ref
+INNER JOIN dup_cards dc ON ref.card_id = dc.card_id
+INNER JOIN dup_primary dp ON dc.card_name = dp.card_name AND dc.card_id != dp.card_id
+SET ref.card_id = dp.card_id;
+
+-- Handle user_cards duplicates
+DELETE uc_old FROM user_cards uc_old
+INNER JOIN dup_cards dc ON uc_old.card_id = dc.card_id
+INNER JOIN dup_primary dp ON dc.card_name = dp.card_name AND dc.card_id != dp.card_id
+INNER JOIN user_cards uc_new ON uc_old.user_id = uc_new.user_id AND uc_new.card_id = dp.card_id;
+
+UPDATE user_cards uc
+INNER JOIN dup_cards dc ON uc.card_id = dc.card_id
+INNER JOIN dup_primary dp ON dc.card_name = dp.card_name AND dc.card_id != dp.card_id
+SET uc.card_id = dp.card_id;
+
+-- Delete non-primary duplicate card entries
+DELETE c FROM cards c
+INNER JOIN dup_cards dc ON c.card_id = dc.card_id
+INNER JOIN dup_primary dp ON dc.card_name = dp.card_name AND dc.card_id != dp.card_id;
+
+DROP TEMPORARY TABLE dup_cards;
+DROP TEMPORARY TABLE dup_primary;

--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -53,14 +53,31 @@ async function syncCardsToDatabase(cdnCards) {
       existingByName[card.card_name] = card;
     }
 
+    // Helper: find existing card by exact name, or fuzzy match (with/without suffix)
+    function findExistingCard(name) {
+      if (existingByName[name]) return existingByName[name];
+      // Try common suffixes that may still be in the DB from before name standardization
+      const suffixes = [' Card', ' Credit Card', ' card', ' credit card'];
+      for (const suffix of suffixes) {
+        if (existingByName[name + suffix]) return existingByName[name + suffix];
+      }
+      // Try stripping suffixes in case CDN has suffix but DB doesn't
+      for (const suffix of suffixes) {
+        if (name.endsWith(suffix) && existingByName[name.slice(0, -suffix.length)]) {
+          return existingByName[name.slice(0, -suffix.length)];
+        }
+      }
+      return null;
+    }
+
     for (const cdnCard of cdnCards) {
       try {
         const name = cdnCard.name;
         const bank = cdnCard.bank;
         const acceptingApplications = cdnCard.accepting_applications ? 1 : 0;
 
-        // Check if card exists by name
-        const existingCard = existingByName[name];
+        // Check if card exists by name (with fuzzy suffix matching)
+        const existingCard = findExistingCard(name);
 
         // Convert tags array to JSON string for database storage
         const tagsJson = cdnCard.tags ? JSON.stringify(cdnCard.tags) : null;


### PR DESCRIPTION
## Summary
- **Root cause**: When card names were standardized (e.g. "Chase Sapphire Preferred Card" → "Chase Sapphire Preferred"), the CDN updated first but the sync handler (`update-cards-github.js`) only matched by exact `card_name`. It couldn't find the old name, so it created a **new card row** with a new `card_id`. All old records stayed orphaned under the original `card_id`.
- **Migration 010**: Merges duplicate cards — moves records/referrals/user_cards from old-name cards to new-name cards, handles exact-name duplicates, cleans up orphaned entries. Covers all ~85 cards from the name standardization.
- **Sync handler fix**: `findExistingCard()` now tries fuzzy suffix matching ("Card", "Credit Card") before falling back to insert, preventing future duplicates on name changes.

## Test plan
- [ ] Run migration 010 against the database
- [ ] Deploy updated sync handler (`sam build && sam deploy`)
- [ ] Verify Chase Sapphire Preferred shows all data points on the graph
- [ ] Spot-check other renamed cards (e.g. Ink Business Cash, Wells Fargo Active Cash) for correct record counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)