### PR TITLE
Refresh card benefits and perks data

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-26T04:59:19.224Z",
+  "generated_at": "2026-03-26T05:11:11.126Z",
   "count": 155,
   "categories": [
     {
@@ -372,11 +372,20 @@
       },
       "benefits": [
         {
-          "name": "Flexible Business Credit",
-          "value": 150,
-          "description": "Choose 2 categories from Indeed, Adobe, FedEx, Grubhub, wireless providers, and transit for annual statement credits",
-          "frequency": "annual",
-          "category": "other"
+          "name": "Business Statement Credits",
+          "value": 240,
+          "description": "Up to $20/month in statement credits on eligible U.S. purchases at FedEx, Grubhub, and office supply stores",
+          "frequency": "monthly",
+          "category": "other",
+          "enrollment_required": true
+        },
+        {
+          "name": "Walmart+ Credit",
+          "value": 155,
+          "description": "Up to $12.95/month plus applicable taxes toward one monthly Walmart+ membership",
+          "frequency": "monthly",
+          "category": "shopping",
+          "enrollment_required": true
         }
       ],
       "tags": [
@@ -407,8 +416,24 @@
         {
           "name": "Dining Credit",
           "value": 120,
-          "description": "$10/month in statement credits at Grubhub, The Cheesecake Factory, Goldbelly, Wine.com, Milk Bar, and select Shake Shack locations",
+          "description": "$10/month in statement credits at Grubhub, The Cheesecake Factory, Goldbelly, Wine.com, and Five Guys",
           "frequency": "monthly",
+          "category": "dining",
+          "enrollment_required": true
+        },
+        {
+          "name": "Dunkin' Credit",
+          "value": 84,
+          "description": "Up to $7/month in statement credits on eligible purchases at U.S. Dunkin' locations",
+          "frequency": "monthly",
+          "category": "dining",
+          "enrollment_required": true
+        },
+        {
+          "name": "Resy Credit",
+          "value": 100,
+          "description": "Up to $50 semiannually at U.S. Resy restaurants and other eligible Resy purchases",
+          "frequency": "semi_annual",
           "category": "dining",
           "enrollment_required": true
         }
@@ -490,18 +515,11 @@
       "benefits": [
         {
           "name": "CLEAR Plus Credit",
-          "value": 189,
+          "value": 209,
           "description": "Statement credit for CLEAR Plus airport security membership",
           "frequency": "annual",
           "category": "security",
           "enrollment_required": true
-        },
-        {
-          "name": "LoungeBuddy Credit",
-          "value": 100,
-          "description": "$100 annual credit for airport lounge access through LoungeBuddy",
-          "frequency": "annual",
-          "category": "lounge"
         }
       ],
       "tags": [
@@ -854,9 +872,16 @@
       "reward_type": "points",
       "benefits": [
         {
-          "name": "Global Entry / TSA PreCheck Credit",
+          "name": "Airline Incidental Credit",
           "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "description": "Annual statement credit for qualifying airline incidentals like seat upgrades, baggage fees, and in-flight services",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Global Entry / TSA PreCheck Credit",
+          "value": 120,
+          "description": "Up to $120 statement credit for Global Entry or TSA PreCheck application fee",
           "frequency": "multi_year",
           "category": "security"
         }
@@ -917,7 +942,7 @@
         },
         {
           "name": "Airline Incidental Credit",
-          "value": 100,
+          "value": 300,
           "description": "Annual credit for airline incidental fees like baggage and seat upgrades",
           "frequency": "annual",
           "category": "travel",
@@ -925,15 +950,15 @@
         },
         {
           "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "value": 120,
+          "description": "Up to $120 statement credit for Global Entry or TSA PreCheck application fee",
           "frequency": "multi_year",
           "category": "security"
         },
         {
           "name": "Priority Pass Select",
           "value": 0,
-          "description": "Unlimited Priority Pass lounge access",
+          "description": "Priority Pass Select memberships for the primary cardholder and up to three authorized users",
           "frequency": "ongoing",
           "category": "lounge"
         }
@@ -1860,8 +1885,8 @@
       "benefits": [
         {
           "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "value": 120,
+          "description": "Up to $120 statement credit for Global Entry or TSA PreCheck application fee",
           "frequency": "multi_year",
           "category": "security"
         }
@@ -1930,14 +1955,14 @@
         {
           "name": "Priority Pass Select",
           "value": 0,
-          "description": "Unlimited Priority Pass lounge access for cardholder and 2 guests",
+          "description": "Complimentary Priority Pass Select membership with access to 1,300+ lounges worldwide",
           "frequency": "ongoing",
           "category": "lounge"
         },
         {
           "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "value": 120,
+          "description": "Up to $120 statement credit for Global Entry or TSA PreCheck application fee",
           "frequency": "multi_year",
           "category": "security"
         },
@@ -2218,13 +2243,6 @@
           "category": "hotel"
         },
         {
-          "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
-          "frequency": "multi_year",
-          "category": "security"
-        },
-        {
           "name": "DoorDash DashPass",
           "value": 0,
           "description": "Complimentary DoorDash DashPass membership",
@@ -2302,39 +2320,39 @@
           "category": "travel"
         },
         {
+          "name": "The Edit Credit",
+          "value": 500,
+          "description": "Up to $250 biannually for prepaid bookings made through The Edit by Chase Travel",
+          "frequency": "semi_annual",
+          "category": "hotel"
+        },
+        {
           "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "value": 120,
+          "description": "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees",
           "frequency": "multi_year",
           "category": "security"
         },
         {
-          "name": "Priority Pass Select",
+          "name": "Sapphire Lounge by The Club Access",
           "value": 0,
-          "description": "Complimentary Priority Pass Select lounge membership",
+          "description": "Access to Chase Sapphire Lounge by The Club with up to two complimentary guests",
           "frequency": "ongoing",
           "category": "lounge"
         },
         {
-          "name": "DoorDash DashPass",
+          "name": "Priority Pass Select",
           "value": 0,
-          "description": "Complimentary DashPass membership and delivery credits",
+          "description": "Priority Pass Select membership with access to 1,300+ lounges worldwide",
           "frequency": "ongoing",
-          "category": "dining"
+          "category": "lounge"
         },
         {
-          "name": "Lyft Pink",
+          "name": "Air Canada Lounge Access",
           "value": 0,
-          "description": "Complimentary Lyft Pink membership",
+          "description": "Eligible boarding pass holders also get access to select Air Canada Maple Leaf Lounges and Cafes",
           "frequency": "ongoing",
-          "category": "rideshare"
-        },
-        {
-          "name": "Instacart+",
-          "value": 0,
-          "description": "Complimentary Instacart+ membership",
-          "frequency": "ongoing",
-          "category": "grocery"
+          "category": "lounge"
         }
       ],
       "tags": [
@@ -3008,16 +3026,9 @@
         {
           "name": "Annual Hotel Credit",
           "value": 100,
-          "description": "Credit for hotel bookings through the ThankYou Rewards portal",
+          "description": "$100 off a single hotel stay of $500 or more booked through Citi Travel once per calendar year",
           "frequency": "annual",
           "category": "hotel"
-        },
-        {
-          "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
-          "frequency": "multi_year",
-          "category": "security"
         }
       ],
       "tags": [
@@ -4241,16 +4252,24 @@
         {
           "name": "Hilton Resort Credit",
           "value": 400,
-          "description": "$400 annual statement credit for eligible purchases at Hilton resorts",
-          "frequency": "annual",
+          "description": "Up to $200 semiannually for eligible purchases at participating Hilton resorts",
+          "frequency": "semi_annual",
           "category": "hotel"
         },
         {
-          "name": "Airline Fee Credit",
+          "name": "Flight Credit",
           "value": 200,
-          "description": "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades",
-          "frequency": "annual",
+          "description": "Up to $50 per quarter on eligible flight purchases made directly with airlines or through amextravel.com",
+          "frequency": "quarterly",
           "category": "travel",
+          "enrollment_required": true
+        },
+        {
+          "name": "CLEAR Plus Credit",
+          "value": 209,
+          "description": "Statement credit for CLEAR Plus airport security membership",
+          "frequency": "annual",
+          "category": "security",
           "enrollment_required": true
         },
         {
@@ -4261,17 +4280,10 @@
           "category": "hotel"
         },
         {
-          "name": "Priority Pass Select",
+          "name": "Additional Free Night Awards",
           "value": 0,
-          "description": "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass",
-          "frequency": "ongoing",
-          "category": "lounge"
-        },
-        {
-          "name": "Diamond Property Credit",
-          "value": 0,
-          "description": "$100 credit on stays of 2+ nights at Hilton properties when you have Diamond status",
-          "frequency": "ongoing",
+          "description": "Earn another Free Night Reward after $30,000 in purchases and one more after $60,000 in a calendar year",
+          "frequency": "annual",
           "category": "hotel"
         }
       ],
@@ -4346,9 +4358,16 @@
       },
       "benefits": [
         {
+          "name": "Hilton Credit",
+          "value": 200,
+          "description": "Up to $50 per quarter on eligible purchases made directly with Hilton portfolio properties",
+          "frequency": "quarterly",
+          "category": "hotel"
+        },
+        {
           "name": "Free Night Award",
           "value": 0,
-          "description": "1 complimentary night annually at most Hilton hotels and resorts worldwide",
+          "description": "Earn a Free Night Reward after $15,000 in purchases in a calendar year",
           "frequency": "annual",
           "category": "hotel"
         },
@@ -4360,11 +4379,11 @@
           "category": "hotel"
         },
         {
-          "name": "Priority Pass Select",
+          "name": "Diamond Status Through Spend",
           "value": 0,
-          "description": "Complimentary Priority Pass Select membership after spending $15,000 in a calendar year",
+          "description": "Upgrade to Hilton Honors Diamond status through the end of the next calendar year after $40,000 in annual purchases",
           "frequency": "ongoing",
-          "category": "lounge"
+          "category": "hotel"
         }
       ],
       "tags": [
@@ -4443,16 +4462,9 @@
         {
           "name": "Free Night Award",
           "value": 0,
-          "description": "One annual free night award at any IHG hotel",
+          "description": "One anniversary free night valid at properties costing up to 40,000 points, with option to top off using points",
           "frequency": "annual",
           "category": "hotel"
-        },
-        {
-          "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
-          "frequency": "multi_year",
-          "category": "security"
         },
         {
           "name": "4th Reward Night Free",
@@ -4466,6 +4478,13 @@
           "value": 0,
           "description": "Automatic IHG One Rewards Platinum Elite status",
           "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "Anniversary Bonus Points",
+          "value": 0,
+          "description": "10,000 bonus points and a $100 statement credit after $20,000 in annual purchases",
+          "frequency": "annual",
           "category": "hotel"
         }
       ],
