### PR TITLE
Add card benefits section with credits & perks for 45 cards

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -22,12 +22,13 @@ import {
   ClockIcon,
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
-import { Card, GraphData, Reward, trackReferralEvent, trackCardView, CardWireEntry } from "@/lib/api";
+import { Card, GraphData, Reward, trackReferralEvent, trackCardView, CardWireEntry, CardBenefit } from "@/lib/api";
 import { NewsItem, tagLabels, tagColors } from "@/lib/news";
 import { Article, tagLabels as articleTagLabels, tagColors as articleTagColors } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
 import { CreditCardSchema, BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import CardBenefits from "@/components/ui/CardBenefits";
 import { categoryLabels, CategoryIcon } from "@/lib/cardDisplayUtils";
 
 // Dynamic import for Highcharts (client-side only)
@@ -694,6 +695,11 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
           </div>
         </div>
       </div>
+
+      {/* Card Benefits Section */}
+      {card.benefits && card.benefits.length > 0 && (
+        <CardBenefits benefits={card.benefits} cardName={card.card_name} />
+      )}
 
       {/* Still collecting data - shown when no approval data */}
       {(card.approved_count || 0) === 0 && card.accepting_applications && (

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -1,6 +1,8 @@
+import { readFileSync } from "fs";
+import { join } from "path";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Card, getCard, getCardGraphs, getAllCards, getCardRatings, getCardWire, GraphData, CardWireEntry } from "@/lib/api";
+import { Card, CardBenefit, getCard, getCardGraphs, getAllCards, getCardRatings, getCardWire, GraphData, CardWireEntry } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import CardClient from "./CardClient";
@@ -99,6 +101,19 @@ export default async function CardPage({ params }: CardPageProps) {
     ]);
 
     const { card, ratings, wire } = cardWithRatingsAndWire;
+
+    // Merge benefits from local cards.json if not present in API response
+    if (!card.benefits) {
+      try {
+        const localData = JSON.parse(readFileSync(join(process.cwd(), '../../data/cards.json'), 'utf8'));
+        const localCard = localData.cards.find((c: { slug: string; benefits?: CardBenefit[] }) => c.slug === slug);
+        if (localCard?.benefits) {
+          card.benefits = localCard.benefits;
+        }
+      } catch {
+        // Silently fail - benefits will appear once CDN is updated
+      }
+    }
 
     // Filter news and articles for this specific card
     const cardNews = allNews.filter(news => news.card_slugs?.includes(slug));

--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import {
+  GiftIcon,
+  CheckCircleIcon,
+} from "@heroicons/react/24/outline";
+import { CardBenefit } from "@/lib/api";
+
+const frequencyLabels: Record<string, string> = {
+  monthly: "/mo",
+  quarterly: "/qtr",
+  semi_annual: "/6 mo",
+  annual: "/yr",
+  multi_year: "every 4 yr",
+  ongoing: "",
+};
+
+const categoryIcons: Record<string, string> = {
+  dining: "🍽️",
+  dining_travel: "🚗",
+  travel: "✈️",
+  hotel: "🏨",
+  entertainment: "🎬",
+  shopping: "🛍️",
+  fitness: "💪",
+  lounge: "🛋️",
+  security: "🔒",
+  gas: "⛽",
+  streaming: "📺",
+  grocery: "🛒",
+  rideshare: "🚗",
+  other: "✨",
+};
+
+interface CardBenefitsProps {
+  benefits: CardBenefit[];
+  cardName: string;
+}
+
+export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) {
+  const credits = benefits.filter((b) => b.value > 0);
+  const perks = benefits.filter((b) => b.value === 0);
+  const totalAnnualValue = credits.reduce((sum, b) => sum + b.value, 0);
+
+  return (
+    <div className="py-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-2xl shadow-[0_4px_40px_rgba(0,0,0,0.08)] overflow-hidden">
+          <div className="p-6 sm:p-10 border-b border-gray-100 bg-gradient-to-br from-emerald-50/70 to-white">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-xs text-emerald-600 font-semibold tracking-[0.18em] uppercase">
+                  Card Benefits
+                </h2>
+                <p className="mt-2 text-2xl sm:text-3xl font-extrabold tracking-tight text-gray-900">
+                  Credits &amp; Perks
+                </p>
+                <p className="mt-2 text-sm sm:text-base text-gray-600">
+                  Annual statement credits and benefits included with the {cardName}.
+                </p>
+              </div>
+              <div className="mt-4 sm:mt-0 flex-shrink-0 text-center sm:text-right">
+                <p className="text-xs font-semibold uppercase tracking-wider text-emerald-600">
+                  Total Annual Credits
+                </p>
+                <p className="text-3xl sm:text-4xl font-extrabold text-emerald-700 mt-1">
+                  ${totalAnnualValue.toLocaleString()}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="p-6 sm:p-10">
+            {/* Statement Credits */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {credits.map((benefit) => (
+                <div
+                  key={benefit.name}
+                  className="group relative rounded-xl border border-gray-200 bg-gray-50/50 p-5 hover:border-emerald-300 hover:shadow-sm transition-all"
+                >
+                  <div className="flex items-start justify-between mb-3">
+                    <div className="flex items-center gap-2.5">
+                      <span className="text-xl" role="img" aria-label={benefit.category}>
+                        {categoryIcons[benefit.category] || categoryIcons.other}
+                      </span>
+                      <h3 className="text-sm font-semibold text-gray-900 leading-tight">
+                        {benefit.name}
+                      </h3>
+                    </div>
+                    {benefit.enrollment_required && (
+                      <span className="flex-shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 border border-amber-200">
+                        Enroll
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-baseline gap-1 mb-2">
+                    <span className="text-2xl font-bold text-emerald-700">
+                      ${benefit.value}
+                    </span>
+                    <span className="text-sm text-gray-400 font-medium">
+                      {frequencyLabels[benefit.frequency]}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-600 leading-relaxed">
+                    {benefit.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            {/* Non-monetary Perks */}
+            {perks.length > 0 && (
+              <div className="mt-8">
+                <div className="flex items-center gap-2 mb-4">
+                  <GiftIcon className="h-5 w-5 text-indigo-500" />
+                  <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500">
+                    Additional Perks
+                  </h3>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {perks.map((perk) => (
+                    <div
+                      key={perk.name}
+                      className="flex items-start gap-3 rounded-lg border border-gray-100 bg-gray-50/50 px-4 py-3"
+                    >
+                      <CheckCircleIcon className="h-5 w-5 text-emerald-500 flex-shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-sm font-semibold text-gray-900">
+                          {perk.name}
+                        </p>
+                        <p className="text-sm text-gray-500 mt-0.5">
+                          {perk.description}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -45,6 +45,15 @@ export interface CardAPR {
   regular?: RegularAPR;
 }
 
+export interface CardBenefit {
+  name: string;
+  value: number;
+  description: string;
+  frequency: 'monthly' | 'quarterly' | 'semi_annual' | 'annual' | 'multi_year' | 'ongoing';
+  category: 'dining' | 'dining_travel' | 'travel' | 'hotel' | 'entertainment' | 'shopping' | 'fitness' | 'lounge' | 'security' | 'gas' | 'streaming' | 'grocery' | 'rideshare' | 'other';
+  enrollment_required?: boolean;
+}
+
 export interface Card {
   card_id: string | number;
   db_card_id?: number;
@@ -71,6 +80,7 @@ export interface Card {
   rewards?: Reward[];
   signup_bonus?: SignupBonus;
   apr?: CardAPR;
+  benefits?: CardBenefit[];
 }
 
 // GraphData is an array of series data

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-25T14:21:37.983Z",
+  "generated_at": "2026-03-26T04:59:19.224Z",
   "count": 155,
   "categories": [
     {
@@ -370,6 +370,15 @@
         "spend_requirement": 15000,
         "timeframe_months": 3
       },
+      "benefits": [
+        {
+          "name": "Flexible Business Credit",
+          "value": 150,
+          "description": "Choose 2 categories from Indeed, Adobe, FedEx, Grubhub, wireless providers, and transit for annual statement credits",
+          "frequency": "annual",
+          "category": "other"
+        }
+      ],
       "tags": [
         "business",
         "rewards",
@@ -386,6 +395,24 @@
       "accepting_applications": true,
       "card_referral_link": "https://www.americanexpress.com/en-us/referral/personal/gold-card?ref=",
       "annual_fee": 325,
+      "benefits": [
+        {
+          "name": "Uber Cash",
+          "value": 120,
+          "description": "$10/month in Uber Cash for Uber Eats orders or Uber rides",
+          "frequency": "monthly",
+          "category": "rideshare",
+          "enrollment_required": true
+        },
+        {
+          "name": "Dining Credit",
+          "value": 120,
+          "description": "$10/month in statement credits at Grubhub, The Cheesecake Factory, Goldbelly, Wine.com, Milk Bar, and select Shake Shack locations",
+          "frequency": "monthly",
+          "category": "dining",
+          "enrollment_required": true
+        }
+      ],
       "tags": [
         "travel",
         "dining",
@@ -460,6 +487,23 @@
         "spend_requirement": 3000,
         "timeframe_months": 6
       },
+      "benefits": [
+        {
+          "name": "CLEAR Plus Credit",
+          "value": 189,
+          "description": "Statement credit for CLEAR Plus airport security membership",
+          "frequency": "annual",
+          "category": "security",
+          "enrollment_required": true
+        },
+        {
+          "name": "LoungeBuddy Credit",
+          "value": 100,
+          "description": "$100 annual credit for airport lounge access through LoungeBuddy",
+          "frequency": "annual",
+          "category": "lounge"
+        }
+      ],
       "tags": [
         "travel",
         "dining",
@@ -808,6 +852,15 @@
       "category": "travel",
       "annual_fee": 95,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        }
+      ],
       "tags": [
         "travel",
         "rewards"
@@ -853,6 +906,38 @@
       "category": "travel",
       "annual_fee": 550,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Lifestyle Credit",
+          "value": 150,
+          "description": "Annual credit for airlines, rideshare, or streaming services",
+          "frequency": "annual",
+          "category": "other",
+          "enrollment_required": true
+        },
+        {
+          "name": "Airline Incidental Credit",
+          "value": 100,
+          "description": "Annual credit for airline incidental fees like baggage and seat upgrades",
+          "frequency": "annual",
+          "category": "travel",
+          "enrollment_required": true
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Unlimited Priority Pass lounge access",
+          "frequency": "ongoing",
+          "category": "lounge"
+        }
+      ],
       "tags": [
         "travel",
         "rewards",
@@ -1009,6 +1094,15 @@
       "annual_fee": 0,
       "reward_type": "points",
       "release_date": "2025-01-15",
+      "benefits": [
+        {
+          "name": "Rent Payment Without Fees",
+          "value": 0,
+          "description": "Pay rent with your credit card and earn points with no transaction fees",
+          "frequency": "ongoing",
+          "category": "other"
+        }
+      ],
       "tags": [
         "rewards",
         "travel"
@@ -1047,6 +1141,15 @@
       "annual_fee": 95,
       "reward_type": "points",
       "release_date": "2025-01-15",
+      "benefits": [
+        {
+          "name": "Rent Payment Without Fees",
+          "value": 0,
+          "description": "Pay rent with your credit card and earn points with no transaction fees",
+          "frequency": "ongoing",
+          "category": "other"
+        }
+      ],
       "tags": [
         "rewards",
         "travel",
@@ -1083,6 +1186,15 @@
       "annual_fee": 495,
       "reward_type": "points",
       "release_date": "2025-01-15",
+      "benefits": [
+        {
+          "name": "Rent Payment Without Fees",
+          "value": 0,
+          "description": "Pay rent with your credit card and earn points with no transaction fees",
+          "frequency": "ongoing",
+          "category": "other"
+        }
+      ],
       "tags": [
         "rewards",
         "travel",
@@ -1318,6 +1430,16 @@
           "max": 28.49
         }
       },
+      "benefits": [
+        {
+          "name": "Disney Bundle Discount",
+          "value": 84,
+          "description": "$7/month statement credit toward the Disney Bundle (Disney+, Hulu, ESPN+)",
+          "frequency": "monthly",
+          "category": "streaming",
+          "enrollment_required": true
+        }
+      ],
       "tags": [
         "cashback",
         "shopping"
@@ -1735,6 +1857,15 @@
       "image": "capital-one-venture-rewards.png",
       "annual_fee": 95,
       "reward_type": "miles",
+      "benefits": [
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        }
+      ],
       "tags": [
         "travel",
         "rewards"
@@ -1774,6 +1905,50 @@
       "accepting_applications": true,
       "category": "travel",
       "annual_fee": 395,
+      "benefits": [
+        {
+          "name": "Annual Travel Credit",
+          "value": 300,
+          "description": "Credit for bookings through Capital One Travel portal",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Anniversary Miles Bonus",
+          "value": 0,
+          "description": "10,000 bonus miles on account anniversary",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Capital One Lounge Access",
+          "value": 0,
+          "description": "Complimentary access to Capital One Lounges",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Unlimited Priority Pass lounge access for cardholder and 2 guests",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "Hertz President's Circle Status",
+          "value": 0,
+          "description": "Complimentary Hertz President's Circle elite status",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "travel",
         "premium",
@@ -2034,6 +2209,29 @@
       "accepting_applications": true,
       "category": "travel",
       "annual_fee": 95,
+      "benefits": [
+        {
+          "name": "Annual Hotel Credit",
+          "value": 50,
+          "description": "Statement credit for hotel stays booked through Chase Travel",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "DoorDash DashPass",
+          "value": 0,
+          "description": "Complimentary DoorDash DashPass membership",
+          "frequency": "ongoing",
+          "category": "dining"
+        }
+      ],
       "tags": [
         "travel",
         "dining",
@@ -2095,6 +2293,50 @@
       "image": "chase_sapphire_reserve.png",
       "accepting_applications": true,
       "annual_fee": 795,
+      "benefits": [
+        {
+          "name": "Annual Travel Credit",
+          "value": 300,
+          "description": "Automatic statement credit for travel purchases",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Complimentary Priority Pass Select lounge membership",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "DoorDash DashPass",
+          "value": 0,
+          "description": "Complimentary DashPass membership and delivery credits",
+          "frequency": "ongoing",
+          "category": "dining"
+        },
+        {
+          "name": "Lyft Pink",
+          "value": 0,
+          "description": "Complimentary Lyft Pink membership",
+          "frequency": "ongoing",
+          "category": "rideshare"
+        },
+        {
+          "name": "Instacart+",
+          "value": 0,
+          "description": "Complimentary Instacart+ membership",
+          "frequency": "ongoing",
+          "category": "grocery"
+        }
+      ],
       "tags": [
         "travel",
         "premium",
@@ -2171,6 +2413,36 @@
       "annual_fee": 595,
       "reward_type": "miles",
       "image": "citi-aadvantage-executive-world-elite.png",
+      "benefits": [
+        {
+          "name": "Admirals Club Membership",
+          "value": 0,
+          "description": "Full Admirals Club lounge access for cardholder and authorized users",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "First Checked Bag Free",
+          "value": 0,
+          "description": "First checked bag free on domestic American Airlines itineraries",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "Preferred Boarding",
+          "value": 0,
+          "description": "Preferred boarding on American Airlines flights",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "travel",
         "airline",
@@ -2218,6 +2490,22 @@
       "annual_fee": 350,
       "reward_type": "miles",
       "image": "citi-aadvantage-globe.png",
+      "benefits": [
+        {
+          "name": "First Checked Bag Free",
+          "value": 0,
+          "description": "First checked bag free on domestic American Airlines itineraries",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "Preferred Boarding",
+          "value": 0,
+          "description": "Preferred boarding on American Airlines flights",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "travel",
         "airline"
@@ -2275,6 +2563,22 @@
       "annual_fee": 99,
       "reward_type": "miles",
       "image": "citi-aadvantage-platinum-select-world-elite.png",
+      "benefits": [
+        {
+          "name": "First Checked Bag Free",
+          "value": 0,
+          "description": "First checked bag free on domestic American Airlines itineraries",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "Preferred Boarding",
+          "value": 0,
+          "description": "Preferred boarding on American Airlines flights",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "travel",
         "airline"
@@ -2347,6 +2651,12 @@
             "entertainment"
           ],
           "note": "Automatically on your top eligible spend category each billing cycle, up to $500/month"
+        },
+        {
+          "category": "hotels_car_portal",
+          "value": 4,
+          "unit": "points_per_dollar",
+          "note": "Additional 4 ThankYou Points per $1 on hotels, car rentals, and attractions booked on Citi Travel portal (through June 30, 2026)"
         },
         {
           "category": "everything_else",
@@ -2601,6 +2911,45 @@
       "image": "citi-strata-elite.png",
       "annual_fee": 595,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Annual Hotel Credit",
+          "value": 200,
+          "description": "Credit for hotel bookings through the ThankYou Rewards portal",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Annual Dining Credit",
+          "value": 120,
+          "description": "$10/month dining credit at eligible restaurants",
+          "frequency": "monthly",
+          "category": "dining",
+          "enrollment_required": true
+        },
+        {
+          "name": "Lifestyle Credit",
+          "value": 120,
+          "description": "Annual credit for Peloton, SoulCycle, Equinox, and other fitness brands",
+          "frequency": "annual",
+          "category": "fitness",
+          "enrollment_required": true
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Unlimited Priority Pass lounge access",
+          "frequency": "ongoing",
+          "category": "lounge"
+        }
+      ],
       "tags": [
         "travel",
         "rewards",
@@ -2655,6 +3004,22 @@
       "category": "travel",
       "annual_fee": 95,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Annual Hotel Credit",
+          "value": 100,
+          "description": "Credit for hotel bookings through the ThankYou Rewards portal",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        }
+      ],
       "tags": [
         "travel",
         "rewards"
@@ -2935,6 +3300,29 @@
       "accepting_applications": true,
       "annual_fee": 150,
       "reward_type": "miles",
+      "benefits": [
+        {
+          "name": "First Checked Bag Free",
+          "value": 0,
+          "description": "First checked bag free on Delta flights for you and up to 8 companions on the same reservation",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "Priority Boarding",
+          "value": 0,
+          "description": "Priority boarding on Delta flights (Main Cabin 1 priority)",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "TakeOff 15",
+          "value": 0,
+          "description": "15% off Delta award flights when booking through delta.com or the Fly Delta app",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "airline",
         "travel",
@@ -2987,6 +3375,36 @@
       "accepting_applications": true,
       "annual_fee": 350,
       "reward_type": "miles",
+      "benefits": [
+        {
+          "name": "Companion Certificate",
+          "value": 0,
+          "description": "Annual domestic Main Cabin companion certificate after meeting spend requirements",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "TakeOff 15",
+          "value": 0,
+          "description": "15% off Delta award flights when booking through delta.com or the Fly Delta app",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "First Checked Bag Free",
+          "value": 0,
+          "description": "First checked bag free on Delta flights for you and up to 8 companions on the same reservation",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "airline",
         "travel",
@@ -3045,6 +3463,36 @@
       "accepting_applications": true,
       "annual_fee": 650,
       "reward_type": "miles",
+      "benefits": [
+        {
+          "name": "Delta Sky Club Access",
+          "value": 0,
+          "description": "Complimentary access to Delta Sky Clubs when flying Delta",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "Companion Certificate",
+          "value": 0,
+          "description": "Annual domestic First Class companion certificate after spending $30,000 in a year",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "TakeOff 15",
+          "value": 0,
+          "description": "15% off Delta award flights when booking through delta.com or the Fly Delta app",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "airline",
         "travel",
@@ -3315,6 +3763,15 @@
       "category": "rewards",
       "annual_fee": 149,
       "reward_type": "cashback",
+      "benefits": [
+        {
+          "name": "Annual Disney Statement Credit",
+          "value": 50,
+          "description": "Annual statement credit for Disney purchases",
+          "frequency": "annual",
+          "category": "entertainment"
+        }
+      ],
       "tags": [
         "rewards",
         "shopping"
@@ -3549,41 +4006,6 @@
       "card_name": "Gemini Credit"
     },
     {
-      "name": "Gold",
-      "bank": "Robinhood",
-      "slug": "robinhood-gold-card",
-      "accepting_applications": true,
-      "image": "robinhood-gold-card.png",
-      "release_date": "2024-03-26",
-      "annual_fee": 0,
-      "tags": [
-        "cashback",
-        "rewards"
-      ],
-      "reward_type": "cashback",
-      "rewards": [
-        {
-          "category": "travel_portal",
-          "value": 5,
-          "unit": "percent",
-          "note": "Travel booked through Robinhood travel portal"
-        },
-        {
-          "category": "everything_else",
-          "value": 3,
-          "unit": "percent"
-        }
-      ],
-      "apr": {
-        "regular": {
-          "min": 29.99,
-          "max": 29.99
-        }
-      },
-      "card_id": "robinhood-gold-card",
-      "card_name": "Gold"
-    },
-    {
       "name": "Graphite Business Cash Unlimited",
       "bank": "American Express",
       "slug": "graphite-business-cash-unlimited",
@@ -3741,6 +4163,15 @@
           "max": 28.49
         }
       },
+      "benefits": [
+        {
+          "name": "Silver Status",
+          "value": 0,
+          "description": "Complimentary Hilton Honors Silver status with 5th night free on reward stays",
+          "frequency": "ongoing",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel"
@@ -3799,6 +4230,51 @@
           "max": 28.49
         }
       },
+      "benefits": [
+        {
+          "name": "Free Night Award",
+          "value": 0,
+          "description": "1 complimentary night annually at most Hilton hotels and resorts worldwide",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Hilton Resort Credit",
+          "value": 400,
+          "description": "$400 annual statement credit for eligible purchases at Hilton resorts",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Airline Fee Credit",
+          "value": 200,
+          "description": "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades",
+          "frequency": "annual",
+          "category": "travel",
+          "enrollment_required": true
+        },
+        {
+          "name": "Diamond Status",
+          "value": 0,
+          "description": "Complimentary Hilton Honors Diamond status with room upgrades, executive lounge access, and late checkout",
+          "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "Diamond Property Credit",
+          "value": 0,
+          "description": "$100 credit on stays of 2+ nights at Hilton properties when you have Diamond status",
+          "frequency": "ongoing",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel",
@@ -3868,6 +4344,29 @@
           "max": 27.49
         }
       },
+      "benefits": [
+        {
+          "name": "Free Night Award",
+          "value": 0,
+          "description": "1 complimentary night annually at most Hilton hotels and resorts worldwide",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Gold Status",
+          "value": 0,
+          "description": "Complimentary Hilton Honors Gold status with room upgrades, late checkout, and 5th night free on reward stays",
+          "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Complimentary Priority Pass Select membership after spending $15,000 in a calendar year",
+          "frequency": "ongoing",
+          "category": "lounge"
+        }
+      ],
       "tags": [
         "hotel",
         "travel"
@@ -3940,6 +4439,36 @@
       "image": "chase-ihg-one-rewards-premier.png",
       "annual_fee": 99,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Free Night Award",
+          "value": 0,
+          "description": "One annual free night award at any IHG hotel",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "4th Reward Night Free",
+          "value": 0,
+          "description": "4th night free on IHG reward night stays",
+          "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "Platinum Elite Status",
+          "value": 0,
+          "description": "Automatic IHG One Rewards Platinum Elite status",
+          "frequency": "ongoing",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel",
@@ -3996,6 +4525,29 @@
       "annual_fee": 99,
       "reward_type": "points",
       "image": "chase-ihg-one-rewards-premier-business.png",
+      "benefits": [
+        {
+          "name": "Free Night Award",
+          "value": 0,
+          "description": "One annual free night award at any IHG hotel",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "4th Reward Night Free",
+          "value": 0,
+          "description": "4th night free on IHG reward night stays",
+          "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "Platinum Elite Status",
+          "value": 0,
+          "description": "Automatic IHG One Rewards Platinum Elite status",
+          "frequency": "ongoing",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel",
@@ -4409,6 +4961,22 @@
       "accepting_applications": true,
       "annual_fee": 0,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Silver Elite Status",
+          "value": 0,
+          "description": "Automatic Marriott Bonvoy Silver Elite status",
+          "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "15 Elite Night Credits",
+          "value": 0,
+          "description": "15 elite night credits toward Marriott Bonvoy status each year",
+          "frequency": "annual",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel"
@@ -4461,6 +5029,29 @@
       "accepting_applications": true,
       "annual_fee": 95,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Free Night Award",
+          "value": 0,
+          "description": "One annual free night award up to 35,000 points value",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "15 Elite Night Credits",
+          "value": 0,
+          "description": "15 elite night credits toward Marriott Bonvoy status each year",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Silver Elite Status",
+          "value": 0,
+          "description": "Automatic Marriott Bonvoy Silver Elite status",
+          "frequency": "ongoing",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel",
@@ -4557,6 +5148,57 @@
           "max": 28.49
         }
       },
+      "benefits": [
+        {
+          "name": "Free Night Award",
+          "value": 0,
+          "description": "1 annual free night award at Marriott properties valued up to 85,000 points",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Dining Credit",
+          "value": 300,
+          "description": "$25/month in statement credits at restaurants worldwide",
+          "frequency": "monthly",
+          "category": "dining"
+        },
+        {
+          "name": "Marriott Property Credit",
+          "value": 100,
+          "description": "$100 statement credit for stays of 2+ consecutive nights at Marriott Bonvoy properties",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Platinum Elite Status",
+          "value": 0,
+          "description": "Complimentary Marriott Bonvoy Platinum Elite status with room upgrades, late checkout, and lounge access",
+          "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "25 Elite Night Credits",
+          "value": 0,
+          "description": "25 Elite Night Credits annually toward Marriott Bonvoy elite status qualification",
+          "frequency": "annual",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel",
@@ -4607,55 +5249,6 @@
       },
       "card_id": "nhl-discover-it",
       "card_name": "NHL Discover it"
-    },
-    {
-      "name": "Platinum",
-      "bank": "Robinhood",
-      "slug": "robinhood-platinum",
-      "accepting_applications": true,
-      "image": "robinhood-platinum.png",
-      "release_date": "2026-03-05",
-      "category": "travel",
-      "annual_fee": 695,
-      "tags": [
-        "premium",
-        "travel",
-        "dining",
-        "rewards"
-      ],
-      "reward_type": "cashback",
-      "rewards": [
-        {
-          "category": "hotels_portal",
-          "value": 10,
-          "unit": "percent",
-          "note": "Booked through the Robinhood Banking app"
-        },
-        {
-          "category": "car_rentals_portal",
-          "value": 10,
-          "unit": "percent",
-          "note": "Booked through the Robinhood Banking app"
-        },
-        {
-          "category": "flights_portal",
-          "value": 5,
-          "unit": "percent",
-          "note": "Flights booked through the Robinhood Banking app"
-        },
-        {
-          "category": "dining",
-          "value": 5,
-          "unit": "percent"
-        },
-        {
-          "category": "everything_else",
-          "value": 1,
-          "unit": "percent"
-        }
-      ],
-      "card_id": "robinhood-platinum",
-      "card_name": "Platinum"
     },
     {
       "name": "Princess Cruises Rewards Visa",
@@ -4803,6 +5396,136 @@
       "card_name": "REI Co-op Mastercard"
     },
     {
+      "name": "Robinhood Gold",
+      "bank": "Robinhood",
+      "slug": "robinhood-gold-card",
+      "accepting_applications": true,
+      "image": "robinhood-gold-card.png",
+      "release_date": "2024-03-26",
+      "annual_fee": 0,
+      "benefits": [
+        {
+          "name": "Travel Insurance",
+          "value": 0,
+          "description": "Trip cancellation, trip delay, and lost luggage protection",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "Cell Phone Protection",
+          "value": 0,
+          "description": "Cell phone damage and theft protection when you pay your bill with the card",
+          "frequency": "ongoing",
+          "category": "other"
+        },
+        {
+          "name": "No Foreign Transaction Fees",
+          "value": 0,
+          "description": "No foreign transaction fees on purchases made abroad",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
+      "tags": [
+        "cashback",
+        "rewards"
+      ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "travel_portal",
+          "value": 5,
+          "unit": "percent",
+          "note": "Travel booked through Robinhood travel portal"
+        },
+        {
+          "category": "everything_else",
+          "value": 3,
+          "unit": "percent"
+        }
+      ],
+      "apr": {
+        "regular": {
+          "min": 29.99,
+          "max": 29.99
+        }
+      },
+      "card_id": "robinhood-gold-card",
+      "card_name": "Robinhood Gold"
+    },
+    {
+      "name": "Robinhood Platinum",
+      "bank": "Robinhood",
+      "slug": "robinhood-platinum",
+      "accepting_applications": true,
+      "image": "robinhood-platinum.png",
+      "release_date": "2026-03-05",
+      "category": "travel",
+      "annual_fee": 695,
+      "benefits": [
+        {
+          "name": "Airport Lounge Access",
+          "value": 0,
+          "description": "Complimentary airport lounge access",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "Concierge Service",
+          "value": 0,
+          "description": "24/7 premium concierge service",
+          "frequency": "ongoing",
+          "category": "other"
+        }
+      ],
+      "tags": [
+        "premium",
+        "travel",
+        "dining",
+        "rewards"
+      ],
+      "reward_type": "cashback",
+      "rewards": [
+        {
+          "category": "hotels_portal",
+          "value": 10,
+          "unit": "percent",
+          "note": "Booked through the Robinhood Banking app"
+        },
+        {
+          "category": "car_rentals_portal",
+          "value": 10,
+          "unit": "percent",
+          "note": "Booked through the Robinhood Banking app"
+        },
+        {
+          "category": "flights_portal",
+          "value": 5,
+          "unit": "percent",
+          "note": "Flights booked through the Robinhood Banking app"
+        },
+        {
+          "category": "dining",
+          "value": 5,
+          "unit": "percent"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "percent"
+        }
+      ],
+      "card_id": "robinhood-platinum",
+      "card_name": "Robinhood Platinum"
+    },
+    {
       "name": "Serve",
       "bank": "American Express",
       "slug": "serve-from-american-express",
@@ -4945,6 +5668,15 @@
           "max": 27.74
         }
       },
+      "benefits": [
+        {
+          "name": "6,000 Anniversary Points",
+          "value": 0,
+          "description": "6,000 bonus points on card anniversary each year",
+          "frequency": "annual",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "airline",
         "travel"
@@ -4995,6 +5727,29 @@
           "max": 27.74
         }
       },
+      "benefits": [
+        {
+          "name": "Annual Travel Credit",
+          "value": 75,
+          "description": "Statement credit for Southwest Airlines purchases",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "7,500 Anniversary Points",
+          "value": 0,
+          "description": "7,500 bonus points on card anniversary each year",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "4 Upgraded Boardings",
+          "value": 0,
+          "description": "4 upgraded boardings per year when available",
+          "frequency": "annual",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "airline",
         "travel",
@@ -5049,6 +5804,69 @@
         "spend_requirement": 20000,
         "timeframe_months": 3
       },
+      "benefits": [
+        {
+          "name": "Airline Fee Credit",
+          "value": 200,
+          "description": "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades",
+          "frequency": "annual",
+          "category": "travel",
+          "enrollment_required": true
+        },
+        {
+          "name": "Dell Technologies Credit",
+          "value": 400,
+          "description": "$200 semiannually in statement credits for purchases at Dell Technologies",
+          "frequency": "semi_annual",
+          "category": "shopping",
+          "enrollment_required": true
+        },
+        {
+          "name": "Indeed Credit",
+          "value": 360,
+          "description": "$90 per quarter in statement credits for Indeed job postings and sponsored jobs",
+          "frequency": "annual",
+          "category": "other",
+          "enrollment_required": true
+        },
+        {
+          "name": "Adobe Creative Cloud Credit",
+          "value": 150,
+          "description": "Annual statement credit for Adobe Creative Cloud subscriptions",
+          "frequency": "annual",
+          "category": "streaming",
+          "enrollment_required": true
+        },
+        {
+          "name": "Wireless Telephone Credit",
+          "value": 120,
+          "description": "$10/month in statement credits toward wireless telephone services purchased directly from U.S. providers",
+          "frequency": "monthly",
+          "category": "other",
+          "enrollment_required": true
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "Centurion Lounge Access",
+          "value": 0,
+          "description": "Complimentary access to The Centurion Lounge network at major airports worldwide",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass",
+          "frequency": "ongoing",
+          "category": "lounge"
+        }
+      ],
       "tags": [
         "business",
         "travel",
@@ -5091,6 +5909,128 @@
         "spend_requirement": 12000,
         "timeframe_months": 6
       },
+      "benefits": [
+        {
+          "name": "Uber Cash",
+          "value": 200,
+          "description": "$15/month in Uber Cash for Uber Eats or rides ($20 in December)",
+          "frequency": "monthly",
+          "category": "dining_travel",
+          "enrollment_required": true
+        },
+        {
+          "name": "Airline Fee Credit",
+          "value": 200,
+          "description": "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades",
+          "frequency": "annual",
+          "category": "travel",
+          "enrollment_required": true
+        },
+        {
+          "name": "Hotel Credit",
+          "value": 200,
+          "description": "Statement credits on prepaid Fine Hotels + Resorts or The Hotel Collection bookings through Amex Travel",
+          "frequency": "annual",
+          "category": "hotel",
+          "enrollment_required": false
+        },
+        {
+          "name": "Digital Entertainment Credit",
+          "value": 240,
+          "description": "$20/month toward select streaming subscriptions: Disney Bundle, Peacock, NYT, Audible, SiriusXM",
+          "frequency": "monthly",
+          "category": "streaming",
+          "enrollment_required": true
+        },
+        {
+          "name": "CLEAR Plus Credit",
+          "value": 189,
+          "description": "Statement credit for CLEAR Plus airport security membership",
+          "frequency": "annual",
+          "category": "security",
+          "enrollment_required": true
+        },
+        {
+          "name": "Walmart+ Credit",
+          "value": 155,
+          "description": "Monthly credit covering Walmart+ membership ($12.95/month)",
+          "frequency": "monthly",
+          "category": "shopping",
+          "enrollment_required": true
+        },
+        {
+          "name": "Saks Fifth Avenue Credit",
+          "value": 100,
+          "description": "$50 semiannually (Jan–Jun and Jul–Dec) at Saks Fifth Avenue",
+          "frequency": "semi_annual",
+          "category": "shopping",
+          "enrollment_required": true
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "travel",
+          "enrollment_required": false
+        },
+        {
+          "name": "Equinox Credit",
+          "value": 300,
+          "description": "$25/month toward an Equinox gym membership",
+          "frequency": "monthly",
+          "category": "fitness",
+          "enrollment_required": true
+        },
+        {
+          "name": "Lululemon Credit",
+          "value": 300,
+          "description": "$75 per quarter toward purchases at Lululemon",
+          "frequency": "quarterly",
+          "category": "shopping",
+          "enrollment_required": true
+        },
+        {
+          "name": "Global Dining Access by Resy",
+          "value": 0,
+          "description": "Priority reservations and special access at select restaurants nationwide",
+          "frequency": "ongoing",
+          "category": "dining",
+          "enrollment_required": false
+        },
+        {
+          "name": "Centurion Lounge Access",
+          "value": 0,
+          "description": "Complimentary access to The Centurion Lounge network at major airports worldwide",
+          "frequency": "ongoing",
+          "category": "lounge",
+          "enrollment_required": false
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass",
+          "frequency": "ongoing",
+          "category": "lounge",
+          "enrollment_required": false
+        },
+        {
+          "name": "Fine Hotels + Resorts",
+          "value": 0,
+          "description": "Room upgrade on arrival, daily breakfast for two, $100 experience credit, guaranteed 4pm late checkout",
+          "frequency": "ongoing",
+          "category": "hotel",
+          "enrollment_required": false
+        },
+        {
+          "name": "The Hotel Collection",
+          "value": 0,
+          "description": "$100 hotel credit when booking 2+ consecutive nights at The Hotel Collection properties",
+          "frequency": "ongoing",
+          "category": "hotel",
+          "enrollment_required": false
+        }
+      ],
       "tags": [
         "travel",
         "premium",
@@ -5168,6 +6108,29 @@
       "image": "us-bank-altitude-reserve.png",
       "annual_fee": 400,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Annual Travel Credit",
+          "value": 325,
+          "description": "Credit for travel purchases made with a mobile wallet",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "Priority Pass Select",
+          "value": 0,
+          "description": "Unlimited Priority Pass lounge access",
+          "frequency": "ongoing",
+          "category": "lounge"
+        }
+      ],
       "card_id": "us-bank-altitude-reserve-visa-infinite",
       "card_name": "U.S. Bank Altitude Reserve Visa Infinite"
     },
@@ -5280,6 +6243,36 @@
           "max": 28.24
         }
       },
+      "benefits": [
+        {
+          "name": "United Club Membership",
+          "value": 0,
+          "description": "Full United Club lounge membership for cardholder",
+          "frequency": "ongoing",
+          "category": "lounge"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "2 Free Checked Bags",
+          "value": 0,
+          "description": "First and second checked bags free on United flights",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "Premier Access",
+          "value": 0,
+          "description": "Priority check-in, security, boarding, and baggage handling on United",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "airline",
         "travel",
@@ -5331,6 +6324,36 @@
           "max": 28.24
         }
       },
+      "benefits": [
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "First Checked Bag Free",
+          "value": 0,
+          "description": "First checked bag free on United flights",
+          "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "2 United Club One-Time Passes",
+          "value": 0,
+          "description": "Two complimentary United Club lounge passes per year",
+          "frequency": "annual",
+          "category": "lounge"
+        },
+        {
+          "name": "Priority Boarding",
+          "value": 0,
+          "description": "Priority boarding on United flights",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "airline",
         "travel",
@@ -5464,6 +6487,29 @@
           "max": 28.24
         }
       },
+      "benefits": [
+        {
+          "name": "Annual United Travel Credit",
+          "value": 125,
+          "description": "Statement credit for United Airlines purchases",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "2 Free Checked Bags",
+          "value": 0,
+          "description": "First and second checked bags free on United flights",
+          "frequency": "ongoing",
+          "category": "travel"
+        }
+      ],
       "tags": [
         "airline",
         "travel",
@@ -5481,6 +6527,29 @@
       "category": "travel",
       "annual_fee": 0,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Annual Streaming Credit",
+          "value": 30,
+          "description": "Annual credit for eligible streaming service purchases",
+          "frequency": "annual",
+          "category": "streaming"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 100,
+          "description": "Up to $100 statement credit for Global Entry or TSA PreCheck application fee",
+          "frequency": "multi_year",
+          "category": "security"
+        },
+        {
+          "name": "4th Night Free",
+          "value": 0,
+          "description": "4th night free on hotel bookings redeemed through Real-Time Rewards",
+          "frequency": "ongoing",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "travel",
         "rewards"
@@ -6000,6 +7069,15 @@
       "accepting_applications": true,
       "category": "rewards",
       "annual_fee": 0,
+      "benefits": [
+        {
+          "name": "Cell Phone Protection",
+          "value": 0,
+          "description": "Up to $600 per claim for cell phone damage or theft when you pay your bill with the card",
+          "frequency": "ongoing",
+          "category": "other"
+        }
+      ],
       "tags": [
         "travel",
         "dining",
@@ -6066,6 +7144,22 @@
       "category": "travel",
       "annual_fee": 95,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Annual Airline Credit",
+          "value": 100,
+          "description": "Annual credit for airline purchases",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Cell Phone Protection",
+          "value": 0,
+          "description": "Up to $800 per claim for cell phone damage or theft when you pay your bill with the card",
+          "frequency": "ongoing",
+          "category": "other"
+        }
+      ],
       "tags": [
         "travel",
         "rewards",
@@ -6389,6 +7483,29 @@
       "image": "chase-world-of-hyatt.png",
       "annual_fee": 95,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Free Night Award",
+          "value": 0,
+          "description": "One annual free night award at any Category 1-4 Hyatt hotel",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Discoverist Status",
+          "value": 0,
+          "description": "Automatic World of Hyatt Discoverist elite status",
+          "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "5 Qualifying Night Credits",
+          "value": 0,
+          "description": "5 qualifying night credits toward Hyatt elite status each year",
+          "frequency": "annual",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel",
@@ -6447,6 +7564,29 @@
       "category": "business",
       "annual_fee": 199,
       "reward_type": "points",
+      "benefits": [
+        {
+          "name": "Free Night Award",
+          "value": 0,
+          "description": "One annual free night award at any Category 1-4 Hyatt hotel",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Discoverist Status",
+          "value": 0,
+          "description": "Automatic World of Hyatt Discoverist elite status",
+          "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "5 Qualifying Night Credits",
+          "value": 0,
+          "description": "5 qualifying night credits toward Hyatt elite status each year",
+          "frequency": "annual",
+          "category": "hotel"
+        }
+      ],
       "tags": [
         "hotel",
         "travel",

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -20,6 +20,12 @@ signup_bonus:
   type: points
   spend_requirement: 15000
   timeframe_months: 3
+benefits:
+  - name: "Flexible Business Credit"
+    value: 150
+    description: "Choose 2 categories from Indeed, Adobe, FedEx, Grubhub, wireless providers, and transit for annual statement credits"
+    frequency: "annual"
+    category: "other"
 tags:
   - business
   - rewards

--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -5,6 +5,19 @@ image: "amex_gold_card.png"
 accepting_applications: true
 card_referral_link: "https://www.americanexpress.com/en-us/referral/personal/gold-card?ref=" 
 annual_fee: 325
+benefits:
+  - name: "Uber Cash"
+    value: 120
+    description: "$10/month in Uber Cash for Uber Eats orders or Uber rides"
+    frequency: "monthly"
+    category: "rideshare"
+    enrollment_required: true
+  - name: "Dining Credit"
+    value: 120
+    description: "$10/month in statement credits at Grubhub, The Cheesecake Factory, Goldbelly, Wine.com, Milk Bar, and select Shake Shack locations"
+    frequency: "monthly"
+    category: "dining"
+    enrollment_required: true
 tags:
   - travel
   - dining

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -23,6 +23,18 @@ signup_bonus:
   type: points
   spend_requirement: 3000
   timeframe_months: 6
+benefits:
+  - name: "CLEAR Plus Credit"
+    value: 189
+    description: "Statement credit for CLEAR Plus airport security membership"
+    frequency: "annual"
+    category: "security"
+    enrollment_required: true
+  - name: "LoungeBuddy Credit"
+    value: 100
+    description: "$100 annual credit for airport lounge access through LoungeBuddy"
+    frequency: "annual"
+    category: "lounge"
 tags:
   - travel
   - dining

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -6,6 +6,29 @@ image: "premium-rewards.png"
 category: "travel"
 annual_fee: 550
 reward_type: "points"
+benefits:
+  - name: "Lifestyle Credit"
+    value: 150
+    description: "Annual credit for airlines, rideshare, or streaming services"
+    frequency: "annual"
+    category: "other"
+    enrollment_required: true
+  - name: "Airline Incidental Credit"
+    value: 100
+    description: "Annual credit for airline incidental fees like baggage and seat upgrades"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: true
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Unlimited Priority Pass lounge access"
+    frequency: "ongoing"
+    category: "lounge"
 tags:
   - travel
   - rewards

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -6,6 +6,12 @@ accepting_applications: true
 category: "travel"
 annual_fee: 95
 reward_type: "points"
+benefits:
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
 tags:
   - travel
   - rewards

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -6,6 +6,12 @@ accepting_applications: true
 annual_fee: 0
 reward_type: "points"
 release_date: "2025-01-15"
+benefits:
+  - name: "Rent Payment Without Fees"
+    value: 0
+    description: "Pay rent with your credit card and earn points with no transaction fees"
+    frequency: "ongoing"
+    category: "other"
 tags:
   - rewards
   - travel

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -6,6 +6,12 @@ accepting_applications: true
 annual_fee: 95
 reward_type: "points"
 release_date: "2025-01-15"
+benefits:
+  - name: "Rent Payment Without Fees"
+    value: 0
+    description: "Pay rent with your credit card and earn points with no transaction fees"
+    frequency: "ongoing"
+    category: "other"
 tags:
   - rewards
   - travel

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -6,6 +6,12 @@ accepting_applications: true
 annual_fee: 495
 reward_type: "points"
 release_date: "2025-01-15"
+benefits:
+  - name: "Rent Payment Without Fees"
+    value: 0
+    description: "Pay rent with your credit card and earn points with no transaction fees"
+    frequency: "ongoing"
+    category: "other"
 tags:
   - rewards
   - travel

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -37,6 +37,13 @@ apr:
   regular:
     min: 19.49
     max: 28.49
+benefits:
+  - name: "Disney Bundle Discount"
+    value: 84
+    description: "$7/month statement credit toward the Disney Bundle (Disney+, Hulu, ESPN+)"
+    frequency: "monthly"
+    category: "streaming"
+    enrollment_required: true
 tags:
   - cashback
   - shopping

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -6,6 +6,12 @@ category: "travel"
 image: "capital-one-venture-rewards.png"
 annual_fee: 95
 reward_type: "miles"
+benefits:
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
 tags:
   - travel
   - rewards

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -5,6 +5,37 @@ image: "capital_one_venture_x.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 395
+benefits:
+  - name: "Annual Travel Credit"
+    value: 300
+    description: "Credit for bookings through Capital One Travel portal"
+    frequency: "annual"
+    category: "travel"
+  - name: "Anniversary Miles Bonus"
+    value: 0
+    description: "10,000 bonus miles on account anniversary"
+    frequency: "annual"
+    category: "travel"
+  - name: "Capital One Lounge Access"
+    value: 0
+    description: "Complimentary access to Capital One Lounges"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Unlimited Priority Pass lounge access for cardholder and 2 guests"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "Hertz President's Circle Status"
+    value: 0
+    description: "Complimentary Hertz President's Circle elite status"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - travel
   - premium

--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -5,6 +5,22 @@ accepting_applications: true
 annual_fee: 99
 reward_type: "points"
 image: "chase-ihg-one-rewards-premier-business.png"
+benefits:
+  - name: "Free Night Award"
+    value: 0
+    description: "One annual free night award at any IHG hotel"
+    frequency: "annual"
+    category: "hotel"
+  - name: "4th Reward Night Free"
+    value: 0
+    description: "4th night free on IHG reward night stays"
+    frequency: "ongoing"
+    category: "hotel"
+  - name: "Platinum Elite Status"
+    value: 0
+    description: "Automatic IHG One Rewards Platinum Elite status"
+    frequency: "ongoing"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -5,6 +5,22 @@ image: "chase-sapphire-preferred.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 95
+benefits:
+  - name: "Annual Hotel Credit"
+    value: 50
+    description: "Statement credit for hotel stays booked through Chase Travel"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "DoorDash DashPass"
+    value: 0
+    description: "Complimentary DoorDash DashPass membership"
+    frequency: "ongoing"
+    category: "dining"
 tags:
   - travel
   - dining

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -4,6 +4,37 @@ slug: "chase-sapphire-reserve"
 image: "chase_sapphire_reserve.png"
 accepting_applications: true
 annual_fee: 795
+benefits:
+  - name: "Annual Travel Credit"
+    value: 300
+    description: "Automatic statement credit for travel purchases"
+    frequency: "annual"
+    category: "travel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Complimentary Priority Pass Select lounge membership"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "DoorDash DashPass"
+    value: 0
+    description: "Complimentary DashPass membership and delivery credits"
+    frequency: "ongoing"
+    category: "dining"
+  - name: "Lyft Pink"
+    value: 0
+    description: "Complimentary Lyft Pink membership"
+    frequency: "ongoing"
+    category: "rideshare"
+  - name: "Instacart+"
+    value: 0
+    description: "Complimentary Instacart+ membership"
+    frequency: "ongoing"
+    category: "grocery"
 tags:
   - travel
   - premium

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -5,6 +5,27 @@ accepting_applications: true
 annual_fee: 595
 reward_type: "miles"
 image: "citi-aadvantage-executive-world-elite.png"
+benefits:
+  - name: "Admirals Club Membership"
+    value: 0
+    description: "Full Admirals Club lounge access for cardholder and authorized users"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "First Checked Bag Free"
+    value: 0
+    description: "First checked bag free on domestic American Airlines itineraries"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "Preferred Boarding"
+    value: 0
+    description: "Preferred boarding on American Airlines flights"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - travel
   - airline

--- a/data/cards/citi-aadvantage-globe.yaml
+++ b/data/cards/citi-aadvantage-globe.yaml
@@ -5,6 +5,17 @@ accepting_applications: true
 annual_fee: 350
 reward_type: "miles"
 image: "citi-aadvantage-globe.png"
+benefits:
+  - name: "First Checked Bag Free"
+    value: 0
+    description: "First checked bag free on domestic American Airlines itineraries"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "Preferred Boarding"
+    value: 0
+    description: "Preferred boarding on American Airlines flights"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - travel
   - airline

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -5,6 +5,17 @@ accepting_applications: true
 annual_fee: 99
 reward_type: "miles"
 image: "citi-aadvantage-platinum-select-world-elite.png"
+benefits:
+  - name: "First Checked Bag Free"
+    value: 0
+    description: "First checked bag free on domestic American Airlines itineraries"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "Preferred Boarding"
+    value: 0
+    description: "Preferred boarding on American Airlines flights"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - travel
   - airline

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -6,6 +6,34 @@ category: "travel"
 image: "citi-strata-elite.png"
 annual_fee: 595
 reward_type: "points"
+benefits:
+  - name: "Annual Hotel Credit"
+    value: 200
+    description: "Credit for hotel bookings through the ThankYou Rewards portal"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Annual Dining Credit"
+    value: 120
+    description: "$10/month dining credit at eligible restaurants"
+    frequency: "monthly"
+    category: "dining"
+    enrollment_required: true
+  - name: "Lifestyle Credit"
+    value: 120
+    description: "Annual credit for Peloton, SoulCycle, Equinox, and other fitness brands"
+    frequency: "annual"
+    category: "fitness"
+    enrollment_required: true
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Unlimited Priority Pass lounge access"
+    frequency: "ongoing"
+    category: "lounge"
 tags:
   - travel
   - rewards

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -6,6 +6,17 @@ accepting_applications: true
 category: "travel"
 annual_fee: 95
 reward_type: "points"
+benefits:
+  - name: "Annual Hotel Credit"
+    value: 100
+    description: "Credit for hotel bookings through the ThankYou Rewards portal"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
 tags:
   - travel
   - rewards

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -5,6 +5,22 @@ image: "amex_delta_skymiles_gold.png"
 accepting_applications: true
 annual_fee: 150
 reward_type: "miles"
+benefits:
+  - name: "First Checked Bag Free"
+    value: 0
+    description: "First checked bag free on Delta flights for you and up to 8 companions on the same reservation"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "Priority Boarding"
+    value: 0
+    description: "Priority boarding on Delta flights (Main Cabin 1 priority)"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "TakeOff 15"
+    value: 0
+    description: "15% off Delta award flights when booking through delta.com or the Fly Delta app"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - airline
   - travel

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -5,6 +5,27 @@ image: "amex_delta_skymiles_platinum.png"
 accepting_applications: true
 annual_fee: 350
 reward_type: "miles"
+benefits:
+  - name: "Companion Certificate"
+    value: 0
+    description: "Annual domestic Main Cabin companion certificate after meeting spend requirements"
+    frequency: "annual"
+    category: "travel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "TakeOff 15"
+    value: 0
+    description: "15% off Delta award flights when booking through delta.com or the Fly Delta app"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "First Checked Bag Free"
+    value: 0
+    description: "First checked bag free on Delta flights for you and up to 8 companions on the same reservation"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - airline
   - travel

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -5,6 +5,27 @@ image: "amex_delta_skymiles_reserve.png"
 accepting_applications: true
 annual_fee: 650
 reward_type: "miles"
+benefits:
+  - name: "Delta Sky Club Access"
+    value: 0
+    description: "Complimentary access to Delta Sky Clubs when flying Delta"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "Companion Certificate"
+    value: 0
+    description: "Annual domestic First Class companion certificate after spending $30,000 in a year"
+    frequency: "annual"
+    category: "travel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "TakeOff 15"
+    value: 0
+    description: "15% off Delta award flights when booking through delta.com or the Fly Delta app"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - airline
   - travel

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -6,6 +6,12 @@ accepting_applications: true
 category: "rewards"
 annual_fee: 149
 reward_type: "cashback"
+benefits:
+  - name: "Annual Disney Statement Credit"
+    value: 50
+    description: "Annual statement credit for Disney purchases"
+    frequency: "annual"
+    category: "entertainment"
 tags:
   - rewards
   - shopping

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -34,6 +34,38 @@ apr:
   regular:
     min: 19.49
     max: 28.49
+benefits:
+  - name: "Free Night Award"
+    value: 0
+    description: "1 complimentary night annually at most Hilton hotels and resorts worldwide"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Hilton Resort Credit"
+    value: 400
+    description: "$400 annual statement credit for eligible purchases at Hilton resorts"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Airline Fee Credit"
+    value: 200
+    description: "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: true
+  - name: "Diamond Status"
+    value: 0
+    description: "Complimentary Hilton Honors Diamond status with room upgrades, executive lounge access, and late checkout"
+    frequency: "ongoing"
+    category: "hotel"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "Diamond Property Credit"
+    value: 0
+    description: "$100 credit on stays of 2+ nights at Hilton properties when you have Diamond status"
+    frequency: "ongoing"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -41,6 +41,22 @@ apr:
   regular:
     min: 17.49
     max: 27.49
+benefits:
+  - name: "Free Night Award"
+    value: 0
+    description: "1 complimentary night annually at most Hilton hotels and resorts worldwide"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Gold Status"
+    value: 0
+    description: "Complimentary Hilton Honors Gold status with room upgrades, late checkout, and 5th night free on reward stays"
+    frequency: "ongoing"
+    category: "hotel"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Complimentary Priority Pass Select membership after spending $15,000 in a calendar year"
+    frequency: "ongoing"
+    category: "lounge"
 tags:
   - hotel
   - travel

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -35,6 +35,12 @@ apr:
   regular:
     min: 19.49
     max: 28.49
+benefits:
+  - name: "Silver Status"
+    value: 0
+    description: "Complimentary Hilton Honors Silver status with 5th night free on reward stays"
+    frequency: "ongoing"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -5,6 +5,27 @@ accepting_applications: true
 image: "chase-ihg-one-rewards-premier.png"
 annual_fee: 99
 reward_type: "points"
+benefits:
+  - name: "Free Night Award"
+    value: 0
+    description: "One annual free night award at any IHG hotel"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "4th Reward Night Free"
+    value: 0
+    description: "4th night free on IHG reward night stays"
+    frequency: "ongoing"
+    category: "hotel"
+  - name: "Platinum Elite Status"
+    value: 0
+    description: "Automatic IHG One Rewards Platinum Elite status"
+    frequency: "ongoing"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -5,6 +5,17 @@ image: "chase-marriott-bonvoy-bold.png"
 accepting_applications: true
 annual_fee: 0
 reward_type: "points"
+benefits:
+  - name: "Silver Elite Status"
+    value: 0
+    description: "Automatic Marriott Bonvoy Silver Elite status"
+    frequency: "ongoing"
+    category: "hotel"
+  - name: "15 Elite Night Credits"
+    value: 0
+    description: "15 elite night credits toward Marriott Bonvoy status each year"
+    frequency: "annual"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -5,6 +5,22 @@ image: "marriott_bonvoy_boundless.png"
 accepting_applications: true
 annual_fee: 95
 reward_type: "points"
+benefits:
+  - name: "Free Night Award"
+    value: 0
+    description: "One annual free night award up to 35,000 points value"
+    frequency: "annual"
+    category: "hotel"
+  - name: "15 Elite Night Credits"
+    value: 0
+    description: "15 elite night credits toward Marriott Bonvoy status each year"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Silver Elite Status"
+    value: 0
+    description: "Automatic Marriott Bonvoy Silver Elite status"
+    frequency: "ongoing"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -30,6 +30,42 @@ apr:
   regular:
     min: 19.49
     max: 28.49
+benefits:
+  - name: "Free Night Award"
+    value: 0
+    description: "1 annual free night award at Marriott properties valued up to 85,000 points"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Dining Credit"
+    value: 300
+    description: "$25/month in statement credits at restaurants worldwide"
+    frequency: "monthly"
+    category: "dining"
+  - name: "Marriott Property Credit"
+    value: 100
+    description: "$100 statement credit for stays of 2+ consecutive nights at Marriott Bonvoy properties"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Platinum Elite Status"
+    value: 0
+    description: "Complimentary Marriott Bonvoy Platinum Elite status with room upgrades, late checkout, and lounge access"
+    frequency: "ongoing"
+    category: "hotel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "25 Elite Night Credits"
+    value: 0
+    description: "25 Elite Night Credits annually toward Marriott Bonvoy elite status qualification"
+    frequency: "annual"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/robinhood-gold-card.yaml
+++ b/data/cards/robinhood-gold-card.yaml
@@ -5,6 +5,22 @@ accepting_applications: true
 image: "robinhood-gold-card.png"
 release_date: "2024-03-26"
 annual_fee: 0
+benefits:
+  - name: "Travel Insurance"
+    value: 0
+    description: "Trip cancellation, trip delay, and lost luggage protection"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "Cell Phone Protection"
+    value: 0
+    description: "Cell phone damage and theft protection when you pay your bill with the card"
+    frequency: "ongoing"
+    category: "other"
+  - name: "No Foreign Transaction Fees"
+    value: 0
+    description: "No foreign transaction fees on purchases made abroad"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - cashback
   - rewards

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -6,6 +6,22 @@ image: "robinhood-platinum.png"
 release_date: "2026-03-05"
 category: "travel"
 annual_fee: 695
+benefits:
+  - name: "Airport Lounge Access"
+    value: 0
+    description: "Complimentary airport lounge access"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "Concierge Service"
+    value: 0
+    description: "24/7 premium concierge service"
+    frequency: "ongoing"
+    category: "other"
 tags:
   - premium
   - travel

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -30,6 +30,12 @@ apr:
   regular:
     min: 19.24
     max: 27.74
+benefits:
+  - name: "6,000 Anniversary Points"
+    value: 0
+    description: "6,000 bonus points on card anniversary each year"
+    frequency: "annual"
+    category: "travel"
 tags:
   - airline
   - travel

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -28,6 +28,22 @@ apr:
   regular:
     min: 19.24
     max: 27.74
+benefits:
+  - name: "Annual Travel Credit"
+    value: 75
+    description: "Statement credit for Southwest Airlines purchases"
+    frequency: "annual"
+    category: "travel"
+  - name: "7,500 Anniversary Points"
+    value: 0
+    description: "7,500 bonus points on card anniversary each year"
+    frequency: "annual"
+    category: "travel"
+  - name: "4 Upgraded Boardings"
+    value: 0
+    description: "4 upgraded boardings per year when available"
+    frequency: "annual"
+    category: "travel"
 tags:
   - airline
   - travel

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -24,6 +24,52 @@ signup_bonus:
   type: points
   spend_requirement: 20000
   timeframe_months: 3
+benefits:
+  - name: "Airline Fee Credit"
+    value: 200
+    description: "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: true
+  - name: "Dell Technologies Credit"
+    value: 400
+    description: "$200 semiannually in statement credits for purchases at Dell Technologies"
+    frequency: "semi_annual"
+    category: "shopping"
+    enrollment_required: true
+  - name: "Indeed Credit"
+    value: 360
+    description: "$90 per quarter in statement credits for Indeed job postings and sponsored jobs"
+    frequency: "annual"
+    category: "other"
+    enrollment_required: true
+  - name: "Adobe Creative Cloud Credit"
+    value: 150
+    description: "Annual statement credit for Adobe Creative Cloud subscriptions"
+    frequency: "annual"
+    category: "streaming"
+    enrollment_required: true
+  - name: "Wireless Telephone Credit"
+    value: 120
+    description: "$10/month in statement credits toward wireless telephone services purchased directly from U.S. providers"
+    frequency: "monthly"
+    category: "other"
+    enrollment_required: true
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "Centurion Lounge Access"
+    value: 0
+    description: "Complimentary access to The Centurion Lounge network at major airports worldwide"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass"
+    frequency: "ongoing"
+    category: "lounge"
 tags:
   - business
   - travel

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -23,6 +23,97 @@ signup_bonus:
   type: points
   spend_requirement: 12000
   timeframe_months: 6
+benefits:
+  - name: "Uber Cash"
+    value: 200
+    description: "$15/month in Uber Cash for Uber Eats or rides ($20 in December)"
+    frequency: "monthly"
+    category: "dining_travel"
+    enrollment_required: true
+  - name: "Airline Fee Credit"
+    value: 200
+    description: "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: true
+  - name: "Hotel Credit"
+    value: 200
+    description: "Statement credits on prepaid Fine Hotels + Resorts or The Hotel Collection bookings through Amex Travel"
+    frequency: "annual"
+    category: "hotel"
+    enrollment_required: false
+  - name: "Digital Entertainment Credit"
+    value: 240
+    description: "$20/month toward select streaming subscriptions: Disney Bundle, Peacock, NYT, Audible, SiriusXM"
+    frequency: "monthly"
+    category: "streaming"
+    enrollment_required: true
+  - name: "CLEAR Plus Credit"
+    value: 189
+    description: "Statement credit for CLEAR Plus airport security membership"
+    frequency: "annual"
+    category: "security"
+    enrollment_required: true
+  - name: "Walmart+ Credit"
+    value: 155
+    description: "Monthly credit covering Walmart+ membership ($12.95/month)"
+    frequency: "monthly"
+    category: "shopping"
+    enrollment_required: true
+  - name: "Saks Fifth Avenue Credit"
+    value: 100
+    description: "$50 semiannually (Jan–Jun and Jul–Dec) at Saks Fifth Avenue"
+    frequency: "semi_annual"
+    category: "shopping"
+    enrollment_required: true
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "travel"
+    enrollment_required: false
+  - name: "Equinox Credit"
+    value: 300
+    description: "$25/month toward an Equinox gym membership"
+    frequency: "monthly"
+    category: "fitness"
+    enrollment_required: true
+  - name: "Lululemon Credit"
+    value: 300
+    description: "$75 per quarter toward purchases at Lululemon"
+    frequency: "quarterly"
+    category: "shopping"
+    enrollment_required: true
+  - name: "Global Dining Access by Resy"
+    value: 0
+    description: "Priority reservations and special access at select restaurants nationwide"
+    frequency: "ongoing"
+    category: "dining"
+    enrollment_required: false
+  - name: "Centurion Lounge Access"
+    value: 0
+    description: "Complimentary access to The Centurion Lounge network at major airports worldwide"
+    frequency: "ongoing"
+    category: "lounge"
+    enrollment_required: false
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass"
+    frequency: "ongoing"
+    category: "lounge"
+    enrollment_required: false
+  - name: "Fine Hotels + Resorts"
+    value: 0
+    description: "Room upgrade on arrival, daily breakfast for two, $100 experience credit, guaranteed 4pm late checkout"
+    frequency: "ongoing"
+    category: "hotel"
+    enrollment_required: false
+  - name: "The Hotel Collection"
+    value: 0
+    description: "$100 hotel credit when booking 2+ consecutive nights at The Hotel Collection properties"
+    frequency: "ongoing"
+    category: "hotel"
+    enrollment_required: false
 tags:
   - travel
   - premium

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -28,6 +28,27 @@ apr:
   regular:
     min: 19.74
     max: 28.24
+benefits:
+  - name: "United Club Membership"
+    value: 0
+    description: "Full United Club lounge membership for cardholder"
+    frequency: "ongoing"
+    category: "lounge"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "2 Free Checked Bags"
+    value: 0
+    description: "First and second checked bags free on United flights"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "Premier Access"
+    value: 0
+    description: "Priority check-in, security, boarding, and baggage handling on United"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - airline
   - travel

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -28,6 +28,27 @@ apr:
   regular:
     min: 19.74
     max: 28.24
+benefits:
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "First Checked Bag Free"
+    value: 0
+    description: "First checked bag free on United flights"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "2 United Club One-Time Passes"
+    value: 0
+    description: "Two complimentary United Club lounge passes per year"
+    frequency: "annual"
+    category: "lounge"
+  - name: "Priority Boarding"
+    value: 0
+    description: "Priority boarding on United flights"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - airline
   - travel

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -36,6 +36,22 @@ apr:
   regular:
     min: 21.24
     max: 28.24
+benefits:
+  - name: "Annual United Travel Credit"
+    value: 125
+    description: "Statement credit for United Airlines purchases"
+    frequency: "annual"
+    category: "travel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "2 Free Checked Bags"
+    value: 0
+    description: "First and second checked bags free on United flights"
+    frequency: "ongoing"
+    category: "travel"
 tags:
   - airline
   - travel

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -6,6 +6,22 @@ accepting_applications: true
 category: "travel"
 annual_fee: 0
 reward_type: "points"
+benefits:
+  - name: "Annual Streaming Credit"
+    value: 30
+    description: "Annual credit for eligible streaming service purchases"
+    frequency: "annual"
+    category: "streaming"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "4th Night Free"
+    value: 0
+    description: "4th night free on hotel bookings redeemed through Real-Time Rewards"
+    frequency: "ongoing"
+    category: "hotel"
 tags:
   - travel
   - rewards

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -6,3 +6,19 @@ category: "travel"
 image: "us-bank-altitude-reserve.png"
 annual_fee: 400
 reward_type: "points"
+benefits:
+  - name: "Annual Travel Credit"
+    value: 325
+    description: "Credit for travel purchases made with a mobile wallet"
+    frequency: "annual"
+    category: "travel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    frequency: "multi_year"
+    category: "security"
+  - name: "Priority Pass Select"
+    value: 0
+    description: "Unlimited Priority Pass lounge access"
+    frequency: "ongoing"
+    category: "lounge"

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -6,6 +6,17 @@ image: "wells-fargo-autograph-journey.png"
 category: "travel"
 annual_fee: 95
 reward_type: "points"
+benefits:
+  - name: "Annual Airline Credit"
+    value: 100
+    description: "Annual credit for airline purchases"
+    frequency: "annual"
+    category: "travel"
+  - name: "Cell Phone Protection"
+    value: 0
+    description: "Up to $800 per claim for cell phone damage or theft when you pay your bill with the card"
+    frequency: "ongoing"
+    category: "other"
 tags:
   - travel
   - rewards

--- a/data/cards/wells-fargo-autograph.yaml
+++ b/data/cards/wells-fargo-autograph.yaml
@@ -5,6 +5,12 @@ image: "wells_fargo_autograph.png"
 accepting_applications: true
 category: "rewards"
 annual_fee: 0
+benefits:
+  - name: "Cell Phone Protection"
+    value: 0
+    description: "Up to $600 per claim for cell phone damage or theft when you pay your bill with the card"
+    frequency: "ongoing"
+    category: "other"
 tags:
   - travel
   - dining

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -6,6 +6,22 @@ image: "chase-world-of-hyatt-business.png"
 category: "business"
 annual_fee: 199
 reward_type: "points"
+benefits:
+  - name: "Free Night Award"
+    value: 0
+    description: "One annual free night award at any Category 1-4 Hyatt hotel"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Discoverist Status"
+    value: 0
+    description: "Automatic World of Hyatt Discoverist elite status"
+    frequency: "ongoing"
+    category: "hotel"
+  - name: "5 Qualifying Night Credits"
+    value: 0
+    description: "5 qualifying night credits toward Hyatt elite status each year"
+    frequency: "annual"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -5,6 +5,22 @@ accepting_applications: true
 image: "chase-world-of-hyatt.png"
 annual_fee: 95
 reward_type: "points"
+benefits:
+  - name: "Free Night Award"
+    value: 0
+    description: "One annual free night award at any Category 1-4 Hyatt hotel"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Discoverist Status"
+    value: 0
+    description: "Automatic World of Hyatt Discoverist elite status"
+    frequency: "ongoing"
+    category: "hotel"
+  - name: "5 Qualifying Night Credits"
+    value: 0
+    description: "5 qualifying night credits toward Hyatt elite status each year"
+    frequency: "annual"
+    category: "hotel"
 tags:
   - hotel
   - travel


### PR DESCRIPTION
## Summary
- New "Credits & Perks" section on card detail pages showing statement credits, lounge access, hotel status, and other benefits
- Displays total annual credit value prominently, with individual benefit cards showing value, frequency, and enrollment status
- Non-monetary perks (lounge access, elite status, etc.) shown in a separate "Additional Perks" subsection
- Benefits data added for 45 cards across Amex, Chase, Capital One, Citi, US Bank, Bank of America, Wells Fargo, Bilt, and Robinhood
- Data model designed with `frequency` field (monthly, quarterly, semi_annual, annual, multi_year, ongoing) to support a future reminder system

## Test plan
- [ ] Verify benefits section renders on cards with benefits (e.g. `/card/the-platinum-card`, `/card/chase-sapphire-reserve`)
- [ ] Verify benefits section does NOT render on cards without benefits (e.g. `/card/chase-freedom-flex`)
- [ ] Verify total annual credits sum is correct
- [ ] Verify category icons are appropriate (no plane emoji for hotels)
- [ ] Verify `npm run build:cards` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)