### PR TITLE
Auto-add card to wallet on data point submission

### DIFF
--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -361,7 +361,7 @@ export default function ExploreClient({ cards, banks, trendingViews, allTimeView
                                   <span className="font-semibold text-gray-900">{rateStr}</span>
                                   <span className="text-gray-500 ml-1 text-xs">{label}</span>
                                   {hasBookingRestriction && (
-                                    <span className="ml-1 text-[10px] text-amber-600 bg-amber-50 rounded px-1 py-0.5 font-medium whitespace-nowrap" title={top.note || ''}>conditions apply</span>
+                                    <span className="ml-1 text-[10px] text-gray-500 bg-gray-100 rounded px-1 py-0.5 font-medium whitespace-nowrap" title={top.note || ''}>conditions apply</span>
                                   )}
                                 </div>
                               </div>

--- a/apps/web-next/src/components/forms/SubmitRecordModal.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordModal.tsx
@@ -9,7 +9,7 @@ import { NumericFormat } from "react-number-format";
 import CardImage from '@/components/ui/CardImage';
 import { useAuth } from "@/auth/AuthProvider";
 import { toast } from "react-toastify";
-import { getRecords } from "@/lib/api";
+import { getRecords, getWallet, addToWallet } from "@/lib/api";
 import confetti from "canvas-confetti";
 
 // Form persistence key prefix (#7)
@@ -179,6 +179,18 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess }
         if (!response.ok) {
           const errorText = await response.text();
           throw new Error(errorText || 'Failed to submit record');
+        }
+
+        // Auto-add card to wallet if not already there (silent — don't block on failure)
+        try {
+          const wallet = await getWallet(token);
+          const alreadyInWallet = wallet.some((w) => w.card_id === card.card_id);
+          if (!alreadyInWallet) {
+            const [year, month] = values.date_applied.split('-').map(Number);
+            await addToWallet(card.card_id as number, month, year, token);
+          }
+        } catch (walletError) {
+          console.warn("Auto-add to wallet failed (non-blocking):", walletError);
         }
 
         toast.success("Your record was submitted successfully!", {


### PR DESCRIPTION
## Summary
- When a user submits a data point for a card, automatically add that card to their wallet
- Checks the wallet first — skips if the card is already there, so existing acquired dates are never overwritten
- Uses the application date from the form as the acquired month/year
- Silent/non-blocking — wallet failures don't affect the data point submission

## Test plan
- [ ] Submit a data point for a card not in your wallet → card should appear in wallet with the application date
- [ ] Submit a data point for a card already in your wallet → wallet entry should remain unchanged
- [ ] Simulate wallet API failure → data point submission should still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)