### PR TITLE
Tighten landing hero top padding to match /explore

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -191,7 +191,7 @@
 
 /* ---------- Hero ---------- */
 .landing-v2 .hero {
-  padding-block: 72px 40px;
+  padding-block: 32px 40px;
   position: relative;
 }
 .landing-v2 .hero-grid {
@@ -2017,7 +2017,7 @@
     /* aligned with Navbar px-4/sm:px-6 — see main .wrap rule */
   }
   .landing-v2 .hero {
-    padding-block: 44px 28px;
+    padding-block: 20px 28px;
   }
   .landing-v2 .page-hero {
     padding-block: 20px 24px;


### PR DESCRIPTION
## Summary
- Landing `.hero` was sitting at 72px top padding (44px mobile) while the shared `.page-hero` used 32px / 20px. Drop `.hero` to the same values so the gap between navbar and content is consistent across the site.

## Test plan
- [x] Desktop: gap between navbar bottom and eyebrow is now 32px (matches `/explore`)
- [x] Mobile: gap halves correctly to ~20px

🤖 Generated with [Claude Code](https://claude.com/claude-code)