### PR TITLE
Annualize multi-year benefits in total annual credits

### DIFF
--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -40,7 +40,10 @@ interface CardBenefitsProps {
 export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) {
   const credits = benefits.filter((b) => b.value > 0);
   const perks = benefits.filter((b) => b.value === 0);
-  const totalAnnualValue = credits.reduce((sum, b) => sum + b.value, 0);
+  const totalAnnualValue = credits.reduce((sum, b) => {
+    if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
+    return sum + b.value;
+  }, 0);
 
   return (
     <div className="py-12">

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-26T05:11:11.126Z",
+  "generated_at": "2026-03-26T05:26:33.149Z",
   "count": 155,
   "categories": [
     {


### PR DESCRIPTION
## Summary
- Multi-year benefits (e.g. Global Entry $120/4yr) now contribute their annualized value ($30/yr) to the "Total Annual Credits" sum instead of the full amount

## Test plan
- [ ] Verify Chase Sapphire Reserve total no longer inflated by $100 Global Entry
- [ ] Verify Platinum card total reflects ~$30 for Global Entry instead of $120

🤖 Generated with [Claude Code](https://claude.com/claude-code)