### PR TITLE
Fix navbar logo left alignment

### DIFF
--- a/apps/web-next/public/assets/CreditOdds_LogoText_with Icon-01.svg
+++ b/apps/web-next/public/assets/CreditOdds_LogoText_with Icon-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 24.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 687 163" style="enable-background:new 0 0 687 163;" xml:space="preserve">
+	 viewBox="60 0 627 163" style="enable-background:new 60 0 627 163;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#504DE1;}
 </style>


### PR DESCRIPTION
## Summary
- The SVG logo exported from Illustrator had ~60px of empty whitespace on the left side baked into the viewBox
- This caused the logo to appear shifted right relative to breadcrumbs and page content below it
- Trimmed the viewBox from `0 0 687 163` to `60 0 627 163` to start at the actual content boundary

## Test plan
- [ ] Verify logo aligns with breadcrumbs and page content on desktop
- [ ] Verify logo still renders correctly on mobile
- [ ] Check footer logo is unaffected (uses a different SVG file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)