### PR TITLE
Enrich benefits: USAA Eagle Navigator

### DIFF
--- a/data/cards/usaa-eagle-navigator.yaml
+++ b/data/cards/usaa-eagle-navigator.yaml
@@ -5,6 +5,7 @@ image: "usaa-eagle-navigator.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 95
+foreign_transaction_fee: false
 tags:
   - travel
   - rewards
@@ -28,3 +29,15 @@ apr:
   regular:
     min: 18.99
     max: 28.99
+benefits:
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 100
+    description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fees, once every 4 years"
+    frequency: "every_4_years"
+    category: "travel"
+    enrollment_required: false
+  - name: "Active Duty Military Benefits"
+    description: "$0 annual fee while on active duty plus reduced APR under Servicemembers Civil Relief Act for eligible service members"
+    frequency: "annual"
+    category: "other"
+    enrollment_required: false


### PR DESCRIPTION
Adds the missing `benefits` section for the USAA Eagle Navigator card.

**Apply link:** Not present in YAML — primary source was the issuer's product page (USAA does not publish a stable apply URL we could fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
