### PR TITLE
Fix card page check misreading strikethrough text as current values

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -105,6 +105,8 @@ function stripHtml(html) {
     .replace(/<nav\b[^<]*(?:(?!<\/nav>)<[^<]*)*<\/nav>/gi, '')
     .replace(/<header\b[^<]*(?:(?!<\/header>)<[^<]*)*<\/header>/gi, '')
     .replace(/<footer\b[^<]*(?:(?!<\/footer>)<[^<]*)*<\/footer>/gi, '')
+    // Mark strikethrough content so the model knows to ignore it
+    .replace(/<(s|del|strike)\b[^>]*>([\s\S]*?)<\/\1>/gi, ' [STRIKETHROUGH: $2] ')
     .replace(/<[^>]+>/g, ' ')
     .replace(/&[a-z#0-9]+;/gi, ' ')
     .replace(/\s+/g, ' ')
@@ -237,6 +239,7 @@ Rules:
 - TIERED BONUSES: Many cards have tiered signup bonuses (e.g., "earn 3 free nights after $3,000 in 3 months, plus 1 more after $4,000 total in 4 months"). When a card has tiered/multi-level bonuses, extract ONLY the BASE/FIRST tier values for value, spend_requirement, and timeframe_months. Then describe the additional tier(s) in "tiered_bonus_note" as a short human-readable string (e.g. "Plus 1 additional Free Night Award after spending $4,000 total in 4 months" or "Plus up to 30,000 additional points (2x on purchases up to $15,000 spent in the first 6 months)"). If the bonus is NOT tiered, set tiered_bonus_note to null.
 - AUTHORIZED USER BONUSES: Do NOT include bonus miles/points earned for adding an authorized user in the "value" field. Only count the primary cardholder's signup bonus from spending. For example, if a card offers "90,000 miles after $4,000 spend + 10,000 miles for adding an authorized user", the value is 90000, NOT 100000. Instead, put the authorized user bonus amount in "authorized_user_bonus" (e.g. 10000). null if no AU bonus.
 - CASH vs POINTS: Do NOT combine cash/dollar bonuses with points/miles. If a card offers "50,000 points + $300 cash bonus", the signup_bonus value is 50000 (points only). Cash bonuses are separate from points/miles and must NOT be added to the value field. A $300 cash bonus is NOT 300 points.
+- STRIKETHROUGH TEXT: Text wrapped in [STRIKETHROUGH: ...] is struck through on the page and represents old/expired values. Always ignore strikethrough values and use the non-strikethrough value instead.
 - Return null for any field you cannot determine with confidence.`;
 
   const response = await fetch('https://api.anthropic.com/v1/messages', {


### PR DESCRIPTION
## Summary
- Strikethrough HTML tags (`<s>`, `<del>`, `<strike>`) were being stripped like all other tags, losing the context that the wrapped text was old/expired
- This caused Haiku to misread promotional comparisons — e.g. picking the struck-through 40,000 instead of the current 60,000 bonus (see #378)
- Now converts strikethrough tags to `[STRIKETHROUGH: ...]` markers before stripping HTML
- Added a prompt rule telling the model to ignore strikethrough values

## Test plan
- [ ] Next check-card-pages run correctly ignores strikethrough values on Wells Fargo Choice Privileges page

🤖 Generated with [Claude Code](https://claude.com/claude-code)