### PR TITLE
Replace LogRocket with Microsoft Clarity

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
+    "@microsoft/clarity": "^1.0.2",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
@@ -22,7 +23,6 @@
     "formik": "^2.4.9",
     "highcharts": "^12.5.0",
     "highcharts-react-official": "^3.2.3",
-    "logrocket": "^12.0.0",
     "next": "^16.1.4",
     "react": "^18",
     "react-dom": "^18",

--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -4,7 +4,7 @@ import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
 import SkipLink from "@/components/ui/SkipLink";
 import WebVitalsReporter from "@/components/ui/WebVitalsReporter";
-import LogRocketInit from "@/components/ui/LogRocketInit";
+import ClarityInit from "@/components/ui/ClarityInit";
 import DataPointPrompt from "@/components/ui/DataPointPrompt";
 import { OrganizationSchema, WebsiteSchema } from "@/components/seo/JsonLd";
 import { ToastContainer } from "react-toastify";
@@ -67,7 +67,7 @@ export default function RootLayout({
           <Footer />
           <ToastContainer />
           <WebVitalsReporter />
-          <LogRocketInit />
+          <ClarityInit />
         </AuthProvider>
       </body>
     </html>

--- a/apps/web-next/src/components/ui/ClarityInit.tsx
+++ b/apps/web-next/src/components/ui/ClarityInit.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import { useEffect } from 'react';
-import LogRocket from 'logrocket';
+import Clarity from '@microsoft/clarity';
 import { useAuth } from '@/auth/AuthProvider';
 
 let initialized = false;
 
-export default function LogRocketInit() {
+export default function ClarityInit() {
   const { authState } = useAuth();
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production' && !initialized) {
-      LogRocket.init('8ouxn1/creditodds');
+      Clarity.init('w0ejzgxumv');
       initialized = true;
     }
   }, []);
@@ -20,10 +20,7 @@ export default function LogRocketInit() {
     if (!initialized) return;
 
     if (authState.user) {
-      LogRocket.identify(authState.user.uid, {
-        name: authState.user.displayName || '',
-        email: authState.user.email || '',
-      });
+      Clarity.identify(authState.user.uid, undefined, undefined, authState.user.displayName || '');
     }
   }, [authState.user]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
+        "@microsoft/clarity": "^1.0.2",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.19",
@@ -101,7 +102,6 @@
         "formik": "^2.4.9",
         "highcharts": "^12.5.0",
         "highcharts-react-official": "^3.2.3",
-        "logrocket": "^12.0.0",
         "next": "^16.1.4",
         "react": "^18",
         "react-dom": "^18",
@@ -3974,6 +3974,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@microsoft/clarity": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.2.tgz",
+      "integrity": "sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -12199,12 +12205,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/logrocket": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-12.0.0.tgz",
-      "integrity": "sha512-7VUI2gi3XxACLqJGZJ/8hRx3KT7z2joNXcBqbefkfWI6rLqMJOq0LUmfLbw3qRPPZTjOBiwpKKVecusL3V5K7Q==",
-      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",


### PR DESCRIPTION
## Summary
- Removed `logrocket` package, installed `@microsoft/clarity`
- Replaced `LogRocketInit` component with `ClarityInit` using project ID `w0ejzgxumv`
- Identifies logged-in users via `Clarity.identify()`, same as LogRocket did
- Only initializes in production

## Test plan
- [x] Next.js build passes
- [ ] Verify Clarity dashboard receives sessions after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)