### PR TITLE
Tag apply links with utm_source=creditodds

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -30,6 +30,7 @@ import { CreditCardSchema, BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import CardBenefits from "@/components/ui/CardBenefits";
 import { categoryLabels, CategoryIcon } from "@/lib/cardDisplayUtils";
+import { withApplySource } from "@/lib/applyLink";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import "../../landing.css";
 
@@ -381,7 +382,7 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
                   <div className="mt-5 w-full flex flex-col gap-2.5">
                     {card.apply_link && (
                       <a
-                        href={card.apply_link}
+                        href={withApplySource(card.apply_link)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center justify-center px-5 py-3.5 border border-transparent text-sm font-semibold rounded-xl text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-sm"
@@ -1087,7 +1088,7 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               {card.apply_link && (
                 <a
-                  href={card.apply_link}
+                  href={withApplySource(card.apply_link)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg"

--- a/apps/web-next/src/lib/applyLink.ts
+++ b/apps/web-next/src/lib/applyLink.ts
@@ -1,0 +1,21 @@
+const UTM_SOURCE = 'creditodds';
+const UTM_MEDIUM = 'referral';
+
+export function withApplySource(url: string | undefined | null): string | undefined {
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    const hasSource =
+      parsed.searchParams.has('utm_source') || parsed.searchParams.has('source');
+    if (hasSource) return url;
+
+    parsed.searchParams.set('utm_source', UTM_SOURCE);
+    if (!parsed.searchParams.has('utm_medium')) {
+      parsed.searchParams.set('utm_medium', UTM_MEDIUM);
+    }
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `withApplySource()` helper in `lib/applyLink.ts` that appends `utm_source=creditodds&utm_medium=referral` to direct apply URLs
- Wired into both apply buttons on the card detail page (top card + bottom CTA)
- Leaves referral (affiliate) URLs untouched — those already carry their own tracking
- Skips URLs that already include a `utm_source` or `source` param so pre-tagged issuer links aren't overwritten

## Why
Credit card issuers (Chase, Amex, etc.) read standard UTM params in their analytics. Tagging our outbound traffic lets them see CreditOdds as the referring source, which helps us build a relationship with their acquisition teams.

## Test plan
- [ ] Click "Apply Now" on any card page → URL should gain `utm_source=creditodds&utm_medium=referral`
- [ ] Click "Apply with Referral" → URL should be unchanged (affiliate tracking stays intact)
- [ ] Pick a card whose `apply_link` already has `utm_source` or `source` set → URL should not be modified
- [ ] Invalid/malformed `apply_link` should render the original href (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)