### PR TITLE
Fix free_nights bonus display in Explore table

### DIFF
--- a/apps/web-next/src/app/explore/ExploreClient.tsx
+++ b/apps/web-next/src/app/explore/ExploreClient.tsx
@@ -382,9 +382,11 @@ export default function ExploreClient({ cards, banks, trendingViews, allTimeView
                             const isCash = bonus.type === 'cash' || bonus.type === 'cashback';
                             const valueStr = isCash
                               ? `$${bonus.value.toLocaleString()}`
-                              : bonus.value >= 1000
-                                ? `${Math.round(bonus.value / 1000)}K ${bonus.type}`
-                                : `${bonus.value.toLocaleString()} ${bonus.type}`;
+                              : bonus.type === 'free_nights'
+                                ? `${bonus.value} Free Night Award${bonus.value !== 1 ? 's' : ''}`
+                                : bonus.value >= 1000
+                                  ? `${Math.round(bonus.value / 1000)}K ${bonus.type}`
+                                  : `${bonus.value.toLocaleString()} ${bonus.type}`;
                             return (
                               <div>
                                 <div className="font-semibold text-gray-900">{valueStr}</div>


### PR DESCRIPTION
## Summary
- Fixed the Explore table showing raw `free_nights` type string (e.g., "3 free_nights") instead of human-readable "3 Free Night Awards"
- Adds `free_nights` handling to match the existing `formatBonusValue()` utility used elsewhere

## Test plan
- [ ] Navigate to Explore tab, find Marriott Bonvoy Boundless — verify it shows "3 Free Night Awards"

🤖 Generated with [Claude Code](https://claude.com/claude-code)