### PR TITLE
Tag all impacted cards on Amex AHA SUB news article

### DIFF
--- a/data/news/2026-04-02-amex-as-high-as-subs-delta-blue-cash.yaml
+++ b/data/news/2026-04-02-amex-as-high-as-subs-delta-blue-cash.yaml
@@ -6,8 +6,18 @@ tags:
   - "bonus-change"
   - "general"
 bank: "American Express"
-card_slug: "delta-skymiles-gold-american-express-card"
-card_name: "Delta SkyMiles Gold American Express"
+card_slugs:
+  - "delta-skymiles-gold-american-express-card"
+  - "delta-skymiles-platinum-american-express-card"
+  - "delta-skymiles-reserve-american-express-card"
+  - "blue-cash-everyday-card"
+  - "blue-cash-preferred-card"
+card_names:
+  - "Delta SkyMiles Gold American Express"
+  - "Delta SkyMiles Platinum American Express"
+  - "Delta SkyMiles Reserve American Express"
+  - "Blue Cash Everyday"
+  - "Blue Cash Preferred"
 source: "Reddit r/CreditCards"
 source_url: "https://www.reddit.com/r/CreditCards/"
 body: |


### PR DESCRIPTION
## Summary
- Article was only tagged with Delta Gold — now includes all 5 impacted cards
- Delta Gold, Platinum, Reserve + Blue Cash Everyday, Preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)