### PR TITLE
Detect CSS-based strikethroughs in card-page check

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -105,8 +105,13 @@ function stripHtml(html) {
     .replace(/<nav\b[^<]*(?:(?!<\/nav>)<[^<]*)*<\/nav>/gi, '')
     .replace(/<header\b[^<]*(?:(?!<\/header>)<[^<]*)*<\/header>/gi, '')
     .replace(/<footer\b[^<]*(?:(?!<\/footer>)<[^<]*)*<\/footer>/gi, '')
-    // Mark strikethrough content so the model knows to ignore it
+    // Mark strikethrough content so the model knows to ignore it.
+    // Covers semantic tags, CSS class tokens (strike/strikethrough/strike-through/line-through),
+    // and inline `text-decoration: line-through` styles. The class regex requires a token
+    // boundary so e.g. Chase's sibling class `strikeThroughFollow` is NOT matched.
     .replace(/<(s|del|strike)\b[^>]*>([\s\S]*?)<\/\1>/gi, ' [STRIKETHROUGH: $2] ')
+    .replace(/<(\w+)\b[^>]*\sclass\s*=\s*["']([^"']*\s)?(?:strike|strikethrough|strike-through|line-through)(\s[^"']*)?["'][^>]*>([\s\S]*?)<\/\1>/gi, ' [STRIKETHROUGH: $4] ')
+    .replace(/<(\w+)\b[^>]*\sstyle\s*=\s*["'][^"']*\bline-through\b[^"']*["'][^>]*>([\s\S]*?)<\/\1>/gi, ' [STRIKETHROUGH: $2] ')
     .replace(/<[^>]+>/g, ' ')
     .replace(/&[a-z#0-9]+;/gi, ' ')
     .replace(/\s+/g, ' ')


### PR DESCRIPTION
## Summary

- Closed [#477](https://github.com/CreditOdds/creditodds/pull/477) — false positive caused by this gap
- Extends `stripHtml` in [scripts/check-card-pages.js](scripts/check-card-pages.js) to mark CSS-classed and inline-styled strikethroughs, not just `<s>`/`<del>`/`<strike>`

## Why

Chase Sapphire Reserve's apply page wraps the old signup bonus in `<span class="strikeThrough">125,000</span>` next to `<span class="strikeThroughFollow">150,000</span>`. The previous regex only matched semantic strikethrough tags, so the `[STRIKETHROUGH: ...]` marker was never inserted. Haiku saw `Earn 125,000 strikethrough 150,000 points` and picked the first number — generating an incorrect downgrade PR.

## What changed

Two extra regex passes in `stripHtml`:

1. Class attribute contains a strike-related token (`strike`, `strikethrough`, `strike-through`, `line-through`) as a complete token — token boundary check ensures Chase's `strikeThroughFollow` (the *new*-price wrapper) is NOT matched.
2. Inline `style` attribute contains `line-through`.

Verified against the live Chase HTML: `[STRIKETHROUGH: 125,000]` is now wrapped, `150,000` is left clean.

## Test plan

- [x] Run regex against captured Chase Sapphire Reserve HTML — 125,000 is wrapped, 150,000 is not
- [x] Edge cases: `not-strikethrough-related` class is NOT matched, multi-class with `strikethrough` token IS matched, plain content unaffected
- [ ] Next scheduled `check-card-pages` run produces no false positive on CSR