### PR TITLE
Nav: drop "Live · data points" chip; migrate /check-odds form to v2

### DIFF
--- a/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
+++ b/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
@@ -191,90 +191,72 @@ export default function CheckOddsClient() {
   return (
     <>
       {/* Input Form */}
-      <div className="bg-white shadow rounded-lg p-6 max-w-2xl mx-auto">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            handleSubmit();
-          }}
-          className="space-y-4"
-        >
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            <div>
-              <label htmlFor="credit-score" className="block text-sm font-medium text-gray-700">
-                Credit Score
-              </label>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <div className="check-tool">
+          <div className="check-field">
+            <label htmlFor="credit-score">Credit score</label>
+            <div className="input-wrap">
               <input
                 id="credit-score"
                 type="number"
                 min={300}
                 max={850}
                 required
-                placeholder="300-850"
+                placeholder="300–850"
                 value={creditScore}
                 onChange={(e) => setCreditScore(e.target.value)}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
               />
             </div>
-            <div>
-              <label htmlFor="income" className="block text-sm font-medium text-gray-700">
-                Annual Income
-              </label>
-              <div className="mt-1 relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <span className="text-gray-500 sm:text-sm">$</span>
-                </div>
-                <input
-                  id="income"
-                  type="text"
-                  inputMode="numeric"
-                  required
-                  placeholder="75,000"
-                  value={income}
-                  onChange={(e) => setIncome(formatIncome(e.target.value))}
-                  className="block w-full pl-7 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                />
-              </div>
+          </div>
+          <div className="check-field">
+            <label htmlFor="income">Annual income</label>
+            <div className="input-wrap has-prefix">
+              <span className="prefix">$</span>
+              <input
+                id="income"
+                type="text"
+                inputMode="numeric"
+                required
+                placeholder="75,000"
+                value={income}
+                onChange={(e) => setIncome(formatIncome(e.target.value))}
+              />
             </div>
-            <div>
-              <label htmlFor="length-credit" className="block text-sm font-medium text-gray-700">
-                Credit History (years)
-              </label>
+          </div>
+          <div className="check-field">
+            <label htmlFor="length-credit">Credit history (years)</label>
+            <div className="input-wrap">
               <input
                 id="length-credit"
                 type="number"
                 min={0}
                 max={100}
                 required
-                placeholder="0-100"
+                placeholder="0–100"
                 value={lengthCredit}
                 onChange={(e) => setLengthCredit(e.target.value)}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
               />
             </div>
           </div>
+          <div className="check-field check-submit-wrap">
+            <label aria-hidden="true" style={{ visibility: 'hidden' }}>·</label>
+            <button type="submit" disabled={loading} className="check-submit">
+              {loading ? 'Checking…' : 'Check odds →'}
+            </button>
+          </div>
+        </div>
 
