### PR TITLE
Fix search to match multi-word queries like "Bank America"

### DIFF
--- a/apps/web-next/src/lib/searchAliases.ts
+++ b/apps/web-next/src/lib/searchAliases.ts
@@ -34,7 +34,10 @@ export function expandSearchTerm(term: string): string[] {
 }
 
 /**
- * Check if a card matches the search input, including aliases
+ * Check if a card matches the search input, including aliases.
+ * Uses multi-word matching: all words in the query must appear
+ * somewhere in the card name or bank name (e.g. "Bank America"
+ * matches "Bank of America").
  */
 export function cardMatchesSearch(
   cardName: string,
@@ -46,8 +49,10 @@ export function cardMatchesSearch(
   const searchTerms = expandSearchTerm(searchInput);
   const lowerCardName = cardName.toLowerCase();
   const lowerBank = bank.toLowerCase();
+  const combined = lowerCardName + ' ' + lowerBank;
 
-  return searchTerms.some(term =>
-    lowerCardName.includes(term) || lowerBank.includes(term)
-  );
+  return searchTerms.some(term => {
+    const words = term.split(/\s+/).filter(Boolean);
+    return words.every(word => combined.includes(word));
+  });
 }


### PR DESCRIPTION
## Summary
- Changed card search from contiguous substring matching to multi-word matching
- Splits search input into individual words and requires **all** words to appear somewhere in the card name or bank name
- Fixes cases like "Bank America" not matching "Bank of America", or "sapphire preferred" not matching when searched without "Chase"

## Test plan
- [ ] Search "Bank America" → should show Bank of America cards
- [ ] Search "sapphire preferred" → should show Chase Sapphire Preferred
- [ ] Search "amex gold" → should still work (alias + word match)
- [ ] Search "chase" → should still show all Chase cards (single-word unchanged)
- [ ] Verify existing alias searches (bofa, csp, csr, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)