### PR TITLE
Update Amex ChatGPT news source to official newsroom

### DIFF
--- a/data/news/2026-03-25-amex-business-platinum-chatgpt-credits.yaml
+++ b/data/news/2026-03-25-amex-business-platinum-chatgpt-credits.yaml
@@ -7,11 +7,11 @@ tags:
 bank: "American Express"
 card_slug: "the-business-platinum-card-from-american-express"
 card_name: "The Business Platinum Card"
-source: "Frequent Miler"
-source_url: "https://frequentmiler.com/amex-adding-300-chatgpt-credits-to-business-platinum-new-corporate-card-coming-too/"
+source: "American Express Newsroom"
+source_url: "https://www.americanexpress.com/en-us/newsroom/articles/amex-for-business/american-express-launches-new-graphite-business-cash-unlimited-c.html"
 body: |
   American Express is adding **$300 in annual ChatGPT credits** to two of its premium business cards, effective **2026**. Cardholders of The Business Platinum Card and American Express Business Gold Card will receive the new benefit as part of Amex's expansion of digital tools for commercial users.
   
   The credits provide business owners with access to ChatGPT's AI-powered capabilities for productivity and operational tasks. This marks Amex's latest move to enhance the value proposition of its business card portfolio amid increasing competition in the premium card segment.
   
-  The benefit rollout follows a broader trend of credit card issuers integrating AI services and digital perks into their offerings. American Express has been steadily expanding ancillary benefits across its business card lineup to justify premium annual fees.
+  The benefit rollout follows a broader trend of credit card issuers integrating AI services and digital perks into their offerings. American Express has been steadily expanding ancillary benefits across its business card lineup to justify premium annual fees. The announcement was part of a broader [Amex newsroom update](https://www.americanexpress.com/en-us/newsroom/articles/amex-for-business/american-express-launches-new-graphite-business-cash-unlimited-c.html) that also introduced the new Graphite Business Cash Unlimited Card.


### PR DESCRIPTION
## Summary
- Changed source from Frequent Miler to the official American Express Newsroom article
- Added reference to the Amex newsroom announcement in the article body, noting it was part of the broader Graphite Business Cash Unlimited Card launch

## Test plan
- [ ] Verify news article renders correctly with updated source link
- [ ] Verify the inline link in the body works

🤖 Generated with [Claude Code](https://claude.com/claude-code)