### PR TITLE
Fix branch name collision in check-card-pages

### DIFF
--- a/.github/workflows/check-card-pages.yml
+++ b/.github/workflows/check-card-pages.yml
@@ -53,9 +53,11 @@ jobs:
       - name: Create PR if changes found
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARD_SLUG: ${{ github.event.inputs.card_slug || '' }}
         run: |
           if [ -n "$(git status --porcelain data/cards/)" ]; then
-            BRANCH="card-page-check-$(date +%Y-%m-%d-%H%M%S)"
+            SLUG="${CARD_SLUG:-all}"
+            BRANCH="card-page-check-${SLUG}-$(date +%Y-%m-%d-%H%M%S)"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary
- When multiple single-card checks run in parallel and finish within the same second, they generate identical branch names and the second push fails
- Fix: include card slug in branch name (e.g. `card-page-check-delta-skymiles-gold-...-20260402-181708`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)