### PR TITLE
Add blur placeholders to landing page images

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -130,6 +130,8 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
                   height={600}
                   sizes="(max-width: 1024px) 100vw, 50vw"
                   priority
+                  placeholder="blur"
+                  blurDataURL="data:image/webp;base64,UklGRjYAAABXRUJQVlA4ICoAAADQAQCdASoQAAwABUB8JYwAAxf/Ug7MgAD98G5365+TmYmXkkJzx1GgAAA="
                 />
               </div>
             </div>
@@ -181,6 +183,8 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
                   width={800}
                   height={600}
                   sizes="(max-width: 1024px) 100vw, 50vw"
+                  placeholder="blur"
+                  blurDataURL="data:image/webp;base64,UklGRjIAAABXRUJQVlA4ICYAAACQAQCdASoQAAwABUB8JZQC7ACgBIAA1t6nPF1bW0fC/zmmxIcAAA=="
                 />
               </div>
             </div>
@@ -236,6 +240,8 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
                   width={800}
                   height={600}
                   sizes="(max-width: 1024px) 100vw, 50vw"
+                  placeholder="blur"
+                  blurDataURL="data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAACwAQCdASoQAAwABUB8JZwAAuTtV66AAP7vyhAm0B73UYijyoRWdQhSOiOHiwZCCt/xE/hoFCr3jgAA"
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Add `placeholder="blur"` + inline `blurDataURL` to all 3 feature section images on the landing page
- Shows a tiny blurred preview instantly while the full image loads, eliminating visual pop-in
- Base64 data URLs are ~50-70 bytes each — zero performance cost

## Test plan
- [ ] Load landing page on throttled connection — images should show blurred preview before loading
- [ ] Verify no layout shift when images load in

🤖 Generated with [Claude Code](https://claude.com/claude-code)