### PR TITLE
Add benefits usage tracker

### DIFF
--- a/apps/api/migrations/018_create_benefit_usage.sql
+++ b/apps/api/migrations/018_create_benefit_usage.sql
@@ -1,0 +1,14 @@
+CREATE TABLE benefit_usage (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL,
+  card_id INT NOT NULL,
+  benefit_name VARCHAR(255) NOT NULL,
+  frequency ENUM('monthly','quarterly','semi_annual','annual','multi_year') NOT NULL,
+  period_start DATE NOT NULL,
+  status ENUM('used','dismissed') NOT NULL DEFAULT 'used',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY unique_usage (user_id, card_id, benefit_name, period_start),
+  INDEX idx_user_id (user_id),
+  FOREIGN KEY (card_id) REFERENCES cards(card_id) ON DELETE CASCADE
+);

--- a/apps/api/src/handlers/benefit-usage.js
+++ b/apps/api/src/handlers/benefit-usage.js
@@ -12,6 +12,7 @@ const responseHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "Content-Type,Authorization",
   "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+  "Cache-Control": "no-store",
 };
 
 exports.BenefitUsageHandler = async (event) => {
@@ -49,10 +50,18 @@ exports.BenefitUsageHandler = async (event) => {
         );
         await mysql.end();
 
+        // Normalize DATE fields to YYYY-MM-DD strings (MySQL returns JS Date objects)
+        const normalized = results.map(r => ({
+          ...r,
+          period_start: r.period_start instanceof Date
+            ? r.period_start.toISOString().slice(0, 10)
+            : String(r.period_start).slice(0, 10),
+        }));
+
         response = {
           statusCode: 200,
           headers: responseHeaders,
-          body: JSON.stringify({ usages: results }),
+          body: JSON.stringify({ usages: normalized }),
         };
       } catch (error) {
         console.error("Error fetching benefit usage:", error);

--- a/apps/api/src/handlers/benefit-usage.js
+++ b/apps/api/src/handlers/benefit-usage.js
@@ -1,0 +1,160 @@
+// Benefit Usage API - Track which card benefits users have redeemed per period
+const mysql = require("serverless-mysql")({
+  config: {
+    host: process.env.ENDPOINT,
+    database: process.env.DATABASE,
+    user: process.env.USERNAME,
+    password: process.env.PASSWORD,
+  },
+});
+
+const responseHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+};
+
+exports.BenefitUsageHandler = async (event) => {
+  console.info("BenefitUsage received:", event);
+
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ statusText: "OK" }),
+    };
+  }
+
+  const userId = event.requestContext?.authorizer?.sub;
+  if (!userId) {
+    return {
+      statusCode: 401,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: "Unauthorized" }),
+    };
+  }
+
+  let response;
+
+  switch (event.httpMethod) {
+    case "GET":
+      try {
+        const year = event.queryStringParameters?.year || new Date().getFullYear();
+        const results = await mysql.query(
+          `SELECT * FROM benefit_usage
+           WHERE user_id = ?
+             AND (YEAR(period_start) = ? OR period_start = '1970-01-01')
+           ORDER BY period_start`,
+          [userId, year]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ usages: results }),
+        };
+      } catch (error) {
+        console.error("Error fetching benefit usage:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: `Failed to fetch benefit usage: ${error.message}` }),
+        };
+      }
+      break;
+
+    case "POST":
+      try {
+        const body = JSON.parse(event.body);
+        const { card_id, benefit_name, frequency, period_start, status } = body;
+
+        if (!card_id || !benefit_name || !frequency || !period_start) {
+          return {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "card_id, benefit_name, frequency, and period_start are required" }),
+          };
+        }
+
+        const validFrequencies = ['monthly', 'quarterly', 'semi_annual', 'annual', 'multi_year'];
+        if (!validFrequencies.includes(frequency)) {
+          return {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: `Invalid frequency. Must be one of: ${validFrequencies.join(', ')}` }),
+          };
+        }
+
+        const validStatuses = ['used', 'dismissed'];
+        const finalStatus = status && validStatuses.includes(status) ? status : 'used';
+
+        await mysql.query(
+          `INSERT INTO benefit_usage (user_id, card_id, benefit_name, frequency, period_start, status)
+           VALUES (?, ?, ?, ?, ?, ?)
+           ON DUPLICATE KEY UPDATE status = VALUES(status), updated_at = CURRENT_TIMESTAMP`,
+          [userId, card_id, benefit_name, frequency, period_start, finalStatus]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ message: "Benefit usage updated" }),
+        };
+      } catch (error) {
+        console.error("Error toggling benefit usage:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: `Failed to update benefit usage: ${error.message}` }),
+        };
+      }
+      break;
+
+    case "DELETE":
+      try {
+        const body = JSON.parse(event.body);
+        const { card_id, benefit_name, period_start } = body;
+
+        if (!card_id || !benefit_name || !period_start) {
+          return {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "card_id, benefit_name, and period_start are required" }),
+          };
+        }
+
+        await mysql.query(
+          `DELETE FROM benefit_usage
+           WHERE user_id = ? AND card_id = ? AND benefit_name = ? AND period_start = ?`,
+          [userId, card_id, benefit_name, period_start]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ message: "Benefit usage removed" }),
+        };
+      } catch (error) {
+        console.error("Error removing benefit usage:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: `Failed to remove benefit usage: ${error.message}` }),
+        };
+      }
+      break;
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: JSON.stringify({ error: `Method ${event.httpMethod} not allowed` }),
+      };
+      break;
+  }
+
+  return response;
+};

--- a/apps/api/src/handlers/delete-account.js
+++ b/apps/api/src/handlers/delete-account.js
@@ -66,6 +66,12 @@ exports.DeleteAccountHandler = async (event) => {
       [userId]
     );
 
