### PR TITLE
Enrich benefits: Wells Fargo Choice Privileges Select Mastercard

### DIFF
--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -5,6 +5,7 @@ image: "choice-privileges-select.png"
 accepting_applications: true
 category: "travel"
 annual_fee: 95
+foreign_transaction_fee: false
 reward_type: "points"
 tags:
   - travel
@@ -39,4 +40,28 @@ apr:
   regular:
     min: 19.74
     max: 28.49
+benefits:
+  - name: "Anniversary Points Bonus"
+    value: 30000
+    description: "30,000 bonus Choice Privileges points each anniversary year — about 3 reward nights at participating Choice hotels"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: false
+  - name: "Choice Privileges Platinum Elite Status"
+    description: "Automatic Platinum Elite membership; earn 25% bonus points on Choice Hotels stays plus elite perks like room upgrades when available"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 120
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fees, once every 4 years"
+    frequency: "every_4_years"
+    category: "travel"
+    enrollment_required: false
+  - name: "Cell Phone Protection"
+    value: 800
+    description: "Up to $800 per claim ($25 deductible) for damage or theft when you pay your monthly cell phone bill with the card"
+    frequency: "per_claim"
+    category: "telecom"
+    enrollment_required: false
 apply_link: https://creditcards.wellsfargo.com/choice-hotels-privileges-select-mastercard


### PR DESCRIPTION
Adds the missing \`benefits\` section for the Wells Fargo Choice Privileges Select Mastercard.

**Apply link (primary source):** https://creditcards.wellsfargo.com/choice-hotels-privileges-select-mastercard

## Changes
- Adds 4 benefits: Anniversary Points Bonus (30,000), Choice Privileges Platinum Elite Status, Global Entry / TSA PreCheck Credit, Cell Phone Protection.
- Sets \`foreign_transaction_fee: false\` (replaces what would have been a standalone \"No Foreign Transaction Fees\" benefit entry — uses the new structured field introduced in #508).

## Note
Uses the \`foreign_transaction_fee\` field defined in #508. The build-cards validator does not enforce JSON Schema's \`additionalProperties: false\` (it does its own field-by-field checks), so the field is accepted today; once #508 lands, the field is also formally documented in the schema, the TypeScript Card interface, and \`docs/adding-cards.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)