### PR TITLE
Add ChatGPT credits benefit to Amex Business cards

### DIFF
--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -27,6 +27,12 @@ benefits:
     frequency: "monthly"
     category: "other"
     enrollment_required: true
+  - name: "ChatGPT Credits"
+    value: 300
+    description: "$300 in annual ChatGPT credits for AI-powered productivity tools"
+    frequency: "annual"
+    category: "other"
+    enrollment_required: true
   - name: "Walmart+ Credit"
     value: 155
     description: "Up to $12.95/month plus applicable taxes toward one monthly Walmart+ membership"

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -25,6 +25,12 @@ signup_bonus:
   spend_requirement: 20000
   timeframe_months: 3
 benefits:
+  - name: "ChatGPT Credits"
+    value: 300
+    description: "$300 in annual ChatGPT credits for AI-powered productivity tools"
+    frequency: "annual"
+    category: "other"
+    enrollment_required: true
   - name: "Airline Fee Credit"
     value: 200
     description: "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades"


### PR DESCRIPTION
## Summary
- Added $300 annual ChatGPT credits benefit to American Express Business Gold card
- Added $300 annual ChatGPT credits benefit to The Business Platinum Card

## Test plan
- [ ] Run `npm run build:cards` to verify YAML parses correctly
- [ ] Check card pages display the new benefit

🤖 Generated with [Claude Code](https://claude.com/claude-code)