### PR TITLE
Apply Social Card Templates design to social-post images

### DIFF
--- a/apps/web-next/src/app/news/[id]/opengraph-image.tsx
+++ b/apps/web-next/src/app/news/[id]/opengraph-image.tsx
@@ -1,6 +1,10 @@
 import { ImageResponse } from 'next/og';
 import { getNewsItem } from '@/lib/news';
-import { OGBackground, OGLogo, loadInterFonts, OG_CACHE_HEADERS, NEWS_TAG_COLORS, NEWS_TAG_LABELS } from '@/components/og/og-utils';
+import {
+  loadInterFonts,
+  OG_CACHE_HEADERS,
+  NEWS_TAG_LABELS,
+} from '@/components/og/og-utils';
 
 export const size = {
   width: 1200,
@@ -8,6 +12,63 @@ export const size = {
 };
 
 export const contentType = 'image/png';
+
+// ── Tone palette (mirrors social-cards.css `.so--*` tone variants) ──
+const TONE = {
+  purple: { accent: '#b794ff', glow: 'rgba(109,63,232,0.42)', hair: '#b794ff', tagBg: '#2a1a52',  tagBorder: 'rgba(183,148,255,0.30)', tagText: '#b794ff' },
+  good:   { accent: '#3eccaa', glow: 'rgba(62,204,170,0.32)', hair: '#3eccaa', tagBg: '#0a2a23',  tagBorder: 'rgba(62,204,170,0.30)',  tagText: '#3eccaa' },
+  warn:   { accent: '#ff7aa3', glow: 'rgba(255,122,163,0.32)', hair: '#ff7aa3', tagBg: '#2d0a1a', tagBorder: 'rgba(255,122,163,0.30)', tagText: '#ff7aa3' },
+  gold:   { accent: '#f0c85a', glow: 'rgba(240,200,90,0.28)', hair: '#f0c85a', tagBg: '#2a200a',  tagBorder: 'rgba(240,200,90,0.30)',  tagText: '#f0c85a' },
+} as const;
+
+type ToneKey = keyof typeof TONE;
+
+// Map news tag → tone (mirrors og-utils NEWS_TAG_COLORS semantics)
+function toneForTag(tag: string): ToneKey {
+  switch (tag) {
+    case 'new-card':       return 'good';
+    case 'discontinued':   return 'warn';
+    case 'fee-change':     return 'gold';
+    case 'limited-time':   return 'gold';
+    case 'bonus-change':
+    case 'benefit-change':
+    case 'policy-change':
+    case 'general':
+    default:               return 'purple';
+  }
+}
+
+const SO_PAPER = '#0d0a1a';
+const SO_INK = '#f4f1ff';
+const SO_INK_2 = '#cfc8e4';
+const SO_MUTED = '#8d85a8';
+const SO_LINE = '#241d3a';
+
+// Pre-fetch the card image server-side and embed as a data URL so Satori
+// (which doesn't support WebP) never has to make the request itself. Some
+// CDN entries are WebP files renamed to .png; we sniff magic bytes and skip
+// those so the news OG falls back to the type-only layout instead of a blank
+// placeholder.
+async function fetchCardImageAsDataUrl(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, { headers: { Accept: 'image/png,image/jpeg,*/*;q=0.5' } });
+    if (!res.ok) return null;
+    const bytes = Buffer.from(await res.arrayBuffer());
+    if (bytes.length < 16) return null;
+    // PNG: 89 50 4E 47 0D 0A 1A 0A
+    if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
+      return `data:image/png;base64,${bytes.toString('base64')}`;
+    }
+    // JPEG: FF D8 FF
+    if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+      return `data:image/jpeg;base64,${bytes.toString('base64')}`;
+    }
+    // WebP and other formats Satori can't decode → skip, fall back to type-only
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -19,163 +80,310 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
     ? new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
     : '';
 
-  // Tag color
   const firstTag = item?.tags?.[0] || 'general';
-  const tagColor = NEWS_TAG_COLORS[firstTag] || NEWS_TAG_COLORS['general'];
   const tagLabel = NEWS_TAG_LABELS[firstTag] || 'News';
+  const tone = TONE[toneForTag(firstTag)];
 
-  // Single card referenced — show card image
+  // Single card referenced — show card image (split layout); otherwise type-only
   const hasSingleCard = item?.card_slugs?.length === 1 && item?.card_image_links?.[0];
-  const cardImageUrl = hasSingleCard
-    ? `https://d3ay3etzd1512y.cloudfront.net/card_images/${item!.card_image_links![0]}`
+  const cardImageDataUrl = hasSingleCard
+    ? await fetchCardImageAsDataUrl(`https://d3ay3etzd1512y.cloudfront.net/card_images/${item!.card_image_links![0]}`)
     : null;
   const cardName = hasSingleCard ? item!.card_names?.[0] : null;
 
+  // Title sizing: split layout has narrower column (~14ch), type-only goes wide.
+  // Bigger type when title is short, smaller when long, matching design's text-balance behavior.
+  const titleSize = cardImageDataUrl
+    ? (title.length > 70 ? 38 : title.length > 45 ? 44 : 50)
+    : (title.length > 90 ? 48 : title.length > 60 ? 58 : 70);
+
   return new ImageResponse(
     (
-      <OGBackground accentColor={tagColor.accent}>
-        {/* Color-coded accent bar at top */}
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          position: 'relative',
+          display: 'flex',
+          background: SO_PAPER,
+          color: SO_INK,
+          fontFamily: 'Inter, system-ui, sans-serif',
+        }}
+      >
+        {/* Dot grid backdrop (faded top→bottom) */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            backgroundImage:
+              'radial-gradient(circle at 1px 1px, rgba(183,148,255,0.07) 1px, transparent 1.4px)',
+            backgroundSize: '24px 24px',
+          }}
+        />
+        {/* Tone radial — top-right primary */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            background: `radial-gradient(ellipse 60% 70% at 90% 10%, ${tone.glow} 0%, transparent 60%)`,
+          }}
+        />
+        {/* Tone radial — bottom-left secondary */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            background: 'radial-gradient(ellipse 50% 60% at 0% 100%, rgba(183,148,255,0.10) 0%, transparent 55%)',
+          }}
+        />
+
+        {/* Hairline accent at top-left of frame */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 64,
+            width: 96,
+            height: 3,
+            background: tone.hair,
+            borderRadius: '0 0 2px 2px',
+            display: 'flex',
+          }}
+        />
+
+        {/* Content area (top:0 → bottom:56px, padding mirrors .so-content) */}
         <div
           style={{
             position: 'absolute',
             top: 0,
             left: 0,
             right: 0,
-            height: 5,
-            background: tagColor.accent,
+            bottom: 56,
+            padding: '40px 56px 8px',
             display: 'flex',
-          }}
-        />
-
-        {/* Main content */}
-        <div
-          style={{
-            display: 'flex',
-            width: '100%',
-            height: '100%',
-            alignItems: 'center',
-            padding: '60px 70px',
+            flexDirection: 'column',
           }}
         >
-          {/* Left side: text */}
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              flex: 1,
-              paddingRight: cardImageUrl ? 40 : 0,
-            }}
-          >
-            {/* Tag badge */}
-            <div style={{ display: 'flex', marginBottom: 16 }}>
+          {/* Layout: split (with card art) OR type-only (full width) */}
+          {cardImageDataUrl ? (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                width: '100%',
+                height: '100%',
+                alignItems: 'center',
+              }}
+            >
+              {/* Left column: text */}
               <div
                 style={{
                   display: 'flex',
-                  alignItems: 'center',
-                  padding: '6px 16px',
-                  background: tagColor.bg,
-                  borderRadius: 50,
-                  color: tagColor.text,
-                  fontSize: 16,
-                  fontWeight: 'bold',
+                  flexDirection: 'column',
+                  flex: 1,
+                  minWidth: 0,
+                  paddingRight: 40,
                 }}
               >
-                {tagLabel}
+                <NewsMeta tone={tone} tagLabel={tagLabel} date={date} />
+                <div
+                  style={{
+                    fontSize: titleSize,
+                    fontWeight: 700,
+                    letterSpacing: -1.2,
+                    lineHeight: 1.05,
+                    color: SO_INK,
+                    marginTop: 22,
+                  }}
+                >
+                  {title}
+                </div>
               </div>
-            </div>
 
