### PR TITLE
Add power rankings image to weekly top cards post

### DIFF
--- a/.github/workflows/weekly-top-cards.yml
+++ b/.github/workflows/weekly-top-cards.yml
@@ -18,8 +18,12 @@ jobs:
 
       - run: npm ci
 
-      - name: Queue weekly top viewed cards post
+      - name: Post weekly top viewed cards with image
         env:
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
           SOCIAL_API_URL: ${{ secrets.SOCIAL_API_URL }}
           SOCIAL_API_KEY: ${{ secrets.SOCIAL_API_KEY }}
         run: node scripts/post-weekly-top-cards.js

--- a/scripts/post-weekly-top-cards.js
+++ b/scripts/post-weekly-top-cards.js
@@ -3,18 +3,30 @@
 /**
  * Weekly Top Viewed Cards Social Post
  *
- * Fetches the top 5 most viewed cards from the past week and queues
- * a social post via the Social Posting Service.
+ * Fetches the top 5 most viewed cards from the past week, generates a
+ * "power rankings" PNG image with card images/names/rank movement,
+ * and posts directly to Twitter with the image attached.
  *
  * Usage: node scripts/post-weekly-top-cards.js [--dry-run]
  *
- * Env vars: SOCIAL_API_URL, SOCIAL_API_KEY
+ * Env vars:
+ *   TWITTER_API_KEY, TWITTER_API_SECRET,
+ *   TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET
+ *
+ * Falls back to Social API queue (without image) if Twitter creds are missing:
+ *   SOCIAL_API_URL, SOCIAL_API_KEY
  */
 
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+const { TwitterApi } = require('twitter-api-v2');
+
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
+const CDN_IMAGES = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
 const EXPLORE_URL = 'https://creditodds.com/explore';
 
