### PR TITLE
Add benefits row to card compare page

### DIFF
--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -519,6 +519,32 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                       <span className="text-gray-400">{'\u2014'}</span>
                     )}
                   </div>
+
+                  {/* Benefits */}
+                  {card.benefits && card.benefits.length > 0 && (() => {
+                    const credits = card.benefits.filter(b => b.value > 0);
+                    const perks = card.benefits.filter(b => b.value === 0);
+                    const totalAnnual = credits.reduce((sum, b) => {
+                      if (b.frequency === 'multi_year') return sum + Math.round(b.value / 4);
+                      return sum + b.value;
+                    }, 0);
+                    return (
+                      <div className="px-4 py-2.5 text-sm">
+                        <span className="text-gray-500 font-medium block mb-1">Benefits</span>
+                        {totalAnnual > 0 && (
+                          <div className="font-semibold text-emerald-700 mb-1">${totalAnnual}/yr in credits</div>
+                        )}
+                        <div className="text-xs text-gray-500 space-y-0.5">
+                          {credits.map(b => (
+                            <div key={b.name}>{b.name} (${b.value}{b.frequency === 'annual' ? '/yr' : b.frequency === 'monthly' ? '/mo' : b.frequency === 'quarterly' ? '/qtr' : ''})</div>
+                          ))}
+                          {perks.length > 0 && (
+                            <div className="text-gray-400 mt-1">+{perks.length} perk{perks.length !== 1 ? 's' : ''}</div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })()}
                 </div>
               </div>
             );
@@ -781,6 +807,48 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                   </td>
                 ))}
               </tr>
+
+              {/* Benefits */}
+              {activeCards.some(c => c.benefits && c.benefits.length > 0) && (() => {
+                const totalCredits = activeCards.map(c => {
+                  if (!c.benefits) return 0;
+                  return c.benefits.filter(b => b.value > 0).reduce((sum, b) => {
+                    if (b.frequency === 'multi_year') return sum + Math.round(b.value / 4);
+                    return sum + b.value;
+                  }, 0);
+                });
+                const bestSet = getBestIndices(totalCredits.map(v => v || null), 'max');
+                return (
+                  <tr className="bg-gray-50/50">
+                    <td className="sticky left-0 z-10 bg-gray-50/50 px-4 py-3 text-sm font-medium text-gray-500">Benefits</td>
+                    {activeCards.map((card, i) => (
+                      <td key={card.slug} className={`px-4 py-3 text-center text-sm ${bestSet.has(i) && totalCredits[i] > 0 ? 'bg-green-50' : ''}`}>
+                        {card.benefits && card.benefits.length > 0 ? (
+                          <div>
+                            {totalCredits[i] > 0 && (
+                              <div className={`font-semibold mb-1.5 ${bestSet.has(i) ? 'text-green-700' : 'text-gray-900'}`}>
+                                ${totalCredits[i]}/yr in credits
+                              </div>
+                            )}
+                            <div className="text-xs text-gray-500 space-y-0.5">
+                              {card.benefits.filter(b => b.value > 0).map(b => (
+                                <div key={b.name}>{b.name} (${b.value}{b.frequency === 'annual' ? '/yr' : b.frequency === 'monthly' ? '/mo' : b.frequency === 'quarterly' ? '/qtr' : ''})</div>
+                              ))}
+                              {card.benefits.filter(b => b.value === 0).length > 0 && (
+                                <div className="text-gray-400 mt-1">
+                                  +{card.benefits.filter(b => b.value === 0).length} perk{card.benefits.filter(b => b.value === 0).length !== 1 ? 's' : ''}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        ) : (
+                          <span className="text-gray-400">{'\u2014'}</span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })()}
 
             </tbody>
           </table>


### PR DESCRIPTION
## Summary
- Adds a **Benefits** row at the bottom of the compare table (desktop and mobile)
- Shows total annual credits value with green highlighting for best value
- Lists individual credits with amounts/frequency and a "+N perks" count for non-monetary benefits
- Only renders when at least one compared card has benefits data

## Test plan
- [x] Verified locally on :3004
- [ ] Compare cards with benefits (e.g. Amex Gold vs Amex Platinum vs Chase Sapphire Preferred)
- [ ] Compare cards without benefits — row should not appear
- [ ] Check mobile stacked view

🤖 Generated with [Claude Code](https://claude.com/claude-code)