### PR TITLE
Fix broken apply link for Citi Secured Mastercard

### DIFF
--- a/data/cards/citi-secured-mastercard.yaml
+++ b/data/cards/citi-secured-mastercard.yaml
@@ -11,4 +11,4 @@ apr:
   regular:
     min: 26.74
     max: 26.74
-apply_link: https://www.citi.com/credit-cards/citi-secured-mastercard
+apply_link: https://www.citi.com/credit-cards/citi-secured-credit-card


### PR DESCRIPTION
## Summary
- Citi changed the URL slug from \`citi-secured-mastercard\` → \`citi-secured-credit-card\`. Updates [citi-secured-mastercard.yaml](data/cards/citi-secured-mastercard.yaml) to match.

## Test plan
- [ ] Click the apply link on the live card page and verify it lands on the Citi application page.