### PR TITLE
Add news: AT&T Points Plus card launch

### DIFF
--- a/data/news/2026-04-20-att-points-plus-card-launch.yaml
+++ b/data/news/2026-04-20-att-points-plus-card-launch.yaml
@@ -1,0 +1,31 @@
+id: "att-points-plus-card-launch"
+date: "2026-04-20"
+title: "Citi Launches Refreshed AT&T Points Plus Card with $250 Welcome Bonus"
+summary: "Citi and AT&T have launched the refreshed AT&T Points Plus Card, replacing the prior AT&T Access Card. The no-annual-fee card earns 3x points on gas and EV charging, 2x on groceries and AT&T services, and offers a $250 statement credit after $500 in spend within the first 3 months."
+tags:
+  - "new-card"
+  - "benefit-change"
+bank: "Citi"
+card_slug: "att-points-plus-from-citi"
+card_name: "AT&T Points Plus from Citi"
+source: "AT&T"
+source_url: "https://about.att.com/blogs/2026/att-points-plus-card.html"
+body: |
+  Citi and AT&T have announced the **AT&T Points Plus Card**, a refreshed no-annual-fee co-branded card that replaces the prior AT&T Access Card. The card targets AT&T wireless and internet customers with a mix of Citi ThankYou Points earnings and recurring statement credits.
+
+  **Earn rates:**
+  - **3x ThankYou Points** at gas stations and EV charging locations
+  - **2x ThankYou Points** at grocery stores (including delivery services)
+  - **2x ThankYou Points** on AT&T products, services, and bill payments
+  - **1x ThankYou Points** on all other purchases
+
+  **Welcome offer:** New cardholders can earn a **$250 statement credit** after spending **$500 on purchases in the first 3 months** — $50 more than the previous welcome offer on the predecessor card.
+
+  **Ongoing benefits:**
+  - **$10 per line monthly discount** on AT&T wireless bills (requires AutoPay and paperless billing)
+  - **$10 monthly discount** on eligible AT&T internet bills (requires AutoPay and paperless billing)
+  - **Monthly spend credits**: $10 statement credit after $500 in spend, or $20 after $1,000 — up to **$240 per year**
+  - **No foreign transaction fees**
+  - Cardholders can pool ThankYou Points with other Citi ThankYou cards to access transfer partners
+
+  The card is now [live on Citi's website](https://www.citi.com/credit-cards/citi-att-pointsplus-credit-card) and accepting applications.


### PR DESCRIPTION
## Summary
- News article covering the launch of the refreshed **AT&T Points Plus Card from Citi**
- Links to the newly added `att-points-plus-from-citi` card
- Source: [AT&T official announcement](https://about.att.com/blogs/2026/att-points-plus-card.html)

## Test plan
- [ ] News item appears on `/news` index
- [ ] `/news/att-points-plus-card-launch` renders with card link
- [ ] Related-card module shows the AT&T Points Plus card

🤖 Generated with [Claude Code](https://claude.com/claude-code)