### PR TITLE
Wrap long card names on card-wire table

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2495,11 +2495,13 @@
   font-weight: 500;
   color: var(--ink);
   font-size: 13px;
+  line-height: 1.3;
   letter-spacing: -0.005em;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 280px;
+  max-width: 320px;
 }
 .landing-v2 .wire-card:hover .wc-name {
   color: var(--accent);


### PR DESCRIPTION
## Summary
- Mirrors [creditodds#470](https://github.com/CreditOdds/creditodds/pull/470) for the card-wire `.wc-name`
- 2-line clamp + `max-width` bump (280px → 320px) so long names display in full on desktop
- Mobile already wrapped; behavior unchanged there

## Test plan
- [x] Verified at 1280px desktop on /card-wire: 54-char name wraps to 2 lines unclipped, 48/47-char names fit on one line, nothing clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)