### PR TITLE
Fix Atlas Card accepting_applications flag

### DIFF
--- a/data/cards/atlas-card.yaml
+++ b/data/cards/atlas-card.yaml
@@ -1,7 +1,7 @@
 name: "Atlas"
 bank: "Lead Bank"
 slug: "atlas-card"
-accepting_applications: false
+accepting_applications: true
 image: "atlas.png"
 apply_link: https://atlascard.com/
 annual_fee: 1000


### PR DESCRIPTION
## Summary
- Atlas is invite-only via a public waitlist, not archived
- Setting accepting_applications: false made the card page show the "no longer accepting applications and has been archived" banner, which is misleading
- Flipping to true so the Apply button links to the atlascard.com waitlist where visitors can request an invite

## Test plan
- [ ] Verify /card/atlas no longer shows the archived banner
- [ ] Confirm the Apply button links to atlascard.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)