### PR TITLE
Add news: Amex caps referral bonuses at 5 per calendar year

### DIFF
--- a/data/news/2026-04-09-amex-referral-cap-five-per-year.yaml
+++ b/data/news/2026-04-09-amex-referral-cap-five-per-year.yaml
@@ -1,0 +1,55 @@
+id: "amex-referral-cap-five-per-year"
+date: "2026-04-09"
+title: "Amex Caps Referral Bonuses at 5 Per Calendar Year Across Membership Rewards Cards"
+summary: "American Express has replaced its currency-based annual referral limit with a flat cap of five referral bonuses per calendar year, effective April 8, 2026. The new terms appear on all Membership Rewards cards and apply to any friend approved from a referral link after the cutoff."
+tags:
+  - policy-change
+bank: "American Express"
+card_slugs:
+  - "american-express-gold-card"
+  - "american-express-green-card"
+  - "the-platinum-card"
+  - "american-express-business-gold-card"
+  - "the-business-platinum-card-from-american-express"
+card_names:
+  - "American Express Gold"
+  - "American Express Green"
+  - "The Platinum Card"
+  - "American Express Business Gold"
+  - "The Business Platinum Card"
+source: "r/churning"
+source_url: "https://www.reddit.com/r/churning/comments/1sfnk60/news_and_updates_thread_april_08_2026/"
+body: |
+  American Express has quietly overhauled how it caps referral bonuses on its Membership Rewards card lineup. Cardholders began seeing a new notice appear on all five MR-earning cards this week stating:
+
+  > You can earn a referral bonus up to a maximum of five (5) times per calendar year.
+
+  The change is confirmed in the official referral terms, with a hard cutover at **12:00 AM ET on April 8, 2026**.
+
+  ## What the Fine Print Says
+
+  The updated terms lay out a two-phase transition for the 2026 calendar year:
+
+  - **Through April 7, 2026 at 11:59 PM ET:** Any referral bonus earned between January 1 and the cutoff counted toward the previous **currency-based annual limit** (Amex historically capped total referral rewards at a set amount of points or cash per card, per year).
+  - **From April 8, 2026 at 12:00 AM ET onward:** Referral bonuses count toward a new **flat cap of 5 referrals per calendar year**, regardless of the point value of each referral.
+
+  The notice is showing up on all five MR-earning cards: **American Express Gold**, **American Express Green**, **The Platinum Card**, **American Express Business Gold**, and **The Business Platinum Card**.
+
+  ## Who Wins and Who Loses
+
+  The flat five-referral cap is a meaningful shift from the previous model, which was denominated in points or dollars:
+
+  - **Lower-bonus cards benefit.** Cards like the Amex Green, where a single referral paid fewer points, previously burned through the currency cap slowly. Under the new rules, every referral counts the same — so five referrals is five referrals, even on lower-SUB cards.
+  - **Higher-bonus cards take a haircut.** On cards like The Platinum Card, where referrals can pay 15,000–25,000 points each, the old currency cap often allowed more than five successful referrals per year before hitting the ceiling. Five referrals is now the hard stop.
+
+  ## Does the Counter Reset? (Speculation)
+
+  One open question, surfaced in the r/churning discussion thread, is how the transition treats cardholders who had **already maxed out their currency-based limit before April 8**. If you hit the old cap on, say, your Business Platinum and Business Gold earlier in 2026, the language suggests those earned bonuses are locked to the old bucket — and the new 5-referral counter starts fresh from zero on April 8.
+
+  In practice, that would mean some cardholders could earn **significantly more referral bonuses in 2026 than in any prior year**, simply because the two caps run in parallel for this one transitional year.
+
+  We have not seen Amex confirm this interpretation directly, and the fine print stops short of spelling it out. Treat the "reset" angle as a reading of the terms, not official guidance — if you're planning to lean into referrals for the rest of the year, watch your account dashboard to see which cap the new approvals actually count against.
+
+  ## Why It Matters
+
+  Referral bonuses are one of the few ways to stack Membership Rewards earnings outside of welcome offers, and Amex has been tightening the knobs on its rewards ecosystem throughout 2026 — from the ["as-high-as" variable SUBs on Delta and Blue Cash cards](/news/amex-as-high-as-subs-delta-blue-cash) to bonus eligibility tweaks across the lineup. A flat per-card cap is simpler to enforce and easier for Amex to adjust in the future — expect this structure to stick.


### PR DESCRIPTION
## Summary
- Adds news article covering Amex's shift from a currency-based annual referral limit to a flat cap of **5 referrals per calendar year**, effective April 8, 2026
- Links all 5 MR-earning cards (Gold, Green, Platinum, Business Gold, Business Platinum)
- Labels the "does the counter reset?" angle as speculation — the fine print doesn't spell it out

## Test plan
- [ ] Verify article renders on /news listing
- [ ] Verify all 5 linked card pages show the article in their news section
- [ ] Build cards to confirm no YAML validation errors

Source: r/churning April 8 2026 news & updates thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)