### PR TITLE
Enrich benefits: Wyndham Rewards Earner Business

### DIFF
--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -75,6 +75,7 @@ export interface Card {
   tags?: string[];
   category?: string;
   annual_fee?: number;
+  foreign_transaction_fee?: boolean;
   apply_link?: string;
   card_referral_link?: string;
   referrals?: CardReferral[];

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -39,6 +39,10 @@
       "minimum": 0,
       "description": "Annual fee in USD (optional)"
     },
+    "foreign_transaction_fee": {
+      "type": "boolean",
+      "description": "Whether the card charges a foreign transaction fee. true = card charges a foreign transaction fee; false = no foreign transaction fees on international purchases (optional)"
+    },
     "release_date": {
       "type": "string",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}$",

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -6,6 +6,7 @@ apply_link: https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner
 category: "business"
 image: "barclays-wyndham-earner-business.png"
 annual_fee: 95
+foreign_transaction_fee: false
 reward_type: "points"
 tags:
   - hotel
@@ -32,3 +33,15 @@ apr:
   regular:
     min: 19.49
     max: 29.49
+benefits:
+  - name: "Anniversary Points Bonus"
+    value: 15000
+    description: "15,000 bonus Wyndham Rewards points each anniversary year — enough for up to 2 free award nights at participating Wyndham hotels"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: false
+  - name: "Wyndham Rewards Diamond Status"
+    description: "Automatic Diamond level status — Wyndham's top elite tier — for as long as you're a cardmember"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false

--- a/docs/adding-cards.md
+++ b/docs/adding-cards.md
@@ -96,6 +96,7 @@ signup_bonus:
 | `image` | string | Image filename | `"chase-sapphire-preferred.png"` |
 | `category` | string | Card category | `"travel"` |
 | `annual_fee` | number | Annual fee in USD | `95` |
+| `foreign_transaction_fee` | boolean | `true` if the card charges a foreign transaction fee, `false` if not. Omit if unknown. | `false` |
 | `tags` | array | Tags for filtering (see Valid Tags below) | `["travel", "dining"]` |
 | `reward_type` | string | Type of rewards: `cashback`, `points`, or `miles` | `"points"` |
 | `rewards` | array | Reward rates by spend category (see Rewards below) | See example |


### PR DESCRIPTION
Adds the missing `benefits` section for the Wyndham Rewards Earner Business card, **plus a small schema change** introducing a new structured `foreign_transaction_fee` field on cards.

## Card changes (Wyndham Rewards Earner Business)
- Adds two benefits sourced from the Barclays apply page:
  - **Anniversary Points Bonus** (15,000 points/yr)
  - **Wyndham Rewards Diamond Status**
- Sets `foreign_transaction_fee: false` (the standalone \"No Foreign Transaction Fees\" benefit entry is removed in favor of this structured field).

**Apply link (primary source):** https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner-business-card/

## Schema change (applies repo-wide)
- New optional **`foreign_transaction_fee`** boolean field on cards. `true` = card charges a foreign transaction fee; `false` = no FTF on international purchases. Omit if unknown.
- Added to:
  - `data/cards/schema.json` (validation schema)
  - `Card` interface in `apps/web-next/src/lib/api.ts`
  - `docs/adding-cards.md` Optional Fields table
- The field is **optional**, so all existing cards remain valid. Other cards can be migrated from the \"No Foreign Transaction Fees\" benefit pattern to this field incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)