### PR TITLE
v2 editorial palette for social-post images

### DIFF
--- a/scripts/lib/og-style.js
+++ b/scripts/lib/og-style.js
@@ -1,0 +1,79 @@
+/**
+ * Shared v2 editorial styling for social-post images.
+ *
+ * Mirrors the palette used by the on-site OG images (components/og/og-utils.tsx)
+ * so Twitter/LinkedIn/Reddit previews all read as one brand: ink canvas
+ * (#1a1330), purple accent glow, emerald/warn for positive/negative movement.
+ */
+
+const V2 = {
+  ink: '#1a1330',
+  ink2: '#3a2f55',
+  accent: '#6d3fe8',
+  accent2: '#f0e9ff',
+  paper: '#ffffff',
+  paper2: '#f7f5fc',
+  line: '#ece8f5',
+  line2: '#ddd7ec',
+  muted: '#6b6384',
+  warn: '#d23a62',
+  gold: '#a8792a',
+  emerald: '#0c8450',
+};
+
+function hexToRgba(hex, alpha) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+/**
+ * Returns SVG fragments for the dark editorial background: ink canvas, a
+ * purple accent radial glow top-right, a softer one bottom-left, and a subtle
+ * mono dot grid. Caller splices `defs` into the `<defs>` block and `rects` at
+ * the start of the canvas.
+ */
+function darkBackground({ width, height, accent = V2.accent, idSuffix = '' }) {
+  const glowId = `v2glow${idSuffix}`;
+  const glow2Id = `v2glow2${idSuffix}`;
+  const dotsId = `v2dots${idSuffix}`;
+  const defs = `
+    <radialGradient id="${glowId}" cx="85%" cy="15%" r="55%">
+      <stop offset="0%" stop-color="${hexToRgba(accent, 0.28)}"/>
+      <stop offset="100%" stop-color="${hexToRgba(accent, 0)}"/>
+    </radialGradient>
+    <radialGradient id="${glow2Id}" cx="10%" cy="90%" r="50%">
+      <stop offset="0%" stop-color="${hexToRgba(accent, 0.16)}"/>
+      <stop offset="100%" stop-color="${hexToRgba(accent, 0)}"/>
+    </radialGradient>
+    <pattern id="${dotsId}" x="0" y="0" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="1" cy="1" r="1" fill="rgba(255,255,255,0.06)"/>
+    </pattern>
+  `;
+  const rects = `
+    <rect width="${width}" height="${height}" fill="${V2.ink}"/>
+    <rect width="${width}" height="${height}" fill="url(#${dotsId})"/>
+    <rect width="${width}" height="${height}" fill="url(#${glowId})"/>
+    <rect width="${width}" height="${height}" fill="url(#${glow2Id})"/>
+  `;
+  return { defs, rects };
+}
+
+/**
+ * Subtle hairline + muted-purple footer text. Caller positions a <g transform>
+ * or embeds this directly at the footer Y offset.
+ */
+function footerBar({ width, y, height, text = 'creditodds.com' }) {
+  return `
+    <line x1="40" y1="${y}" x2="${width - 40}" y2="${y}" stroke="rgba(255,255,255,0.08)" stroke-width="1"/>
+    <text x="${width / 2}" y="${y + Math.round(height / 2) + 6}" text-anchor="middle" font-family="Arial,sans-serif" font-size="16" font-weight="600" fill="${V2.muted}">${text}</text>
+  `;
+}
+
+module.exports = {
+  V2,
+  hexToRgba,
+  darkBackground,
+  footerBar,
+};

--- a/scripts/post-best-rankings.js
+++ b/scripts/post-best-rankings.js
@@ -18,6 +18,7 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 const sharp = require('sharp');
+const { V2, darkBackground, footerBar } = require('./lib/og-style');
 
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
 const CDN_IMAGES = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
@@ -142,8 +143,8 @@ function getBadgeOrMovementSvg(card) {
     const pillWidth = textWidth + 24;
     const x = -pillWidth;
     return `<g>
-      <rect x="${x}" y="-10" width="${pillWidth}" height="24" rx="12" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
-      <text x="${x + pillWidth / 2}" y="7" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#4f46e5">${badgeText}</text>
+      <rect x="${x}" y="-10" width="${pillWidth}" height="24" rx="12" fill="rgba(109,63,232,0.18)" stroke="rgba(109,63,232,0.45)" stroke-width="1"/>
+      <text x="${x + pillWidth / 2}" y="7" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#ffffff">${badgeText}</text>
     </g>`;
   }
 
