### PR TITLE
Add CardImage component with load error fallback

### DIFF
--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 import { useAuth } from "@/auth/AuthProvider";
 import {
   getAdminStats,
@@ -507,17 +507,15 @@ function RecordsTab({
               <tr key={record.record_id} className="hover:bg-gray-50">
                 <td className="px-4 py-3 whitespace-nowrap">
                   <div className="flex items-center">
-                    {record.card_image_link && (
-                      <div className="flex-shrink-0 h-8 w-12 relative mr-3">
-                        <Image
-                          src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${record.card_image_link}`}
-                          alt={record.card_name}
-                          fill
-                          className="object-contain"
-                          sizes="48px"
-                        />
-                      </div>
-                    )}
+                    <div className="flex-shrink-0 h-8 w-12 relative mr-3">
+                      <CardImage
+                        cardImageLink={record.card_image_link}
+                        alt={record.card_name}
+                        fill
+                        className="object-contain"
+                        sizes="48px"
+                      />
+                    </div>
                     <div>
                       <div className="text-sm font-medium text-gray-900 truncate max-w-[200px]">
                         {record.card_name}
@@ -607,17 +605,15 @@ function ReferralsTab({
               >
                 <td className="px-4 py-3 whitespace-nowrap">
                   <div className="flex items-center">
-                    {referral.card_image_link && (
-                      <div className="flex-shrink-0 h-8 w-12 relative mr-3">
-                        <Image
-                          src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
-                          alt={referral.card_name}
-                          fill
-                          className="object-contain"
-                          sizes="48px"
-                        />
-                      </div>
-                    )}
+                    <div className="flex-shrink-0 h-8 w-12 relative mr-3">
+                      <CardImage
+                        cardImageLink={referral.card_image_link}
+                        alt={referral.card_name}
+                        fill
+                        className="object-contain"
+                        sizes="48px"
+                      />
+                    </div>
                     <div>
                       <div className="text-sm font-medium text-gray-900 truncate max-w-[150px]">
                         {referral.card_name}
@@ -906,17 +902,15 @@ function UserLookupTab({
                       <tr key={card.id} className="hover:bg-gray-50">
                         <td className="px-4 py-3 whitespace-nowrap">
                           <div className="flex items-center">
-                            {card.card_image_link && (
-                              <div className="flex-shrink-0 h-8 w-12 relative mr-3">
-                                <Image
-                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
-                                  alt={card.card_name}
-                                  fill
-                                  className="object-contain"
-                                  sizes="48px"
-                                />
-                              </div>
-                            )}
+                            <div className="flex-shrink-0 h-8 w-12 relative mr-3">
+                              <CardImage
+                                cardImageLink={card.card_image_link}
+                                alt={card.card_name}
+                                fill
+                                className="object-contain"
+                                sizes="48px"
+                              />
+                            </div>
                             <span className="text-sm font-medium text-gray-900">{card.card_name}</span>
                           </div>
                         </td>
@@ -961,17 +955,15 @@ function UserLookupTab({
                       <tr key={record.record_id} className="hover:bg-gray-50">
                         <td className="px-4 py-3 whitespace-nowrap">
                           <div className="flex items-center">
-                            {record.card_image_link && (
-                              <div className="flex-shrink-0 h-8 w-12 relative mr-3">
-                                <Image
-                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${record.card_image_link}`}
-                                  alt={record.card_name}
-                                  fill
-                                  className="object-contain"
-                                  sizes="48px"
-                                />
-                              </div>
-                            )}
+                            <div className="flex-shrink-0 h-8 w-12 relative mr-3">
+                              <CardImage
+                                cardImageLink={record.card_image_link}
+                                alt={record.card_name}
+                                fill
+                                className="object-contain"
+                                sizes="48px"
+                              />
+                            </div>
                             <div>
                               <div className="text-sm font-medium text-gray-900 truncate max-w-[200px]">
                                 {record.card_name}
@@ -1065,17 +1057,15 @@ function UserLookupTab({
                       <tr key={referral.referral_id} className="hover:bg-gray-50">
                         <td className="px-4 py-3 whitespace-nowrap">
                           <div className="flex items-center">
-                            {referral.card_image_link && (
-                              <div className="flex-shrink-0 h-8 w-12 relative mr-3">
-                                <Image
-                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
-                                  alt={referral.card_name}
-                                  fill
-                                  className="object-contain"
-                                  sizes="48px"
-                                />
-                              </div>
-                            )}
+                            <div className="flex-shrink-0 h-8 w-12 relative mr-3">
+                              <CardImage
+                                cardImageLink={referral.card_image_link}
+                                alt={referral.card_name}
+                                fill
+                                className="object-contain"
+                                sizes="48px"
+                              />
+                            </div>
                             <div>
                               <div className="text-sm font-medium text-gray-900 truncate max-w-[150px]">
                                 {referral.card_name}
@@ -1225,17 +1215,15 @@ function CardDataTab({ getToken }: { getToken: () => Promise<string | null> }) {
           {selectedCard ? (
             <div className="flex items-center justify-between border border-gray-300 rounded-md px-3 py-2">
               <div className="flex items-center gap-2">
-                {selectedCard.card_image_link && (
-                  <div className="flex-shrink-0 h-6 w-10 relative">
-                    <Image
-                      src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${selectedCard.card_image_link}`}
-                      alt={selectedCard.card_name}
-                      fill
-                      className="object-contain"
-                      sizes="40px"
-                    />
-                  </div>
-                )}
+                <div className="flex-shrink-0 h-6 w-10 relative">
+                  <CardImage
+                    cardImageLink={selectedCard.card_image_link}
+                    alt={selectedCard.card_name}
+                    fill
+                    className="object-contain"
+                    sizes="40px"
+                  />
+                </div>
                 <span className="text-sm text-gray-900">{selectedCard.card_name}</span>
                 <span className="text-xs text-gray-500">({selectedCard.bank})</span>
               </div>
@@ -1265,17 +1253,15 @@ function CardDataTab({ getToken }: { getToken: () => Promise<string | null> }) {
                       onClick={() => handleSelectCard(card)}
                       className="px-3 py-2 hover:bg-indigo-50 cursor-pointer text-sm flex items-center gap-2"
                     >
-                      {card.card_image_link && (
-                        <div className="flex-shrink-0 h-5 w-8 relative">
-                          <Image
-                            src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
-                            alt={card.card_name}
-                            fill
-                            className="object-contain"
-                            sizes="32px"
-                          />
-                        </div>
-                      )}
+                      <div className="flex-shrink-0 h-5 w-8 relative">
+                        <CardImage
+                          cardImageLink={card.card_image_link}
+                          alt={card.card_name}
+                          fill
+                          className="object-contain"
+                          sizes="32px"
+                        />
+                      </div>
                       <span>{card.card_name}</span>
                       <span className="text-gray-400 text-xs">({card.bank})</span>
                     </li>
@@ -1750,17 +1736,15 @@ function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<stri
           {selectedCard ? (
             <div className="flex items-center justify-between border border-gray-300 rounded-md px-3 py-2">
               <div className="flex items-center gap-2">
-                {selectedCard.card_image_link && (
-                  <div className="flex-shrink-0 h-6 w-10 relative">
-                    <Image
-                      src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${selectedCard.card_image_link}`}
-                      alt={selectedCard.card_name}
-                      fill
-                      className="object-contain"
-                      sizes="40px"
-                    />
-                  </div>
-                )}
+                <div className="flex-shrink-0 h-6 w-10 relative">
+                  <CardImage
+                    cardImageLink={selectedCard.card_image_link}
+                    alt={selectedCard.card_name}
+                    fill
+                    className="object-contain"
+                    sizes="40px"
+                  />
+                </div>
                 <span className="text-sm text-gray-900">{selectedCard.card_name}</span>
                 <span className="text-xs text-gray-500">({selectedCard.bank})</span>
               </div>
@@ -1794,17 +1778,15 @@ function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<stri
                       }}
                       className="px-3 py-2 hover:bg-indigo-50 cursor-pointer text-sm flex items-center gap-2"
                     >
-                      {card.card_image_link && (
-                        <div className="flex-shrink-0 h-5 w-8 relative">
-                          <Image
-                            src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
-                            alt={card.card_name}
-                            fill
-                            className="object-contain"
-                            sizes="32px"
-                          />
-                        </div>
-                      )}
+                      <div className="flex-shrink-0 h-5 w-8 relative">
+                        <CardImage
+                          cardImageLink={card.card_image_link}
+                          alt={card.card_name}
+                          fill
+                          className="object-contain"
+                          sizes="32px"
+                        />
+                      </div>
                       <span>{card.card_name}</span>
                       <span className="text-gray-400 text-xs">({card.bank})</span>
                     </li>

--- a/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
+++ b/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { Card } from '@/lib/api';
 
 interface BankCardsTableProps {
@@ -89,10 +89,8 @@ export default function BankCardsTable({ cards }: BankCardsTableProps) {
                 <td className="whitespace-nowrap py-4 pl-4 pr-3 sm:pl-6">
                   <Link href={`/card/${card.slug}`} className="flex items-center group">
                     <div className="h-10 w-16 flex-shrink-0 mr-4">
-                      <Image
-                        src={card.card_image_link
-                          ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                          : '/assets/generic-card.svg'}
+                      <CardImage
+                        cardImageLink={card.card_image_link}
                         alt={card.card_name}
                         width={64}
                         height={40}

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -290,10 +290,8 @@ export default function CardClient({ card, graphData, news, articles, ratings }:
             {/* Mobile card image first */}
             <div className="mb-6 lg:hidden">
               <div className="w-full max-w-sm mx-auto">
-                <Image
-                  src={card.card_image_link
-                    ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                    : '/assets/generic-card.svg'}
+                <CardImage
+                  cardImageLink={card.card_image_link}
                   alt={card.card_name}
                   className="w-full rounded-xl shadow-[0_12px_40px_rgba(0,0,0,0.2)]"
                   width={360}
@@ -311,10 +309,8 @@ export default function CardClient({ card, graphData, news, articles, ratings }:
               <div className="order-2 mt-8 flex flex-col items-center lg:order-1 lg:col-span-4 lg:mt-0">
                 {/* Card Image */}
                 <div className="hidden w-full max-w-sm lg:mx-0 lg:block lg:max-w-[330px]">
-                  <Image
-                    src={card.card_image_link
-                      ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                      : '/assets/generic-card.svg'}
+                  <CardImage
+                    cardImageLink={card.card_image_link}
                     alt={card.card_name}
                     className="w-full rounded-xl shadow-[0_12px_40px_rgba(0,0,0,0.2)]"
                     width={360}

--- a/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
+++ b/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 import { useAuth } from "@/auth/AuthProvider";
 import { checkOdds, CheckOddsCard, CheckOddsResponse, getWallet, WalletCard } from "@/lib/api";
 import { calculateApplicationRules, RuleResult } from "@/lib/applicationRules";
@@ -386,10 +386,8 @@ export default function CheckOddsClient() {
                             <td className="py-3 pl-3 pr-2 sm:py-4 sm:pl-6 sm:pr-3">
                               <Link href={`/card/${card.slug}`} className="flex items-center group">
                                 <div className="h-8 w-12 sm:h-10 sm:w-16 flex-shrink-0 mr-3">
-                                  <Image
-                                    src={card.card_image_link
-                                      ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                                      : '/assets/generic-card.svg'}
+                                  <CardImage
+                                    cardImageLink={card.card_image_link}
                                     alt={card.card_name}
                                     width={64}
                                     height={40}

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Image from 'next/image';
 import Link from 'next/link';
+import CardImage from '@/components/ui/CardImage';
 import Downshift from 'downshift';
 import {
   MagnifyingGlassIcon,
@@ -50,10 +50,8 @@ function CardPicker({
     return (
       <div className="bg-white rounded-lg border border-gray-200 p-3 flex items-center gap-3">
         <div className="flex-shrink-0 h-10 w-16 relative">
-          <Image
-            src={selectedCard.card_image_link
-              ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${selectedCard.card_image_link}`
-              : '/assets/generic-card.svg'}
+          <CardImage
+            cardImageLink={selectedCard.card_image_link}
             alt={selectedCard.card_name}
             fill
             className="object-contain rounded"
@@ -153,10 +151,8 @@ function CardPicker({
                   >
                     <div className={`flex items-center gap-2 ${isArchived ? 'opacity-60' : ''}`}>
                       <div className={`flex-shrink-0 h-6 w-10 relative ${isArchived ? 'grayscale' : ''}`}>
-                        <Image
-                          src={item.card_image_link
-                            ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${item.card_image_link}`
-                            : '/assets/generic-card.svg'}
+                        <CardImage
+                          cardImageLink={item.card_image_link}
                           alt=""
                           fill
                           className="object-contain"
@@ -391,10 +387,8 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                 {/* Card header */}
                 <div className="px-4 py-4 bg-gray-50 border-b border-gray-200 flex items-center gap-3">
                   <div className="flex-shrink-0 h-12 w-20 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain rounded"
@@ -553,10 +547,8 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                 {activeCards.map((card) => (
                   <td key={card.slug} className="px-4 py-3 text-center">
                     <div className="mx-auto w-32 h-20 relative">
-                      <Image
-                        src={card.card_image_link
-                          ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                          : '/assets/generic-card.svg'}
+                      <CardImage
+                        cardImageLink={card.card_image_link}
                         alt={card.card_name}
                         fill
                         className="object-contain rounded-lg"

--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 import { Card } from "@/lib/api";
 import { cardMatchesSearch } from "@/lib/searchAliases";
 
@@ -123,10 +123,8 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
                 className="flex-shrink-0 bg-white rounded-lg shadow p-2 hover:shadow-md transition-shadow flex items-center gap-2 w-[200px] sm:w-[220px]"
               >
                 <div className="h-10 w-16 relative flex-shrink-0">
-                  <Image
-                    src={card.card_image_link
-                      ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                      : '/assets/generic-card.svg'}
+                  <CardImage
+                    cardImageLink={card.card_image_link}
                     alt={card.card_name}
                     fill
                     className="object-contain"
@@ -319,10 +317,8 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
                         <td className="py-3 pl-3 pr-2 sm:py-4 sm:pl-6 sm:pr-3">
                           <Link href={`/card/${card.slug}`} className="flex items-center group">
                             <div className="h-8 w-12 sm:h-10 sm:w-16 flex-shrink-0 mr-3">
-                              <Image
-                                src={card.card_image_link
-                                  ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                                  : '/assets/generic-card.svg'}
+                              <CardImage
+                                cardImageLink={card.card_image_link}
                                 alt={card.card_name}
                                 width={64}
                                 height={40}

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useAuth } from "@/auth/AuthProvider";
@@ -565,10 +565,8 @@ export default function ProfileClient() {
                     className={`relative text-left rounded-lg p-3 transition-colors cursor-pointer ${inactive ? 'bg-gray-100 opacity-60' : 'bg-gray-50 hover:bg-gray-100'}`}
                   >
                     <div className="aspect-[1.586/1] relative mb-2">
-                      <Image
-                        src={card.card_image_link
-                          ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                          : '/assets/generic-card.svg'}
+                      <CardImage
+                        cardImageLink={card.card_image_link}
                         alt={card.card_name}
                         fill
                         className={`object-contain ${inactive ? 'grayscale' : ''}`}
@@ -648,17 +646,15 @@ export default function ProfileClient() {
                 {records.map((record, index) => (
                   <div key={record.record_id || index} className="p-4">
                     <div className="flex items-start gap-3">
-                      {record.card_image_link && (
-                        <div className="flex-shrink-0 h-12 w-20 relative">
-                          <Image
-                            className="object-contain"
-                            src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${record.card_image_link}`}
-                            alt={record.card_name}
-                            fill
-                            sizes="80px"
-                          />
-                        </div>
-                      )}
+                      <div className="flex-shrink-0 h-12 w-20 relative">
+                        <CardImage
+                          className="object-contain"
+                          cardImageLink={record.card_image_link}
+                          alt={record.card_name}
+                          fill
+                          sizes="80px"
+                        />
+                      </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-start justify-between">
                           <p className="text-sm font-medium text-gray-900 truncate">{record.card_name}</p>
@@ -720,17 +716,15 @@ export default function ProfileClient() {
                       <tr key={record.record_id || index}>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">
-                            {record.card_image_link && (
-                              <div className="flex-shrink-0 h-10 w-16 relative">
-                                <Image
-                                  className="object-contain"
-                                  src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${record.card_image_link}`}
-                                  alt={record.card_name}
-                                  fill
-                                  sizes="64px"
-                                />
-                              </div>
-                            )}
+                            <div className="flex-shrink-0 h-10 w-16 relative">
+                              <CardImage
+                                className="object-contain"
+                                cardImageLink={record.card_image_link}
+                                alt={record.card_name}
+                                fill
+                                sizes="64px"
+                              />
+                            </div>
                             <div className="ml-4">
                               <div className="text-sm font-medium text-gray-900">
                                 {record.card_name}
@@ -829,17 +823,15 @@ export default function ProfileClient() {
               <tr key={referral.referral_id} className={isArchived ? 'opacity-60' : ''}>
                 <td className="px-4 py-3 whitespace-nowrap">
                   <div className="flex items-center">
-                    {referral.card_image_link && (
-                      <div className={`flex-shrink-0 h-8 w-12 relative ${isArchived ? 'grayscale' : ''}`}>
-                        <Image
-                          className="object-contain"
-                          src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
-                          alt={referral.card_name}
-                          fill
-                          sizes="48px"
-                        />
-                      </div>
-                    )}
+                    <div className={`flex-shrink-0 h-8 w-12 relative ${isArchived ? 'grayscale' : ''}`}>
+                      <CardImage
+                        className="object-contain"
+                        cardImageLink={referral.card_image_link}
+                        alt={referral.card_name}
+                        fill
+                        sizes="48px"
+                      />
+                    </div>
                     <div className="ml-3">
                       <div className="text-sm font-medium text-gray-900">{referral.card_name}</div>
                     </div>
@@ -896,17 +888,15 @@ export default function ProfileClient() {
             const renderReferralMobileCard = (referral: Referral, isArchived: boolean) => (
               <div key={referral.referral_id} className={`p-4 ${isArchived ? 'opacity-60' : ''}`}>
                 <div className="flex items-start gap-3">
-                  {referral.card_image_link && (
-                    <div className={`flex-shrink-0 h-12 w-20 relative ${isArchived ? 'grayscale' : ''}`}>
-                      <Image
-                        className="object-contain"
-                        src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${referral.card_image_link}`}
-                        alt={referral.card_name}
-                        fill
-                        sizes="80px"
-                      />
-                    </div>
-                  )}
+                  <div className={`flex-shrink-0 h-12 w-20 relative ${isArchived ? 'grayscale' : ''}`}>
+                    <CardImage
+                      className="object-contain"
+                      cardImageLink={referral.card_image_link}
+                      alt={referral.card_name}
+                      fill
+                      sizes="80px"
+                    />
+                  </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between">
                       <p className="text-sm font-medium text-gray-900 truncate">{referral.card_name}</p>

--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -81,10 +82,8 @@ export default async function AmexMRToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function BiltToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function CapitalOneMilesToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -79,10 +80,8 @@ export default async function ChaseURToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function CitiThankYouToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function DeltaSkyMilesToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function HiltonHonorsToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function IHGToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -79,10 +80,8 @@ export default async function MarriottBonvoyToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function SouthwestRRToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function UnitedMilesToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
@@ -78,10 +79,8 @@ export default async function HyattToUsdPage() {
                   className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
-                    <Image
-                      src={card.card_image_link
-                        ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                        : '/assets/generic-card.svg'}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
                       alt={card.card_name}
                       fill
                       className="object-contain"

--- a/apps/web-next/src/components/articles/RelatedCards.tsx
+++ b/apps/web-next/src/components/articles/RelatedCards.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 import { CreditCardIcon } from "@heroicons/react/24/outline";
 import { RelatedCardInfo } from "@/lib/articles";
 
@@ -25,20 +25,14 @@ export function RelatedCards({ cards }: RelatedCardsProps) {
             href={`/card/${card.slug}`}
             className="flex items-center gap-4 p-4 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-sm transition-all"
           >
-            {card.image ? (
-              <Image
-                src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.image}`}
-                alt={card.name}
-                width={64}
-                height={40}
-                className="rounded object-contain flex-shrink-0"
-                sizes="64px"
-              />
-            ) : (
-              <div className="w-16 h-10 bg-gray-100 rounded flex items-center justify-center flex-shrink-0">
-                <CreditCardIcon className="h-6 w-6 text-gray-400" />
-              </div>
-            )}
+            <CardImage
+              cardImageLink={card.image}
+              alt={card.name}
+              width={64}
+              height={40}
+              className="rounded object-contain flex-shrink-0"
+              sizes="64px"
+            />
             <div className="min-w-0">
               <p className="text-sm font-medium text-gray-900 truncate">{card.name}</p>
               <p className="text-xs text-gray-500">{card.bank}</p>

--- a/apps/web-next/src/components/best/BestCardList.tsx
+++ b/apps/web-next/src/components/best/BestCardList.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
 import { Card } from '@/lib/api';
 import { BestPageCard } from '@/lib/best';
@@ -53,19 +53,13 @@ export function BestCardList({ cards }: BestCardListProps) {
                 {/* Card image */}
                 <div className="flex-shrink-0">
                   <Link href={`/card/${card.slug}`}>
-                    {card.card_image_link ? (
-                      <Image
-                        src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
-                        alt={card.card_name}
-                        width={160}
-                        height={100}
-                        className="rounded-lg shadow-sm"
-                      />
-                    ) : (
-                      <div className="w-40 h-25 bg-gray-200 rounded-lg flex items-center justify-center">
-                        <span className="text-gray-400 text-xs">No image</span>
-                      </div>
-                    )}
+                    <CardImage
+                      cardImageLink={card.card_image_link}
+                      alt={card.card_name}
+                      width={160}
+                      height={100}
+                      className="rounded-lg shadow-sm"
+                    />
                   </Link>
                 </div>
 

--- a/apps/web-next/src/components/best/BestComparisonTable.tsx
+++ b/apps/web-next/src/components/best/BestComparisonTable.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
 import { Card } from '@/lib/api';
 import { BestPageCard } from '@/lib/best';
@@ -98,17 +98,13 @@ export function BestComparisonTable({ cards }: BestComparisonTableProps) {
                   <td className="px-4 py-3 align-top">
                     <div className="flex items-start gap-3 min-w-0">
                       <Link href={`/card/${card.slug}`} className="flex-shrink-0">
-                        {card.card_image_link ? (
-                          <Image
-                            src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
-                            alt={card.card_name}
-                            width={48}
-                            height={30}
-                            className="rounded shadow-sm"
-                          />
-                        ) : (
-                          <div className="w-12 h-[30px] bg-gray-200 rounded" />
-                        )}
+                        <CardImage
+                          cardImageLink={card.card_image_link}
+                          alt={card.card_name}
+                          width={48}
+                          height={30}
+                          className="rounded shadow-sm"
+                        />
                       </Link>
                       <div className="min-w-0">
                         <Link

--- a/apps/web-next/src/components/forms/ReferralModal.tsx
+++ b/apps/web-next/src/components/forms/ReferralModal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from "react";
-import Image from "next/image";
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle, Listbox, ListboxButton, ListboxOption, ListboxOptions, Label } from "@headlessui/react";
+import CardImage from '@/components/ui/CardImage';
 import { LinkIcon, CheckIcon, ChevronUpDownIcon } from "@heroicons/react/24/outline";
 import { useFormik } from "formik";
 import * as Yup from "yup";
@@ -131,8 +131,8 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
                         <span className="flex items-center">
                           {selected.card_image_link && (
                             <div className="h-8 w-12 flex-shrink-0 relative">
-                              <Image
-                                src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${selected.card_image_link}`}
+                              <CardImage
+                                cardImageLink={selected.card_image_link}
                                 alt=""
                                 fill
                                 className="object-contain"
@@ -164,8 +164,8 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
                                 <div className="flex items-center">
                                   {card.card_image_link && (
                                     <div className="h-8 w-12 flex-shrink-0 relative">
-                                      <Image
-                                        src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
+                                      <CardImage
+                                        cardImageLink={card.card_image_link}
                                         alt=""
                                         fill
                                         className="object-contain"

--- a/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
@@ -3,7 +3,7 @@
 import { Fragment } from "react";
 import { Dialog, DialogPanel, Transition, TransitionChild } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/solid";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 
 interface WalletCard {
   id: number;
@@ -79,10 +79,8 @@ export default function SubmitRecordCardPicker({ show, onClose, cards, onSelectC
                           className="w-full flex items-center gap-4 p-3 rounded-lg border border-gray-200 hover:border-indigo-300 hover:bg-indigo-50 transition-colors text-left"
                         >
                           <div className="flex-shrink-0 h-10 w-16 relative">
-                            <Image
-                              src={card.card_image_link
-                                ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                                : '/assets/generic-card.svg'}
+                            <CardImage
+                              cardImageLink={card.card_image_link}
                               alt={card.card_name}
                               fill
                               className="object-contain"

--- a/apps/web-next/src/components/forms/SubmitRecordModal.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordModal.tsx
@@ -6,7 +6,7 @@ import { XMarkIcon, ExclamationCircleIcon } from "@heroicons/react/24/solid";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import { NumericFormat } from "react-number-format";
-import Image from "next/image";
+import CardImage from '@/components/ui/CardImage';
 import { useAuth } from "@/auth/AuthProvider";
 import { toast } from "react-toastify";
 import { getRecords } from "@/lib/api";
@@ -262,17 +262,15 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess }
                     <div className="p-8">
                       {/* Card image and name */}
                       <div className="mb-6">
-                        {card.card_image_link && (
-                          <div className="block w-full rounded-lg overflow-hidden mb-4 relative h-48">
-                            <Image
-                              src={`https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`}
-                              alt={card.card_name}
-                              fill
-                              className="object-contain"
-                              sizes="(max-width: 448px) 100vw, 448px"
-                            />
-                          </div>
-                        )}
+                        <div className="block w-full rounded-lg overflow-hidden mb-4 relative h-48">
+                          <CardImage
+                            cardImageLink={card.card_image_link}
+                            alt={card.card_name}
+                            fill
+                            className="object-contain"
+                            sizes="(max-width: 448px) 100vw, 448px"
+                          />
+                        </div>
                         <h2 className="text-lg font-medium text-gray-900">{card.card_name}</h2>
                       </div>
 

--- a/apps/web-next/src/components/news/NewsTable.tsx
+++ b/apps/web-next/src/components/news/NewsTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 import { BuildingLibraryIcon, CreditCardIcon } from "@heroicons/react/24/outline";
 import { NewsItem, tagLabels, tagColors, NewsTag } from "@/lib/news";
 import { ExpandableText } from "@/components/ui/ExpandableText";
@@ -26,8 +26,6 @@ function TagBadge({ tag }: { tag: NewsTag }) {
   );
 }
 
-const CARD_IMG_CDN = 'https://d3ay3etzd1512y.cloudfront.net/card_images/';
-
 function CardStack({ item }: { item: NewsItem }) {
   const slugs = item.card_slugs ?? [];
   const names = item.card_names ?? [];
@@ -41,8 +39,8 @@ function CardStack({ item }: { item: NewsItem }) {
         className="flex items-center text-sm text-indigo-600 hover:text-indigo-900 whitespace-nowrap"
       >
         {images[0] ? (
-          <Image
-            src={`${CARD_IMG_CDN}${images[0]}`}
+          <CardImage
+            cardImageLink={images[0]}
             alt={names[0]}
             width={32}
             height={20}
@@ -70,8 +68,8 @@ function CardStack({ item }: { item: NewsItem }) {
               style={{ zIndex: slugs.length - i }}
             >
               {images[i] ? (
-                <Image
-                  src={`${CARD_IMG_CDN}${images[i]}`}
+                <CardImage
+                  cardImageLink={images[i]}
                   alt={names[i] || slug}
                   width={36}
                   height={23}
@@ -170,8 +168,8 @@ export default function NewsTable({ newsItems }: { newsItems: NewsItem[] }) {
                           href={`/card/${item.card_slugs?.[i] ?? item.card_slug}`}
                           style={{ zIndex: (item.card_image_links?.length ?? 1) - i }}
                         >
-                          <Image
-                            src={`${CARD_IMG_CDN}${img}`}
+                          <CardImage
+                            cardImageLink={img}
                             alt={item.card_names?.[i] ?? item.card_name ?? ''}
                             width={36}
                             height={23}

--- a/apps/web-next/src/components/ui/CardImage.tsx
+++ b/apps/web-next/src/components/ui/CardImage.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Image, { ImageProps } from 'next/image';
+import { useState } from 'react';
+
+const CARD_IMAGE_CDN = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
+const FALLBACK_IMAGE = '/assets/generic-card.svg';
+
+type CardImageProps = Omit<ImageProps, 'src' | 'onError'> & {
+  cardImageLink?: string | null;
+};
+
+export default function CardImage({ cardImageLink, alt, ...props }: CardImageProps) {
+  const [errored, setErrored] = useState(false);
+
+  const src = !errored && cardImageLink
+    ? `${CARD_IMAGE_CDN}/${cardImageLink}`
+    : FALLBACK_IMAGE;
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      onError={() => setErrored(true)}
+      {...props}
+    />
+  );
+}

--- a/apps/web-next/src/components/ui/CardSelect.tsx
+++ b/apps/web-next/src/components/ui/CardSelect.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState, useEffect, useCallback } from "react";
 import Downshift from "downshift";
-import Image from "next/image";
+import CardImage from "@/components/ui/CardImage";
 import { ClockIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { Card } from "@/lib/api";
 import { cardMatchesSearch } from "@/lib/searchAliases";
@@ -162,11 +162,8 @@ export default function CardSelect({ allCards }: CardSelectProps) {
                     >
                       <div className={`flex items-center ${isArchived ? 'opacity-60' : ''}`}>
                         <div className={`flex-shrink-0 h-8 w-12 relative ${isArchived ? 'grayscale' : ''}`}>
-                          <Image
-                            src={item.card_image_link
-                              ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${item.card_image_link}`
-                              : '/assets/generic-card.svg'
-                            }
+                          <CardImage
+                            cardImageLink={item.card_image_link}
                             alt=""
                             fill
                             className="object-contain"

--- a/apps/web-next/src/components/ui/DataPointPrompt.tsx
+++ b/apps/web-next/src/components/ui/DataPointPrompt.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import Downshift from 'downshift';
 import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react';
 import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline';
@@ -94,12 +94,8 @@ function CardPicker({
                     >
                       <div className="flex items-center">
                         <div className="flex-shrink-0 h-7 w-11 relative">
-                          <Image
-                            src={
-                              item.card_image_link
-                                ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${item.card_image_link}`
-                                : '/assets/generic-card.svg'
-                            }
+                          <CardImage
+                            cardImageLink={item.card_image_link}
                             alt=""
                             fill
                             className="object-contain"

--- a/apps/web-next/src/components/ui/RecordsTicker.tsx
+++ b/apps/web-next/src/components/ui/RecordsTicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { RecentRecord } from '@/lib/api';
 
 interface RecordsTickerProps {
@@ -24,10 +24,8 @@ export default function RecordsTicker({ records }: RecordsTickerProps) {
             >
               {/* Card Image */}
               <div className="h-8 w-12 flex-shrink-0 relative mr-3">
-                <Image
-                  src={record.card_image_link
-                    ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${record.card_image_link}`
-                    : '/assets/generic-card.svg'}
+                <CardImage
+                  cardImageLink={record.card_image_link}
                   alt={record.card_name}
                   fill
                   className="object-contain"

--- a/apps/web-next/src/components/wallet/AddToWalletModal.tsx
+++ b/apps/web-next/src/components/wallet/AddToWalletModal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import Image from 'next/image';
 import { XMarkIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import CardImage from '@/components/ui/CardImage';
 import { Card, getAllCards, addToWallet } from '@/lib/api';
 import { useAuth } from '@/auth/AuthProvider';
 
@@ -153,10 +153,8 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
                       className="w-full flex items-center p-3 rounded-lg border border-gray-200 hover:border-indigo-500 hover:bg-indigo-50 transition-colors text-left"
                     >
                       <div className="h-10 w-16 flex-shrink-0 mr-3">
-                        <Image
-                          src={card.card_image_link
-                            ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                            : '/assets/generic-card.svg'}
+                        <CardImage
+                          cardImageLink={card.card_image_link}
                           alt={card.card_name}
                           width={64}
                           height={40}
@@ -185,10 +183,8 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
                 <div className="mb-6 p-4 bg-gray-50 rounded-lg">
                   <div className="flex items-center">
                     <div className="h-12 w-20 flex-shrink-0 mr-4">
-                      <Image
-                        src={selectedCard.card_image_link
-                          ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${selectedCard.card_image_link}`
-                          : '/assets/generic-card.svg'}
+                      <CardImage
+                        cardImageLink={selectedCard.card_image_link}
                         alt={selectedCard.card_name}
                         width={80}
                         height={48}

--- a/apps/web-next/src/components/wallet/BestCardByCategory.tsx
+++ b/apps/web-next/src/components/wallet/BestCardByCategory.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import { Card, WalletCard, Reward } from '@/lib/api';
 import { formatRewardWithUsdEquivalent, getRewardUsdRate } from '@/lib/cardDisplayUtils';
 
@@ -128,10 +128,8 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
                 <td className="px-4 py-3 whitespace-nowrap">
                   <div className="flex items-center gap-3">
                     <div className="flex-shrink-0 h-8 w-12 relative">
-                      <Image
-                        src={card.card_image_link
-                          ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                          : '/assets/generic-card.svg'}
+                      <CardImage
+                        cardImageLink={card.card_image_link}
                         alt={card.card_name}
                         fill
                         className="object-contain"
@@ -163,10 +161,8 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
             <span className="text-sm font-medium text-gray-900">{label}</span>
             <div className="flex items-center gap-2">
               <div className="flex-shrink-0 h-6 w-10 relative">
-                <Image
-                  src={card.card_image_link
-                    ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                    : '/assets/generic-card.svg'}
+                <CardImage
+                  cardImageLink={card.card_image_link}
                   alt={card.card_name}
                   fill
                   className="object-contain"

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import Image from 'next/image';
+import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
 import { XMarkIcon, TrashIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { addToWallet, removeFromWallet, WalletCard, getCardRatings, getUserCardRating, submitCardRating } from '@/lib/api';
@@ -179,10 +179,8 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
             <div className="mb-6 p-4 bg-gray-50 rounded-lg">
               <div className="flex items-center">
                 <div className="h-12 w-20 flex-shrink-0 mr-4">
-                  <Image
-                    src={card.card_image_link
-                      ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${card.card_image_link}`
-                      : '/assets/generic-card.svg'}
+                  <CardImage
+                    cardImageLink={card.card_image_link}
                     alt={card.card_name}
                     width={80}
                     height={48}


### PR DESCRIPTION
## Summary
- Creates a shared `CardImage` component that wraps Next.js `Image` with `onError` handling — falls back to `generic-card.svg` when a card image fails to load
- Replaces inline CDN URL construction + fallback logic across 32 files with the new component
- OG image routes (server-side `img` tags) are unchanged

## Test plan
- [ ] Verify card images still load correctly on /explore, /card/*, /compare, /best/* pages
- [ ] Verify that a card with a missing/broken image shows the generic card SVG instead of a broken image icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)