### PR TITLE
Switch card JSON-LD from Product to CreditCard type

### DIFF
--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -72,7 +72,7 @@ interface CreditCardSchemaProps {
 export function CreditCardSchema({ card, ratings }: CreditCardSchemaProps) {
   const schema = {
     '@context': 'https://schema.org',
-    '@type': 'Product',
+    '@type': 'CreditCard',
     name: card.card_name,
     brand: {
       '@type': 'Brand',


### PR DESCRIPTION
## Summary
- Changes `@type` in `CreditCardSchema` from `Product` to `CreditCard` (a schema.org subtype of `FinancialProduct`/`LoanOrCredit`)
- Resolves two Google Search Console warnings: merchant-listing fields (`hasMerchantReturnPolicy`, `shippingDetails`) and Product-snippet fields (`aggregateRating`, `review`) — neither classification fits a credit card
- `aggregateRating` is still emitted when ratings exist; `CreditCard` supports it the same way `Product` does

## Test plan
- [ ] After deploy, run Google Rich Results Test on a card page (e.g. https://creditodds.com/card/chase-sapphire-preferred) and confirm no merchant-listing or Product-snippet warnings
- [ ] Verify the `<script type="application/ld+json">` block in view-source shows `"@type":"CreditCard"`
- [ ] Monitor Search Console over the next crawl cycle to confirm both warning categories clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)