+    // 2b. Delete benefit usage records
+    await mysql.query(
+      "DELETE FROM benefit_usage WHERE user_id = ?",
+      [userId]
+    );
+
     // 3. Anonymize records (keep data points but remove user association)
     await mysql.query(
       "UPDATE records SET submitter_id = NULL WHERE submitter_id = ?",

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -377,6 +377,52 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  BenefitUsageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/benefit-usage.BenefitUsageHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Track benefit usage per period for user wallet cards
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetBenefitUsage:
+          Type: Api
+          Properties:
+            Path: /benefit-usage
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        PostBenefitUsage:
+          Type: Api
+          Properties:
+            Path: /benefit-usage
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        DeleteBenefitUsage:
+          Type: Api
+          Properties:
+            Path: /benefit-usage
+            Method: DELETE
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        BenefitUsageOptions:
+          Type: Api
+          Properties:
+            Path: /benefit-usage
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
   ReferralStatsFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -702,7 +702,7 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
 
       {/* Card Benefits Section */}
       {card.benefits && card.benefits.length > 0 && (
-        <CardBenefits benefits={card.benefits} cardName={card.card_name} />
+        <CardBenefits benefits={card.benefits} cardName={card.card_name} slug={card.slug} />
       )}
 
       {/* Still collecting data - shown when no approval data */}

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -6,7 +6,7 @@ import CardImage from "@/components/ui/CardImage";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useAuth } from "@/auth/AuthProvider";
-import { getAllCards, getProfile, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, deleteAccount, WalletCard, Card } from "@/lib/api";
+import { getAllCards, getProfile, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, deleteAccount, getBenefitUsage, toggleBenefitUsage, removeBenefitUsage, WalletCard, Card, BenefitUsageRecord } from "@/lib/api";
 import { getNews, NewsItem, tagLabels, tagColors, NewsTag } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
 import { PlusIcon, WalletIcon, TrashIcon, DocumentTextIcon, LinkIcon, NewspaperIcon, ChartBarIcon, ExclamationTriangleIcon, ArchiveBoxIcon, Cog6ToothIcon, GiftIcon } from "@heroicons/react/24/outline";
