### PR TITLE
Add Product schema with annual fee and star ratings for rich results

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -19,7 +19,7 @@ import {
   ShareIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
-import { Card, GraphData, Reward, trackReferralEvent, getCardRatings } from "@/lib/api";
+import { Card, GraphData, Reward, trackReferralEvent } from "@/lib/api";
 import { NewsItem, tagLabels, tagColors } from "@/lib/news";
 import { Article, tagLabels as articleTagLabels, tagColors as articleTagColors } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -76,27 +76,21 @@ function StarIcon({ filled, half, className }: { filled?: boolean; half?: boolea
   );
 }
 
-function CardRatingDisplay({ cardName }: { cardName: string }) {
-  const [aggregate, setAggregate] = useState<{ count: number; average: number | null }>({ count: 0, average: null });
-
-  useEffect(() => {
-    getCardRatings(cardName).then(setAggregate).catch(() => {});
-  }, [cardName]);
-
-  if (aggregate.count === 0 || aggregate.average === null) return null;
+function CardRatingDisplay({ ratings }: { ratings: { count: number; average: number | null } }) {
+  if (ratings.count === 0 || ratings.average === null) return null;
 
   return (
     <div className="mt-6 w-full rounded-xl border border-gray-200 bg-white px-5 py-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between">
         <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">User Rating</p>
         <span className="text-sm text-gray-500 whitespace-nowrap">
-          {aggregate.average.toFixed(1)}/4 from {aggregate.count} {aggregate.count === 1 ? 'rating' : 'ratings'}
+          {ratings.average.toFixed(1)}/4 from {ratings.count} {ratings.count === 1 ? 'rating' : 'ratings'}
         </span>
       </div>
       <div className="flex items-center gap-0.5">
         {[1, 2, 3, 4].map((star) => {
-          const filled = star <= Math.floor(aggregate.average!);
-          const half = !filled && star === Math.ceil(aggregate.average!) && aggregate.average! % 1 >= 0.25;
+          const filled = star <= Math.floor(ratings.average!);
+          const half = !filled && star === Math.ceil(ratings.average!) && ratings.average! % 1 >= 0.25;
           return (
             <StarIcon
               key={star}
@@ -116,9 +110,10 @@ interface CardClientProps {
   graphData: GraphData[];
   news: NewsItem[];
   articles: Article[];
+  ratings: { count: number; average: number | null };
 }
 
-export default function CardClient({ card, graphData, news, articles }: CardClientProps) {
+export default function CardClient({ card, graphData, news, articles, ratings }: CardClientProps) {
   const [showModal, setShowModal] = useState(false);
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [copiedShareLink, setCopiedShareLink] = useState(false);
@@ -223,7 +218,7 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
   return (
     <div className="bg-gray-50 min-h-screen">
       {/* JSON-LD Structured Data (#12) */}
-      <CreditCardSchema card={card} />
+      <CreditCardSchema card={card} ratings={ratings} />
       <BreadcrumbSchema items={[
         { name: 'Home', url: 'https://creditodds.com' },
         { name: card.bank, url: `https://creditodds.com/bank/${encodeURIComponent(card.bank)}` },
@@ -357,7 +352,7 @@ export default function CardClient({ card, graphData, news, articles }: CardClie
                 )}
 
                 {/* Card Rating (read-only) */}
-                <CardRatingDisplay cardName={card.card_name} />
+                <CardRatingDisplay ratings={ratings} />
 
                 {/* Apply Buttons */}
                 {card.accepting_applications && (card.apply_link || randomReferralUrl) && (

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getCard, getCardGraphs, getAllCards, GraphData } from "@/lib/api";
+import { getCard, getCardGraphs, getAllCards, getCardRatings, GraphData } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import CardClient from "./CardClient";
@@ -71,11 +71,14 @@ export default async function CardPage({ params }: CardPageProps) {
       getArticles().catch(() => [] as Article[]),
     ]);
 
+    // Fetch ratings after we have the card name
+    const ratings = await getCardRatings(card.card_name).catch(() => ({ count: 0, average: null }));
+
     // Filter news and articles for this specific card
     const cardNews = allNews.filter(news => news.card_slugs?.includes(slug));
     const cardArticles = allArticles.filter(a => a.related_cards?.includes(slug));
 
-    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} />;
+    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} />;
   } catch {
     notFound();
   }

--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -66,35 +66,43 @@ export function WebsiteSchema({
 
 interface CreditCardSchemaProps {
   card: Card;
+  ratings?: { count: number; average: number | null };
 }
 
-export function CreditCardSchema({ card }: CreditCardSchemaProps) {
+export function CreditCardSchema({ card, ratings }: CreditCardSchemaProps) {
   const schema = {
     '@context': 'https://schema.org',
-    '@type': 'FinancialProduct',
+    '@type': 'Product',
     name: card.card_name,
-    provider: {
-      '@type': 'Organization',
+    brand: {
+      '@type': 'Brand',
       name: card.bank,
     },
-    category: 'Credit Card',
     description: `${card.card_name} by ${card.bank}. Average approved credit score: ${card.approved_median_credit_score || 'N/A'}, average approved income: $${card.approved_median_income?.toLocaleString() || 'N/A'}.`,
+    image: card.slug ? `https://creditodds.com/card/${card.slug}/opengraph-image` : undefined,
     offers: {
       '@type': 'Offer',
       availability: card.accepting_applications
         ? 'https://schema.org/InStock'
         : 'https://schema.org/Discontinued',
+      ...(card.annual_fee != null ? {
+        price: String(card.annual_fee),
+        priceCurrency: 'USD',
+        priceSpecification: {
+          '@type': 'UnitPriceSpecification',
+          price: String(card.annual_fee),
+          priceCurrency: 'USD',
+          unitText: 'ANNUAL',
+        },
+      } : {}),
     },
-    aggregateRating: card.approved_count && card.approved_count > 0 ? {
+    aggregateRating: ratings && ratings.count > 0 && ratings.average !== null ? {
       '@type': 'AggregateRating',
-      ratingValue: ((card.approved_count / ((card.approved_count || 0) + (card.rejected_count || 0))) * 5).toFixed(1),
-      ratingCount: (card.approved_count || 0) + (card.rejected_count || 0),
-      bestRating: 5,
+      ratingValue: ratings.average.toFixed(1),
+      ratingCount: ratings.count,
+      bestRating: 4,
       worstRating: 1,
     } : undefined,
-    ...(card.apr?.regular ? {
-      annualPercentageRate: card.apr.regular.max,
-    } : {}),
     additionalProperty: [
       {
         '@type': 'PropertyValue',


### PR DESCRIPTION
## Summary
- Switch card page JSON-LD from `FinancialProduct` to `Product` type (matches TPG pattern for Google rich results)
- Add annual fee as `Offer` price with `UnitPriceSpecification` + `unitText: ANNUAL` — shows "$95.00/yr" in search
- Replace approval-rate-based `aggregateRating` with actual user ratings (1-4 scale) for star display in search
- Fetch ratings server-side so JSON-LD is populated for crawlers
- Simplify `CardRatingDisplay` to use server-provided data instead of redundant client-side fetch

## Test plan
- [ ] Visit a card page, inspect JSON-LD in page source — verify `@type: Product`, `offers.price`, and `aggregateRating`
- [ ] Test with [Google Rich Results Test](https://search.google.com/test/rich-results) for a card URL
- [ ] Verify card page still renders correctly with star rating display

🤖 Generated with [Claude Code](https://claude.com/claude-code)