### PR TITLE
Retry card-check with browser when Haiku extraction returns no signal

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -139,7 +139,7 @@ async function fetchPageContent(url) {
         const html = await response.text();
         const stripped = stripHtml(html);
         if (stripped.length >= 100) {
-          return stripped;
+          return { content: stripped, usedBrowser: false };
         }
         console.warn(`  Simple fetch returned too little content (${stripped.length} chars) — falling back to browser`);
       }
@@ -149,7 +149,8 @@ async function fetchPageContent(url) {
   }
 
   // Fall back to Playwright for JS-rendered pages
-  return fetchWithBrowser(url);
+  const content = await fetchWithBrowser(url);
+  return content ? { content, usedBrowser: true } : null;
 }
 
 let _browser = null;
@@ -276,6 +277,20 @@ Rules:
 }
 
 // ─── Change detection ─────────────────────────────────────────────────────────
+
+// True when Haiku returned no signal — every primary field is null/undefined.
+// Used to decide whether to retry a simple-fetch result with the browser, since
+// JS-rendered pages (e.g. citi.com) return real HTML but with empty bonus
+// placeholders that Haiku can't extract from.
+function isExtractionEmpty(extracted) {
+  if (!extracted) return true;
+  if (extracted.annual_fee != null) return false;
+  const sb = extracted.signup_bonus;
+  if (sb && (sb.value != null || sb.spend_requirement != null || sb.timeframe_months != null)) {
+    return false;
+  }
+  return true;
+}
 
 function detectChanges(card, extracted) {
   if (!extracted) return [];
@@ -458,11 +473,12 @@ async function main() {
     try {
       await withTimeout((async () => {
         // Fetch page
-        const pageContent = await fetchPageContent(apply_link);
-        if (!pageContent) {
+        const fetchResult = await fetchPageContent(apply_link);
+        if (!fetchResult) {
           console.log('  Skipped (could not fetch page)\n');
           return;
         }
+        let { content: pageContent, usedBrowser } = fetchResult;
         console.log(`  Fetched ${pageContent.length} chars`);
 
         // Extract with Claude Haiku
@@ -472,6 +488,23 @@ async function main() {
         } catch (err) {
           console.warn(`  Extraction error: ${err.message} — skipping\n`);
           return;
+        }
+
+        // Self-heal: simple-fetch HTML can be 200 OK but missing JS-rendered
+        // bonus values (e.g. citi.com). Haiku then returns all-null, which the
+        // detector silently treats as "no changes". Retry once with the browser.
+        if (!usedBrowser && isExtractionEmpty(extracted)) {
+          console.log('  Extraction returned no signal — retrying with browser');
+          const browserContent = await fetchWithBrowser(apply_link);
+          if (browserContent) {
+            pageContent = browserContent;
+            try {
+              extracted = await extractCardTerms(name, bank, apply_link, pageContent);
+            } catch (err) {
+              console.warn(`  Retry extraction error: ${err.message} — skipping\n`);
+              return;
+            }
+          }
         }
 
         if (!extracted) {


### PR DESCRIPTION
## Summary
- Citi apply pages (and similar JS-rendered SPAs) return 200 with full HTML, but the bonus values are JS-rendered placeholders. Haiku gets nothing to extract, returns all-null, and `detectChanges` silently treats that as "no changes" — indistinguishable from a real match. ~16 cards on `citi.com` are at risk.
- After Haiku returns all-null on a simple-fetch result, retry once via Playwright before declaring no changes.
- Verified locally on Citi Strata Premier: simple fetch → all-null → retry → browser fetch → extracts AF 95 / 60k points / \$4k / 3mo, matches YAML.

### Why this matters
Between Apr 16 and Apr 27 there were no card-check change PRs merged — partly a real blind spot, not just a quiet news cycle. Citi cards (Strata Premier, Strata, Strata Elite, Double Cash, AAdvantage Globe, etc.) have been silently passing every daily run.

### What changed
`scripts/check-card-pages.js`:
- `fetchPageContent` now returns `{ content, usedBrowser }` so the caller knows which fetch path was used.
- New `isExtractionEmpty(extracted)` helper — true when `annual_fee`, `signup_bonus.value`, `signup_bonus.spend_requirement`, and `signup_bonus.timeframe_months` are all null.
- After extraction, if the simple-fetch path was used and extraction is empty, re-fetch via `fetchWithBrowser` and re-extract once.

### Out of scope
Bilt-style cards with no `signup_bonus` block in YAML still won't have new SUBs detected (the comparison requires both sides to have a signup_bonus). That's a separate change.

## Test plan
- [x] Citi Strata Premier — verified retry triggers and browser extraction returns correct values
- [ ] Watch tomorrow's scheduled run — confirm Citi cards are exercised via the retry path and no false positives are introduced
- [ ] Manually run on 1-2 more Citi cards (e.g. Citi Double Cash) before merge if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)