### PR TITLE
Restore LogRocket, remove Microsoft Clarity

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
-    "@microsoft/clarity": "^1.0.2",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
@@ -24,6 +23,7 @@
     "formik": "^2.4.9",
     "highcharts": "^12.5.0",
     "highcharts-react-official": "^3.2.3",
+    "logrocket": "^12.1.0",
     "next": "^16.1.4",
     "react": "^18",
     "react-dom": "^18",

--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { AuthProvider } from "@/auth/AuthProvider";
 import { ConditionalNavbar, ConditionalFooter } from "@/components/layout/ConditionalChrome";
 import SkipLink from "@/components/ui/SkipLink";
 import WebVitalsReporter from "@/components/ui/WebVitalsReporter";
-import ClarityInit from "@/components/ui/ClarityInit";
+import LogRocketInit from "@/components/ui/LogRocketInit";
 import DataPointPrompt from "@/components/ui/DataPointPrompt";
 import { OrganizationSchema, WebsiteSchema } from "@/components/seo/JsonLd";
 import { ToastContainer } from "react-toastify";
@@ -73,7 +73,7 @@ export default function RootLayout({
           <ConditionalFooter />
           <ToastContainer />
           <WebVitalsReporter />
-          <ClarityInit />
+          <LogRocketInit />
         </AuthProvider>
       </body>
     </html>

--- a/apps/web-next/src/components/ui/LogRocketInit.tsx
+++ b/apps/web-next/src/components/ui/LogRocketInit.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import { useEffect } from 'react';
-import Clarity from '@microsoft/clarity';
+import LogRocket from 'logrocket';
 import { useAuth } from '@/auth/AuthProvider';
 
 let initialized = false;
 
-export default function ClarityInit() {
+export default function LogRocketInit() {
   const { authState } = useAuth();
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production' && !initialized) {
-      Clarity.init('w0ejzgxumv');
+      LogRocket.init('8ouxn1/creditodds');
       initialized = true;
     }
   }, []);
@@ -20,7 +20,10 @@ export default function ClarityInit() {
     if (!initialized) return;
 
     if (authState.user) {
-      Clarity.identify(authState.user.uid, undefined, undefined, authState.user.displayName || '');
+      LogRocket.identify(authState.user.uid, {
+        name: authState.user.displayName || '',
+        email: authState.user.email || '',
+      });
     }
   }, [authState.user]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,6 @@
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
-        "@microsoft/clarity": "^1.0.2",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.19",
@@ -116,6 +115,7 @@
         "formik": "^2.4.9",
         "highcharts": "^12.5.0",
         "highcharts-react-official": "^3.2.3",
+        "logrocket": "^12.1.0",
         "next": "^16.1.4",
         "react": "^18",
         "react-dom": "^18",
@@ -4876,12 +4876,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
-    },
-    "node_modules/@microsoft/clarity": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.2.tgz",
-      "integrity": "sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==",
-      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -13716,6 +13710,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/logrocket": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-12.1.0.tgz",
+      "integrity": "sha512-WZXCwtPam15ktseKzP2SAd2PgHXmr41++8Lgg30VyW/mpAbHaJAZm5//C+l9Yt5x6HLfwH76PuY47RXpKUvTuA==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",


### PR DESCRIPTION
## Summary
- Free tier on LogRocket reset, switching back from Clarity
- Restores `LogRocketInit.tsx` (identical to pre-Clarity version), removes `ClarityInit.tsx`
- Swaps npm deps: `@microsoft/clarity` → `logrocket`

## Test plan
- [ ] Verify LogRocket session appears in dashboard after deploy
- [ ] Verify no Clarity script loads in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)