### PR TITLE
Add CardWire: changelog for card metric changes

### DIFF
--- a/apps/api/migrations/012_create_card_wire.sql
+++ b/apps/api/migrations/012_create_card_wire.sql
@@ -1,0 +1,20 @@
+-- Add metric snapshot columns to cards for change detection
+ALTER TABLE cards
+  ADD COLUMN signup_bonus_value INT DEFAULT NULL,
+  ADD COLUMN signup_bonus_type VARCHAR(10) DEFAULT NULL,
+  ADD COLUMN reward_top_rate DECIMAL(5,2) DEFAULT NULL,
+  ADD COLUMN reward_top_unit VARCHAR(20) DEFAULT NULL,
+  ADD COLUMN apr_min DECIMAL(5,2) DEFAULT NULL,
+  ADD COLUMN apr_max DECIMAL(5,2) DEFAULT NULL;
+
+-- Create card_wire changelog table
+CREATE TABLE IF NOT EXISTS card_wire (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  card_id INT NOT NULL,
+  field VARCHAR(50) NOT NULL,
+  old_value VARCHAR(100) DEFAULT NULL,
+  new_value VARCHAR(100) DEFAULT NULL,
+  changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_card_changed (card_id, changed_at DESC),
+  CONSTRAINT fk_wire_card FOREIGN KEY (card_id) REFERENCES cards(card_id) ON DELETE CASCADE
+);

--- a/apps/api/src/handlers/card-wire.js
+++ b/apps/api/src/handlers/card-wire.js
@@ -1,0 +1,83 @@
+const mysql = require("serverless-mysql")({
+  config: {
+    host: process.env.ENDPOINT,
+    database: process.env.DATABASE,
+    user: process.env.USERNAME,
+    password: process.env.PASSWORD,
+  },
+});
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+exports.CardWireHandler = async (event) => {
+  console.info("received:", event);
+
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ statusText: "OK" }),
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return {
+      statusCode: 405,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: `Method ${event.httpMethod} not allowed` }),
+    };
+  }
+
+  try {
+    const cardId = event.queryStringParameters?.card_id;
+    const limit = Math.min(
+      parseInt(event.queryStringParameters?.limit || "50", 10),
+      200
+    );
+
+    let rows;
+    if (cardId) {
+      rows = await mysql.query(
+        `SELECT cw.id, cw.card_id, c.card_name, cw.field,
+                cw.old_value, cw.new_value, cw.changed_at
+         FROM card_wire cw
+         JOIN cards c ON c.card_id = cw.card_id
+         WHERE cw.card_id = ?
+         ORDER BY cw.changed_at DESC
+         LIMIT ?`,
+        [parseInt(cardId, 10), limit]
+      );
+    } else {
+      rows = await mysql.query(
+        `SELECT cw.id, cw.card_id, c.card_name, c.card_image_link,
+                cw.field, cw.old_value, cw.new_value, cw.changed_at
+         FROM card_wire cw
+         JOIN cards c ON c.card_id = cw.card_id
+         ORDER BY cw.changed_at DESC
+         LIMIT ?`,
+        [limit]
+      );
+    }
+    await mysql.end();
+
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ changes: rows }),
+    };
+  } catch (error) {
+    console.error("Error fetching card wire:", error);
+    await mysql.end();
+    return {
+      statusCode: 500,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: "Failed to fetch card wire" }),
+    };
+  }
+};

--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -33,18 +33,85 @@ async function fetchCardsFromCDN() {
   });
 }
 
