### PR TITLE
Add bank Twitter @mentions to X-only tweet variants

### DIFF
--- a/data/bank-twitter-handles.json
+++ b/data/bank-twitter-handles.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Twitter/X handles for card issuers, keyed by bank name as it appears in cards.json. Include the leading '@'. Set to null or omit the bank to skip mentions. Used by scripts/lib/bank-handles.js to append @mentions to tweets only.",
+  "American Express": "@AmericanExpress",
+  "Bank of America": "@BankofAmerica",
+  "Barclays": "@BarclaysUS",
+  "Bilt": "@biltrewards",
+  "Capital One": "@CapitalOne",
+  "Chase": "@Chase",
+  "Citi": "@Citi",
+  "Discover": "@Discover",
+  "Elan Financial Services": null,
+  "First Electronic Bank": null,
+  "Goldman Sachs": "@GoldmanSachs",
+  "Lead Bank": null,
+  "Robinhood": "@RobinhoodApp",
+  "U.S. Bank": "@usbank",
+  "USAA": "@USAA",
+  "WebBank": null,
+  "Wells Fargo": "@WellsFargo"
+}

--- a/scripts/lib/bank-handles.js
+++ b/scripts/lib/bank-handles.js
@@ -1,0 +1,122 @@
+/**
+ * Bank Twitter handle lookup — used by social posting scripts to append
+ * issuer @mentions to tweets. Handles live in data/bank-twitter-handles.json
+ * keyed by bank name (as it appears in cards.json `bank` field).
+ *
+ * Only used for Twitter/X posts. Other platforms should not receive these
+ * mentions since the handle format is X-specific.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HANDLES_PATH = path.join(__dirname, '..', '..', 'data', 'bank-twitter-handles.json');
+const CARDS_PATH = path.join(__dirname, '..', '..', 'data', 'cards.json');
+
+let _handles = null;
+function loadHandles() {
+  if (_handles) return _handles;
+  try {
+    const raw = fs.readFileSync(HANDLES_PATH, 'utf8');
+    _handles = JSON.parse(raw);
+  } catch (err) {
+    console.warn(`  Warning: failed to load bank handles (${err.message}); skipping @mentions`);
+    _handles = {};
+  }
+  return _handles;
+}
+
+let _cardNameToBank = null;
+function loadCardNameToBank() {
+  if (_cardNameToBank) return _cardNameToBank;
+  try {
+    const raw = fs.readFileSync(CARDS_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    const cards = Array.isArray(parsed) ? parsed : (parsed.cards || []);
+    _cardNameToBank = {};
+    for (const card of cards) {
+      const name = card.card_name || card.name;
+      if (name && card.bank) _cardNameToBank[name] = card.bank;
+    }
+  } catch (err) {
+    console.warn(`  Warning: failed to load cards.json for bank lookup (${err.message})`);
+    _cardNameToBank = {};
+  }
+  return _cardNameToBank;
+}
+
+/**
+ * Resolve an array of card names to their issuer bank names using
+ * local data/cards.json. Unknown cards are dropped.
+ */
+function resolveBanksFromCardNames(cardNames) {
+  if (!Array.isArray(cardNames) || cardNames.length === 0) return [];
+  const map = loadCardNameToBank();
+  const banks = [];
+  for (const name of cardNames) {
+    if (name && map[name]) banks.push(map[name]);
+  }
+  return banks;
+}
+
+/**
+ * Resolve a bank name to its Twitter handle (including the leading @).
+ * Returns null if no handle is configured.
+ */
+function getBankHandle(bankName) {
+  if (!bankName) return null;
+  const handles = loadHandles();
+  const handle = handles[bankName];
+  if (!handle || typeof handle !== 'string') return null;
+  return handle.startsWith('@') ? handle : `@${handle}`;
+}
+
+/**
+ * Resolve a list of bank names into a de-duplicated, order-preserving array
+ * of Twitter handles. Skips banks that aren't in the handles file.
+ */
+function getBankHandles(bankNames) {
+  if (!Array.isArray(bankNames)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const name of bankNames) {
+    const handle = getBankHandle(name);
+    if (handle && !seen.has(handle)) {
+      seen.add(handle);
+      out.push(handle);
+    }
+  }
+  return out;
+}
+
+/**
+ * Append bank @mentions to a tweet body, respecting a max-length ceiling.
+ * Handles are joined with spaces on a new line (blank-line separated). If
+ * adding all handles would push the tweet past `maxLength`, drops handles
+ * from the end until it fits. Returns the original text if nothing fits.
+ *
+ * @param {string} text - The tweet body (no URL).
+ * @param {string[]} bankNames - Bank names to mention.
+ * @param {number} [maxLength=260] - Max total characters for text+mentions.
+ */
+function appendBankHandles(text, bankNames, maxLength = 260) {
+  const handles = getBankHandles(bankNames);
+  if (handles.length === 0) return text;
+
+  let kept = [...handles];
+  while (kept.length > 0) {
+    const suffix = '\n\n' + kept.join(' ');
+    if ((text + suffix).length <= maxLength) {
+      return text + suffix;
+    }
+    kept.pop();
+  }
+  return text;
+}
+
+module.exports = {
+  getBankHandle,
+  getBankHandles,
+  appendBankHandles,
+  resolveBanksFromCardNames,
+};

