### PR TITLE
Enrich benefits: Southwest Rapid Rewards Plus

### DIFF
--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -33,4 +33,47 @@ image: "chase-southwest-rapid-rewards-plus.png"
 tags:
   - airline
   - travel
+benefits:
+  - name: "Anniversary Points Bonus"
+    value: 3000
+    description: "3,000 bonus points credited to your Rapid Rewards account each year on your account anniversary"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: false
+  - name: "Companion Pass Boost"
+    value: 10000
+    description: "10,000 Companion Pass qualifying points deposited each year by January 31"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: false
+  - name: "First Checked Bag Free"
+    description: "First checked bag free for the cardmember plus up to 8 passengers on the same reservation"
+    frequency: "per_flight"
+    category: "travel"
+    enrollment_required: false
+  - name: "10% Flight Discount"
+    description: "10% off promo code for one Southwest flight per anniversary year (excludes Basic fare)"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false
+  - name: "Complimentary Standard Seat"
+    description: "Select a Standard seat within 48 hours prior to departure for the cardmember plus up to 8 passengers on the same reservation, when available"
+    frequency: "per_flight"
+    category: "travel"
+    enrollment_required: false
+  - name: "25% Inflight Purchase Credit"
+    description: "25% back on inflight drinks and Wi-Fi purchases when paid with the card"
+    frequency: "per_purchase"
+    category: "statement_credit"
+    enrollment_required: false
+  - name: "DashPass Membership"
+    description: "Complimentary DashPass for at least one year plus $10 quarterly off non-restaurant DoorDash orders when activated by Dec 31, 2027"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: true
+  - name: "No Foreign Transaction Fees"
+    description: "No foreign transaction fees on purchases made outside the US"
+    frequency: "per_purchase"
+    category: "travel"
+    enrollment_required: false
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/plus


### PR DESCRIPTION
Adds the missing `benefits` section for the Southwest Rapid Rewards Plus card.

**Apply link (primary source):** https://creditcards.chase.com/travel-credit-cards/southwest/plus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
