### PR TITLE
Fix NaN display for non-numeric signup bonuses

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -348,8 +348,10 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
                         <p className="text-xl font-bold text-amber-900">
                           {card.signup_bonus.type === "cash"
                             ? `$${card.signup_bonus.value.toLocaleString()}`
-                            : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type.charAt(0).toUpperCase() + card.signup_bonus.type.slice(1)}`}
-                          {card.signup_bonus.type !== "cash" && (
+                            : typeof card.signup_bonus.value !== 'number'
+                              ? String(card.signup_bonus.value)
+                              : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type.charAt(0).toUpperCase() + card.signup_bonus.type.slice(1)}`}
+                          {card.signup_bonus.type !== "cash" && typeof card.signup_bonus.value === 'number' && (
                             <span className="text-sm font-medium text-amber-700/70 ml-1.5">
                               (~${(card.signup_bonus.value * (getValuationDetails(card.card_name)?.cpp ?? 1.0) / 100).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })})
                             </span>
@@ -608,8 +610,10 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
                         <p className="text-xl font-bold text-amber-900">
                           {card.signup_bonus.type === "cash"
                             ? `$${card.signup_bonus.value.toLocaleString()}`
-                            : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type.charAt(0).toUpperCase() + card.signup_bonus.type.slice(1)}`}
-                          {card.signup_bonus.type !== "cash" && (
+                            : typeof card.signup_bonus.value !== 'number'
+                              ? String(card.signup_bonus.value)
+                              : `${card.signup_bonus.value.toLocaleString()} ${card.signup_bonus.type.charAt(0).toUpperCase() + card.signup_bonus.type.slice(1)}`}
+                          {card.signup_bonus.type !== "cash" && typeof card.signup_bonus.value === 'number' && (
                             <span className="ml-1.5 text-sm font-medium text-amber-700/70">
                               (~${(card.signup_bonus.value * (getValuationDetails(card.card_name)?.cpp ?? 1.0) / 100).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })})
                             </span>

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -104,6 +104,7 @@ export function getCentsPerPoint(card: Card): number | null {
 
 export function formatEstimatedValue(card: Card): string | null {
   if (!card.signup_bonus) return null;
+  if (typeof card.signup_bonus.value !== 'number') return null;
   const cpp = getCentsPerPoint(card);
   if (cpp === null) return null;
   const value = Math.round((card.signup_bonus.value * cpp) / 100);
@@ -116,6 +117,7 @@ export function formatBonusValue(card: Card): string {
   if (type === 'cash' || type === 'cashback') {
     return `$${value.toLocaleString()}`;
   }
+  if (typeof value !== 'number') return String(value);
   return `${value.toLocaleString()} ${type}`;
 }
 


### PR DESCRIPTION
## Summary
- Cards with string bonus values (e.g. "4 Free Night Awards" on Marriott Bonvoy Boundless) showed `~$NaN` because the code multiplied a string by cents-per-point
- Added `typeof value === 'number'` guards in 3 places:
  - `formatEstimatedValue()` — returns null for non-numeric values
  - `formatBonusValue()` — returns the string as-is without appending the type
  - `CardClient.tsx` — skips the `(~$X)` estimate on both desktop and mobile

Now "4 Free Night Awards" renders cleanly without a dollar estimate.

## Test plan
- [ ] Check [Marriott Bonvoy Boundless card page](https://creditodds.com/card/marriott-bonvoy-boundless-credit-card) — should show "4 Free Night Awards" with no `~$NaN`
- [ ] Verify cards with numeric bonuses still show the dollar estimate as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)