### PR TITLE
Add brand logos to tool converter pages

### DIFF
--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
@@ -60,7 +60,10 @@ export default async function AmexMRToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Amex Membership Rewards to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/amex.jpg" alt="Amex" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Amex Membership Rewards to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Amex Membership Rewards points.
         </p>

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function BiltToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Bilt Rewards Points to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/bilt.jpg" alt="Bilt" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Bilt Rewards Points to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Bilt Rewards points.
         </p>

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function CapitalOneMilesToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Capital One Miles to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/capital-one.jpg" alt="Capital One" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Capital One Miles to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Capital One miles.
         </p>

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
@@ -58,7 +58,10 @@ export default async function ChaseURToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Chase Ultimate Rewards to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/chase.jpg" alt="Chase" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Chase Ultimate Rewards to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Chase Ultimate Rewards points.
         </p>

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function CitiThankYouToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Citi ThankYou Points to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/citi.png" alt="Citi" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Citi ThankYou Points to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Citi ThankYou points.
         </p>

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function DeltaSkyMilesToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Delta SkyMiles to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/delta.jpg" alt="Delta" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Delta SkyMiles to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Delta SkyMiles.
         </p>

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function HiltonHonorsToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Hilton Honors Points to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/hilton.jpg" alt="Hilton" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Hilton Honors Points to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Hilton Honors points.
         </p>

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function IHGToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">IHG One Rewards Points to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/ihg.jpg" alt="IHG" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">IHG One Rewards Points to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your IHG One Rewards points.
         </p>

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
@@ -58,7 +58,10 @@ export default async function MarriottBonvoyToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Marriott Bonvoy Points to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/marriott.jpg" alt="Marriott" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Marriott Bonvoy Points to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Marriott Bonvoy points.
         </p>

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function SouthwestRRToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">Southwest Rapid Rewards to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/southwest.jpg" alt="Southwest" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">Southwest Rapid Rewards to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your Southwest Rapid Rewards points.
         </p>

--- a/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function UnitedMilesToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">United Miles to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/united.jpg" alt="United" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">United Miles to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your United MileagePlus miles.
         </p>

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
@@ -57,7 +57,10 @@ export default async function HyattToUsdPage() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-gray-900">World of Hyatt Points to USD Converter</h1>
+        <div className="flex items-center gap-3">
+          <Image src="/logos/hyatt.jpg" alt="Hyatt" width={32} height={32} className="rounded-md" />
+          <h1 className="text-2xl font-bold text-gray-900">World of Hyatt Points to USD Converter</h1>
+        </div>
         <p className="mt-2 text-gray-600">
           Estimate the dollar value of your World of Hyatt points.
         </p>


### PR DESCRIPTION
## Summary
- Add 32x32 brand logo next to the h1 title on all 12 individual tool converter pages
- Fix IHG logo filename typo (`igh.jpg` → `ihg.jpg`)
- Update tools index page to use actual logo images instead of initials placeholders

## Test plan
- [ ] Visit each of the 12 `/tools/*` pages and verify the logo renders next to the title
- [ ] Check `/tools` index page logos still render correctly
- [ ] Verify layout on mobile (logo + title should stay on one line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)