### PR TITLE
Add news: American Express 20% Transfer Bonus to Hilton Honors Through May 30, 2026

### DIFF
--- a/data/news/2026-04-29-amex-hilton-transfer-bonus-20-percent-2026.yaml
+++ b/data/news/2026-04-29-amex-hilton-transfer-bonus-20-percent-2026.yaml
@@ -1,0 +1,35 @@
+id: "amex-hilton-transfer-bonus-20-percent-2026"
+title: "American Express Offering 20% Transfer Bonus to Hilton Honors Through May 30, 2026"
+summary: "American Express is offering a **20% transfer bonus** to Hilton Honors, allowing cardholders to convert Membership Rewards points at a favorable rate (1,000 MR = 2,400 HH points). The promotion runs through **May 30, 2026**."
+tags:
+  - "limited-time"
+  - "bonus-change"
+bank: "American Express"
+card_slugs:
+  - "american-express-business-gold-card"
+  - "american-express-gold-card"
+  - "american-express-green-card"
+  - "amex-everyday-credit-card"
+  - "amex-everyday-preferred-credit-card"
+  - "hilton-honors-card"
+  - "hilton-honors-american-express-aspire-card"
+  - "hilton-honors-american-express-surpass-card"
+card_names:
+  - "American Express Business Gold"
+  - "American Express Gold"
+  - "American Express Green"
+  - "Amex Everyday"
+  - "Amex Everyday Preferred"
+  - "Hilton Honors"
+  - "Hilton Honors American Express Aspire"
+  - "Hilton Honors American Express Surpass"
+source: "Your Best Credit Cards"
+source_url: "https://yourbestcreditcards.com/current-transfer-bonuses/amex-hilton-honors-ends-may-30-2026/"
+date: "2026-04-29"
+body: |
+  American Express is running a **20% transfer bonus** on Membership Rewards (MR) points transferred to Hilton Honors, valid through **May 30, 2026**. This means cardholders can convert **1,000 MR points into 2,400 Hilton Honors (HH) points**, providing significantly better value than the standard 1:1 transfer rate.
+  
+  This bonus comes after community discussions about the relative scarcity of Amex transfer bonuses earlier in 2026, making this promotion notable for cardholders looking to maximize redemption value on their MR balances.
+  
+  The bonus applies to any American Express card that earns Membership Rewards points, including premium cards like the Gold and Business Gold, as well as entry-level options. Hilton Honors cardholders can also leverage this promotion to bolster their balances ahead of planned travel.
+  


### PR DESCRIPTION
## Summary
- Auto-generated from r/churning via `scripts/auto-news-from-reddit.js`
- Source swapped from Reddit to verified third-party (Your Best Credit Cards) per first-party preference
- Covers 20% MR → Hilton Honors transfer bonus running through May 30, 2026

## Test plan
- [ ] YAML renders cleanly on `/news/[id]` page
- [ ] `card_slugs` resolve to existing cards (Amex MR earners + Hilton co-brands)
- [ ] Date is today's PR submission date (2026-04-29)
- [ ] No duplicate of existing news items

🤖 Generated with [Claude Code](https://claude.com/claude-code)