### PR TITLE
Enrich benefits: British Airways Visa Signature

### DIFF
--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -4,6 +4,7 @@ slug: "british-airways-visa-signature-card"
 accepting_applications: true
 image: "british-airways.png"
 annual_fee: 95
+foreign_transaction_fee: false
 reward_type: "miles"
 tags:
   - airline
@@ -29,4 +30,26 @@ apr:
   regular:
     min: 19.24
     max: 29.99
+benefits:
+  - name: "Travel Together Ticket"
+    description: "Companion travel ticket (or 50% Avios discount for solo travel) when you spend $30,000 in a calendar year"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false
+  - name: "Reward Flight Statement Credit"
+    value: 600
+    description: "Up to three statement credits per year — $100 for Economy/Premium Economy or $200 for Business/First — on taxes and carrier charges paid for British Airways reward flights"
+    frequency: "annual"
+    category: "statement_credit"
+    enrollment_required: false
+  - name: "10% Flight Discount"
+    description: "10% off British Airways flights from the US to London booked via the designated cardmember website"
+    frequency: "per_purchase"
+    category: "travel"
+    enrollment_required: false
+  - name: "DashPass Membership"
+    description: "Complimentary DashPass for at least one year when activated by Dec 31, 2027"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: true
 apply_link: https://creditcards.chase.com/travel-credit-cards/british-airways


### PR DESCRIPTION
Adds the missing `benefits` section for the British Airways Visa Signature card.

**Apply link (primary source):** https://creditcards.chase.com/travel-credit-cards/british-airways

🤖 Generated with [Claude Code](https://claude.com/claude-code)
