### PR TITLE
Add points valuation link to card page metadata row

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -8,7 +8,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   BuildingLibraryIcon,
 } from "@heroicons/react/24/solid";
-import { getValuation } from "@/lib/valuations";
+import { getValuationDetails } from "@/lib/valuations";
 import {
   ExclamationTriangleIcon,
   PencilSquareIcon,
@@ -17,6 +17,7 @@ import {
   BanknotesIcon,
   ScaleIcon,
   ShareIcon,
+  CalculatorIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
 import { Card, GraphData, Reward, trackReferralEvent } from "@/lib/api";
@@ -338,7 +339,7 @@ export default function CardClient({ card, graphData, news, articles, ratings }:
                             : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type.charAt(0).toUpperCase() + card.signup_bonus.type.slice(1)}`}
                           {card.signup_bonus.type !== "cash" && (
                             <span className="text-sm font-medium text-amber-700/70 ml-1.5">
-                              (~${(card.signup_bonus.value * getValuation(card.card_name) / 100).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })})
+                              (~${(card.signup_bonus.value * (getValuationDetails(card.card_name)?.cpp ?? 1.0) / 100).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })})
                             </span>
                           )}
                         </p>
@@ -484,6 +485,23 @@ export default function CardClient({ card, graphData, news, articles, ratings }:
                       </span>
                     </>
                   )}
+                  {card.reward_type && card.reward_type !== 'cashback' && (() => {
+                    const valuation = getValuationDetails(card.card_name);
+                    if (!valuation?.toolSlug) return null;
+                    const unit = card.reward_type === 'miles' ? 'mile' : 'point';
+                    return (
+                      <>
+                        <span className="text-gray-300">&middot;</span>
+                        <Link
+                          href={`/tools/${valuation.toolSlug}-to-usd`}
+                          className="inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+                        >
+                          {valuation.cpp.toFixed(1)}¢/{unit}
+                          <CalculatorIcon className="h-3.5 w-3.5" />
+                        </Link>
+                      </>
+                    );
+                  })()}
                 </div>
 
                 {/* Rewards Section - 2-column grid, sorted highest first */}
@@ -581,7 +599,7 @@ export default function CardClient({ card, graphData, news, articles, ratings }:
                             : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type.charAt(0).toUpperCase() + card.signup_bonus.type.slice(1)}`}
                           {card.signup_bonus.type !== "cash" && (
                             <span className="ml-1.5 text-sm font-medium text-amber-700/70">
-                              (~${(card.signup_bonus.value * getValuation(card.card_name) / 100).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })})
+                              (~${(card.signup_bonus.value * (getValuationDetails(card.card_name)?.cpp ?? 1.0) / 100).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })})
                             </span>
                           )}
                         </p>

