### PR TITLE
Precompute card stats to avoid per-request window-function cost

### DIFF
--- a/apps/api/migrations/019_create_card_stats.sql
+++ b/apps/api/migrations/019_create_card_stats.sql
@@ -1,0 +1,30 @@
+-- Precomputed per-card stats to avoid window-function computation on every card page request.
+-- Populated by the RefreshCardStats Lambda (scheduled every 5 minutes).
+
+CREATE TABLE IF NOT EXISTS card_stats (
+  card_id INT NOT NULL PRIMARY KEY,
+  total_records INT NOT NULL DEFAULT 0,
+  approved_count INT NOT NULL DEFAULT 0,
+  rejected_count INT NOT NULL DEFAULT 0,
+  approved_median_credit_score INT NULL,
+  approved_median_income INT NULL,
+  approved_median_length_credit INT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_card_stats_card FOREIGN KEY (card_id) REFERENCES cards(card_id) ON DELETE CASCADE
+);
+
+-- Supports the refresh job's per-card aggregates and the approved-only median subqueries.
+-- Guarded so the migration is idempotent if the index already exists.
+SET @idx_exists := (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'records'
+    AND index_name = 'idx_records_card_review_result'
+);
+SET @sql := IF(@idx_exists = 0,
+  'CREATE INDEX idx_records_card_review_result ON records (card_id, admin_review, result)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/apps/api/src/handlers/all-cards.js
+++ b/apps/api/src/handlers/all-cards.js
@@ -40,14 +40,8 @@ async function fetchCardStatsAndMetadata() {
   try {
     const [statsResults, cardResults] = await Promise.all([
       mysql.query(`
-        SELECT
-          card_id,
-          COUNT(*) as total_records,
-          SUM(CASE WHEN result = 1 THEN 1 ELSE 0 END) as approved_count,
-          SUM(CASE WHEN result = 0 THEN 1 ELSE 0 END) as rejected_count
-        FROM records
-        WHERE admin_review = 1
-        GROUP BY card_id
+        SELECT card_id, total_records, approved_count, rejected_count
+        FROM card_stats
       `),
       mysql.query(`
         SELECT card_id, card_name, card_image_link, accepting_applications, tags

--- a/apps/api/src/handlers/card-by-id.js
+++ b/apps/api/src/handlers/card-by-id.js
@@ -58,40 +58,20 @@ async function fetchCardFromDB(cardName) {
 
     const dbCard = cardResults[0];
 
-    // Get the stats and referrals in parallel
+    // Stats come from the precomputed card_stats table (refreshed by RefreshCardStats Lambda).
+    // Missing row = card has no records yet; fall back to zeros.
     const [statsResults, referralResults] = await Promise.all([
       mysql.query(`
         SELECT
-          COUNT(*) as total_records,
-          SUM(CASE WHEN result = 1 THEN 1 ELSE 0 END) as approved_count,
-          SUM(CASE WHEN result = 0 THEN 1 ELSE 0 END) as rejected_count,
-          (SELECT ROUND(AVG(val)) FROM (
-            SELECT credit_score AS val,
-              ROW_NUMBER() OVER (ORDER BY credit_score) AS rn,
-              COUNT(*) OVER () AS cnt
-            FROM records
-            WHERE card_id = ? AND result = 1 AND admin_review = 1 AND credit_score IS NOT NULL
-          ) t WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
-          ) as approved_median_credit_score,
-          (SELECT ROUND(AVG(val)) FROM (
-            SELECT listed_income AS val,
-              ROW_NUMBER() OVER (ORDER BY listed_income) AS rn,
-              COUNT(*) OVER () AS cnt
-            FROM records
-            WHERE card_id = ? AND result = 1 AND admin_review = 1 AND listed_income IS NOT NULL
-          ) t WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
-          ) as approved_median_income,
-          (SELECT ROUND(AVG(val)) FROM (
-            SELECT length_credit AS val,
-              ROW_NUMBER() OVER (ORDER BY length_credit) AS rn,
-              COUNT(*) OVER () AS cnt
-            FROM records
-            WHERE card_id = ? AND result = 1 AND admin_review = 1 AND length_credit IS NOT NULL
-          ) t WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
-          ) as approved_median_length_credit
-        FROM records
-        WHERE card_id = ? AND admin_review = 1
-      `, [dbCard.card_id, dbCard.card_id, dbCard.card_id, dbCard.card_id]),
+          total_records,
+          approved_count,
+          rejected_count,
+          approved_median_credit_score,
+          approved_median_income,
+          approved_median_length_credit
+        FROM card_stats
+        WHERE card_id = ?
+      `, [dbCard.card_id]),
       mysql.query(`
         SELECT referral_id, referral_link
         FROM referrals

--- a/apps/api/src/handlers/refresh-card-stats.js
+++ b/apps/api/src/handlers/refresh-card-stats.js
@@ -1,0 +1,149 @@
+// Recomputes per-card stats and upserts them into the card_stats table.
+// Triggered by EventBridge on a schedule; also callable via HTTP for ops use.
+
+const mysql = require("serverless-mysql")({
+  config: {
+    host: process.env.ENDPOINT,
+    database: process.env.DATABASE,
+    user: process.env.USERNAME,
+    password: process.env.PASSWORD,
+  },
+});
+
+const responseHeaders = {
+  "Access-Control-Allow-Origin": "*",
+};
+
+// One query computes totals + all three medians for every card in a single pass.
+// Per-card window functions via PARTITION BY — no N+1 loop.
+const REFRESH_SQL = `
+  INSERT INTO card_stats (
+    card_id,
+    total_records,
+    approved_count,
+    rejected_count,
+    approved_median_credit_score,
+    approved_median_income,
+    approved_median_length_credit
+  )
+  WITH totals AS (
+    SELECT
+      card_id,
+      COUNT(*) AS total_records,
+      SUM(CASE WHEN result = 1 THEN 1 ELSE 0 END) AS approved_count,
+      SUM(CASE WHEN result = 0 THEN 1 ELSE 0 END) AS rejected_count
+    FROM records
+    WHERE admin_review = 1
+    GROUP BY card_id
+  ),
+  ranked_score AS (
+    SELECT
+      card_id,
+      credit_score AS val,
+      ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY credit_score) AS rn,
+      COUNT(*) OVER (PARTITION BY card_id) AS cnt
+    FROM records
+    WHERE result = 1 AND admin_review = 1 AND credit_score IS NOT NULL
+  ),
+  median_score AS (
+    SELECT card_id, ROUND(AVG(val)) AS median_val
+    FROM ranked_score
+    WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
+    GROUP BY card_id
+  ),
+  ranked_income AS (
+    SELECT
+      card_id,
+      listed_income AS val,
+      ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY listed_income) AS rn,
+      COUNT(*) OVER (PARTITION BY card_id) AS cnt
+    FROM records
+    WHERE result = 1 AND admin_review = 1 AND listed_income IS NOT NULL
+  ),
+  median_income AS (
+    SELECT card_id, ROUND(AVG(val)) AS median_val
+    FROM ranked_income
+    WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
+    GROUP BY card_id
+  ),
+  ranked_length AS (
+    SELECT
+      card_id,
+      length_credit AS val,
+      ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY length_credit) AS rn,
+      COUNT(*) OVER (PARTITION BY card_id) AS cnt
+    FROM records
+    WHERE result = 1 AND admin_review = 1 AND length_credit IS NOT NULL
+  ),
+  median_length AS (
+    SELECT card_id, ROUND(AVG(val)) AS median_val
+    FROM ranked_length
+    WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
+    GROUP BY card_id
+  )
+  SELECT
+    t.card_id,
+    t.total_records,
+    t.approved_count,
+    t.rejected_count,
+    ms.median_val,
+    mi.median_val,
+    ml.median_val
+  FROM totals t
+  LEFT JOIN median_score  ms ON ms.card_id = t.card_id
+  LEFT JOIN median_income mi ON mi.card_id = t.card_id
+  LEFT JOIN median_length ml ON ml.card_id = t.card_id
+  ON DUPLICATE KEY UPDATE
+    total_records = VALUES(total_records),
+    approved_count = VALUES(approved_count),
+    rejected_count = VALUES(rejected_count),
+    approved_median_credit_score = VALUES(approved_median_credit_score),
+    approved_median_income = VALUES(approved_median_income),
+    approved_median_length_credit = VALUES(approved_median_length_credit)
+`;
+
+async function refresh() {
+  const started = Date.now();
+  const result = await mysql.query(REFRESH_SQL);
+  await mysql.end();
+  return {
+    affectedRows: result.affectedRows,
+    durationMs: Date.now() - started,
+  };
+}
+
+exports.RefreshCardStatsHandler = async (event) => {
+  // HTTP OPTIONS preflight
+  if (event && event.httpMethod === "OPTIONS") {
+    return { statusCode: 200, headers: responseHeaders, body: "" };
+  }
+
+  try {
+    const stats = await refresh();
+    console.info("refresh-card-stats succeeded", stats);
+
+    // Scheduled invocations (EventBridge) don't have httpMethod — return raw object.
+    if (!event || !event.httpMethod) {
+      return { ok: true, ...stats };
+    }
+
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ ok: true, ...stats }),
+    };
+  } catch (error) {
+    console.error("refresh-card-stats failed:", error);
+    await mysql.end().catch(() => {});
+
+    if (!event || !event.httpMethod) {
+      throw error;
+    }
+
+    return {
+      statusCode: 500,
+      headers: responseHeaders,
+      body: JSON.stringify({ ok: false, error: error.message }),
+    };
+  }
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -885,6 +885,44 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  RefreshCardStatsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/refresh-card-stats.RefreshCardStatsHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 300
+      Description: Recomputes per-card stats (totals + medians) into card_stats on a schedule
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        ScheduledRefresh:
+          Type: Schedule
+          Properties:
+            Schedule: rate(5 minutes)
+            Description: Refresh precomputed card stats
+            Enabled: true
+        ManualRefresh:
+          Type: Api
+          Properties:
+            Path: /admin/refresh-card-stats
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        ManualRefreshOptions:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /admin/refresh-card-stats
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+
   CardWireFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
## Summary
- Card pages were recomputing totals + 3 medians via `ROW_NUMBER()` window functions on the `records` table on every request (see [card-by-id.js:63-94](apps/api/src/handlers/card-by-id.js) before this PR). Moved to a precomputed `card_stats` table refreshed every 5 minutes by a new `RefreshCardStats` Lambda.
- `card-by-id.js` and `all-cards.js` now do simple indexed reads against `card_stats` — `SELECT ... WHERE card_id = ?` instead of per-request window aggregations.
- Added a manual `POST /admin/refresh-card-stats` endpoint for ops use (e.g. after a bulk DB change).

## Changes
- **New**: `migrations/019_create_card_stats.sql` — `card_stats` table + guarded composite index on `records(card_id, admin_review, result)`.
- **New**: `src/handlers/refresh-card-stats.js` — single query computes totals + all three medians for every card in one pass using `PARTITION BY`, upserts via `ON DUPLICATE KEY UPDATE`. Dual-entry point: EventBridge schedule and HTTP.
- **Modified**: `template.yml` — `RefreshCardStatsFunction` with `rate(5 minutes)` schedule and admin HTTP endpoint.
- **Modified**: `card-by-id.js` — 32-line window-function block replaced with 10-line `SELECT FROM card_stats`.
- **Modified**: `all-cards.js` — aggregate `GROUP BY` swapped for `SELECT FROM card_stats`.

## Tradeoffs
- Stats are now eventually consistent with up to 5 min of staleness. Record submissions are low-volume; users won't notice.
- If `card_stats` is empty (new card, never refreshed), endpoints return zeros rather than computing live. The scheduled refresh fills it in on next tick.

## Deploy order (important)
1. **Run migration first** (table must exist before handler code reads from it) — use the standard VPC-Lambda migration process.
2. `sam build && sam deploy`.
3. Invoke refresh once to backfill: `aws lambda invoke --function-name <stack>-RefreshCardStatsFunction-* /tmp/out.json`.
4. Verify: `SELECT COUNT(*) FROM card_stats;` should match count of cards with records.

## Test plan
- [ ] Migration runs cleanly and creates `card_stats` + index.
- [ ] `RefreshCardStatsFunction` invocation populates `card_stats` for all cards with records.
- [ ] `card-by-id` returns the same stat numbers as before the change for a sampled card.
- [ ] `all-cards` listing shows identical `approved_count` / `total_records` for sampled cards.
- [ ] EventBridge schedule fires and `updated_at` advances every 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)