### PR TITLE
Add Card Wire page and fix duplicate card_wire entries

### DIFF
--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -69,10 +69,17 @@ async function detectAndRecordChanges(cardId, oldMetrics, newMetrics) {
     { field: "apr_max", old: oldMetrics.apr_max, new: newMetrics.apr_max },
   ];
 
+  // Normalize values: parse through float so DECIMAL(5,2) "3.00" and integer 3 compare equal
+  function normalize(v) {
+    if (v == null) return null;
+    const n = parseFloat(v);
+    return isNaN(n) ? String(v) : String(n);
+  }
+
   const changes = [];
   for (const t of trackedFields) {
-    const oldStr = t.old != null ? String(t.old) : null;
-    const newStr = t.new != null ? String(t.new) : null;
+    const oldStr = normalize(t.old);
+    const newStr = normalize(t.new);
 
     // Skip if values match or both null
     if (oldStr === newStr) continue;

--- a/apps/web-next/src/app/card-wire/CardWireTable.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireTable.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import CardImage from '@/components/ui/CardImage';
+import { CreditCardIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+import { CardWireEntry } from '@/lib/api';
+
+const PAGE_SIZE = 25;
+
+const fieldLabels: Record<string, string> = {
+  annual_fee: 'Annual Fee',
+  signup_bonus_value: 'Sign-up Bonus',
+  reward_top_rate: 'Top Reward Rate',
+  apr_min: 'APR Min',
+  apr_max: 'APR Max',
+};
+
+function formatValue(field: string, value: string | null): string {
+  if (value === null || value === '') return '—';
+  const num = parseFloat(value);
+  if (isNaN(num)) return value;
+
+  if (field === 'annual_fee') {
+    return num === 0 ? '$0' : `$${num.toLocaleString()}`;
+  }
+  if (field === 'signup_bonus_value') {
+    return num.toLocaleString();
+  }
+  if (field === 'reward_top_rate' || field === 'apr_min' || field === 'apr_max') {
+    return `${num}%`;
+  }
+  return value;
+}
+
+function formatDate(ts: string): string {
+  return new Date(ts).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+interface Props {
+  entries: CardWireEntry[];
+  slugMap: Record<string, string>;
+}
+
+export default function CardWireTable({ entries, slugMap }: Props) {
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  const visible = entries.slice(0, visibleCount);
+  const hasMore = visibleCount < entries.length;
+
+  if (entries.length === 0) {
+    return (
+      <div className="bg-white shadow sm:rounded-lg overflow-hidden">
+        <div className="px-6 py-12 text-center text-gray-500">
+          No card changes recorded yet. Check back soon!
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white shadow sm:rounded-lg overflow-hidden">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+              Date
+            </th>
+            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Card
+            </th>
+            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">
+              Feature
+            </th>
+            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Change
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {visible.map((entry) => {
+            const slug = slugMap[entry.card_name];
+            const label = fieldLabels[entry.field] ?? entry.field;
+            const oldFmt = formatValue(entry.field, entry.old_value);
+            const newFmt = formatValue(entry.field, entry.new_value);
+
+            return (
+              <tr key={entry.id} className="hover:bg-gray-50">
+                {/* Date */}
+                <td className="px-3 sm:px-6 py-2 whitespace-nowrap text-xs text-gray-500">
+                  {formatDate(entry.changed_at)}
+                </td>
+
+                {/* Card */}
+                <td className="px-3 sm:px-6 py-2">
+                  {slug ? (
+                    <Link
+                      href={`/card/${slug}`}
+                      className="flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-900"
+                    >
+                      {entry.card_image_link ? (
+                        <CardImage
+                          cardImageLink={entry.card_image_link}
+                          alt={entry.card_name}
+                          width={40}
+                          height={25}
+                          className="rounded-sm object-contain flex-shrink-0"
+                          sizes="40px"
+                        />
+                      ) : (
+                        <CreditCardIcon className="h-5 w-5 text-gray-400 flex-shrink-0" />
+                      )}
+                      <span className="whitespace-nowrap">{entry.card_name}</span>
+                    </Link>
+                  ) : (
+                    <div className="flex items-center gap-2 text-sm text-gray-900">
+                      {entry.card_image_link ? (
+                        <CardImage
+                          cardImageLink={entry.card_image_link}
+                          alt={entry.card_name}
+                          width={40}
+                          height={25}
+                          className="rounded-sm object-contain flex-shrink-0"
+                          sizes="40px"
+                        />
+                      ) : (
+                        <CreditCardIcon className="h-5 w-5 text-gray-400 flex-shrink-0" />
+                      )}
+                      <span className="whitespace-nowrap">{entry.card_name}</span>
+                    </div>
+                  )}
+                </td>
+
+                {/* Feature (hidden on mobile — shown inline in Change col instead) */}
+                <td className="px-3 sm:px-6 py-2 hidden sm:table-cell whitespace-nowrap text-sm text-gray-600">
+                  {label}
+                </td>
+
+                {/* Change */}
+                <td className="px-3 sm:px-6 py-2">
+                  <div className="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-2">
+                    <span className="text-xs text-gray-400 sm:hidden">{label}</span>
+                    <div className="flex items-center gap-1.5 text-sm">
+                      <span className="text-gray-500">{oldFmt}</span>
+                      <ArrowRightIcon className="h-3 w-3 text-gray-400 flex-shrink-0" />
+                      <span className="font-medium text-gray-900">{newFmt}</span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {hasMore && (
+        <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 text-center">
+          <button
+            onClick={() => setVisibleCount((prev) => prev + PAGE_SIZE)}
+            className="inline-flex items-center px-4 py-2 text-sm font-medium text-indigo-600 bg-white border border-indigo-300 rounded-md hover:bg-indigo-50 transition-colors"
+          >
+            Show More ({entries.length - visibleCount} remaining)
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web-next/src/app/card-wire/page.tsx
+++ b/apps/web-next/src/app/card-wire/page.tsx
@@ -1,0 +1,96 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { BoltIcon } from '@heroicons/react/24/outline';
+import { getAllCardWire, getAllCards } from '@/lib/api';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import CardWireTable from './CardWireTable';
+
+export const metadata: Metadata = {
+  title: 'Card Wire - Credit Card Updates & Changes',
+  description: 'A live feed of credit card changes — annual fee updates, sign-up bonus changes, reward rate shifts, and APR adjustments across all major cards.',
+  openGraph: {
+    title: 'Card Wire | CreditOdds',
+    description: 'Live feed of credit card changes — fees, bonuses, rates, and more.',
+    url: 'https://creditodds.com/card-wire',
+    type: 'website',
+  },
+  alternates: {
+    canonical: 'https://creditodds.com/card-wire',
+  },
+};
+
+export const revalidate = 300;
+
+export default async function CardWirePage() {
+  const [entries, cards] = await Promise.all([
+    getAllCardWire(200),
+    getAllCards(),
+  ]);
+
+  // Build card_name → slug map for linking
+  const slugMap: Record<string, string> = {};
+  for (const card of cards) {
+    slugMap[card.card_name] = String(card.slug ?? card.card_id);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <BreadcrumbSchema items={[
+        { name: 'Home', url: 'https://creditodds.com' },
+        { name: 'Card Wire', url: 'https://creditodds.com/card-wire' },
+      ]} />
+
+      {/* Breadcrumbs */}
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <ol className="flex items-center space-x-4 py-4 overflow-hidden">
+            <li>
+              <Link href="/" className="text-gray-400 hover:text-gray-500">
+                Home
+              </Link>
+            </li>
+            <li>
+              <div className="flex items-center">
+                <svg className="flex-shrink-0 h-5 w-5 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+                <span className="ml-4 text-sm font-medium text-gray-500 truncate">Card Wire</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        {/* Header */}
+        <div className="flex items-center justify-center gap-3">
+          <BoltIcon className="h-8 w-8 text-indigo-600" aria-hidden="true" />
+          <h1 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
+            Card Wire
+          </h1>
+        </div>
+        <p className="mt-2 text-center text-lg text-gray-500">
+          Live feed of credit card changes — fees, bonuses, rates, and more
+        </p>
+
+        {/* Table */}
+        <div className="mt-8 -mx-4 sm:mx-0">
+          <CardWireTable entries={entries} slugMap={slugMap} />
+        </div>
+
+        {/* CTA */}
+        <div className="mt-12 text-center">
+          <p className="text-gray-600 mb-4">
+            Browse all cards and compare their current offers.
+          </p>
+          <Link
+            href="/explore"
+            className="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+          >
+            Explore All Cards
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -354,6 +354,15 @@ export async function getCardWire(cardId: number): Promise<CardWireEntry[]> {
   return data.changes || [];
 }
 
+export async function getAllCardWire(limit = 100): Promise<CardWireEntry[]> {
+  const res = await fetch(`${API_BASE}/card-wire?limit=${limit}`, {
+    next: { revalidate: 300 },
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.changes || [];
+}
+
 // Track referral impressions and clicks (no auth required)
 export async function trackReferralEvent(
   referralId: number,


### PR DESCRIPTION
## Summary
- New `/card-wire` page: thin-row table feed of all credit card changes (annual fee, sign-up bonus, reward rate, APR) with card logo, name, feature label, and old → new values
- Adds `getAllCardWire()` to `api.ts` to fetch up to 200 entries without filtering by card
- Fixes a bug in `update-cards-github.js` where `DECIMAL(5,2)` columns (`reward_top_rate`, `apr_min`, `apr_max`) returned from MySQL as `"3.00"` were not matching CDN JSON integers like `3`, causing identical duplicate rows to be inserted into `card_wire` on every sync

## Test plan
- [ ] Visit `/card-wire` and confirm the table loads with card logos, names, and change values
- [ ] Confirm card names link to their card detail pages
- [ ] Trigger a card sync and confirm no new duplicate rows are generated for unchanged cards
- [ ] Confirm "Show More" pagination works

🤖 Generated with [Claude Code](https://claude.com/claude-code)