### PR TITLE
Fix double footer on /_admin

### DIFF
--- a/apps/web-next/src/components/layout/ConditionalChrome.tsx
+++ b/apps/web-next/src/components/layout/ConditionalChrome.tsx
@@ -23,6 +23,13 @@ const V2_FOOTER_ROUTES = new Set<string>([
   '/forgot',
   '/contact',
   '/admin',
+  // /_admin is the underscore-prefixed entry that next.config.mjs rewrites
+  // to /admin. The rewrite preserves the URL bar, so usePathname() returns
+  // '/_admin' here even though the rendered page is admin/page.tsx
+  // (which already renders its own V2Footer). Without this entry,
+  // ConditionalFooter would also render the legacy <Footer /> and the
+  // admin page would show two footers stacked.
+  '/_admin',
   '/tools',
 ]);
 
@@ -35,9 +42,15 @@ const V2_FOOTER_PREFIXES = [
   '/tools/',
 ];
 
-function isV2FooterRoute(pathname: string): boolean {
-  if (V2_FOOTER_ROUTES.has(pathname)) return true;
-  return V2_FOOTER_PREFIXES.some((p) => pathname.startsWith(p));
+function isV2FooterRoute(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  // Strip a single trailing slash so '/admin/' matches '/admin'.
+  const normalized =
+    pathname.length > 1 && pathname.endsWith('/')
+      ? pathname.slice(0, -1)
+      : pathname;
+  if (V2_FOOTER_ROUTES.has(normalized)) return true;
+  return V2_FOOTER_PREFIXES.some((p) => normalized.startsWith(p));
 }
 
 export function ConditionalNavbar() {


### PR DESCRIPTION
## Summary
- Adds `/_admin` to `V2_FOOTER_ROUTES` in `ConditionalChrome.tsx`
- Hardens `isV2FooterRoute()` against `null`/`undefined` pathnames and a trailing slash

## Root cause
`next.config.mjs` rewrites `/_admin → /admin` to keep the admin entry path off App Router's normal routing (underscore folders are private). The rewrite preserves the URL bar, so `usePathname()` inside the layout sees `/_admin`, which wasn't in `V2_FOOTER_ROUTES`. Result: `ConditionalFooter` rendered the legacy indigo-gradient `<Footer />` while `admin/page.tsx` also rendered `<V2Footer />` — two footers stacked.

Confirmed by curling SSR before the fix: `/_admin` returned `<footer class="bg-gradient-to-r from-indigo-900 …">`. After the fix it returns no SSR footer (just like `/admin`).

## Test plan
- [ ] Open `/_admin` while logged in as admin → exactly one footer (white "foot" v2 footer) renders at the bottom
- [ ] Open `/admin` directly → unchanged, single footer
- [ ] Spot-check a few other V2 routes (`/`, `/explore`, `/best`, `/login`) → still one footer each
- [ ] Open a legacy/non-V2 route → still one (legacy) footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)