### PR TITLE
Enrich benefits: Aer Lingus Visa Signature

### DIFF
--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -4,6 +4,7 @@ slug: "aer-lingus-visa-signature-card"
 accepting_applications: true
 image: "aer-lingus.png"
 annual_fee: 95
+foreign_transaction_fee: false
 reward_type: "miles"
 tags:
   - airline
@@ -32,4 +33,25 @@ apr:
   regular:
     min: 18.49
     max: 28.49
+benefits:
+  - name: "Companion Pass"
+    description: "Complimentary economy companion ticket valid for 12 months when you spend $30,000 on the card in a calendar year"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false
+  - name: "Priority Boarding"
+    description: "Priority boarding for the cardmember and authorized users on Aer Lingus flights between the US and Ireland"
+    frequency: "per_flight"
+    category: "travel"
+    enrollment_required: false
+  - name: "10% Flight Discount"
+    description: "10% off Aer Lingus flights from the US to Europe when booking via the designated cardmember website"
+    frequency: "per_purchase"
+    category: "travel"
+    enrollment_required: false
+  - name: "DashPass Membership"
+    description: "Complimentary DashPass for at least one year when activated by Dec 31, 2027"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: true
 apply_link: https://creditcards.chase.com/travel-credit-cards/aer-lingus


### PR DESCRIPTION
Adds the missing `benefits` section for the Aer Lingus Visa Signature card.

**Apply link (primary source):** https://creditcards.chase.com/travel-credit-cards/aer-lingus

🤖 Generated with [Claude Code](https://claude.com/claude-code)