--- a/scripts/post-best-rankings.js
+++ b/scripts/post-best-rankings.js
@@ -19,6 +19,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 const sharp = require('sharp');
 const { V2, darkBackground, footerBar } = require('./lib/og-style');
+const { appendBankHandles } = require('./lib/bank-handles');
 
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
 const CDN_IMAGES = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
@@ -236,8 +237,10 @@ async function generateBestRankingsImage(categoryTitle, updatedAt, topCards) {
 
 // ─── Tweet text ──────────────────────────────────────────────────────────────
 
-function buildTweetText(categoryTitle, topCards) {
-  // Try with badges first, fall back to without if over 280 chars
+function buildPostText(categoryTitle, topCards) {
+  const banks = topCards.map(c => c.bank).filter(Boolean);
+
+  // Try with badges first, fall back to without if text goes over 280
   for (const includeBadges of [true, false]) {
     const list = topCards
       .map(card => {
@@ -246,13 +249,24 @@ function buildTweetText(categoryTitle, topCards) {
       })
       .join('\n');
 
-    const text = `${categoryTitle} \u2014 Our Top 5:\n\n${list}`;
-    if (text.length <= 280) return text;
+    const base = `${categoryTitle} \u2014 Our Top 5:\n\n${list}`;
+    if (base.length <= 280) {
+      const withHandles = appendBankHandles(base, banks, 280);
+      return {
+        textContent: base,
+        twitterText: withHandles !== base ? withHandles : null,
+      };
+    }
   }
 
   // Shouldn't happen, but truncate if still over
   const list = topCards.map(card => `${card.rank}. ${card.name}`).join('\n');
-  return `${categoryTitle} \u2014 Our Top 5:\n\n${list}`.slice(0, 280);
+  const base = (`${categoryTitle} \u2014 Our Top 5:\n\n${list}`).slice(0, 280);
+  const withHandles = appendBankHandles(base, banks, 280);
+  return {
+    textContent: base,
+    twitterText: withHandles !== base ? withHandles : null,
+  };
 }
 
 function buildLinkUrl(slug) {
@@ -266,7 +280,7 @@ function buildLinkUrl(slug) {
 
 // ─── Queue post ──────────────────────────────────────────────────────────────
 
-async function queuePost(textContent, linkUrl, sourceId, imageBuffer) {
+async function queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffer) {
   const apiUrl = process.env.SOCIAL_API_URL;
   const apiKey = process.env.SOCIAL_API_KEY;
 
@@ -278,6 +292,9 @@ async function queuePost(textContent, linkUrl, sourceId, imageBuffer) {
     source_type: 'best-rankings',
     source_id: sourceId,
   };
+  if (twitterText && twitterText !== textContent) {
+    body.twitter_text = twitterText;
+  }
 
   if (imageBuffer) {
     body.image_base64 = imageBuffer.toString('base64');
@@ -323,11 +340,14 @@ async function main() {
   const imageBuffer = await generateBestRankingsImage(bestData.title, bestData.updatedAt, enrichedCards);
   console.log(`  Image generated: ${(imageBuffer.length / 1024).toFixed(0)}KB`);
 
-  const tweetText = buildTweetText(bestData.title, enrichedCards);
+  const { textContent, twitterText } = buildPostText(bestData.title, enrichedCards);
   const linkUrl = buildLinkUrl(bestData.slug);
   const sourceId = `best-${bestData.slug}-${new Date().toISOString().slice(0, 10)}`;
 
-  console.log(`\nPost text (${tweetText.length} chars):\n${tweetText}`);
+  console.log(`\nPost text (${textContent.length} chars):\n${textContent}`);
+  if (twitterText) {
+    console.log(`\nTwitter variant (${twitterText.length} chars):\n${twitterText}`);
+  }
   console.log(`\nLink (posted as reply): ${linkUrl}`);
 
   if (dryRun) {
@@ -339,7 +359,7 @@ async function main() {
   }
 
   console.log('\nQueuing post with image via Social Posting Service...');
-  const result = await queuePost(tweetText, linkUrl, sourceId, imageBuffer);
+  const result = await queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffer);
   console.log(`Queued successfully! Post ID: ${result.id}`);
 }
 

--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -18,6 +18,7 @@ const fs = require('fs');
 const path = require('path');
 const sharp = require('sharp');
 const { V2, darkBackground, footerBar, hexToRgba } = require('./lib/og-style');
+const { appendBankHandles } = require('./lib/bank-handles');
 
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
 const CDN_IMAGES = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
@@ -223,7 +224,7 @@ async function generateCardWireImage(cardName, bank, changes, cardImageBuffer) {
 
 // ── Tweet text ──
 
-function buildTweetText(cardName, changes) {
+function buildPostText(cardName, changes, bank) {
   const parts = changes.map(c => {
     const label = fieldLabels[c.field] || c.field;
     const dir = getDirection(c.field, c.old_value, c.new_value);
@@ -237,7 +238,11 @@ function buildTweetText(cardName, changes) {
   if (text.length > 270) {
     text = text.substring(0, 267) + '...';
   }
-  return text;
+  const withHandles = appendBankHandles(text, bank ? [bank] : [], 280);
+  return {
+    textContent: text,
+    twitterText: withHandles !== text ? withHandles : null,
+  };
 }
 
 function buildLinkUrl(slug) {
@@ -250,7 +255,7 @@ function buildLinkUrl(slug) {
 
 // ── Social API queue ──
 
-async function queuePost(textContent, linkUrl, sourceId, imageBuffer) {
+async function queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffer) {
   const apiUrl = process.env.SOCIAL_API_URL;
   const apiKey = process.env.SOCIAL_API_KEY;
   if (!apiUrl || !apiKey) throw new Error('SOCIAL_API_URL and SOCIAL_API_KEY are required');
@@ -262,6 +267,9 @@ async function queuePost(textContent, linkUrl, sourceId, imageBuffer) {
     source_id: sourceId,
     platforms: ['twitter'],
   };
+  if (twitterText && twitterText !== textContent) {
+    body.twitter_text = twitterText;
+  }
 
   if (imageBuffer) {
     body.image_base64 = imageBuffer.toString('base64');
@@ -349,11 +357,14 @@ async function main() {
     console.log(`  Image: ${(imageBuffer.length / 1024).toFixed(0)}KB`);
 
     // Build post text
-    const tweetText = buildTweetText(cardName, cardChanges);
+    const { textContent, twitterText } = buildPostText(cardName, cardChanges, bank);
     const linkUrl = buildLinkUrl(slug);
     const sourceId = `wire-${slug}-${new Date().toISOString().slice(0, 10)}`;
 
-    console.log(`  Text (${tweetText.length} chars): ${tweetText.replace(/\n/g, ' | ')}`);
+    console.log(`  Text (${textContent.length} chars): ${textContent.replace(/\n/g, ' | ')}`);
+    if (twitterText) {
+      console.log(`  Twitter variant (${twitterText.length} chars): ${twitterText.replace(/\n/g, ' | ')}`);
+    }
 
     if (dryRun) {
       const outPath = path.join(__dirname, '..', `card-wire-preview-${slug}.png`);
@@ -363,7 +374,7 @@ async function main() {
     }
 
     try {
-      const result = await queuePost(tweetText, linkUrl, sourceId, imageBuffer);
+      const result = await queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffer);
       console.log(`  Queued! Post ID: ${result.id}\n`);
     } catch (err) {
       console.error(`  Failed to queue: ${err.message}\n`);

--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 const { TwitterApi } = require('twitter-api-v2');
+const { appendBankHandles, resolveBanksFromCardNames } = require('./lib/bank-handles');
 
 // Parse CLI args
 function parseArgs() {
@@ -65,16 +66,22 @@ function buildUrl(type, item) {
 /**
  * Generate an engaging social media post using Claude Haiku.
  */
+function getCardNameList(item) {
+  if (item.card_name) return [item.card_name];
+  if (Array.isArray(item.related_cards) && item.related_cards.length > 0) {
+    return item.related_cards.slice();
+  }
+  return [];
+}
+
 async function generatePost(type, item) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     throw new Error('ANTHROPIC_API_KEY environment variable is required');
   }
 
-  const cardNames = item.card_name
-    || (item.related_cards && item.related_cards.length > 0
-      ? item.related_cards.join(', ')
-      : 'N/A');
+  const cardList = getCardNameList(item);
+  const cardNames = cardList.length > 0 ? cardList.join(', ') : 'N/A';
 
   const prompt = `Write a short tweet for CreditOdds about this credit card ${type}:
 Title: ${item.title}
@@ -193,6 +200,14 @@ async function main() {
     let postText;
     try {
       postText = await generatePost(type, item);
+      const banks = resolveBanksFromCardNames(getCardNameList(item));
+      if (banks.length > 0) {
+        const withHandles = appendBankHandles(postText, banks, 260);
+        if (withHandles !== postText) {
+          console.log(`  Appended bank handles: ${withHandles.slice(postText.length).trim()}`);
+          postText = withHandles;
+        }
+      }
       console.log(`  Generated post (${postText.length} chars): ${postText}`);
     } catch (err) {
       console.error(`  Failed to generate post: ${err.message}`);

--- a/scripts/post-weekly-top-cards.js
+++ b/scripts/post-weekly-top-cards.js
@@ -17,6 +17,7 @@ const fs = require('fs');
 const path = require('path');
 const sharp = require('sharp');
 const { V2, darkBackground, footerBar } = require('./lib/og-style');
+const { appendBankHandles } = require('./lib/bank-handles');
 
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
 const CDN_IMAGES = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
@@ -227,7 +228,7 @@ async function generateRankingsImage(topCards) {
   return image.toBuffer();
 }
 
-function buildTweetText(topCards) {
+function buildPostText(topCards) {
   const list = topCards
     .map((card) => {
       const arrow = card.movement === 'up' ? '\u2B06\uFE0F'
@@ -238,7 +239,13 @@ function buildTweetText(topCards) {
     })
     .join('\n');
 
-  return `Credit Card Power Rankings \u2014 This Week\u2019s Top 5 Most Viewed:\n\n${list}`;
+  const base = `Credit Card Power Rankings \u2014 This Week\u2019s Top 5 Most Viewed:\n\n${list}`;
+  const banks = topCards.map(c => c.bank).filter(Boolean);
+  const withHandles = appendBankHandles(base, banks, 260);
+  return {
+    textContent: base,
+    twitterText: withHandles !== base ? withHandles : null,
+  };
 }
 
 function buildLinkUrl() {
@@ -251,7 +258,7 @@ function buildLinkUrl() {
   return url.toString();
 }
 
-async function queuePost(textContent, linkUrl, sourceId, imageBuffer) {
+async function queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffer) {
   const apiUrl = process.env.SOCIAL_API_URL;
   const apiKey = process.env.SOCIAL_API_KEY;
 
@@ -263,6 +270,9 @@ async function queuePost(textContent, linkUrl, sourceId, imageBuffer) {
     source_type: 'weekly-top-cards',
     source_id: sourceId,
   };
+  if (twitterText && twitterText !== textContent) {
+    body.twitter_text = twitterText;
+  }
 
   if (imageBuffer) {
     body.image_base64 = imageBuffer.toString('base64');
@@ -305,11 +315,14 @@ async function main() {
   const imageBuffer = await generateRankingsImage(topCards);
   console.log(`  Image generated: ${(imageBuffer.length / 1024).toFixed(0)}KB`);
 
-  const tweetText = buildTweetText(topCards);
+  const { textContent, twitterText } = buildPostText(topCards);
   const linkUrl = buildLinkUrl();
   const sourceId = `weekly-${new Date().toISOString().slice(0, 10)}`;
 
-  console.log(`\nPost text (${tweetText.length} chars):\n${tweetText}`);
+  console.log(`\nPost text (${textContent.length} chars):\n${textContent}`);
+  if (twitterText) {
+    console.log(`\nTwitter variant (${twitterText.length} chars):\n${twitterText}`);
+  }
   console.log(`\nLink (posted as reply): ${linkUrl}`);
 
   if (dryRun) {
@@ -321,7 +334,7 @@ async function main() {
   }
 
   console.log('\nQueuing post with image via Social Posting Service...');
-  const result = await queuePost(tweetText, linkUrl, sourceId, imageBuffer);
+  const result = await queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffer);
   console.log(`Queued successfully! Post ID: ${result.id}`);
 }
 

--- a/scripts/queue-social.js
+++ b/scripts/queue-social.js
@@ -12,6 +12,7 @@
 
 const fs = require('fs');
 const yaml = require('js-yaml');
+const { appendBankHandles, resolveBanksFromCardNames } = require('./lib/bank-handles');
 
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -98,16 +99,25 @@ function getSummary(item) {
   return text.split(/\n{2,}/)[0].trim();
 }
 
+function getCardNameList(item) {
+  if (item.card_name) return [item.card_name];
+  if (Array.isArray(item.related_cards) && item.related_cards.length > 0) {
+    return item.related_cards.slice();
+  }
+  if (Array.isArray(item.cards) && item.cards.length > 0) {
+    return item.cards
+      .map((card) => card.card_name || card.slug || card)
+      .filter(Boolean);
+  }
+  return [];
+}
+
 async function generatePost(type, item) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error('ANTHROPIC_API_KEY is required');
 
-  const cardNames = item.card_name
-    || (item.related_cards && item.related_cards.length > 0
-      ? item.related_cards.join(', ')
-      : (item.cards && item.cards.length > 0
-        ? item.cards.map((card) => card.card_name || card.slug || card).join(', ')
-        : 'N/A'));
+  const cardList = getCardNameList(item);
+  const cardNames = cardList.length > 0 ? cardList.join(', ') : 'N/A';
 
   const summary = getSummary(item);
   const label = type === 'news'
@@ -159,11 +169,21 @@ Rules:
   return text;
 }
 
-async function queuePost(textContent, linkUrl, sourceType, sourceId) {
+async function queuePost(textContent, twitterText, linkUrl, sourceType, sourceId) {
   const apiUrl = process.env.SOCIAL_API_URL;
   const apiKey = process.env.SOCIAL_API_KEY;
 
   if (!apiUrl || !apiKey) throw new Error('SOCIAL_API_URL and SOCIAL_API_KEY are required');
+
+  const body = {
+    text_content: textContent,
+    link_url: linkUrl,
+    source_type: sourceType,
+    source_id: sourceId,
+  };
+  if (twitterText && twitterText !== textContent) {
+    body.twitter_text = twitterText;
+  }
 
   const response = await fetchWithRetry(`${apiUrl}/social/queue`, {
     method: 'POST',
@@ -171,12 +191,7 @@ async function queuePost(textContent, linkUrl, sourceType, sourceId) {
       'Content-Type': 'application/json',
       'x-api-key': apiKey,
     },
-    body: JSON.stringify({
-      text_content: textContent,
-      link_url: linkUrl,
-      source_type: sourceType,
-      source_id: sourceId,
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {
@@ -214,16 +229,25 @@ async function main() {
     console.log(`  URL: ${url}`);
 
     let postText;
+    let twitterText = null;
     try {
       postText = await generatePost(type, item);
       console.log(`  Generated post (${postText.length} chars): ${postText}`);
+      const banks = resolveBanksFromCardNames(getCardNameList(item));
+      if (banks.length > 0) {
+        const withHandles = appendBankHandles(postText, banks, 260);
+        if (withHandles !== postText) {
+          twitterText = withHandles;
+          console.log(`  Twitter variant (${twitterText.length} chars): ${twitterText}`);
+        }
+      }
     } catch (err) {
       console.error(`  Failed to generate post: ${err.message}`);
       continue;
     }
 
     try {
-      const result = await queuePost(postText, url, sourceType, sourceId);
+      const result = await queuePost(postText, twitterText, url, sourceType, sourceId);
       console.log(`  Queued successfully! Post ID: ${result.id}\n`);
     } catch (err) {
       console.error(`  Failed to queue: ${err.message}\n`);


### PR DESCRIPTION
## Summary
- New `data/bank-twitter-handles.json` maps issuer → X handle. Major issuers filled in (Chase, Amex, Citi, Capital One, BofA, US Bank, Wells Fargo, Discover, Barclays US, Bilt, Robinhood, Goldman, USAA). Niche bank-partners (WebBank, Elan, Lead, First Electronic) set to `null` and skipped.
- New `scripts/lib/bank-handles.js` helper with `getBankHandle`, `getBankHandles`, `appendBankHandles`, `resolveBanksFromCardNames`.
- All 5 social posting scripts wired up. Queue scripts send `twitter_text` (with @handles) alongside `text_content` (clean) per the new Social Posting Service contract — so Reddit/LinkedIn/Facebook posts stay handle-free. `post-social.js` (direct Twitter API) inlines handles since it's X-only.

Handles are de-duplicated, placed on a new line, and length-aware — drops from the end if the tweet would exceed the character limit. If no handles fit or none resolve, `twitter_text` is omitted entirely (backwards-compatible).

## Test plan
- [ ] Verify handle values, especially: `@BarclaysUS` (not UK `@Barclays`), `@Chase` (not `@ChaseSupport`), `@biltrewards`, `@RobinhoodApp`
- [ ] Dry-run `node scripts/post-weekly-top-cards.js --dry-run` and confirm Twitter variant shows handles on a new line, text_content does not
- [ ] Dry-run `node scripts/post-best-rankings.js --category <any-slug> --dry-run`
- [ ] Dry-run `node scripts/post-card-wire.js --changes '<JSON>' --dry-run`
- [ ] Spot-check a live tweet after the next news/article push — the URL reply-composer on X should still unfurl correctly with handles present

🤖 Generated with [Claude Code](https://claude.com/claude-code)