### PR TITLE
Wrap long card names on explore table

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1627,12 +1627,13 @@
   font-weight: 600;
   color: var(--ink);
   font-size: 14px;
-  line-height: 1.2;
+  line-height: 1.25;
   letter-spacing: -0.005em;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 320px;
+  max-width: 360px;
 }
 .landing-v2 .ct-card:hover .ct-name {
   color: var(--accent);


### PR DESCRIPTION
## Summary
- Replace ellipsis truncation on `.ct-name` (explore table) with a 2-line clamp
- Bump `max-width` from 320px → 360px so long names fit before clamping kicks in
- Mobile behavior unchanged (was already wrapping)

## Test plan
- [x] Verified at 1280px desktop: 54-char name wraps to 2 lines unclipped, shorter names stay on 1 line
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)