### PR TITLE
Add car_rentals_portal to categories.yaml

### DIFF
--- a/data/categories.yaml
+++ b/data/categories.yaml
@@ -33,6 +33,8 @@ categories:
     label: Hotels (via Portal)
   - id: flights_portal
     label: Flights (via Portal)
+  - id: car_rentals_portal
+    label: Car Rentals (via Portal)
   - id: hotels_car_portal
     label: Hotels & Car Rentals (via Portal)
   - id: amazon


### PR DESCRIPTION
## Summary
- Adds missing `car_rentals_portal` category to `categories.yaml` validation file
- Fixes the cards build failure from PR #294 which added this category to Robinhood Platinum but missed the validation file

## Test plan
- [ ] Cards build workflow should pass on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)