### PR TITLE
Add news: Citi ThankYou hotel transfer devaluation (4/19)

### DIFF
--- a/data/news/2026-04-17-citi-thankyou-hotel-points-transfer-devaluation.yaml
+++ b/data/news/2026-04-17-citi-thankyou-hotel-points-transfer-devaluation.yaml
@@ -1,0 +1,19 @@
+id: "citi-thankyou-hotel-points-transfer-devaluation"
+title: "Citi ThankYou Devalues Hotel Points Transfers for Choice Privileges and I Prefer Cards"
+summary: "Citi is devaluing ThankYou points transfers to Choice Privileges and I Prefer hotel programs effective **April 19, 2026**. Cardholders should transfer points before the devaluation takes effect."
+tags:
+  - "benefit-change"
+  - "policy-change"
+bank: "Citi"
+source: "r/churning"
+source_url: "https://www.reddit.com/r/churning/comments/1smy4jy/news_and_updates_thread_april_16_2026/ogk9jsw/"
+date: "2026-04-17"
+body: |
+  Citi is implementing a devaluation to ThankYou points transfers effective **April 19, 2026**. The devaluation impacts transfers to Choice Privileges and I Prefer hotel programs.
+  
+  According to the announcement, cardholders should act quickly if they plan to transfer points before the new rates take effect. The source notes that Citi's policy changes can be implemented with minimal notice, so waiting until the last moment is risky.
+  
+  Affected cardholders should review their ThankYou points balances and consider transferring to these hotel programs before the deadline if they intend to lock in current redemption rates. The exact rate changes were not detailed in the available sources, but this represents a meaningful shift in the value proposition of ThankYou points for hotel redemptions.
+  
+  This devaluation is part of Citi's ongoing adjustments to its rewards transfer partners and redemption values.
+  


### PR DESCRIPTION
## Summary
- Adds news item covering Citi's reduction of ThankYou transfer ratios to Choice Privileges (1:2 → 1:1.5) and Preferred Hotels iPrefer (1:4 → 1:2), effective April 19, 2026.
- Sourced from r/churning 4/16 thread; verified via onemileatatime.

## Test plan
- [ ] Verify YAML parses and appears in `/news` listing after build
- [ ] Confirm rates and effective date against linked source