### PR TITLE
Drop EventBridge schedule to unblock deploy

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -909,7 +909,7 @@ Resources:
       Runtime: nodejs22.x
       MemorySize: 256
       Timeout: 300
-      Description: Recomputes per-card stats (totals + medians) into card_stats on a schedule
+      Description: Recomputes per-card stats (totals + medians) into card_stats. Triggered via admin HTTP endpoint (scheduled trigger pending IAM grant for events:*)
       Environment:
         Variables:
           ENDPOINT: !Ref ENDPOINT
@@ -917,12 +917,6 @@ Resources:
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
       Events:
-        ScheduledRefresh:
-          Type: Schedule
-          Properties:
-            Schedule: rate(5 minutes)
-            Description: Refresh precomputed card stats
-            Enabled: true
         ManualRefresh:
           Type: Api
           Properties:


### PR DESCRIPTION
## Summary
- PR [#407](https://github.com/CreditOdds/creditodds/pull/407) deploy failed on `RefreshCardStatsFunctionScheduledRefresh` — CFN deploy role is missing `events:DescribeRule` / `events:PutRule`. Stack rolled back.
- Keep the Lambda + HTTP endpoint (both deployed cleanly); drop the `rate(5 minutes)` schedule so the deploy completes.
- Refresh runs on demand via `POST /admin/refresh-card-stats` until the schedule is restored.

## Follow-up
- Grant `events:*` (or narrower: `events:DescribeRule`, `events:PutRule`, `events:PutTargets`, `events:DeleteRule`, `events:RemoveTargets`) to the SAM deploy role.
- Re-add the `ScheduledRefresh` event block in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)