### PR TITLE
Add apply links to Bilt cards

### DIFF
--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -3,6 +3,7 @@ bank: "Bilt"
 slug: "bilt-blue"
 image: "bilt_blue.png"
 accepting_applications: true
+apply_link: https://www.biltrewards.com/card/apply
 annual_fee: 0
 reward_type: "points"
 release_date: "2025-01-15"

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -3,6 +3,7 @@ bank: "Bilt"
 slug: "bilt-obsidian"
 image: "bilt_obsidian.png"
 accepting_applications: true
+apply_link: https://www.biltrewards.com/card/apply
 annual_fee: 95
 reward_type: "points"
 release_date: "2025-01-15"

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -3,6 +3,7 @@ bank: "Bilt"
 slug: "bilt-palladium"
 image: "bilt_palladium.png"
 accepting_applications: true
+apply_link: https://www.biltrewards.com/card/apply
 annual_fee: 495
 reward_type: "points"
 release_date: "2025-01-15"


### PR DESCRIPTION
## Summary
- Add apply link to Bilt Blue, Obsidian, and Palladium
- All share the same apply page: https://www.biltrewards.com/card/apply
- Enables check-card-pages to monitor these cards (with Playwright fallback if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)