### PR TITLE
Add Live indicator to Card Wire and link from News

### DIFF
--- a/apps/web-next/src/app/card-wire/page.tsx
+++ b/apps/web-next/src/app/card-wire/page.tsx
@@ -79,6 +79,13 @@ export default async function CardWirePage() {
           <h1 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
             Card Wire
           </h1>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="relative flex h-3 w-3">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
+            </span>
+            <span className="text-sm font-semibold text-green-600 uppercase tracking-wide">Live</span>
+          </span>
         </div>
         <p className="mt-2 text-center text-lg text-gray-500">
           Live feed of credit card changes — fees, bonuses, rates, and more

--- a/apps/web-next/src/app/news/page.tsx
+++ b/apps/web-next/src/app/news/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import { NewspaperIcon, PlusCircleIcon } from "@heroicons/react/24/outline";
+import { NewspaperIcon, PlusCircleIcon, BoltIcon } from "@heroicons/react/24/outline";
 import { getNews } from "@/lib/news";
 import NewsTable from "@/components/news/NewsTable";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
@@ -85,8 +85,23 @@ export default async function NewsPage() {
           Stay up to date with the latest credit card updates and changes
         </p>
 
+        {/* Card Wire Link */}
+        <div className="mt-4 flex justify-center">
+          <Link
+            href="/card-wire"
+            className="inline-flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+          >
+            <BoltIcon className="h-4 w-4" />
+            See latest card changes on Card Wire
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+            </span>
+          </Link>
+        </div>
+
         {/* Add News Link */}
-        <div className="mt-4 text-center">
+        <div className="mt-2 text-center">
           <a
             href="https://github.com/CreditOdds/creditodds/blob/main/data/news/README.md"
             target="_blank"


### PR DESCRIPTION
## Summary
- Added a pulsing green orb with "Live" label next to the Card Wire page title
- Added a link to Card Wire on the News page (below subtitle, above table) with bolt icon and pulsing green dot

## Test plan
- [ ] Visit /card-wire — green pulsing orb and "Live" text appear next to the title
- [ ] Visit /news — "See latest card changes on Card Wire" link appears below subtitle
- [ ] Click the Card Wire link on /news — navigates to /card-wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)