### PR TITLE
Add news: Marriott Bonvoy free night award top-off increase

### DIFF
--- a/data/news/2026-03-12-marriott-bonvoy-free-night-top-off-increase.yaml
+++ b/data/news/2026-03-12-marriott-bonvoy-free-night-top-off-increase.yaml
@@ -1,0 +1,44 @@
+id: "marriott-bonvoy-free-night-top-off-increase"
+date: "2026-03-12"
+title: "Marriott Bonvoy Raises Free Night Award Top-Off Limit to 25,000 Points"
+summary: "Marriott Bonvoy increased the Free Night Award top-off limit from 15,000 to 25,000 points, allowing cardholders to use their annual free night certificates at higher-category properties by supplementing with additional Bonvoy points."
+tags:
+  - "benefit-change"
+card_slugs:
+  - "marriott-bonvoy-boundless-credit-card"
+  - "marriott-bonvoy-brilliant-american-express"
+  - "marriott-bonvoy-bold-credit-card"
+card_names:
+  - "Marriott Bonvoy Boundless"
+  - "Marriott Bonvoy Brilliant American Express"
+  - "Marriott Bonvoy Bold"
+source: "Upgraded Points"
+source_url: "https://upgradedpoints.com/news/marriott-bonvoy-free-night-award-top-off-increase/"
+body: |
+  Marriott Bonvoy has increased the top-off limit on Free Night Awards from **15,000 to 25,000 points**, effective **March 12, 2026**. This change gives co-branded credit card holders significantly more flexibility when redeeming their annual free night certificates at higher-category Marriott properties.
+
+  ## What Changed
+
+  Free Night Awards are annual certificates earned through Marriott's co-branded credit cards with Chase and American Express. Previously, cardholders could add up to **15,000 Bonvoy points** on top of their certificate's base value to book a more expensive property. The new limit of **25,000 points** represents a **67% increase** in top-off capacity.
+
+  For example, the **Marriott Bonvoy Boundless** card earns a Free Night Award worth up to **35,000 points** each account anniversary. With the old 15,000-point top-off, cardholders could book properties costing up to **50,000 points per night**. Under the new limit, that same certificate can now be used at properties costing up to **60,000 points per night**, opening the door to a wider range of hotels including many Category 6 properties.
+
+  The **Marriott Bonvoy Brilliant American Express** card, which provides a Free Night Award worth up to **85,000 points**, can now be topped off to cover stays at properties costing up to **110,000 points per night** — putting some of Marriott's most luxurious resorts within reach.
+
+  ## Which Cards Are Affected
+
+  The change applies to Free Night Awards earned through all three Marriott co-branded credit cards:
+
+  - **Marriott Bonvoy Boundless** (Chase) — Free Night Award up to 35,000 points, now tops off to 60,000
+  - **Marriott Bonvoy Brilliant** (American Express) — Free Night Award up to 85,000 points, now tops off to 110,000
+  - **Marriott Bonvoy Bold** (Chase) — Free Night Award up to 35,000 points, now tops off to 60,000
+
+  ## Why This Matters
+
+  Marriott's dynamic pricing model means that popular properties and peak dates can cost well above their historical category caps. The increased top-off limit helps bridge the gap between a certificate's base value and real-world redemption costs, making Free Night Awards more practical for premium stays.
+
+  This is particularly valuable for Brilliant cardholders, who pay a **$650 annual fee** and rely on the Free Night Award as a major source of value. Being able to reach **110,000 points per night** instead of **100,000** expands the pool of eligible properties at top-tier brands like The Ritz-Carlton, St. Regis, and W Hotels.
+
+  ## How to Use the Top-Off
+
+  To use the top-off feature, cardholders simply search for an eligible property on Marriott's website or app and select a Free Night Award as the payment method. If the nightly rate exceeds the certificate's base value but falls within the new 25,000-point top-off range, Marriott will automatically deduct the additional points from the member's Bonvoy account. Members must have sufficient points in their account to cover the difference.


### PR DESCRIPTION
## Summary
- Adds news article covering Marriott Bonvoy raising the Free Night Award top-off limit from 15,000 to 25,000 points (effective March 12, 2026)
- Links all three Marriott co-branded cards (Boundless, Brilliant, Bold)
- Source: Upgraded Points

🤖 Generated with [Claude Code](https://claude.com/claude-code)