-            {/* Date */}
-            {date && (
+              {/* Right column: card art tilted */}
               <div
                 style={{
-                  color: 'rgba(255,255,255,0.7)',
-                  fontSize: 22,
-                  marginBottom: 14,
+                  width: 380,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                  transform: 'rotate(-4deg)',
                 }}
               >
-                {date}
+                <div
+                  style={{
+                    display: 'flex',
+                    borderRadius: 16,
+                    overflow: 'hidden',
+                    boxShadow:
+                      '0 30px 60px -20px rgba(0,0,0,0.6), 0 8px 22px -8px rgba(109,63,232,0.35)',
+                  }}
+                >
+                  <img
+                    src={cardImageDataUrl}
+                    alt={cardName || ''}
+                    width={380}
+                    height={238}
+                    style={{ borderRadius: 16, display: 'block' }}
+                  />
+                </div>
               </div>
-            )}
-
-            {/* Title */}
-            <div
-              style={{
-                color: 'white',
-                fontSize: cardImageUrl
-                  ? (title.length > 60 ? 34 : 40)
-                  : (title.length > 80 ? 40 : 48),
-                fontWeight: 'bold',
-                letterSpacing: -1,
-                lineHeight: 1.2,
-                maxWidth: cardImageUrl ? 620 : 1000,
-                overflow: 'hidden',
-                display: '-webkit-box',
-                WebkitLineClamp: 3,
-                WebkitBoxOrient: 'vertical',
-              }}
-            >
-              {title}
             </div>
-          </div>
-
-          {/* Right side: card image (tilted) */}
-          {cardImageUrl && (
+          ) : (
+            // Type-only: title spans full width
             <div
               style={{
                 display: 'flex',
                 flexDirection: 'column',
-                alignItems: 'center',
-                flexShrink: 0,
-                transform: 'rotate(-3deg)',
+                width: '100%',
+                height: '100%',
               }}
             >
+              <NewsMeta tone={tone} tagLabel={tagLabel} date={date} />
               <div
                 style={{
                   display: 'flex',
-                  borderRadius: 16,
-                  boxShadow: '0 25px 80px rgba(0,0,0,0.4), 0 10px 30px rgba(0,0,0,0.3)',
+                  flex: 1,
+                  alignItems: 'center',
+                  width: '100%',
+                  marginTop: 22,
                 }}
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={cardImageUrl}
-                  alt={cardName || ''}
-                  width={380}
-                  height={240}
-                  style={{ borderRadius: 16 }}
-                />
-              </div>
-              {cardName && (
                 <div
                   style={{
-                    marginTop: 16,
-                    color: 'rgba(255,255,255,0.8)',
-                    fontSize: 18,
-                    textAlign: 'center',
-                    maxWidth: 380,
+                    fontSize: titleSize,
+                    fontWeight: 700,
+                    letterSpacing: -1.5,
+                    lineHeight: 1.0,
+                    color: SO_INK,
+                    width: '100%',
                   }}
                 >
-                  {cardName}
+                  {title}
                 </div>
-              )}
+              </div>
             </div>
           )}
         </div>
 
-        {/* Logo in bottom left */}
+        {/* Footer band */}
         <div
           style={{
             position: 'absolute',
-            bottom: 30,
-            left: 40,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            height: 56,
+            padding: '0 56px',
             display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            background: 'rgba(7,5,15,0.55)',
+            borderTop: `1px solid ${SO_LINE}`,
           }}
         >
-          <OGLogo size={40} />
+          {/* Wordmark — concentric ring brand-mark + name */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <BrandMark size={22} accent={tone.accent} />
+            <div
+              style={{
+                display: 'flex',
+                fontSize: 18,
+                fontWeight: 600,
+                letterSpacing: -0.4,
+                color: SO_INK,
+              }}
+            >
+              <span>Credit</span>
+              <span style={{ color: tone.accent, fontWeight: 500 }}>Odds</span>
+            </div>
+          </div>
+          {/* URL + meta */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              fontSize: 13,
+              color: SO_MUTED,
+              letterSpacing: 1,
+              textTransform: 'uppercase',
+            }}
+          >
+            <div style={{ display: 'flex', fontSize: 14, color: SO_INK_2, letterSpacing: 0.3, textTransform: 'none' }}>
+              <span>creditodds.com</span>
+              <span style={{ color: SO_MUTED, margin: '0 4px' }}>/</span>
+              <span style={{ color: tone.accent }}>news</span>
+            </div>
+            <div style={{ display: 'flex', width: 1, height: 14, background: '#362d52', margin: '0 4px' }} />
+            <div style={{ display: 'flex' }}>{date ? date.toUpperCase() : 'CREDITODDS NEWSROOM'}</div>
+          </div>
         </div>
-      </OGBackground>
+      </div>
     ),
     { ...size, fonts, headers: OG_CACHE_HEADERS }
+  );
+}
+
+// ── Subcomponents ──
+
+function NewsMeta({
+  tone,
+  tagLabel,
+  date,
+}: {
+  tone: typeof TONE[ToneKey];
+  tagLabel: string;
+  date: string;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: '8px 12px',
+          borderRadius: 6,
+          fontSize: 13,
+          fontWeight: 700,
+          letterSpacing: 1.2,
+          textTransform: 'uppercase',
+          background: tone.tagBg,
+          color: tone.tagText,
+          border: `1px solid ${tone.tagBorder}`,
+          marginRight: 14,
+        }}
+      >
+        {tagLabel}
+      </div>
+      {date && (
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 13,
+            color: SO_MUTED,
+            letterSpacing: 1.4,
+            textTransform: 'uppercase',
+            fontWeight: 500,
+          }}
+        >
+          {date}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BrandMark({ size = 22, accent = '#b794ff' }: { size?: number; accent?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" style={{ display: 'block' }}>
+      <circle cx="16" cy="16" r="14" fill="none" stroke={SO_INK} strokeOpacity="0.25" strokeWidth="2" />
+      <path d="M 16 4 A 12 12 0 0 1 26.39 22" fill="none" stroke={accent} strokeWidth="3" strokeLinecap="round" />
+      <circle cx="16" cy="16" r="3" fill={accent} />
+    </svg>
   );
 }

--- a/scripts/lib/og-style.js
+++ b/scripts/lib/og-style.js
@@ -1,11 +1,18 @@
 /**
- * Shared v2 editorial styling for social-post images.
+ * Shared editorial styling for social-post images.
  *
- * Mirrors the palette used by the on-site OG images (components/og/og-utils.tsx)
- * so Twitter/LinkedIn/Reddit previews all read as one brand: ink canvas
- * (#1a1330), purple accent glow, emerald/warn for positive/negative movement.
+ * Mirrors the dark "Social Card Templates" design system:
+ *   - Deep ink canvas (#0d0a1a) with dot-grid backdrop and tone-tinted radial glow
+ *   - Tone variants: purple (default), good (green), warn (red/pink), gold
+ *   - Inter Tight display + JetBrains Mono eyebrows/numbers (we substitute Arial
+ *     for missing system fonts inside the SVG renderer; sharp/librsvg is happy)
+ *   - Branded footer with concentric-ring brand mark, "creditodds.com/path", meta
+ *
+ * The legacy V2 palette and helpers (darkBackground/footerBar) are preserved so
+ * existing call-sites that haven't been migrated keep rendering.
  */
 
