### PR TITLE
Auto-create apply-link-check label in workflow

### DIFF
--- a/.github/workflows/check-apply-links.yml
+++ b/.github/workflows/check-apply-links.yml
@@ -48,6 +48,11 @@ jobs:
           TOTAL=$(jq -r '.total' "$RESULT_FILE")
           CHECKED_AT=$(jq -r '.checked_at' "$RESULT_FILE")
 
+          # Ensure the label exists (idempotent — ignore if already created)
+          gh label create "apply-link-check" \
+            --description "Tracks broken card apply_link URLs detected by the daily health check" \
+            --color "d73a4a" 2>/dev/null || true
+
           # Find any open issue tagged with our label
           EXISTING_ISSUE=$(gh issue list \
             --state open \


### PR DESCRIPTION
## Summary
- The first run of [check-apply-links.yml](.github/workflows/check-apply-links.yml) failed at the final step with `could not add label: 'apply-link-check' not found` because the label didn't exist in the repo.
- This adds an idempotent `gh label create` call before issue creation. Subsequent runs are no-ops if the label already exists.

## Test plan
- [ ] Merge and re-trigger the workflow; confirm the issue is created (or updated/closed as appropriate).