### PR TITLE
Speed up card pages: cache ratings + fix fetch waterfall

### DIFF
--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -84,17 +84,20 @@ export default async function CardPage({ params }: CardPageProps) {
   const { name: slug } = await params;
 
   try {
-    // Fetch card, graph data, news, articles, and all cards in parallel for faster loading
-    const [card, graphData, allNews, allArticles, allCards] = await Promise.all([
-      getCard(slug),
-      getCardGraphs(slug).catch(() => [] as GraphData[]), // Empty array for new cards with no data
+    // Fetch all data in parallel — chain getCard → getCardRatings together
+    // so ratings fetches concurrently with graphs/news/articles instead of after them all
+    const [cardWithRatings, graphData, allNews, allArticles, allCards] = await Promise.all([
+      getCard(slug).then(async (card) => ({
+        card,
+        ratings: await getCardRatings(card.card_name).catch(() => ({ count: 0, average: null })),
+      })),
+      getCardGraphs(slug).catch(() => [] as GraphData[]),
       getNews().catch(() => [] as NewsItem[]),
       getArticles().catch(() => [] as Article[]),
       getAllCards().catch(() => [] as Card[]),
     ]);
 
-    // Fetch ratings after we have the card name
-    const ratings = await getCardRatings(card.card_name).catch(() => ({ count: 0, average: null }));
+    const { card, ratings } = cardWithRatings;
 
     // Filter news and articles for this specific card
     const cardNews = allNews.filter(news => news.card_slugs?.includes(slug));

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -467,7 +467,7 @@ export interface CardRatingAggregates {
 
 export async function getCardRatings(cardName: string): Promise<CardRatingAggregates> {
   const res = await fetch(`${API_BASE}/ratings?card_name=${encodeURIComponent(cardName)}`, {
-    cache: 'no-store',
+    next: { revalidate: 300 },
   });
   if (!res.ok) return { count: 0, average: null };
   return res.json();


### PR DESCRIPTION
## Summary
- **Cache `getCardRatings()`** — was using `cache: 'no-store'`, hitting the API cold on every single page load. Now uses ISR (`revalidate: 300`) like everything else. This was the biggest bottleneck.
- **Eliminate fetch waterfall** — `getCardRatings()` was waiting for the entire `Promise.all` (card + graphs + news + articles + allCards) to finish before starting. Now it chains off `getCard()` inside the `Promise.all`, so it fetches concurrently with the other calls.

**Before:** `[getCard + getGraphs + getNews + getArticles + getAllCards]` → then `[getCardRatings]` (uncached)
**After:** `[getCard → getCardRatings] + [getGraphs] + [getNews] + [getArticles] + [getAllCards]` (all cached)

## Test plan
- [ ] Verify card pages load noticeably faster
- [ ] Verify ratings still display correctly
- [ ] Check network tab — `/ratings` should return cached responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)