@@ -4529,7 +4548,7 @@
         {
           "name": "Free Night Award",
           "value": 0,
-          "description": "One annual free night award at any IHG hotel",
+          "description": "One anniversary free night valid at properties costing up to 40,000 points, with option to top off using points",
           "frequency": "annual",
           "category": "hotel"
         },
@@ -4545,6 +4564,13 @@
           "value": 0,
           "description": "Automatic IHG One Rewards Platinum Elite status",
           "frequency": "ongoing",
+          "category": "hotel"
+        },
+        {
+          "name": "Anniversary Bonus Points",
+          "value": 0,
+          "description": "10,000 bonus points and a $100 statement credit after $20,000 in annual purchases",
+          "frequency": "annual",
           "category": "hotel"
         }
       ],
@@ -4970,9 +4996,9 @@
           "category": "hotel"
         },
         {
-          "name": "15 Elite Night Credits",
+          "name": "5 Elite Night Credits",
           "value": 0,
-          "description": "15 elite night credits toward Marriott Bonvoy status each year",
+          "description": "5 elite night credits toward Marriott Bonvoy status each year",
           "frequency": "annual",
           "category": "hotel"
         }
@@ -5464,25 +5490,60 @@
       "annual_fee": 695,
       "benefits": [
         {
-          "name": "Airport Lounge Access",
+          "name": "Priority Pass Lounge Access",
           "value": 0,
-          "description": "Complimentary airport lounge access",
+          "description": "Unlimited Priority Pass airport lounge access",
           "frequency": "ongoing",
           "category": "lounge"
         },
         {
-          "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
-          "frequency": "multi_year",
-          "category": "security"
-        },
-        {
-          "name": "Concierge Service",
+          "name": "Robinhood Gold Membership",
           "value": 0,
-          "description": "24/7 premium concierge service",
+          "description": "Complimentary Robinhood Gold membership included with the card",
           "frequency": "ongoing",
           "category": "other"
+        },
+        {
+          "name": "DoorDash Credit",
+          "value": 250,
+          "description": "$250 annual DoorDash credit plus complimentary DashPass membership",
+          "frequency": "annual",
+          "category": "dining"
+        },
+        {
+          "name": "Autonomous Ride Credit",
+          "value": 250,
+          "description": "$250 annual credit for eligible autonomous ride purchases",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Health Wearable Credit",
+          "value": 200,
+          "description": "$200 annual credit toward eligible health wearable purchases",
+          "frequency": "annual",
+          "category": "fitness"
+        },
+        {
+          "name": "One Medical Membership",
+          "value": 0,
+          "description": "Complimentary Amazon One Medical membership",
+          "frequency": "ongoing",
+          "category": "other"
+        },
+        {
+          "name": "Function Health Membership",
+          "value": 0,
+          "description": "Complimentary Function Health membership",
+          "frequency": "ongoing",
+          "category": "fitness"
+        },
+        {
+          "name": "Oura Membership",
+          "value": 0,
+          "description": "Complimentary Oura membership",
+          "frequency": "ongoing",
+          "category": "fitness"
         }
       ],
       "tags": [
@@ -5815,24 +5876,32 @@
         },
         {
           "name": "Dell Technologies Credit",
-          "value": 400,
-          "description": "$200 semiannually in statement credits for purchases at Dell Technologies",
-          "frequency": "semi_annual",
+          "value": 1150,
+          "description": "Up to $150 back on U.S. Dell purchases, plus another $1,000 after $5,000 in annual Dell spend",
+          "frequency": "annual",
           "category": "shopping",
+          "enrollment_required": true
+        },
+        {
+          "name": "Hilton for Business Credit",
+          "value": 200,
+          "description": "Up to $50 per quarter on eligible purchases made directly with Hilton portfolio properties",
+          "frequency": "quarterly",
+          "category": "hotel",
           "enrollment_required": true
         },
         {
           "name": "Indeed Credit",
           "value": 360,
           "description": "$90 per quarter in statement credits for Indeed job postings and sponsored jobs",
-          "frequency": "annual",
+          "frequency": "quarterly",
           "category": "other",
           "enrollment_required": true
         },
         {
-          "name": "Adobe Creative Cloud Credit",
-          "value": 150,
-          "description": "Annual statement credit for Adobe Creative Cloud subscriptions",
+          "name": "Adobe Creative Solutions Credit",
+          "value": 250,
+          "description": "$250 statement credit after $600 or more in annual U.S. purchases made directly with Adobe",
           "frequency": "annual",
           "category": "streaming",
           "enrollment_required": true
@@ -5847,10 +5916,18 @@
         },
         {
           "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
+          "value": 120,
+          "description": "Up to $120 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
           "frequency": "multi_year",
           "category": "security"
+        },
+        {
+          "name": "CLEAR Plus Credit",
+          "value": 209,
+          "description": "Statement credit for CLEAR Plus airport security membership",
+          "frequency": "annual",
+          "category": "security",
+          "enrollment_required": true
         },
         {
           "name": "Centurion Lounge Access",
@@ -5935,6 +6012,14 @@
           "enrollment_required": false
         },
         {
+          "name": "Uber One Credit",
+          "value": 120,
+          "description": "Up to $10/month back on an auto-renewing Uber One membership",
+          "frequency": "monthly",
+          "category": "rideshare",
+          "enrollment_required": true
+        },
+        {
           "name": "Digital Entertainment Credit",
           "value": 240,
           "description": "$20/month toward select streaming subscriptions: Disney Bundle, Peacock, NYT, Audible, SiriusXM",
@@ -5944,7 +6029,7 @@
         },
         {
           "name": "CLEAR Plus Credit",
-          "value": 189,
+          "value": 209,
           "description": "Statement credit for CLEAR Plus airport security membership",
           "frequency": "annual",
           "category": "security",
@@ -5968,8 +6053,8 @@
         },
         {
           "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
+          "value": 120,
+          "description": "Up to $120 statement credit every 4 years for Global Entry or TSA PreCheck application fee",
           "frequency": "multi_year",
           "category": "travel",
           "enrollment_required": false
@@ -6247,14 +6332,14 @@
         {
           "name": "United Club Membership",
           "value": 0,
-          "description": "Full United Club lounge membership for cardholder",
+          "description": "United Club membership for the primary cardholder, including eligible travel companions",
           "frequency": "ongoing",
           "category": "lounge"
         },
         {
           "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "value": 120,
+          "description": "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees",
           "frequency": "multi_year",
           "category": "security"
         },
@@ -6270,6 +6355,48 @@
           "value": 0,
           "description": "Priority check-in, security, boarding, and baggage handling on United",
           "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "Award Flight Discounts",
+          "value": 0,
+          "description": "Earn a 10,000-mile award flight discount after $20,000 in purchases, up to two times each calendar year",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Renowned Hotels Credit",
+          "value": 200,
+          "description": "Up to $200 each anniversary year on prepaid Renowned Hotels and Resorts for United Cardmembers bookings",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Rideshare Credit",
+          "value": 150,
+          "description": "Up to $12 monthly from January through November and $18 in December after annual opt-in",
+          "frequency": "monthly",
+          "category": "rideshare"
+        },
+        {
+          "name": "Avis / Budget TravelBank Credit",
+          "value": 100,
+          "description": "Up to $100 each anniversary year in United TravelBank cash on Avis or Budget bookings through cars.united.com",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Instacart Credit",
+          "value": 240,
+          "description": "Two $10 Instacart credits each month through 12/31/27",
+          "frequency": "monthly",
+          "category": "grocery"
+        },
+        {
+          "name": "JSX Credit",
+          "value": 200,
+          "description": "Up to $200 each anniversary year on flights purchased directly with JSX",
+          "frequency": "annual",
           "category": "travel"
         }
       ],
