### PR TITLE
Update Check Card Pages schedule to 7 AM ET

### DIFF
--- a/.github/workflows/check-card-pages.yml
+++ b/.github/workflows/check-card-pages.yml
@@ -2,7 +2,7 @@ name: Check Card Pages
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # Daily at 6 AM UTC / 2 AM EST (offset from auto-card-update at 3 PM UTC)
+    - cron: '0 11 * * *'  # Daily at 11 AM UTC / 7 AM ET
   workflow_dispatch:
     inputs:
       card_slug:


### PR DESCRIPTION
## Summary
- Changed cron from `0 6 * * *` (6 AM UTC / 2 AM ET) to `0 11 * * *` (11 AM UTC / 7 AM ET)

## Test plan
- [ ] Verify next scheduled run triggers around 7 AM ET

🤖 Generated with [Claude Code](https://claude.com/claude-code)