### PR TITLE
Add news: Wells Fargo Adds Cathay Pacific as Transfer Partner

### DIFF
--- a/data/news/2026-04-28-wells-fargo-cathay-pacific-transfer-partner.yaml
+++ b/data/news/2026-04-28-wells-fargo-cathay-pacific-transfer-partner.yaml
@@ -1,0 +1,18 @@
+id: "wells-fargo-cathay-pacific-transfer-partner"
+title: "Wells Fargo Adds Cathay Pacific as Transfer Partner"
+summary: "Wells Fargo has quietly added Cathay Pacific Asia Miles as a new transfer partner for its rewards program. This expansion gives cardholders another premium airline option for redeeming their points."
+tags:
+  - "general"
+bank: "Wells Fargo"
+source: "AwardWallet"
+source_url: "https://awardwallet.com/news/wells-fargo-rewards/cathay-transfer-partner/"
+date: "2026-04-28"
+body: |
+  Wells Fargo has expanded its transfer partner lineup by adding **Cathay Pacific Asia Miles** as a new redemption option. The addition appears to have been made quietly without a major announcement from the bank.
+  
+  This move gives Wells Fargo rewards cardholders access to one of Asia's premier frequent flyer programs, enabling them to transfer points directly to Cathay Pacific for award flights and other travel benefits.
+  
+  The specific details about transfer ratios, minimum transfer amounts, and which Wells Fargo cards are eligible for transfers to Cathay Pacific have not been detailed in available reports. Cardholders interested in using this new transfer option should check their account or contact Wells Fargo directly for complete terms and conditions.
+  
+  This addition to the transfer partner ecosystem reflects ongoing efforts by major banks to expand redemption flexibility and appeal to customers with diverse travel preferences.
+  


### PR DESCRIPTION
## Summary
- Auto-generated news item via `scripts/auto-news-from-reddit.js` from r/churning daily thread (2026-04-27)
- Wells Fargo has added Cathay Pacific Asia Miles as a transfer partner
- Source swapped from Reddit to AwardWallet (first-party-style coverage; preferred over r/churning per project rules)

## Test plan
- [ ] YAML renders correctly on `/news/wells-fargo-cathay-pacific-transfer-partner`
- [ ] No `card_slugs` field set (general bank-level news, no specific cards) — verify nothing breaks
- [ ] Date matches PR submission date (2026-04-28)
- [ ] Source/source_url point to AwardWallet, not Reddit

🤖 Generated with [Claude Code](https://claude.com/claude-code)