### PR TITLE
Add similar cards section to card detail page

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -18,6 +18,7 @@ import {
   ScaleIcon,
   ShareIcon,
   CalculatorIcon,
+  CreditCardIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
 import { Card, GraphData, Reward, trackReferralEvent } from "@/lib/api";
@@ -112,9 +113,10 @@ interface CardClientProps {
   news: NewsItem[];
   articles: Article[];
   ratings: { count: number; average: number | null };
+  similarCards?: Card[];
 }
 
-export default function CardClient({ card, graphData, news, articles, ratings }: CardClientProps) {
+export default function CardClient({ card, graphData, news, articles, ratings, similarCards = [] }: CardClientProps) {
   const [showModal, setShowModal] = useState(false);
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [copiedShareLink, setCopiedShareLink] = useState(false);
@@ -913,6 +915,42 @@ export default function CardClient({ card, graphData, news, articles, ratings }:
                   <div className="mt-3 flex items-center justify-between text-xs text-gray-500">
                     <span>{article.author}</span>
                     <span>{article.reading_time} min read</span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Similar Cards Section */}
+      {similarCards.length > 0 && (
+        <div className="bg-white py-12">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center gap-3 mb-6">
+              <CreditCardIcon className="h-6 w-6 text-indigo-600" />
+              <h2 className="text-2xl font-bold text-gray-900">
+                Similar Cards
+              </h2>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {similarCards.map((c) => (
+                <Link
+                  key={c.slug}
+                  href={`/card/${c.slug}`}
+                  className="flex items-center gap-4 p-4 bg-gray-50 rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-sm transition-all"
+                >
+                  <CardImage
+                    cardImageLink={c.card_image_link}
+                    alt={c.card_name}
+                    width={64}
+                    height={40}
+                    className="rounded object-contain flex-shrink-0"
+                    sizes="64px"
+                  />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-900 truncate">{c.card_name}</p>
+                    <p className="text-xs text-gray-500">{c.bank}</p>
                   </div>
                 </Link>
               ))}

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -1,9 +1,30 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getCard, getCardGraphs, getAllCards, getCardRatings, GraphData } from "@/lib/api";
+import { Card, getCard, getCardGraphs, getAllCards, getCardRatings, GraphData } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import CardClient from "./CardClient";
+
+function getSimilarCards(card: Card, allCards: Card[], limit = 6): Card[] {
+  const candidates = allCards.filter(c => c.slug !== card.slug && c.active !== false);
+
+  const scored = candidates.map(c => {
+    let score = 0;
+    if (card.reward_type && c.reward_type === card.reward_type) score += 3;
+    if (c.bank === card.bank) score += 2;
+    if (card.tags && c.tags) {
+      score += card.tags.filter(t => c.tags!.includes(t)).length;
+    }
+    if (card.category && c.category === card.category) score += 1;
+    return { card: c, score };
+  });
+
+  return scored
+    .filter(s => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(s => s.card);
+}
 
 // Revalidate every 5 minutes for fresh data while enabling caching
 export const revalidate = 300;
@@ -63,12 +84,13 @@ export default async function CardPage({ params }: CardPageProps) {
   const { name: slug } = await params;
 
   try {
-    // Fetch card, graph data, news, and articles in parallel for faster loading
-    const [card, graphData, allNews, allArticles] = await Promise.all([
+    // Fetch card, graph data, news, articles, and all cards in parallel for faster loading
+    const [card, graphData, allNews, allArticles, allCards] = await Promise.all([
       getCard(slug),
       getCardGraphs(slug).catch(() => [] as GraphData[]), // Empty array for new cards with no data
       getNews().catch(() => [] as NewsItem[]),
       getArticles().catch(() => [] as Article[]),
+      getAllCards().catch(() => [] as Card[]),
     ]);
 
     // Fetch ratings after we have the card name
@@ -78,7 +100,10 @@ export default async function CardPage({ params }: CardPageProps) {
     const cardNews = allNews.filter(news => news.card_slugs?.includes(slug));
     const cardArticles = allArticles.filter(a => a.related_cards?.includes(slug));
 
-    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} />;
+    // Find similar cards based on reward type, bank, tags, and category
+    const similarCards = getSimilarCards(card, allCards);
+
+    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} />;
   } catch {
     notFound();
   }


### PR DESCRIPTION
## Summary
- Adds a "Similar Cards" section at the bottom of each card page, above the apply CTA
- Scores cards by reward type (+3), bank (+2), shared tags (+1 each), and category (+1)
- Shows up to 6 similar cards with card image, name, and bank in a 3-column grid

## Test plan
- [ ] Visit a card page (e.g. `/card/citi-strata-premier`) and verify similar cards appear
- [ ] Check that similar cards are relevant (same reward type, bank, etc.)
- [ ] Verify cards with no matches don't show the section
- [ ] Test responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)