### PR TITLE
Add news: Alaska Airlines moving to BofA as single Atmos Rewards issuer

### DIFF
--- a/data/news/2026-04-21-alaska-airlines-bank-of-america-single-issuer.yaml
+++ b/data/news/2026-04-21-alaska-airlines-bank-of-america-single-issuer.yaml
@@ -1,0 +1,24 @@
+id: "alaska-airlines-bank-of-america-single-issuer"
+title: "Alaska Airlines Moving Toward Bank of America as Single Atmos Rewards Card Issuer"
+summary: "Alaska Airlines is working to consolidate its Atmos Rewards co-brand credit card portfolio under Bank of America as the sole issuer. The airline announced the expanded partnership but provided no specific timeline for the transition."
+tags:
+  - "policy-change"
+bank: "Bank of America"
+card_slugs:
+  - "atmos-rewards-ascent"
+  - "atmos-rewards-business"
+  - "atmos-rewards-summit"
+card_names:
+  - "Atmos Rewards Ascent"
+  - "Atmos Rewards Business"
+  - "Atmos Rewards Summit"
+source: "Alaska Airlines Newsroom"
+source_url: "https://news.alaskaair.com/company/alaska-air-group-and-bank-of-america-expand-partnership/"
+date: "2026-04-21"
+body: |
+  Alaska Airlines announced an expanded partnership with **Bank of America** that includes plans to consolidate its Atmos Rewards credit card program under Bank of America as the single issuer for all co-brand cards.
+  
+  The airline issued a press release reiterating its intent to move toward this unified issuer structure, though **no specific timeline** was provided for when the transition will be complete. The announcement represents a significant shift in the airline's credit card strategy and consolidates card issuance responsibility under one financial institution.
+  
+  Cardholders should monitor official Alaska Airlines communications for details about any potential changes to existing card accounts, benefits, or terms as this transition progresses.
+  


### PR DESCRIPTION
## Summary
- Auto-generated from r/churning News and Updates Thread (April 20, 2026) via `scripts/auto-news-from-reddit.js`
- Source swapped from Reddit to first-party Alaska Airlines press release per source-attribution preference
- Covers Atmos Rewards Ascent, Business, and Summit cards

## Test plan
- [ ] Verify YAML renders correctly on `/news/alaska-airlines-bank-of-america-single-issuer` after deploy
- [ ] Confirm linked `card_slugs` resolve to real cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)