### PR TITLE
Add card page view tracking with explore page sorting

### DIFF
--- a/apps/api/migrations/011_create_card_view_counts.sql
+++ b/apps/api/migrations/011_create_card_view_counts.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS card_view_counts (
+  card_id INT NOT NULL,
+  view_date DATE NOT NULL,
+  view_count INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (card_id, view_date),
+  INDEX idx_view_date (view_date),
+  CONSTRAINT fk_view_card FOREIGN KEY (card_id) REFERENCES cards(card_id) ON DELETE CASCADE
+);

--- a/apps/api/src/handlers/card-view.js
+++ b/apps/api/src/handlers/card-view.js
@@ -1,0 +1,135 @@
+// Track card page views and return view counts
+const mysql = require("serverless-mysql")({
+  config: {
+    host: process.env.ENDPOINT,
+    database: process.env.DATABASE,
+    user: process.env.USERNAME,
+    password: process.env.PASSWORD,
+  },
+});
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+exports.CardViewHandler = async (event) => {
+  console.info("received:", event);
+
+  let response = {};
+
+  switch (event.httpMethod) {
+    case "OPTIONS":
+      response = {
+        statusCode: 200,
+        headers: responseHeaders,
+        body: JSON.stringify({ statusText: "OK" }),
+      };
+      break;
+
+    case "POST":
+      try {
+        const body = JSON.parse(event.body);
+        const { card_id } = body;
+
+        if (!card_id || !Number.isInteger(card_id) || card_id <= 0) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "card_id must be a positive integer" }),
+          };
+          break;
+        }
+
+        // Filter out obvious bots
+        const userAgent = event.headers?.['User-Agent'] || event.headers?.['user-agent'] || '';
+        if (/bot|crawler|spider|scraper/i.test(userAgent)) {
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({ success: true }),
+          };
+          break;
+        }
+
+        await mysql.query(
+          `INSERT INTO card_view_counts (card_id, view_date, view_count)
+           VALUES (?, CURDATE(), 1)
+           ON DUPLICATE KEY UPDATE view_count = view_count + 1`,
+          [card_id]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ success: true }),
+        };
+      } catch (error) {
+        console.error("Error tracking card view:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to track view" }),
+        };
+      }
+      break;
+
+    case "GET":
+      try {
+        const period = event.queryStringParameters?.period;
+        let rows;
+
+        if (period && period !== '0') {
+          const days = Math.min(Math.max(parseInt(period, 10) || 30, 1), 365);
+          rows = await mysql.query(
+            `SELECT card_id, SUM(view_count) AS views
+             FROM card_view_counts
+             WHERE view_date >= CURDATE() - INTERVAL ? DAY
+             GROUP BY card_id`,
+            [days]
+          );
+        } else {
+          rows = await mysql.query(
+            `SELECT card_id, SUM(view_count) AS views
+             FROM card_view_counts
+             GROUP BY card_id`
+          );
+        }
+        await mysql.end();
+
+        const views = {};
+        for (const row of rows) {
+          views[row.card_id] = Number(row.views);
+        }
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ views }),
+        };
+      } catch (error) {
+        console.error("Error fetching view counts:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to fetch view counts" }),
+        };
+      }
+      break;
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: `CardView only accepts GET and POST methods, you tried: ${event.httpMethod}`,
+      };
+      break;
+  }
+
+  console.info(`response from: ${event.path} statusCode: ${response.statusCode}`);
+  return response;
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -411,6 +411,49 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  CardViewFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/card-view.CardViewHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Track card page views and return view counts
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        TrackView:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /card-view
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        GetViews:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /card-view
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        CardViewOptions:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /card-view
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+
   LeaderboardFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -21,7 +21,7 @@ import {
   CreditCardIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
-import { Card, GraphData, Reward, trackReferralEvent } from "@/lib/api";
+import { Card, GraphData, Reward, trackReferralEvent, trackCardView } from "@/lib/api";
 import { NewsItem, tagLabels, tagColors } from "@/lib/news";
 import { Article, tagLabels as articleTagLabels, tagColors as articleTagColors } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -178,6 +178,17 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
     }
     return null;
   }, [selectedReferral]);
+
+  // Track card page view
+  const viewTracked = useRef(false);
+  useEffect(() => {
+    if (card.card_id && !viewTracked.current) {
+      viewTracked.current = true;
+      trackCardView(Number(card.card_id)).catch(() => {
+        // Silently fail - tracking shouldn't break the page
+      });
+    }
+  }, [card.card_id]);
 
   // Track impression when referral is shown
   const impressionTracked = useRef(false);

--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -9,9 +9,11 @@ import { cardMatchesSearch } from "@/lib/searchAliases";
 interface ExploreClientProps {
   cards: Card[];
   banks: string[];
+  trendingViews?: Record<number, number>;
+  allTimeViews?: Record<number, number>;
 }
 
