### PR TITLE
Add annual Companion Fare benefit to Atmos Rewards Ascent

### DIFF
--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -32,4 +32,10 @@ signup_bonus:
   spend_requirement: 4000
   timeframe_months: 4
   note: "Plus a $99 Companion Fare (plus taxes and fees from $23)"
+benefits:
+  - name: "Companion Fare"
+    value: 0
+    description: "$99 Companion Fare (plus taxes and fees from $23) each account anniversary after spending $6,000 or more in purchases within the prior anniversary year"
+    frequency: "annual"
+    category: "travel"
 apply_link: https://www.bankofamerica.com/credit-cards/products/alaska-airlines-credit-card/


### PR DESCRIPTION
## Summary
- Adds the recurring **$99 Companion Fare** annual benefit (requires \$6,000 spend in the prior anniversary year) to `atmos-rewards-ascent.yaml`
- The welcome-offer instance of the same fare was added as a `signup_bonus.note` in [#446](https://github.com/CreditOdds/creditodds/pull/446); this captures the separate annual benefit per the project rule that recurring anniversary bonuses belong in `benefits`, not as a SUB note

## Source
[BoA Alaska / Atmos Rewards Ascent apply page](https://www.bankofamerica.com/credit-cards/products/alaska-airlines-credit-card/) — "Get a \$99 Companion Fare (plus taxes and fees from \$23) each account anniversary after you spend \$6,000 or more in purchases within the prior anniversary year."

## Test plan
- [x] `npm run build:cards` passes (160 cards built)
- [ ] Verify benefit renders on the card detail page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)