### PR TITLE
Add asterisk to explore top reward with booking restrictions

### DIFF
--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -351,6 +351,7 @@ export default function ExploreClient({ cards, banks, trendingViews, allTimeView
                             if (!top) return <span className="text-gray-400">—</span>;
                             const rateStr = top.unit === 'percent' ? `${top.value}%` : `${top.value}x`;
                             const label = categoryLabels[top.category] || top.category;
+                            const hasBookingRestriction = top.note && /book|portal|through|travel center/i.test(top.note);
                             return (
                               <div className="flex items-center gap-1.5">
                                 <span className="text-gray-400 flex-shrink-0">
@@ -359,6 +360,9 @@ export default function ExploreClient({ cards, banks, trendingViews, allTimeView
                                 <div className="min-w-0">
                                   <span className="font-semibold text-gray-900">{rateStr}</span>
                                   <span className="text-gray-500 ml-1 text-xs">{label}</span>
+                                  {hasBookingRestriction && (
+                                    <span className="text-gray-400 ml-1 text-[10px]">*</span>
+                                  )}
                                 </div>
                               </div>
                             );


### PR DESCRIPTION
## Summary
- Cards like Amex Platinum show "5x Airlines" in the explore table, but that rate requires booking through Amex Travel — which is misleading
- Now shows a small `*` next to the top reward when the reward's `note` field mentions booking, portal, or travel center restrictions
- Detects via regex: `/book|portal|through|travel center/i`
- Applies to ~20 cards with portal/booking-restricted top rewards

## Test plan
- [ ] The Platinum Card shows "5x Airlines *"
- [ ] Chase Sapphire Preferred shows "5x Travel (via Portal)" (no asterisk — portal category already says it)
- [ ] Citi Double Cash shows "2% Everything Else" (no asterisk — no restriction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)