### PR TITLE
Rebrand: CitiBusiness AAdvantage → Citi AAdvantage Business World Elite

### DIFF
--- a/apps/api/migrations/022_rename_citibusiness_aadvantage_to_business_world_elite.sql
+++ b/apps/api/migrations/022_rename_citibusiness_aadvantage_to_business_world_elite.sql
@@ -1,0 +1,2 @@
+-- Citi rebrand (April 24, 2026): CitiBusiness AAdvantage Platinum Select -> Citi AAdvantage Business World Elite
+UPDATE cards SET card_name = 'Citi AAdvantage Business World Elite Mastercard' WHERE card_name = 'CitiBusiness AAdvantage Platinum Select Mastercard';

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -432,9 +432,16 @@ export default function CardClient({ card, graphData, news, articles, ratings, s
               <div className="order-1 lg:order-2 lg:col-span-8">
                 {/* Title */}
                 <div className="flex flex-col items-center gap-2 lg:flex-row lg:items-start lg:justify-between">
-                  <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 tracking-tight text-center lg:text-left">
-                    {card.card_name}
-                  </h1>
+                  <div className="text-center lg:text-left">
+                    <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 tracking-tight">
+                      {card.card_name}
+                    </h1>
+                    {card.previous_names && card.previous_names.length > 0 && (
+                      <p className="mt-1 text-sm italic text-gray-500">
+                        Previously {card.previous_names.join(', ')}
+                      </p>
+                    )}
+                  </div>
                   <div className="relative lg:mt-1 lg:flex-shrink-0" ref={shareMenuRef}>
                     <div className="flex items-center gap-3">
                       <Link

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -59,6 +59,7 @@ export interface Card {
   card_id: string | number;
   db_card_id?: number;
   card_name: string;
+  previous_names?: string[];
   slug: string;
   bank: string;
   card_image_link?: string;

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-29T21:19:03.663Z",
+  "generated_at": "2026-04-29T21:31:18.199Z",
   "count": 160,
   "categories": [
     {
@@ -2901,6 +2901,61 @@
       "card_name": "Chase Slate Edge"
     },
     {
+      "name": "Citi AAdvantage Business World Elite Mastercard",
+      "bank": "Citi",
+      "slug": "citibusiness-aadvantage-platinum-select-maste",
+      "previous_names": [
+        "CitiBusiness AAdvantage Platinum Select Mastercard"
+      ],
+      "accepting_applications": true,
+      "image": "citi-business-aadvantage-platinum-select.png",
+      "annual_fee": 99,
+      "reward_type": "miles",
+      "tags": [
+        "travel",
+        "airline",
+        "business"
+      ],
+      "rewards": [
+        {
+          "category": "airlines",
+          "value": 2,
+          "unit": "points_per_dollar",
+          "note": "On eligible American Airlines purchases"
+        },
+        {
+          "category": "car_rentals",
+          "value": 2,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "gas",
+          "value": 2,
+          "unit": "points_per_dollar"
+        },
+        {
+          "category": "everything_else",
+          "value": 1,
+          "unit": "points_per_dollar"
+        }
+      ],
+      "signup_bonus": {
+        "value": 65000,
+        "type": "miles",
+        "spend_requirement": 4000,
+        "timeframe_months": 4
+      },
+      "apr": {
+        "regular": {
+          "min": 21.24,
+          "max": 29.99
+        }
+      },
+      "apply_link": "https://www.citi.com/credit-cards/citi-aadvantage-business-credit-card",
+      "card_id": "citibusiness-aadvantage-platinum-select-maste",
+      "card_name": "Citi AAdvantage Business World Elite Mastercard"
+    },
+    {
       "name": "Citi AAdvantage Executive World Elite Mastercard",
       "bank": "Citi",
       "slug": "citi-aadvantage-executive-world-elite-masterc",
@@ -3294,7 +3349,7 @@
           "max": 26.74
         }
       },
-      "apply_link": "https://www.citi.com/credit-cards/citi-secured-mastercard",
+      "apply_link": "https://www.citi.com/credit-cards/citi-secured-credit-card",
       "card_id": "citi-secured-mastercard",
       "card_name": "Citi Secured Mastercard"
     },
@@ -3577,58 +3632,6 @@
       "apply_link": "https://www.citi.com/credit-cards/citi-strata-premier-credit-card",
       "card_id": "citi-strata-premier",
       "card_name": "Citi Strata Premier"
-    },
-    {
-      "name": "CitiBusiness AAdvantage Platinum Select Mastercard",
-      "bank": "Citi",
-      "slug": "citibusiness-aadvantage-platinum-select-maste",
-      "accepting_applications": true,
-      "image": "citi-business-aadvantage-platinum-select.png",
-      "annual_fee": 99,
-      "reward_type": "miles",
-      "tags": [
-        "travel",
-        "airline",
-        "business"
-      ],
-      "rewards": [
-        {
-          "category": "airlines",
-          "value": 2,
-          "unit": "points_per_dollar",
-          "note": "On eligible American Airlines purchases"
-        },
-        {
-          "category": "car_rentals",
-          "value": 2,
-          "unit": "points_per_dollar"
-        },
-        {
-          "category": "gas",
-          "value": 2,
-          "unit": "points_per_dollar"
-        },
-        {
-          "category": "everything_else",
-          "value": 1,
-          "unit": "points_per_dollar"
-        }
-      ],
-      "signup_bonus": {
-        "value": 65000,
-        "type": "miles",
-        "spend_requirement": 4000,
-        "timeframe_months": 4
-      },
-      "apr": {
-        "regular": {
-          "min": 21.24,
-          "max": 29.99
-        }
-      },
-      "apply_link": "https://www.citi.com/credit-cards/citibusiness-aadvantage-platinum-select-mastercard",
-      "card_id": "citibusiness-aadvantage-platinum-select-maste",
-      "card_name": "CitiBusiness AAdvantage Platinum Select Mastercard"
     },
     {
       "name": "Coinbase One",

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -1,6 +1,8 @@
-name: "CitiBusiness AAdvantage Platinum Select Mastercard"
+name: "Citi AAdvantage Business World Elite Mastercard"
 bank: "Citi"
 slug: "citibusiness-aadvantage-platinum-select-maste"
+previous_names:
+  - "CitiBusiness AAdvantage Platinum Select Mastercard"
 accepting_applications: true
 image: "citi-business-aadvantage-platinum-select.png"
 annual_fee: 99
@@ -32,4 +34,4 @@ apr:
   regular:
     min: 21.24
     max: 29.99
-apply_link: https://www.citi.com/credit-cards/citibusiness-aadvantage-platinum-select-mastercard
+apply_link: https://www.citi.com/credit-cards/citi-aadvantage-business-credit-card

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -7,6 +7,11 @@
       "type": "string",
       "description": "Full name of the credit card"
     },
+    "previous_names": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Prior names this card was known by, e.g. before a rebrand. Rendered on the card detail page."
+    },
     "bank": {
       "type": "string",
       "description": "Issuing bank or financial institution"


### PR DESCRIPTION
## Summary
Citi rebranded the **CitiBusiness AAdvantage Platinum Select Mastercard** to the **Citi AAdvantage Business World Elite Mastercard** on April 24, 2026 as part of the Barclays AAdvantage transition (background: [Feb 24 news article](data/news/2026-02-24-barclays-aadvantage-cards-citi-transition.yaml)).

This PR updates the card and introduces a small `previous_names` UI affordance to surface rebrands to users.

## Changes
- **Migration 022** ([sql](apps/api/migrations/022_rename_citibusiness_aadvantage_to_business_world_elite.sql)) — already applied to prod (\`Rows matched: 1, Changed: 1\`)
- **YAML** ([citibusiness-aadvantage-platinum-select-maste.yaml](data/cards/citibusiness-aadvantage-platinum-select-maste.yaml)):
  - \`name\` → \"Citi AAdvantage Business World Elite Mastercard\"
  - \`previous_names\` → [\"CitiBusiness AAdvantage Platinum Select Mastercard\"]
  - \`apply_link\` → working Citi URL
  - \`slug\` preserved for URL stability
- **Schema** ([schema.json](data/cards/schema.json)) — new optional \`previous_names\` array of strings
- **TypeScript** ([api.ts](apps/web-next/src/lib/api.ts)) — added \`previous_names?: string[]\` to \`Card\` interface
- **UI** ([CardClient.tsx](apps/web-next/src/app/card/[name]/CardClient.tsx)) — renders subtle italic subtitle under the card title:

  > Previously CitiBusiness AAdvantage Platinum Select Mastercard

## Why \`previous_names\` instead of just renaming
- Users who knew the old name still find the card via search engines / muscle memory and immediately understand they're in the right place
- Reusable for future rebrands (Barclays Aviator → Citi AAdvantage variants, etc.)
- Schema-validated, optional, zero-cost when absent

## Verification
- [x] Migration applied successfully via temporary RunMigrationFunction (deployed, invoked, removed in same session)
- [x] \`npm run build:cards\` passes — card now shows as \"Citi AAdvantage Business World Elite Mastercard\"
- [x] Card detail page renders without errors in local preview (visible \"Previously\" line will appear after CDN propagation, ~5 min post-merge per cache layers)

## Test plan
- [ ] After merge, verify the card page shows new name + \"Previously CitiBusiness AAdvantage Platinum Select Mastercard\" subtitle
- [ ] Verify apply link works
- [ ] Verify approval-odds stats still attach correctly (DB \`card_id\` should be unchanged since we only renamed)