### PR TITLE
Add news: American Airlines becomes 5th US carrier to raise bag fees

### DIFF
--- a/data/news/2026-04-09-american-airlines-bag-fee-increase.yaml
+++ b/data/news/2026-04-09-american-airlines-bag-fee-increase.yaml
@@ -1,0 +1,65 @@
+id: "american-airlines-bag-fee-increase"
+date: "2026-04-09"
+title: "American Airlines Becomes 5th Major US Carrier to Raise Checked Bag Fees"
+summary: "American Airlines announced April 9, 2026 that it is raising checked bag fees and tightening basic economy rules, citing the 'current operating environment.' First checked bag jumps to $45 prepaid ($50 at the airport), and second bag rises to $55 prepaid. AAdvantage credit cardholders will continue to get their first checked bag free on domestic flights — sharply increasing the card's breakeven value."
+tags:
+  - general
+bank: "Citi"
+card_slugs:
+  - "citi-aadvantage-platinum-select-world-elite-m"
+  - "citi-aadvantage-executive-world-elite-masterc"
+  - "citi-aadvantage-globe"
+  - "citibusiness-aadvantage-platinum-select-maste"
+  - "american-airlines-aadvantage-mileu-mastercard"
+card_names:
+  - "Citi AAdvantage Platinum Select World Elite Mastercard"
+  - "Citi AAdvantage Executive World Elite Mastercard"
+  - "Citi AAdvantage Globe"
+  - "CitiBusiness AAdvantage Platinum Select Mastercard"
+  - "American Airlines AAdvantage MileU Mastercard"
+source: "USA TODAY"
+source_url: "https://www.usatoday.com/story/travel/airline-news/2026/04/09/american-airlines-checked-baged-fees-increase/89527275007/"
+body: |
+  American Airlines announced on **April 9, 2026** that it is raising checked bag fees and tightening basic economy rules, making it the **fifth major US carrier** to hike bag fees in recent weeks. The airline attributed the changes to "continuing evaluation of pricing in light of the current operating environment."
+
+  JetBlue kicked off the wave at the end of March, followed by Delta, Southwest, and United — all citing rising jet fuel prices tied to the war in Iran. American is the last of the big carriers to follow suit.
+
+  ## New Main Cabin Bag Fees
+
+  The new fees apply to tickets booked on or after **April 9** for domestic flights (including Alaska, Hawaii, Puerto Rico, and the US Virgin Islands), Canada, and short-haul international. Travelers who prepay online or via the app save $5 per bag.
+
+  | Bag | Old Price | New Prepaid | New at Airport |
+  |-----|-----------|-------------|----------------|
+  | **First checked bag** | $35 / $40 | **$45** | **$50** |
+  | **Second checked bag** | $45 / $50 | **$55** | **$60** |
+  | **Third checked bag** | $150 | **$200** | $200 |
+
+  Premium cabin passengers, active-duty US military, and AAdvantage elite status members still get checked bags free.
+
+  ## AAdvantage Credit Cards Just Got More Valuable
+
+  Crucially, **American confirmed that AAdvantage credit cardholders who receive their first checked bag free on domestic flights will continue to do so**. That benefit — standard on the mid-tier and premium Citi AAdvantage co-brands — just became noticeably more valuable.
+
+  The per-roundtrip savings now math out like this:
+
+  - **Solo traveler, one roundtrip:** $90 saved (vs. $70 before)
+  - **Cardholder + 1 companion (up to 8 on reservation), one roundtrip:** $180 saved
+  - **Family of 4, one roundtrip:** $360 saved
+
+  At a **$99 annual fee**, the [Citi AAdvantage Platinum Select World Elite Mastercard](/card/citi-aadvantage-platinum-select-world-elite-m) now pays for itself on a single domestic roundtrip — even for a solo traveler. The [Citi AAdvantage Executive Card](/card/citi-aadvantage-executive-world-elite-masterc) and [CitiBusiness AAdvantage Platinum Select](/card/citibusiness-aadvantage-platinum-select-maste) also grant first-checked-bag-free to passengers on the same itinerary.
+
+  ## Basic Economy Is Getting Squeezed
+
+  The basic economy changes go further than just bag fees. Starting with tickets purchased **May 18 or later**:
+
+  - **First checked bag:** $55 (domestic)
+  - **Second checked bag:** $65 (domestic)
+  - **Seat selection:** will now require a fee
+  - **Upgrades:** basic economy passengers are ineligible, **even with status**
+  - **Boarding:** later in the year, passengers without status or a co-branded card will board in **Group 7** — but cardholders keep priority or preferred boarding
+
+  South America routes (excluding Colombia, Ecuador, Guyana, and Peru) see an immediate jump for tickets purchased April 9 or later: **$70 for the first bag and $100 for the second**, with no prepaid discount. Tickets to Panama, Colombia, Ecuador, and Peru see similar hikes effective May 18.
+
+  ## Why It Matters
+
+  With all five major US carriers now charging $45–$55 for a first checked bag, the economics of airline co-branded cards have shifted meaningfully in just a few weeks. For frequent AA flyers, the free-checked-bag perk alone now justifies the annual fee of the entry-level Citi AAdvantage card on a single roundtrip — and the tightening of basic economy rules makes co-brand perks like priority boarding harder to replicate without a card.


### PR DESCRIPTION
## Summary
- Adds news article covering American Airlines' April 9, 2026 announcement hiking checked bag fees (first bag \$45 prepaid, second \$55 prepaid)
- Notes AAdvantage cardholders keep their free-checked-bag perk on domestic flights — now worth more per roundtrip
- Links all 5 Citi/AA co-branded cards
- Tagged \`general\` (not \`fee-change\`, since the change is to airline bag fees, not card fees)

## Test plan
- [ ] Verify article renders on /news listing
- [ ] Verify all 5 linked card pages show the article in their news section
- [ ] Build cards to confirm no YAML validation errors

Source: USA TODAY

🤖 Generated with [Claude Code](https://claude.com/claude-code)