### PR TITLE
Tag both cards in Amex ChatGPT credits news

### DIFF
--- a/data/news/2026-03-25-amex-business-platinum-chatgpt-credits.yaml
+++ b/data/news/2026-03-25-amex-business-platinum-chatgpt-credits.yaml
@@ -5,8 +5,12 @@ summary: "American Express announced that cardholders of The Business Platinum C
 tags:
   - "benefit-change"
 bank: "American Express"
-card_slug: "the-business-platinum-card-from-american-express"
-card_name: "The Business Platinum Card"
+card_slugs:
+  - "the-business-platinum-card-from-american-express"
+  - "american-express-business-gold-card"
+card_names:
+  - "The Business Platinum Card"
+  - "American Express Business Gold"
 source: "American Express Newsroom"
 source_url: "https://www.americanexpress.com/en-us/newsroom/articles/amex-for-business/american-express-launches-new-graphite-business-cash-unlimited-c.html"
 body: |


### PR DESCRIPTION
## Summary
- Changed from singular `card_slug`/`card_name` to plural `card_slugs`/`card_names` to tag both The Business Platinum Card and American Express Business Gold in the ChatGPT credits news article

## Test plan
- [ ] Verify news article shows links to both card pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)