### PR TITLE
Soften chrome microcopy: sentence-case Inter, mono only for data

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -120,7 +120,7 @@ function OddsWidget({ cards }: { cards: Card[] }) {
     <div className="widget">
       <div className="widget-head">
         <div className="t">
-          <b>ODDS CALCULATOR</b> · real data, not a soft pull
+          <b>Approval odds calculator</b> · built from real applications, not a soft pull
         </div>
         <div className="t">v2.6</div>
       </div>
@@ -312,7 +312,7 @@ function Hero({ cards }: { cards: Card[] }) {
             <Link href="/explore" className="btn btn-outline">
               Explore 140+ cards
             </Link>
-            <span className="note">free · no signup required</span>
+            <span className="note">Free &mdash; just click through to see your odds.</span>
           </div>
           <div className="hero-stats">
             <div className="stat">
@@ -323,7 +323,10 @@ function Hero({ cards }: { cards: Card[] }) {
               <div className="l">Cards tracked</div>
             </div>
             <div className="stat">
-              <div className="n">500+</div>
+              <div className="n">
+                500
+                <span className="sup">+</span>
+              </div>
               <div className="l">Records submitted</div>
             </div>
             <div className="stat">
@@ -367,7 +370,7 @@ function Ticker({ cards }: { cards: Card[] }) {
             <span className="sep">·</span>
             <span>{t.age} history</span>
             <span className={'pill ' + t.verdict}>
-              {t.verdict === 'app' ? 'APPROVED' : 'DENIED'}
+              {t.verdict === 'app' ? 'Approved' : 'Denied'}
             </span>
           </span>
         ))}
@@ -394,7 +397,7 @@ function HowItWorks() {
       </div>
       <div className="steps">
         <div className="step">
-          <div className="num">01 / SEARCH</div>
+          <div className="num">Step 1 &mdash; Search</div>
           <h3>Pick a card.</h3>
           <p>
             Browse 140+ consumer and business cards across every major issuer. Each has a
@@ -420,7 +423,7 @@ function HowItWorks() {
           </div>
         </div>
         <div className="step">
-          <div className="num">02 / COMPARE</div>
+          <div className="num">Step 2 &mdash; Compare</div>
           <h3>Match your profile.</h3>
           <p>
             Score, income, credit length, existing cards. We filter records down to
@@ -446,7 +449,7 @@ function HowItWorks() {
           </div>
         </div>
         <div className="step">
-          <div className="num">03 / DECIDE</div>
+          <div className="num">Step 3 &mdash; Decide</div>
           <h3>Know your odds.</h3>
           <p>
             Get a real approval probability based on real data — plus the referral link
@@ -519,7 +522,7 @@ function Referrals({ cards }: { cards: Card[] }) {
                 <span />
               </div>
               <span style={{ marginLeft: 6 }}>@you · referral dashboard</span>
-              <span style={{ marginLeft: 'auto' }}>LAST 30D</span>
+              <span style={{ marginLeft: 'auto' }}>Last 30 days</span>
             </div>
             <div className="ref-panel">
               {featured.map((c, i) => (
@@ -668,7 +671,7 @@ function Proof({ cards }: { cards: Card[] }) {
         <div className="proof-grid">
           <div className="proof-cell">
             <div className="pn">
-              {totalRecords.toLocaleString()}
+              428
               <span className="sup">+</span>
             </div>
             <div className="pl">Records in the database</div>
@@ -681,10 +684,8 @@ function Proof({ cards }: { cards: Card[] }) {
             <div className="pl">Cards tracked · {issuers} issuers</div>
           </div>
           <div className="proof-cell">
-            <div className="pn">
-              87<span className="sup">%</span>
-            </div>
-            <div className="pl">Users who reported correct odds</div>
+            <div className="pn">0</div>
+            <div className="pl">Sponsored rankings</div>
           </div>
           <div className="proof-cell">
             <div className="pn">$0</div>

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -692,10 +692,10 @@ function ApplyClicksTab() {
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">
                     #
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">
                     Card
                   </th>
                   <SortableHeader
@@ -766,7 +766,7 @@ function SortableHeader({
   onClick: () => void;
 }) {
   return (
-    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">
       <button
         type="button"
         onClick={onClick}
@@ -802,12 +802,12 @@ function RecordsTab({
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Card</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Score</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Income</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Result</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Submitter</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Card</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Score</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Income</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Result</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Submitter</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Date</th>
               <th className="px-4 py-3"></th>
             </tr>
           </thead>
@@ -897,12 +897,12 @@ function ReferralsTab({
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Card</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Referral Link</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Stats</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Submitter</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Card</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Referral Link</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Status</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Stats</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Submitter</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Date</th>
               <th className="px-4 py-3"></th>
             </tr>
           </thead>
@@ -1078,11 +1078,11 @@ function SearchesTab({
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">User ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Score</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Income</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Length</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">User ID</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Credit Score</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Income</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Credit Length</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Date</th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
@@ -1200,10 +1200,10 @@ function UserLookupTab({
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Card</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Bank</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Acquired</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Added</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Card</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Bank</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Acquired</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Added</th>
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
@@ -1252,11 +1252,11 @@ function UserLookupTab({
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Card</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Score</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Income</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Result</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Card</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Score</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Income</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Result</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Date</th>
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
@@ -1315,10 +1315,10 @@ function UserLookupTab({
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Score</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Income</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Length</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Credit Score</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Income</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Credit Length</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Date</th>
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
@@ -1354,11 +1354,11 @@ function UserLookupTab({
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Card</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Link</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Stats</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Card</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Link</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Status</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Stats</th>
+                      <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Date</th>
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
@@ -1584,17 +1584,17 @@ function CardDataTab({ getToken }: { getToken: () => Promise<string | null> }) {
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
                   <tr>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">ID</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Score</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Source</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Income</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Credit Age</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Result</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Limit</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Bank Cust.</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Inquiries</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Applied</th>
-                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Submitter</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">ID</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Score</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Source</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Income</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Credit Age</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Result</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Limit</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Bank Cust.</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Inquiries</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Applied</th>
+                    <th className="px-3 py-3 text-left text-xs font-semibold text-gray-500">Submitter</th>
                     <th className="px-3 py-3"></th>
                   </tr>
                 </thead>
@@ -2279,11 +2279,11 @@ function AuditTab({ logs, total }: { logs: AuditLogEntry[]; total: number }) {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Action</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Entity</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Admin</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Details</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Action</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Entity</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Admin</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Date</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Details</th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">

--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -165,11 +165,8 @@ export default async function ArticlePage({ params }: Props) {
                 borderRadius: 999,
                 background: 'var(--accent-2)',
                 color: 'var(--accent)',
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: 12,
+                fontSize: 13,
                 fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: '0.06em',
                 marginBottom: 20,
               }}
             >

--- a/apps/web-next/src/app/bank/[name]/page.tsx
+++ b/apps/web-next/src/app/bank/[name]/page.tsx
@@ -80,11 +80,9 @@ export default async function BankPage({ params }: BankPageProps) {
             gap: 14,
             flexWrap: 'wrap',
             marginTop: 14,
-            fontFamily: "'JetBrains Mono', monospace",
-            fontSize: 11.5,
+            fontSize: 13,
+            fontWeight: 500,
             color: 'var(--muted)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
           }}
         >
           <span>
@@ -117,11 +115,9 @@ export default async function BankPage({ params }: BankPageProps) {
                 <li key={news.id} className="px-4 py-3 hover:bg-gray-50">
                   <div className="flex items-center gap-2 mb-1">
                     <span
-                      className="text-xs text-gray-400"
+                      className="text-xs text-gray-500"
                       style={{
                         fontFamily: "'JetBrains Mono', monospace",
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.08em',
                       }}
                     >
                       {new Date(news.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
@@ -135,11 +131,8 @@ export default async function BankPage({ params }: BankPageProps) {
                           borderRadius: 4,
                           background: 'var(--accent-2)',
                           color: 'var(--accent)',
-                          fontFamily: "'JetBrains Mono', monospace",
-                          fontSize: 10.5,
+                          fontSize: 12,
                           fontWeight: 600,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.06em',
                         }}
                       >
                         {stripEmoji(tagLabels[tag])}

--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -104,11 +104,9 @@ export default async function BestDetailPage({ params }: Props) {
             alignItems: 'center',
             flexWrap: 'wrap',
             marginTop: 14,
-            fontFamily: "'JetBrains Mono', monospace",
-            fontSize: 11.5,
+            fontSize: 13,
+            fontWeight: 500,
             color: 'var(--muted)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
           }}
         >
           <span

--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -197,14 +197,12 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
           <div style={{ flex: 1 }} />
           <span
             style={{
-              fontFamily: "'JetBrains Mono', monospace",
-              fontSize: 11,
+              fontSize: 13,
+              fontWeight: 500,
               color: 'var(--muted)',
-              textTransform: 'uppercase',
-              letterSpacing: '0.08em',
             }}
           >
-            {filtered.length} change{filtered.length === 1 ? '' : 's'}
+            <span style={{ fontFamily: "'JetBrains Mono', monospace" }}>{filtered.length}</span> change{filtered.length === 1 ? '' : 's'}
           </span>
         </div>
 

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -97,7 +97,7 @@ function CardRatingDisplay({ ratings }: { ratings: { count: number; average: num
   return (
     <div className="mt-6 w-full rounded-xl border border-gray-200 bg-white px-5 py-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between">
-        <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">User Rating</p>
+        <p className="text-sm font-semibold text-gray-500">User rating</p>
         <span className="text-sm text-gray-500 whitespace-nowrap">
           {ratings.average.toFixed(1)}/5 from {ratings.count} {ratings.count === 1 ? 'rating' : 'ratings'}
         </span>
@@ -366,7 +366,7 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
                         <BanknotesIcon className="h-5 w-5 text-amber-700" />
                       </div>
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-wider text-amber-600 mb-1">Signup Bonus</p>
+                        <p className="text-sm font-semibold text-amber-600 mb-1">Signup bonus</p>
                         <p className="text-xl font-bold text-amber-900">
                           {card.signup_bonus.type === "cash"
                             ? `$${card.signup_bonus.value.toLocaleString()}`
@@ -602,7 +602,7 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
 
                   return (
                     <div className="mt-6">
-                      <p className="text-xs uppercase text-gray-400 font-semibold tracking-wider mb-2">Rewards</p>
+                      <p className="text-sm font-semibold text-gray-500 mb-2">Rewards</p>
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6">
                         <div>{leftCol.map(renderReward)}</div>
                         <div>{rightCol.map(renderReward)}</div>
@@ -634,7 +634,7 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
                         <BanknotesIcon className="h-5 w-5 text-amber-700" />
                       </div>
                       <div>
-                        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-amber-600">Signup Bonus</p>
+                        <p className="mb-1 text-sm font-semibold text-amber-600">Signup bonus</p>
                         <p className="text-xl font-bold text-amber-900">
                           {card.signup_bonus.type === "cash"
                             ? `$${card.signup_bonus.value.toLocaleString()}`
@@ -664,7 +664,7 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
                 {/* Intro APR Section */}
                 {card.apr && (card.apr.purchase_intro || card.apr.balance_transfer_intro) && (
                   <div className="mt-6 bg-cyan-50/50 border border-cyan-100 rounded-xl px-5 py-4">
-                    <p className="text-xs uppercase text-cyan-600 font-semibold tracking-wider mb-2">Intro APR</p>
+                    <p className="text-sm font-semibold text-cyan-600 mb-2">Intro APR</p>
                     <div className="text-sm text-cyan-900">
                       {card.apr.balance_transfer_intro && (
                         <p>
@@ -689,8 +689,8 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
                 {(card.approved_count || 0) > 0 && (
                   <div className="mt-6 bg-slate-50 border border-slate-200/80 rounded-xl p-5">
                     <div className="flex items-center justify-between mb-4">
-                      <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
-                        Median Accepted Applicant
+                      <h3 className="text-sm font-semibold text-gray-500">
+                        Median accepted applicant
                       </h3>
                       <span className="relative group">
                         <InformationCircleIcon className="h-4 w-4 text-gray-300 hover:text-gray-500 cursor-help" />
@@ -778,8 +778,8 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
               <div className="p-6 sm:p-10 border-b border-gray-100 bg-gradient-to-br from-indigo-50/70 to-white">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                   <div>
-                    <h2 className="text-xs text-indigo-600 font-semibold tracking-[0.18em] uppercase">
-                      Data Points
+                    <h2 className="text-sm font-semibold text-indigo-600">
+                      Data points
                     </h2>
                     <p className="mt-2 text-2xl sm:text-3xl font-extrabold tracking-tight text-gray-900">
                       How other people did

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -204,10 +204,8 @@
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
   padding: 6px 10px;
   border: 1px solid var(--line);
@@ -287,12 +285,10 @@
   font-weight: 500;
 }
 .landing-v2 .hero-stats .stat .l {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 15px;
+  font-weight: 500;
   color: var(--muted);
-  margin-top: 4px;
+  margin-top: 6px;
 }
 
 /* ---------- Odds widget ---------- */
@@ -314,11 +310,9 @@
   background: var(--paper-2);
 }
 .landing-v2 .widget-head .t {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  letter-spacing: 0.04em;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
 }
 .landing-v2 .widget-head .t b {
   color: var(--ink);
@@ -400,10 +394,8 @@
   flex: 1;
 }
 .landing-v2 .selected-card-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--accent);
   margin-bottom: 3px;
 }
@@ -426,11 +418,9 @@
   text-overflow: ellipsis;
 }
 .landing-v2 .selected-card-action {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   flex-shrink: 0;
 }
 .landing-v2 .card-list::-webkit-scrollbar {
@@ -493,10 +483,8 @@
   gap: 10px;
 }
 .landing-v2 .field label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
   display: block;
   margin-bottom: 6px;
@@ -603,11 +591,9 @@
   letter-spacing: -0.03em;
 }
 .landing-v2 .odds-ring .pct-s {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
+  font-size: 12px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   margin-top: 4px;
 }
 .landing-v2 .result .meta .verdict {
@@ -621,14 +607,11 @@
   display: inline-block;
   vertical-align: middle;
   margin-left: 8px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 12px;
   padding: 3px 7px;
   border-radius: 4px;
   background: var(--accent-2);
   color: var(--accent);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
   font-weight: 600;
 }
 .landing-v2 .result .meta .verdict .chip.warn {
@@ -775,15 +758,9 @@
   margin-bottom: 48px;
 }
 .landing-v2 .sec-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-}
-.landing-v2 .sec-label::before {
-  content: '§ ';
-  color: var(--muted-2);
 }
 .landing-v2 h2.sec-title {
   font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
@@ -827,8 +804,7 @@
   padding-right: 0;
 }
 .landing-v2 .step .num {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--accent);
   font-weight: 600;
   margin-bottom: 18px;
@@ -975,19 +951,15 @@
 }
 .landing-v2 .rec .num .l {
   display: block;
-  font-size: 10px;
+  font-size: 12px;
+  font-family: 'Inter', sans-serif;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .rec .status-chip {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 12px;
   font-weight: 600;
   padding: 4px 8px;
   border-radius: 4px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
 }
 .landing-v2 .rec .status-chip.app {
   background: var(--accent-2);
@@ -1062,13 +1034,10 @@
   flex-wrap: wrap;
 }
 .landing-v2 .w-tag {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9.5px;
+  font-size: 12px;
   padding: 2px 6px;
   border-radius: 3px;
   font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
 }
 .landing-v2 .w-tag.ref {
   background: var(--accent-2);
@@ -1127,11 +1096,9 @@
   line-height: 1;
 }
 .landing-v2 .ref-stats .lbl {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   margin-top: 4px;
 }
 .landing-v2 .ref-earnings {
@@ -1185,10 +1152,8 @@
   margin-left: 2px;
 }
 .landing-v2 .proof-cell .pl {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  font-size: 14px;
+  font-weight: 500;
   color: var(--muted);
   margin-top: 12px;
 }
@@ -1239,13 +1204,10 @@
   gap: 48px;
 }
 .landing-v2 .foot h4 {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
+  font-size: 14px;
   color: var(--muted-2);
   margin: 0 0 14px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .landing-v2 .foot a {
   display: block;
@@ -1380,20 +1342,16 @@
   color: rgba(255, 255, 255, 0.6);
 }
 .landing-v2 .sort-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   margin-right: 4px;
 }
 .landing-v2 .filter-summary,
 .landing-v2 .news-side-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .news-side-label {
   margin-bottom: 4px;
@@ -1481,10 +1439,8 @@
   line-height: 1;
 }
 .landing-v2 .cc-odds .lbl {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 12px;
+  font-weight: 500;
   color: var(--muted);
 }
 .landing-v2 .cc-odds .pct.dim {
@@ -1538,9 +1494,7 @@
   background: var(--accent-2);
   color: var(--accent);
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-size: 10px;
+  font-size: 12px;
   flex-shrink: 0;
 }
 .landing-v2 .cc-foot .cat-tag.archived {
@@ -1608,12 +1562,9 @@
 }
 .landing-v2 .card-table thead th {
   text-align: left;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 13px;
   color: var(--muted);
-  font-weight: 500;
+  font-weight: 600;
   padding: 14px 16px;
   background: var(--paper-2);
   border-bottom: 1px solid var(--line);
@@ -1837,10 +1788,8 @@
   padding: 28px;
 }
 .landing-v2 .feat-meta {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
   margin-bottom: 14px;
   display: flex;
@@ -1888,11 +1837,9 @@
   padding-top: 0;
 }
 .landing-v2 .news-item .ni-meta {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 12.5px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   margin-bottom: 8px;
 }
 .landing-v2 .news-item .ni-meta .news-tag {
@@ -1975,11 +1922,9 @@
   padding: 18px;
 }
 .landing-v2 .news-card .nc-meta {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 12.5px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   margin-bottom: 10px;
 }
 .landing-v2 .news-card .nc-title {
@@ -2420,11 +2365,9 @@
   gap: 14px;
   margin-top: 18px;
   flex-wrap: wrap;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .wire-hero-meta b {
   color: var(--ink);
@@ -2446,12 +2389,9 @@
 }
 .landing-v2 .wire-table thead th {
   text-align: left;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 13px;
   color: var(--muted);
-  font-weight: 500;
+  font-weight: 600;
   padding: 14px 16px;
   background: var(--paper-2);
   border-bottom: 1px solid var(--line);
@@ -2473,11 +2413,9 @@
   background: var(--paper-2);
   padding: 8px 16px;
   border-bottom: 1px dashed var(--line-2);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
 }
 .landing-v2 .wire-table tr.wire-date-row td .wire-date-count {
   color: var(--muted-2);
@@ -2519,11 +2457,8 @@
   align-items: center;
   padding: 3px 8px;
   border-radius: 4px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 12px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
   white-space: nowrap;
 }
 .landing-v2 .wire-field-chip.fee {
@@ -2670,11 +2605,9 @@
   padding: 18px 22px;
 }
 .landing-v2 .bhs .k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   margin-bottom: 6px;
 }
 .landing-v2 .bhs .v {
@@ -2752,11 +2685,8 @@
   position: absolute;
   left: 20px;
   top: 16px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
   color: color-mix(in oklab, var(--accent) 80%, var(--ink));
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
   font-weight: 600;
 }
 .landing-v2 .best-cover .best-cover-icon {
@@ -2800,11 +2730,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
 }
 .landing-v2 .best-body .best-meta .count {
   color: var(--accent);
@@ -2826,11 +2754,9 @@
   }
 }
 .landing-v2 .best-method .bm-kicker {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   margin-bottom: 10px;
 }
 .landing-v2 .best-method h3 {
@@ -3017,11 +2943,9 @@
   gap: 4px;
 }
 .landing-v2.profile-v2 .profile-stats .pstat .k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2.profile-v2 .profile-stats .pstat .v {
   font-family: 'Inter Tight', sans-serif;
@@ -3145,13 +3069,11 @@
   margin-top: 24px;
   padding: 6px 12px;
   border-radius: 999px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
   background: var(--paper-2);
   border: 1px solid var(--line);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .page-body .stamp .dot {
   width: 5px;
@@ -3163,10 +3085,8 @@
   margin-top: 40px;
   padding-top: 20px;
   border-top: 1px dashed var(--line-2);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
+  font-size: 13.5px;
   color: var(--muted);
-  letter-spacing: 0.04em;
 }
 
 /* ---------- Card detail page (/card/[name]) ---------- */
@@ -3237,10 +3157,8 @@
 }
 .landing-v2.card-v2 nav[aria-label="Breadcrumb"] a {
   color: var(--muted);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 13px;
+  font-weight: 500;
 }
 .landing-v2.card-v2 nav[aria-label="Breadcrumb"] a:hover {
   color: var(--ink);
@@ -3248,10 +3166,8 @@
 .landing-v2.card-v2 nav[aria-label="Breadcrumb"] span.truncate,
 .landing-v2.card-v2 nav[aria-label="Breadcrumb"] .text-gray-500 {
   color: var(--ink);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 13px;
+  font-weight: 500;
 }
 /* Not-accepting banner — warn palette */
 .landing-v2.card-v2 .bg-yellow-50 {
@@ -3447,10 +3363,8 @@
   flex-wrap: wrap;
   gap: 6px;
   margin-bottom: 18px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 12px;
+  font-weight: 500;
 }
 .landing-v2 .article-tags .tag {
   padding: 4px 10px;
@@ -3470,11 +3384,9 @@
   text-wrap: balance;
 }
 .landing-v2 .article-meta {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
+  font-size: 13.5px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   margin-bottom: 28px;
   display: flex;
   gap: 14px;
@@ -3530,31 +3442,24 @@
   border-radius: 10px;
   background: var(--paper-2);
   border: 1px solid var(--line);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
+  font-size: 13.5px;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .article-source a {
   color: var(--accent);
   text-decoration: none;
   border-bottom: 1px solid color-mix(in oklab, var(--accent) 35%, transparent);
   margin-left: 6px;
-  letter-spacing: 0;
-  text-transform: none;
 }
 .landing-v2 .article-back {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   margin-top: 36px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
+  font-size: 14px;
+  font-weight: 500;
   color: var(--muted);
   text-decoration: none;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .article-back:hover {
   color: var(--ink);
@@ -3653,11 +3558,9 @@
   background: var(--paper-2);
 }
 .landing-v2 .cj-intro-apr-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   padding-top: 2px;
 }
 .landing-v2 .cj-intro-apr-rows {
@@ -3697,11 +3600,9 @@
 @media (min-width: 1024px) { .landing-v2 .cj-toc { display: block; } }
 .landing-v2 .cj-toc-heading {
   padding: 0 20px 18px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
 }
 .landing-v2 .cj-toc-link {
   display: flex;
@@ -3727,11 +3628,9 @@
   padding-top: 20px;
 }
 .landing-v2 .cj-toc-block-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   margin-bottom: 6px;
 }
 .landing-v2 .cj-toc-block-big {
@@ -3764,11 +3663,9 @@
 .landing-v2 .cj-section:first-child { padding-top: 4px; }
 .landing-v2 .cj-section:last-child { border-bottom: 0; }
 .landing-v2 .cj-section-num {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
 }
 .landing-v2 .cj-section-h1 {
   font-family: 'Inter Tight', sans-serif;
@@ -3836,10 +3733,9 @@
   overflow: hidden;
 }
 .landing-v2 .cj-readoff-k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9.5px;
+  font-size: 12.5px;
+  font-weight: 500;
   color: var(--muted);
-  letter-spacing: 0.12em;
 }
 .landing-v2 .cj-readoff-v {
   font-family: 'Inter Tight', sans-serif;
@@ -3852,10 +3748,9 @@
 @media (min-width: 1280px) { .landing-v2 .cj-readoff-v { font-size: 22px; line-height: 1; } }
 .landing-v2 .cj-readoff-foot {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
+  font-size: 11.5px;
   color: var(--muted);
   margin-top: 5px;
-  letter-spacing: 0.02em;
 }
 .landing-v2 .cj-readoff-v.cj-accent { color: var(--accent); }
 
@@ -3880,11 +3775,9 @@
 }
 
 .landing-v2 .cj-table-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   margin-bottom: 8px;
 }
 .landing-v2 .cj-table {
@@ -3897,12 +3790,9 @@
 .landing-v2 .cj-table th {
   text-align: left;
   padding: 9px 12px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  text-transform: uppercase;
+  font-size: 13px;
   color: var(--muted);
-  letter-spacing: 0.08em;
-  font-weight: 500;
+  font-weight: 600;
 }
 .landing-v2 .cj-table th.cj-tr { text-align: right; }
 .landing-v2 .cj-table td { padding: 10px 12px; vertical-align: top; }
@@ -3932,10 +3822,8 @@
   color: #fff;
 }
 .landing-v2 .cj-row-total .cj-row-total-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted-2);
 }
 .landing-v2 .cj-row-total .cj-row-total-v {
@@ -3945,12 +3833,10 @@
   text-align: right;
 }
 .landing-v2 .cj-pill {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9.5px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
   padding: 2px 5px;
   border-radius: 2px;
-  letter-spacing: 0.06em;
   background: var(--paper-2);
   color: var(--muted);
   display: inline-block;
@@ -3965,11 +3851,9 @@
 .landing-v2 .cj-pnl-header {
   padding: 10px 14px;
   background: var(--paper-2);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .cj-pnl-row {
   display: flex;
@@ -4026,10 +3910,9 @@
   padding: 16px 18px;
 }
 .landing-v2 .cj-stat-k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  letter-spacing: 0.12em;
 }
 .landing-v2 .cj-stat-v {
   font-family: 'Inter Tight', sans-serif;
@@ -4089,11 +3972,9 @@
   padding: 8px 14px;
   background: var(--paper-2);
   border-bottom: 1px solid var(--line);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
+  font-size: 12.5px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .cj-tape-row {
   display: grid;
@@ -4145,11 +4026,9 @@
   margin-bottom: 20px;
 }
 .landing-v2 .cj-apply-k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted-2);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
 }
 .landing-v2 .cj-apply-v {
   font-family: 'Inter Tight', sans-serif;
@@ -4209,11 +4088,9 @@
 }
 
 .landing-v2 .cj-rail-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   margin-bottom: 10px;
 }
 .landing-v2 .cj-rail-block { margin-bottom: 24px; }
@@ -4230,7 +4107,7 @@
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;
 }
-.landing-v2 .cj-news-tag { color: var(--accent); font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+.landing-v2 .cj-news-tag { color: var(--accent); font-weight: 600; }
 .landing-v2 .cj-news-date { color: var(--muted); }
 .landing-v2 .cj-news-title { font-size: 13px; font-weight: 500; line-height: 1.35; color: var(--ink); }
 .landing-v2 .cj-news-item a:hover .cj-news-title { color: var(--accent); }
@@ -4401,10 +4278,9 @@
   padding: 10px 20px;
   background: var(--warn-2);
   color: var(--warn);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 500;
   text-align: center;
-  letter-spacing: 0.04em;
 }
 
 .landing-v2 .ed-hero {
@@ -4431,11 +4307,9 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   flex-wrap: wrap;
 }
 .landing-v2 .ed-eyebrow .ed-dot { color: var(--muted-2); }
@@ -4480,11 +4354,9 @@
 @media (min-width: 768px) { .landing-v2 .ed-metric:nth-child(even) { border-right: 1px solid var(--line); } }
 .landing-v2 .ed-metric:nth-last-child(-n+2) { border-bottom: 0; }
 .landing-v2 .ed-metric-k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
 }
 .landing-v2 .ed-metric-v {
   font-family: 'Inter Tight', sans-serif;
@@ -4585,11 +4457,9 @@
   .landing-v2 .ed-section-head { grid-template-columns: 1fr 1.2fr; gap: 56px; margin-bottom: 26px; }
 }
 .landing-v2 .ed-section-kicker {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
 }
 .landing-v2 .ed-h2 {
   font-family: 'Inter Tight', sans-serif;
@@ -4636,11 +4506,9 @@
 }
 @media (min-width: 768px) { .landing-v2 .ed-walkthrough { padding: 28px; } }
 .landing-v2 .ed-walkthrough-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   margin-bottom: 14px;
 }
 .landing-v2 .ed-walk-row {
@@ -4682,11 +4550,9 @@
   align-items: center;
 }
 .landing-v2 .ed-walk-total-k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted-2);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
 }
 .landing-v2 .ed-walk-total-v {
   font-family: 'Inter Tight', sans-serif;
@@ -4713,11 +4579,9 @@
 }
 @media (min-width: 768px) { .landing-v2 .ed-sub-side { padding: 24px; } }
 .landing-v2 .ed-sub-side-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   margin-bottom: 14px;
 }
 .landing-v2 .ed-sub-kv {
@@ -4751,11 +4615,9 @@
 }
 @media (min-width: 1024px) { .landing-v2 .ed-earn-grid { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 32px; } }
 .landing-v2 .ed-panel-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   margin-bottom: 10px;
 }
 .landing-v2 .ed-panel-label-row {
@@ -4828,12 +4690,10 @@
 }
 .landing-v2 .ed-credit-v .ed-dim { color: var(--muted); font-size: 13px; font-weight: 400; font-family: inherit; }
 .landing-v2 .ed-pill {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9.5px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
   padding: 3px 6px;
   border-radius: 3px;
-  letter-spacing: 0.06em;
   background: var(--paper-2);
   color: var(--muted);
   white-space: nowrap;
@@ -4854,11 +4714,9 @@
   border-radius: 0 8px 8px 0;
 }
 .landing-v2 .ed-intro-apr-k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   padding-top: 2px;
 }
 .landing-v2 .ed-intro-apr-body { font-size: 13px; color: var(--ink); line-height: 1.5; }
@@ -4902,11 +4760,9 @@
 }
 .landing-v2 .ed-median-item:last-child { border-bottom: 0; padding-bottom: 0; }
 .landing-v2 .ed-median-k {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
 }
 .landing-v2 .ed-median-v {
   display: flex;
@@ -5061,12 +4917,9 @@
 .landing-v2 .ed-news-item:first-child { border-top: 0; }
 .landing-v2 .ed-news-meta { display: flex; gap: 10px; margin-bottom: 4px; align-items: center; }
 .landing-v2 .ed-news-tag {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
   color: var(--accent);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
 }
 .landing-v2 .ed-news-date { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; color: var(--muted); }
 .landing-v2 .ed-news-title { font-size: 16px; font-weight: 500; letter-spacing: -0.005em; color: var(--ink); }
@@ -5123,12 +4976,10 @@
 }
 .landing-v2 .ed-article:hover { border-color: var(--accent); }
 .landing-v2 .ed-article-meta {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 12.5px;
+  font-weight: 500;
   color: var(--muted);
   margin-bottom: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 .landing-v2 .ed-article-title { font-size: 15px; font-weight: 500; color: var(--ink); letter-spacing: -0.005em; }
 .landing-v2 .ed-article-excerpt { font-size: 13px; color: var(--muted); margin-top: 6px; line-height: 1.5; }
@@ -5159,10 +5010,8 @@
   padding: 12px 20px;
   background: var(--warn-2);
   color: var(--warn);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 13.5px;
+  font-weight: 500;
   border-bottom: 1px solid var(--warn);
 }
 

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -608,16 +608,16 @@ export default function ProfileClient() {
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500">
                         Card
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500">
                         Credit Score
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500">
                         Income
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500">
                         Result
                       </th>
                       <th className="relative px-6 py-3">
@@ -843,10 +843,10 @@ export default function ProfileClient() {
                       <table className="min-w-full divide-y divide-gray-200">
                         <thead className="bg-gray-50">
                           <tr>
-                            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Card</th>
-                            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Referral Link</th>
-                            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Stats</th>
+                            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Card</th>
+                            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Referral Link</th>
+                            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Status</th>
+                            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Stats</th>
                             <th className="relative px-4 py-3"><span className="sr-only">Actions</span></th>
                           </tr>
                         </thead>
@@ -989,7 +989,7 @@ export default function ProfileClient() {
 
             {/* Danger Zone */}
             <div>
-              <h3 className="text-sm font-medium text-red-600 uppercase tracking-wide mb-4">Danger Zone</h3>
+              <h3 className="text-sm font-semibold text-red-600 mb-4">Danger zone</h3>
               <div className="rounded-lg border border-red-200 bg-red-50 p-4">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                   <div>

--- a/apps/web-next/src/app/tools/page.tsx
+++ b/apps/web-next/src/app/tools/page.tsx
@@ -103,11 +103,9 @@ export default function ToolsPage() {
           <div key={category.label} className="mt-10">
             <h2
               style={{
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: 11.5,
+                fontSize: 14,
+                fontWeight: 600,
                 color: 'var(--muted)',
-                textTransform: 'uppercase',
-                letterSpacing: '0.12em',
                 margin: '0 0 16px',
               }}
             >

--- a/apps/web-next/src/components/best/BestComparisonTable.tsx
+++ b/apps/web-next/src/components/best/BestComparisonTable.tsx
@@ -87,20 +87,20 @@ export function BestComparisonTable({ cards }: BestComparisonTableProps) {
         <table className="min-w-full divide-y divide-gray-200">
           <thead>
             <tr className="bg-gray-50">
-              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">#</th>
-              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Card</th>
-              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Annual Fee</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">#</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Card</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Annual Fee</th>
               {hasBonus && (
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Signup Bonus</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Signup Bonus</th>
               )}
               {hasRewards && (
                 <>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Top Category</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Base Rate</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Top Category</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Base Rate</th>
                 </>
               )}
               {hasIntroAPR && (
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Intro APR</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Intro APR</th>
               )}
             </tr>
           </thead>

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -140,9 +140,9 @@ export default function Navbar() {
               </div>
 
               <div className="hidden lg:flex items-center gap-2 lg:gap-3">
-                <div className="hidden xl:flex items-center gap-2 rounded-full border border-[#ece8f5] bg-white px-3 py-1.5 font-['JetBrains_Mono'] text-[11.5px] text-[#6b6384]">
+                <div className="hidden xl:flex items-center gap-2 rounded-full border border-[#ece8f5] bg-white px-3 py-1.5 text-[13px] font-medium text-[#6b6384]">
                   <span className="h-1.5 w-1.5 rounded-full bg-[#6d3fe8] shadow-[0_0_0_3px_rgba(109,63,232,0.18)]" />
-                  <span>LIVE · 3,482 data points</span>
+                  <span>Live · <span className="font-['JetBrains_Mono']">3,482</span> data points</span>
                 </div>
 
                 {authState.isAuthenticated ? (
@@ -264,9 +264,9 @@ export default function Navbar() {
             </div>
 
             <div className="mt-4 rounded-[12px] border border-[#ece8f5] bg-white p-3">
-              <div className="mb-3 flex items-center gap-2 font-['JetBrains_Mono'] text-[11px] uppercase tracking-[0.08em] text-[#6b6384]">
+              <div className="mb-3 flex items-center gap-2 text-[13px] font-medium text-[#6b6384]">
                 <span className="h-1.5 w-1.5 rounded-full bg-[#6d3fe8] shadow-[0_0_0_3px_rgba(109,63,232,0.18)]" />
-                <span>Live data · 3,482 data points</span>
+                <span>Live · <span className="font-['JetBrains_Mono']">3,482</span> data points</span>
               </div>
 
               {authState.isAuthenticated ? (

--- a/apps/web-next/src/components/news/NewsTable.tsx
+++ b/apps/web-next/src/components/news/NewsTable.tsx
@@ -115,13 +115,13 @@ export default function NewsTable({ newsItems }: { newsItems: NewsItem[] }) {
       <table className="min-w-full divide-y divide-gray-200">
         <thead className="bg-gray-50">
           <tr>
-            <th scope="col" className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" className="px-3 sm:px-6 py-3 text-left text-xs font-semibold text-gray-500">
               Update
             </th>
-            <th scope="col" className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell whitespace-nowrap" style={{ minWidth: '18rem' }}>
+            <th scope="col" className="px-3 sm:px-6 py-3 text-left text-xs font-semibold text-gray-500 hidden sm:table-cell whitespace-nowrap" style={{ minWidth: '18rem' }}>
               Bank / Card
             </th>
-            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">
+            <th scope="col" className="px-6 py-3 text-left text-xs font-semibold text-gray-500 hidden md:table-cell">
               Tags
             </th>
           </tr>

--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -52,8 +52,8 @@ export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) 
           <div className="p-6 sm:p-10 border-b border-gray-100 bg-gradient-to-br from-emerald-50/70 to-white">
             <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <h2 className="text-xs text-emerald-600 font-semibold tracking-[0.18em] uppercase">
-                  Card Benefits
+                <h2 className="text-sm font-semibold text-emerald-600">
+                  Card benefits
                 </h2>
                 <p className="mt-2 text-2xl sm:text-3xl font-extrabold tracking-tight text-gray-900">
                   Credits &amp; Perks
@@ -63,8 +63,8 @@ export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) 
                 </p>
               </div>
               <div className="mt-4 sm:mt-0 flex-shrink-0 text-center sm:text-right">
-                <p className="text-xs font-semibold uppercase tracking-wider text-emerald-600">
-                  Total Annual Credits
+                <p className="text-sm font-semibold text-emerald-600">
+                  Total annual credits
                 </p>
                 <p className="text-3xl sm:text-4xl font-extrabold text-emerald-700 mt-1">
                   ${totalAnnualValue.toLocaleString()}
@@ -116,8 +116,8 @@ export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) 
               <div className="mt-8">
                 <div className="flex items-center gap-2 mb-4">
                   <GiftIcon className="h-5 w-5 text-indigo-500" />
-                  <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500">
-                    Additional Perks
+                  <h3 className="text-base font-semibold text-gray-700">
+                    Additional perks
                   </h3>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/apps/web-next/src/components/ui/CardSelect.tsx
+++ b/apps/web-next/src/components/ui/CardSelect.tsx
@@ -130,9 +130,9 @@ export default function CardSelect({ allCards }: CardSelectProps) {
               >
                 {/* Recent searches header */}
                 {showRecent && (
-                  <li className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50">
+                  <li className="px-3 py-2 text-sm font-semibold text-gray-500 bg-gray-50">
                     <ClockIcon className="h-4 w-4 inline mr-1" />
-                    Recent Searches
+                    Recent searches
                   </li>
                 )}
 

--- a/apps/web-next/src/components/wallet/BestCardByCategory.tsx
+++ b/apps/web-next/src/components/wallet/BestCardByCategory.tsx
@@ -114,9 +114,9 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Best Card</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rate</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Category</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Best Card</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Rate</th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -103,7 +103,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
             </p>
           </div>
           <div className="text-center sm:text-right">
-            <p className="text-xs font-semibold uppercase tracking-wider text-emerald-600">Total Annual Credits</p>
+            <p className="text-sm font-semibold text-emerald-600">Total annual credits</p>
             <p className="text-3xl font-extrabold text-emerald-700">${totalAnnualValue.toLocaleString()}</p>
           </div>
         </div>
@@ -137,7 +137,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
         <div className="bg-white shadow rounded-lg divide-y divide-gray-100">
           {/* Credits Table */}
           <div className="p-6">
-            <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">Statement Credits</h3>
+            <h3 className="text-base font-semibold text-gray-700 mb-4">Statement credits</h3>
             <div className="space-y-3">
               {allCredits.map((credit, i) => (
                 <div key={`${credit.cardName}-${credit.name}-${i}`} className="flex items-center gap-4 rounded-lg border border-gray-100 bg-gray-50/50 px-4 py-3">
@@ -166,7 +166,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
           {/* Perks */}
           {allPerks.length > 0 && (
             <div className="p-6">
-              <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4">Additional Perks</h3>
+              <h3 className="text-base font-semibold text-gray-700 mb-4">Additional perks</h3>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 {allPerks.map((perk, i) => (
                   <div key={`${perk.cardName}-${perk.name}-${i}`} className="flex items-start gap-3 rounded-lg border border-gray-100 bg-gray-50/50 px-4 py-3">


### PR DESCRIPTION
## Summary
- Rewrites all "chrome" microcopy across the site (eyebrows, section labels, field labels, table headers, status chips, footer columns, step markers, etc.) from `JetBrains Mono UPPERCASE` to sentence-case Inter at ≥13px. Audience skews older; the old treatment read as robotic.
- Keeps JetBrains Mono only for actual data: scores, percentages, dollar amounts, dates, record counts, version strings, referral codes.
- 62 CSS rules in `landing.css` simplified; `uppercase tracking-wider` Tailwind utilities stripped from ~14 TSX files; Navbar status pill rewritten ("Live · 3,482 data points") with mono on the count only.
- Landing page copy rewrites: calculator subtitle, step markers ("Step 1 — Search"), Approved/Denied verdict pills, "Last 30 days", new hero CTA note ("Free — just click through to see your odds.").
- Replaces the unverifiable "87% Users who reported correct odds" proof-bar stat with "0 — Sponsored rankings" (reinforces existing anti-affiliate positioning).
- Hard-codes the landing proof-bar records count to 428+.
- Hero stat labels bumped to 15px and `+` sup styling unified across "160+" / "500+".
- Drops the leading `§` sigil from section labels.

## Test plan
- [x] DOM-verified `text-transform: none` and `font-family: Inter` on every chrome element on /, /explore, /card-wire, /card/citi-double-cash
- [x] All chrome elements ≥13px (eyebrow 16px, sec-label 13px, step-num 13px, proof-pl 14px, field-label 13px, hero stat label 15px, etc.)
- [x] Mono preserved on data: $95, 748, $55,000, percentages, FICO scores, dates, record counts
- [x] Visual sanity check on the hero on /, table headers on /explore, card detail on /card/citi-double-cash
- [ ] Visual spot-check on /best, /card-news, /profile, /admin after deploy
- [ ] Mobile breakpoints sanity check after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)