### PR TITLE
Track accepting_applications changes in Card Wire

### DIFF
--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -49,6 +49,7 @@ function extractMetrics(cdnCard) {
   }
 
   return {
+    accepting_applications: cdnCard.accepting_applications === false ? 0 : 1,
     annual_fee: cdnCard.annual_fee ?? null,
     signup_bonus_value: cdnCard.signup_bonus?.value ?? null,
     signup_bonus_type: cdnCard.signup_bonus?.type ?? null,
@@ -62,6 +63,7 @@ function extractMetrics(cdnCard) {
 // Compare old and new metrics, insert card_wire rows for any changes
 async function detectAndRecordChanges(cardId, oldMetrics, newMetrics) {
   const trackedFields = [
+    { field: "accepting_applications", old: oldMetrics.accepting_applications, new: newMetrics.accepting_applications },
     { field: "annual_fee", old: oldMetrics.annual_fee, new: newMetrics.annual_fee },
     { field: "signup_bonus_value", old: oldMetrics.signup_bonus_value, new: newMetrics.signup_bonus_value },
     { field: "reward_top_rate", old: oldMetrics.reward_top_rate, new: newMetrics.reward_top_rate },
@@ -114,7 +116,7 @@ async function syncCardsToDatabase(cdnCards) {
   try {
     // Get existing cards from database (include metric columns for change detection)
     const existingCards = await mysql.query(
-      `SELECT card_id, card_name, bank, annual_fee,
+      `SELECT card_id, card_name, bank, accepting_applications, annual_fee,
               signup_bonus_value, signup_bonus_type,
               reward_top_rate, reward_top_unit,
               apr_min, apr_max

--- a/apps/web-next/src/app/card-wire/CardWireTable.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireTable.tsx
@@ -9,6 +9,7 @@ import { CardWireEntry } from '@/lib/api';
 const PAGE_SIZE = 50;
 
 const fieldLabels: Record<string, string> = {
+  accepting_applications: 'Applications',
   annual_fee: 'Annual Fee',
   signup_bonus_value: 'Sign-up Bonus',
   reward_top_rate: 'Top Reward Rate',
@@ -17,6 +18,7 @@ const fieldLabels: Record<string, string> = {
 };
 
 const chipColors: Record<string, { bg: string; text: string }> = {
+  accepting_applications: { bg: 'bg-rose-100', text: 'text-rose-800' },
   annual_fee: { bg: 'bg-amber-100', text: 'text-amber-800' },
   signup_bonus_value: { bg: 'bg-blue-100', text: 'text-blue-800' },
   reward_top_rate: { bg: 'bg-emerald-100', text: 'text-emerald-800' },
@@ -31,6 +33,11 @@ function formatValue(field: string, value: string | null, bonusType?: string): s
   if (value === null || value === '') return '—';
   const num = parseFloat(value);
 
+  if (field === 'accepting_applications') {
+    if (value === '1' || value === 'true') return 'Accepting';
+    if (value === '0' || value === 'false') return 'No longer accepting';
+    return value;
+  }
   if (field === 'annual_fee') {
     if (!isNaN(num)) return num === 0 ? '$0' : `$${num.toLocaleString()}`;
     return value;

--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -44,6 +44,7 @@ async function fetchWithRetry(url, options, { maxRetries = 3, baseDelay = 2000 }
 // ── Formatting helpers (mirrors CardWireTable.tsx logic) ──
 
 const fieldLabels = {
+  accepting_applications: 'Applications',
   annual_fee: 'Annual Fee',
   signup_bonus_value: 'Sign-up Bonus',
   reward_top_rate: 'Top Reward Rate',
@@ -56,6 +57,11 @@ const higherIsBad = new Set(['annual_fee', 'apr_min', 'apr_max']);
 function formatValue(field, value) {
   if (value === null || value === '') return '\u2014';
   const num = parseFloat(value);
+  if (field === 'accepting_applications') {
+    if (value === '1' || value === 'true') return 'Accepting';
+    if (value === '0' || value === 'false') return 'No longer accepting';
+    return value;
+  }
   if (field === 'annual_fee') {
     return !isNaN(num) ? (num === 0 ? '$0' : `$${num.toLocaleString()}`) : value;
   }


### PR DESCRIPTION
## Summary
- When a card flips to/from accepting applications, the change now shows up on /card-wire alongside annual_fee, sign-up bonus, etc.
- Paired PR #389 marks Amazon Business Prime Amex as accepting_applications: false — with this change that flip will register as a Card Wire entry once synced.

## Changes
- apps/api/src/handlers/update-cards-github.js
  - Include accepting_applications in the existing-cards SELECT (so we have the old value to diff against)
  - Add accepting_applications to extractMetrics (0 or 1)
  - Add accepting_applications to the trackedFields list in detectAndRecordChanges
- apps/web-next/src/app/card-wire/CardWireTable.tsx
  - Add "Applications" field label, rose chip color, and human formatting: "Accepting" / "No longer accepting"
  - Direction logic works unchanged: 1→0 = negative (red), 0→1 = positive (green)
- scripts/post-card-wire.js
  - Mirror label and formatter so social image/text render the change correctly

## Test plan
- [ ] Typecheck passes: npx tsc --noEmit (confirmed locally)
- [ ] After deploy, set a card's accepting_applications to false, trigger the sync, verify a new row on /card-wire with "Accepting → No longer accepting" and red styling
- [ ] Verify social post preview via post-card-wire.js --dry-run for an accepting_applications change

🤖 Generated with [Claude Code](https://claude.com/claude-code)