### PR TITLE
Alias-aware search on landing odds widget + /explore

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import CardImage from '@/components/ui/CardImage';
 import { Card } from '@/lib/api';
+import { cardMatchesSearch } from '@/lib/searchAliases';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import './landing.css';
 
@@ -103,9 +104,8 @@ function OddsWidget({ cards }: { cards: Card[] }) {
 
   const filtered = useMemo(() => {
     if (!query) return activeCards;
-    const q = query.toLowerCase();
-    return activeCards.filter(
-      (c) => c.card_name.toLowerCase().includes(q) || c.bank.toLowerCase().includes(q)
+    return activeCards.filter((c) =>
+      cardMatchesSearch(c.card_name, c.bank, query)
     );
   }, [query, activeCards]);
 

--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -6,6 +6,7 @@ import CardImage from '@/components/ui/CardImage';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import type { Card, Reward } from '@/lib/api';
 import { categoryLabels } from '@/lib/cardDisplayUtils';
+import { cardMatchesSearch } from '@/lib/searchAliases';
 import '../landing.css';
 
 interface ExploreV2ClientProps {
@@ -121,14 +122,11 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
   }, [cards, includeArchived]);
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
+    const q = query.trim();
     const pool = cards.filter((c) => {
       if (!includeArchived && !c.accepting_applications) return false;
       if (cat !== 'All' && cardCategory(c) !== cat) return false;
-      if (q) {
-        const haystack = `${c.card_name} ${c.bank}`.toLowerCase();
-        if (!haystack.includes(q)) return false;
-      }
+      if (q && !cardMatchesSearch(c.card_name, c.bank, q)) return false;
       return true;
     });
     const sorted = [...pool];


### PR DESCRIPTION
## Summary
- Swap plain `.includes()` string match on the landing-page odds calculator and the `/explore` card filter for the shared `cardMatchesSearch` helper from `lib/searchAliases`
- Typing **amex** now surfaces American Express cards (Gold, Platinum, Blue Cash, Green, etc.). Same for **csp** → Chase Sapphire Preferred, **bofa** → Bank of America, **cap one**/**capone** → Capital One, **wf** → Wells Fargo, **usb** → U.S. Bank
- Also preserves multi-word matching (e.g. "Bank America" → Bank of America)

## Test plan
- [x] Type "amex" into the landing odds calculator — returns 6 Amex cards
- [ ] Confirm /explore search still works for normal names
- [ ] Spot-check bofa / csp / cfu / wf

🤖 Generated with [Claude Code](https://claude.com/claude-code)