### PR TITLE
Footer: Card wire + Tools; /best stat swap; v2 explore skeleton

### DIFF
--- a/apps/web-next/src/app/best/BestV2Client.tsx
+++ b/apps/web-next/src/app/best/BestV2Client.tsx
@@ -18,7 +18,7 @@ import '../landing.css';
 
 interface BestV2ClientProps {
   pages: BestPage[];
-  totalRecords: number;
+  totalIssuers: number;
   totalCards: number;
 }
 
@@ -44,7 +44,7 @@ function formatShortDate(iso?: string): string {
 
 export default function BestV2Client({
   pages,
-  totalRecords,
+  totalIssuers,
   totalCards,
 }: BestV2ClientProps) {
   const latestUpdate = pages
@@ -67,8 +67,8 @@ export default function BestV2Client({
       <div className="wrap">
         <div className="best-hero-stats">
           <div className="bhs">
-            <div className="k">Records analyzed</div>
-            <div className="v">{totalRecords.toLocaleString()}</div>
+            <div className="k">Issuers covered</div>
+            <div className="v">{totalIssuers}</div>
           </div>
           <div className="bhs">
             <div className="k">Cards ranked</div>

--- a/apps/web-next/src/app/best/page.tsx
+++ b/apps/web-next/src/app/best/page.tsx
@@ -23,10 +23,9 @@ export const revalidate = 300;
 export default async function BestIndexPage() {
   const [pages, cards] = await Promise.all([getBestPages(), getAllCards()]);
 
-  const totalRecords = cards.reduce(
-    (acc, c) => acc + (c.approved_count ?? 0) + (c.rejected_count ?? 0),
-    0
-  );
+  const totalIssuers = new Set(
+    cards.map((c) => c.bank?.trim()).filter(Boolean)
+  ).size;
 
   const collectionJsonLd = {
     "@context": "https://schema.org",
@@ -56,7 +55,7 @@ export default async function BestIndexPage() {
           { name: 'Best Cards', url: 'https://creditodds.com/best' },
         ]}
       />
-      <BestV2Client pages={pages} totalRecords={totalRecords} totalCards={cards.length} />
+      <BestV2Client pages={pages} totalIssuers={totalIssuers} totalCards={cards.length} />
     </>
   );
 }

--- a/apps/web-next/src/app/explore/loading.tsx
+++ b/apps/web-next/src/app/explore/loading.tsx
@@ -1,41 +1,144 @@
 import "../landing.css";
 
+function Bar({ w, h = 12, r = 6 }: { w: string | number; h?: number; r?: number }) {
+  return (
+    <div
+      className="sk-pulse"
+      style={{
+        width: typeof w === 'number' ? `${w}px` : w,
+        height: h,
+        borderRadius: r,
+      }}
+    />
+  );
+}
+
 export default function Loading() {
   return (
-    <div className="landing-v2 min-h-screen">
-      <div className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-        {/* Header skeleton */}
-        <div className="text-center mb-8">
-          <div className="h-10 bg-gray-200 rounded w-64 mx-auto mb-4 animate-pulse" />
-          <div className="h-6 bg-gray-200 rounded w-96 mx-auto animate-pulse" />
-        </div>
+    <div className="landing-v2">
+      <style>{`
+        .sk-pulse {
+          background: linear-gradient(90deg, #ece8f5 0%, #f5f1fb 50%, #ece8f5 100%);
+          background-size: 200% 100%;
+          animation: skShimmer 1.4s ease-in-out infinite;
+        }
+        @keyframes skShimmer {
+          0% { background-position: 200% 0; }
+          100% { background-position: -200% 0; }
+        }
+        .sk-cc {
+          background: #fff;
+          border: 1px solid #ddd7ec;
+          border-radius: 14px;
+          padding: 20px;
+          display: flex;
+          flex-direction: column;
+          gap: 14px;
+        }
+        .sk-cc-top { display: flex; align-items: flex-start; gap: 14px; }
+        .sk-cc-thumb { width: 68px; height: 44px; border-radius: 6px; flex-shrink: 0; }
+        .sk-cc-rows {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 10px;
+          border-top: 1px dashed #ece8f5;
+          padding-top: 12px;
+        }
+        .sk-cc-foot {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding-top: 10px;
+          border-top: 1px solid #ece8f5;
+        }
+        .sk-grid {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 20px;
+          padding: 32px 0 80px;
+        }
+        @media (max-width: 960px) { .sk-grid { grid-template-columns: repeat(2, 1fr); } }
+        @media (max-width: 640px) { .sk-grid { grid-template-columns: 1fr; } }
+        .sk-filter {
+          display: flex;
+          flex-direction: column;
+          gap: 14px;
+          padding: 20px 0 8px;
+          border-bottom: 1px solid #ece8f5;
+        }
+        .sk-search-row { display: flex; gap: 10px; align-items: center; }
+        .sk-chip-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+      `}</style>
 
-        {/* Search bar skeleton */}
-        <div className="max-w-xl mx-auto mb-8">
-          <div className="h-12 bg-gray-200 rounded-lg animate-pulse" />
-        </div>
+      <section className="page-hero wrap">
+        <h1 className="page-title" aria-hidden="true">
+          <Bar w="min(560px, 80%)" h={44} r={8} />
+        </h1>
+        <p className="page-sub" style={{ display: 'flex', flexDirection: 'column', gap: 8 }} aria-hidden="true">
+          <Bar w="min(640px, 90%)" h={14} />
+          <Bar w="min(420px, 60%)" h={14} />
+        </p>
+      </section>
 
-        {/* Filter buttons skeleton */}
-        <div className="flex justify-center gap-2 mb-8">
-          {[...Array(6)].map((_, i) => (
-            <div key={i} className="h-10 w-10 bg-gray-200 rounded-full animate-pulse" />
-          ))}
-        </div>
-
-        {/* Table skeleton */}
-        <div className="bg-white shadow rounded-lg overflow-hidden">
-          <div className="divide-y divide-gray-200">
-            {[...Array(10)].map((_, i) => (
-              <div key={i} className="p-4 flex items-center gap-4">
-                <div className="h-12 w-20 bg-gray-200 rounded animate-pulse" />
-                <div className="flex-1">
-                  <div className="h-5 bg-gray-200 rounded w-48 mb-2 animate-pulse" />
-                  <div className="h-4 bg-gray-200 rounded w-24 animate-pulse" />
-                </div>
-                <div className="h-6 w-16 bg-gray-200 rounded animate-pulse" />
-              </div>
+      <div className="wrap">
+        <div className="sk-filter" aria-hidden="true">
+          <div className="sk-search-row">
+            <Bar w="100%" h={40} r={10} />
+            <Bar w={84} h={40} r={10} />
+          </div>
+          <div className="sk-chip-row">
+            <Bar w={40} h={14} />
+            {[64, 92, 80, 72].map((w, i) => (
+              <Bar key={i} w={w} h={28} r={999} />
             ))}
           </div>
+          <div className="sk-chip-row">
+            <Bar w={32} h={14} />
+            {[60, 88, 100, 92, 110].map((w, i) => (
+              <Bar key={i} w={w} h={28} r={999} />
+            ))}
+          </div>
+          <div className="sk-chip-row" style={{ justifyContent: 'space-between' }}>
+            <div className="sk-chip-row">
+              <Bar w={32} h={14} />
+              {[80, 80, 80, 80].map((w, i) => (
+                <Bar key={i} w={w} h={28} r={999} />
+              ))}
+            </div>
+            <Bar w={120} h={14} />
+          </div>
+        </div>
+
+        <div className="sk-grid" role="status" aria-label="Loading cards">
+          {[...Array(9)].map((_, i) => (
+            <div key={i} className="sk-cc">
+              <div className="sk-cc-top">
+                <div className="sk-cc-thumb sk-pulse" />
+                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  <Bar w="80%" h={14} />
+                  <Bar w="55%" h={11} />
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
+                  <Bar w={56} h={22} />
+                  <Bar w={48} h={10} />
+                </div>
+              </div>
+              <div className="sk-cc-rows">
+                <Bar w="60%" h={11} />
+                <Bar w="40%" h={11} />
+                <Bar w="55%" h={11} />
+                <Bar w="50%" h={11} />
+                <Bar w="50%" h={11} />
+                <Bar w="60%" h={11} />
+                <Bar w="65%" h={11} />
+                <Bar w="55%" h={11} />
+              </div>
+              <div className="sk-cc-foot">
+                <Bar w={90} h={11} />
+                <Bar w={48} h={16} r={4} />
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/apps/web-next/src/components/landing-v2/Chrome.tsx
+++ b/apps/web-next/src/components/landing-v2/Chrome.tsx
@@ -82,6 +82,8 @@ export function V2Footer() {
             <Link href="/explore">Explore cards</Link>
             <Link href="/check-odds">Check odds</Link>
             <Link href="/best">Best cards</Link>
+            <Link href="/card-wire">Card wire</Link>
+            <Link href="/tools">Tools</Link>
             <Link href="/news">Card news</Link>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- Add **Card wire** and **Tools** links to the Product column of the v2 footer.
- Replace **Records analyzed** with **Issuers covered** on the `/best` hero stats — the records sum was reading low (404); issuer count is a sturdier headline metric.
- Rewrite `/explore` `loading.tsx` to match the v2 design system (paper background, dashed-border card skeletons in `.card-grid` shape, shimmer pulse) — the previous skeleton used the legacy `bg-gray-200` Tailwind look.

## Test plan
- [x] Footer Product section renders Card wire + Tools links pointing to `/card-wire` and `/tools`
- [x] `/best` shows "Issuers covered: 17" instead of "Records analyzed: 404"
- [x] `/explore` skeleton uses `.sk-pulse`/`.sk-grid` (v2) — verified via streamed HTML with cache cleared
- [ ] Visual spot-check of `/explore` skeleton on a slow connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)