### PR TITLE
Rename Robinhood cards to include brand prefix

### DIFF
--- a/apps/api/migrations/016_rename_robinhood_cards.sql
+++ b/apps/api/migrations/016_rename_robinhood_cards.sql
@@ -1,3 +1,2 @@
--- Rename Robinhood cards to include "Robinhood" prefix
+-- Rename Robinhood Gold
 UPDATE cards SET card_name = 'Robinhood Gold' WHERE card_name = 'Gold';
-UPDATE cards SET card_name = 'Robinhood Platinum' WHERE card_name = 'Platinum';

--- a/apps/api/migrations/016_rename_robinhood_cards.sql
+++ b/apps/api/migrations/016_rename_robinhood_cards.sql
@@ -1,0 +1,3 @@
+-- Rename Robinhood cards to include "Robinhood" prefix
+UPDATE cards SET card_name = 'Robinhood Gold' WHERE card_name = 'Gold';
+UPDATE cards SET card_name = 'Robinhood Platinum' WHERE card_name = 'Platinum';

--- a/apps/api/migrations/016a_rename_robinhood_platinum.sql
+++ b/apps/api/migrations/016a_rename_robinhood_platinum.sql
@@ -1,0 +1,2 @@
+-- Rename Robinhood Platinum
+UPDATE cards SET card_name = 'Robinhood Platinum' WHERE card_name = 'Platinum';

--- a/data/cards/robinhood-gold-card.yaml
+++ b/data/cards/robinhood-gold-card.yaml
@@ -1,4 +1,4 @@
-name: "Gold"
+name: "Robinhood Gold"
 bank: "Robinhood"
 slug: "robinhood-gold-card"
 accepting_applications: true

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -1,4 +1,4 @@
-name: "Platinum"
+name: "Robinhood Platinum"
 bank: "Robinhood"
 slug: "robinhood-platinum"
 accepting_applications: true


### PR DESCRIPTION
## Summary
- Renames "Gold" → "Robinhood Gold" and "Platinum" → "Robinhood Platinum" in YAML card definitions
- Adds DB migration `016_rename_robinhood_cards.sql` to update `card_name` in the cards table
- Reverts the naming change from migrations 013/014

## Test plan
- [ ] Run migration 016 against the database
- [ ] Run `npm run build:cards` to rebuild cards.json
- [ ] Verify card pages load correctly with new names

🤖 Generated with [Claude Code](https://claude.com/claude-code)