### PR TITLE
Improve Card Wire mobile UI and add pagination

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireTable.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireTable.tsx
@@ -3,10 +3,10 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
-import { CreditCardIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+import { CreditCardIcon, ArrowRightIcon, ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { CardWireEntry } from '@/lib/api';
 
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 50;
 
 const fieldLabels: Record<string, string> = {
   annual_fee: 'Annual Fee',
@@ -79,10 +79,15 @@ interface Props {
 }
 
 export default function CardWireTable({ entries, slugMap, bonusTypeMap }: Props) {
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [page, setPage] = useState(1);
 
-  const visible = entries.slice(0, visibleCount);
-  const hasMore = visibleCount < entries.length;
+  const totalPages = Math.ceil(entries.length / PAGE_SIZE);
+  const visible = entries.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  function goToPage(p: number) {
+    setPage(p);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
 
   if (entries.length === 0) {
     return (
@@ -94,56 +99,74 @@ export default function CardWireTable({ entries, slugMap, bonusTypeMap }: Props)
     );
   }
 
+  function renderEntry(entry: CardWireEntry) {
+    const slug = slugMap[entry.card_name];
+    const label = fieldLabels[entry.field] ?? entry.field;
+    const chip = chipColors[entry.field] ?? { bg: 'bg-gray-100', text: 'text-gray-700' };
+    const bonusType = bonusTypeMap[entry.card_name] || '';
+    const oldFmt = formatValue(entry.field, entry.old_value, bonusType);
+    const newFmt = formatValue(entry.field, entry.new_value, bonusType);
+    const direction = getChangeDirection(entry.field, entry.old_value, entry.new_value);
+
+    const newValueColor =
+      direction === 'positive'
+        ? 'text-green-600'
+        : direction === 'negative'
+          ? 'text-red-600'
+          : 'text-gray-900';
+
+    return { slug, label, chip, oldFmt, newFmt, newValueColor };
+  }
+
+  const pagination = totalPages > 1 && (
+    <div className="px-4 sm:px-6 py-3 bg-gray-50 border-t border-gray-200 flex items-center justify-between">
+      <button
+        onClick={() => goToPage(page - 1)}
+        disabled={page === 1}
+        className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <ChevronLeftIcon className="h-4 w-4" />
+        <span className="hidden sm:inline">Previous</span>
+      </button>
+      <span className="text-sm text-gray-600">
+        Page {page} of {totalPages}
+      </span>
+      <button
+        onClick={() => goToPage(page + 1)}
+        disabled={page === totalPages}
+        className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <span className="hidden sm:inline">Next</span>
+        <ChevronRightIcon className="h-4 w-4" />
+      </button>
+    </div>
+  );
+
   return (
-    <div className="bg-white shadow sm:rounded-lg overflow-hidden">
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead className="bg-gray-50">
-          <tr>
-            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-              Date
-            </th>
-            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              Card
-            </th>
-            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">
-              Feature
-            </th>
-            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              Change
-            </th>
-          </tr>
-        </thead>
-        <tbody className="bg-white divide-y divide-gray-200">
-          {visible.map((entry) => {
-            const slug = slugMap[entry.card_name];
-            const label = fieldLabels[entry.field] ?? entry.field;
-            const chip = chipColors[entry.field] ?? { bg: 'bg-gray-100', text: 'text-gray-700' };
-            const bonusType = bonusTypeMap[entry.card_name] || '';
-            const oldFmt = formatValue(entry.field, entry.old_value, bonusType);
-            const newFmt = formatValue(entry.field, entry.new_value, bonusType);
-            const direction = getChangeDirection(entry.field, entry.old_value, entry.new_value);
-
-            const newValueColor =
-              direction === 'positive'
-                ? 'text-green-600'
-                : direction === 'negative'
-                  ? 'text-red-600'
-                  : 'text-gray-900';
-
-            return (
-              <tr key={entry.id} className="hover:bg-gray-50">
-                {/* Date */}
-                <td className="px-3 sm:px-6 py-2 whitespace-nowrap text-xs text-gray-500">
-                  {formatDate(entry.changed_at)}
-                </td>
-
-                {/* Card */}
-                <td className="px-3 sm:px-6 py-2">
-                  {slug ? (
-                    <Link
-                      href={`/card/${slug}`}
-                      className="flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-900"
-                    >
+    <>
+      {/* Mobile: card list grouped by date */}
+      <div className="sm:hidden bg-white shadow rounded-lg overflow-hidden">
+        {(() => {
+          const groups: { date: string; entries: CardWireEntry[] }[] = [];
+          for (const entry of visible) {
+            const date = formatDate(entry.changed_at);
+            const last = groups[groups.length - 1];
+            if (last && last.date === date) {
+              last.entries.push(entry);
+            } else {
+              groups.push({ date, entries: [entry] });
+            }
+          }
+          return groups.map((group) => (
+            <div key={group.date}>
+              <div className="px-4 py-2 bg-gray-100 border-y border-gray-200">
+                <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">{group.date}</span>
+              </div>
+              <div className="divide-y divide-gray-200">
+                {group.entries.map((entry) => {
+                  const { slug, label, chip, oldFmt, newFmt, newValueColor } = renderEntry(entry);
+                  const cardContent = (
+                    <div className="flex items-center gap-2">
                       {entry.card_image_link ? (
                         <CardImage
                           cardImageLink={entry.card_image_link}
@@ -156,63 +179,124 @@ export default function CardWireTable({ entries, slugMap, bonusTypeMap }: Props)
                       ) : (
                         <CreditCardIcon className="h-5 w-5 text-gray-400 flex-shrink-0" />
                       )}
-                      <span className="whitespace-nowrap">{entry.card_name}</span>
-                    </Link>
-                  ) : (
-                    <div className="flex items-center gap-2 text-sm text-gray-900">
-                      {entry.card_image_link ? (
-                        <CardImage
-                          cardImageLink={entry.card_image_link}
-                          alt={entry.card_name}
-                          width={40}
-                          height={25}
-                          className="rounded-sm object-contain flex-shrink-0"
-                          sizes="40px"
-                        />
-                      ) : (
-                        <CreditCardIcon className="h-5 w-5 text-gray-400 flex-shrink-0" />
-                      )}
-                      <span className="whitespace-nowrap">{entry.card_name}</span>
+                      <span className="font-medium text-sm">{entry.card_name}</span>
                     </div>
-                  )}
-                </td>
+                  );
 
-                {/* Feature (hidden on mobile — shown inline in Change col instead) */}
-                <td className="px-3 sm:px-6 py-2 hidden sm:table-cell">
-                  <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${chip.bg} ${chip.text}`}>
-                    {label}
-                  </span>
-                </td>
+                  return (
+                    <div key={entry.id} className="px-4 py-3 space-y-1.5">
+                      {slug ? (
+                        <Link href={`/card/${slug}`} className="text-indigo-600 hover:text-indigo-900">
+                          {cardContent}
+                        </Link>
+                      ) : (
+                        <div className="text-gray-900">{cardContent}</div>
+                      )}
+                      <div className="flex items-center gap-2">
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${chip.bg} ${chip.text}`}>
+                          {label}
+                        </span>
+                        <div className="flex items-center gap-1.5 text-sm">
+                          <span className="text-gray-500">{oldFmt}</span>
+                          <ArrowRightIcon className="h-3 w-3 text-gray-400 flex-shrink-0" />
+                          <span className={`font-medium ${newValueColor}`}>{newFmt}</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ));
+        })()}
+        {pagination}
+      </div>
 
-                {/* Change */}
-                <td className="px-3 sm:px-6 py-2">
-                  <div className="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-2">
-                    <span className={`sm:hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${chip.bg} ${chip.text} w-fit`}>
+      {/* Desktop: table */}
+      <div className="hidden sm:block bg-white shadow sm:rounded-lg overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                Date
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Card
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Feature
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Change
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {visible.map((entry) => {
+              const { slug, label, chip, oldFmt, newFmt, newValueColor } = renderEntry(entry);
+
+              return (
+                <tr key={entry.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-2 whitespace-nowrap text-xs text-gray-500">
+                    {formatDate(entry.changed_at)}
+                  </td>
+                  <td className="px-6 py-2">
+                    {slug ? (
+                      <Link
+                        href={`/card/${slug}`}
+                        className="flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-900"
+                      >
+                        {entry.card_image_link ? (
+                          <CardImage
+                            cardImageLink={entry.card_image_link}
+                            alt={entry.card_name}
+                            width={40}
+                            height={25}
+                            className="rounded-sm object-contain flex-shrink-0"
+                            sizes="40px"
+                          />
+                        ) : (
+                          <CreditCardIcon className="h-5 w-5 text-gray-400 flex-shrink-0" />
+                        )}
+                        <span className="whitespace-nowrap">{entry.card_name}</span>
+                      </Link>
+                    ) : (
+                      <div className="flex items-center gap-2 text-sm text-gray-900">
+                        {entry.card_image_link ? (
+                          <CardImage
+                            cardImageLink={entry.card_image_link}
+                            alt={entry.card_name}
+                            width={40}
+                            height={25}
+                            className="rounded-sm object-contain flex-shrink-0"
+                            sizes="40px"
+                          />
+                        ) : (
+                          <CreditCardIcon className="h-5 w-5 text-gray-400 flex-shrink-0" />
+                        )}
+                        <span className="whitespace-nowrap">{entry.card_name}</span>
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-6 py-2">
+                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${chip.bg} ${chip.text}`}>
                       {label}
                     </span>
-                    <div className="flex items-center gap-1.5 text-sm">
-                      <span className="text-gray-500">{oldFmt}</span>
+                  </td>
+                  <td className="px-6 py-2">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-gray-500">{oldFmt}</span>
                       <ArrowRightIcon className="h-3 w-3 text-gray-400 flex-shrink-0" />
-                      <span className={`font-medium ${newValueColor}`}>{newFmt}</span>
+                      <span className={`text-sm font-medium ${newValueColor}`}>{newFmt}</span>
                     </div>
-                  </div>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-
-      {hasMore && (
-        <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 text-center">
-          <button
-            onClick={() => setVisibleCount((prev) => prev + PAGE_SIZE)}
-            className="inline-flex items-center px-4 py-2 text-sm font-medium text-indigo-600 bg-white border border-indigo-300 rounded-md hover:bg-indigo-50 transition-colors"
-          >
-            Show More ({entries.length - visibleCount} remaining)
-          </button>
-        </div>
-      )}
-    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {pagination}
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- **Mobile layout**: Replace cramped table with a card list grouped by date headers (grey row separators) for much better readability
- **Pagination**: Replace infinite "Show More" with prev/next pagination at 50 items per page (both mobile and desktop)
- **Desktop**: Table layout unchanged, just swapped to pagination

## Test plan
- [ ] Open `/card-wire` on mobile (or Chrome DevTools device emulation)
- [ ] Verify entries are grouped under date headers
- [ ] Verify pagination controls work (prev/next, disabled states at boundaries)
- [ ] Verify desktop table still renders correctly with pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)