-type SortOption = 'popular' | 'name' | 'recent' | 'bank';
+type SortOption = 'popular' | 'trending' | 'all-time-views' | 'name' | 'recent' | 'bank';
 
 // Emoji quick filters - maps to card tags
 const emojiFilters = [
@@ -27,7 +29,7 @@ const emojiFilters = [
   { emoji: '⭐', label: 'Rewards', tag: 'rewards' },
 ];
 
-export default function ExploreClient({ cards, banks }: ExploreClientProps) {
+export default function ExploreClient({ cards, banks, trendingViews, allTimeViews }: ExploreClientProps) {
   const [search, setSearch] = useState("");
   const [selectedBank, setSelectedBank] = useState<string>("");
   const [sortBy, setSortBy] = useState<SortOption>('popular');
@@ -77,6 +79,22 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
           return a.card_name.localeCompare(b.card_name);
         });
         break;
+      case 'trending':
+        filtered = [...filtered].sort((a, b) => {
+          const aViews = trendingViews?.[Number(a.db_card_id || a.card_id)] || 0;
+          const bViews = trendingViews?.[Number(b.db_card_id || b.card_id)] || 0;
+          if (aViews !== bViews) return bViews - aViews;
+          return a.card_name.localeCompare(b.card_name);
+        });
+        break;
+      case 'all-time-views':
+        filtered = [...filtered].sort((a, b) => {
+          const aViews = allTimeViews?.[Number(a.db_card_id || a.card_id)] || 0;
+          const bViews = allTimeViews?.[Number(b.db_card_id || b.card_id)] || 0;
+          if (aViews !== bViews) return bViews - aViews;
+          return a.card_name.localeCompare(b.card_name);
+        });
+        break;
       case 'recent':
         filtered = [...filtered].sort((a, b) => {
           // Cards with release_date come first, sorted by most recent
@@ -97,7 +115,7 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
     }
 
     return filtered;
-  }, [cards, search, selectedBank, sortBy, activeEmoji, showArchived, showBusiness]);
+  }, [cards, search, selectedBank, sortBy, activeEmoji, showArchived, showBusiness, trendingViews, allTimeViews]);
 
   // Count archived cards
   const archivedCount = useMemo(() => {
@@ -208,6 +226,8 @@ export default function ExploreClient({ cards, banks }: ExploreClientProps) {
             className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
           >
             <option value="popular">Sort by Most Popular</option>
+            <option value="trending">Sort by Trending (30 days)</option>
+            <option value="all-time-views">Sort by Most Viewed</option>
             <option value="name">Sort by Name</option>
             <option value="recent">Sort by Release Date</option>
             <option value="bank">Sort by Bank</option>

--- a/apps/web-next/src/app/explore/page.tsx
+++ b/apps/web-next/src/app/explore/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import { getAllCards, getRecentRecords } from "@/lib/api";
+import { getAllCards, getRecentRecords, getCardViewCounts } from "@/lib/api";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import ExploreClient from "./ExploreClient";
@@ -21,9 +21,11 @@ export const metadata: Metadata = {
 };
 
 export default async function ExplorePage() {
-  const [cards, recentRecords] = await Promise.all([
+  const [cards, recentRecords, trendingViews, allTimeViews] = await Promise.all([
     getAllCards(),
     getRecentRecords(),
+    getCardViewCounts('trending').catch(() => ({})),
+    getCardViewCounts('all-time').catch(() => ({})),
   ]);
 
   // Sort cards: by total records (most first), then by bank, then by name
@@ -82,7 +84,7 @@ export default async function ExplorePage() {
         </p>
 
         {/* Client component for filtering/search */}
-        <ExploreClient cards={sortedCards} banks={banks} />
+        <ExploreClient cards={sortedCards} banks={banks} trendingViews={trendingViews} allTimeViews={allTimeViews} />
       </div>
 
       {/* Missing card CTA */}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -302,6 +302,27 @@ export async function getRecentRecords(): Promise<RecentRecord[]> {
   return res.json();
 }
 
+// Track card page views (no auth required, fire-and-forget)
+export async function trackCardView(cardId: number): Promise<void> {
+  await fetch(`${API_BASE}/card-view`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ card_id: cardId }),
+  });
+  // Fire and forget - don't throw on error
+}
+
+// Get card view counts for explore page sorting
+export async function getCardViewCounts(period: 'trending' | 'all-time' = 'trending'): Promise<Record<number, number>> {
+  const days = period === 'trending' ? 30 : 0;
+  const res = await fetch(`${API_BASE}/card-view?period=${days}`, {
+    next: { revalidate: 300 },
+  });
+  if (!res.ok) return {};
+  const data = await res.json();
+  return data.views || {};
+}
+
 // Track referral impressions and clicks (no auth required)
 export async function trackReferralEvent(
   referralId: number,


### PR DESCRIPTION
## Summary
- New `card_view_counts` table with daily aggregates per card (migration `011`)
- New `POST /card-view` Lambda endpoint — fire-and-forget atomic increment with basic bot filtering
- New `GET /card-view?period=30` endpoint — returns aggregated view counts by period
- Card detail page tracks views on mount (same `useRef` pattern as referral impressions)
- Explore page gains two new sort options: **Trending (30 days)** and **Most Viewed (all time)**

## Deployment status
- [x] Migration ran successfully (`card_view_counts` table created)
- [x] Backend deployed via SAM (CardViewFunction live)
- [ ] Frontend deploys automatically when merged to main

## Test plan
- [ ] Visit a card detail page and verify `POST /card-view` fires in network tab
- [ ] Check explore page — new sort options appear in dropdown
- [ ] After some views accumulate, verify trending/all-time sort orders cards correctly
- [ ] Verify bot User-Agents are filtered (return 200 but don't increment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)