### PR TITLE
Remove temporary RunMigrationFunction

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -885,23 +885,6 @@ Resources:
             Auth:
               Authorizer: NONE
 
-  # TEMPORARY: wired up only to run migration 019 (create card_stats).
-  # Remove this block in a follow-up PR once migration is applied.
-  RunMigrationFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: src/handlers/run-migration.RunMigrationHandler
-      Runtime: nodejs22.x
-      MemorySize: 256
-      Timeout: 300
-      Description: One-shot migration runner; invoke with {"migration":"<file>"}
-      Environment:
-        Variables:
-          ENDPOINT: !Ref ENDPOINT
-          DATABASE: !Ref DATABASE
-          USERNAME: !Ref USERNAME
-          PASSWORD: !Ref PASSWORD
-
   RefreshCardStatsFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
## Summary
Migration 019 (`card_stats` table + composite index on `records`) has been applied. The one-shot `RunMigrationFunction` SAM resource is no longer needed and can be removed.

## Verification (pre-merge)
- `card_stats` table: 66 rows populated by `RefreshCardStatsFunction` (1.1s).
- `GET /card?card_name=chase-sapphire-preferred` returns `total_records=11, approved_count=8, median_credit_score=763`.
- `GET /cards` listing: 64 cards with records.

## Notes
- `src/handlers/run-migration.js` is kept in the repo — only the SAM resource is removed. Can be re-wired in the future for new migrations.
- The EventBridge schedule for `RefreshCardStats` is still disabled pending `events:*` IAM grant (tracked separately). Until then the refresh runs on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)