### PR TITLE
Remove eyebrow pills from page heroes

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -285,19 +285,6 @@ function Hero({ cards }: { cards: Card[] }) {
     <section className="hero wrap">
       <div className="hero-grid">
         <div>
-          <div className="eyebrow hero-eyebrow">
-            <span
-              style={{
-                width: 6,
-                height: 6,
-                borderRadius: '50%',
-                background: 'var(--accent)',
-              }}
-            />
-            <span>
-              <b>Community-powered</b> · crowdsourced approval data
-            </span>
-          </div>
           <h1 className="hero-title">
             {HEADLINE.pre}
             <em>{HEADLINE.em}</em>

--- a/apps/web-next/src/app/about/page.tsx
+++ b/apps/web-next/src/app/about/page.tsx
@@ -18,17 +18,6 @@ export default function AboutPage() {
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>About · the story behind the site</span>
-        </div>
         <h1 className="page-title">
           Can I get <em>this card?</em>
         </h1>

--- a/apps/web-next/src/app/articles/author/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/author/[slug]/page.tsx
@@ -82,17 +82,6 @@ export default async function AuthorPage({ params }: Props) {
       />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Articles · by author</span>
-        </div>
         <h1 className="page-title">
           Everything by <em>{author.name}.</em>
         </h1>

--- a/apps/web-next/src/app/articles/category/[tag]/page.tsx
+++ b/apps/web-next/src/app/articles/category/[tag]/page.tsx
@@ -81,17 +81,6 @@ export default async function CategoryPage({ params }: Props) {
       />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Articles · {tagLabel.toLowerCase()}</span>
-        </div>
         <h1 className="page-title">{tagLabel} <em>articles.</em></h1>
         <p className="page-sub">{tagDescription}</p>
       </section>

--- a/apps/web-next/src/app/articles/page.tsx
+++ b/apps/web-next/src/app/articles/page.tsx
@@ -54,17 +54,6 @@ export default async function ArticlesPage() {
       />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Articles · guides &amp; strategies</span>
-        </div>
         <h1 className="page-title">
           Deeper reads, <em>same data discipline.</em>
         </h1>

--- a/apps/web-next/src/app/bank/[name]/page.tsx
+++ b/apps/web-next/src/app/bank/[name]/page.tsx
@@ -66,17 +66,6 @@ export default async function BankPage({ params }: BankPageProps) {
       />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Issuer · {cards.length} card{cards.length === 1 ? '' : 's'}</span>
-        </div>
         <h1 className="page-title">
           {bankName}
           <em>.</em>

--- a/apps/web-next/src/app/best/BestV2Client.tsx
+++ b/apps/web-next/src/app/best/BestV2Client.tsx
@@ -55,17 +55,6 @@ export default function BestV2Client({
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Best cards · ranked by data</span>
-        </div>
         <h1 className="page-title">
           The best cards, ranked by <em>the data.</em>
         </h1>

--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -95,17 +95,6 @@ export default async function BestDetailPage({ params }: Props) {
       />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Best cards · ranked by data</span>
-        </div>
         <h1 className="page-title">{page.title}</h1>
         <p className="page-sub">{page.description}</p>
         <div

--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -159,17 +159,6 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Card wire · live feed</span>
-        </div>
         <h1 className="page-title">
           The wire. <em>Every change.</em>
         </h1>

--- a/apps/web-next/src/app/check-odds/page.tsx
+++ b/apps/web-next/src/app/check-odds/page.tsx
@@ -26,17 +26,6 @@ export default function CheckOddsPage() {
         ]}
       />
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Check odds · your profile vs. the data</span>
-        </div>
         <h1 className="page-title">
           Check your <em>odds.</em>
         </h1>

--- a/apps/web-next/src/app/compare/page.tsx
+++ b/apps/web-next/src/app/compare/page.tsx
@@ -62,17 +62,6 @@ export default async function ComparePage() {
       />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Compare · side by side</span>
-        </div>
         <h1 className="page-title">
           Compare <em>credit cards.</em>
         </h1>

--- a/apps/web-next/src/app/contact/page.tsx
+++ b/apps/web-next/src/app/contact/page.tsx
@@ -17,17 +17,6 @@ export default function ContactPage() {
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Contact · we&apos;re listening</span>
-        </div>
         <h1 className="page-title">
           Get in <em>touch.</em>
         </h1>

--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -158,17 +158,6 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Explore · {cards.length} cards</span>
-        </div>
         <h1 className="page-title">
           Every card, <em>every outcome.</em>
         </h1>

--- a/apps/web-next/src/app/how/page.tsx
+++ b/apps/web-next/src/app/how/page.tsx
@@ -18,17 +18,6 @@ export default function HowPage() {
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>How it works · the method</span>
-        </div>
         <h1 className="page-title">
           Our approach to <em>credit card odds.</em>
         </h1>

--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -77,17 +77,6 @@ export default function NewsV2Client({ items }: NewsV2ClientProps) {
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Card news · updated daily</span>
-        </div>
         <h1 className="page-title">
           News without the <em>affiliate spin.</em>
         </h1>

--- a/apps/web-next/src/app/not-found.tsx
+++ b/apps/web-next/src/app/not-found.tsx
@@ -6,17 +6,6 @@ export default function NotFound() {
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>404 · not found</span>
-        </div>
         <h1 className="page-title">
           This page doesn&apos;t <em>exist.</em>
         </h1>

--- a/apps/web-next/src/app/privacy/page.tsx
+++ b/apps/web-next/src/app/privacy/page.tsx
@@ -64,17 +64,6 @@ export default function PrivacyPage() {
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Privacy · plain English</span>
-        </div>
         <h1 className="page-title">
           Use of private <em>information policy.</em>
         </h1>

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -362,17 +362,6 @@ export default function ProfileClient() {
       <div className="profile-wrap">
         {/* Profile page hero */}
         <section className="profile-hero">
-          <div className="eyebrow">
-            <span
-              style={{
-                width: 6,
-                height: 6,
-                borderRadius: '50%',
-                background: 'var(--accent)',
-              }}
-            />
-            <span>Your profile · signed in</span>
-          </div>
           <h1 className="profile-greeting">
             Welcome back, <em>{displayName}.</em>
           </h1>

--- a/apps/web-next/src/app/terms/page.tsx
+++ b/apps/web-next/src/app/terms/page.tsx
@@ -11,17 +11,6 @@ export default function TermsPage() {
   return (
     <div className="landing-v2">
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: "50%",
-              background: "var(--accent)",
-            }}
-          />
-          <span>Terms · the legal bit</span>
-        </div>
         <h1 className="page-title">
           Terms of <em>use.</em>
         </h1>

--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
@@ -37,17 +37,6 @@ export default async function AmexMRToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Amex Membership Rewards to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function BiltToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Bilt Rewards Points to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function CapitalOneMilesToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Capital One Miles to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
@@ -35,17 +35,6 @@ export default async function ChaseURToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Chase Ultimate Rewards to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function CitiThankYouToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Citi ThankYou Points to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function DeltaSkyMilesToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Delta SkyMiles to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function HiltonHonorsToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Hilton Honors Points to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function IHGToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           IHG One Rewards Points to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
@@ -35,17 +35,6 @@ export default async function MarriottBonvoyToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Marriott Bonvoy Points to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/page.tsx
+++ b/apps/web-next/src/app/tools/page.tsx
@@ -89,17 +89,6 @@ export default function ToolsPage() {
       />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · {totalTools} calculators</span>
-        </div>
         <h1 className="page-title">
           Free calculators. <em>Real math.</em>
         </h1>

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function SouthwestRRToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           Southwest Rapid Rewards to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function UnitedMilesToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           United Miles to USD Converter.
         </h1>

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
@@ -34,17 +34,6 @@ export default async function HyattToUsdPage() {
       ]} />
 
       <section className="page-hero wrap">
-        <div className="eyebrow">
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-            }}
-          />
-          <span>Tools · converter</span>
-        </div>
         <h1 className="page-title">
           World of Hyatt Points to USD Converter.
         </h1>


### PR DESCRIPTION
## Summary
- Drop the small "·"-style pill ("Community-powered · crowdsourced approval data", "Explore · 160 cards", etc.) from above page titles
- Applied to landing hero, all page heroes, profile, and not-found (32 files)

## Test plan
- [x] Landing — pill above "See your real odds" is gone
- [x] Explore — pill above "Every card, every outcome." is gone
- [x] News — pill above "News without the affiliate spin." is gone
- [x] About — pill above "Can I get this card?" is gone
- [ ] Spot-check tools/, articles/, bank/, best/, compare/, check-odds/, profile/ in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)