### PR TITLE
Update SUBs: Citi AAdvantage Platinum Select (80k→50k) + Atmos Ascent (70k→80k)

### DIFF
--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -27,8 +27,8 @@ rewards:
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 70000
-  type: points
-  spend_requirement: 3000
-  timeframe_months: 3
+  value: 80000
+  type: "points"
+  spend_requirement: 4000
+  timeframe_months: 4
 apply_link: https://www.bankofamerica.com/credit-cards/products/alaska-airlines-credit-card/

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -34,10 +34,10 @@ rewards:
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 80000
-  type: miles
-  spend_requirement: 3500
-  timeframe_months: 4
+  value: 50000
+  type: "miles"
+  spend_requirement: 2500
+  timeframe_months: 3
 apr:
   regular:
     min: 19.49


### PR DESCRIPTION
## Summary
Two stale signup bonuses caught by `check-card-pages.js` after the [silent-null-extraction fix](https://github.com/CreditOdds/creditodds/pull/439) landed. Verified directly on the issuer pages before opening this PR.

### Citi AAdvantage Platinum Select
On-page text: *"Earn 50,000 AAdvantage® bonus miles after \$2,500 in purchases in the first 3 months."*
- value: 80,000 → **50,000** miles
- spend_requirement: \$3,500 → **\$2,500**
- timeframe_months: 4 → **3**

This is a real downgrade — we'd been showing 80k miles to users while Citi has actually been offering 50k. This is exactly the kind of silent miss [#439](https://github.com/CreditOdds/creditodds/pull/439) was designed to surface.

### Atmos Rewards Ascent (BoA Alaska)
On-page text: *"Earn 80,000 bonus points and a \$99 Companion Fare (plus taxes and fees from \$23) after spending \$4,000 or more on purchases within the first 120 days of opening your account."*
- value: 70,000 → **80,000** points
- spend_requirement: \$3,000 → **\$4,000**
- timeframe_months: 3 → **4** (120 days)

Note: not capturing the \$99 Companion Fare or 50% flight discount in this PR — those are perk-level details that should be a deliberate `signup_bonus.note` decision, not auto-script scope.

## Test plan
- [x] Spot-verified both detected values directly on the issuer apply pages via headless browser
- [ ] Run `npm run build:cards` to validate YAML before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)