### PR TITLE
Mirror bank page reward styling on explore table

### DIFF
--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import type { Card, Reward } from '@/lib/api';
-import { categoryLabels } from '@/lib/cardDisplayUtils';
+import { categoryLabels, CategoryIcon } from '@/lib/cardDisplayUtils';
 import { cardMatchesSearch } from '@/lib/searchAliases';
 import '../landing.css';
 
@@ -93,6 +93,44 @@ function rewardTypeLabel(card: Card): string {
     default:
       return '—';
   }
+}
+
+function rewardTypeEmoji(card: Card): string | null {
+  switch (card.reward_type) {
+    case 'cashback':
+      return '💵';
+    case 'points':
+      return '✨';
+    case 'miles':
+      return '✈️';
+    default:
+      return null;
+  }
+}
+
+function RewardTypeCell({ card }: { card: Card }) {
+  if (!card.reward_type) return <span className="muted">—</span>;
+  const emoji = rewardTypeEmoji(card);
+  return (
+    <span className="ct-reward-type">
+      {emoji && <span aria-hidden="true" className="ct-reward-type-icon">{emoji}</span>}
+      <span className="ct-reward-type-label">{rewardTypeLabel(card)}</span>
+    </span>
+  );
+}
+
+function TopRewardCell({ card }: { card: Card }) {
+  const top = topReward(card);
+  if (!top) return <span className="muted">—</span>;
+  const rate = top.unit === 'percent' ? `${top.value}%` : `${top.value}x`;
+  const label = categoryLabels[top.category] || top.category;
+  return (
+    <span className="ct-top-reward">
+      <CategoryIcon category={top.category} className="ct-top-reward-icon" />
+      <span className="ct-top-reward-rate">{rate}</span>
+      <span className="ct-top-reward-label">{label}</span>
+    </span>
+  );
 }
 
 export default function ExploreV2Client({ cards, trendingViews }: ExploreV2ClientProps) {
@@ -411,8 +449,8 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
                       <td className={'num hide-sm fee-' + feeTone(c.annual_fee)}>
                         {feeLabel}
                       </td>
-                      <td className="hide-sm">{rewardTypeLabel(c)}</td>
-                      <td className="hide-md">{formatTopReward(c)}</td>
+                      <td className="hide-sm"><RewardTypeCell card={c} /></td>
+                      <td className="hide-md"><TopRewardCell card={c} /></td>
                       <td className="hide-sm">
                         {bonus.main}
                         {bonus.sub ? (

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1588,7 +1588,7 @@
 }
 .landing-v2 .card-table td.num {
   text-align: right;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'Inter', sans-serif;
   font-size: 13px;
   font-weight: 500;
   white-space: nowrap;
@@ -1645,7 +1645,7 @@
 }
 .landing-v2 .ct-sub {
   display: block;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'Inter', sans-serif;
   font-size: 10.5px;
   color: var(--muted);
   font-weight: 400;
@@ -1669,13 +1669,48 @@
 .landing-v2 .card-table .muted {
   color: var(--muted-2);
 }
+.landing-v2 .ct-reward-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  font-weight: 500;
+}
+.landing-v2 .ct-reward-type-icon {
+  font-size: 13px;
+  line-height: 1;
+}
+.landing-v2 .ct-top-reward {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.landing-v2 .ct-top-reward-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--muted-2);
+  flex-shrink: 0;
+}
+.landing-v2 .ct-top-reward-rate {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  color: var(--ink);
+  font-size: 13px;
+}
+.landing-v2 .ct-top-reward-label {
+  font-family: 'Inter', sans-serif;
+  color: var(--muted);
+  font-size: 12px;
+}
 .landing-v2 .card-table .ct-mobile-summary {
   display: none;
   margin-top: 6px;
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'Inter', sans-serif;
   font-size: 11px;
   color: var(--ink-2);
 }


### PR DESCRIPTION
## Summary
- Reward type column on the explore table now shows the 💵/✨/✈️ emoji next to the label, matching the bank page.
- Top reward column now shows the category icon + bold rate + lighter category label (e.g. ✈ 5x Airlines), matching the bank page.
- Swept remaining JetBrains Mono in the explore table (numeric fee column, sub rows, mobile summary) to Inter to follow the upstream typography direction.

## Test plan
- [x] Desktop: Reward type and Top reward columns render with icons and match bank page style
- [x] Mobile: row summary and counts render in Inter, no JetBrains Mono in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)