### PR TITLE
Add statement credit value to Amex converter + paginate tool news

### DIFF
--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/ConverterClient.tsx
@@ -7,6 +7,7 @@ export default function ConverterClient() {
       inputLabel="Amex Membership Rewards Points"
       unitLabel="point"
       valuationSlug="amex-membership-rewards"
+      statementCreditCpp={0.6}
     />
   );
 }

--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Amex Membership Rewards to USD (Converter/Calculator) | CreditOdds',
@@ -100,34 +101,7 @@ export default async function AmexMRToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Amex News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Amex News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Bilt Rewards Points to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function BiltToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Bilt News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Bilt News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Capital One Miles to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function CapitalOneMilesToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Capital One News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Capital One News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Chase Ultimate Rewards to USD (Converter/Calculator) | CreditOdds',
@@ -98,34 +99,7 @@ export default async function ChaseURToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Chase News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Chase News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Citi ThankYou Points to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function CitiThankYouToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Citi News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Citi News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Delta SkyMiles to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function DeltaSkyMilesToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Delta News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Delta News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Hilton Honors Points to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function HiltonHonorsToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Hilton News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Hilton News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'IHG One Rewards Points to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function IHGToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">IHG News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="IHG News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Marriott Bonvoy Points to USD (Converter/Calculator) | CreditOdds',
@@ -98,34 +99,7 @@ export default async function MarriottBonvoyToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Marriott News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Marriott News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'Southwest Rapid Rewards to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function SouthwestRRToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Southwest News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Southwest News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'United Miles to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function UnitedMilesToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">United News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="United News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
+import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
 
 export const metadata: Metadata = {
   title: 'World of Hyatt Points to USD (Converter/Calculator) | CreditOdds',
@@ -97,34 +98,7 @@ export default async function HyattToUsdPage() {
           </div>
         )}
 
-        {news.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Hyatt News</h2>
-            <div className="mt-4 space-y-3">
-              {news.map(item => (
-                <div key={item.id} className="bg-white rounded-lg shadow p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="text-xs text-gray-500">
-                        {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                      </p>
-                      <p className="text-sm font-medium text-gray-900 mt-1">
-                        {item.body ? (
-                          <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
-                            {item.title}
-                          </Link>
-                        ) : (
-                          item.title
-                        )}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PaginatedNewsList news={news} heading="Hyatt News" />
       </div>
     </div>
   );

--- a/apps/web-next/src/components/tools/PaginatedNewsList.tsx
+++ b/apps/web-next/src/components/tools/PaginatedNewsList.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+interface NewsItem {
+  id: string;
+  title: string;
+  summary: string;
+  date: string;
+  body?: string;
+}
+
+const PAGE_SIZE = 5;
+
+export default function PaginatedNewsList({
+  news,
+  heading,
+}: {
+  news: NewsItem[];
+  heading: string;
+}) {
+  const [visible, setVisible] = useState(PAGE_SIZE);
+  const hasMore = visible < news.length;
+
+  if (news.length === 0) return null;
+
+  return (
+    <div className="mt-12">
+      <h2 className="text-lg font-semibold text-gray-900">{heading}</h2>
+      <div className="mt-4 space-y-3">
+        {news.slice(0, visible).map(item => (
+          <div key={item.id} className="bg-white rounded-lg shadow p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-xs text-gray-500">
+                  {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                </p>
+                <p className="text-sm font-medium text-gray-900 mt-1">
+                  {item.body ? (
+                    <Link href={`/news/${item.id}`} className="hover:text-indigo-600 transition-colors">
+                      {item.title}
+                    </Link>
+                  ) : (
+                    item.title
+                  )}
+                </p>
+                <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      {hasMore && (
+        <button
+          onClick={() => setVisible(v => v + PAGE_SIZE)}
+          className="mt-4 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+        >
+          Show more ({news.length - visible} remaining)
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web-next/src/components/tools/RewardValueConverter.tsx
+++ b/apps/web-next/src/components/tools/RewardValueConverter.tsx
@@ -8,6 +8,7 @@ interface RewardValueConverterProps {
   inputLabel: string;
   unitLabel: string;
   valuationSlug: string;
+  statementCreditCpp?: number;
 }
 
 function formatNumber(value: string): string {
@@ -25,6 +26,7 @@ export default function RewardValueConverter({
   inputLabel,
   unitLabel,
   valuationSlug,
+  statementCreditCpp,
 }: RewardValueConverterProps) {
   const [amount, setAmount] = useState('');
   const parsedAmount = parseNumber(amount);
@@ -33,6 +35,9 @@ export default function RewardValueConverter({
     [fallbackCpp, valuationSlug]
   );
   const usdValue = parsedAmount * (centsPerUnit / 100);
+  const statementCreditValue = statementCreditCpp
+    ? parsedAmount * (statementCreditCpp / 100)
+    : null;
 
   return (
     <div className="mt-6 max-w-lg">
@@ -53,20 +58,33 @@ export default function RewardValueConverter({
         </div>
 
         {parsedAmount > 0 && (
-          <div className="mt-4 p-4 bg-indigo-50 rounded-md">
-            <p className="text-sm text-gray-600">Estimated Value</p>
-            <p className="text-3xl font-bold text-indigo-600">
-              ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-            </p>
-            <p className="mt-1 text-xs text-gray-500">
-              {formatNumber(String(parsedAmount))} {inputLabel.toLowerCase()} &times; {centsPerUnit}&cent; per {unitLabel}
-            </p>
+          <div className={`mt-4 ${statementCreditCpp ? 'grid grid-cols-2 gap-3' : ''}`}>
+            <div className="p-4 bg-indigo-50 rounded-md">
+              <p className="text-sm text-gray-600">{statementCreditCpp ? 'Travel / Transfer' : 'Estimated Value'}</p>
+              <p className="text-3xl font-bold text-indigo-600">
+                ${usdValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+              </p>
+              <p className="mt-1 text-xs text-gray-500">
+                {centsPerUnit}&cent; per {unitLabel}
+              </p>
+            </div>
+            {statementCreditValue !== null && (
+              <div className="p-4 bg-gray-50 rounded-md">
+                <p className="text-sm text-gray-600">Statement Credit</p>
+                <p className="text-3xl font-bold text-gray-600">
+                  ${statementCreditValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </p>
+                <p className="mt-1 text-xs text-gray-500">
+                  {statementCreditCpp}&cent; per {unitLabel}
+                </p>
+              </div>
+            )}
           </div>
         )}
       </div>
 
       <p className="mt-4 text-xs text-gray-400">
-        Based on a valuation of {centsPerUnit} cents per {unitLabel}. Actual redemption value varies by booking.
+        Based on a valuation of {centsPerUnit} cents per {unitLabel}{statementCreditCpp ? ` for travel, ${statementCreditCpp} cents for statement credit` : ''}. Actual redemption value varies by booking.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Amex converter**: Shows travel/transfer value (1.2 cpp) and statement credit value (0.6 cpp, 10,000 pts = $60) side by side
- **Tool page news**: All 12 converter pages now show only 5 news items with a "Show more" button (loads 5 more at a time), via a shared `PaginatedNewsList` component

## Test plan
- [ ] `/tools/amex-membership-rewards-to-usd` — two value boxes side by side, 10k pts = $120 travel / $60 statement credit
- [ ] News section shows 5 items with "Show more" button
- [ ] Other converters (United, Delta, etc.) show single value, paginated news

🤖 Generated with [Claude Code](https://claude.com/claude-code)