### PR TITLE
Migrate ratings to 5-star scale

### DIFF
--- a/apps/api/migrations/015_migrate_ratings_to_5_scale.sql
+++ b/apps/api/migrations/015_migrate_ratings_to_5_scale.sql
@@ -1,0 +1,6 @@
+-- Migrate ratings from 1-4 scale to 0-5 scale
+-- Mapping: 1->0, 2->2, 3->4, 4->5
+-- Run as 3 separate invocations (Lambda doesn't support multi-statement SQL):
+-- 1) 015a - drop CHECK constraint
+-- 2) 015b - remap values with CASE
+-- 3) 015c - add new CHECK constraint

--- a/apps/api/migrations/015a_drop_rating_check.sql
+++ b/apps/api/migrations/015a_drop_rating_check.sql
@@ -1,0 +1,1 @@
+ALTER TABLE card_ratings DROP CHECK card_ratings_chk_1

--- a/apps/api/migrations/015b_remap_ratings.sql
+++ b/apps/api/migrations/015b_remap_ratings.sql
@@ -1,0 +1,1 @@
+UPDATE card_ratings SET rating = CASE rating WHEN 1 THEN 0 WHEN 2 THEN 2 WHEN 3 THEN 4 WHEN 4 THEN 5 END WHERE rating IN (1, 2, 3, 4)

--- a/apps/api/migrations/015c_add_rating_check.sql
+++ b/apps/api/migrations/015c_add_rating_check.sql
@@ -1,0 +1,1 @@
+ALTER TABLE card_ratings ADD CONSTRAINT card_ratings_chk_1 CHECK (rating >= 0 AND rating <= 5)

--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -178,11 +178,11 @@ exports.CardRatingsUserHandler = async (event) => {
           break;
         }
 
-        if (rating < 1 || rating > 4 || !Number.isInteger(rating)) {
+        if (rating < 0 || rating > 5 || !Number.isInteger(rating)) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "rating must be an integer between 1 and 4" }),
+            body: JSON.stringify({ error: "rating must be an integer between 0 and 5" }),
           };
           break;
         }

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -87,11 +87,11 @@ function CardRatingDisplay({ ratings }: { ratings: { count: number; average: num
       <div className="mb-3 flex items-center justify-between">
         <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">User Rating</p>
         <span className="text-sm text-gray-500 whitespace-nowrap">
-          {ratings.average.toFixed(1)}/4 from {ratings.count} {ratings.count === 1 ? 'rating' : 'ratings'}
+          {ratings.average.toFixed(1)}/5 from {ratings.count} {ratings.count === 1 ? 'rating' : 'ratings'}
         </span>
       </div>
       <div className="flex items-center gap-0.5">
-        {[1, 2, 3, 4].map((star) => {
+        {[1, 2, 3, 4, 5].map((star) => {
           const filled = star <= Math.floor(ratings.average!);
           const half = !filled && star === Math.ceil(ratings.average!) && ratings.average! % 1 >= 0.25;
           return (

--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -100,8 +100,8 @@ export function CreditCardSchema({ card, ratings }: CreditCardSchemaProps) {
       '@type': 'AggregateRating',
       ratingValue: ratings.average.toFixed(1),
       ratingCount: ratings.count,
-      bestRating: 4,
-      worstRating: 1,
+      bestRating: 5,
+      worstRating: 0,
     } : undefined,
     additionalProperty: [
       {

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -18,15 +18,17 @@ interface EditWalletCardModalProps {
 const RATING_LABELS: Record<number, string> = {
   1: 'Very Bad',
   2: 'Bad',
-  3: 'Good',
-  4: 'Very Good',
+  3: 'Average',
+  4: 'Good',
+  5: 'Very Good',
 };
 
 const RATING_COLORS: Record<number, { bg: string; text: string; fill: string }> = {
   1: { bg: 'bg-red-100', text: 'text-red-700', fill: 'text-red-400' },
   2: { bg: 'bg-orange-100', text: 'text-orange-700', fill: 'text-orange-400' },
-  3: { bg: 'bg-green-100', text: 'text-green-700', fill: 'text-green-400' },
-  4: { bg: 'bg-emerald-100', text: 'text-emerald-700', fill: 'text-emerald-500' },
+  3: { bg: 'bg-yellow-100', text: 'text-yellow-700', fill: 'text-yellow-400' },
+  4: { bg: 'bg-green-100', text: 'text-green-700', fill: 'text-green-400' },
+  5: { bg: 'bg-emerald-100', text: 'text-emerald-700', fill: 'text-emerald-500' },
 };
 
 function StarIcon({ filled, className }: { filled?: boolean; className?: string }) {
@@ -214,7 +216,7 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
                 {userRating ? 'Your rating (click to change):' : 'Rate this card:'}
               </label>
               <div className="flex items-center gap-1">
-                {[1, 2, 3, 4].map((star) => {
+                {[1, 2, 3, 4, 5].map((star) => {
                   const active = (hoveredRating ?? userRating ?? 0) >= star;
                   const colors = RATING_COLORS[hoveredRating ?? userRating ?? star];
                   return (


### PR DESCRIPTION
## Summary
- Migrated existing ratings from 1-4 to 0-5 scale (1→0, 2→2, 3→4, 4→5)
- Updated API validation to accept 0-5
- Updated card page and wallet modal UI to show 5 stars
- Updated SEO JSON-LD schema (bestRating: 5, worstRating: 0)
- DB migration already run in production

## Test plan
- [ ] Verify card pages show 5 stars with correct averages
- [ ] Verify wallet modal shows 5 clickable stars with correct labels
- [ ] Verify new ratings can be submitted (1-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)