### PR TITLE
Card Wire: OG image, colored chips, positive/negative indicators

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireTable.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireTable.tsx
@@ -16,21 +16,52 @@ const fieldLabels: Record<string, string> = {
   apr_max: 'APR Max',
 };
 
-function formatValue(field: string, value: string | null): string {
+const chipColors: Record<string, { bg: string; text: string }> = {
+  annual_fee: { bg: 'bg-amber-100', text: 'text-amber-800' },
+  signup_bonus_value: { bg: 'bg-blue-100', text: 'text-blue-800' },
+  reward_top_rate: { bg: 'bg-emerald-100', text: 'text-emerald-800' },
+  apr_min: { bg: 'bg-purple-100', text: 'text-purple-800' },
+  apr_max: { bg: 'bg-purple-100', text: 'text-purple-800' },
+};
+
+// Fields where an increase is BAD for the consumer
+const higherIsBad = new Set(['annual_fee', 'apr_min', 'apr_max']);
+
+function formatValue(field: string, value: string | null, bonusType?: string): string {
   if (value === null || value === '') return '—';
   const num = parseFloat(value);
-  if (isNaN(num)) return value;
 
   if (field === 'annual_fee') {
-    return num === 0 ? '$0' : `$${num.toLocaleString()}`;
+    if (!isNaN(num)) return num === 0 ? '$0' : `$${num.toLocaleString()}`;
+    return value;
   }
   if (field === 'signup_bonus_value') {
-    return num.toLocaleString();
+    if (!isNaN(num)) {
+      const suffix = bonusType ? ` ${bonusType}` : '';
+      return `${num.toLocaleString()}${suffix}`;
+    }
+    // Non-numeric SUB like "5 Free Night Awards"
+    return value;
   }
   if (field === 'reward_top_rate' || field === 'apr_min' || field === 'apr_max') {
-    return `${num}%`;
+    if (!isNaN(num)) return `${num}%`;
+    return value;
   }
   return value;
+}
+
+function getChangeDirection(field: string, oldValue: string | null, newValue: string | null): 'positive' | 'negative' | 'neutral' {
+  if (oldValue === null || newValue === null) return 'neutral';
+  const oldNum = parseFloat(oldValue);
+  const newNum = parseFloat(newValue);
+  if (isNaN(oldNum) || isNaN(newNum)) return 'neutral';
+  if (oldNum === newNum) return 'neutral';
+
+  const increased = newNum > oldNum;
+  if (higherIsBad.has(field)) {
+    return increased ? 'negative' : 'positive';
+  }
+  return increased ? 'positive' : 'negative';
 }
 
 function formatDate(ts: string): string {
@@ -44,9 +75,10 @@ function formatDate(ts: string): string {
 interface Props {
   entries: CardWireEntry[];
   slugMap: Record<string, string>;
+  bonusTypeMap: Record<string, string>;
 }
 
-export default function CardWireTable({ entries, slugMap }: Props) {
+export default function CardWireTable({ entries, slugMap, bonusTypeMap }: Props) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const visible = entries.slice(0, visibleCount);
@@ -85,8 +117,18 @@ export default function CardWireTable({ entries, slugMap }: Props) {
           {visible.map((entry) => {
             const slug = slugMap[entry.card_name];
             const label = fieldLabels[entry.field] ?? entry.field;
-            const oldFmt = formatValue(entry.field, entry.old_value);
-            const newFmt = formatValue(entry.field, entry.new_value);
+            const chip = chipColors[entry.field] ?? { bg: 'bg-gray-100', text: 'text-gray-700' };
+            const bonusType = bonusTypeMap[entry.card_name] || '';
+            const oldFmt = formatValue(entry.field, entry.old_value, bonusType);
+            const newFmt = formatValue(entry.field, entry.new_value, bonusType);
+            const direction = getChangeDirection(entry.field, entry.old_value, entry.new_value);
+
+            const newValueColor =
+              direction === 'positive'
+                ? 'text-green-600'
+                : direction === 'negative'
+                  ? 'text-red-600'
+                  : 'text-gray-900';
 
             return (
               <tr key={entry.id} className="hover:bg-gray-50">
@@ -136,18 +178,22 @@ export default function CardWireTable({ entries, slugMap }: Props) {
                 </td>
 
                 {/* Feature (hidden on mobile — shown inline in Change col instead) */}
-                <td className="px-3 sm:px-6 py-2 hidden sm:table-cell whitespace-nowrap text-sm text-gray-600">
-                  {label}
+                <td className="px-3 sm:px-6 py-2 hidden sm:table-cell">
+                  <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${chip.bg} ${chip.text}`}>
+                    {label}
+                  </span>
                 </td>
 
                 {/* Change */}
                 <td className="px-3 sm:px-6 py-2">
                   <div className="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-2">
-                    <span className="text-xs text-gray-400 sm:hidden">{label}</span>
+                    <span className={`sm:hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${chip.bg} ${chip.text} w-fit`}>
+                      {label}
+                    </span>
                     <div className="flex items-center gap-1.5 text-sm">
                       <span className="text-gray-500">{oldFmt}</span>
                       <ArrowRightIcon className="h-3 w-3 text-gray-400 flex-shrink-0" />
-                      <span className="font-medium text-gray-900">{newFmt}</span>
+                      <span className={`font-medium ${newValueColor}`}>{newFmt}</span>
                     </div>
                   </div>
                 </td>

--- a/apps/web-next/src/app/card-wire/opengraph-image.tsx
+++ b/apps/web-next/src/app/card-wire/opengraph-image.tsx
@@ -1,0 +1,90 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts } from '@/components/og/og-utils';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'edge';
+
+export default async function OGImage() {
+  const fonts = await loadInterFonts();
+
+  return new ImageResponse(
+    (
+      <OGBackground accentColor="#f59e0b">
+        {/* Main content */}
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 60,
+          }}
+        >
+          {/* Lightning bolt icon */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 120,
+              height: 120,
+              borderRadius: 24,
+              background: 'rgba(255,255,255,0.12)',
+              marginBottom: 40,
+            }}
+          >
+            <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+            </svg>
+          </div>
+
+          {/* Title */}
+          <div
+            style={{
+              color: 'white',
+              fontSize: 56,
+              fontWeight: 'bold',
+              letterSpacing: -1,
+              marginBottom: 16,
+            }}
+          >
+            Card Wire
+          </div>
+
+          {/* Subtitle */}
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.9)',
+              fontSize: 28,
+              textAlign: 'center',
+              maxWidth: 800,
+            }}
+          >
+            Live feed of credit card changes — fees, bonuses, rates, and more
+          </div>
+        </div>
+
+        {/* Logo in bottom left */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/apps/web-next/src/app/card-wire/page.tsx
+++ b/apps/web-next/src/app/card-wire/page.tsx
@@ -29,8 +29,19 @@ export default async function CardWirePage() {
 
   // Build card_name → slug map for linking
   const slugMap: Record<string, string> = {};
+  const bonusTypeMap: Record<string, string> = {};
   for (const card of cards) {
     slugMap[card.card_name] = String(card.slug ?? card.card_id);
+    if (card.signup_bonus?.type) {
+      const typeLabels: Record<string, string> = {
+        points: 'pts',
+        miles: 'miles',
+        cashback: 'cash',
+        cash: 'cash',
+        free_nights: 'free nights',
+      };
+      bonusTypeMap[card.card_name] = typeLabels[card.signup_bonus.type] || card.signup_bonus.type;
+    }
   }
 
   return (
@@ -75,7 +86,7 @@ export default async function CardWirePage() {
 
         {/* Table */}
         <div className="mt-8 -mx-4 sm:mx-0">
-          <CardWireTable entries={entries} slugMap={slugMap} />
+          <CardWireTable entries={entries} slugMap={slugMap} bonusTypeMap={bonusTypeMap} />
         </div>
 
         {/* CTA */}


### PR DESCRIPTION
## Summary
- Added OG image for `/card-wire` page (lightning bolt icon, matching site theme)
- Feature column now uses colored chips: amber (Annual Fee), blue (Sign-up Bonus), emerald (Top Reward Rate), purple (APR)
- Change values colored green/red for positive/negative — inverted for Annual Fee and APR (increase = red)
- Sign-up bonus values show type suffix (pts, miles, cash, free nights)

## Test plan
- [x] Verified page loads on localhost:3005
- [x] OG image renders at `/card-wire/opengraph-image`
- [ ] Visual review of chip colors and green/red indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)