### PR TITLE
Add news: Avianca LifeMiles Devaluation — Award Pricing Increases Across Short and Long-Haul Flights

### DIFF
--- a/data/news/2026-04-29-avianca-lifemiles-devaluation-2026.yaml
+++ b/data/news/2026-04-29-avianca-lifemiles-devaluation-2026.yaml
@@ -1,0 +1,26 @@
+id: "avianca-lifemiles-devaluation-2026"
+title: "Avianca LifeMiles Devaluation — Award Pricing Increases Across Short and Long-Haul Flights"
+summary: "Avianca has devalued its LifeMiles currency with increased award pricing for both short-haul and long-haul flights. Short-haul United awards now cost **12,100 miles**, while transatlantic economy awards to Europe increased to **48,000 miles** (from ~40,000), and business class to Europe jumped to **92,000+ miles** (from 55,000–63,000). Dynamic pricing makes it harder to find competitive redemptions."
+tags:
+  - "policy-change"
+bank: "Avianca"
+source: "Upgraded Points"
+source_url: "https://upgradedpoints.com/news/avianca-lifemiles-devaluation-2026/"
+date: "2026-04-29"
+body: |
+  Avianca has implemented another devaluation of its LifeMiles program, with **increased award pricing across both short-haul and long-haul routes**. The changes reflect higher redemption costs and dynamic pricing that makes securing value increasingly difficult.
+  
+  ## Updated Award Pricing
+  
+  Short-haul United flights now require **12,100 miles** in economy. Transatlantic routes have seen more significant increases:
+  
+  - **US to Europe economy**: increased to **48,000 miles** (previously around **40,000**)
+  - **US to Europe business**: now **92,000+ miles** (previously **55,000–63,000**)
+  - **Examples like JFK-Zurich**: business class jumped from **55,000 to 63,000+ miles**
+  
+  ## Impact on Program Value
+  
+  The devaluation compounds existing concerns about LifeMiles' value proposition. While the program historically offered competitive one-world alliance pricing, it came with notably high cancellation fees. As award costs continue to creep upward, redemptions are becoming less attractive for cardholders and miles accumulators.
+  
+  The implementation of **dynamic pricing** makes it harder to consistently find the lowest available award levels, forcing users to book strategically or accept premium pricing for flexibility.
+  


### PR DESCRIPTION
## Summary
- Auto-generated news item from r/churning via `scripts/auto-news-from-reddit.js` (2026-04-29 run)
- 1 survivor after dedupe + verification; 2 candidates dropped (1 duplicate, 1 semantic duplicate of an existing news item)
- Source swapped from r/churning to the verified third-party source (Upgraded Points), per the project rule that prefers reputable third-party over Reddit when no first-party source is available

## Test plan
- [ ] YAML renders correctly on `/news/avianca-lifemiles-devaluation-2026`
- [ ] Article body markdown (headings, bold, lists) renders cleanly
- [ ] Confirm `bank: "Avianca"` filter behavior is acceptable (Avianca is an airline, not a card issuer — listing page may need a card_slugs link if we want it tied to specific transfer-partner cards)
- [ ] Verify news appears on `/news` index in correct date order

🤖 Generated with [Claude Code](https://claude.com/claude-code)