### PR TITLE
Fix Playwright browser not closing when no card changes detected

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -496,6 +496,7 @@ async function main() {
   if (allChanges.length === 0) {
     console.log('No changes detected. Exiting.');
     if (fs.existsSync(SUMMARY_FILE)) fs.unlinkSync(SUMMARY_FILE);
+    await closeBrowser();
     return;
   }
 


### PR DESCRIPTION
## Summary
- The `check-card-pages.js` script has an early return when no card changes are detected, but this path was missing a `closeBrowser()` call
- The orphan `chrome-headless-shell` process kept the GitHub Actions job hanging until the 30-minute timeout cancelled it
- Added `await closeBrowser()` before the early return

## Test plan
- [ ] Next scheduled run of Check Card Pages completes in ~10-15 minutes instead of timing out at 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)