-async function sleep(ms) {
+function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
@@ -35,44 +47,230 @@ async function fetchWithRetry(url, options, { maxRetries = 3, baseDelay = 2000 }
 }
 
 async function fetchTopCards() {
-  // Fetch view counts for the last 7 days
-  const viewsRes = await fetch(`${API_BASE}/card-view?period=7`);
-  if (!viewsRes.ok) throw new Error(`Failed to fetch views: ${viewsRes.status}`);
-  const { views } = await viewsRes.json();
+  // Fetch 7-day and 14-day views to compute this week vs last week
+  const [views7Res, views14Res, cardsRes] = await Promise.all([
+    fetch(`${API_BASE}/card-view?period=7`),
+    fetch(`${API_BASE}/card-view?period=14`),
+    fetch(`${API_BASE}/cards`),
+  ]);
 
-  // Fetch all cards to map db_card_id -> card_name
-  const cardsRes = await fetch(`${API_BASE}/cards`);
+  if (!views7Res.ok) throw new Error(`Failed to fetch 7d views: ${views7Res.status}`);
+  if (!views14Res.ok) throw new Error(`Failed to fetch 14d views: ${views14Res.status}`);
   if (!cardsRes.ok) throw new Error(`Failed to fetch cards: ${cardsRes.status}`);
+
+  const { views: views7 } = await views7Res.json();
+  const { views: views14 } = await views14Res.json();
   const cards = await cardsRes.json();
 
-  // Build lookup: numeric db_card_id -> card name
-  const cardNameById = {};
+  // Build lookup: numeric db_card_id -> card info
+  const cardById = {};
   for (const card of cards) {
     if (card.db_card_id) {
-      cardNameById[card.db_card_id] = card.card_name || card.name;
+      cardById[card.db_card_id] = {
+        name: card.card_name || card.name,
+        image: card.card_image_link,
+        slug: card.slug || card.card_id,
+        bank: card.bank,
+      };
     }
   }
 
-  // Sort views descending and pick top 5 that have a known card name
-  const ranked = Object.entries(views)
-    .map(([id, count]) => ({ id: Number(id), count, name: cardNameById[Number(id)] }))
+  // Compute last week views = 14d - 7d
+  const lastWeekViews = {};
+  for (const [id, count14] of Object.entries(views14)) {
+    const count7 = views7[id] || 0;
+    lastWeekViews[id] = count14 - count7;
+  }
+
+  // Last week's ranking (for movement comparison)
+  const lastWeekRanked = Object.entries(lastWeekViews)
+    .filter(([id]) => cardById[Number(id)])
+    .sort((a, b) => b[1] - a[1]);
+  const lastWeekRankMap = {};
+  lastWeekRanked.forEach(([id], i) => { lastWeekRankMap[Number(id)] = i + 1; });
+
+  // This week's top 5
+  const thisWeek = Object.entries(views7)
+    .map(([id, count]) => ({
+      id: Number(id),
+      count,
+      ...cardById[Number(id)],
+    }))
     .filter(entry => entry.name)
     .sort((a, b) => b.count - a.count)
     .slice(0, 5);
 
-  if (ranked.length < 5) {
-    throw new Error(`Only found ${ranked.length} cards with views — need at least 5`);
+  if (thisWeek.length < 5) {
+    throw new Error(`Only found ${thisWeek.length} cards with views — need at least 5`);
   }
 
-  return ranked;
+  // Add movement info
+  for (let i = 0; i < thisWeek.length; i++) {
+    const card = thisWeek[i];
+    const currentRank = i + 1;
+    const previousRank = lastWeekRankMap[card.id];
+    if (!previousRank) {
+      card.movement = 'new';
+    } else if (previousRank > currentRank) {
+      card.movement = 'up';
+      card.movementAmount = previousRank - currentRank;
+    } else if (previousRank < currentRank) {
+      card.movement = 'down';
+      card.movementAmount = currentRank - previousRank;
+    } else {
+      card.movement = 'same';
+    }
+    card.rank = currentRank;
+  }
+
+  return thisWeek;
+}
+
+async function fetchCardImage(imageFilename) {
+  try {
+    const url = `${CDN_IMAGES}/${imageFilename}`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const buffer = Buffer.from(await res.arrayBuffer());
+    // Resize to consistent dimensions for the rankings image
+    return await sharp(buffer)
+      .resize(200, 126, { fit: 'contain', background: { r: 255, g: 255, b: 255, alpha: 0 } })
+      .png()
+      .toBuffer();
+  } catch (err) {
+    console.log(`  Warning: failed to fetch image ${imageFilename}: ${err.message}`);
+    return null;
+  }
+}
+
+function escapeXml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+async function generateRankingsImage(topCards) {
+  // Fetch all card images in parallel
+  const cardImages = await Promise.all(
+    topCards.map(card => card.image ? fetchCardImage(card.image) : Promise.resolve(null))
+  );
+
+  const width = 1080;
+  const rowHeight = 140;
+  const headerHeight = 120;
+  const footerHeight = 60;
+  const height = headerHeight + (rowHeight * 5) + footerHeight;
+
+  // Build composite layers
+  const composites = [];
+
+  // Movement indicator helper
+  function getMovementSvg(card) {
+    if (card.movement === 'up') {
+      return `<g>
+        <polygon points="0,12 8,0 16,12" fill="#16a34a"/>
+        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#16a34a">+${card.movementAmount}</text>
+      </g>`;
+    } else if (card.movement === 'down') {
+      return `<g>
+        <polygon points="0,0 8,12 16,0" fill="#dc2626"/>
+        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#dc2626">-${card.movementAmount}</text>
+      </g>`;
+    } else if (card.movement === 'new') {
+      return `<text x="0" y="12" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#7c3aed">NEW</text>`;
+    } else {
+      return `<text x="0" y="12" font-family="Arial,sans-serif" font-size="16" fill="#9ca3af">—</text>`;
+    }
+  }
+
+  // Date string
+  const now = new Date();
+  const weekStr = now.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+
+  // Row colors (alternating)
+  const rowColors = ['#f8fafc', '#ffffff'];
+
+  // Build rows SVG
+  let rowsSvg = '';
+  for (let i = 0; i < 5; i++) {
+    const card = topCards[i];
+    const y = headerHeight + (i * rowHeight);
+    const bgColor = rowColors[i % 2];
+    const rankColors = ['#4f46e5', '#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe'];
+
+    rowsSvg += `
+      <rect x="0" y="${y}" width="${width}" height="${rowHeight}" fill="${bgColor}"/>
+      <!-- Rank circle -->
+      <circle cx="55" cy="${y + rowHeight / 2}" r="28" fill="${rankColors[i]}"/>
+      <text x="55" y="${y + rowHeight / 2 + 10}" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="white">${card.rank}</text>
+      <!-- Card name + bank -->
+      <text x="310" y="${y + rowHeight / 2 - 8}" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#1e293b">${escapeXml(card.name)}</text>
+      <text x="310" y="${y + rowHeight / 2 + 18}" font-family="Arial,sans-serif" font-size="16" fill="#64748b">${escapeXml(card.bank || '')}</text>
+      <!-- Movement indicator -->
+      <g transform="translate(${width - 80}, ${y + rowHeight / 2 - 6})">
+        ${getMovementSvg(card)}
+      </g>
+    `;
+  }
+
+  // Full SVG
+  const svg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" style="stop-color:#4f46e5"/>
+        <stop offset="100%" style="stop-color:#7c3aed"/>
+      </linearGradient>
+    </defs>
+
+    <!-- Background -->
+    <rect width="${width}" height="${height}" fill="#ffffff"/>
+
+    <!-- Header -->
+    <rect x="0" y="0" width="${width}" height="${headerHeight}" fill="url(#headerGrad)"/>
+    <text x="40" y="52" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white">Weekly Power Rankings</text>
+    <text x="40" y="85" font-family="Arial,sans-serif" font-size="18" fill="rgba(255,255,255,0.85)">Top 5 Most Viewed Credit Cards — Week of ${escapeXml(weekStr)}</text>
+
+    <!-- Rows -->
+    ${rowsSvg}
+
+    <!-- Footer -->
+    <rect x="0" y="${height - footerHeight}" width="${width}" height="${footerHeight}" fill="#f1f5f9"/>
+    <text x="${width / 2}" y="${height - 22}" text-anchor="middle" font-family="Arial,sans-serif" font-size="16" font-weight="600" fill="#64748b">creditodds.com</text>
+  </svg>`;
+
+  // Render SVG to PNG base, then composite card images on top
+  let image = sharp(Buffer.from(svg)).png();
+
+  // Overlay card images
+  const overlays = [];
+  for (let i = 0; i < 5; i++) {
+    if (cardImages[i]) {
+      const y = headerHeight + (i * rowHeight) + Math.round((rowHeight - 86) / 2);
+      overlays.push({
+        input: await sharp(cardImages[i]).resize(136, 86, { fit: 'contain', background: { r: 0, g: 0, b: 0, alpha: 0 } }).png().toBuffer(),
+        left: 110,
+        top: y,
+      });
+    }
+  }
+
+  if (overlays.length > 0) {
+    image = sharp(await image.toBuffer()).composite(overlays).png();
+  }
+
+  return image.toBuffer();
 }
 
 function buildTweetText(topCards) {
   const list = topCards
-    .map((card, i) => `${i + 1}. ${card.name}`)
+    .map((card) => {
+      const arrow = card.movement === 'up' ? '\u2B06\uFE0F'
+        : card.movement === 'down' ? '\u2B07\uFE0F'
+        : card.movement === 'new' ? '\uD83C\uDD95'
+        : '\u2796';
+      return `${card.rank}. ${card.name} ${arrow}`;
+    })
     .join('\n');
 
-  return `Five most viewed credit cards on CreditOdds this week:\n\n${list}`;
+  return `Credit Card Power Rankings \u2014 This Week\u2019s Top 5 Most Viewed:\n\n${list}`;
 }
 
 function buildLinkUrl() {
@@ -80,7 +278,32 @@ function buildLinkUrl() {
   url.searchParams.set('utm_source', 'twitter');
   url.searchParams.set('utm_medium', 'social');
   url.searchParams.set('utm_campaign', 'weekly-top-cards');
+  const weekStr = new Date().toISOString().slice(0, 10);
+  url.searchParams.set('utm_content', `weekly-${weekStr}`);
   return url.toString();
+}
+
+async function postToTwitter(tweetText, linkUrl, imageBuffer) {
+  const client = new TwitterApi({
+    appKey: process.env.TWITTER_API_KEY,
+    appSecret: process.env.TWITTER_API_SECRET,
+    accessToken: process.env.TWITTER_ACCESS_TOKEN,
+    accessSecret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
+  });
+
+  // Upload image
+  const mediaId = await client.v1.uploadMedia(imageBuffer, { mimeType: 'image/png' });
+  console.log(`  Uploaded image, media ID: ${mediaId}`);
+
+  // Post tweet with image
+  const fullText = `${tweetText}\n\n${linkUrl}`;
+  const { data } = await client.v2.tweet({
+    text: fullText,
+    media: { media_ids: [mediaId] },
+  });
+
+  console.log(`  Tweet posted: https://x.com/creditodds/status/${data.id}`);
+  return data;
 }
 
 async function queuePost(textContent, linkUrl, sourceId) {
@@ -114,13 +337,21 @@ async function queuePost(textContent, linkUrl, sourceId) {
 async function main() {
   const dryRun = process.argv.includes('--dry-run');
 
-  console.log('=== Weekly Top Viewed Cards ===\n');
+  console.log('=== Weekly Top Viewed Cards - Power Rankings ===\n');
 
   const topCards = await fetchTopCards();
   console.log('Top 5 cards by views (last 7 days):');
   for (const card of topCards) {
-    console.log(`  ${card.name}: ${card.count} views`);
+    const arrow = card.movement === 'up' ? `+${card.movementAmount}`
+      : card.movement === 'down' ? `-${card.movementAmount}`
+      : card.movement === 'new' ? 'NEW'
+      : '—';
+    console.log(`  #${card.rank} ${card.name}: ${card.count} views (${arrow})`);
   }
+
+  console.log('\nGenerating power rankings image...');
+  const imageBuffer = await generateRankingsImage(topCards);
+  console.log(`  Image generated: ${(imageBuffer.length / 1024).toFixed(0)}KB`);
 
   const tweetText = buildTweetText(topCards);
   const linkUrl = buildLinkUrl();
@@ -128,15 +359,32 @@ async function main() {
 
   console.log(`\nTweet text (${tweetText.length} chars):\n${tweetText}`);
   console.log(`\nLink: ${linkUrl}`);
-  console.log(`Source ID: ${sourceId}`);
 
   if (dryRun) {
-    console.log('\n[DRY RUN] Skipping queue.');
+    // Save image locally for preview
+    const outPath = path.join(__dirname, '..', 'weekly-rankings-preview.png');
+    fs.writeFileSync(outPath, imageBuffer);
+    console.log(`\n[DRY RUN] Image saved to: ${outPath}`);
+    console.log('[DRY RUN] Skipping post.');
     return;
   }
 
-  const result = await queuePost(tweetText, linkUrl, sourceId);
-  console.log(`\nQueued successfully! Post ID: ${result.id}`);
+  // Try direct Twitter post with image first
+  const twitterEnabled = process.env.TWITTER_API_KEY
+    && process.env.TWITTER_API_SECRET
+    && process.env.TWITTER_ACCESS_TOKEN
+    && process.env.TWITTER_ACCESS_TOKEN_SECRET;
+
+  if (twitterEnabled) {
+    console.log('\nPosting to Twitter with image...');
+    await postToTwitter(tweetText, linkUrl, imageBuffer);
+    console.log('\nDone!');
+  } else {
+    // Fallback: queue without image
+    console.log('\nTwitter creds not found — falling back to Social API queue (no image).');
+    const result = await queuePost(tweetText, linkUrl, sourceId);
+    console.log(`Queued successfully! Post ID: ${result.id}`);
+  }
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- Generates a **power rankings PNG image** for the weekly top 5 most viewed cards post
- Each card shows: rank number, card image (from CDN), card name, issuer, and movement indicator
- Movement computed by comparing 7-day vs 14-day view data (up/down/new/same)
- Posts directly to Twitter with image via `v1.uploadMedia()` + `v2.tweet()`
- Falls back to Social API queue (text-only) if Twitter creds are missing
- Updated workflow to pass Twitter secrets alongside existing Social API secrets
- `--dry-run` flag saves the image locally for preview

## Test plan
- [x] `--dry-run` generates correct image locally with all 5 cards, images, and movement arrows
- [ ] Trigger workflow manually via GitHub Actions to test live posting

🤖 Generated with [Claude Code](https://claude.com/claude-code)