@@ -151,13 +152,13 @@ function getBadgeOrMovementSvg(card) {
     const movement = card.previousRank - card.rank;
     if (movement > 0) {
       return `<g>
-        <polygon points="0,12 8,0 16,12" fill="#16a34a"/>
-        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#16a34a">+${movement}</text>
+        <polygon points="0,12 8,0 16,12" fill="${V2.emerald}"/>
+        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="${V2.emerald}">+${movement}</text>
       </g>`;
     } else if (movement < 0) {
       return `<g>
-        <polygon points="0,0 8,12 16,0" fill="#dc2626"/>
-        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#dc2626">${movement}</text>
+        <polygon points="0,0 8,12 16,0" fill="${V2.warn}"/>
+        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="${V2.warn}">${movement}</text>
       </g>`;
     }
   }
@@ -180,41 +181,36 @@ async function generateBestRankingsImage(categoryTitle, updatedAt, topCards) {
     ? new Date(updatedAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
     : new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
 
-  const rankColors = ['#4f46e5', '#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe'];
-  const rowColors = ['#f8fafc', '#ffffff'];
-
   let rowsSvg = '';
   for (let i = 0; i < 5; i++) {
     const card = topCards[i];
     const y = headerHeight + (i * rowHeight);
-    const bgColor = rowColors[i % 2];
+    const bgFill = i % 2 === 0 ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0)';
 
     rowsSvg += `
-      <rect x="0" y="${y}" width="${width}" height="${rowHeight}" fill="${bgColor}"/>
-      <circle cx="55" cy="${y + rowHeight / 2}" r="28" fill="${rankColors[i]}"/>
+      <rect x="0" y="${y}" width="${width}" height="${rowHeight}" fill="${bgFill}"/>
+      <line x1="40" y1="${y}" x2="${width - 40}" y2="${y}" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+      <circle cx="55" cy="${y + rowHeight / 2}" r="28" fill="${V2.accent}"/>
       <text x="55" y="${y + rowHeight / 2 + 10}" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="white">${card.rank}</text>
-      <text x="310" y="${y + rowHeight / 2 - 8}" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#1e293b">${escapeXml(card.name)}</text>
-      <text x="310" y="${y + rowHeight / 2 + 18}" font-family="Arial,sans-serif" font-size="16" fill="#64748b">${escapeXml(card.bank)}</text>
+      <text x="310" y="${y + rowHeight / 2 - 8}" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#ffffff">${escapeXml(card.name)}</text>
+      <text x="310" y="${y + rowHeight / 2 + 18}" font-family="Arial,sans-serif" font-size="16" fill="rgba(255,255,255,0.6)">${escapeXml(card.bank)}</text>
       <g transform="translate(${width - 30}, ${y + rowHeight / 2 - 6})">
         ${getBadgeOrMovementSvg(card)}
       </g>
     `;
   }
 
+  const bg = darkBackground({ width, height, accent: V2.accent });
+
   const svg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
     <defs>
-      <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" style="stop-color:#4f46e5"/>
-        <stop offset="100%" style="stop-color:#7c3aed"/>
-      </linearGradient>
+      ${bg.defs}
     </defs>
-    <rect width="${width}" height="${height}" fill="#ffffff"/>
-    <rect x="0" y="0" width="${width}" height="${headerHeight}" fill="url(#headerGrad)"/>
-    <text x="40" y="52" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white">${escapeXml(categoryTitle)}</text>
-    <text x="40" y="85" font-family="Arial,sans-serif" font-size="18" fill="rgba(255,255,255,0.85)">Updated ${escapeXml(updatedDate)}</text>
+    ${bg.rects}
+    <text x="40" y="58" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="#ffffff" letter-spacing="-0.5">${escapeXml(categoryTitle)}</text>
+    <text x="40" y="92" font-family="Arial,sans-serif" font-size="16" fill="${V2.accent}" letter-spacing="1.5">UPDATED \u00B7 ${escapeXml(updatedDate).toUpperCase()}</text>
     ${rowsSvg}
-    <rect x="0" y="${height - footerHeight}" width="${width}" height="${footerHeight}" fill="#f1f5f9"/>
-    <text x="${width / 2}" y="${height - 22}" text-anchor="middle" font-family="Arial,sans-serif" font-size="16" font-weight="600" fill="#64748b">creditodds.com</text>
+    ${footerBar({ width, y: height - footerHeight, height: footerHeight })}
   </svg>`;
 
   let image = sharp(Buffer.from(svg)).png();

--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -17,6 +17,7 @@
 const fs = require('fs');
 const path = require('path');
 const sharp = require('sharp');
+const { V2, darkBackground, footerBar, hexToRgba } = require('./lib/og-style');
 
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
 const CDN_IMAGES = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
@@ -133,7 +134,7 @@ async function generateCardWireImage(cardName, bank, changes, cardImageBuffer) {
   // Section header
   const sectionHeaderY = headerHeight + cardImageAreaHeight;
   changesSvg += `
-    <text x="40" y="${sectionHeaderY + 26}" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#6b7280" letter-spacing="0.1em">WHAT CHANGED</text>
+    <text x="40" y="${sectionHeaderY + 26}" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="${V2.accent}" letter-spacing="1.5">WHAT CHANGED</text>
   `;
 
   for (let i = 0; i < changes.length; i++) {
@@ -144,58 +145,65 @@ async function generateCardWireImage(cardName, bank, changes, cardImageBuffer) {
     const oldFormatted = formatValue(c.field, c.old_value);
     const newFormatted = formatValue(c.field, c.new_value);
 
-    const arrowColor = dir === 'positive' ? '#16a34a' : dir === 'negative' ? '#dc2626' : '#6b7280';
-    const arrowBg = dir === 'positive' ? '#f0fdf4' : dir === 'negative' ? '#fef2f2' : '#f9fafb';
-    const valueBg = dir === 'positive' ? '#dcfce7' : dir === 'negative' ? '#fee2e2' : '#f3f4f6';
+    const accentColor = dir === 'positive' ? V2.emerald : dir === 'negative' ? V2.warn : V2.muted;
+    const rowBg = dir === 'positive'
+      ? hexToRgba(V2.emerald, 0.12)
+      : dir === 'negative'
+      ? hexToRgba(V2.warn, 0.14)
+      : 'rgba(255,255,255,0.05)';
+    const pillBg = dir === 'positive'
+      ? hexToRgba(V2.emerald, 0.22)
+      : dir === 'negative'
+      ? hexToRgba(V2.warn, 0.22)
+      : 'rgba(255,255,255,0.12)';
 
     // Row background
-    changesSvg += `<rect x="30" y="${y}" width="${width - 60}" height="${changeRowHeight - 10}" rx="12" fill="${arrowBg}"/>`;
+    changesSvg += `<rect x="30" y="${y}" width="${width - 60}" height="${changeRowHeight - 10}" rx="12" fill="${rowBg}" stroke="${hexToRgba(accentColor, 0.3)}" stroke-width="1"/>`;
 
     // Field label
-    changesSvg += `<text x="55" y="${y + 35}" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#374151">${escapeXml(label)}</text>`;
+    changesSvg += `<text x="55" y="${y + 35}" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#ffffff">${escapeXml(label)}</text>`;
 
     // Old value → New value
-    changesSvg += `<text x="55" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" fill="#9ca3af">${escapeXml(oldFormatted)}</text>`;
-    changesSvg += `<text x="${55 + oldFormatted.length * 13 + 15}" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" fill="#9ca3af">\u2192</text>`;
-    changesSvg += `<text x="${55 + oldFormatted.length * 13 + 40}" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" font-weight="bold" fill="${arrowColor}">${escapeXml(newFormatted)}</text>`;
+    changesSvg += `<text x="55" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" fill="rgba(255,255,255,0.5)">${escapeXml(oldFormatted)}</text>`;
+    changesSvg += `<text x="${55 + oldFormatted.length * 13 + 15}" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" fill="rgba(255,255,255,0.5)">\u2192</text>`;
+    changesSvg += `<text x="${55 + oldFormatted.length * 13 + 40}" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" font-weight="bold" fill="${accentColor}">${escapeXml(newFormatted)}</text>`;
 
     // Direction badge on right
     const badgeText = dir === 'positive' ? '\u2B06 Better' : dir === 'negative' ? '\u2B07 Worse' : '\u2796 Changed';
     changesSvg += `
-      <rect x="${width - 195}" y="${y + 25}" width="130" height="36" rx="18" fill="${valueBg}"/>
-      <text x="${width - 130}" y="${y + 49}" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="${arrowColor}">${badgeText}</text>
+      <rect x="${width - 195}" y="${y + 25}" width="130" height="36" rx="18" fill="${pillBg}"/>
+      <text x="${width - 130}" y="${y + 49}" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="${accentColor}">${badgeText}</text>
     `;
   }
 