@@ -114,6 +114,8 @@ export default function ProfileClient() {
   const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
   const [profileLoaded, setProfileLoaded] = useState(false);
   const [walletLoaded, setWalletLoaded] = useState(false);
+  const [benefitUsage, setBenefitUsage] = useState<BenefitUsageRecord[]>([]);
+  const [benefitUsageLoaded, setBenefitUsageLoaded] = useState(false);
   const [recordsLoaded, setRecordsLoaded] = useState(false);
   const [referralsLoaded, setReferralsLoaded] = useState(false);
   const [showReferralModal, setShowReferralModal] = useState(false);
@@ -226,6 +228,17 @@ export default function ProfileClient() {
       setWalletLoaded(true);
     };
 
+    const loadBenefitUsage = async () => {
+      try {
+        const result = await getBenefitUsage(token);
+        setBenefitUsage(result || []);
+      } catch (error) {
+        console.error("Benefit usage error:", error);
+        setBenefitUsage([]);
+      }
+      setBenefitUsageLoaded(true);
+    };
+
     const loadRecords = async () => {
       try {
         const result = await getRecords(token);
@@ -257,6 +270,7 @@ export default function ProfileClient() {
 
     loadProfile();
     loadWallet();
+    loadBenefitUsage();
     loadRecords();
     loadReferrals();
   };
@@ -289,6 +303,43 @@ export default function ProfileClient() {
       alert("Failed to delete record. Please try again.");
     } finally {
       setDeletingRecordId(null);
+    }
+  };
+
+  const handleToggleBenefitUsage = async (
+    cardId: number, benefitName: string, frequency: string, periodStart: string, status: 'used' | 'dismissed'
+  ) => {
+    const token = await getToken();
+    if (!token) return;
+    // Optimistic update
+    setBenefitUsage(prev => {
+      const key = `${cardId}-${benefitName}-${periodStart}`;
+      const idx = prev.findIndex(r => `${r.card_id}-${r.benefit_name}-${r.period_start}` === key);
+      if (idx >= 0) {
+        const updated = [...prev];
+        updated[idx] = { ...updated[idx], status };
+        return updated;
+      }
+      return [...prev, { id: 0, card_id: cardId, benefit_name: benefitName, frequency: frequency as BenefitUsageRecord['frequency'], period_start: periodStart, status, created_at: '', updated_at: '' }];
+    });
+    try {
+      await toggleBenefitUsage({ card_id: cardId, benefit_name: benefitName, frequency, period_start: periodStart, status }, token);
+    } catch (error) {
+      console.error("Error toggling benefit usage:", error);
+    }
+  };
+
+  const handleRemoveBenefitUsage = async (cardId: number, benefitName: string, periodStart: string) => {
+    const token = await getToken();
+    if (!token) return;
+    // Optimistic update
+    setBenefitUsage(prev => prev.filter(r =>
+      !(r.card_id === cardId && r.benefit_name === benefitName && r.period_start === periodStart)
+    ));
+    try {
+      await removeBenefitUsage({ card_id: cardId, benefit_name: benefitName, period_start: periodStart }, token);
+    } catch (error) {
+      console.error("Error removing benefit usage:", error);
     }
   };
 
@@ -597,14 +648,20 @@ export default function ProfileClient() {
 
         {/* Benefits Tab */}
         {activeTab === 'benefits' && (
-          !walletLoaded ? (
+          !(walletLoaded && benefitUsageLoaded) ? (
           <div className="bg-white shadow rounded-lg p-6">
             <div className="flex items-center justify-center py-12">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
             </div>
           </div>
           ) : (
-          <WalletBenefits walletCards={walletCards} allCards={allCards} />
+          <WalletBenefits
+            walletCards={walletCards}
+            allCards={allCards}
+            usageRecords={benefitUsage}
+            onToggleUsage={handleToggleBenefitUsage}
+            onRemoveUsage={handleRemoveBenefitUsage}
+          />
           )
         )}
 

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -199,6 +199,24 @@ export default function ProfileClient() {
     }
   }, [authState.isAuthenticated, authState.isLoading, router]);
 
+  // Refetch benefit usage when page becomes visible again (tab switch or navigate back)
+  useEffect(() => {
+    const handleVisibilityChange = async () => {
+      if (document.visibilityState === 'visible' && authState.isAuthenticated) {
+        const token = await getToken();
+        if (!token) return;
+        try {
+          const result = await getBenefitUsage(token);
+          setBenefitUsage(result || []);
+        } catch (error) {
+          console.error("Benefit usage refresh error:", error);
+        }
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [authState.isAuthenticated, getToken]);
+
   const loadData = async () => {
     const token = await getToken();
     if (!token) {

--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -35,9 +35,10 @@ const categoryIcons: Record<string, string> = {
 interface CardBenefitsProps {
   benefits: CardBenefit[];
   cardName: string;
+  slug?: string;
 }
 
-export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) {
+export default function CardBenefits({ benefits, cardName, slug }: CardBenefitsProps) {
   const credits = benefits.filter((b) => b.value > 0);
   const perks = benefits.filter((b) => b.value === 0);
   const totalAnnualValue = credits.reduce((sum, b) => {
@@ -140,6 +141,36 @@ export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) 
                 </div>
               </div>
             )}
+
+            {/* Community feedback note */}
+            <div className="mt-8 pt-6 border-t border-gray-100">
+              <p className="text-xs text-gray-400 text-center">
+                Benefits data is community-maintained and may not be fully up to date.{" "}
+                See something wrong?{" "}
+                <a
+                  href={`https://github.com/CreditOdds/creditodds/issues/new?title=${encodeURIComponent(`[Benefits] ${cardName}`)}&body=${encodeURIComponent(`Card: ${cardName}\n\nWhat needs to be corrected?\n\n`)}&labels=benefits`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-600 hover:text-emerald-700 underline underline-offset-2"
+                >
+                  Let us know
+                </a>
+                {slug && (
+                  <>
+                    {" or "}
+                    <a
+                      href={`https://github.com/CreditOdds/creditodds/edit/main/data/cards/${slug}.yaml`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-emerald-600 hover:text-emerald-700 underline underline-offset-2"
+                    >
+                      edit directly on GitHub
+                    </a>
+                  </>
+                )}
+                .
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import CardImage from "@/components/ui/CardImage";
-import { Card, CardBenefit, WalletCard } from "@/lib/api";
+import { Card, CardBenefit, WalletCard, BenefitUsageRecord } from "@/lib/api";
 import {
   CheckCircleIcon,
   GiftIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
 } from "@heroicons/react/24/outline";
 
 const frequencyLabels: Record<string, string> = {
@@ -35,22 +37,110 @@ const categoryIcons: Record<string, string> = {
   other: "✨",
 };
 
-interface CardWithBenefits {
-  walletCard: WalletCard;
-  cardData: Card;
-  benefits: CardBenefit[];
+const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function getCurrentQuarter(): number {
+  return Math.floor(new Date().getMonth() / 3) + 1;
+}
+
+function getPeriodStart(frequency: string, year: number, quarter: number, monthIndex?: number): string {
+  switch (frequency) {
+    case 'monthly': {
+      const m = monthIndex ?? ((quarter - 1) * 3);
+      return `${year}-${String(m + 1).padStart(2, '0')}-01`;
+    }
+    case 'quarterly': {
+      const qMonth = (quarter - 1) * 3;
+      return `${year}-${String(qMonth + 1).padStart(2, '0')}-01`;
+    }
+    case 'semi_annual': {
+      const hMonth = quarter <= 2 ? 0 : 6;
+      return `${year}-${String(hMonth + 1).padStart(2, '0')}-01`;
+    }
+    case 'annual':
+      return `${year}-01-01`;
+    case 'multi_year':
+      return '1970-01-01';
+    default:
+      return `${year}-01-01`;
+  }
+}
+
+// All benefit values in YAML are annual totals, so quarterly portion is always value / 4
+function getQuarterValue(benefit: CardBenefit): number {
+  if (benefit.frequency === 'ongoing' || benefit.frequency === 'multi_year') return 0;
+  return benefit.value / 4;
+}
+
+// Get the value a single period checkbox represents
+function getPerPeriodValue(benefit: CardBenefit): number {
+  switch (benefit.frequency) {
+    case 'monthly': return Math.round(benefit.value / 12);
+    case 'quarterly': return Math.round(benefit.value / 4);
+    case 'semi_annual': return Math.round(benefit.value / 2);
+    case 'annual': return benefit.value;
+    case 'multi_year': return benefit.value;
+    default: return 0;
+  }
+}
+
+function getPeriodLabel(frequency: string, year: number, quarter: number, monthIndex?: number): string {
+  switch (frequency) {
+    case 'monthly':
+      return monthNames[monthIndex ?? ((quarter - 1) * 3)];
+    case 'quarterly':
+      return `Q${quarter} ${year}`;
+    case 'semi_annual':
+      return quarter <= 2 ? `H1 ${year} (Jan–Jun)` : `H2 ${year} (Jul–Dec)`;
+    case 'annual':
+      return `${year}`;
+    default:
+      return '';
+  }
+}
+
+interface TrackedBenefit {
+  benefit: CardBenefit;
+  cardId: number;
+  cardName: string;
+  cardSlug: string;
+  cardImage?: string;
 }
 
 interface WalletBenefitsProps {
   walletCards: WalletCard[];
   allCards: Card[];
+  usageRecords: BenefitUsageRecord[];
+  onToggleUsage: (cardId: number, benefitName: string, frequency: string, periodStart: string, status: 'used' | 'dismissed') => Promise<void>;
+  onRemoveUsage: (cardId: number, benefitName: string, periodStart: string) => Promise<void>;
 }
 
-export default function WalletBenefits({ walletCards, allCards }: WalletBenefitsProps) {
-  const [viewMode, setViewMode] = useState<'by-card' | 'all-credits'>('all-credits');
+export default function WalletBenefits({ walletCards, allCards, usageRecords, onToggleUsage, onRemoveUsage }: WalletBenefitsProps) {
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+  const [selectedQuarter, setSelectedQuarter] = useState(getCurrentQuarter());
+  const [confirmingUncheck, setConfirmingUncheck] = useState<string | null>(null);
+  const [loadingToggle, setLoadingToggle] = useState<string | null>(null);
+  const confirmTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  useEffect(() => {
+    return () => {
+      if (confirmTimeout.current) clearTimeout(confirmTimeout.current);
+    };
+  }, []);
+
+  // Build lookup map from usage records
+  const usageLookup = useMemo(() => {
+    const map = new Map<string, BenefitUsageRecord>();
+    for (const record of usageRecords) {
+      const key = `${record.card_id}-${record.benefit_name}-${record.period_start}`;
+      map.set(key, record);
+    }
+    return map;
+  }, [usageRecords]);
+
+  // Match wallet cards to card data
   const cardsWithBenefits = useMemo(() => {
-    const result: CardWithBenefits[] = [];
+    const result: { walletCard: WalletCard; cardData: Card; benefits: CardBenefit[] }[] = [];
     for (const wc of walletCards) {
       const cardData = allCards.find(c => c.card_name === wc.card_name);
       if (cardData?.benefits && cardData.benefits.length > 0) {
@@ -60,24 +150,155 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
     return result;
   }, [walletCards, allCards]);
 
-  const allCredits = useMemo(() => {
+  // Trackable credits: value > 0, not ongoing
+  const trackedBenefits = useMemo((): TrackedBenefit[] => {
     return cardsWithBenefits.flatMap(c =>
-      c.benefits.filter(b => b.value > 0).map(b => ({ ...b, cardName: c.cardData.card_name, cardSlug: c.cardData.slug, cardImage: c.cardData.card_image_link }))
-    ).sort((a, b) => b.value - a.value);
-  }, [cardsWithBenefits]);
-
-  const allPerks = useMemo(() => {
-    return cardsWithBenefits.flatMap(c =>
-      c.benefits.filter(b => b.value === 0).map(b => ({ ...b, cardName: c.cardData.card_name, cardSlug: c.cardData.slug, cardImage: c.cardData.card_image_link }))
+      c.benefits
+        .filter(b => b.value > 0 && b.frequency !== 'ongoing')
+        .map(b => ({
+          benefit: b,
+          cardId: c.walletCard.card_id,
+          cardName: c.cardData.card_name,
+          cardSlug: c.cardData.slug,
+          cardImage: c.cardData.card_image_link,
+        }))
     );
   }, [cardsWithBenefits]);
 
+  const periodicBenefits = trackedBenefits.filter(t => t.benefit.frequency !== 'multi_year');
+  const multiYearBenefits = trackedBenefits.filter(t => t.benefit.frequency === 'multi_year');
+
+  // Perks (value === 0)
+  const allPerks = useMemo(() => {
+    return cardsWithBenefits.flatMap(c =>
+      c.benefits.filter(b => b.value === 0).map(b => ({
+        ...b,
+        cardName: c.cardData.card_name,
+        cardSlug: c.cardData.slug,
+      }))
+    );
+  }, [cardsWithBenefits]);
+
+  // Total annual value
   const totalAnnualValue = useMemo(() => {
-    return allCredits.reduce((sum, b) => {
-      if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
-      return sum + b.value;
+    return trackedBenefits.reduce((sum, t) => {
+      if (t.benefit.frequency === 'multi_year') return sum + Math.round(t.benefit.value / 4);
+      return sum + t.benefit.value;
     }, 0);
-  }, [allCredits]);
+  }, [trackedBenefits]);
+
+  // Calculate quarter summary
+  const quarterSummary = useMemo(() => {
+    let available = 0;
+    let used = 0;
+
+    for (const t of periodicBenefits) {
+      const { benefit, cardId } = t;
+      const qValue = getQuarterValue(benefit);
+      available += qValue;
+
+      if (benefit.frequency === 'monthly') {
+        const perMonth = benefit.value / 12;
+        for (let i = 0; i < 3; i++) {
+          const monthIdx = (selectedQuarter - 1) * 3 + i;
+          const ps = getPeriodStart('monthly', selectedYear, selectedQuarter, monthIdx);
+          const key = `${cardId}-${benefit.name}-${ps}`;
+          if (usageLookup.has(key) && usageLookup.get(key)!.status === 'used') {
+            used += perMonth;
+          }
+        }
+      } else {
+        const ps = getPeriodStart(benefit.frequency, selectedYear, selectedQuarter);
+        const key = `${cardId}-${benefit.name}-${ps}`;
+        if (usageLookup.has(key) && usageLookup.get(key)!.status === 'used') {
+          used += qValue;
+        }
+      }
+    }
+
+    return { available: Math.round(available), used: Math.round(used) };
+  }, [periodicBenefits, selectedYear, selectedQuarter, usageLookup]);
+
+  // Calculate annual summary across all 4 quarters
+  const annualSummary = useMemo(() => {
+    let used = 0;
+
+    for (const t of periodicBenefits) {
+      const { benefit, cardId } = t;
+
+      if (benefit.frequency === 'monthly') {
+        const perMonth = benefit.value / 12;
+        for (let q = 1; q <= 4; q++) {
+          for (let i = 0; i < 3; i++) {
+            const monthIdx = (q - 1) * 3 + i;
+            const ps = getPeriodStart('monthly', selectedYear, q, monthIdx);
+            const key = `${cardId}-${benefit.name}-${ps}`;
+            if (usageLookup.has(key) && usageLookup.get(key)!.status === 'used') {
+              used += perMonth;
+            }
+          }
+        }
+      } else if (benefit.frequency === 'quarterly') {
+        const perQ = benefit.value / 4;
+        for (let q = 1; q <= 4; q++) {
+          const ps = getPeriodStart('quarterly', selectedYear, q);
+          const key = `${cardId}-${benefit.name}-${ps}`;
+          if (usageLookup.has(key) && usageLookup.get(key)!.status === 'used') {
+            used += perQ;
+          }
+        }
+      } else if (benefit.frequency === 'semi_annual') {
+        const perHalf = benefit.value / 2;
+        for (const q of [1, 3] as const) {
+          const ps = getPeriodStart('semi_annual', selectedYear, q);
+          const key = `${cardId}-${benefit.name}-${ps}`;
+          if (usageLookup.has(key) && usageLookup.get(key)!.status === 'used') {
+            used += perHalf;
+          }
+        }
+      } else if (benefit.frequency === 'annual') {
+        const ps = getPeriodStart('annual', selectedYear, 1);
+        const key = `${cardId}-${benefit.name}-${ps}`;
+        if (usageLookup.has(key) && usageLookup.get(key)!.status === 'used') {
+          used += benefit.value;
+        }
+      }
+    }
+
+    return { available: totalAnnualValue, used: Math.round(used) };
+  }, [periodicBenefits, selectedYear, totalAnnualValue, usageLookup]);
+
+  const handleCheck = async (cardId: number, benefitName: string, frequency: string, periodStart: string, status: 'used' | 'dismissed' = 'used') => {
+    const key = `${cardId}-${benefitName}-${periodStart}`;
+    setLoadingToggle(key);
+    try {
+      await onToggleUsage(cardId, benefitName, frequency, periodStart, status);
+    } finally {
+      setLoadingToggle(null);
+    }
+  };
+
+  const handleUncheck = async (cardId: number, benefitName: string, periodStart: string) => {
+    const key = `${cardId}-${benefitName}-${periodStart}`;
+
+    // If not already confirming, show confirmation
+    if (confirmingUncheck !== key) {
+      setConfirmingUncheck(key);
+      if (confirmTimeout.current) clearTimeout(confirmTimeout.current);
+      confirmTimeout.current = setTimeout(() => setConfirmingUncheck(null), 3000);
+      return;
+    }
+
+    // Confirmed — uncheck
+    setConfirmingUncheck(null);
+    if (confirmTimeout.current) clearTimeout(confirmTimeout.current);
+    setLoadingToggle(key);
+    try {
+      await onRemoveUsage(cardId, benefitName, periodStart);
+    } finally {
+      setLoadingToggle(null);
+    }
+  };
 
   if (cardsWithBenefits.length === 0) {
     return (
@@ -91,167 +312,305 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
     );
   }
 
+  const qPct = quarterSummary.available > 0 ? Math.round((quarterSummary.used / quarterSummary.available) * 100) : 0;
+  const aPct = annualSummary.available > 0 ? Math.round((annualSummary.used / annualSummary.available) * 100) : 0;
+
+  // Group periodic benefits by card
+  const benefitsByCard = useMemo(() => {
+    const map = new Map<number, { cardName: string; cardSlug: string; cardImage?: string; benefits: TrackedBenefit[] }>();
+    for (const t of periodicBenefits) {
+      if (!map.has(t.cardId)) {
+        map.set(t.cardId, { cardName: t.cardName, cardSlug: t.cardSlug, cardImage: t.cardImage, benefits: [] });
+      }
+      map.get(t.cardId)!.benefits.push(t);
+    }
+    return Array.from(map.entries());
+  }, [periodicBenefits]);
+
+  const renderCheckbox = (cardId: number, benefit: CardBenefit, periodStart: string, label: string) => {
+    const key = `${cardId}-${benefit.name}-${periodStart}`;
+    const record = usageLookup.get(key);
+    const isUsed = record?.status === 'used';
+    const isLoading = loadingToggle === key;
+    const isConfirming = confirmingUncheck === key;
+
+    return (
+      <div key={key} className="relative inline-flex items-center gap-1.5">
+        <button
+          disabled={isLoading}
+          onClick={() => isUsed ? handleUncheck(cardId, benefit.name, periodStart) : handleCheck(cardId, benefit.name, benefit.frequency, periodStart)}
+          className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+            isUsed
+              ? 'bg-emerald-100 text-emerald-700 border border-emerald-200'
+              : 'bg-gray-50 text-gray-500 border border-gray-200 hover:bg-gray-100'
+          } ${isLoading ? 'opacity-50' : ''}`}
+        >
+          {isLoading ? (
+            <div className="h-3.5 w-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+          ) : isUsed ? (
+            <CheckCircleIcon className="h-3.5 w-3.5" />
+          ) : (
+            <div className="h-3.5 w-3.5 rounded-full border-2 border-gray-300" />
+          )}
+          {label}
+        </button>
+        {isConfirming && (
+          <div className="absolute top-full left-0 mt-1 z-10 bg-white rounded-lg shadow-lg border border-gray-200 px-3 py-2 whitespace-nowrap">
+            <p className="text-xs text-gray-600 mb-1.5">Unmark this?</p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => handleUncheck(cardId, benefit.name, periodStart)}
+                className="text-xs px-2 py-0.5 bg-red-50 text-red-600 rounded hover:bg-red-100"
+              >
+                Yes
+              </button>
+              <button
+                onClick={() => setConfirmingUncheck(null)}
+                className="text-xs px-2 py-0.5 bg-gray-50 text-gray-600 rounded hover:bg-gray-100"
+              >
+                No
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div className="space-y-6">
       {/* Summary Header */}
       <div className="bg-gradient-to-br from-emerald-50 to-white shadow rounded-lg p-6 border border-emerald-100">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Your Card Benefits</h2>
-            <p className="mt-1 text-sm text-gray-500">
-              Credits and perks from {cardsWithBenefits.length} {cardsWithBenefits.length === 1 ? 'card' : 'cards'} in your wallet
-            </p>
+        <div className="mb-4">
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-gray-900">Benefits Tracker</h2>
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-indigo-100 text-indigo-700 border border-indigo-200">Experimental</span>
           </div>
-          <div className="text-center sm:text-right">
-            <p className="text-xs font-semibold uppercase tracking-wider text-emerald-600">Total Annual Credits</p>
-            <p className="text-3xl font-extrabold text-emerald-700">${totalAnnualValue.toLocaleString()}</p>
+          <p className="mt-1 text-sm text-gray-500">
+            {cardsWithBenefits.length} {cardsWithBenefits.length === 1 ? 'card' : 'cards'} · ${totalAnnualValue.toLocaleString()}/yr in credits
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {/* Quarter */}
+          <div>
+            <div className="flex items-baseline justify-between mb-1.5">
+              <p className="text-xs font-semibold uppercase tracking-wider text-emerald-600">Q{selectedQuarter} {selectedYear}</p>
+              <p className="text-sm text-gray-400">{qPct}%</p>
+            </div>
+            <div className="h-2 bg-gray-200 rounded-full overflow-hidden mb-1">
+              <div className="h-full bg-emerald-500 rounded-full transition-all duration-300" style={{ width: `${qPct}%` }} />
+            </div>
+            <p className="text-lg font-bold text-emerald-700">${quarterSummary.used} <span className="text-sm font-normal text-gray-400">of ${quarterSummary.available}</span></p>
+          </div>
+          {/* Annual */}
+          <div>
+            <div className="flex items-baseline justify-between mb-1.5">
+              <p className="text-xs font-semibold uppercase tracking-wider text-indigo-600">{selectedYear} Annual</p>
+              <p className="text-sm text-gray-400">{aPct}%</p>
+            </div>
+            <div className="h-2 bg-gray-200 rounded-full overflow-hidden mb-1">
+              <div className="h-full bg-indigo-500 rounded-full transition-all duration-300" style={{ width: `${aPct}%` }} />
+            </div>
+            <p className="text-lg font-bold text-indigo-700">${annualSummary.used} <span className="text-sm font-normal text-gray-400">of ${annualSummary.available}</span></p>
           </div>
         </div>
       </div>
 
-      {/* View Toggle */}
-      <div className="flex gap-2">
+      {/* Quarter/Year Navigation */}
+      <div className="flex items-center justify-center gap-2">
         <button
-          onClick={() => setViewMode('all-credits')}
-          className={`px-3 py-1.5 text-sm font-medium rounded-md ${
-            viewMode === 'all-credits'
-              ? 'bg-indigo-100 text-indigo-700'
-              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-          }`}
+          onClick={() => setSelectedYear(selectedYear - 1)}
+          className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
         >
-          All Credits
+          <ChevronLeftIcon className="h-4 w-4" />
         </button>
+        <div className="flex bg-gray-100 rounded-lg p-0.5">
+          {[1, 2, 3, 4].map(q => (
+            <button
+              key={q}
+              onClick={() => setSelectedQuarter(q)}
+              className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                selectedQuarter === q
+                  ? 'bg-white text-indigo-700 shadow-sm'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              Q{q}
+            </button>
+          ))}
+        </div>
+        <span className="text-sm font-medium text-gray-700 mx-1">{selectedYear}</span>
         <button
-          onClick={() => setViewMode('by-card')}
-          className={`px-3 py-1.5 text-sm font-medium rounded-md ${
-            viewMode === 'by-card'
-              ? 'bg-indigo-100 text-indigo-700'
-              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-          }`}
+          onClick={() => setSelectedYear(selectedYear + 1)}
+          className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
         >
-          By Card
+          <ChevronRightIcon className="h-4 w-4" />
         </button>
       </div>
 
-      {viewMode === 'all-credits' ? (
-        <div className="bg-white shadow rounded-lg divide-y divide-gray-100">
-          {/* Credits Table */}
-          <div className="p-6">
-            <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">Statement Credits</h3>
-            <div className="space-y-3">
-              {allCredits.map((credit, i) => (
-                <div key={`${credit.cardName}-${credit.name}-${i}`} className="flex items-center gap-4 rounded-lg border border-gray-100 bg-gray-50/50 px-4 py-3">
-                  <span className="text-xl flex-shrink-0">{categoryIcons[credit.category] || categoryIcons.other}</span>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold text-gray-900">{credit.name}</p>
-                    <p className="text-xs text-gray-500 truncate">{credit.description}</p>
-                  </div>
-                  <Link href={`/card/${credit.cardSlug}`} className="hidden sm:block flex-shrink-0">
-                    <CardImage cardImageLink={credit.cardImage} alt={credit.cardName} width={48} height={30} className="rounded object-contain" sizes="48px" />
+      {/* Benefits by Card */}
+      {benefitsByCard.length > 0 ? (
+        <div className="space-y-4">
+          {benefitsByCard.map(([cardId, card]) => (
+            <div key={cardId} className="bg-white shadow rounded-lg overflow-hidden">
+              <div className="px-4 py-3 sm:px-5 border-b border-gray-100 bg-gray-50/50">
+                <div className="flex items-center gap-3">
+                  <Link href={`/card/${card.cardSlug}`}>
+                    <CardImage cardImageLink={card.cardImage} alt={card.cardName} width={48} height={30} className="rounded object-contain flex-shrink-0" sizes="48px" />
                   </Link>
-                  <div className="text-right flex-shrink-0">
-                    <p className="text-lg font-bold text-emerald-700">${credit.value}</p>
-                    <p className="text-xs text-gray-400">{frequencyLabels[credit.frequency]}</p>
+                  <Link href={`/card/${card.cardSlug}`} className="text-sm font-semibold text-gray-900 hover:text-indigo-600 truncate">
+                    {card.cardName}
+                  </Link>
+                </div>
+              </div>
+              <div className="divide-y divide-gray-50">
+                {card.benefits.map((t) => {
+                  const { benefit } = t;
+                  return (
+                    <div key={`${cardId}-${benefit.name}`} className="px-4 py-3 sm:px-5">
+                      <div className="flex items-start justify-between gap-3 mb-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className="text-base flex-shrink-0">{categoryIcons[benefit.category] || categoryIcons.other}</span>
+                          <div className="min-w-0">
+                            <span className="text-sm font-medium text-gray-900">{benefit.name}</span>
+                            {benefit.enrollment_required && (
+                              <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 border border-amber-200">
+                                Enroll
+                              </span>
+                            )}
+                            <p className="text-xs text-gray-400 truncate">{benefit.description}</p>
+                          </div>
+                        </div>
+                        <div className="flex items-baseline gap-1 flex-shrink-0">
+                          <span className="text-sm font-bold text-emerald-700">${getPerPeriodValue(benefit)}</span>
+                          <span className="text-xs text-gray-400">{frequencyLabels[benefit.frequency]}</span>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {benefit.frequency === 'monthly' && (
+                          <>
+                            {[0, 1, 2].map(i => {
+                              const monthIdx = (selectedQuarter - 1) * 3 + i;
+                              const ps = getPeriodStart('monthly', selectedYear, selectedQuarter, monthIdx);
+                              return renderCheckbox(cardId, benefit, ps, monthNames[monthIdx]);
+                            })}
+                          </>
+                        )}
+                        {benefit.frequency === 'quarterly' && (
+                          renderCheckbox(cardId, benefit, getPeriodStart('quarterly', selectedYear, selectedQuarter), `Q${selectedQuarter}`)
+                        )}
+                        {benefit.frequency === 'semi_annual' && (
+                          renderCheckbox(
+                            cardId, benefit,
+                            getPeriodStart('semi_annual', selectedYear, selectedQuarter),
+                            getPeriodLabel('semi_annual', selectedYear, selectedQuarter)
+                          )
+                        )}
+                        {benefit.frequency === 'annual' && (
+                          renderCheckbox(cardId, benefit, getPeriodStart('annual', selectedYear, selectedQuarter), `${selectedYear}`)
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="bg-white shadow rounded-lg p-6 text-center text-gray-500">
+          No trackable credits for this quarter.
+        </div>
+      )}
+
+      {/* One-Time Credits (multi_year) */}
+      {multiYearBenefits.length > 0 && (
+        <div className="bg-white shadow rounded-lg overflow-hidden">
+          <div className="px-4 py-3 sm:px-5 border-b border-gray-100">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500">One-Time Credits</h3>
+          </div>
+          <div className="divide-y divide-gray-50">
+            {multiYearBenefits.map(t => {
+              const { benefit, cardId, cardName, cardSlug, cardImage } = t;
+              const ps = '1970-01-01';
+              const key = `${cardId}-${benefit.name}-${ps}`;
+              const record = usageLookup.get(key);
+              const isLoading = loadingToggle === key;
+
+              return (
+                <div key={key} className="px-4 py-3 sm:px-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span className="text-base flex-shrink-0">{categoryIcons[benefit.category] || categoryIcons.other}</span>
+                      <div className="min-w-0">
+                        <span className="text-sm font-medium text-gray-900">{benefit.name}</span>
+                        <p className="text-xs text-gray-400 truncate">{benefit.description}</p>
+                        <Link href={`/card/${cardSlug}`} className="text-xs text-indigo-600 hover:text-indigo-800">
+                          {cardName}
+                        </Link>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <span className="text-sm font-bold text-emerald-700 mr-2">${benefit.value}</span>
+                      <button
+                        disabled={isLoading}
+                        onClick={() => record?.status === 'used'
+                          ? onRemoveUsage(cardId, benefit.name, ps)
+                          : handleCheck(cardId, benefit.name, benefit.frequency, ps, 'used')
+                        }
+                        className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                          record?.status === 'used'
+                            ? 'bg-emerald-100 text-emerald-700 border border-emerald-200'
+                            : 'bg-gray-50 text-gray-500 border border-gray-200 hover:bg-gray-100'
+                        } ${isLoading ? 'opacity-50' : ''}`}
+                      >
+                        Used
+                      </button>
+                      <button
+                        disabled={isLoading}
+                        onClick={() => record?.status === 'dismissed'
+                          ? onRemoveUsage(cardId, benefit.name, ps)
+                          : handleCheck(cardId, benefit.name, benefit.frequency, ps, 'dismissed')
+                        }
+                        className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                          record?.status === 'dismissed'
+                            ? 'bg-gray-200 text-gray-700 border border-gray-300'
+                            : 'bg-gray-50 text-gray-400 border border-gray-200 hover:bg-gray-100'
+                        } ${isLoading ? 'opacity-50' : ''}`}
+                      >
+                        Not interested
+                      </button>
+                    </div>
                   </div>
-                  {credit.enrollment_required && (
-                    <span className="hidden sm:inline-flex flex-shrink-0 items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 border border-amber-200">
-                      Enroll
-                    </span>
-                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Perks */}
+      {allPerks.length > 0 && (
+        <div className="bg-white shadow rounded-lg overflow-hidden">
+          <div className="px-4 py-3 sm:px-5 border-b border-gray-100">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500">Additional Perks</h3>
+          </div>
+          <div className="p-4 sm:p-5">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {allPerks.map((perk, i) => (
+                <div key={`${perk.cardName}-${perk.name}-${i}`} className="flex items-start gap-3 rounded-lg border border-gray-100 bg-gray-50/50 px-4 py-3">
+                  <CheckCircleIcon className="h-5 w-5 text-emerald-500 flex-shrink-0 mt-0.5" />
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-gray-900">{perk.name}</p>
+                    <p className="text-xs text-gray-500">{perk.description}</p>
+                    <Link href={`/card/${perk.cardSlug}`} className="text-xs text-indigo-600 hover:text-indigo-800 mt-1 inline-block">
+                      {perk.cardName}
+                    </Link>
+                  </div>
                 </div>
               ))}
             </div>
           </div>
-
-          {/* Perks */}
-          {allPerks.length > 0 && (
-            <div className="p-6">
-              <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">Additional Perks</h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {allPerks.map((perk, i) => (
-                  <div key={`${perk.cardName}-${perk.name}-${i}`} className="flex items-start gap-3 rounded-lg border border-gray-100 bg-gray-50/50 px-4 py-3">
-                    <CheckCircleIcon className="h-5 w-5 text-emerald-500 flex-shrink-0 mt-0.5" />
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold text-gray-900">{perk.name}</p>
-                      <p className="text-xs text-gray-500">{perk.description}</p>
-                      <Link href={`/card/${perk.cardSlug}`} className="text-xs text-indigo-600 hover:text-indigo-800 mt-1 inline-block">
-                        {perk.cardName}
-                      </Link>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      ) : (
-        /* By Card View */
-        <div className="space-y-4">
-          {cardsWithBenefits.map(({ walletCard, cardData, benefits }) => {
-            const credits = benefits.filter(b => b.value > 0);
-            const perks = benefits.filter(b => b.value === 0);
-            const cardTotal = credits.reduce((sum, b) => {
-              if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
-              return sum + b.value;
-            }, 0);
-
-            return (
-              <div key={walletCard.id} className="bg-white shadow rounded-lg overflow-hidden">
-                <div className="p-4 sm:p-5 border-b border-gray-100 bg-gray-50/50">
-                  <div className="flex items-center gap-4">
-                    <Link href={`/card/${cardData.slug}`}>
-                      <CardImage cardImageLink={cardData.card_image_link} alt={cardData.card_name} width={64} height={40} className="rounded object-contain flex-shrink-0" sizes="64px" />
-                    </Link>
-                    <div className="flex-1 min-w-0">
-                      <Link href={`/card/${cardData.slug}`} className="text-sm font-semibold text-gray-900 hover:text-indigo-600 truncate block">
-                        {cardData.card_name}
-                      </Link>
-                      <p className="text-xs text-gray-500">{cardData.bank}</p>
-                    </div>
-                    <div className="text-right flex-shrink-0">
-                      <p className="text-lg font-bold text-emerald-700">${cardTotal.toLocaleString()}</p>
-                      <p className="text-xs text-gray-400">/yr in credits</p>
-                    </div>
-                  </div>
-                </div>
-                <div className="p-4 sm:p-5">
-                  {credits.length > 0 && (
-                    <div className="space-y-2">
-                      {credits.map((b, i) => (
-                        <div key={i} className="flex items-center justify-between py-1">
-                          <div className="flex items-center gap-2 min-w-0">
-                            <span className="text-base flex-shrink-0">{categoryIcons[b.category] || categoryIcons.other}</span>
-                            <span className="text-sm text-gray-700 truncate">{b.name}</span>
-                            {b.enrollment_required && (
-                              <span className="flex-shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 border border-amber-200">
-                                Enroll
-                              </span>
-                            )}
-                          </div>
-                          <div className="flex items-baseline gap-1 flex-shrink-0">
-                            <span className="text-sm font-bold text-emerald-700">${b.value}</span>
-                            <span className="text-xs text-gray-400">{frequencyLabels[b.frequency]}</span>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  {perks.length > 0 && (
-                    <div className={credits.length > 0 ? "mt-3 pt-3 border-t border-gray-100" : ""}>
-                      <div className="flex flex-wrap gap-2">
-                        {perks.map((p, i) => (
-                          <span key={i} className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-gray-100 text-xs text-gray-600">
-                            <CheckCircleIcon className="h-3.5 w-3.5 text-emerald-500" />
-                            {p.name}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            );
-          })}
         </div>
       )}
     </div>

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -613,6 +613,21 @@ export default function WalletBenefits({ walletCards, allCards, usageRecords, on
           </div>
         </div>
       )}
+
+      {/* Community feedback note */}
+      <p className="text-xs text-gray-400 text-center">
+        Benefits data is community-maintained and may not be fully up to date.{" "}
+        See something wrong?{" "}
+        <a
+          href="https://github.com/CreditOdds/creditodds/issues/new?title=%5BBenefits%5D%20Incorrect%20or%20missing%20benefit&body=Card%3A%20%0A%0AWhat%20needs%20to%20be%20corrected%3F%0A%0A&labels=benefits"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-emerald-600 hover:text-emerald-700 underline underline-offset-2"
+        >
+          Let us know on GitHub
+        </a>
+        .
+      </p>
     </div>
   );
 }

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -281,6 +281,65 @@ export async function removeFromWallet(cardId: number, token: string): Promise<{
   return res.json();
 }
 
+// Benefit Usage tracking
+export interface BenefitUsageRecord {
+  id: number;
+  card_id: number;
+  benefit_name: string;
+  frequency: 'monthly' | 'quarterly' | 'semi_annual' | 'annual' | 'multi_year';
+  period_start: string;
+  status: 'used' | 'dismissed';
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getBenefitUsage(token: string, year?: number): Promise<BenefitUsageRecord[]> {
+  const yearParam = year || new Date().getFullYear();
+  const res = await fetch(`${API_BASE}/benefit-usage?year=${yearParam}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    console.error('getBenefitUsage error:', res.status, errorText);
+    throw new Error(`Failed to fetch benefit usage: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.usages || [];
+}
+
+export async function toggleBenefitUsage(
+  data: { card_id: number; benefit_name: string; frequency: string; period_start: string; status?: 'used' | 'dismissed' },
+  token: string,
+): Promise<{ message: string }> {
+  const res = await fetch(`${API_BASE}/benefit-usage`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to toggle benefit usage');
+  return res.json();
+}
+
+export async function removeBenefitUsage(
+  data: { card_id: number; benefit_name: string; period_start: string },
+  token: string,
+): Promise<{ message: string }> {
+  const res = await fetch(`${API_BASE}/benefit-usage`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to remove benefit usage');
+  return res.json();
+}
+
 // Recent records for ticker (no auth required)
 export interface RecentRecord {
   record_id: number;

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -295,7 +295,7 @@ export interface BenefitUsageRecord {
 
 export async function getBenefitUsage(token: string, year?: number): Promise<BenefitUsageRecord[]> {
   const yearParam = year || new Date().getFullYear();
-  const res = await fetch(`${API_BASE}/benefit-usage?year=${yearParam}`, {
+  const res = await fetch(`${API_BASE}/benefit-usage?year=${yearParam}&_=${Date.now()}`, {
     headers: { Authorization: `Bearer ${token}` },
     cache: 'no-store',
   });
@@ -305,7 +305,11 @@ export async function getBenefitUsage(token: string, year?: number): Promise<Ben
     throw new Error(`Failed to fetch benefit usage: ${res.status}`);
   }
   const data = await res.json();
-  return data.usages || [];
+  // Normalize period_start to YYYY-MM-DD (MySQL DATE returns as ISO datetime string)
+  return (data.usages || []).map((r: BenefitUsageRecord) => ({
+    ...r,
+    period_start: r.period_start ? r.period_start.slice(0, 10) : r.period_start,
+  }));
 }
 
 export async function toggleBenefitUsage(


### PR DESCRIPTION
## Summary
- New feature: users can track which card benefits they've used each period
- Quarterly view with per-month/quarter/half/year checkboxes
- Progress bars for both quarterly and annual utilization
- One-Time Credits section for multi-year benefits (Used / Not interested)
- Uncheck confirmation to prevent accidental unmarking
- New `benefit_usage` DB table + `/benefit-usage` API endpoint (already deployed)
- Marked as Experimental

## Test plan
- [x] Migration deployed and verified
- [x] API deployed with auth fix (`authorizer.sub`)
- [x] Math fix: values are annual totals, divided correctly for per-period display
- [x] Tested locally — check/uncheck persists across page navigations

🤖 Generated with [Claude Code](https://claude.com/claude-code)