@@ -6327,8 +6454,8 @@
       "benefits": [
         {
           "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "value": 120,
+          "description": "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees",
           "frequency": "multi_year",
           "category": "security"
         },
@@ -6351,6 +6478,48 @@
           "value": 0,
           "description": "Priority boarding on United flights",
           "frequency": "ongoing",
+          "category": "travel"
+        },
+        {
+          "name": "Award Flight Discount",
+          "value": 0,
+          "description": "Earn a 10,000-mile award flight discount after $20,000 in annual purchases",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "United Hotels Credit",
+          "value": 100,
+          "description": "Up to $100 each anniversary year on prepaid hotel stays booked directly through United Hotels",
+          "frequency": "annual",
+          "category": "hotel"
+        },
+        {
+          "name": "Rideshare Credit",
+          "value": 60,
+          "description": "Up to $5 back each month on eligible rideshare purchases after annual opt-in",
+          "frequency": "monthly",
+          "category": "rideshare"
+        },
+        {
+          "name": "Avis / Budget TravelBank Credit",
+          "value": 50,
+          "description": "Up to $50 each anniversary year in United TravelBank cash on Avis or Budget bookings through cars.united.com",
+          "frequency": "annual",
+          "category": "travel"
+        },
+        {
+          "name": "Instacart Credit",
+          "value": 120,
+          "description": "$10 monthly Instacart credit through 12/31/27",
+          "frequency": "monthly",
+          "category": "grocery"
+        },
+        {
+          "name": "JSX Credit",
+          "value": 100,
+          "description": "Up to $100 each anniversary year on flights purchased directly with JSX",
+          "frequency": "annual",
           "category": "travel"
         }
       ],