+// Extract metric values from a CDN card for change detection
+function extractMetrics(cdnCard) {
+  let rewardTopRate = null;
+  let rewardTopUnit = null;
+  if (cdnCard.rewards && cdnCard.rewards.length > 0) {
+    const topReward = cdnCard.rewards.reduce(
+      (best, r) => (r.value > (best?.value || 0) ? r : best),
+      null
+    );
+    if (topReward) {
+      rewardTopRate = topReward.value;
+      rewardTopUnit = topReward.unit;
+    }
+  }
+
+  return {
+    annual_fee: cdnCard.annual_fee ?? null,
+    signup_bonus_value: cdnCard.signup_bonus?.value ?? null,
+    signup_bonus_type: cdnCard.signup_bonus?.type ?? null,
+    reward_top_rate: rewardTopRate,
+    reward_top_unit: rewardTopUnit,
+    apr_min: cdnCard.apr?.regular?.min ?? null,
+    apr_max: cdnCard.apr?.regular?.max ?? null,
+  };
+}
+
+// Compare old and new metrics, insert card_wire rows for any changes
+async function detectAndRecordChanges(cardId, oldMetrics, newMetrics) {
+  const trackedFields = [
+    { field: "annual_fee", old: oldMetrics.annual_fee, new: newMetrics.annual_fee },
+    { field: "signup_bonus_value", old: oldMetrics.signup_bonus_value, new: newMetrics.signup_bonus_value },
+    { field: "reward_top_rate", old: oldMetrics.reward_top_rate, new: newMetrics.reward_top_rate },
+    { field: "apr_min", old: oldMetrics.apr_min, new: newMetrics.apr_min },
+    { field: "apr_max", old: oldMetrics.apr_max, new: newMetrics.apr_max },
+  ];
+
+  const changes = [];
+  for (const t of trackedFields) {
+    const oldStr = t.old != null ? String(t.old) : null;
+    const newStr = t.new != null ? String(t.new) : null;
+
+    // Skip if values match or both null
+    if (oldStr === newStr) continue;
+
+    // Skip initial backfill (old is null = first time populating metrics)
+    if (oldStr === null) continue;
+
+    changes.push({ field: t.field, old_value: oldStr, new_value: newStr });
+  }
+
+  if (changes.length > 0) {
+    const placeholders = changes.map(() => "(?, ?, ?, ?)").join(", ");
+    const flat = changes.flatMap((c) => [cardId, c.field, c.old_value, c.new_value]);
+    await mysql.query(
+      `INSERT INTO card_wire (card_id, field, old_value, new_value) VALUES ${placeholders}`,
+      flat
+    );
+  }
+
+  return changes;
+}
+
 // Sync cards from CDN to MySQL database
 async function syncCardsToDatabase(cdnCards) {
   const results = {
     added: [],
     updated: [],
     errors: [],
+    wire_changes: [],
   };
 
   try {
-    // Get existing cards from database
+    // Get existing cards from database (include metric columns for change detection)
     const existingCards = await mysql.query(
-      "SELECT card_id, card_name, bank FROM cards"
+      `SELECT card_id, card_name, bank, annual_fee,
+              signup_bonus_value, signup_bonus_type,
+              reward_top_rate, reward_top_unit,
+              apr_min, apr_max
+       FROM cards`
     );
 
     // Create lookup map by card_name
@@ -83,7 +150,18 @@ async function syncCardsToDatabase(cdnCards) {
         const tagsJson = cdnCard.tags ? JSON.stringify(cdnCard.tags) : null;
 
         if (existingCard) {
-          // Update existing card
+          // Detect metric changes before updating
+          const newMetrics = extractMetrics(cdnCard);
+          const changes = await detectAndRecordChanges(
+            existingCard.card_id,
+            existingCard,
+            newMetrics
+          );
+          if (changes.length > 0) {
+            results.wire_changes.push({ card: name, changes });
+          }
+
+          // Update existing card (including metric snapshot columns)
           await mysql.query(
             `UPDATE cards SET
               card_name = ?,
@@ -94,19 +172,44 @@ async function syncCardsToDatabase(cdnCards) {
               tags = ?,
               annual_fee = ?,
               apply_link = ?,
-              card_referral_link = ?
+              card_referral_link = ?,
+              signup_bonus_value = ?,
+              signup_bonus_type = ?,
+              reward_top_rate = ?,
+              reward_top_unit = ?,
+              apr_min = ?,
+              apr_max = ?
             WHERE card_id = ?`,
-            [name, bank, acceptingApplications, cdnCard.image || null, cdnCard.release_date || null, tagsJson, cdnCard.annual_fee || null, cdnCard.apply_link || null, cdnCard.card_referral_link || null, existingCard.card_id]
+            [
+              name, bank, acceptingApplications,
+              cdnCard.image || null, cdnCard.release_date || null, tagsJson,
+              newMetrics.annual_fee, cdnCard.apply_link || null, cdnCard.card_referral_link || null,
+              newMetrics.signup_bonus_value, newMetrics.signup_bonus_type,
+              newMetrics.reward_top_rate, newMetrics.reward_top_unit,
+              newMetrics.apr_min, newMetrics.apr_max,
+              existingCard.card_id,
+            ]
           );
           results.updated.push(name);
         } else {
           // Insert new card - get next available card_id
+          const newMetrics = extractMetrics(cdnCard);
           const maxIdResult = await mysql.query("SELECT MAX(card_id) as max_id FROM cards");
           const nextId = (maxIdResult[0]?.max_id || 0) + 1;
           await mysql.query(
-            `INSERT INTO cards (card_id, card_name, bank, accepting_applications, card_image_link, release_date, tags, annual_fee, apply_link, card_referral_link, active)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
-            [nextId, name, bank, acceptingApplications, cdnCard.image || null, cdnCard.release_date || null, tagsJson, cdnCard.annual_fee || null, cdnCard.apply_link || null, cdnCard.card_referral_link || null]
+            `INSERT INTO cards (card_id, card_name, bank, accepting_applications, card_image_link,
+              release_date, tags, annual_fee, apply_link, card_referral_link,
+              signup_bonus_value, signup_bonus_type, reward_top_rate, reward_top_unit,
+              apr_min, apr_max, active)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+            [
+              nextId, name, bank, acceptingApplications,
+              cdnCard.image || null, cdnCard.release_date || null, tagsJson,
+              newMetrics.annual_fee, cdnCard.apply_link || null, cdnCard.card_referral_link || null,
+              newMetrics.signup_bonus_value, newMetrics.signup_bonus_type,
+              newMetrics.reward_top_rate, newMetrics.reward_top_unit,
+              newMetrics.apr_min, newMetrics.apr_max,
+            ]
           );
           results.added.push(name);
         }

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -884,3 +884,37 @@ Resources:
               Ref: CreditCardOddsAPI
             Auth:
               Authorizer: NONE
+
+  CardWireFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/card-wire.CardWireHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Returns card metric change history (CardWire)
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetCardWire:
+          Type: Api
+          Properties:
+            Path: /card-wire
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+        CardWireOptions:
+          Type: Api
+          Properties:
+            Path: /card-wire
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -19,9 +19,10 @@ import {
   ShareIcon,
   CalculatorIcon,
   CreditCardIcon,
+  ClockIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
-import { Card, GraphData, Reward, trackReferralEvent, trackCardView } from "@/lib/api";
+import { Card, GraphData, Reward, trackReferralEvent, trackCardView, CardWireEntry } from "@/lib/api";
 import { NewsItem, tagLabels, tagColors } from "@/lib/news";
 import { Article, tagLabels as articleTagLabels, tagColors as articleTagColors } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -114,9 +115,10 @@ interface CardClientProps {
   articles: Article[];
   ratings: { count: number; average: number | null };
   similarCards?: Card[];
+  wire?: CardWireEntry[];
 }
 
-export default function CardClient({ card, graphData, news, articles, ratings, similarCards = [] }: CardClientProps) {
+export default function CardClient({ card, graphData, news, articles, ratings, similarCards = [], wire = [] }: CardClientProps) {
   const [showModal, setShowModal] = useState(false);
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [copiedShareLink, setCopiedShareLink] = useState(false);
@@ -887,6 +889,90 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
                   )}
                 </div>
               ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* CardWire - Metric Changes Timeline */}
+      {wire.length > 0 && (
+        <div className="bg-white py-12">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center gap-3 mb-6">
+              <ClockIcon className="h-6 w-6 text-indigo-600" />
+              <h2 className="text-2xl font-bold text-gray-900">CardWire</h2>
+              <span className="text-sm text-gray-500">Metric changes</span>
+            </div>
+            <div className="space-y-3">
+              {wire.map((entry) => {
+                const fieldLabel: Record<string, string> = {
+                  annual_fee: "Annual Fee",
+                  signup_bonus_value: "Signup Bonus",
+                  reward_top_rate: "Top Reward Rate",
+                  apr_min: "APR (Min)",
+                  apr_max: "APR (Max)",
+                };
+
+                const formatValue = (val: string | null, field: string) => {
+                  if (val === null) return "N/A";
+                  if (field === "annual_fee") return `$${Number(val).toLocaleString()}`;
+                  if (field === "signup_bonus_value") return Number(val).toLocaleString();
+                  if (field.startsWith("apr_")) return `${val}%`;
+                  if (field === "reward_top_rate") return `${val}x`;
+                  return val;
+                };
+
+                const isIncrease =
+                  entry.old_value !== null &&
+                  entry.new_value !== null &&
+                  Number(entry.new_value) > Number(entry.old_value);
+                const isDecrease =
+                  entry.old_value !== null &&
+                  entry.new_value !== null &&
+                  Number(entry.new_value) < Number(entry.old_value);
+
+                return (
+                  <div
+                    key={entry.id}
+                    className="flex items-start gap-4 p-4 bg-gray-50 rounded-lg border border-gray-200"
+                  >
+                    <div className="flex-shrink-0 mt-0.5">
+                      <div
+                        className={`h-2.5 w-2.5 rounded-full ${
+                          isIncrease ? "bg-green-400" : isDecrease ? "bg-red-400" : "bg-gray-400"
+                        }`}
+                      />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900">
+                        {fieldLabel[entry.field] || entry.field}:{" "}
+                        <span className="text-gray-500 line-through">
+                          {formatValue(entry.old_value, entry.field)}
+                        </span>
+                        {" → "}
+                        <span
+                          className={
+                            isIncrease
+                              ? "text-green-700 font-semibold"
+                              : isDecrease
+                                ? "text-red-700 font-semibold"
+                                : "font-semibold"
+                          }
+                        >
+                          {formatValue(entry.new_value, entry.field)}
+                        </span>
+                      </p>
+                      <p className="text-xs text-gray-500 mt-0.5">
+                        {new Date(entry.changed_at).toLocaleDateString("en-US", {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        })}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Card, getCard, getCardGraphs, getAllCards, getCardRatings, GraphData } from "@/lib/api";
+import { Card, getCard, getCardGraphs, getAllCards, getCardRatings, getCardWire, GraphData, CardWireEntry } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import CardClient from "./CardClient";
@@ -86,10 +86,11 @@ export default async function CardPage({ params }: CardPageProps) {
   try {
     // Fetch all data in parallel — chain getCard → getCardRatings together
     // so ratings fetches concurrently with graphs/news/articles instead of after them all
-    const [cardWithRatings, graphData, allNews, allArticles, allCards] = await Promise.all([
+    const [cardWithRatingsAndWire, graphData, allNews, allArticles, allCards] = await Promise.all([
       getCard(slug).then(async (card) => ({
         card,
         ratings: await getCardRatings(card.card_name).catch(() => ({ count: 0, average: null })),
+        wire: await getCardWire(Number(card.card_id)).catch(() => [] as CardWireEntry[]),
       })),
       getCardGraphs(slug).catch(() => [] as GraphData[]),
       getNews().catch(() => [] as NewsItem[]),
@@ -97,7 +98,7 @@ export default async function CardPage({ params }: CardPageProps) {
       getAllCards().catch(() => [] as Card[]),
     ]);
 
-    const { card, ratings } = cardWithRatings;
+    const { card, ratings, wire } = cardWithRatingsAndWire;
 
     // Filter news and articles for this specific card
     const cardNews = allNews.filter(news => news.card_slugs?.includes(slug));
@@ -106,7 +107,7 @@ export default async function CardPage({ params }: CardPageProps) {
     // Find similar cards based on reward type, bank, tags, and category
     const similarCards = getSimilarCards(card, allCards);
 
-    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} />;
+    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} />;
   } catch {
     notFound();
   }

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -323,6 +323,27 @@ export async function getCardViewCounts(period: 'trending' | 'all-time' = 'trend
   return data.views || {};
 }
 
+// CardWire - card metric change history
+export interface CardWireEntry {
+  id: number;
+  card_id: number;
+  card_name: string;
+  card_image_link?: string;
+  field: string;
+  old_value: string | null;
+  new_value: string | null;
+  changed_at: string;
+}
+
+export async function getCardWire(cardId: number): Promise<CardWireEntry[]> {
+  const res = await fetch(`${API_BASE}/card-wire?card_id=${cardId}&limit=20`, {
+    next: { revalidate: 300 },
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.changes || [];
+}
+
 // Track referral impressions and clicks (no auth required)
 export async function trackReferralEvent(
   referralId: number,


### PR DESCRIPTION
## Summary
- **New `card_wire` table** that logs when card metrics change (annual fee, signup bonus, top reward rate, APR min/max)
- **Change detection in `update-cards-github.js`** — compares old DB values against incoming CDN values during sync, inserts `card_wire` rows on diff
- **New metric columns on `cards` table** (`signup_bonus_value`, `signup_bonus_type`, `reward_top_rate`, `reward_top_unit`, `apr_min`, `apr_max`) for comparison baseline
- **New `GET /card-wire` API endpoint** — public, returns changelog entries by card_id (or global feed)
- **CardWire timeline on card detail page** — shows metric changes with old→new values, color-coded increase/decrease dots

### How it works
1. YAML change → `build-cards.yml` → CDN sync → `update-cards-github.js`
2. Sync handler reads current DB metric values, compares against incoming CDN data
3. If a tracked field changed, inserts a `card_wire` row with old/new values
4. First sync after migration backfills metric columns silently (no false "changed" entries)
5. Card page fetches and displays the timeline

### Files changed
| File | Change |
|------|--------|
| `apps/api/migrations/012_create_card_wire.sql` | New migration |
| `apps/api/src/handlers/card-wire.js` | New API handler |
| `apps/api/src/handlers/update-cards-github.js` | Change detection + metric sync |
| `apps/api/template.yml` | Register CardWireFunction |
| `apps/web-next/src/lib/api.ts` | CardWireEntry type + getCardWire() |
| `apps/web-next/src/app/card/[name]/page.tsx` | Fetch wire data |
| `apps/web-next/src/app/card/[name]/CardClient.tsx` | Render CardWire timeline |

## Deployment steps
1. Run migration `012_create_card_wire.sql` via temporary Lambda
2. Deploy API: `cd apps/api && sam build && sam deploy`
3. Trigger initial sync: `POST /sync-cards` to backfill metric columns
4. Frontend auto-deploys via Amplify on merge

## Test plan
- [ ] Run migration against DB
- [ ] Deploy API and verify `GET /card-wire` returns empty `{ changes: [] }`
- [ ] Trigger sync — verify metric columns populated on `cards` table, no false `card_wire` rows
- [ ] Change a YAML value (e.g. annual_fee), push, verify `card_wire` row created
- [ ] Verify CardWire timeline renders on card page with correct formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)