### PR TITLE
v2 editorial palette for OG images

### DIFF
--- a/apps/web-next/src/app/card/[name]/opengraph-image.tsx
+++ b/apps/web-next/src/app/card/[name]/opengraph-image.tsx
@@ -94,8 +94,11 @@ export default async function OGImage({ params }: Props) {
               <div
                 style={{
                   display: 'flex',
-                  borderRadius: 16,
-                  boxShadow: '0 25px 80px rgba(0,0,0,0.4), 0 10px 30px rgba(0,0,0,0.3)',
+                  padding: 6,
+                  borderRadius: 20,
+                  background: 'rgba(255,255,255,0.08)',
+                  boxShadow:
+                    '0 0 0 1px rgba(255,255,255,0.12), 0 30px 80px rgba(0,0,0,0.5), 0 0 60px rgba(109,63,232,0.25)',
                 }}
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -104,7 +107,7 @@ export default async function OGImage({ params }: Props) {
                   alt={card.card_name}
                   width={420}
                   height={265}
-                  style={{ borderRadius: 16 }}
+                  style={{ borderRadius: 14 }}
                 />
               </div>
             </div>

--- a/apps/web-next/src/app/opengraph-image.tsx
+++ b/apps/web-next/src/app/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from 'next/og';
-import { OGBackground, OGLogo, loadInterFonts, formatStatNumber } from '@/components/og/og-utils';
+import { OGBackground, loadInterFonts } from '@/components/og/og-utils';
 
 export const size = {
   width: 1200,
@@ -10,40 +10,8 @@ export const contentType = 'image/png';
 
 export const runtime = 'edge';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
-
 export default async function OGImage() {
-  let totalRecords = 0;
-  let totalContributors = 0;
-  let cardCount = 0;
-
-  try {
-    const [leaderboardRes, cardsRes] = await Promise.all([
-      fetch(`${API_BASE}/leaderboard?limit=1`, { next: { revalidate: 300 } }),
-      fetch(`${API_BASE}/cards`, { next: { revalidate: 300 } }),
-    ]);
-
-    if (leaderboardRes.ok) {
-      const data = await leaderboardRes.json();
-      totalRecords = data.stats?.total_records || 0;
-      totalContributors = data.stats?.total_contributors || 0;
-    }
-
-    if (cardsRes.ok) {
-      const cards = await cardsRes.json();
-      cardCount = Array.isArray(cards) ? cards.length : 0;
-    }
-  } catch {
-    // Graceful fallback — use zeros
-  }
-
   const fonts = await loadInterFonts();
-
-  const pills = [
-    totalRecords > 0 ? `${formatStatNumber(totalRecords)} Data Points` : 'Real Data Points',
-    totalContributors > 0 ? `${formatStatNumber(totalContributors)} Users` : 'Community Powered',
-    cardCount > 0 ? `${formatStatNumber(cardCount)} Cards Tracked` : '100% Free',
-  ];
 
   return new ImageResponse(
     (
@@ -103,32 +71,6 @@ export default async function OGImage() {
             }}
           >
             Discover Your Credit Card Approval Odds
-          </div>
-
-          {/* Dynamic stat pills */}
-          <div
-            style={{
-              display: 'flex',
-              marginTop: 40,
-              gap: 20,
-            }}
-          >
-            {pills.map((pill) => (
-              <div
-                key={pill}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  padding: '12px 24px',
-                  background: 'rgba(255,255,255,0.15)',
-                  borderRadius: 50,
-                  color: 'white',
-                  fontSize: 20,
-                }}
-              >
-                {pill}
-              </div>
-            ))}
           </div>
         </div>
       </OGBackground>

--- a/apps/web-next/src/components/og/og-utils.tsx
+++ b/apps/web-next/src/components/og/og-utils.tsx
@@ -1,24 +1,44 @@
 import React from 'react';
 
-// ── Color constants for OG images (hex equivalents of Tailwind classes) ──
+// ── v2 palette anchors (match .landing-v2 CSS tokens) ──
+// --ink: #1a1330, --accent: #6d3fe8, --accent-2: #f0e9ff, --paper: #ffffff,
+// --paper-2: #f7f5fc, --line: #ece8f5, --warn: #d23a62, --gold: #a8792a
+
+export const V2 = {
+  ink: '#1a1330',
+  ink2: '#3a2f55',
+  accent: '#6d3fe8',
+  accent2: '#f0e9ff',
+  paper: '#ffffff',
+  paper2: '#f7f5fc',
+  line: '#ece8f5',
+  line2: '#ddd7ec',
+  muted: '#6b6384',
+  warn: '#d23a62',
+  gold: '#a8792a',
+} as const;
+
+// ── Color constants for OG images (aligned with v2 accent palette) ──
+// Structure preserved for backward compat — each tag has a soft bg (used as chip),
+// a text color (readable against bg), and an accent (used as subtle glow hint).
 
 export const NEWS_TAG_COLORS: Record<string, { bg: string; text: string; accent: string }> = {
-  'new-card':       { bg: '#ecfdf5', text: '#047857', accent: '#10b981' },
-  'discontinued':   { bg: '#fef2f2', text: '#b91c1c', accent: '#ef4444' },
-  'bonus-change':   { bg: '#eff6ff', text: '#1d4ed8', accent: '#3b82f6' },
-  'fee-change':     { bg: '#fffbeb', text: '#b45309', accent: '#f59e0b' },
-  'benefit-change': { bg: '#f5f3ff', text: '#6d28d9', accent: '#8b5cf6' },
-  'limited-time':   { bg: '#fff7ed', text: '#c2410c', accent: '#f97316' },
-  'policy-change':  { bg: '#f8fafc', text: '#334155', accent: '#64748b' },
-  'general':        { bg: '#eef2ff', text: '#4338ca', accent: '#6366f1' },
+  'new-card':       { bg: '#e6f7ee', text: '#0c8450', accent: '#0c8450' }, // emerald (positive)
+  'discontinued':   { bg: '#ffe6ed', text: '#d23a62', accent: '#d23a62' }, // warn
+  'bonus-change':   { bg: '#f0e9ff', text: '#6d3fe8', accent: '#6d3fe8' }, // accent
+  'fee-change':     { bg: '#faf0d9', text: '#a8792a', accent: '#a8792a' }, // gold
+  'benefit-change': { bg: '#f0e9ff', text: '#6d3fe8', accent: '#6d3fe8' }, // accent
+  'limited-time':   { bg: '#faf0d9', text: '#a8792a', accent: '#a8792a' }, // gold
+  'policy-change':  { bg: '#f7f5fc', text: '#3a2f55', accent: '#6b6384' }, // neutral
+  'general':        { bg: '#f7f5fc', text: '#3a2f55', accent: '#6b6384' }, // neutral
 };
 
 export const ARTICLE_TAG_COLORS: Record<string, { bg: string; text: string; accent: string }> = {
-  'strategy':      { bg: '#f3e8ff', text: '#6b21a8', accent: '#a855f7' },
-  'guide':         { bg: '#dbeafe', text: '#1e40af', accent: '#3b82f6' },
-  'analysis':      { bg: '#dcfce7', text: '#166534', accent: '#22c55e' },
-  'news-analysis': { bg: '#ffedd5', text: '#9a3412', accent: '#f97316' },
-  'beginner':      { bg: '#ccfbf1', text: '#115e59', accent: '#14b8a6' },
+  'strategy':      { bg: '#f0e9ff', text: '#6d3fe8', accent: '#6d3fe8' }, // accent
+  'guide':         { bg: '#f7f5fc', text: '#3a2f55', accent: '#6b6384' }, // neutral
+  'analysis':      { bg: '#e6f7ee', text: '#0c8450', accent: '#0c8450' }, // emerald
+  'news-analysis': { bg: '#faf0d9', text: '#a8792a', accent: '#a8792a' }, // gold
+  'beginner':      { bg: '#f0e9ff', text: '#6d3fe8', accent: '#6d3fe8' }, // accent
 };
 
 export const NEWS_TAG_LABELS: Record<string, string> = {
@@ -98,7 +118,11 @@ export function OGLogo({ size = 48 }: { size?: number }) {
   );
 }
 
-// ── OGBackground component ──
+// ── OGBackground component (v2 editorial style) ──
+//
+// Deep ink base (#1a1330) with a soft purple accent glow — matches the
+// .landing-v2 aesthetic. Kept dark so white text in the 40+ call-sites still
+// reads; social-preview contrast is also better on dark.
 
 export function OGBackground({
   children,
@@ -107,7 +131,7 @@ export function OGBackground({
   children: React.ReactNode;
   accentColor?: string;
 }) {
-  const warmGlow = accentColor || '#f59e0b';
+  const glow = accentColor || V2.accent;
 
   return (
     <div
@@ -115,12 +139,12 @@ export function OGBackground({
         width: '100%',
         height: '100%',
         display: 'flex',
-        background: 'linear-gradient(115deg, #e8e8e8 0%, #9a9a9a 8%, #f0f0f0 16%, #858585 24%, #d8d8d8 32%, #a8a8a8 40%, #ececec 48%, #929292 56%, #dcdcdc 64%, #b0b0b0 72%, #f2f2f2 80%, #8e8e8e 88%, #d0d0d0 96%)',
+        background: V2.paper2,
         fontFamily: 'Inter, system-ui, sans-serif',
         padding: 8,
       }}
     >
-      {/* Inner rounded content area */}
+      {/* Inner rounded content area — editorial paper frame around ink canvas */}
       <div
         style={{
           display: 'flex',
@@ -128,10 +152,11 @@ export function OGBackground({
           position: 'relative',
           borderRadius: 16,
           overflow: 'hidden',
-          background: 'linear-gradient(135deg, #3730A3 0%, #504DE1 30%, #7C3AED 60%, #4F46E5 100%)',
+          background: V2.ink,
+          boxShadow: `inset 0 0 0 1px ${hexToRgba('#ffffff', 0.06)}`,
         }}
       >
-        {/* Dot grid pattern overlay */}
+        {/* Subtle mono grid */}
         <div
           style={{
             position: 'absolute',
@@ -139,13 +164,14 @@ export function OGBackground({
             left: 0,
             right: 0,
             bottom: 0,
-            backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.12) 1px, transparent 1px)',
-            backgroundSize: '24px 24px',
+            backgroundImage:
+              'radial-gradient(circle, rgba(255,255,255,0.06) 1px, transparent 1px)',
+            backgroundSize: '28px 28px',
             display: 'flex',
           }}
         />
 
-        {/* Cool indigo glow — top left */}
+        {/* Primary purple accent glow — top right */}
         <div
           style={{
             position: 'absolute',
@@ -153,12 +179,15 @@ export function OGBackground({
             left: 0,
             right: 0,
             bottom: 0,
-            backgroundImage: 'radial-gradient(circle at 15% 20%, rgba(99,102,241,0.4) 0%, transparent 50%)',
+            backgroundImage: `radial-gradient(circle at 85% 15%, ${hexToRgba(
+              glow,
+              0.28
+            )} 0%, transparent 55%)`,
             display: 'flex',
           }}
         />
 
-        {/* Warm accent glow — bottom right */}
+        {/* Secondary cooler accent glow — bottom left */}
         <div
           style={{
             position: 'absolute',
@@ -166,7 +195,10 @@ export function OGBackground({
             left: 0,
             right: 0,
             bottom: 0,
-            backgroundImage: `radial-gradient(circle at 85% 80%, ${hexToRgba(warmGlow, 0.25)} 0%, transparent 50%)`,
+            backgroundImage: `radial-gradient(circle at 10% 90%, ${hexToRgba(
+              glow,
+              0.16
+            )} 0%, transparent 50%)`,
             display: 'flex',
           }}
         />


### PR DESCRIPTION
## Summary
- Swap the OG background gradient (metallic frame + bright indigo/violet inner) for the v2 editorial palette: deep ink canvas (#1a1330) with soft purple accent glows and a subtle mono dot grid
- Realign NEWS_TAG_COLORS and ARTICLE_TAG_COLORS with the v2 accent / emerald / gold / warn palette so tag chips on the news and article OGs match the on-site chips
- Remove the 3 stat chips from the landing-page OG — cleaner and more editorial
- Add a white hairline + purple accent halo behind card images on /card/[name] OGs so dark metallic cards (Amex Platinum, Sapphire Reserve) stay readable against the ink canvas
- All 41 OG image files inherit the refresh through the shared OGBackground — no per-page edits needed

## Test plan
- [x] npm run build passes, 0 errors
- [x] Spot-rendered /opengraph-image (landing), /card/chase-sapphire-reserve/opengraph-image, /card/the-platinum-card/opengraph-image, /news/[id]/opengraph-image
- [ ] Paste a link into X/Slack after deploy to verify preview cards
- [ ] Clear Facebook/LinkedIn OG caches for existing URLs if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)