@@ -6529,13 +6698,6 @@
       "reward_type": "points",
       "benefits": [
         {
-          "name": "Annual Streaming Credit",
-          "value": 30,
-          "description": "Annual credit for eligible streaming service purchases",
-          "frequency": "annual",
-          "category": "streaming"
-        },
-        {
           "name": "Global Entry / TSA PreCheck Credit",
           "value": 100,
           "description": "Up to $100 statement credit for Global Entry or TSA PreCheck application fee",
@@ -6543,11 +6705,11 @@
           "category": "security"
         },
         {
-          "name": "4th Night Free",
+          "name": "Airport Lounge Access",
           "value": 0,
-          "description": "4th night free on hotel bookings redeemed through Real-Time Rewards",
+          "description": "Complimentary airport lounge access through the Visa Airport Companion program",
           "frequency": "ongoing",
-          "category": "hotel"
+          "category": "lounge"
         }
       ],
       "tags": [

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -21,11 +21,18 @@ signup_bonus:
   spend_requirement: 15000
   timeframe_months: 3
 benefits:
-  - name: "Flexible Business Credit"
-    value: 150
-    description: "Choose 2 categories from Indeed, Adobe, FedEx, Grubhub, wireless providers, and transit for annual statement credits"
-    frequency: "annual"
+  - name: "Business Statement Credits"
+    value: 240
+    description: "Up to $20/month in statement credits on eligible U.S. purchases at FedEx, Grubhub, and office supply stores"
+    frequency: "monthly"
     category: "other"
+    enrollment_required: true
+  - name: "Walmart+ Credit"
+    value: 155
+    description: "Up to $12.95/month plus applicable taxes toward one monthly Walmart+ membership"
+    frequency: "monthly"
+    category: "shopping"
+    enrollment_required: true
 tags:
   - business
   - rewards

--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -14,8 +14,20 @@ benefits:
     enrollment_required: true
   - name: "Dining Credit"
     value: 120
-    description: "$10/month in statement credits at Grubhub, The Cheesecake Factory, Goldbelly, Wine.com, Milk Bar, and select Shake Shack locations"
+    description: "$10/month in statement credits at Grubhub, The Cheesecake Factory, Goldbelly, Wine.com, and Five Guys"
     frequency: "monthly"
+    category: "dining"
+    enrollment_required: true
+  - name: "Dunkin' Credit"
+    value: 84
+    description: "Up to $7/month in statement credits on eligible purchases at U.S. Dunkin' locations"
+    frequency: "monthly"
+    category: "dining"
+    enrollment_required: true
+  - name: "Resy Credit"
+    value: 100
+    description: "Up to $50 semiannually at U.S. Resy restaurants and other eligible Resy purchases"
+    frequency: "semi_annual"
     category: "dining"
     enrollment_required: true
 tags:

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -25,16 +25,11 @@ signup_bonus:
   timeframe_months: 6
 benefits:
   - name: "CLEAR Plus Credit"
-    value: 189
+    value: 209
     description: "Statement credit for CLEAR Plus airport security membership"
     frequency: "annual"
     category: "security"
     enrollment_required: true
-  - name: "LoungeBuddy Credit"
-    value: 100
-    description: "$100 annual credit for airport lounge access through LoungeBuddy"
-    frequency: "annual"
-    category: "lounge"
 tags:
   - travel
   - dining

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -14,19 +14,19 @@ benefits:
     category: "other"
     enrollment_required: true
   - name: "Airline Incidental Credit"
-    value: 100
+    value: 300
     description: "Annual credit for airline incidental fees like baggage and seat upgrades"
     frequency: "annual"
     category: "travel"
     enrollment_required: true
   - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    value: 120
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     category: "security"
   - name: "Priority Pass Select"
     value: 0
-    description: "Unlimited Priority Pass lounge access"
+    description: "Priority Pass Select memberships for the primary cardholder and up to three authorized users"
     frequency: "ongoing"
     category: "lounge"
 tags:

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -7,9 +7,14 @@ category: "travel"
 annual_fee: 95
 reward_type: "points"
 benefits:
-  - name: "Global Entry / TSA PreCheck Credit"
+  - name: "Airline Incidental Credit"
     value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    description: "Annual statement credit for qualifying airline incidentals like seat upgrades, baggage fees, and in-flight services"
+    frequency: "annual"
+    category: "travel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 120
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     category: "security"
 tags:

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -8,8 +8,8 @@ annual_fee: 95
 reward_type: "miles"
 benefits:
   - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    value: 120
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     category: "security"
 tags:

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -23,12 +23,12 @@ benefits:
     category: "lounge"
   - name: "Priority Pass Select"
     value: 0
-    description: "Unlimited Priority Pass lounge access for cardholder and 2 guests"
+    description: "Complimentary Priority Pass Select membership with access to 1,300+ lounges worldwide"
     frequency: "ongoing"
     category: "lounge"
   - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    value: 120
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     category: "security"
   - name: "Hertz President's Circle Status"

--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -8,7 +8,7 @@ image: "chase-ihg-one-rewards-premier-business.png"
 benefits:
   - name: "Free Night Award"
     value: 0
-    description: "One annual free night award at any IHG hotel"
+    description: "One anniversary free night valid at properties costing up to 40,000 points, with option to top off using points"
     frequency: "annual"
     category: "hotel"
   - name: "4th Reward Night Free"
@@ -20,6 +20,11 @@ benefits:
     value: 0
     description: "Automatic IHG One Rewards Platinum Elite status"
     frequency: "ongoing"
+    category: "hotel"
+  - name: "Anniversary Bonus Points"
+    value: 0
+    description: "10,000 bonus points and a $100 statement credit after $20,000 in annual purchases"
+    frequency: "annual"
     category: "hotel"
 tags:
   - hotel

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -11,11 +11,6 @@ benefits:
     description: "Statement credit for hotel stays booked through Chase Travel"
     frequency: "annual"
     category: "hotel"
-  - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
-    frequency: "multi_year"
-    category: "security"
   - name: "DoorDash DashPass"
     value: 0
     description: "Complimentary DoorDash DashPass membership"

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -10,31 +10,31 @@ benefits:
     description: "Automatic statement credit for travel purchases"
     frequency: "annual"
     category: "travel"
+  - name: "The Edit Credit"
+    value: 500
+    description: "Up to $250 biannually for prepaid bookings made through The Edit by Chase Travel"
+    frequency: "semi_annual"
+    category: "hotel"
   - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    value: 120
+    description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees"
     frequency: "multi_year"
     category: "security"
-  - name: "Priority Pass Select"
+  - name: "Sapphire Lounge by The Club Access"
     value: 0
-    description: "Complimentary Priority Pass Select lounge membership"
+    description: "Access to Chase Sapphire Lounge by The Club with up to two complimentary guests"
     frequency: "ongoing"
     category: "lounge"
-  - name: "DoorDash DashPass"
+  - name: "Priority Pass Select"
     value: 0
-    description: "Complimentary DashPass membership and delivery credits"
+    description: "Priority Pass Select membership with access to 1,300+ lounges worldwide"
     frequency: "ongoing"
-    category: "dining"
-  - name: "Lyft Pink"
+    category: "lounge"
+  - name: "Air Canada Lounge Access"
     value: 0
-    description: "Complimentary Lyft Pink membership"
+    description: "Eligible boarding pass holders also get access to select Air Canada Maple Leaf Lounges and Cafes"
     frequency: "ongoing"
-    category: "rideshare"
-  - name: "Instacart+"
-    value: 0
-    description: "Complimentary Instacart+ membership"
-    frequency: "ongoing"
-    category: "grocery"
+    category: "lounge"
 tags:
   - travel
   - premium

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -9,14 +9,9 @@ reward_type: "points"
 benefits:
   - name: "Annual Hotel Credit"
     value: 100
-    description: "Credit for hotel bookings through the ThankYou Rewards portal"
+    description: "$100 off a single hotel stay of $500 or more booked through Citi Travel once per calendar year"
     frequency: "annual"
     category: "hotel"
-  - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
-    frequency: "multi_year"
-    category: "security"
 tags:
   - travel
   - rewards

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -42,29 +42,30 @@ benefits:
     category: "hotel"
   - name: "Hilton Resort Credit"
     value: 400
-    description: "$400 annual statement credit for eligible purchases at Hilton resorts"
-    frequency: "annual"
+    description: "Up to $200 semiannually for eligible purchases at participating Hilton resorts"
+    frequency: "semi_annual"
     category: "hotel"
-  - name: "Airline Fee Credit"
+  - name: "Flight Credit"
     value: 200
-    description: "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades"
-    frequency: "annual"
+    description: "Up to $50 per quarter on eligible flight purchases made directly with airlines or through amextravel.com"
+    frequency: "quarterly"
     category: "travel"
+    enrollment_required: true
+  - name: "CLEAR Plus Credit"
+    value: 209
+    description: "Statement credit for CLEAR Plus airport security membership"
+    frequency: "annual"
+    category: "security"
     enrollment_required: true
   - name: "Diamond Status"
     value: 0
     description: "Complimentary Hilton Honors Diamond status with room upgrades, executive lounge access, and late checkout"
     frequency: "ongoing"
     category: "hotel"
-  - name: "Priority Pass Select"
+  - name: "Additional Free Night Awards"
     value: 0
-    description: "Complimentary membership to 1,400+ airport lounges worldwide through Priority Pass"
-    frequency: "ongoing"
-    category: "lounge"
-  - name: "Diamond Property Credit"
-    value: 0
-    description: "$100 credit on stays of 2+ nights at Hilton properties when you have Diamond status"
-    frequency: "ongoing"
+    description: "Earn another Free Night Reward after $30,000 in purchases and one more after $60,000 in a calendar year"
+    frequency: "annual"
     category: "hotel"
 tags:
   - hotel

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -42,9 +42,14 @@ apr:
     min: 17.49
     max: 27.49
 benefits:
+  - name: "Hilton Credit"
+    value: 200
+    description: "Up to $50 per quarter on eligible purchases made directly with Hilton portfolio properties"
+    frequency: "quarterly"
+    category: "hotel"
   - name: "Free Night Award"
     value: 0
-    description: "1 complimentary night annually at most Hilton hotels and resorts worldwide"
+    description: "Earn a Free Night Reward after $15,000 in purchases in a calendar year"
     frequency: "annual"
     category: "hotel"
   - name: "Gold Status"
@@ -52,11 +57,11 @@ benefits:
     description: "Complimentary Hilton Honors Gold status with room upgrades, late checkout, and 5th night free on reward stays"
     frequency: "ongoing"
     category: "hotel"
-  - name: "Priority Pass Select"
+  - name: "Diamond Status Through Spend"
     value: 0
-    description: "Complimentary Priority Pass Select membership after spending $15,000 in a calendar year"
+    description: "Upgrade to Hilton Honors Diamond status through the end of the next calendar year after $40,000 in annual purchases"
     frequency: "ongoing"
-    category: "lounge"
+    category: "hotel"
 tags:
   - hotel
   - travel

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -8,14 +8,9 @@ reward_type: "points"
 benefits:
   - name: "Free Night Award"
     value: 0
-    description: "One annual free night award at any IHG hotel"
+    description: "One anniversary free night valid at properties costing up to 40,000 points, with option to top off using points"
     frequency: "annual"
     category: "hotel"
-  - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
-    frequency: "multi_year"
-    category: "security"
   - name: "4th Reward Night Free"
     value: 0
     description: "4th night free on IHG reward night stays"
@@ -25,6 +20,11 @@ benefits:
     value: 0
     description: "Automatic IHG One Rewards Platinum Elite status"
     frequency: "ongoing"
+    category: "hotel"
+  - name: "Anniversary Bonus Points"
+    value: 0
+    description: "10,000 bonus points and a $100 statement credit after $20,000 in annual purchases"
+    frequency: "annual"
     category: "hotel"
 tags:
   - hotel

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -11,9 +11,9 @@ benefits:
     description: "Automatic Marriott Bonvoy Silver Elite status"
     frequency: "ongoing"
     category: "hotel"
-  - name: "15 Elite Night Credits"
+  - name: "5 Elite Night Credits"
     value: 0
-    description: "15 elite night credits toward Marriott Bonvoy status each year"
+    description: "5 elite night credits toward Marriott Bonvoy status each year"
     frequency: "annual"
     category: "hotel"
 tags:

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -7,21 +7,46 @@ release_date: "2026-03-05"
 category: "travel"
 annual_fee: 695
 benefits:
-  - name: "Airport Lounge Access"
+  - name: "Priority Pass Lounge Access"
     value: 0
-    description: "Complimentary airport lounge access"
+    description: "Unlimited Priority Pass airport lounge access"
     frequency: "ongoing"
     category: "lounge"
-  - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
-    frequency: "multi_year"
-    category: "security"
-  - name: "Concierge Service"
+  - name: "Robinhood Gold Membership"
     value: 0
-    description: "24/7 premium concierge service"
+    description: "Complimentary Robinhood Gold membership included with the card"
     frequency: "ongoing"
     category: "other"
+  - name: "DoorDash Credit"
+    value: 250
+    description: "$250 annual DoorDash credit plus complimentary DashPass membership"
+    frequency: "annual"
+    category: "dining"
+  - name: "Autonomous Ride Credit"
+    value: 250
+    description: "$250 annual credit for eligible autonomous ride purchases"
+    frequency: "annual"
+    category: "travel"
+  - name: "Health Wearable Credit"
+    value: 200
+    description: "$200 annual credit toward eligible health wearable purchases"
+    frequency: "annual"
+    category: "fitness"
+  - name: "One Medical Membership"
+    value: 0
+    description: "Complimentary Amazon One Medical membership"
+    frequency: "ongoing"
+    category: "other"
+  - name: "Function Health Membership"
+    value: 0
+    description: "Complimentary Function Health membership"
+    frequency: "ongoing"
+    category: "fitness"
+  - name: "Oura Membership"
+    value: 0
+    description: "Complimentary Oura membership"
+    frequency: "ongoing"
+    category: "fitness"
 tags:
   - premium
   - travel

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -32,20 +32,26 @@ benefits:
     category: "travel"
     enrollment_required: true
   - name: "Dell Technologies Credit"
-    value: 400
-    description: "$200 semiannually in statement credits for purchases at Dell Technologies"
-    frequency: "semi_annual"
+    value: 1150
+    description: "Up to $150 back on U.S. Dell purchases, plus another $1,000 after $5,000 in annual Dell spend"
+    frequency: "annual"
     category: "shopping"
+    enrollment_required: true
+  - name: "Hilton for Business Credit"
+    value: 200
+    description: "Up to $50 per quarter on eligible purchases made directly with Hilton portfolio properties"
+    frequency: "quarterly"
+    category: "hotel"
     enrollment_required: true
   - name: "Indeed Credit"
     value: 360
     description: "$90 per quarter in statement credits for Indeed job postings and sponsored jobs"
-    frequency: "annual"
+    frequency: "quarterly"
     category: "other"
     enrollment_required: true
-  - name: "Adobe Creative Cloud Credit"
-    value: 150
-    description: "Annual statement credit for Adobe Creative Cloud subscriptions"
+  - name: "Adobe Creative Solutions Credit"
+    value: 250
+    description: "$250 statement credit after $600 or more in annual U.S. purchases made directly with Adobe"
     frequency: "annual"
     category: "streaming"
     enrollment_required: true
@@ -56,10 +62,16 @@ benefits:
     category: "other"
     enrollment_required: true
   - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    value: 120
+    description: "Up to $120 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     category: "security"
+  - name: "CLEAR Plus Credit"
+    value: 209
+    description: "Statement credit for CLEAR Plus airport security membership"
+    frequency: "annual"
+    category: "security"
+    enrollment_required: true
   - name: "Centurion Lounge Access"
     value: 0
     description: "Complimentary access to The Centurion Lounge network at major airports worldwide"

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -42,6 +42,12 @@ benefits:
     frequency: "annual"
     category: "hotel"
     enrollment_required: false
+  - name: "Uber One Credit"
+    value: 120
+    description: "Up to $10/month back on an auto-renewing Uber One membership"
+    frequency: "monthly"
+    category: "rideshare"
+    enrollment_required: true
   - name: "Digital Entertainment Credit"
     value: 240
     description: "$20/month toward select streaming subscriptions: Disney Bundle, Peacock, NYT, Audible, SiriusXM"
@@ -49,7 +55,7 @@ benefits:
     category: "streaming"
     enrollment_required: true
   - name: "CLEAR Plus Credit"
-    value: 189
+    value: 209
     description: "Statement credit for CLEAR Plus airport security membership"
     frequency: "annual"
     category: "security"
@@ -67,8 +73,8 @@ benefits:
     category: "shopping"
     enrollment_required: true
   - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    value: 120
+    description: "Up to $120 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     category: "travel"
     enrollment_required: false

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -31,12 +31,12 @@ apr:
 benefits:
   - name: "United Club Membership"
     value: 0
-    description: "Full United Club lounge membership for cardholder"
+    description: "United Club membership for the primary cardholder, including eligible travel companions"
     frequency: "ongoing"
     category: "lounge"
   - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    value: 120
+    description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees"
     frequency: "multi_year"
     category: "security"
   - name: "2 Free Checked Bags"
@@ -48,6 +48,36 @@ benefits:
     value: 0
     description: "Priority check-in, security, boarding, and baggage handling on United"
     frequency: "ongoing"
+    category: "travel"
+  - name: "Award Flight Discounts"
+    value: 0
+    description: "Earn a 10,000-mile award flight discount after $20,000 in purchases, up to two times each calendar year"
+    frequency: "annual"
+    category: "travel"
+  - name: "Renowned Hotels Credit"
+    value: 200
+    description: "Up to $200 each anniversary year on prepaid Renowned Hotels and Resorts for United Cardmembers bookings"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Rideshare Credit"
+    value: 150
+    description: "Up to $12 monthly from January through November and $18 in December after annual opt-in"
+    frequency: "monthly"
+    category: "rideshare"
+  - name: "Avis / Budget TravelBank Credit"
+    value: 100
+    description: "Up to $100 each anniversary year in United TravelBank cash on Avis or Budget bookings through cars.united.com"
+    frequency: "annual"
+    category: "travel"
+  - name: "Instacart Credit"
+    value: 240
+    description: "Two $10 Instacart credits each month through 12/31/27"
+    frequency: "monthly"
+    category: "grocery"
+  - name: "JSX Credit"
+    value: 200
+    description: "Up to $200 each anniversary year on flights purchased directly with JSX"
+    frequency: "annual"
     category: "travel"
 tags:
   - airline

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -30,8 +30,8 @@ apr:
     max: 28.24
 benefits:
   - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+    value: 120
+    description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees"
     frequency: "multi_year"
     category: "security"
   - name: "First Checked Bag Free"
@@ -48,6 +48,36 @@ benefits:
     value: 0
     description: "Priority boarding on United flights"
     frequency: "ongoing"
+    category: "travel"
+  - name: "Award Flight Discount"
+    value: 0
+    description: "Earn a 10,000-mile award flight discount after $20,000 in annual purchases"
+    frequency: "annual"
+    category: "travel"
+  - name: "United Hotels Credit"
+    value: 100
+    description: "Up to $100 each anniversary year on prepaid hotel stays booked directly through United Hotels"
+    frequency: "annual"
+    category: "hotel"
+  - name: "Rideshare Credit"
+    value: 60
+    description: "Up to $5 back each month on eligible rideshare purchases after annual opt-in"
+    frequency: "monthly"
+    category: "rideshare"
+  - name: "Avis / Budget TravelBank Credit"
+    value: 50
+    description: "Up to $50 each anniversary year in United TravelBank cash on Avis or Budget bookings through cars.united.com"
+    frequency: "annual"
+    category: "travel"
+  - name: "Instacart Credit"
+    value: 120
+    description: "$10 monthly Instacart credit through 12/31/27"
+    frequency: "monthly"
+    category: "grocery"
+  - name: "JSX Credit"
+    value: 100
+    description: "Up to $100 each anniversary year on flights purchased directly with JSX"
+    frequency: "annual"
     category: "travel"
 tags:
   - airline

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -7,21 +7,16 @@ category: "travel"
 annual_fee: 0
 reward_type: "points"
 benefits:
-  - name: "Annual Streaming Credit"
-    value: 30
-    description: "Annual credit for eligible streaming service purchases"
-    frequency: "annual"
-    category: "streaming"
   - name: "Global Entry / TSA PreCheck Credit"
     value: 100
     description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     category: "security"
-  - name: "4th Night Free"
+  - name: "Airport Lounge Access"
     value: 0
-    description: "4th night free on hotel bookings redeemed through Real-Time Rewards"
+    description: "Complimentary airport lounge access through the Visa Airport Companion program"
     frequency: "ongoing"
-    category: "hotel"
+    category: "lounge"
 tags:
   - travel
   - rewards


### PR DESCRIPTION
## Summary
- refresh stale Credits & Perks entries across issuer card YAML files
- regenerate data/cards.json after updating verified benefits
- align newer Amex, Chase, Bank of America, Capital One, Citi, U.S. Bank, and Robinhood perk data

## Testing
- node scripts/build-cards.js