### PR TITLE
Restore 5-minute EventBridge schedule on RefreshCardStats

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -892,7 +892,7 @@ Resources:
       Runtime: nodejs22.x
       MemorySize: 256
       Timeout: 300
-      Description: Recomputes per-card stats (totals + medians) into card_stats. Triggered via admin HTTP endpoint (scheduled trigger pending IAM grant for events:*)
+      Description: Recomputes per-card stats (totals + medians) into card_stats every 5 minutes; also callable via admin HTTP endpoint
       Environment:
         Variables:
           ENDPOINT: !Ref ENDPOINT
@@ -900,6 +900,12 @@ Resources:
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
       Events:
+        ScheduledRefresh:
+          Type: Schedule
+          Properties:
+            Schedule: rate(5 minutes)
+            Description: Refresh precomputed card stats
+            Enabled: true
         ManualRefresh:
           Type: Api
           Properties:


### PR DESCRIPTION
## Summary
Re-adds the `rate(5 minutes)` Schedule event on `RefreshCardStatsFunction` that was temporarily dropped in [#408](https://github.com/CreditOdds/creditodds/pull/408). The blocking IAM issue has been resolved.

## IAM change (already applied)
Attached managed policy `arn:aws:iam::aws:policy/AmazonEventBridgeFullAccess` to the `CloudFormationServiceRole` used by this stack. Matches the pattern of other attached managed policies on that role (Lambda, API Gateway, IAM, S3 — all `Full*` managed).

## Effect
- `card_stats` auto-refreshes every 5 min — record submissions reflect in card-page medians within 5 min of submit.
- `POST /admin/refresh-card-stats` remains available for on-demand refresh.

## Test plan
- [ ] `sam deploy` succeeds (EventBridge rule now creatable).
- [ ] `aws events list-rules | grep RefreshCardStats` shows the rule in `ENABLED` state.
- [ ] `SELECT MAX(updated_at) FROM card_stats` advances every 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)