### PR TITLE
Backfill Amazon Business Prime accepting_applications card_wire entry

### DIFF
--- a/apps/api/migrations/018_backfill_amazon_prime_accepting_applications_wire.sql
+++ b/apps/api/migrations/018_backfill_amazon_prime_accepting_applications_wire.sql
@@ -1,0 +1,22 @@
+-- Backfill a card_wire entry for the Amazon Business Prime American Express
+-- card's accepting_applications change (1 -> 0).
+--
+-- Context: PR #389 flipped accepting_applications to false when Amazon
+-- announced US Bank as the new issuer for its business card portfolio.
+-- The sync ran, but PR #390 (which added accepting_applications tracking
+-- to update-cards-github.js) hadn't been deployed yet, so no card_wire
+-- row was written. This inserts the retroactive row so the change shows
+-- up on /card-wire.
+--
+-- card_id 77 = Amazon Business Prime American Express (verified via
+-- /cards API: db_card_id=77).
+
+INSERT INTO card_wire (card_id, field, old_value, new_value, changed_at)
+SELECT 77, 'accepting_applications', '1', '0', '2026-04-13 13:14:00'
+WHERE NOT EXISTS (
+  SELECT 1 FROM card_wire
+  WHERE card_id = 77
+    AND field = 'accepting_applications'
+    AND old_value = '1'
+    AND new_value = '0'
+);


### PR DESCRIPTION
## Why
PR #389 flipped accepting_applications: false on Amazon Business Prime Amex this morning (Amex is ending issuance on 2026-08-14 as Amazon transitions to US Bank). The sync ran — but against the pre-PR-#390 Lambda that didn't track accepting_applications, so no card_wire row was written. The card is now in a state where CDN and DB agree (false) but /card-wire never reflected the transition.

## What
- Adds migrations/018_backfill_amazon_prime_accepting_applications_wire.sql — a guarded INSERT that adds the missing card_wire row (old_value=1, new_value=0) for card_id 77.

## Deployment steps after merge
1. Deploy the updated Lambda so future accepting_applications changes are tracked automatically:
   cd apps/api && sam build && sam deploy
2. Run the migration against prod:
   node apps/api/scripts/run-migration.js migrations/018_backfill_amazon_prime_accepting_applications_wire.sql
   (or via the temporary-Lambda pattern if local can't reach the VPC — see CLAUDE.md notes)

## Verify
curl https://d2ojrhbh2dincr.cloudfront.net/card-wire?limit=5 — first row should be Amazon Business Prime with field=accepting_applications.