### PR TITLE
Fix portal category consistency and rename Robinhood Platinum

### DIFF
--- a/apps/api/migrations/013_rename_robinhood_platinum.sql
+++ b/apps/api/migrations/013_rename_robinhood_platinum.sql
@@ -1,0 +1,2 @@
+-- Rename "Robinhood Platinum" to "Platinum" (bank field provides "Robinhood" context)
+UPDATE cards SET card_name = 'Platinum' WHERE card_name = 'Robinhood Platinum';

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -31,6 +31,7 @@ export const categoryLabels: Record<string, string> = {
   hotels_portal: "Hotels (via Portal)",
   flights_portal: "Flights (via Portal)",
   hotels_car_portal: "Hotels & Car Rentals (via Portal)",
+  car_rentals_portal: "Car Rentals (via Portal)",
   amazon: "Amazon.com",
   rei: "REI",
   everything_else: "Everything Else",
@@ -80,6 +81,7 @@ export function CategoryIcon({ category, className }: { category: string; classN
         </svg>
       );
     case "car_rentals":
+    case "car_rentals_portal":
       return <TruckIcon className={iconClass} />;
     case "entertainment":
       return <FilmIcon className={iconClass} />;

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -1,4 +1,4 @@
-name: "Robinhood Platinum"
+name: "Platinum"
 bank: "Robinhood"
 slug: "robinhood-platinum"
 accepting_applications: true
@@ -13,12 +13,14 @@ tags:
   - rewards
 reward_type: "cashback"
 rewards:
-  - category: hotels
+  - category: hotels_portal
     value: 10
     unit: percent
-  - category: car_rentals
+    note: "Booked through the Robinhood Banking app"
+  - category: car_rentals_portal
     value: 10
     unit: percent
+    note: "Booked through the Robinhood Banking app"
   - category: flights_portal
     value: 5
     unit: percent

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -10,7 +10,7 @@ rewards:
     value: 3
     unit: points_per_dollar
     note: "United purchases"
-  - category: hotels
+  - category: hotels_portal
     value: 5
     unit: points_per_dollar
     note: "Hotels prepaid through Renowned Hotels and Resorts for United Cardmembers"

--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -22,7 +22,7 @@ rewards:
     choices: 1
     eligible_categories: [gas, wholesale_clubs, utilities]
     note: "Choose 1 everyday category each quarter, up to $1,500"
-  - category: travel
+  - category: hotels_car_portal
     value: 5.5
     unit: percent
     note: "Hotel and car reservations booked in the Travel Center"


### PR DESCRIPTION
## Summary
- **United Quest**: `hotels` → `hotels_portal` (5x is only through Renowned Hotels program, not all hotels)
- **US Bank Shopper**: `travel` → `hotels_car_portal` (5.5% is only through US Bank Travel Center)
- **Robinhood Platinum**: `hotels` → `hotels_portal`, `car_rentals` → `car_rentals_portal` (both portal-only via Robinhood app), added clarifying notes
- Added new `car_rentals_portal` category label and icon mapping in `cardDisplayUtils.tsx`
- Renamed "Robinhood Platinum" → "Platinum" for consistent naming on the Robinhood bank page (matches "Gold Card" pattern)
- DB migration `013` to update card_name in the database

## Test plan
- [ ] Verify United Quest card page shows "Hotels (via Portal)" instead of "Hotels"
- [ ] Verify US Bank Shopper card page shows "Hotels & Car Rentals (via Portal)" instead of "Travel"
- [ ] Verify Robinhood Platinum card page shows portal categories with notes
- [ ] Verify `/bank/Robinhood` page shows "Platinum" and "Gold Card" consistently
- [ ] Run migration 013 on production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)