-  // Header gradient color based on overall sentiment
+  // Header accent color based on overall sentiment
   const allPositive = changes.every(c => getDirection(c.field, c.old_value, c.new_value) === 'positive');
   const allNegative = changes.every(c => getDirection(c.field, c.old_value, c.new_value) === 'negative');
-  const gradStart = allPositive ? '#059669' : allNegative ? '#dc2626' : '#4f46e5';
-  const gradEnd = allPositive ? '#10b981' : allNegative ? '#ef4444' : '#7c3aed';
+  const accentColor = allPositive ? V2.emerald : allNegative ? V2.warn : V2.accent;
+
+  const bg = darkBackground({ width, height, accent: accentColor });
 
   const svg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
     <defs>
-      <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" style="stop-color:${gradStart}"/>
-        <stop offset="100%" style="stop-color:${gradEnd}"/>
-      </linearGradient>
+      ${bg.defs}
     </defs>
-    <rect width="${width}" height="${height}" fill="#ffffff"/>
+    ${bg.rects}
+
+    <!-- Accent bar above title -->
+    <rect x="40" y="32" width="60" height="3" fill="${accentColor}"/>
 
     <!-- Header -->
-    <rect x="0" y="0" width="${width}" height="${headerHeight}" fill="url(#hg)"/>
-    <text x="40" y="42" font-family="Arial,sans-serif" font-size="32" font-weight="bold" fill="white">${escapeXml(cardName)}</text>
-    <text x="40" y="72" font-family="Arial,sans-serif" font-size="18" fill="rgba(255,255,255,0.85)">${escapeXml(bank || '')} \u2022 CardWire Update</text>
+    <text x="40" y="66" font-family="Arial,sans-serif" font-size="32" font-weight="bold" fill="#ffffff" letter-spacing="-0.5">${escapeXml(cardName)}</text>
+    <text x="40" y="92" font-family="Arial,sans-serif" font-size="16" fill="${accentColor}" letter-spacing="1.2">${escapeXml((bank || '').toUpperCase())} \u00B7 CARDWIRE UPDATE</text>
 
