### PR TITLE
Fix white gap below odds widget footer on initial load

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -319,6 +319,7 @@
   font-weight: 600;
 }
 .landing-v2 .widget-body {
+  flex: 1;
   padding: 20px;
   display: grid;
   gap: 18px;


### PR DESCRIPTION
## Summary
- The hero grid stretches the odds widget to match the left column's height, but neither widget child had `flex-grow`, so when content was shorter than the column, empty space appeared below the purple footer (visible on initial load and gone after picking a card with enough records to render the dist bar).
- Fix: `flex: 1` on `.widget-body` so it absorbs leftover space and the footer is always flush with the bottom of the card.

## Test plan
- [x] Open landing page on initial load — footer flush with the widget's bottom border (no white gap).
- [x] Switch between cards with and without records — footer stays flush in both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)