### PR TITLE
Add Playwright fallback for JS-rendered card pages

### DIFF
--- a/.github/workflows/check-card-pages.yml
+++ b/.github/workflows/check-card-pages.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
       - name: Check card pages
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "js-yaml": "^4.1.0",
         "twitter-api-v2": "^1.29.0"
       },
+      "devDependencies": {
+        "playwright": "^1.52.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       }
@@ -14969,6 +14972,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "js-yaml": "^4.1.0",
     "twitter-api-v2": "^1.29.0"
   },
+  "devDependencies": {
+    "playwright": "^1.52.0"
+  },
   "engines": {
     "node": ">=18.0.0"
   }

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -100,6 +100,7 @@ function stripHtml(html) {
 }
 
 async function fetchPageContent(url) {
+  // Try simple fetch first
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -117,31 +118,74 @@ async function fetchPageContent(url) {
 
     clearTimeout(timer);
 
-    if (!response.ok) {
-      console.warn(`  HTTP ${response.status} — skipping`);
+    if (response.ok) {
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('text/html')) {
+        const html = await response.text();
+        const stripped = stripHtml(html);
+        if (stripped.length >= 100) {
+          return stripped;
+        }
+        console.warn(`  Simple fetch returned too little content (${stripped.length} chars) — falling back to browser`);
+      }
+    }
+  } catch (err) {
+    console.warn(`  Simple fetch failed: ${err.message} — falling back to browser`);
+  }
+
+  // Fall back to Playwright for JS-rendered pages
+  return fetchWithBrowser(url);
+}
+
+let _browser = null;
+
+async function getBrowser() {
+  if (!_browser) {
+    try {
+      const { chromium } = require('playwright');
+      _browser = await chromium.launch({ headless: true });
+    } catch (err) {
+      console.warn(`  Playwright not available: ${err.message}`);
       return null;
     }
+  }
+  return _browser;
+}
 
-    const contentType = response.headers.get('content-type') || '';
-    if (!contentType.includes('text/html')) {
-      console.warn(`  Non-HTML response (${contentType}) — skipping`);
-      return null;
-    }
+async function fetchWithBrowser(url) {
+  const browser = await getBrowser();
+  if (!browser) return null;
 
-    const html = await response.text();
+  let page;
+  try {
+    const context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
+    page = await context.newPage();
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    // Wait for content to render
+    await page.waitForTimeout(3000);
+    const html = await page.content();
+    await context.close();
+
     const stripped = stripHtml(html);
     if (stripped.length < 100) {
-      console.warn(`  Page content too short (${stripped.length} chars) — likely blocked`);
+      console.warn(`  Browser fetch still too short (${stripped.length} chars) — skipping`);
       return null;
     }
+    console.log(`  Browser fetch succeeded (${stripped.length} chars)`);
     return stripped;
   } catch (err) {
-    if (err.name === 'AbortError') {
-      console.warn(`  Timeout after ${FETCH_TIMEOUT_MS / 1000}s — skipping`);
-    } else {
-      console.warn(`  Fetch error: ${err.message} — skipping`);
-    }
+    console.warn(`  Browser fetch error: ${err.message} — skipping`);
+    if (page) await page.context().close().catch(() => {});
     return null;
+  }
+}
+
+async function closeBrowser() {
+  if (_browser) {
+    await _browser.close();
+    _browser = null;
   }
 }
 
@@ -427,10 +471,12 @@ async function main() {
     console.log(`\nPR summary written to ${SUMMARY_FILE}`);
   }
 
+  await closeBrowser();
   console.log('\n=== Complete ===');
 }
 
-main().catch(err => {
+main().catch(async (err) => {
   console.error('Fatal error:', err);
+  await closeBrowser();
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Amex card pages are client-side rendered and return empty HTML to simple `fetch` (45 chars)
- Added Playwright headless browser as fallback when content is too short (<100 chars)
- Simple fetch is tried first (fast path for Chase, Barclays, etc.)
- Playwright browser instance is reused across multiple cards in a single run
- Affects all 23 cards with `americanexpress.com` apply links

## Changes
- `scripts/check-card-pages.js` — Playwright fallback with lazy browser init
- `.github/workflows/check-card-pages.yml` — installs Chromium + system deps
- `package.json` — adds `playwright` as devDependency

## Test plan
- [ ] Merge and run workflow on a Delta card to verify Amex pages now return content
- [ ] Verify non-Amex cards still use fast fetch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)