### PR TITLE
News: Amex introduces as-high-as variable SUBs on Delta and Blue Cash

### DIFF
--- a/data/news/2026-04-02-amex-as-high-as-subs-delta-blue-cash.yaml
+++ b/data/news/2026-04-02-amex-as-high-as-subs-delta-blue-cash.yaml
@@ -1,0 +1,41 @@
+id: "amex-as-high-as-subs-delta-blue-cash"
+date: "2026-04-02"
+title: "American Express Introduces \"As-High-As\" Variable Bonuses on Delta and Blue Cash Cards"
+summary: "Amex has quietly switched several Delta SkyMiles and Blue Cash cards from fixed signup bonuses to variable \"as-high-as\" (AHA) offers. The new ceilings exceed previous standard baselines — Delta Gold up to 80K miles, Platinum up to 90K, Reserve up to 100K — though they fall short of the elevated limited-time offers that just expired."
+tags:
+  - "bonus-change"
+  - "general"
+bank: "American Express"
+card_slug: "delta-skymiles-gold-american-express-card"
+card_name: "Delta SkyMiles Gold American Express"
+source: "Reddit r/CreditCards"
+source_url: "https://www.reddit.com/r/CreditCards/"
+body: |
+  American Express has rolled out a new variable pricing model for signup bonuses on its Delta SkyMiles and Blue Cash card lineups, effective **April 2, 2026** — the day after the previous elevated limited-time Delta offers expired.
+
+  ## Delta SkyMiles Personal Cards
+
+  The new "as-high-as" (AHA) ceilings compared to previous standard baselines:
+
+  | Card | Previous Standard SUB | New AHA Ceiling | Best-Ever SUB (just expired) |
+  |------|----------------------|-----------------|------------------------------|
+  | **Delta Gold** | 50,000 miles | Up to 80,000 miles | 90,000 miles |
+  | **Delta Platinum** | 60,000 miles | Up to 90,000 miles | 100,000 miles |
+  | **Delta Reserve** | 70,000 miles | Up to 100,000 miles | 125,000 miles |
+
+  Delta Business cards remain unaffected with fixed bonuses (60K Biz Gold, 70K Biz Platinum, 80K Biz Reserve).
+
+  ## Blue Cash Cards
+
+  | Card | Previous Standard SUB | New AHA Ceiling |
+  |------|----------------------|-----------------|
+  | **Blue Cash Everyday** | $200 | Up to $200 |
+  | **Blue Cash Preferred** | $250 | Up to $350 |
+
+  Blue Business Cash and Blue Business Plus are unaffected.
+
+  ## What This Means
+
+  Under the AHA model, the bonus you're offered may vary based on factors like your credit profile and relationship with Amex. The advertised ceiling represents the maximum possible offer, not a guaranteed amount. Some cardholders report seeing higher offers in incognito mode or through targeted mailers.
+
+  With Hilton SUBs expiring April 15 and Marriott offers ending May 13, the industry is watching to see if Amex extends the AHA model to those co-brand cards next.


### PR DESCRIPTION
## Summary
- New news article covering Amex's shift to variable "as-high-as" (AHA) signup bonuses
- Delta Gold up to 80K, Platinum up to 90K, Reserve up to 100K (previous standard baselines were 50K/60K/70K)
- Blue Cash Preferred now up to $350 (was $250)
- Notes that Hilton and Marriott co-brands may follow when their current limited-time offers expire

🤖 Generated with [Claude Code](https://claude.com/claude-code)