### PR TITLE
Skip signup_bonus.value check when note exists

### DIFF
--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -36,5 +36,4 @@ signup_bonus:
   spend_requirement: 4000
   timeframe_months: 3
   note: "Plus $300 Bilt Cash as a signup bonus"
-check_ignore:
-  - signup_bonus.value
+

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -47,5 +47,4 @@ apr:
     min: 18.24
     max: 27.74
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/inspire
-check_ignore:
-  - signup_bonus.value
+

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -34,5 +34,4 @@ apr:
     min: 18.24
     max: 27.74
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/premier
-check_ignore:
-  - signup_bonus.value
+

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -295,6 +295,10 @@ function detectChanges(card, extracted) {
     const cur = current.signup_bonus;
 
     for (const key of ['value', 'spend_requirement', 'timeframe_months']) {
+      // Skip value comparison when a note exists — the value was manually
+      // curated to account for tiered/combined bonuses that Haiku misreads.
+      if (key === 'value' && cur.note) continue;
+
       if (sb[key] !== null && sb[key] !== undefined && cur[key] !== undefined) {
         const field = `signup_bonus.${key}`;
         if (sb[key] !== cur[key] && !ignoreFields.has(field)) {


### PR DESCRIPTION
## Summary
- Cards with a `signup_bonus.note` have manually curated values (e.g. Disney Visa's $100 eGift + $50 statement credit = $150). Haiku only extracts the base tier, causing repeated false positives like #369.
- Now skips the `value` comparison when a note already exists on the card
- Removes `check_ignore` from Bilt Palladium, Disney Inspire Visa, and Disney Premier Visa — no longer needed since the note handles it

## Test plan
- [ ] Verify next scheduled run doesn't flag Disney Visa, Disney Inspire, Disney Premier, or Bilt Palladium

🤖 Generated with [Claude Code](https://claude.com/claude-code)