### PR TITLE
Default explore page sort to Trending (30 days)

### DIFF
--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -27,7 +27,7 @@ function getTopReward(rewards: Reward[] | undefined): Reward | null {
 export default function ExploreClient({ cards, banks, trendingViews, allTimeViews }: ExploreClientProps) {
   const [search, setSearch] = useState("");
   const [selectedBank, setSelectedBank] = useState<string>("");
-  const [sortBy, setSortBy] = useState<SortOption>('popular');
+  const [sortBy, setSortBy] = useState<SortOption>('trending');
   const [showArchived, setShowArchived] = useState(false);
   const [showBusiness, setShowBusiness] = useState(false);
 


### PR DESCRIPTION
## Summary
- Change default sort on /explore from "Most Popular" (all-time records) to "Trending (30 days)" (recent page views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)