--- a/apps/web-next/src/lib/valuations.ts
+++ b/apps/web-next/src/lib/valuations.ts
@@ -6,33 +6,38 @@ export interface Valuation {
   cpp: number;
   match: string[];
   exclude?: string[];
+  toolSlug?: string; // path segment for /tools/<toolSlug>-to-usd
 }
 
 const valuations: Valuation[] = [
-  { program: "Chase Ultimate Rewards", slug: "chase-ultimate-rewards", cpp: 1.25, match: ["chase sapphire", "freedom"] },
-  { program: "Amex Membership Rewards", slug: "amex-membership-rewards", cpp: 1.2, match: ["american express", "amex", "gold card", "platinum card"], exclude: ["delta", "hilton", "skymiles"] },
-  { program: "Delta SkyMiles", slug: "delta-skymiles", cpp: 1.1, match: ["delta", "skymiles"] },
-  { program: "United MileagePlus", slug: "united-mileageplus", cpp: 1.2, match: ["united"] },
-  { program: "Hilton Honors", slug: "hilton-honors", cpp: 0.5, match: ["hilton"] },
-  { program: "World of Hyatt", slug: "world-of-hyatt", cpp: 2.0, match: ["hyatt"] },
-  { program: "IHG One Rewards", slug: "ihg-one-rewards", cpp: 0.5, match: ["ihg"] },
-  { program: "Marriott Bonvoy", slug: "marriott-bonvoy", cpp: 0.7, match: ["marriott", "bonvoy"] },
-  { program: "Capital One Miles", slug: "capital-one-miles", cpp: 1.0, match: ["capital one"] },
-  { program: "Bilt Rewards", slug: "bilt-rewards", cpp: 1.5, match: ["bilt"] },
-  { program: "Citi ThankYou", slug: "citi-thankyou", cpp: 1.0, match: ["citi"] },
+  { program: "Chase Ultimate Rewards", slug: "chase-ultimate-rewards", cpp: 1.25, match: ["chase sapphire", "freedom"], toolSlug: "chase-ultimate-rewards" },
+  { program: "Amex Membership Rewards", slug: "amex-membership-rewards", cpp: 1.2, match: ["american express", "amex", "gold card", "platinum card"], exclude: ["delta", "hilton", "skymiles"], toolSlug: "amex-membership-rewards" },
+  { program: "Delta SkyMiles", slug: "delta-skymiles", cpp: 1.1, match: ["delta", "skymiles"], toolSlug: "delta-skymiles" },
+  { program: "United MileagePlus", slug: "united-mileageplus", cpp: 1.2, match: ["united"], toolSlug: "united-miles" },
+  { program: "Hilton Honors", slug: "hilton-honors", cpp: 0.5, match: ["hilton"], toolSlug: "hilton-honors-points" },
+  { program: "World of Hyatt", slug: "world-of-hyatt", cpp: 2.0, match: ["hyatt"], toolSlug: "world-of-hyatt-points" },
+  { program: "IHG One Rewards", slug: "ihg-one-rewards", cpp: 0.5, match: ["ihg"], toolSlug: "ihg-one-rewards-points" },
+  { program: "Marriott Bonvoy", slug: "marriott-bonvoy", cpp: 0.7, match: ["marriott", "bonvoy"], toolSlug: "marriott-bonvoy-points" },
+  { program: "Capital One Miles", slug: "capital-one-miles", cpp: 1.0, match: ["capital one"], toolSlug: "capital-one-miles" },
+  { program: "Bilt Rewards", slug: "bilt-rewards", cpp: 1.5, match: ["bilt"], toolSlug: "bilt-rewards-points" },
+  { program: "Citi ThankYou", slug: "citi-thankyou", cpp: 1.0, match: ["citi"], toolSlug: "citi-thankyou-points" },
   { program: "Wells Fargo Rewards", slug: "wells-fargo-rewards", cpp: 1.0, match: ["wells fargo"] },
-  { program: "Southwest Rapid Rewards", slug: "southwest-rapid-rewards", cpp: 1.4, match: ["southwest"] },
+  { program: "Southwest Rapid Rewards", slug: "southwest-rapid-rewards", cpp: 1.4, match: ["southwest"], toolSlug: "southwest-rapid-rewards" },
 ];
 
 const DEFAULT_CPP = 1.0;
 
 export function getValuation(cardName: string): number {
+  return getValuationDetails(cardName)?.cpp ?? DEFAULT_CPP;
+}
+
+export function getValuationDetails(cardName: string): Valuation | undefined {
   const name = cardName.toLowerCase();
   for (const v of valuations) {
     if (v.exclude && v.exclude.some(ex => name.includes(ex))) continue;
-    if (v.match.some(m => name.includes(m))) return v.cpp;
+    if (v.match.some(m => name.includes(m))) return v;
   }
-  return DEFAULT_CPP;
+  return undefined;
 }
 
 export function getValuationBySlug(slug: string): Valuation | undefined {


### PR DESCRIPTION
## Summary
- Add CPP valuation link (e.g. "1.25¢/point") to card page metadata row, next to the reward type badge
- Links to the relevant converter tool page (e.g. `/tools/chase-ultimate-rewards-to-usd`)
- Only shown for points/miles cards (not cashback) that have a matching tool page
- Add `getValuationDetails()` helper and `toolSlug` field to valuations library

## Test plan
- [ ] Visit a points card (e.g. Chase Sapphire Preferred) — verify CPP link appears after the "Points" badge
- [ ] Visit a miles card (e.g. United Explorer) — verify CPP link appears with "¢/mile"
- [ ] Visit a cashback card (e.g. Citi Double Cash) — verify no CPP link appears
- [ ] Click the CPP link — verify it navigates to the correct converter tool page
- [ ] Check mobile layout — metadata row should wrap cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)