### PR TITLE
Tighten landing stats: one-row mobile, drop bottom proof row

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -122,7 +122,6 @@ function OddsWidget({ cards }: { cards: Card[] }) {
         <div className="t">
           <b>Approval odds calculator</b> · built from real applications, not a soft pull
         </div>
-        <div className="t">v2.6</div>
       </div>
       <div className="widget-body">
         <div className="card-search">
@@ -659,44 +658,6 @@ function Wallet({ cards }: { cards: Card[] }) {
   );
 }
 
-function Proof({ cards }: { cards: Card[] }) {
-  const totalRecords = cards.reduce(
-    (acc, c) => acc + (c.approved_count ?? 0) + (c.rejected_count ?? 0),
-    0
-  );
-  const issuers = new Set(cards.map((c) => c.bank)).size;
-  return (
-    <section className="proof">
-      <div className="wrap">
-        <div className="proof-grid">
-          <div className="proof-cell">
-            <div className="pn">
-              428
-              <span className="sup">+</span>
-            </div>
-            <div className="pl">Records in the database</div>
-          </div>
-          <div className="proof-cell">
-            <div className="pn">
-              {cards.length}
-              <span className="sup">+</span>
-            </div>
-            <div className="pl">Cards tracked · {issuers} issuers</div>
-          </div>
-          <div className="proof-cell">
-            <div className="pn">0</div>
-            <div className="pl">Sponsored rankings</div>
-          </div>
-          <div className="proof-cell">
-            <div className="pn">$0</div>
-            <div className="pl">Cost to use · forever</div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function Final() {
   return (
     <section className="final">
@@ -747,7 +708,6 @@ export default function LandingClient({ initialCards }: LandingClientProps) {
       <HowItWorks />
       <Referrals cards={initialCards} />
       <Wallet cards={initialCards} />
-      <Proof cards={initialCards} />
       <Final />
       <V2Footer />
     </div>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2137,11 +2137,18 @@
   }
   .landing-v2 .hero-stats {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 18px 16px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
   }
-  .landing-v2 .hero-stats .stat:last-child {
-    grid-column: 1 / -1;
+  .landing-v2 .hero-stats .stat .n {
+    font-size: 30px;
+  }
+  .landing-v2 .hero-stats .stat .n .sup {
+    font-size: 15px;
+  }
+  .landing-v2 .hero-stats .stat .l {
+    font-size: 12px;
+    margin-top: 4px;
   }
   .landing-v2 .widget-head {
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Hero stats now fit on a single row on mobile (3-col grid, 30px numerals, 15px `+`)
- Remove the `v2.6` badge from the odds calculator widget head
- Drop the bottom `Proof` stat row — its numbers are already covered by the hero stats above

## Test plan
- [x] Mobile (375px): hero stats sit on one row, no overflow
- [x] Desktop: hero stats unchanged
- [x] Bottom proof section is gone, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)