### PR TITLE
Add all 7 USAA credit cards

### DIFF
--- a/data/cards/usaa-cashback-rewards-plus.yaml
+++ b/data/cards/usaa-cashback-rewards-plus.yaml
@@ -1,0 +1,31 @@
+name: "USAA Cashback Rewards Plus"
+bank: "USAA"
+slug: "usaa-cashback-rewards-plus"
+image: "usaa-cashback-rewards-plus.png"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0
+tags:
+  - cashback
+  - rewards
+reward_type: "cashback"
+rewards:
+  - category: military_base
+    value: 5
+    unit: percent
+    note: "First $5,000/year"
+  - category: gas
+    value: 5
+    unit: percent
+    note: "First $3,000/year"
+  - category: groceries
+    value: 3
+    unit: percent
+    note: "First $3,000/year"
+  - category: everything_else
+    value: 1
+    unit: percent
+apr:
+  regular:
+    min: 16.90
+    max: 30.90

--- a/data/cards/usaa-eagle-navigator.yaml
+++ b/data/cards/usaa-eagle-navigator.yaml
@@ -1,0 +1,30 @@
+name: "USAA Eagle Navigator"
+bank: "USAA"
+slug: "usaa-eagle-navigator"
+image: "usaa-eagle-navigator.png"
+accepting_applications: true
+category: "travel"
+annual_fee: 95
+tags:
+  - travel
+  - rewards
+reward_type: "points"
+rewards:
+  - category: travel
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 2
+    unit: points_per_dollar
+signup_bonus:
+  value: 30000
+  type: points
+  spend_requirement: 3000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.99
+    max: 28.99

--- a/data/cards/usaa-preferred-cash-rewards.yaml
+++ b/data/cards/usaa-preferred-cash-rewards.yaml
@@ -1,0 +1,31 @@
+name: "USAA Preferred Cash Rewards"
+bank: "USAA"
+slug: "usaa-preferred-cash-rewards"
+image: "usaa-preferred-cash-rewards.png"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0
+tags:
+  - cashback
+  - rewards
+  - balance_transfer
+reward_type: "cashback"
+rewards:
+  - category: everything_else
+    value: 1.5
+    unit: percent
+signup_bonus:
+  value: 250
+  type: cash
+  spend_requirement: 1000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.49
+    max: 28.49

--- a/data/cards/usaa-rate-advantage.yaml
+++ b/data/cards/usaa-rate-advantage.yaml
@@ -1,0 +1,16 @@
+name: "USAA Rate Advantage"
+bank: "USAA"
+slug: "usaa-rate-advantage"
+image: "usaa-rate-advantage.png"
+accepting_applications: true
+category: "balance_transfer"
+annual_fee: 0
+tags:
+  - balance_transfer
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 10.40
+    max: 24.40

--- a/data/cards/usaa-rewards.yaml
+++ b/data/cards/usaa-rewards.yaml
@@ -1,0 +1,24 @@
+name: "USAA Rewards"
+bank: "USAA"
+slug: "usaa-rewards"
+image: "usaa-rewards.png"
+accepting_applications: true
+category: "rewards"
+annual_fee: 0
+tags:
+  - rewards
+reward_type: "points"
+rewards:
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+apr:
+  regular:
+    min: 13.40
+    max: 27.40

--- a/data/cards/usaa-secured-american-express.yaml
+++ b/data/cards/usaa-secured-american-express.yaml
@@ -1,0 +1,14 @@
+name: "USAA Secured American Express"
+bank: "USAA"
+slug: "usaa-secured-american-express"
+image: "usaa-secured-american-express.png"
+accepting_applications: true
+category: "secured"
+annual_fee: 35
+tags:
+  - secured
+  - credit_builder
+apr:
+  regular:
+    min: 11.40
+    max: 21.40

--- a/data/cards/usaa-secured-visa-platinum.yaml
+++ b/data/cards/usaa-secured-visa-platinum.yaml
@@ -1,0 +1,14 @@
+name: "USAA Secured Visa Platinum"
+bank: "USAA"
+slug: "usaa-secured-visa-platinum"
+image: "usaa-secured-visa-platinum.png"
+accepting_applications: true
+category: "secured"
+annual_fee: 0
+tags:
+  - secured
+  - credit_builder
+apr:
+  regular:
+    min: 11.40
+    max: 21.40

--- a/data/categories.yaml
+++ b/data/categories.yaml
@@ -59,5 +59,7 @@ categories:
     label: Shipping
   - id: foreign_transactions
     label: Foreign Transactions
+  - id: military_base
+    label: Military Base
   - id: everything_else
     label: Everything Else


### PR DESCRIPTION
## Summary
- Adds 7 USAA credit cards: Eagle Navigator, Preferred Cash Rewards, Cashback Rewards Plus, Rewards (Visa Signature), Rate Advantage, Secured American Express, and Secured Visa Platinum
- Adds `military_base` category to `data/categories.yaml` for the Cashback Rewards Plus card
- Card images to be added separately

## Test plan
- [ ] Run `npm run build:cards` to verify YAML parses correctly
- [ ] Verify cards appear on /explore page after deploy
- [ ] Add card images (`usaa-*.png`) in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)