### PR TITLE
Filter profile news to cardholder-relevant tags only

### DIFF
--- a/apps/web-next/src/app/profile/profileSelectors.test.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.test.ts
@@ -34,8 +34,9 @@ describe("profileSelectors", () => {
     ).toEqual(["Chase Sapphire Preferred"]);
 
     const relevantNews = getRelevantNews(walletCards as never, [
-      { id: "1", title: "Preferred gets a new offer", summary: "", card_slugs: ["chase-sapphire-preferred"] },
-      { id: "2", title: "Unrelated", summary: "", card_slugs: ["other-card"] },
+      { id: "1", title: "Annual fee increase", summary: "", tags: ["fee-change"], card_slugs: ["chase-sapphire-preferred"] },
+      { id: "2", title: "Unrelated", summary: "", tags: ["bonus-change"], card_slugs: ["other-card"] },
+      { id: "3", title: "New signup bonus", summary: "", tags: ["bonus-change"], card_slugs: ["chase-sapphire-preferred"] },
     ] as never, lookups);
 
     expect(relevantNews.map((item) => item.id)).toEqual(["1"]);

--- a/apps/web-next/src/app/profile/profileSelectors.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.ts
@@ -87,6 +87,14 @@ export function getEligibleRecordCards<T extends NamedCardRecord>(walletCards: W
   return walletCards.filter((walletCard) => !cardsWithRecords.has(walletCard.card_name));
 }
 
+// Tags relevant to existing cardholders (exclude signup bonus / new card news)
+const CARDHOLDER_RELEVANT_TAGS = new Set([
+  'benefit-change',
+  'fee-change',
+  'policy-change',
+  'discontinued',
+]);
+
 export function getRelevantNews(walletCards: WalletCard[], newsItems: NewsItem[], lookups: CardLookups) {
   const walletCardSlugs = new Set<string>();
 
@@ -97,5 +105,8 @@ export function getRelevantNews(walletCards: WalletCard[], newsItems: NewsItem[]
     }
   }
 
-  return newsItems.filter((newsItem) => newsItem.card_slugs?.some((slug) => walletCardSlugs.has(slug)));
+  return newsItems.filter((newsItem) =>
+    newsItem.card_slugs?.some((slug) => walletCardSlugs.has(slug))
+    && newsItem.tags?.some((tag) => CARDHOLDER_RELEVANT_TAGS.has(tag))
+  );
 }


### PR DESCRIPTION
## Summary
- Only show news tagged with `benefit-change`, `fee-change`, `policy-change`, or `discontinued` on the profile page
- Excludes `bonus-change`, `new-card`, and `limited-time` news since those are for prospective applicants, not existing cardholders

## Test plan
- [x] Unit tests updated and passing
- [ ] Verify profile page no longer shows signup bonus change news for wallet cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)