-    <!-- Card image area (white background, image composited later) -->
-    <rect x="0" y="${headerHeight}" width="${width}" height="${cardImageAreaHeight}" fill="#f8fafc"/>
+    <!-- Card image area (darker inset) -->
+    <rect x="0" y="${headerHeight}" width="${width}" height="${cardImageAreaHeight}" fill="rgba(0,0,0,0.18)"/>
 
     <!-- Changes -->
     ${changesSvg}
 
     <!-- Footer -->
-    <rect x="0" y="${height - footerHeight}" width="${width}" height="${footerHeight}" fill="#f1f5f9"/>
-    <text x="${width / 2}" y="${height - 17}" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="600" fill="#64748b">creditodds.com/card-wire</text>
+    ${footerBar({ width, y: height - footerHeight, height: footerHeight, text: 'creditodds.com/card-wire' })}
   </svg>`;
 
   let image = sharp(Buffer.from(svg)).png();

--- a/scripts/post-weekly-top-cards.js
+++ b/scripts/post-weekly-top-cards.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const sharp = require('sharp');
+const { V2, darkBackground, footerBar } = require('./lib/og-style');
 
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
 const CDN_IMAGES = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
@@ -155,58 +156,54 @@ async function generateRankingsImage(topCards) {
   function getMovementSvg(card) {
     if (card.movement === 'up') {
       return `<g>
-        <polygon points="0,12 8,0 16,12" fill="#16a34a"/>
-        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#16a34a">+${card.movementAmount}</text>
+        <polygon points="0,12 8,0 16,12" fill="${V2.emerald}"/>
+        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="${V2.emerald}">+${card.movementAmount}</text>
       </g>`;
     } else if (card.movement === 'down') {
       return `<g>
-        <polygon points="0,0 8,12 16,0" fill="#dc2626"/>
-        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#dc2626">-${card.movementAmount}</text>
+        <polygon points="0,0 8,12 16,0" fill="${V2.warn}"/>
+        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="${V2.warn}">-${card.movementAmount}</text>
       </g>`;
     } else if (card.movement === 'new') {
-      return `<text x="0" y="12" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#7c3aed">NEW</text>`;
+      return `<text x="0" y="12" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="${V2.accent}">NEW</text>`;
     } else {
-      return `<text x="0" y="12" font-family="Arial,sans-serif" font-size="16" fill="#9ca3af">\u2014</text>`;
+      return `<text x="0" y="12" font-family="Arial,sans-serif" font-size="16" fill="rgba(255,255,255,0.45)">\u2014</text>`;
     }
   }
 
   const now = new Date();
   const weekStr = now.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
