### PR TITLE
Refine secondary typography across card views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repo Notes
+
+- For user-requested work, start a fresh branch from `main` unless the user explicitly asks to continue from another branch.

--- a/apps/web-next/src/app/bank/[name]/page.tsx
+++ b/apps/web-next/src/app/bank/[name]/page.tsx
@@ -117,7 +117,7 @@ export default async function BankPage({ params }: BankPageProps) {
                     <span
                       className="text-xs text-gray-500"
                       style={{
-                        fontFamily: "'JetBrains Mono', monospace",
+                        fontFamily: "'Inter', sans-serif",
                       }}
                     >
                       {new Date(news.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}

--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -202,7 +202,7 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
               color: 'var(--muted)',
             }}
           >
-            <span style={{ fontFamily: "'JetBrains Mono', monospace" }}>{filtered.length}</span> change{filtered.length === 1 ? '' : 's'}
+            <span style={{ fontFamily: "'Inter', sans-serif" }}>{filtered.length}</span> change{filtered.length === 1 ? '' : 's'}
           </span>
         </div>
 
@@ -212,7 +212,7 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
               padding: '80px 0',
               textAlign: 'center',
               color: 'var(--muted)',
-              fontFamily: "'JetBrains Mono', monospace",
+              fontFamily: "'Inter', sans-serif",
               fontSize: 13,
             }}
           >

--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -332,15 +332,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
                     <span className="v">
                       {bonus.main}
                       {bonus.sub ? (
-                        <span
-                          style={{
-                            display: 'block',
-                            color: 'var(--muted)',
-                            fontWeight: 400,
-                            fontSize: 10.5,
-                            marginTop: 2,
-                          }}
-                        >
+                        <span className="bonus-sub">
                           {bonus.sub}
                         </span>
                       ) : null}
@@ -424,7 +416,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
                       <td className="hide-sm">
                         {bonus.main}
                         {bonus.sub ? (
-                          <span className="ct-sub">{bonus.sub}</span>
+                          <span className="bonus-sub">{bonus.sub}</span>
                         ) : null}
                       </td>
                       <td className="num ct-approval-col">

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1418,7 +1418,7 @@
   letter-spacing: -0.01em;
 }
 .landing-v2 .cc-iss {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'Inter', sans-serif;
   font-size: 11px;
   color: var(--muted);
   margin-top: 3px;
@@ -1638,7 +1638,7 @@
   color: var(--accent);
 }
 .landing-v2 .ct-iss {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'Inter', sans-serif;
   font-size: 11px;
   color: var(--muted);
   margin-top: 2px;
@@ -1646,6 +1646,14 @@
 .landing-v2 .ct-sub {
   display: block;
   font-family: 'JetBrains Mono', monospace;
+  font-size: 10.5px;
+  color: var(--muted);
+  font-weight: 400;
+  margin-top: 2px;
+}
+.landing-v2 .bonus-sub {
+  display: block;
+  font-family: 'Inter', sans-serif;
   font-size: 10.5px;
   color: var(--muted);
   font-weight: 400;
@@ -5022,4 +5030,3 @@
   font-weight: 500;
   border-bottom: 1px solid var(--warn);
 }
-


### PR DESCRIPTION
## Summary
- switch Explorer issuer labels and bonus spend-requirement subtext from JetBrains Mono to Inter
- align Card Wire meta/empty-state text and bank news dates with the softer secondary font
- add a repo note to start new user-requested branches from main by default

## Testing
- verified locally on /explore, /card-wire, and /bank/chase