### PR TITLE
Polish landing page mobile layout

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -485,105 +485,6 @@ function HowItWorks() {
   );
 }
 
-function Records() {
-  const rows = [
-    { u: 'JK', user: '@jkolin', d: '2d · CHI', card: 'Sapphire Reserve', score: 762, income: '$120K', status: 'app' as const },
-    { u: 'RP', user: '@raelle_p', d: '3d · NYC', card: 'Amex Platinum', score: 710, income: '$95K', status: 'den' as const },
-    { u: 'DS', user: '@dsirota', d: '5d · SF', card: 'Venture X', score: 741, income: '$84K', status: 'app' as const },
-    { u: 'MN', user: '@m_nair', d: '6d · AUS', card: 'Citi Double Cash', score: 684, income: '$52K', status: 'app' as const },
-    { u: 'TK', user: '@tkang', d: '1w · SEA', card: 'Bilt', score: 722, income: '$110K', status: 'pen' as const },
-    { u: 'AL', user: '@alee', d: '1w · BOS', card: 'Amex Gold', score: 698, income: '$68K', status: 'den' as const },
-  ];
-  const statusLabel = { app: 'Approved', den: 'Denied', pen: 'Pending' };
-  return (
-    <section className="sec wrap" id="records">
-      <div className="split reverse">
-        <div className="visual">
-          <div className="visual-card">
-            <div className="vc-head">
-              <div className="dot-row">
-                <span />
-                <span />
-                <span />
-              </div>
-              <span style={{ marginLeft: 6 }}>records.creditodds.com</span>
-              <span style={{ marginLeft: 'auto' }}>FILTER · FICO 680–760</span>
-            </div>
-            <div className="records-table">
-              {rows.map((r, i) => (
-                <div className="rec" key={i}>
-                  <div className="avatar">{r.u}</div>
-                  <div className="meta-user">
-                    <div className="u">
-                      {r.user} ·{' '}
-                      <span style={{ color: 'var(--muted)', fontWeight: 400 }}>
-                        {r.card}
-                      </span>
-                    </div>
-                    <div className="d">{r.d}</div>
-                  </div>
-                  <div className="rec-details">
-                    <div className="num">
-                      <span className="l">Score</span>
-                      {r.score}
-                    </div>
-                    <div className="num">
-                      <span className="l">Income</span>
-                      {r.income}
-                    </div>
-                    <div className={'status-chip ' + r.status}>{statusLabel[r.status]}</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-        <div>
-          <div className="sec-label">Records</div>
-          <h2 className="sec-title" style={{ marginBottom: 20 }}>
-            Read the <em>room</em> before you read the fine print.
-          </h2>
-          <p className="body-copy">
-            Each record is a real application: FICO, income, credit length, recent
-            inquiries, and whether the issuer said yes. No affiliate spin, no editorial
-            bias. Just what people actually submitted.
-          </p>
-          <div className="feature-grid">
-            {[
-              ['Anonymous', 'Nothing identifying is required or shown.'],
-              ['Verified', 'Records flagged as suspicious are removed.'],
-              ['Open data', 'Every record is queryable, not buried in blog posts.'],
-              ['Freshness', 'Approval criteria change. Filter by recency.'],
-            ].map(([t, d]) => (
-              <div key={t} style={{ borderTop: '1px solid var(--line)', paddingTop: 12 }}>
-                <div
-                  style={{
-                    fontFamily: "'Inter Tight', 'Inter', sans-serif",
-                    fontSize: 18,
-                    letterSpacing: '-0.01em',
-                  }}
-                >
-                  {t}
-                </div>
-                <div
-                  style={{
-                    fontSize: 13,
-                    color: 'var(--muted)',
-                    marginTop: 4,
-                    lineHeight: 1.5,
-                  }}
-                >
-                  {d}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function Referrals({ cards }: { cards: Card[] }) {
   const featured = useMemo(() => {
     const bySlug = (slug: string) => cards.find((c) => c.slug === slug);
@@ -856,7 +757,6 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
       <Hero cards={initialCards} />
       <Ticker cards={initialCards} />
       <HowItWorks />
-      <Records />
       <Referrals cards={initialCards} />
       <Wallet cards={initialCards} />
       <Proof cards={initialCards} />

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -764,7 +764,7 @@
 
 /* ---------- Section generic ---------- */
 .landing-v2 .sec {
-  padding: 96px 0;
+  padding-block: 96px;
   border-top: 1px solid var(--line);
 }
 .landing-v2 .sec-head {
@@ -2067,7 +2067,7 @@
     padding-block: 20px 24px;
   }
   .landing-v2 .sec {
-    padding: 72px 0;
+    padding-block: 72px;
   }
   .landing-v2 .hero-sub,
   .landing-v2 .page-sub,
@@ -2236,7 +2236,7 @@
     font-size: 11.5px;
   }
   .landing-v2 .sec {
-    padding: 60px 0;
+    padding-block: 60px;
   }
   .landing-v2 .sec-head {
     gap: 24px;
@@ -2277,18 +2277,26 @@
     width: fit-content;
   }
   .landing-v2 .ref-row {
-    grid-template-columns: 44px 1fr;
+    grid-template-columns: 44px 1fr 1fr;
+    row-gap: 6px;
+  }
+  .landing-v2 .ref-thumb {
+    grid-row: 1 / 3;
+  }
+  .landing-v2 .ref-meta {
+    grid-column: 2 / 4;
   }
   .landing-v2 .ref-stats,
   .landing-v2 .ref-stats.ref-stats-secondary {
     margin-left: 0;
     text-align: left;
+    grid-row: 2;
   }
   .landing-v2 .ref-stats {
     grid-column: 2;
   }
   .landing-v2 .ref-stats.ref-stats-secondary {
-    grid-column: 2;
+    grid-column: 3;
   }
   .landing-v2 .ref-earnings {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Fix horizontal padding on `.sec` blocks: switch `padding: Xpx 0` shorthand to `padding-block` so the `.wrap` class's `padding-inline` is no longer stomped — text on the "How it works" section (and other `.sec` blocks) was flush to the screen edge on mobile
- Remove the Records section from the landing flow
- On mobile referral rows, stack Clicks and Conv side by side under the card name/code instead of vertically

## Test plan
- [x] Verified at 375px viewport: `.sec` blocks now render with 16px horizontal gutter
- [x] Verified Referrals section: Clicks and Conv on the same grid row (cols 2 and 3) under meta
- [x] Records section no longer renders; page flow is Hero → How it works → Referrals → Wallet → Final CTA
- [ ] Spot-check on real device after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)