-          {error && (
-            <div className="rounded-md bg-red-50 p-3">
-              <p className="text-sm text-red-800">{error}</p>
-            </div>
-          )}
+        {error && <div className="check-error">{error}</div>}
 
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {loading ? 'Checking...' : 'Check Odds'}
-          </button>
-
-          {!authState.isAuthenticated && (
-            <p className="text-xs text-center text-gray-500">
-              Sign in is required to view results
-            </p>
-          )}
-        </form>
-      </div>
+        {!authState.isAuthenticated && (
+          <p className="check-hint">Sign in is required to view results.</p>
+        )}
+      </form>
 
       {/* Results */}
       {results && (

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1238,6 +1238,118 @@
   padding-block: 20px 24px;
   border-bottom: 1px solid var(--line);
 }
+.landing-v2.check-v2 .page-hero {
+  border-bottom: 0;
+  padding-block: 20px 8px;
+}
+
+/* ---------- Check odds tool bar ---------- */
+.landing-v2 .check-tool {
+  display: grid;
+  grid-template-columns: 1.2fr 1.2fr 1fr auto;
+  gap: 14px;
+  align-items: end;
+  padding: 20px 0 16px;
+  border-top: 1px solid var(--line);
+}
+.landing-v2 .check-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.landing-v2 .check-field label {
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 600;
+}
+.landing-v2 .check-field .input-wrap {
+  position: relative;
+}
+.landing-v2 .check-field input {
+  width: 100%;
+  height: 44px;
+  padding: 0 14px;
+  border-radius: 10px;
+  border: 1px solid var(--line-2);
+  background: var(--paper);
+  font-size: 15px;
+  font-family: inherit;
+  color: var(--ink);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+.landing-v2 .check-field input::placeholder {
+  color: var(--muted-2);
+}
+.landing-v2 .check-field input:focus {
+  border-color: var(--accent);
+}
+.landing-v2 .check-field .prefix {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  font-size: 15px;
+  pointer-events: none;
+}
+.landing-v2 .check-field .input-wrap.has-prefix input {
+  padding-left: 28px;
+}
+.landing-v2 .check-submit {
+  height: 44px;
+  padding: 0 22px;
+  border-radius: 10px;
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.08s ease;
+  white-space: nowrap;
+}
+.landing-v2 .check-submit:hover {
+  background: var(--ink-2);
+}
+.landing-v2 .check-submit:active {
+  transform: translateY(1px);
+}
+.landing-v2 .check-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.landing-v2 .check-error {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  background: color-mix(in oklab, #c4302b 8%, transparent);
+  border: 1px solid color-mix(in oklab, #c4302b 25%, transparent);
+  color: #802520;
+  border-radius: 8px;
+  font-size: 13px;
+}
+.landing-v2 .check-hint {
+  margin-top: 12px;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+@media (max-width: 768px) {
+  .landing-v2 .check-tool {
+    grid-template-columns: 1fr 1fr;
+  }
+  .landing-v2 .check-submit-wrap {
+    grid-column: 1 / -1;
+  }
+  .landing-v2 .check-submit {
+    width: 100%;
+  }
+}
+@media (max-width: 480px) {
+  .landing-v2 .check-tool {
+    grid-template-columns: 1fr;
+  }
+}
 .landing-v2 .page-title {
   font-family: 'Inter Tight', 'Inter', sans-serif;
   font-weight: 500;

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -140,11 +140,6 @@ export default function Navbar() {
               </div>
 
               <div className="hidden lg:flex items-center gap-2 lg:gap-3">
-                <div className="hidden xl:flex items-center gap-2 rounded-full border border-[#ece8f5] bg-white px-3 py-1.5 text-[13px] font-medium text-[#6b6384]">
-                  <span className="h-1.5 w-1.5 rounded-full bg-[#6d3fe8] shadow-[0_0_0_3px_rgba(109,63,232,0.18)]" />
-                  <span>Live · <span className="tabular-nums">3,482</span> data points</span>
-                </div>
-
                 {authState.isAuthenticated ? (
                   <>
                     <Link
@@ -264,11 +259,6 @@ export default function Navbar() {
             </div>
 
             <div className="mt-4 rounded-[12px] border border-[#ece8f5] bg-white p-3">
-              <div className="mb-3 flex items-center gap-2 text-[13px] font-medium text-[#6b6384]">
-                <span className="h-1.5 w-1.5 rounded-full bg-[#6d3fe8] shadow-[0_0_0_3px_rgba(109,63,232,0.18)]" />
-                <span>Live · <span className="tabular-nums">3,482</span> data points</span>
-              </div>
-
               {authState.isAuthenticated ? (
                 <div className="space-y-2">
                   <Link


### PR DESCRIPTION
## Summary
- Remove the desktop xl: and mobile-menu "Live · 3,482 data points" chips from the navbar
- Migrate the /check-odds form from legacy Tailwind (white-card with indigo button) to the v2 editorial system — inline tool bar with 3 labeled inputs + primary button
- Drop the `.page-hero` divider on /check-odds (scoped under `.check-v2`) so the form fuses with the hero instead of sitting orphaned below a horizontal rule

Results rendering below the form is still legacy Tailwind — left for a follow-up migration.

## Test plan
- [ ] /check-odds renders the new horizontal tool bar (3 inputs + Check odds button) flush below the hero with no divider between
- [ ] Form validation still shows the inline `.check-error` panel for bad inputs
- [ ] Submitting as a guest redirects to /login with form params; submitting authenticated still calls the odds API
- [ ] Navbar no longer shows "Live · 3,482 data points" on desktop (xl breakpoint) or in the mobile drawer
- [ ] Mobile (≤768px): tool bar reflows to 2 columns, button spans full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)