### PR TITLE
Add news: Amex Platinum 125K Sign-Up Bonus Expected to Return Early May

### DIFF
--- a/data/news/2026-04-30-amex-platinum-125k-bonus-may-2026.yaml
+++ b/data/news/2026-04-30-amex-platinum-125k-bonus-may-2026.yaml
@@ -1,0 +1,20 @@
+id: "amex-platinum-125k-bonus-may-2026"
+title: "Amex Platinum 125K Sign-Up Bonus Expected to Return Early May"
+summary: "Based on test site findings, the **125,000-point sign-up bonus** for Amex Platinum variants (MS/CS) is expected to return around **early May 2026**. The discovery came from test environment data with an expiration date of 7/8, which community members use to estimate upcoming offer launches. While test sites have occasionally been inaccurate, they historically serve as reliable predictors of elevated bonuses.\n"
+tags:
+  - "bonus-change"
+  - "limited-time"
+bank: "American Express"
+card_name: "Amex Platinum"
+source: "r/churning"
+source_url: "https://www.reddit.com/r/churning/comments/1syte6h/news_and_updates_thread_april_29_2026/oj11r84/"
+date: "2026-04-30"
+body: |
+  Community members tracking Amex Platinum offers have identified a **125,000-point sign-up bonus** appearing on American Express test environments, signaling a potential return of this elevated bonus in the coming weeks.
+  
+  According to findings shared in r/churning, the bonus was discovered using the "qwww trick" to access test site data. The test environment listed an expiration date of **7/8**, which when backdated by approximately two months, points to an expected launch around **early May 2026**.
+  
+  The **125K offer targets MS/CS (Marriott Starwood/Club) Platinum variants** specifically. While test environments are not guaranteed to reflect final offers—having been inaccurate once or twice in the past—they have historically proven reliable in predicting when Amex elevates sign-up bonuses.
+  
+  This aligns with previous reports of elevated Platinum bonuses, though verification has confirmed the existence of 125K offers on standard Amex Platinum products as recently as mid-April 2025. Exact timing and card variant specificity remain subject to change based on final promotional decisions.
+  


### PR DESCRIPTION
## Summary
- Auto-generated from r/churning via `scripts/auto-news-from-reddit.js`
- 1 survivor: speculative 125K bonus return on MS/CS Amex Platinum variants based on test-site findings
- Source kept as `r/churning` — verification matched UpgradedPoints (third-party blog, not first-party); only partial corroboration of a past 125K offer, not the test-site/early-May claim. No first-party / DoC / NerdWallet / TPG source available, so no swap performed.
- `date: 2026-04-30` (PR submission date)

## Test plan
- [ ] YAML renders cleanly on `/news` listing
- [ ] `card_name: "Amex Platinum"` resolves to a known card slug for related-card linkage
- [ ] Headline + summary read correctly with bold markdown
- [ ] Confirm editorial judgment on publishing speculative test-site predictions (human review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)