-  const rowColors = ['#f8fafc', '#ffffff'];
 
   let rowsSvg = '';
   for (let i = 0; i < 5; i++) {
     const card = topCards[i];
     const y = headerHeight + (i * rowHeight);
-    const bgColor = rowColors[i % 2];
-    const rankColors = ['#4f46e5', '#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe'];
+    const bgFill = i % 2 === 0 ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0)';
 
     rowsSvg += `
-      <rect x="0" y="${y}" width="${width}" height="${rowHeight}" fill="${bgColor}"/>
-      <circle cx="55" cy="${y + rowHeight / 2}" r="28" fill="${rankColors[i]}"/>
+      <rect x="0" y="${y}" width="${width}" height="${rowHeight}" fill="${bgFill}"/>
+      <line x1="40" y1="${y}" x2="${width - 40}" y2="${y}" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+      <circle cx="55" cy="${y + rowHeight / 2}" r="28" fill="${V2.accent}"/>
       <text x="55" y="${y + rowHeight / 2 + 10}" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="white">${card.rank}</text>
-      <text x="310" y="${y + rowHeight / 2 - 8}" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#1e293b">${escapeXml(card.name)}</text>
-      <text x="310" y="${y + rowHeight / 2 + 18}" font-family="Arial,sans-serif" font-size="16" fill="#64748b">${escapeXml(card.bank || '')}</text>
+      <text x="310" y="${y + rowHeight / 2 - 8}" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#ffffff">${escapeXml(card.name)}</text>
+      <text x="310" y="${y + rowHeight / 2 + 18}" font-family="Arial,sans-serif" font-size="16" fill="rgba(255,255,255,0.6)">${escapeXml(card.bank || '')}</text>
       <g transform="translate(${width - 80}, ${y + rowHeight / 2 - 6})">
         ${getMovementSvg(card)}
       </g>
     `;
   }
 
+  const bg = darkBackground({ width, height, accent: V2.accent });
+
   const svg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
     <defs>
-      <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" style="stop-color:#4f46e5"/>
-        <stop offset="100%" style="stop-color:#7c3aed"/>
-      </linearGradient>
+      ${bg.defs}
     </defs>
-    <rect width="${width}" height="${height}" fill="#ffffff"/>
-    <rect x="0" y="0" width="${width}" height="${headerHeight}" fill="url(#headerGrad)"/>
-    <text x="40" y="52" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white">Weekly Power Rankings</text>
-    <text x="40" y="85" font-family="Arial,sans-serif" font-size="18" fill="rgba(255,255,255,0.85)">Top 5 Most Viewed Credit Cards \u2014 Week of ${escapeXml(weekStr)}</text>
+    ${bg.rects}
+    <text x="40" y="58" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="#ffffff" letter-spacing="-0.5">Weekly Power Rankings</text>
+    <text x="40" y="92" font-family="Arial,sans-serif" font-size="16" fill="${V2.accent}" letter-spacing="1.5">TOP 5 MOST VIEWED \u00B7 WEEK OF ${escapeXml(weekStr).toUpperCase()}</text>
     ${rowsSvg}
-    <rect x="0" y="${height - footerHeight}" width="${width}" height="${footerHeight}" fill="#f1f5f9"/>
-    <text x="${width / 2}" y="${height - 22}" text-anchor="middle" font-family="Arial,sans-serif" font-size="16" font-weight="600" fill="#64748b">creditodds.com</text>
+    ${footerBar({ width, y: height - footerHeight, height: footerHeight })}
   </svg>`;
 
   let image = sharp(Buffer.from(svg)).png();


### PR DESCRIPTION
## Summary
The three Node posters — `post-best-rankings.js`, `post-weekly-top-cards.js`, `post-card-wire.js` — were still rendering PNGs in the v1 palette (white canvas + indigo→violet gradient header + graduated indigo rank circles + slate grays), which looked disjointed next to the v2 dark OG images the on-site redesign now ships.

This PR aligns all three with the shared v2 ink canvas (#1a1330) + purple accent glow + dot-grid background. Rank circles collapse to `--accent`; positive → emerald, negative → warn. Card-wire also tints each change row by sentiment to echo the on-site CardWire chip styling.

Shared palette + SVG helpers extracted into `scripts/lib/og-style.js` so future social images pick up the treatment without duplication.

## Preview
Dry-run outputs verified locally for all three scripts (best-travel-cards, weekly top 5, a 2-field card-wire update).

## Test plan
- [x] `post-best-rankings.js --dry-run` renders clean on dark canvas
- [x] `post-weekly-top-cards.js --dry-run` renders clean with emerald/warn/accent movement indicators
- [x] `post-card-wire.js --dry-run` renders with sentiment-tinted rows and an accent header bar
- [ ] After merge, check next scheduled post on Twitter/X to confirm platform unfurling works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)