### PR TITLE
Reddit fetch via Cloudflare Worker proxy

### DIFF
--- a/.github/workflows/auto-news-reddit-dryrun.yml
+++ b/.github/workflows/auto-news-reddit-dryrun.yml
@@ -39,6 +39,8 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
+          REDDIT_PROXY_URL: ${{ secrets.REDDIT_PROXY_URL }}
+          REDDIT_PROXY_SECRET: ${{ secrets.REDDIT_PROXY_SECRET }}
         run: |
           ARGS="--dry-run --min-score ${{ inputs.min_score }} --max-items ${{ inputs.max_items }}"
           if [ -n "${{ inputs.thread_id }}" ]; then

--- a/scripts/auto-news-from-reddit.js
+++ b/scripts/auto-news-from-reddit.js
@@ -538,12 +538,9 @@ async function main() {
 }
 
 async function fetchSpecificThread(id) {
-  const USER_AGENT = process.env.REDDIT_USER_AGENT || 'creditodds-news-bot/0.1';
-  const res = await fetch(`https://www.reddit.com/r/churning/comments/${id}.json?limit=500&raw_json=1`, {
-    headers: { 'User-Agent': USER_AGENT },
-  });
-  if (!res.ok) throw new Error(`Reddit ${res.status}`);
-  const j = await res.json();
+  // Reuse the shared OAuth/proxy-aware helper from fetch-churning-thread.js.
+  const { _redditJson } = require('./fetch-churning-thread');
+  const j = await _redditJson(`/r/churning/comments/${id}.json?limit=500&raw_json=1`);
   const post = j[0].data.children[0].data;
   const flat = [];
   const walk = (children, depth = 0, parentId = null) => {

--- a/scripts/fetch-churning-thread.js
+++ b/scripts/fetch-churning-thread.js
@@ -14,24 +14,44 @@
 
 const USER_AGENT =
   process.env.REDDIT_USER_AGENT ||
-  'creditodds-news-bot/0.1 (+https://creditodds.com)';
+  'web:creditodds-news:v0.1 (by /u/creditodds)';
+
+const PROXY_URL = process.env.REDDIT_PROXY_URL || null;
+const PROXY_SECRET = process.env.REDDIT_PROXY_SECRET || null;
 
 const TITLE_PATTERN = /^news and updates thread\b/i;
 
-async function redditJson(url) {
-  const res = await fetch(url, {
+/**
+ * Fetch a Reddit JSON path. If REDDIT_PROXY_URL is set, route through the
+ * Cloudflare worker (required from GitHub Actions because Reddit blocks
+ * datacenter IPs); otherwise hit www.reddit.com directly (works locally).
+ */
+async function redditJson(pathWithQuery) {
+  if (PROXY_URL) {
+    if (!PROXY_SECRET) {
+      throw new Error('REDDIT_PROXY_URL is set but REDDIT_PROXY_SECRET is not');
+    }
+    const proxied = `${PROXY_URL.replace(/\/$/, '')}/?path=${encodeURIComponent(pathWithQuery)}`;
+    const res = await fetch(proxied, {
+      headers: { Authorization: `Bearer ${PROXY_SECRET}`, Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      throw new Error(`Reddit proxy ${proxied} -> ${res.status} ${res.statusText}`);
+    }
+    return res.json();
+  }
+  const direct = `https://www.reddit.com${pathWithQuery}`;
+  const res = await fetch(direct, {
     headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
   });
   if (!res.ok) {
-    throw new Error(`Reddit fetch ${url} -> ${res.status} ${res.statusText}`);
+    throw new Error(`Reddit fetch ${direct} -> ${res.status} ${res.statusText}`);
   }
   return res.json();
 }
 
 async function findLatestNewsThread() {
-  const data = await redditJson(
-    'https://www.reddit.com/r/churning/new.json?limit=25'
-  );
+  const data = await redditJson('/r/churning/new.json?limit=25');
   const posts = (data?.data?.children || []).map((c) => c.data);
   const match = posts.find((p) => TITLE_PATTERN.test(p.title || ''));
   if (!match) {
@@ -72,7 +92,7 @@ function flattenComments(children, parentId = null, depth = 0, acc = []) {
 async function fetchChurningThread(opts = {}) {
   const thread = await findLatestNewsThread();
   const commentsJson = await redditJson(
-    `https://www.reddit.com/r/churning/comments/${thread.id}.json?limit=500&raw_json=1&sort=top`
+    `/r/churning/comments/${thread.id}.json?limit=500&raw_json=1&sort=top`
   );
   const commentsTree = commentsJson?.[1]?.data?.children || [];
   const comments = flattenComments(commentsTree);
@@ -117,4 +137,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { fetchChurningThread };
+module.exports = { fetchChurningThread, _redditJson: redditJson };

--- a/worker/reddit-proxy/worker.js
+++ b/worker/reddit-proxy/worker.js
@@ -1,0 +1,68 @@
+/**
+ * Cloudflare Worker — Reddit JSON proxy for r/churning.
+ *
+ * Reddit blocks unauthenticated reads from datacenter IPs (AWS/GCP/Azure),
+ * which prevents GitHub Actions from fetching subreddit JSON directly. This
+ * worker runs on Cloudflare's edge — its IPs are usually accepted — and
+ * proxies a narrow set of Reddit GET endpoints behind a shared secret.
+ *
+ * Deploy:
+ *   cd worker/reddit-proxy
+ *   npx wrangler login
+ *   npx wrangler secret put PROXY_SECRET   # paste a long random string
+ *   npx wrangler deploy
+ *
+ * Use from a client:
+ *   GET https://<worker-url>/?path=/r/churning/new.json&limit=25
+ *   Headers: Authorization: Bearer <PROXY_SECRET>
+ */
+
+const REDDIT_BASE = 'https://www.reddit.com';
+const ALLOWED_PATH_PREFIXES = ['/r/churning/'];
+const UA = 'web:creditodds-news:v0.1 (by /u/creditodds)';
+
+export default {
+  async fetch(request, env) {
+    const auth = request.headers.get('authorization') || '';
+    const expected = `Bearer ${env.PROXY_SECRET || ''}`;
+    if (!env.PROXY_SECRET || auth !== expected) {
+      return json({ error: 'unauthorized' }, 401);
+    }
+
+    const url = new URL(request.url);
+    const path = url.searchParams.get('path');
+    if (!path || !path.startsWith('/')) {
+      return json({ error: 'missing or invalid path param' }, 400);
+    }
+    if (!ALLOWED_PATH_PREFIXES.some((p) => path.startsWith(p))) {
+      return json({ error: 'path not allowed' }, 403);
+    }
+
+    const target = REDDIT_BASE + path;
+    let upstream;
+    try {
+      upstream = await fetch(target, {
+        headers: { 'User-Agent': UA, Accept: 'application/json' },
+        cf: { cacheTtl: 60, cacheEverything: false },
+      });
+    } catch (err) {
+      return json({ error: 'upstream fetch failed', detail: String(err) }, 502);
+    }
+
+    const body = await upstream.text();
+    return new Response(body, {
+      status: upstream.status,
+      headers: {
+        'Content-Type': upstream.headers.get('content-type') || 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  },
+};
+
+function json(obj, status = 200) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/worker/reddit-proxy/wrangler.toml
+++ b/worker/reddit-proxy/wrangler.toml
@@ -1,0 +1,6 @@
+name = "creditodds-reddit-proxy"
+main = "worker.js"
+compatibility_date = "2026-04-12"
+
+# PROXY_SECRET is set via:
+#   npx wrangler secret put PROXY_SECRET


### PR DESCRIPTION
## Why

Reddit blocks unauthenticated reads from datacenter IPs (AWS/GCP/Azure ranges that GitHub Actions runs on). Yesterday's dry-run hit 403s for that reason. Reddit's script-app OAuth would have solved it but new client IDs are no longer being issued. The next cheapest path: a tiny Cloudflare Worker on the edge (different IP space, usually unblocked) that proxies a narrow set of /r/churning paths.

## What's in this PR

- worker/reddit-proxy/worker.js — Cloudflare Worker. Authorization: Bearer header gate. Allow-list locked to /r/churning/* paths. 60s edge cache.
- worker/reddit-proxy/wrangler.toml — deploy config.
- scripts/fetch-churning-thread.js — when REDDIT_PROXY_URL is set, route through the worker; otherwise hit www.reddit.com (works locally). Exports the helper so other scripts share one path.
- scripts/auto-news-from-reddit.js — fetchSpecificThread now uses the shared helper too.
- .github/workflows/auto-news-reddit-dryrun.yml — passes the new secrets through.

## Setup steps (for @melchermaxwell, one-time)

1. \`cd worker/reddit-proxy && npx wrangler login\`
2. Generate a long random string. Set it on the worker: \`npx wrangler secret put PROXY_SECRET\`
3. \`npx wrangler deploy\` — note the deployed URL (something like \`https://creditodds-reddit-proxy.<account>.workers.dev\`)
4. Add the two repo secrets:
   - \`gh secret set REDDIT_PROXY_URL --repo CreditOdds/creditodds\` (paste the worker URL)
   - \`gh secret set REDDIT_PROXY_SECRET --repo CreditOdds/creditodds\` (paste the same random string)

Then re-run the "Auto News Reddit Dry Run" workflow.

## Test plan
- [ ] Worker deploys cleanly
- [ ] Workflow run reaches the "extracting candidates" step (no Reddit 403)
- [ ] Inspect the news-preview artifact to validate output quality