+// ── Legacy v2 paper palette (still used by the on-site OG images) ──
 const V2 = {
   ink: '#1a1330',
   ink2: '#3a2f55',
@@ -21,6 +28,41 @@ const V2 = {
   emerald: '#0c8450',
 };
 
+// ── Social-card design palette (matches social-cards.css `:root` tokens) ──
+const SO = {
+  paper:    '#0d0a1a',
+  paper2:   '#13101f',
+  card:     '#15122a',
+  card2:    '#1a1538',
+  line:     '#241d3a',
+  line2:    '#362d52',
+  ink:      '#f4f1ff',
+  ink2:     '#cfc8e4',
+  muted:    '#8d85a8',
+  muted2:   '#5a5270',
+  accent:   '#b794ff',
+  accent2:  '#2a1a52',
+  accent3:  '#6d3fe8',
+  warn:     '#ff7aa3',
+  warn2:    '#2d0a1a',
+  good:     '#3eccaa',
+  good2:    '#0a2a23',
+  gold:     '#f0c85a',
+  gold2:    '#2a200a',
+};
+
+// ── Tone variants (radial glow + hairline + tag chip styling per template) ──
+const TONES = {
+  purple: { accent: SO.accent, glow: 'rgba(109,63,232,0.42)', hair: SO.accent, tagBg: SO.accent2, tagText: SO.accent, tagBorder: 'rgba(183,148,255,0.30)' },
+  good:   { accent: SO.good,   glow: 'rgba(62,204,170,0.32)', hair: SO.good,   tagBg: SO.good2,   tagText: SO.good,   tagBorder: 'rgba(62,204,170,0.30)' },
+  warn:   { accent: SO.warn,   glow: 'rgba(255,122,163,0.32)',hair: SO.warn,   tagBg: SO.warn2,   tagText: SO.warn,   tagBorder: 'rgba(255,122,163,0.30)' },
+  gold:   { accent: SO.gold,   glow: 'rgba(240,200,90,0.28)', hair: SO.gold,   tagBg: SO.gold2,   tagText: SO.gold,   tagBorder: 'rgba(240,200,90,0.30)' },
+};
+
+function getTone(name) {
+  return TONES[name] || TONES.purple;
+}
+
 function hexToRgba(hex, alpha) {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
@@ -28,12 +70,14 @@ function hexToRgba(hex, alpha) {
   return `rgba(${r},${g},${b},${alpha})`;
 }
 
-/**
- * Returns SVG fragments for the dark editorial background: ink canvas, a
- * purple accent radial glow top-right, a softer one bottom-left, and a subtle
- * mono dot grid. Caller splices `defs` into the `<defs>` block and `rects` at
- * the start of the canvas.
- */
+function escapeXml(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Legacy backdrop (paper/ink hybrid) — kept for backward compat
+// ─────────────────────────────────────────────────────────────────────────────
+
 function darkBackground({ width, height, accent = V2.accent, idSuffix = '' }) {
   const glowId = `v2glow${idSuffix}`;
   const glow2Id = `v2glow2${idSuffix}`;
@@ -60,10 +104,6 @@ function darkBackground({ width, height, accent = V2.accent, idSuffix = '' }) {
   return { defs, rects };
 }
 
-/**
- * Subtle hairline + muted-purple footer text. Caller positions a <g transform>
- * or embeds this directly at the footer Y offset.
- */
 function footerBar({ width, y, height, text = 'creditodds.com' }) {
   return `
     <line x1="40" y1="${y}" x2="${width - 40}" y2="${y}" stroke="rgba(255,255,255,0.08)" stroke-width="1"/>
@@ -71,9 +111,198 @@ function footerBar({ width, y, height, text = 'creditodds.com' }) {
   `;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Social-card frame (the design system used by Card Wire / Best Rankings)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns SVG fragments for the design's deep-purple frame:
+ *   - solid ink fill (#0d0a1a)
+ *   - tone-tinted radial glow upper-right + soft accent glow lower-left
+ *   - subtle dot-grid overlay
+ *   - 1px inset accent border (the "soft contained card" hint)
+ *   - hairline accent (96×3px) at top-left in the tone color
+ *
+ * Caller splices `defs` into `<defs>` and `rects` at the start of the canvas.
+ */
+function soFrame({ width, height, tone = 'purple', idSuffix = '' }) {
+  const t = getTone(tone);
+  const glowId = `soglow${idSuffix}`;
+  const glow2Id = `soglow2${idSuffix}`;
+  const dotsId = `sodots${idSuffix}`;
+
+  const defs = `
+    <radialGradient id="${glowId}" cx="90%" cy="10%" r="65%">
+      <stop offset="0%" stop-color="${t.glow}"/>
+      <stop offset="60%" stop-color="${t.glow.replace(/[\d.]+\)$/, '0)')}"/>
+    </radialGradient>
+    <radialGradient id="${glow2Id}" cx="0%" cy="100%" r="55%">
+      <stop offset="0%" stop-color="rgba(183,148,255,0.10)"/>
+      <stop offset="55%" stop-color="rgba(183,148,255,0)"/>
+    </radialGradient>
+    <pattern id="${dotsId}" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="1" cy="1" r="1" fill="rgba(183,148,255,0.07)"/>
+    </pattern>
+  `;
+  const rects = `
+    <rect width="${width}" height="${height}" fill="${SO.paper}"/>
+    <rect width="${width}" height="${height}" fill="url(#${dotsId})"/>
+    <rect width="${width}" height="${height}" fill="url(#${glowId})"/>
+    <rect width="${width}" height="${height}" fill="url(#${glow2Id})"/>
+    <rect x="0.5" y="0.5" width="${width - 1}" height="${height - 1}" fill="none" stroke="rgba(183,148,255,0.06)" stroke-width="1"/>
+    <rect x="64" y="0" width="96" height="3" rx="0" ry="0" fill="${t.hair}"/>
+  `;
+  return { defs, rects };
+}
+
+/**
+ * The shared brand footer band that anchors every social card. Renders:
+ *   - 1px top border in --so-line
+ *   - Wordmark on the left (concentric-ring brand mark + "Credit" + accent "Odds")
+ *   - URL + optional meta on the right (mono caps, accent-colored path segment)
+ *
+ * The footer is 56px tall in the design and sits flush at the bottom.
+ */
+function soFooter({ width, height = 56, y, sectionPath = '', meta = '', tone = 'purple' }) {
+  const t = getTone(tone);
+  const padX = 56;
+  const cy = y + height / 2;
+
+  // Brand mark — concentric "odds meter" ring
+  const markSize = 22;
+  const markX = padX;
+  const markY = cy - markSize / 2;
+  const markCenterX = markX + markSize / 2;
+  const markCenterY = markY + markSize / 2;
+  const markR = markSize / 2 - 1;
+  const markArcR = markR - 1;
+
+  // Compute arc end point (90° → 270° = three-quarters of the way clockwise from top)
+  // We trace from 12 o'clock to 4 o'clock (= 120deg arc) for the accent stroke
+  const arcStart = { x: markCenterX, y: markCenterY - markArcR };
+  const arcEnd = {
+    x: markCenterX + markArcR * Math.cos((-30 * Math.PI) / 180),
+    y: markCenterY + markArcR * Math.sin((-30 * Math.PI) / 180),
+  };
+  const brandMarkSvg = `
+    <g>
+      <circle cx="${markCenterX}" cy="${markCenterY}" r="${markR}" fill="none" stroke="${SO.ink}" stroke-opacity="0.25" stroke-width="1.5"/>
+      <path d="M ${arcStart.x} ${arcStart.y} A ${markArcR} ${markArcR} 0 0 1 ${arcEnd.x} ${arcEnd.y}" fill="none" stroke="${t.accent}" stroke-width="2.2" stroke-linecap="round"/>
+      <circle cx="${markCenterX}" cy="${markCenterY}" r="2.2" fill="${t.accent}"/>
+    </g>
+  `;
+
+  // Wordmark text — placed right of the mark
+  const wordX = markX + markSize + 10;
+  const wordmark = `
+    <text x="${wordX}" y="${cy + 6}" font-family="Arial,sans-serif" font-size="17" font-weight="700" fill="${SO.ink}" letter-spacing="-0.3">Credit<tspan fill="${t.accent}" font-weight="500">Odds</tspan></text>
+  `;
+
+  // Right side: URL + optional divider + meta (mono caps)
+  // creditodds.com/<path>  ·  meta
+  const rightX = width - padX;
+  const urlPath = sectionPath ? `creditodds.com/${sectionPath}` : 'creditodds.com';
+  const metaText = meta ? meta.toUpperCase() : '';
+
+  // Right-side text uses tspans for color segments. Render with text-anchor="end"
+  // and chunk by approximate width: we measure conservatively by character count.
+  const urlSvg = sectionPath
+    ? `<tspan fill="${SO.ink2}">creditodds.com</tspan><tspan fill="${SO.muted}" dx="2"> / </tspan><tspan fill="${t.accent}" dx="2">${escapeXml(sectionPath)}</tspan>`
+    : `<tspan fill="${SO.ink2}">creditodds.com</tspan>`;
+
+  let rightContent = '';
+  if (metaText) {
+    rightContent = `
+      <text x="${rightX}" y="${cy + 5}" text-anchor="end" font-family="Menlo,Consolas,monospace" font-size="12" fill="${SO.muted}" letter-spacing="1.2">${escapeXml(metaText)}</text>
+      <line x1="${rightX - estimateTextWidth(metaText, 12, true) - 18}" y1="${cy - 7}" x2="${rightX - estimateTextWidth(metaText, 12, true) - 18}" y2="${cy + 7}" stroke="${SO.line2}" stroke-width="1"/>
+      <text x="${rightX - estimateTextWidth(metaText, 12, true) - 28}" y="${cy + 5}" text-anchor="end" font-family="Menlo,Consolas,monospace" font-size="13" letter-spacing="0.4">${urlSvg}</text>
+    `;
+  } else {
+    rightContent = `
+      <text x="${rightX}" y="${cy + 5}" text-anchor="end" font-family="Menlo,Consolas,monospace" font-size="13" letter-spacing="0.4">${urlSvg}</text>
+    `;
+  }
+
+  void urlPath;
+
+  return `
+    <rect x="0" y="${y}" width="${width}" height="${height}" fill="rgba(7,5,15,0.55)"/>
+    <line x1="0" y1="${y}" x2="${width}" y2="${y}" stroke="${SO.line}" stroke-width="1"/>
+    ${brandMarkSvg}
+    ${wordmark}
+    ${rightContent}
+  `;
+}
+
+/**
+ * Mono eyebrow row: "<KEY> · <text>" with the key in the tone accent.
+ * Mirrors `.so-eyebrow` from the design.
+ */
+function soEyebrow({ x, y, key, text, tone = 'purple', size = 14 }) {
+  const t = getTone(tone);
+  const keyText = key ? `<tspan fill="${t.accent}" font-weight="600">${escapeXml(key)}</tspan>` : '';
+  const sep = key && text ? `<tspan fill="${SO.muted2}" dx="6"> · </tspan>` : '';
+  const tail = text ? `<tspan fill="${SO.muted}" dx="6">${escapeXml(text)}</tspan>` : '';
+  return `<text x="${x}" y="${y}" font-family="Menlo,Consolas,monospace" font-size="${size}" letter-spacing="1.4" font-weight="500">${keyText}${sep}${tail}</text>`;
+}
+
+/**
+ * Render the design's mini "card art" placeholder when we don't have a real
+ * card image — solid gradient swatch with chip + network text. Used for slots
+ * where we want the design to read even if a CDN fetch failed.
+ */
+function soArtPlaceholderSvg({ x, y, w, h, palette = 'purple', name = '', network = '' }) {
+  const palettes = {
+    discover:    ['#4d4d56', '#2d2d3a'],
+    quicksilver: ['#c8ccd0', '#8d9097'],
+    'bofa-red':  ['#b81c2f', '#6e0e1c'],
+    'platinum-co': ['#1a3a6e', '#0a1f3e'],
+    'citi-blue': ['#2d8fc7', '#0d4070'],
+    atmos:       ['#1a2540', '#0a1530'],
+    aadvantage:  ['#d0d4d8', '#9ea3aa'],
+    bilt:        ['#2a2a2a', '#060606'],
+    purple:      ['#6d3fe8', '#2a1a52'],
+  };
+  const [g1, g2] = palettes[palette] || palettes.purple;
+  const lightOnDark = !['quicksilver', 'aadvantage'].includes(palette);
+  const txtColor = lightOnDark ? 'rgba(255,255,255,0.85)' : '#2d2d3a';
+  const gradId = `pal-${palette}-${Math.random().toString(36).slice(2, 8)}`;
+
+  return `
+    <defs>
+      <linearGradient id="${gradId}" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="${g1}"/>
+        <stop offset="100%" stop-color="${g2}"/>
+      </linearGradient>
+    </defs>
+    <rect x="${x}" y="${y}" width="${w}" height="${h}" rx="${Math.min(14, h * 0.06)}" fill="url(#${gradId})"/>
+    <rect x="${x + w * 0.12}" y="${y + h * 0.36}" width="${w * 0.14}" height="${h * 0.28}" rx="3" fill="#d6c280"/>
+    ${name ? `<text x="${x + w - w * 0.08}" y="${y + h * 0.22}" text-anchor="end" font-family="Arial,sans-serif" font-size="${Math.round(h * 0.09)}" font-weight="500" fill="${txtColor}">${escapeXml(String(name).slice(0, 32))}</text>` : ''}
+    ${network ? `<text x="${x + w - w * 0.08}" y="${y + h - h * 0.12}" text-anchor="end" font-family="Arial,sans-serif" font-size="${Math.round(h * 0.11)}" font-weight="700" fill="${txtColor}" letter-spacing="0.5">${escapeXml(network)}</text>` : ''}
+  `;
+}
+
+// ── Naive width estimator for monospace at a given px size ──
+function estimateTextWidth(str, fontSize, isMonospace = false) {
+  // Mono ~ 0.6 em per char. Sans ~ 0.55. Caps adds ~5%.
+  const factor = isMonospace ? 0.62 : 0.56;
+  return Math.ceil(String(str).length * fontSize * factor);
+}
+
 module.exports = {
+  // Legacy palette + helpers
   V2,
   hexToRgba,
   darkBackground,
   footerBar,
+  // Social-card design system
+  SO,
+  TONES,
+  getTone,
+  escapeXml,
+  soFrame,
+  soFooter,
+  soEyebrow,
+  soArtPlaceholderSvg,
+  estimateTextWidth,
 };

--- a/scripts/post-best-rankings.js
+++ b/scripts/post-best-rankings.js
@@ -18,7 +18,14 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 const sharp = require('sharp');
-const { V2, darkBackground, footerBar } = require('./lib/og-style');
+const {
+  SO,
+  getTone,
+  escapeXml,
+  soFrame,
+  soFooter,
+  soEyebrow,
+} = require('./lib/og-style');
 const { appendBankHandles } = require('./lib/bank-handles');
 
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
@@ -43,10 +50,6 @@ async function fetchWithRetry(url, options, { maxRetries = 3, baseDelay = 2000 }
       return response;
     }
   }
-}
-
-function escapeXml(str) {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 // ─── CLI args ────────────────────────────────────────────────────────────────
@@ -120,6 +123,28 @@ async function fetchCardDetails(bestCards) {
 }
 
 // ─── Image generation ────────────────────────────────────────────────────────
+//
+// Layout follows the "T1 — Ranking" template in the design system:
+//   1200×630 frame, dot-grid + tone-tinted glow backdrop, hairline accent at top.
+//   Header row: eyebrow + title on the left, count + "Cards ranked" on the right.
+//   List: 5 evenly-spaced rows, each with rank num (vertical accent bar + "01"),
+//   small card art (1.6:1), name + issuer, optional badge pill on the right.
+
+const FRAME_W = 1200;
+const FRAME_H = 630;
+const FOOTER_H = 56;
+const PADDING_X = 56;
+const CONTENT_TOP = 40;
+
+const RANK_ART_W = 86;
+const RANK_ART_H = Math.round(RANK_ART_W / 1.6); // 54
+
+// Pick a tone for the category — travel-ish lists go gold; the rest stay purple.
+function pickTone(slug = '', title = '') {
+  const s = (slug + ' ' + title).toLowerCase();
+  if (/travel|airline|flight|hotel|cruise|vacation/.test(s)) return 'gold';
+  return 'purple';
+}
 
 async function fetchCardImage(imageFilename) {
   try {
@@ -127,8 +152,29 @@ async function fetchCardImage(imageFilename) {
     const res = await fetch(url);
     if (!res.ok) return null;
     const buffer = Buffer.from(await res.arrayBuffer());
-    return await sharp(buffer)
-      .resize(200, 126, { fit: 'contain', background: { r: 255, g: 255, b: 255, alpha: 0 } })
+    // Render the source card image into the row's small slot — the issuer
+    // image (already has its own background) sits on the dark `.so-cardart`
+    // surface and is clipped by a 1px inner border.
+    const inner = await sharp(buffer)
+      .resize(RANK_ART_W - 6, RANK_ART_H - 6, {
+        fit: 'contain',
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+      })
+      .png()
+      .toBuffer();
+    const slotSvg = `<svg width="${RANK_ART_W}" height="${RANK_ART_H}" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="${RANK_ART_W}" height="${RANK_ART_H}" rx="6" ry="6" fill="${SO.card2}"/>
+    </svg>`;
+    return await sharp(Buffer.from(slotSvg))
+      .composite([
+        { input: inner, left: 3, top: 3 },
+        {
+          input: Buffer.from(`<svg width="${RANK_ART_W}" height="${RANK_ART_H}" xmlns="http://www.w3.org/2000/svg">
+            <rect x="0.5" y="0.5" width="${RANK_ART_W - 1}" height="${RANK_ART_H - 1}" rx="6" ry="6" fill="none" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+          </svg>`),
+          left: 0, top: 0,
+        },
+      ])
       .png()
       .toBuffer();
   } catch (err) {
@@ -137,98 +183,177 @@ async function fetchCardImage(imageFilename) {
   }
 }
 
-function getBadgeOrMovementSvg(card) {
+// Tag pill on the right side. Prefers explicit badge; falls back to rank-movement.
+function getRowTagSvg(card, tone, rightX, centerY) {
+  const t = getTone(tone);
   if (card.badge) {
-    const badgeText = escapeXml(card.badge);
-    const textWidth = card.badge.length * 8;
-    const pillWidth = textWidth + 24;
-    const x = -pillWidth;
-    return `<g>
-      <rect x="${x}" y="-10" width="${pillWidth}" height="24" rx="12" fill="rgba(109,63,232,0.18)" stroke="rgba(109,63,232,0.45)" stroke-width="1"/>
-      <text x="${x + pillWidth / 2}" y="7" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#ffffff">${badgeText}</text>
-    </g>`;
+    const text = String(card.badge).toUpperCase();
+    const textW = Math.ceil(text.length * 11 * 0.6);
+    const pillW = textW + 20;
+    const pillH = 22;
+    const x = rightX - pillW;
+    const y = centerY - pillH / 2;
+    return `
+      <rect x="${x}" y="${y}" width="${pillW}" height="${pillH}" rx="4" ry="4"
+            fill="${SO.accent2}" stroke="none"/>
+      <text x="${x + pillW / 2}" y="${y + pillH / 2 + 4}" text-anchor="middle"
+            font-family="Menlo,Consolas,monospace" font-size="11" font-weight="600" fill="${t.accent}" letter-spacing="0.8">${escapeXml(text)}</text>
+    `;
   }
 
   if (card.previousRank) {
     const movement = card.previousRank - card.rank;
-    if (movement > 0) {
-      return `<g>
-        <polygon points="0,12 8,0 16,12" fill="${V2.emerald}"/>
-        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="${V2.emerald}">+${movement}</text>
-      </g>`;
-    } else if (movement < 0) {
-      return `<g>
-        <polygon points="0,0 8,12 16,0" fill="${V2.warn}"/>
-        <text x="20" y="12" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="${V2.warn}">${movement}</text>
-      </g>`;
-    }
+    if (movement === 0) return '';
+    const positive = movement > 0;
+    const color = positive ? SO.good : SO.warn;
+    const arrow = positive ? '▲' : '▼';
+    const text = `${arrow} ${Math.abs(movement)}`;
+    const textW = Math.ceil(text.length * 12 * 0.6);
+    const pillW = textW + 18;
+    const pillH = 22;
+    const x = rightX - pillW;
+    const y = centerY - pillH / 2;
+    return `
+      <rect x="${x}" y="${y}" width="${pillW}" height="${pillH}" rx="4" ry="4"
+            fill="${positive ? 'rgba(62,204,170,0.12)' : 'rgba(255,122,163,0.12)'}" stroke="none"/>
+      <text x="${x + pillW / 2}" y="${y + pillH / 2 + 4}" text-anchor="middle"
+            font-family="Menlo,Consolas,monospace" font-size="11" font-weight="600" fill="${color}" letter-spacing="0.8">${escapeXml(text)}</text>
+    `;
   }
 
   return '';
 }
 
-async function generateBestRankingsImage(categoryTitle, updatedAt, topCards) {
+function fitName(name, maxChars) {
+  if (name.length <= maxChars) return name;
+  return name.slice(0, maxChars - 1).trim() + '…';
+}
+
+async function generateBestRankingsImage(categoryTitle, updatedAt, topCards, slug = '') {
+  const tone = pickTone(slug, categoryTitle);
+  const t = getTone(tone);
+
   const cardImages = await Promise.all(
     topCards.map(card => card.image ? fetchCardImage(card.image) : Promise.resolve(null))
   );
-
-  const width = 1080;
-  const rowHeight = 140;
-  const headerHeight = 120;
-  const footerHeight = 60;
-  const height = headerHeight + (rowHeight * 5) + footerHeight;
 
   const updatedDate = updatedAt
     ? new Date(updatedAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
     : new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
 
-  let rowsSvg = '';
-  for (let i = 0; i < 5; i++) {
-    const card = topCards[i];
-    const y = headerHeight + (i * rowHeight);
-    const bgFill = i % 2 === 0 ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0)';
+  // ── Header layout ──
+  const eyebrowY = CONTENT_TOP + 18;
+  const titleSize = 44;
+  const titleBaseY = eyebrowY + 26 + titleSize - 4;
 
-    rowsSvg += `
-      <rect x="0" y="${y}" width="${width}" height="${rowHeight}" fill="${bgFill}"/>
-      <line x1="40" y1="${y}" x2="${width - 40}" y2="${y}" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
-      <circle cx="55" cy="${y + rowHeight / 2}" r="28" fill="${V2.accent}"/>
-      <text x="55" y="${y + rowHeight / 2 + 10}" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="white">${card.rank}</text>
-      <text x="310" y="${y + rowHeight / 2 - 8}" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#ffffff">${escapeXml(card.name)}</text>
-      <text x="310" y="${y + rowHeight / 2 + 18}" font-family="Arial,sans-serif" font-size="16" fill="rgba(255,255,255,0.6)">${escapeXml(card.bank)}</text>
-      <g transform="translate(${width - 30}, ${y + rowHeight / 2 - 6})">
-        ${getBadgeOrMovementSvg(card)}
-      </g>
-    `;
+  const countSize = 44;
+  const rightEdge = FRAME_W - PADDING_X;
+  const countText = String(topCards.length);
+  const countBaseY = titleBaseY;
+  const countLabelY = countBaseY + 22;
+  const headerBottom = countLabelY + 16;
+
+  // ── List layout: evenly-spaced rows in the remaining content area ──
+  const listTop = headerBottom + 8;
+  const listBottom = FRAME_H - FOOTER_H - 12;
+  const listH = listBottom - listTop;
+  const numRows = topCards.length;
+  const rowH = listH / numRows;
+
+  const numColW = 44;
+  const numColX = PADDING_X;
+  const artColX = numColX + numColW + 18;
+  const nameColX = artColX + RANK_ART_W + 18;
+
+  const frame = soFrame({ width: FRAME_W, height: FRAME_H, tone });
+
+  // ── Header SVG ──
+  const eyebrowSvg = soEyebrow({
+    x: PADDING_X,
+    y: eyebrowY,
+    key: 'Ranked',
+    text: `Updated ${updatedDate}`,
+    tone,
+    size: 13,
+  });
+
+  const titleSvg = `
+    <text x="${PADDING_X}" y="${titleBaseY}" font-family="Arial,sans-serif" font-size="${titleSize}" font-weight="600" fill="${SO.ink}" letter-spacing="-1.1">${escapeXml(categoryTitle)}</text>
+  `;
+
+  const countCluster = `
+    <text x="${rightEdge}" y="${countBaseY}" text-anchor="end" font-family="Arial,sans-serif" font-size="${countSize}" font-weight="500" fill="${t.accent}" letter-spacing="-1.3">${countText}</text>
+    <text x="${rightEdge}" y="${countLabelY}" text-anchor="end" font-family="Menlo,Consolas,monospace" font-size="10" font-weight="500" fill="${SO.muted}" letter-spacing="1.4">CARDS RANKED</text>
+  `;
+
+  // ── Row SVG ──
+  let rowsSvg = '';
+  for (let i = 0; i < numRows; i++) {
+    const card = topCards[i];
+    const yTop = listTop + i * rowH;
+    const yCenter = yTop + rowH / 2;
+    const isFirst = i === 0;
+    const numColor = isFirst ? t.accent : SO.muted;
+    const barColor = isFirst ? t.accent : SO.line;
+
+    if (i > 0) {
+      rowsSvg += `<line x1="${PADDING_X}" y1="${yTop}" x2="${FRAME_W - PADDING_X}" y2="${yTop}" stroke="${SO.line}" stroke-width="1"/>`;
+    }
+
+    rowsSvg += `<rect x="${PADDING_X - 6}" y="${yCenter - 11}" width="3" height="22" rx="2" ry="2" fill="${barColor}"/>`;
+    const numText = String(i + 1).padStart(2, '0');
+    rowsSvg += `<text x="${numColX + numColW / 2 + 4}" y="${yCenter + 9}" text-anchor="middle" font-family="Arial,sans-serif" font-size="26" font-weight="500" fill="${numColor}" letter-spacing="-0.8">${numText}</text>`;
+
+    const artY = yCenter - RANK_ART_H / 2;
+    rowsSvg += `<rect x="${artColX}" y="${artY}" width="${RANK_ART_W}" height="${RANK_ART_H}" rx="6" ry="6" fill="${SO.card2}" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>`;
+
+    const nameMaxChars = 38;
+    const nameText = fitName(card.name, nameMaxChars);
+    rowsSvg += `<text x="${nameColX}" y="${yCenter - 4}" font-family="Arial,sans-serif" font-size="19" font-weight="600" fill="${SO.ink}" letter-spacing="-0.3">${escapeXml(nameText)}</text>`;
+    rowsSvg += `<text x="${nameColX}" y="${yCenter + 16}" font-family="Menlo,Consolas,monospace" font-size="11" fill="${SO.muted}" letter-spacing="0.8">${escapeXml((card.bank || '').toUpperCase())}</text>`;
+
+    rowsSvg += getRowTagSvg(card, tone, FRAME_W - PADDING_X, yCenter);
   }
 
-  const bg = darkBackground({ width, height, accent: V2.accent });
+  const footerSvg = soFooter({
+    width: FRAME_W,
+    height: FOOTER_H,
+    y: FRAME_H - FOOTER_H,
+    sectionPath: 'best',
+    meta: `${numRows} cards · ${updatedDate}`,
+    tone,
+  });
 
-  const svg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+  const svg = `<svg width="${FRAME_W}" height="${FRAME_H}" xmlns="http://www.w3.org/2000/svg">
     <defs>
-      ${bg.defs}
+      ${frame.defs}
     </defs>
-    ${bg.rects}
-    <text x="40" y="58" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="#ffffff" letter-spacing="-0.5">${escapeXml(categoryTitle)}</text>
-    <text x="40" y="92" font-family="Arial,sans-serif" font-size="16" fill="${V2.accent}" letter-spacing="1.5">UPDATED \u00B7 ${escapeXml(updatedDate).toUpperCase()}</text>
+    ${frame.rects}
+
+    ${eyebrowSvg}
+    ${titleSvg}
+    ${countCluster}
+
     ${rowsSvg}
-    ${footerBar({ width, y: height - footerHeight, height: footerHeight })}
+
+    ${footerSvg}
   </svg>`;
 
   let image = sharp(Buffer.from(svg)).png();
 
   const overlays = [];
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < numRows; i++) {
     if (cardImages[i]) {
-      const y = headerHeight + (i * rowHeight) + Math.round((rowHeight - 86) / 2);
+      const yTop = listTop + i * rowH;
+      const yCenter = yTop + rowH / 2;
       overlays.push({
-        input: await sharp(cardImages[i]).resize(136, 86, { fit: 'contain', background: { r: 0, g: 0, b: 0, alpha: 0 } }).png().toBuffer(),
-        left: 110,
-        top: y,
+        input: cardImages[i],
+        left: artColX,
+        top: Math.round(yCenter - RANK_ART_H / 2),
       });
     }
   }
-
-  if (overlays.length > 0) {
+  if (overlays.length) {
     image = sharp(await image.toBuffer()).composite(overlays).png();
   }
 
@@ -337,7 +462,7 @@ async function main() {
   }
 
   console.log('\nGenerating best rankings image...');
-  const imageBuffer = await generateBestRankingsImage(bestData.title, bestData.updatedAt, enrichedCards);
+  const imageBuffer = await generateBestRankingsImage(bestData.title, bestData.updatedAt, enrichedCards, bestData.slug);
   console.log(`  Image generated: ${(imageBuffer.length / 1024).toFixed(0)}KB`);
 
   const { textContent, twitterText } = buildPostText(bestData.title, enrichedCards);

--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -17,7 +17,14 @@
 const fs = require('fs');
 const path = require('path');
 const sharp = require('sharp');
-const { V2, darkBackground, footerBar, hexToRgba } = require('./lib/og-style');
+const {
+  SO,
+  getTone,
+  escapeXml,
+  soFrame,
+  soFooter,
+  soEyebrow,
+} = require('./lib/og-style');
 const { appendBankHandles } = require('./lib/bank-handles');
 
 const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
@@ -103,124 +110,337 @@ async function fetchCardImage(imageFilename) {
     const url = `${CDN_IMAGES}/${imageFilename}`;
     const res = await fetch(url);
     if (!res.ok) return null;
-    const buffer = Buffer.from(await res.arrayBuffer());
-    return await sharp(buffer)
-      .resize(280, 176, { fit: 'contain', background: { r: 255, g: 255, b: 255, alpha: 0 } })
-      .png()
-      .toBuffer();
+    return Buffer.from(await res.arrayBuffer());
   } catch {
     return null;
   }
 }
 
 // ── Image generation ──
+//
+// Layout follows the "T2 — CardWire" template in the design system:
+//   1200×630 frame, dot-grid + tone-tinted glow backdrop, hairline accent at top.
+//   Left column: eyebrow + card name title + "What changed" stat block (single
+//   primary change, with "+N more" badge if multiple). Right column: tilted
+//   card art with a back-glow placeholder card behind.
 
-function escapeXml(str) {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+const FRAME_W = 1200;
+const FRAME_H = 630;
+const FOOTER_H = 56;
+const CONTENT_TOP = 40;
+const PADDING_X = 56;
+const COL_GAP = 36;
+const RIGHT_COL_W = 420;
+const CARD_ART_W = 360;
+const CARD_ART_H = Math.round(CARD_ART_W / 1.6);
+
+// Pick the most-noteworthy change (positive/negative beats neutral; first wins ties)
+function pickPrimaryChange(changes) {
+  const ranked = changes.map((c, i) => ({
+    c,
+    dir: getDirection(c.field, c.old_value, c.new_value),
+    idx: i,
+  }));
+  ranked.sort((a, b) => {
+    const aScore = a.dir === 'neutral' ? 1 : 0;
+    const bScore = b.dir === 'neutral' ? 1 : 0;
+    if (aScore !== bScore) return aScore - bScore;
+    return a.idx - b.idx;
+  });
+  return { primary: ranked[0], rest: ranked.slice(1) };
 }
 
-async function generateCardWireImage(cardName, bank, changes, cardImageBuffer) {
-  const width = 1080;
-  const headerHeight = 100;
-  const cardImageAreaHeight = 200;
-  const changeRowHeight = 100;
-  const footerHeight = 50;
-  const changesHeight = changes.length * changeRowHeight + 40; // 40 for section header
-  const height = headerHeight + cardImageAreaHeight + changesHeight + footerHeight;
-
-  // Build change rows
-  let changesSvg = '';
-  const changesStartY = headerHeight + cardImageAreaHeight + 40; // after section header
-
-  // Section header
-  const sectionHeaderY = headerHeight + cardImageAreaHeight;
-  changesSvg += `
-    <text x="40" y="${sectionHeaderY + 26}" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="${V2.accent}" letter-spacing="1.5">WHAT CHANGED</text>
-  `;
-
-  for (let i = 0; i < changes.length; i++) {
-    const c = changes[i];
-    const y = changesStartY + (i * changeRowHeight);
-    const dir = getDirection(c.field, c.old_value, c.new_value);
-    const label = fieldLabels[c.field] || c.field;
-    const oldFormatted = formatValue(c.field, c.old_value);
-    const newFormatted = formatValue(c.field, c.new_value);
-
-    const accentColor = dir === 'positive' ? V2.emerald : dir === 'negative' ? V2.warn : V2.muted;
-    const rowBg = dir === 'positive'
-      ? hexToRgba(V2.emerald, 0.12)
-      : dir === 'negative'
-      ? hexToRgba(V2.warn, 0.14)
-      : 'rgba(255,255,255,0.05)';
-    const pillBg = dir === 'positive'
-      ? hexToRgba(V2.emerald, 0.22)
-      : dir === 'negative'
-      ? hexToRgba(V2.warn, 0.22)
-      : 'rgba(255,255,255,0.12)';
-
-    // Row background
-    changesSvg += `<rect x="30" y="${y}" width="${width - 60}" height="${changeRowHeight - 10}" rx="12" fill="${rowBg}" stroke="${hexToRgba(accentColor, 0.3)}" stroke-width="1"/>`;
-
-    // Field label
-    changesSvg += `<text x="55" y="${y + 35}" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#ffffff">${escapeXml(label)}</text>`;
-
-    // Old value → New value
-    changesSvg += `<text x="55" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" fill="rgba(255,255,255,0.5)">${escapeXml(oldFormatted)}</text>`;
-    changesSvg += `<text x="${55 + oldFormatted.length * 13 + 15}" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" fill="rgba(255,255,255,0.5)">\u2192</text>`;
-    changesSvg += `<text x="${55 + oldFormatted.length * 13 + 40}" y="${y + 62}" font-family="Arial,sans-serif" font-size="22" font-weight="bold" fill="${accentColor}">${escapeXml(newFormatted)}</text>`;
-
-    // Direction badge on right
-    const badgeText = dir === 'positive' ? '\u2B06 Better' : dir === 'negative' ? '\u2B07 Worse' : '\u2796 Changed';
-    changesSvg += `
-      <rect x="${width - 195}" y="${y + 25}" width="130" height="36" rx="18" fill="${pillBg}"/>
-      <text x="${width - 130}" y="${y + 49}" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="${accentColor}">${badgeText}</text>
-    `;
-  }
-
-  // Header accent color based on overall sentiment
+function overallTone(changes) {
   const allPositive = changes.every(c => getDirection(c.field, c.old_value, c.new_value) === 'positive');
   const allNegative = changes.every(c => getDirection(c.field, c.old_value, c.new_value) === 'negative');
-  const accentColor = allPositive ? V2.emerald : allNegative ? V2.warn : V2.accent;
+  if (allPositive) return 'good';
+  if (allNegative) return 'warn';
+  return 'purple';
+}
 
-  const bg = darkBackground({ width, height, accent: accentColor });
+function eyebrowVerb(tone) {
+  return tone === 'good' ? 'CardWire · improvement'
+       : tone === 'warn' ? 'CardWire · downgrade'
+       :                   'CardWire · update';
+}
 
-  const svg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+// Word-wrap a string into up to maxLines lines of approximately maxChars each.
+function wrapText(text, maxChars, maxLines) {
+  const words = String(text).trim().split(/\s+/);
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    if (!current) { current = word; continue; }
+    if ((current + ' ' + word).length <= maxChars) {
+      current += ' ' + word;
+    } else {
+      lines.push(current);
+      if (lines.length >= maxLines) break;
+      current = word;
+    }
+  }
+  if (current && lines.length < maxLines) lines.push(current);
+  // Tail truncation if we overflowed
+  if (lines.length === maxLines) {
+    const used = lines.join(' ');
+    if (used.length < text.length - 2) {
+      const last = lines[maxLines - 1];
+      lines[maxLines - 1] = (last.length > maxChars - 1 ? last.slice(0, maxChars - 1) : last) + '…';
+    }
+  }
+  return lines.length ? lines : [text];
+}
+
+function estimateMonoWidth(s, fontSize) {
+  return Math.ceil(String(s).length * fontSize * 0.6);
+}
+
+// Render the card image inside a tilted, rounded frame with a soft drop shadow.
+// Returns { buffer, width, height } for compositing onto the main canvas.
+async function renderTiltedCardArt(cardImageBuffer) {
+  const innerW = CARD_ART_W;
+  const innerH = CARD_ART_H;
+
+  // Inner card frame: rounded background with the issuer image centered inside
+  const innerSvg = `<svg width="${innerW}" height="${innerH}" xmlns="http://www.w3.org/2000/svg">
+    <rect x="0" y="0" width="${innerW}" height="${innerH}" rx="14" ry="14" fill="${SO.card2}"/>
+  </svg>`;
+  let inner = sharp(Buffer.from(innerSvg)).png();
+
+  if (cardImageBuffer) {
+    const padding = 18;
+    const fitted = await sharp(cardImageBuffer)
+      .resize(innerW - padding * 2, innerH - padding * 2, {
+        fit: 'contain',
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+      })
+      .png()
+      .toBuffer();
+    inner = sharp(await inner.toBuffer()).composite([{ input: fitted, left: padding, top: padding }]).png();
+  }
+
+  // Subtle gloss + 1px inner border to match `.so-cardart::after`
+  const glossSvg = `<svg width="${innerW}" height="${innerH}" xmlns="http://www.w3.org/2000/svg">
     <defs>
-      ${bg.defs}
+      <linearGradient id="gloss" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="rgba(255,255,255,0.10)"/>
+        <stop offset="35%" stop-color="rgba(255,255,255,0)"/>
+        <stop offset="65%" stop-color="rgba(255,255,255,0)"/>
+        <stop offset="100%" stop-color="rgba(255,255,255,0.04)"/>
+      </linearGradient>
+      <clipPath id="round"><rect x="0" y="0" width="${innerW}" height="${innerH}" rx="14" ry="14"/></clipPath>
     </defs>
-    ${bg.rects}
+    <g clip-path="url(#round)">
+      <rect x="0" y="0" width="${innerW}" height="${innerH}" fill="url(#gloss)"/>
+    </g>
+    <rect x="0.5" y="0.5" width="${innerW - 1}" height="${innerH - 1}" rx="14" ry="14" fill="none" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  </svg>`;
+  inner = sharp(await inner.toBuffer()).composite([{ input: Buffer.from(glossSvg), left: 0, top: 0 }]).png();
 
-    <!-- Accent bar above title -->
-    <rect x="40" y="32" width="60" height="3" fill="${accentColor}"/>
+  // Pad onto a transparent canvas large enough to fit -3deg rotation and shadow
+  const padW = 480;
+  const padH = 320;
+  const offsetX = Math.round((padW - innerW) / 2);
+  const offsetY = Math.round((padH - innerH) / 2);
+  const canvasSvg = `<svg width="${padW}" height="${padH}" xmlns="http://www.w3.org/2000/svg"></svg>`;
+  let padded = sharp(Buffer.from(canvasSvg)).composite([{ input: await inner.toBuffer(), left: offsetX, top: offsetY }]).png();
 
-    <!-- Header -->
-    <text x="40" y="66" font-family="Arial,sans-serif" font-size="32" font-weight="bold" fill="#ffffff" letter-spacing="-0.5">${escapeXml(cardName)}</text>
-    <text x="40" y="92" font-family="Arial,sans-serif" font-size="16" fill="${accentColor}" letter-spacing="1.2">${escapeXml((bank || '').toUpperCase())} \u00B7 CARDWIRE UPDATE</text>
+  // Rotate -3deg (canvas auto-expands to fit)
+  const rotated = await sharp(await padded.toBuffer())
+    .rotate(-3, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+    .toBuffer();
+  const rotMeta = await sharp(rotated).metadata();
 
-    <!-- Card image area (darker inset) -->
-    <rect x="0" y="${headerHeight}" width="${width}" height="${cardImageAreaHeight}" fill="rgba(0,0,0,0.18)"/>
+  // Approximate drop shadow: blur the alpha channel into a dark layer
+  const alphaBlur = await sharp(rotated)
+    .extractChannel('alpha')
+    .blur(18)
+    .toBuffer();
+  const shadow = await sharp({
+    create: {
+      width: rotMeta.width,
+      height: rotMeta.height,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0.65 },
+    },
+  })
+    .joinChannel(alphaBlur)
+    .png()
+    .toBuffer();
 
-    <!-- Changes -->
-    ${changesSvg}
+  const finalH = rotMeta.height + 14;
+  const finalCanvasSvg = `<svg width="${rotMeta.width}" height="${finalH}" xmlns="http://www.w3.org/2000/svg"></svg>`;
+  const finalImg = await sharp(Buffer.from(finalCanvasSvg))
+    .composite([
+      { input: shadow, left: 0, top: 14 },
+      { input: rotated, left: 0, top: 0 },
+    ])
+    .png()
+    .toBuffer();
 
-    <!-- Footer -->
-    ${footerBar({ width, y: height - footerHeight, height: footerHeight, text: 'creditodds.com/card-wire' })}
+  return { buffer: finalImg, width: rotMeta.width, height: finalH };
+}
+
+async function generateCardWireImage(cardName, bank, changes, cardImageBuffer, timestamp = 'Just now') {
+  const tone = overallTone(changes);
+  const t = getTone(tone);
+  const { primary, rest } = pickPrimaryChange(changes);
+
+  const dir = primary.dir;
+  const fieldLabel = fieldLabels[primary.c.field] || primary.c.field;
+  const oldFormatted = formatValue(primary.c.field, primary.c.old_value);
+  const newFormatted = formatValue(primary.c.field, primary.c.new_value);
+
+  const pillText = dir === 'positive' ? '↑ BETTER'
+                 : dir === 'negative' ? '↓ WORSE'
+                 : '• CHANGED';
+  const pillColor = dir === 'positive' ? SO.good
+                  : dir === 'negative' ? SO.warn
+                  : SO.accent;
+  const pillBg = dir === 'positive' ? 'rgba(62,204,170,0.12)'
+               : dir === 'negative' ? 'rgba(255,122,163,0.12)'
+               : 'rgba(183,148,255,0.12)';
+  const toColor = dir === 'positive' ? SO.good
+                : dir === 'negative' ? SO.warn
+                : SO.accent;
+
+  // ── Layout coords (left text column + right card art column) ──
+  const leftX = PADDING_X;
+  const leftColW = FRAME_W - PADDING_X * 2 - RIGHT_COL_W - COL_GAP;
+  const rightColX = PADDING_X + leftColW + COL_GAP;
+
+  const eyebrowY = CONTENT_TOP + 18;
+  const titleSize = 40;
+  const titleLineH = Math.round(titleSize * 1.05);
+  const titleLines = wrapText(cardName, 22, 2);
+  const titleBaseY = eyebrowY + 26 + titleSize - 4;
+  const issuerLabelY = titleBaseY + (titleLines.length - 1) * titleLineH + 26;
+
+  const changeBlockH = 132;
+  const remainingTop = issuerLabelY + 12;
+  const remainingBottom = FRAME_H - FOOTER_H - 16;
+  const changeBlockY = Math.round(remainingTop + (remainingBottom - remainingTop - changeBlockH) / 2);
+
+  // ── Build SVG ──
+  const frame = soFrame({ width: FRAME_W, height: FRAME_H, tone });
+
+  const eyebrowSvg = soEyebrow({
+    x: leftX,
+    y: eyebrowY,
+    key: (bank || 'CARD').toUpperCase(),
+    text: eyebrowVerb(tone),
+    tone,
+    size: 13,
+  });
+
+  const titleSvg = titleLines.map((line, i) => `
+    <text x="${leftX}" y="${titleBaseY + i * titleLineH}" font-family="Arial,sans-serif" font-size="${titleSize}" font-weight="600" fill="${SO.ink}" letter-spacing="-1">${escapeXml(line)}</text>
+  `).join('');
+
+  // "What changed" block (`.so-change` in design)
+  const blockX = leftX;
+  const blockW = leftColW;
+  const accentBarW = 3;
+
+  const pillW = 110;
+  const pillH = 30;
+  const pillX = blockX + blockW - 24 - pillW;
+  const pillY = changeBlockY + 20;
+
+  const valueY = changeBlockY + changeBlockH - 28;
+  const valueSize = 28;
+  const fromX = blockX + 24;
+  const fromW = estimateMonoWidth(oldFormatted, valueSize);
+  const arrowX = fromX + fromW + 18;
+  const arrowW = estimateMonoWidth('→', valueSize - 2);
+  const toX = arrowX + arrowW + 18;
+  const fromCenterY = valueY - Math.round(valueSize * 0.32);
+
+  const changeBlockSvg = `
+    <rect x="${blockX}" y="${changeBlockY}" width="${blockW}" height="${changeBlockH}" rx="12" ry="12"
+          fill="${SO.card2}" stroke="${SO.line}" stroke-width="1"/>
+    <rect x="${blockX}" y="${changeBlockY}" width="${blockW}" height="${changeBlockH}" rx="12" ry="12"
+          fill="rgba(0,0,0,0.18)"/>
+    <rect x="${blockX}" y="${changeBlockY + 12}" width="${accentBarW}" height="${changeBlockH - 24}" rx="2" ry="2" fill="${t.hair}"/>
+
+    <text x="${blockX + 24}" y="${changeBlockY + 30}" font-family="Menlo,Consolas,monospace" font-size="11" fill="${SO.muted}" letter-spacing="1.4" font-weight="500">WHAT CHANGED${rest.length ? `  ·  +${rest.length} MORE` : ''}</text>
+
+    <text x="${blockX + 24}" y="${changeBlockY + 56}" font-family="Arial,sans-serif" font-size="19" font-weight="600" fill="${SO.ink}" letter-spacing="-0.2">${escapeXml(fieldLabel)}</text>
+
+    <text x="${fromX}" y="${valueY}" font-family="Menlo,Consolas,monospace" font-size="${valueSize}" font-weight="500" fill="${SO.muted}" letter-spacing="-0.3">${escapeXml(oldFormatted)}</text>
+    <line x1="${fromX}" y1="${fromCenterY}" x2="${fromX + fromW}" y2="${fromCenterY}" stroke="${SO.muted2}" stroke-width="2"/>
+    <text x="${arrowX}" y="${valueY}" font-family="Menlo,Consolas,monospace" font-size="${valueSize - 2}" fill="${SO.muted2}">→</text>
+    <text x="${toX}" y="${valueY}" font-family="Menlo,Consolas,monospace" font-size="${valueSize}" font-weight="500" fill="${toColor}" letter-spacing="-0.3">${escapeXml(newFormatted)}</text>
+
+    <rect x="${pillX}" y="${pillY}" width="${pillW}" height="${pillH}" rx="${pillH / 2}" ry="${pillH / 2}"
+          fill="${pillBg}" stroke="${pillColor}" stroke-width="1"/>
+    <text x="${pillX + pillW / 2}" y="${pillY + pillH / 2 + 4}" text-anchor="middle"
+          font-family="Menlo,Consolas,monospace" font-size="12" font-weight="600" fill="${pillColor}" letter-spacing="0.8">${pillText}</text>
+  `;
+
+  // Right column: decorative back-glow card behind the foreground card art
+  const rightColCenterX = rightColX + RIGHT_COL_W / 2;
+  const rightColCenterY = CONTENT_TOP + (FRAME_H - FOOTER_H - CONTENT_TOP) / 2;
+  const backGlowW = 340;
+  const backGlowH = Math.round(backGlowW / 1.6);
+  const backGlowX = rightColCenterX - backGlowW / 2 + 20;
+  const backGlowY = rightColCenterY - backGlowH / 2 - 10;
+
+  const backGlowSvg = `
+    <defs>
+      <linearGradient id="backGlowGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="rgba(183,148,255,0.18)"/>
+        <stop offset="100%" stop-color="rgba(109,63,232,0.06)"/>
+      </linearGradient>
+    </defs>
+    <g transform="rotate(6 ${backGlowX + backGlowW / 2} ${backGlowY + backGlowH / 2})">
+      <rect x="${backGlowX}" y="${backGlowY}" width="${backGlowW}" height="${backGlowH}" rx="14" ry="14"
+            fill="url(#backGlowGrad)" stroke="${SO.line}" stroke-width="1"/>
+    </g>
+  `;
+
+  const footerSvg = soFooter({
+    width: FRAME_W,
+    height: FOOTER_H,
+    y: FRAME_H - FOOTER_H,
+    sectionPath: 'card-wire',
+    meta: timestamp,
+    tone,
+  });
+
+  const svg = `<svg width="${FRAME_W}" height="${FRAME_H}" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      ${frame.defs}
+    </defs>
+    ${frame.rects}
+
+    ${eyebrowSvg}
+    ${titleSvg}
+
+    <text x="${leftX}" y="${issuerLabelY - 4}" font-family="Menlo,Consolas,monospace" font-size="13" fill="${SO.muted}" letter-spacing="1.2">${escapeXml(bank ? bank.toUpperCase() : '')}</text>
+
+    ${changeBlockSvg}
+
+    ${backGlowSvg}
+
+    ${footerSvg}
   </svg>`;
 
   let image = sharp(Buffer.from(svg)).png();
 
-  // Overlay card image centered in the card image area
-  if (cardImageBuffer) {
-    const imgTop = headerHeight + Math.round((cardImageAreaHeight - 176) / 2);
-    image = sharp(await image.toBuffer()).composite([{
-      input: cardImageBuffer,
-      left: Math.round((width - 280) / 2),
-      top: imgTop,
-    }]).png();
-  }
+  // Composite the tilted card art on top of the back-glow rect
+  const cardArt = await renderTiltedCardArt(cardImageBuffer);
+  const cardLeft = Math.round(rightColCenterX - cardArt.width / 2);
+  const cardTop = Math.round(rightColCenterY - cardArt.height / 2);
+  image = sharp(await image.toBuffer()).composite([{
+    input: cardArt.buffer,
+    left: cardLeft,
+    top: cardTop,
+  }]).png();
 
   return image.toBuffer();
 }
+
 
 // ── Tweet text ──
 


### PR DESCRIPTION
## Summary
- Reskins **CardWire tweets** (`scripts/post-card-wire.js`), **Best-rankings tweets** (`scripts/post-best-rankings.js`), and the **per-news OG image** (`apps/web-next/src/app/news/[id]/opengraph-image.tsx`) to the new dark editorial Social Card Templates design (deep ink frame, tone-tinted glow, Inter Tight title, mono eyebrows, brand-mark + URL footer).
- Extracts shared SVG primitives into `scripts/lib/og-style.js` (`SO` palette, `TONES`, `soFrame`, `soFooter`, `soEyebrow`) so a tweet, OG unfurl, and LinkedIn preview all read as one brand.
- News OG card images are now pre-fetched server-side and embedded as data URLs so Satori never sees the CDN's mislabeled WebP files; those entries gracefully fall back to the type-only layout.

## Templates implemented
- **T2 CardWire** — one-card delta with `from → to` stat block, ↑ BETTER / ↓ WORSE pill, tilted card art with back-glow. Picks one primary change; adds `+N more` when multiple fields move. Tone: good (all positive), warn (all negative), purple (mixed).
- **T1 Ranking** — eyebrow + title + count cluster, 5 evenly-spaced rows with vertical accent bar, card thumbnail, issuer line, and badge/rank-movement pill. Travel/airline/hotel slugs use gold; others purple.
- **T3 News** — tag-derived tone, split layout when a single card image is available, type-only full-width title otherwise.

## Test plan
- [x] `node scripts/post-card-wire.js --changes '[…]' --dry-run` — verified 1200×630 PNG, good/warn/purple tones render correctly with real card images
- [x] `node scripts/post-best-rankings.js --category best-secured-cards --dry-run` and `--category best-airline-cards --dry-run` — purple + gold variants both render at 1200×630 with real card thumbnails and badge pills
- [x] Hit `/news/[id]/opengraph-image` in dev for a PNG-image story (split layout) and a WebP-image story (type-only fallback) — both render correctly
- [x] `eslint` clean on the modified TypeScript file

🤖 Generated with [Claude Code](https://claude.com/claude-code)