### PR TITLE
News: Alaska Lounge SFO returns to Priority Pass + Amex Plum discontinued

### DIFF
--- a/data/news/2026-04-13-alaska-lounge-sfo-priority-pass-return.yaml
+++ b/data/news/2026-04-13-alaska-lounge-sfo-priority-pass-return.yaml
@@ -1,0 +1,18 @@
+id: "alaska-lounge-sfo-priority-pass-return"
+title: "Alaska Lounge at SFO Rejoins Priority Pass with $15 Co-Pay"
+summary: "The Alaska Lounge at San Francisco International Airport (SFO) has rejoined Priority Pass membership, allowing cardholders to access the lounge with a **$15 co-pay** per visit. This marks the lounge's return to the Priority Pass network."
+tags:
+  - "benefit-change"
+  - "policy-change"
+source: "r/churning"
+source_url: "https://www.reddit.com/r/churning/comments/1shh8qz/news_and_updates_thread_april_10_2026/offs1c8/"
+date: "2026-04-13"
+body: |
+  The Alaska Lounge at San Francisco International Airport (SFO) has just rejoined Priority Pass, expanding lounge access options for cardholders enrolled in the network.
+  
+  Priority Pass members can now access the Alaska Lounge at SFO, though entry comes with a **$15 co-pay** per visit. This represents the lounge's return to the Priority Pass program after a previous absence from the network.
+  
+  For travelers holding Priority Pass memberships through various premium credit cards—including those from American Express, Chase, Citi, and Capital One—this addition provides another domestic lounge option on the West Coast. The co-pay requirement is typical for select Priority Pass partner lounges, distinguishing them from unlimited-access standard member lounges.
+  
+  This development may be of interest to frequent travelers through SFO and those evaluating credit cards that offer Priority Pass memberships as a cardholder benefit.
+  

--- a/data/news/2026-04-13-amex-plum-card-discontinued.yaml
+++ b/data/news/2026-04-13-amex-plum-card-discontinued.yaml
@@ -1,0 +1,18 @@
+id: "amex-plum-card-discontinued"
+title: "American Express Business Plum Card Discontinued"
+summary: "American Express has discontinued the Business Plum Card and is no longer accepting new sign-ups as of **April 10, 2026**. The card was removed from Amex's business card lineup, with referral links becoming inactive shortly after."
+tags:
+  - "discontinued"
+bank: "American Express"
+source: "r/churning"
+source_url: "https://www.reddit.com/r/churning/comments/1shh8qz/news_and_updates_thread_april_10_2026/ofi3piu/"
+date: "2026-04-13"
+body: |
+  American Express has officially discontinued the Business Plum Card, ending its availability to new customers. The discontinuation was confirmed on **April 10, 2026**.
+  
+  According to reports from the r/churning community, the card had already been removed from Amex's published list of business card offerings. However, referral links to the product page remained active for a brief period before those too were deactivated.
+  
+  The Business Plum Card served as a cash-back focused business credit card offering from American Express. Its discontinuation marks the end of availability for this product line, though existing cardholders are typically allowed to maintain their accounts.
+  
+  The removal appears to be part of Amex's broader business card portfolio management, though the company has not provided official public commentary on the reasons for discontinuation.
+  


### PR DESCRIPTION
## Summary
First two news items produced end-to-end by the new r/churning pipeline (scripts/auto-news-from-reddit.js). Both were extracted from the April 10 News and Updates Thread, verified against external sources, and reviewed by hand before merging.

- Alaska Lounge at SFO has rejoined Priority Pass with a $15 co-pay. Verified against [onemileatatime.com](https://onemileatatime.com/news/alaska-lounge-priority-pass/).
- The Amex Business Plum Card has been discontinued. Verified against [Doctor of Credit](https://www.doctorofcredit.com/american-express-plum-card-has-been-discontinued).

A third candidate (YouTube Premium Family plan price increase) was dropped because it isn't really credit-card news — it tangentially affects the Amex Platinum's Digital Entertainment credit but isn't a card change.

## Test plan
- [x] npm run build:news passes (60 items total)
- [ ] On merge: build-news.yml publishes news.json and queues social posts