### PR TITLE
Make reward restriction indicator more visible

### DIFF
--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -361,7 +361,7 @@ export default function ExploreClient({ cards, banks, trendingViews, allTimeView
                                   <span className="font-semibold text-gray-900">{rateStr}</span>
                                   <span className="text-gray-500 ml-1 text-xs">{label}</span>
                                   {hasBookingRestriction && (
-                                    <span className="text-gray-400 ml-1 text-[10px]">*</span>
+                                    <span className="ml-1 text-[10px] text-amber-600 bg-amber-50 rounded px-1 py-0.5 font-medium whitespace-nowrap" title={top.note || ''}>conditions apply</span>
                                   )}
                                 </div>
                               </div>


### PR DESCRIPTION
## Summary
- Replace the tiny `*` with a small "conditions apply" label in amber
- Hovering shows the full restriction note as a tooltip
- Much more readable and clearly communicates there's a catch

🤖 Generated with [Claude Code](https://claude.com/claude-code)