### PR TITLE
Enrich bank page card table and improve mobile display

### DIFF
--- a/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
+++ b/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
@@ -3,13 +3,22 @@
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
-import { Card } from '@/lib/api';
+import { Card, Reward } from '@/lib/api';
+import { categoryLabels, CategoryIcon } from '@/lib/cardDisplayUtils';
 
 interface BankCardsTableProps {
   cards: Card[];
+  trendingViews?: Record<number, number>;
 }
 
-export default function BankCardsTable({ cards }: BankCardsTableProps) {
+function getTopReward(rewards: Reward[] | undefined): Reward | null {
+  if (!rewards || rewards.length === 0) return null;
+  const sorted = [...rewards].sort((a, b) => b.value - a.value);
+  const best = sorted.find(r => r.category !== 'everything_else');
+  return best || sorted[0];
+}
+
+export default function BankCardsTable({ cards, trendingViews }: BankCardsTableProps) {
   const [showArchived, setShowArchived] = useState(false);
 
   // Count active and archived cards
@@ -31,12 +40,17 @@ export default function BankCardsTable({ cards }: BankCardsTableProps) {
     return cards
       .filter(card => showArchived || card.accepting_applications)
       .sort((a, b) => {
+        // Active cards first
         if (a.accepting_applications !== b.accepting_applications) {
           return a.accepting_applications ? -1 : 1;
         }
+        // Then by trending views (descending)
+        const aViews = trendingViews?.[Number(a.db_card_id || a.card_id)] || 0;
+        const bViews = trendingViews?.[Number(b.db_card_id || b.card_id)] || 0;
+        if (aViews !== bViews) return bViews - aViews;
         return a.card_name.localeCompare(b.card_name);
       });
-  }, [cards, showArchived]);
+  }, [cards, showArchived, trendingViews]);
 
   return (
     <div>
@@ -78,40 +92,140 @@ export default function BankCardsTable({ cards }: BankCardsTableProps) {
               <th scope="col" className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
                 Card
               </th>
-              <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                Status
+              <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 hidden sm:table-cell">
+                Annual Fee
+              </th>
+              <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 hidden sm:table-cell">
+                Reward Type
+              </th>
+              <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 hidden lg:table-cell">
+                Top Reward
+              </th>
+              <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 hidden lg:table-cell">
+                Signup Bonus
+              </th>
+              <th scope="col" className="px-3 py-3.5 text-right text-sm font-semibold text-gray-900 hidden sm:table-cell">
+                Approval Rate
               </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200 bg-white">
             {filteredCards.map((card) => (
               <tr key={card.card_id} className="hover:bg-gray-50">
-                <td className="whitespace-nowrap py-4 pl-4 pr-3 sm:pl-6">
+                <td className="py-3 pl-3 pr-2 sm:py-4 sm:pl-6 sm:pr-3">
                   <Link href={`/card/${card.slug}`} className="flex items-center group">
-                    <div className="h-10 w-16 flex-shrink-0 mr-4">
+                    <div className="h-8 w-12 sm:h-10 sm:w-16 flex-shrink-0 mr-3">
                       <CardImage
                         cardImageLink={card.card_image_link}
                         alt={card.card_name}
                         width={64}
                         height={40}
-                        className="h-10 w-16 object-contain"
+                        className="h-8 w-12 sm:h-10 sm:w-16 object-contain"
                       />
                     </div>
-                    <div className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900">
-                      {card.card_name}
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 sm:truncate">
+                        {card.card_name}
+                      </div>
+                      <div className="text-xs text-gray-500 flex flex-wrap items-center gap-x-1.5 sm:hidden">
+                        {card.annual_fee !== undefined && card.annual_fee > 0 && (
+                          <span className="text-amber-600 font-medium">${card.annual_fee}/yr</span>
+                        )}
+                        {card.reward_type && (
+                          <span>
+                            {card.annual_fee !== undefined && card.annual_fee > 0 && '· '}
+                            {card.reward_type === 'cashback' ? '💵 Cash Back' :
+                             card.reward_type === 'points' ? '✨ Points' :
+                             card.reward_type === 'miles' ? '✈️ Miles' : card.reward_type}
+                          </span>
+                        )}
+                        {!card.accepting_applications && (
+                          <span className="inline-flex rounded-full bg-gray-100 px-1.5 text-xs font-medium text-gray-600">
+                            Archived
+                          </span>
+                        )}
+                      </div>
                     </div>
                   </Link>
                 </td>
-                <td className="whitespace-nowrap px-3 py-4 text-sm">
-                  {card.accepting_applications ? (
-                    <span className="inline-flex rounded-full bg-green-100 px-2 text-xs font-semibold leading-5 text-green-800">
-                      Active
+                <td className="whitespace-nowrap px-3 py-4 text-sm hidden sm:table-cell">
+                  {card.annual_fee !== undefined ? (
+                    card.annual_fee === 0 ? <span className="text-gray-500">$0</span> :
+                    <span className="text-amber-700 font-medium">${card.annual_fee}</span>
+                  ) : '—'}
+                </td>
+                <td className="whitespace-nowrap px-3 py-4 text-sm hidden sm:table-cell">
+                  {card.reward_type ? (
+                    <span className="inline-flex items-center gap-1 text-gray-600 text-xs font-medium">
+                      <span aria-hidden="true">
+                        {card.reward_type === 'cashback' ? '💵' :
+                         card.reward_type === 'points' ? '✨' :
+                         card.reward_type === 'miles' ? '✈️' : ''}
+                      </span>
+                      {card.reward_type === 'cashback' ? 'Cash Back' :
+                       card.reward_type === 'points' ? 'Points' :
+                       card.reward_type === 'miles' ? 'Miles' :
+                       card.reward_type}
                     </span>
                   ) : (
-                    <span className="inline-flex rounded-full bg-gray-100 px-2 text-xs font-semibold leading-5 text-gray-800">
-                      Archived
-                    </span>
+                    <span className="text-gray-400">—</span>
                   )}
+                </td>
+                <td className="px-3 py-4 text-sm hidden lg:table-cell">
+                  {(() => {
+                    const top = getTopReward(card.rewards);
+                    if (!top) return <span className="text-gray-400">—</span>;
+                    const rateStr = top.unit === 'percent' ? `${top.value}%` : `${top.value}x`;
+                    const label = categoryLabels[top.category] || top.category;
+                    const hasBookingRestriction = top.note && /book|portal|through|travel center/i.test(top.note);
+                    return (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-gray-400 flex-shrink-0">
+                          <CategoryIcon category={top.category} className="h-4 w-4" />
+                        </span>
+                        <div className="min-w-0">
+                          <span className="font-semibold text-gray-900">{rateStr}</span>
+                          <span className="text-gray-500 ml-1 text-xs">{label}</span>
+                          {hasBookingRestriction && (
+                            <span className="ml-1 text-[10px] text-gray-500 bg-gray-100 rounded px-1 py-0.5 font-medium whitespace-nowrap" title={top.note || ''}>conditions apply</span>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })()}
+                </td>
+                <td className="px-3 py-4 text-sm hidden lg:table-cell">
+                  {(() => {
+                    const bonus = card.signup_bonus;
+                    if (!bonus || !bonus.value) return <span className="text-gray-400">—</span>;
+                    const isCash = bonus.type === 'cash' || bonus.type === 'cashback';
+                    const valueStr = isCash
+                      ? `$${bonus.value.toLocaleString()}`
+                      : bonus.value >= 1000
+                        ? `${Math.round(bonus.value / 1000)}K ${bonus.type}`
+                        : `${bonus.value.toLocaleString()} ${bonus.type}`;
+                    return (
+                      <div>
+                        <div className="font-semibold text-gray-900">{valueStr}</div>
+                        <div className="text-xs text-gray-500">
+                          ${bonus.spend_requirement.toLocaleString()} in {bonus.timeframe_months}mo
+                        </div>
+                      </div>
+                    );
+                  })()}
+                </td>
+                <td className="whitespace-nowrap px-3 py-4 text-sm text-right hidden sm:table-cell">
+                  {(() => {
+                    const total = (card.approved_count || 0) + (card.rejected_count || 0);
+                    if (total === 0) return <span className="text-gray-400">—</span>;
+                    const rate = Math.round(((card.approved_count || 0) / total) * 100);
+                    return (
+                      <div>
+                        <span className={rate >= 50 ? 'text-green-700 font-medium' : 'text-red-700 font-medium'}>{rate}%</span>
+                        <span className="text-gray-400 text-xs ml-1">({total})</span>
+                      </div>
+                    );
+                  })()}
                 </td>
               </tr>
             ))}

--- a/apps/web-next/src/app/bank/[name]/page.tsx
+++ b/apps/web-next/src/app/bank/[name]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { getCardsByBank, getAllBanks } from "@/lib/api";
+import { getCardsByBank, getAllBanks, getCardViewCounts } from "@/lib/api";
 import { BuildingLibraryIcon } from "@heroicons/react/24/solid";
 import { NewspaperIcon } from "@heroicons/react/24/outline";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
@@ -45,9 +45,10 @@ export default async function BankPage({ params }: BankPageProps) {
   const { name } = await params;
   const bankName = decodeURIComponent(name);
 
-  const [cards, allNews] = await Promise.all([
+  const [cards, allNews, trendingViews] = await Promise.all([
     getCardsByBank(bankName),
     getNews(),
+    getCardViewCounts('trending').catch(() => ({})),
   ]);
 
   if (cards.length === 0) {
@@ -88,25 +89,21 @@ export default async function BankPage({ params }: BankPageProps) {
 
       {/* Header */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="text-center">
-          <div className="flex justify-center items-center mb-4">
-            <BuildingLibraryIcon className="h-12 w-12 text-indigo-600" aria-hidden="true" />
-          </div>
+        <div className="flex justify-center items-center gap-3">
+          <BuildingLibraryIcon className="h-10 w-10 text-indigo-600 flex-shrink-0" aria-hidden="true" />
           <h1 className="text-4xl font-extrabold text-gray-900 sm:text-5xl">
             {bankName}
           </h1>
         </div>
 
-        {/* Main Content Grid */}
-        <div className="mt-8 grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Cards Table - Full width on mobile, 2/3 on desktop */}
-          <div className="col-span-1 lg:col-span-2 -mx-4 sm:mx-0">
-            <BankCardsTable cards={cards} />
-          </div>
+        {/* Cards Table - Full width */}
+        <div className="mt-8 -mx-4 sm:mx-0">
+          <BankCardsTable cards={cards} trendingViews={trendingViews} />
+        </div>
 
-          {/* News Sidebar - Below cards on mobile, 1/3 on desktop */}
-          <div className="col-span-1">
-            <div className="bg-white shadow ring-1 ring-black ring-opacity-5 rounded-lg overflow-hidden sticky top-4">
+        {/* News Section */}
+        <div className="mt-8 -mx-4 sm:mx-0">
+          <div className="bg-white sm:shadow sm:ring-1 sm:ring-black sm:ring-opacity-5 sm:rounded-lg overflow-hidden">
               <div className="px-4 py-4 border-b border-gray-200">
                 <div className="flex items-center gap-2">
                   <NewspaperIcon className="h-5 w-5 text-indigo-600" />
@@ -171,7 +168,6 @@ export default async function BankPage({ params }: BankPageProps) {
                   View all card news →
                 </Link>
               </div>
-            </div>
           </div>
         </div>
       </div>

--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -302,17 +302,24 @@ export default function ExploreClient({ cards, banks, trendingViews, allTimeView
                               />
                             </div>
                             <div className="min-w-0 flex-1">
-                              <div className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">
+                              <div className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 sm:truncate">
                                 {card.card_name}
                               </div>
                               <div className="text-xs text-gray-500 flex flex-wrap items-center gap-x-2">
                                 <span>{card.bank}</span>
-                                {/* Show fee and status on mobile inline */}
+                                {/* Show fee, reward type, and SUB on mobile inline */}
                                 <span className="sm:hidden">
                                   {card.annual_fee !== undefined && card.annual_fee > 0 && (
                                     <span className="text-amber-600 font-medium">· ${card.annual_fee}/yr</span>
                                   )}
                                 </span>
+                                {card.reward_type && (
+                                  <span className="sm:hidden">
+                                    · {card.reward_type === 'cashback' ? '💵 Cash Back' :
+                                       card.reward_type === 'points' ? '✨ Points' :
+                                       card.reward_type === 'miles' ? '✈️ Miles' : card.reward_type}
+                                  </span>
+                                )}
                                 {!card.accepting_applications && (
                                   <span className="sm:hidden inline-flex rounded-full bg-gray-100 px-1.5 text-xs font-medium text-gray-600">
                                     Archived


### PR DESCRIPTION
## Summary
- **Bank page table**: Replaced minimal Status column with Annual Fee, Reward Type, Top Reward, Signup Bonus, and Approval Rate — matching the explore page
- **Bank page layout**: Moved news from sidebar to full-width section below cards table, giving the table room to breathe
- **Bank page sorting**: Cards now sort by trending (30-day views) instead of alphabetical
- **Mobile improvements**: Long card names wrap instead of truncating; reward type shown inline under card name on both bank and explore pages

## Test plan
- [ ] Bank page desktop: verify all new columns render correctly
- [ ] Bank page mobile: verify card names wrap and inline info displays
- [ ] Explore page mobile: verify card names wrap and reward type shows inline
- [ ] News section renders correctly below the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)