### PR TITLE
Fix broken apply link for Amex Blue Business Cash

### DIFF
--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -26,4 +26,4 @@ apr:
 tags:
   - business
   - cashback
-apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/amex-blue-business-cash-credit-card/
+apply_link: https://www.americanexpress.com/en-us/business/credit-cards/blue-business-cash


### PR DESCRIPTION
## Summary
- Update Blue Business Cash apply link to a working Amex URL — the old `/us/credit-cards/business/...` path was broken.

## Test plan
- [ ] Click the apply link on the Blue Business Cash card page after deploy and confirm it lands on the Amex application page.