### PR TITLE
Add news: Bilt May 2026 Transfer Bonus to British Airways with Tiered Multipliers

### DIFF
--- a/data/news/2026-04-28-bilt-may-2026-british-airways-transfer-bonus.yaml
+++ b/data/news/2026-04-28-bilt-may-2026-british-airways-transfer-bonus.yaml
@@ -1,0 +1,32 @@
+id: "bilt-may-2026-british-airways-transfer-bonus"
+title: "Bilt May 2026 Transfer Bonus to British Airways with Tiered Multipliers"
+summary: "Bilt cardholders can transfer points to British Airways in May 2026 with tiered bonuses ranging from **40% (Blue)** to **75% (Platinum)**. An additional **150 Bilt Cash** can be used to upgrade to a higher tier."
+tags:
+  - "limited-time"
+  - "bonus-change"
+bank: "Bilt"
+card_slugs:
+  - "bilt-blue"
+  - "bilt-mastercard"
+  - "bilt-obsidian"
+  - "bilt-palladium"
+card_names:
+  - "Bilt Blue"
+  - "Bilt Mastercard"
+  - "Bilt Obsidian"
+  - "Bilt Palladium"
+source: "The Points Guy"
+source_url: "https://thepointsguy.com/news/bilt-rent-day-promo/"
+date: "2026-04-28"
+body: |
+  Bilt is offering enhanced transfer bonuses to British Airways for May 2026 as part of its Rent Day promotions. The bonus structure is tiered by card level:
+  
+  - **Bilt Blue**: 40% bonus
+  - **Bilt Mastercard** (Silver): 50% bonus
+  - **Bilt Obsidian** (Gold): 60% bonus
+  - **Bilt Palladium** (Platinum): 75% bonus
+  
+  Cardholders have the option to use **150 Bilt Cash** to buy up to a higher tier level for the transfer, allowing Blue cardholders to potentially access the higher multipliers if desired.
+  
+  This promotion aligns with Bilt's monthly Rent Day transfer bonus program, which rotates airline and travel partners throughout the year. The **May 1** start date marks the beginning of this limited-time offer, making it ideal for cardholders looking to maximize point transfers to British Airways during this window.
+  


### PR DESCRIPTION
## Summary
- Auto-generated news item from r/churning via `scripts/auto-news-from-reddit.js`
- Bilt's May 2026 Rent Day transfer bonus to British Airways: 40% (Blue) / 50% (Mastercard) / 60% (Obsidian) / 75% (Palladium); 150 Bilt Cash to buy up a tier
- Source swapped from r/churning to The Points Guy (the first-party-ish URL the script verified against)

## Test plan
- [ ] YAML parses and renders on `/news/bilt-may-2026-british-airways-transfer-bonus`
- [ ] All four `card_slugs` (`bilt-blue`, `bilt-mastercard`, `bilt-obsidian`, `bilt-palladium`) resolve to existing cards
- [ ] Source link to TPG opens correctly
- [ ] `date: 2026-04-28` matches PR submission date

🤖 Generated with [Claude Code](https://claude.com/claude-code)