### PR TITLE
Fix broken apply links for Costco Anywhere Visa cards

### DIFF
--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -29,4 +29,4 @@ apr:
   regular:
     min: 18.74
     max: 26.74
-apply_link: https://www.citi.com/credit-cards/costco-citi-business-card
+apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-business-card

--- a/data/cards/costco-anywhere-visa-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-card-by-citi.yaml
@@ -28,4 +28,4 @@ apr:
   regular:
     min: 18.74
     max: 26.74
-apply_link: https://www.citi.com/credit-cards/costco-citi-card
+apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-card


### PR DESCRIPTION
## Summary
- Citi changed the URL slugs for both Costco Anywhere Visa cards. Updates apply_links to the new working URLs.
- [costco-anywhere-visa-card-by-citi.yaml](data/cards/costco-anywhere-visa-card-by-citi.yaml): \`/costco-citi-card\` → \`/costco-anywhere-visa-card\`
- [costco-anywhere-visa-business-card-by-citi.yaml](data/cards/costco-anywhere-visa-business-card-by-citi.yaml): \`/costco-citi-business-card\` → \`/costco-anywhere-visa-business-card\`

## Test plan
- [ ] Click both apply links on the live card pages and verify they land on the Citi application page.