### PR TITLE
Benefit value_unit field — render points/miles correctly, not as $

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -22,6 +22,7 @@ import {
   CardWireEntry,
 } from "@/lib/api";
 import { getValuationDetails } from "@/lib/valuations";
+import { formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
 import { NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { Article } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -270,6 +271,7 @@ export default function CardClient({
 
   const creditBenefits = (card.benefits || []).filter((b) => b.value > 0);
   const totalCredits = creditBenefits.reduce((sum, b) => {
+    if (!isMonetaryBenefit(b)) return sum;
     if (b.frequency === "ongoing") return sum;
     if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
     return sum + b.value;
@@ -781,7 +783,7 @@ export default function CardClient({
                             <div className="cj-cell-detail">{b.description}</div>
                           </td>
                           <td className="cj-tr">
-                            ${b.value.toLocaleString()}
+                            {formatBenefitValue(b)}
                           </td>
                         </tr>
                       ))}

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -102,17 +102,25 @@ export default async function CardPage({ params }: CardPageProps) {
 
     const { card, ratings, wire } = cardWithRatingsAndWire;
 
-    // Merge benefits from local cards.json if not present in API response
-    if (!card.benefits) {
-      try {
-        const localData = JSON.parse(readFileSync(join(process.cwd(), '../../data/cards.json'), 'utf8'));
-        const localCard = localData.cards.find((c: { slug: string; benefits?: CardBenefit[] }) => c.slug === slug);
-        if (localCard?.benefits) {
+    // Merge benefits from local cards.json: use as fallback when API has none,
+    // and overlay value_unit on API benefits while CloudFront catches up to the
+    // schema (so points-valued benefits render correctly even before CDN refresh).
+    try {
+      const localData = JSON.parse(readFileSync(join(process.cwd(), '../../data/cards.json'), 'utf8'));
+      const localCard = localData.cards.find((c: { slug: string; benefits?: CardBenefit[] }) => c.slug === slug);
+      if (localCard?.benefits) {
+        if (!card.benefits) {
           card.benefits = localCard.benefits;
+        } else {
+          const localByName = new Map(localCard.benefits.map((b: CardBenefit) => [b.name, b]));
+          card.benefits = card.benefits.map((b) => {
+            const local = localByName.get(b.name) as CardBenefit | undefined;
+            return local?.value_unit ? { ...b, value_unit: local.value_unit } : b;
+          });
         }
-      } catch {
-        // Silently fail - benefits will appear once CDN is updated
       }
+    } catch {
+      // Silently fail - benefits will appear once CDN is updated
     }
 
     // Filter news and articles for this specific card

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -12,6 +12,7 @@ import {
   InformationCircleIcon,
 } from '@heroicons/react/24/outline';
 import { Card, Reward } from '@/lib/api';
+import { formatBenefitValue, isMonetaryBenefit } from '@/lib/cardDisplayUtils';
 import { cardMatchesSearch } from '@/lib/searchAliases';
 import {
   categoryLabels,
@@ -525,6 +526,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                     const credits = card.benefits.filter(b => b.value > 0);
                     const perks = card.benefits.filter(b => b.value === 0);
                     const totalAnnual = credits.reduce((sum, b) => {
+                      if (!isMonetaryBenefit(b)) return sum;
                       if (b.frequency === 'multi_year') return sum + Math.round(b.value / 4);
                       return sum + b.value;
                     }, 0);
@@ -536,7 +538,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                         )}
                         <div className="text-xs text-gray-500 space-y-0.5">
                           {credits.map(b => (
-                            <div key={b.name}>{b.name} (${b.value}{b.frequency === 'annual' ? '/yr' : b.frequency === 'monthly' ? '/mo' : b.frequency === 'quarterly' ? '/qtr' : ''})</div>
+                            <div key={b.name}>{b.name} ({formatBenefitValue(b)}{b.frequency === 'annual' ? '/yr' : b.frequency === 'monthly' ? '/mo' : b.frequency === 'quarterly' ? '/qtr' : ''})</div>
                           ))}
                           {perks.length > 0 && (
                             <div className="text-gray-400 mt-1">+{perks.length} perk{perks.length !== 1 ? 's' : ''}</div>
@@ -813,6 +815,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                 const totalCredits = activeCards.map(c => {
                   if (!c.benefits) return 0;
                   return c.benefits.filter(b => b.value > 0).reduce((sum, b) => {
+                    if (!isMonetaryBenefit(b)) return sum;
                     if (b.frequency === 'multi_year') return sum + Math.round(b.value / 4);
                     return sum + b.value;
                   }, 0);
@@ -832,7 +835,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                             )}
                             <div className="text-xs text-gray-500 space-y-0.5">
                               {card.benefits.filter(b => b.value > 0).map(b => (
-                                <div key={b.name}>{b.name} (${b.value}{b.frequency === 'annual' ? '/yr' : b.frequency === 'monthly' ? '/mo' : b.frequency === 'quarterly' ? '/qtr' : ''})</div>
+                                <div key={b.name}>{b.name} ({formatBenefitValue(b)}{b.frequency === 'annual' ? '/yr' : b.frequency === 'monthly' ? '/mo' : b.frequency === 'quarterly' ? '/qtr' : ''})</div>
                               ))}
                               {card.benefits.filter(b => b.value === 0).length > 0 && (
                                 <div className="text-gray-400 mt-1">

--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -5,6 +5,7 @@ import {
   CheckCircleIcon,
 } from "@heroicons/react/24/outline";
 import { CardBenefit } from "@/lib/api";
+import { formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
 
 const frequencyLabels: Record<string, string> = {
   monthly: "/mo",
@@ -40,7 +41,9 @@ interface CardBenefitsProps {
 export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) {
   const credits = benefits.filter((b) => b.value > 0);
   const perks = benefits.filter((b) => b.value === 0);
+  // Only sum USD-valued credits — points/miles can't be meaningfully added in dollars.
   const totalAnnualValue = credits.reduce((sum, b) => {
+    if (!isMonetaryBenefit(b)) return sum;
     if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
     return sum + b.value;
   }, 0);
@@ -98,7 +101,7 @@ export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) 
                   </div>
                   <div className="flex items-baseline gap-1 mb-2">
                     <span className="text-2xl font-bold text-emerald-700">
-                      ${benefit.value}
+                      {formatBenefitValue(benefit)}
                     </span>
                     <span className="text-sm text-gray-400 font-medium">
                       {frequencyLabels[benefit.frequency]}

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import CardImage from "@/components/ui/CardImage";
 import { Card, CardBenefit, WalletCard } from "@/lib/api";
+import { formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
 import {
   CheckCircleIcon,
   GiftIcon,
@@ -74,6 +75,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
 
   const totalAnnualValue = useMemo(() => {
     return allCredits.reduce((sum, b) => {
+      if (!isMonetaryBenefit(b)) return sum;
       if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
       return sum + b.value;
     }, 0);
@@ -150,7 +152,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
                     <CardImage cardImageLink={credit.cardImage} alt={credit.cardName} width={48} height={30} className="rounded object-contain" sizes="48px" />
                   </Link>
                   <div className="text-right flex-shrink-0">
-                    <p className="text-lg font-bold text-emerald-700">${credit.value}</p>
+                    <p className="text-lg font-bold text-emerald-700">{formatBenefitValue(credit)}</p>
                     <p className="text-xs text-gray-400">{frequencyLabels[credit.frequency]}</p>
                   </div>
                   {credit.enrollment_required && (
@@ -191,6 +193,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
             const credits = benefits.filter(b => b.value > 0);
             const perks = benefits.filter(b => b.value === 0);
             const cardTotal = credits.reduce((sum, b) => {
+              if (!isMonetaryBenefit(b)) return sum;
               if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
               return sum + b.value;
             }, 0);
@@ -229,7 +232,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
                             )}
                           </div>
                           <div className="flex items-baseline gap-1 flex-shrink-0">
-                            <span className="text-sm font-bold text-emerald-700">${b.value}</span>
+                            <span className="text-sm font-bold text-emerald-700">{formatBenefitValue(b)}</span>
                             <span className="text-xs text-gray-400">{frequencyLabels[b.frequency]}</span>
                           </div>
                         </div>

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -49,6 +49,7 @@ export interface CardAPR {
 export interface CardBenefit {
   name: string;
   value: number;
+  value_unit?: 'usd' | 'points' | 'miles';
   description: string;
   frequency: 'monthly' | 'quarterly' | 'semi_annual' | 'annual' | 'multi_year' | 'ongoing';
   category: 'dining' | 'dining_travel' | 'travel' | 'hotel' | 'entertainment' | 'shopping' | 'fitness' | 'lounge' | 'security' | 'gas' | 'streaming' | 'grocery' | 'rideshare' | 'other';

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -9,7 +9,7 @@ import {
   ComputerDesktopIcon,
   CreditCardIcon,
 } from "@heroicons/react/24/outline";
-import { Card, Reward } from "@/lib/api";
+import { Card, CardBenefit, Reward } from "@/lib/api";
 import { getValuation } from "@/lib/valuations";
 
 export const categoryLabels: Record<string, string> = {
@@ -92,6 +92,20 @@ export function CategoryIcon({ category, className }: { category: string; classN
     default:
       return <CreditCardIcon className={iconClass} />;
   }
+}
+
+// Benefit value rendering helpers — distinguishes USD-valued benefits from
+// points/miles-valued ones so a "10,000 points" Companion Pass Boost doesn't
+// render as "$10,000" or get summed into Total Annual Credits.
+export function isMonetaryBenefit(benefit: { value_unit?: string }): boolean {
+  return !benefit.value_unit || benefit.value_unit === 'usd';
+}
+
+export function formatBenefitValue(benefit: CardBenefit): string {
+  const v = benefit.value.toLocaleString();
+  if (benefit.value_unit === 'points') return `${v} points`;
+  if (benefit.value_unit === 'miles') return `${v} miles`;
+  return `$${v}`;
 }
 
 // Cents-per-point estimates by program (driven by data/valuations.yaml)

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -39,6 +39,7 @@ apr:
 benefits:
   - name: "Anniversary Points Bonus"
     value: 5000
+    value_unit: "points"
     description: "5,000 bonus TrueBlue points each year after your account anniversary"
     frequency: "annual"
     category: "rewards"

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -41,6 +41,7 @@ apr:
 benefits:
   - name: "Anniversary Points Bonus"
     value: 5000
+    value_unit: "points"
     description: "5,000 bonus TrueBlue points each year after your account anniversary"
     frequency: "annual"
     category: "rewards"

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -36,12 +36,14 @@ tags:
 benefits:
   - name: "Anniversary Points Bonus"
     value: 3000
+    value_unit: "points"
     description: "3,000 bonus points credited to your Rapid Rewards account each year on your account anniversary"
     frequency: "annual"
     category: "rewards"
     enrollment_required: false
   - name: "Companion Pass Boost"
     value: 10000
+    value_unit: "points"
     description: "10,000 Companion Pass qualifying points deposited each year by January 31"
     frequency: "annual"
     category: "rewards"

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -43,6 +43,7 @@ apr:
 benefits:
   - name: "Anniversary Points Bonus"
     value: 30000
+    value_unit: "points"
     description: "30,000 bonus Choice Privileges points each anniversary year — about 3 reward nights at participating Choice hotels"
     frequency: "annual"
     category: "rewards"

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -36,6 +36,7 @@ apr:
 benefits:
   - name: "Anniversary Points Bonus"
     value: 15000
+    value_unit: "points"
     description: "15,000 bonus Wyndham Rewards points each anniversary year — enough for up to 2 free award nights at participating Wyndham hotels"
     frequency: "annual"
     category: "rewards"


### PR DESCRIPTION
## Problem
The Companion Pass Boost on Southwest Rapid Rewards Plus was rendering as **\"$10,000\"** because the UI ([CardBenefits.tsx:101](apps/web-next/src/components/ui/CardBenefits.tsx)) blindly prefixes `$` to `benefit.value` and sums everything into a \"Total annual credits\" figure.

Six benefits across five cards on main were affected:

| Card | Benefit | value | Currently shows | Should show |
|---|---|---|---|---|
| JetBlue Plus | Anniversary Points Bonus | 5,000 | \"$5,000\" | \"5,000 points\" |
| JetBlue Business | Anniversary Points Bonus | 5,000 | \"$5,000\" | \"5,000 points\" |
| Southwest Plus | Anniversary Points Bonus | 3,000 | \"$3,000\" | \"3,000 points\" |
| Southwest Plus | Companion Pass Boost | 10,000 | \"$10,000\" | \"10,000 points\" |
| Wells Fargo Choice Privileges Select | Anniversary Points Bonus | 30,000 | \"$30,000\" | \"30,000 points\" |
| Wyndham Earner Business | Anniversary Points Bonus | 15,000 | \"$15,000\" | \"15,000 points\" |

## Approach
**Show points, don't convert.** Conversion via cents-per-point valuations is fragile (rates fluctuate, valuations are subjective, and the rendered Total Credits would silently bake in editorial assumptions).

### Schema change
- Add optional `value_unit?: 'usd' | 'points' | 'miles'` to the `CardBenefit` interface in [api.ts](apps/web-next/src/lib/api.ts). Default is `'usd'` so all existing data is unchanged.

### UI helpers
- New utilities in [cardDisplayUtils.tsx](apps/web-next/src/lib/cardDisplayUtils.tsx):
  - `isMonetaryBenefit(b)` — `true` when `value_unit` is `'usd'` or undefined.
  - `formatBenefitValue(b)` — returns `\"$5,000\"` for USD, `\"5,000 points\"` for points, `\"5,000 miles\"` for miles.

### UI updates
All three render sites updated:
- [CardBenefits.tsx](apps/web-next/src/components/ui/CardBenefits.tsx) — card detail page
- [WalletBenefits.tsx](apps/web-next/src/components/wallet/WalletBenefits.tsx) — profile wallet view (both \"All Credits\" and \"By Card\" modes)
- [CompareClient.tsx](apps/web-next/src/app/compare/CompareClient.tsx) — compare table (mobile and desktop)

For each: renders with `formatBenefitValue` and excludes non-monetary benefits from \"Total Annual Credits\" sums.

### Data
Sets `value_unit: \"points\"` on the 6 affected benefits.

## Test plan
- [x] TypeScript compiles
- [x] `build:cards` runs cleanly (160 cards built)
- [x] All 5 affected pages return 200 with no compile errors
- [ ] Visual check on `/card/southwest-rapid-rewards-plus-credit-card` once deployed — the Companion Pass Boost should render as \"10,000 points\" instead of \"$10,000\", and the Total Annual Credits should not include it.
- [ ] Same check on the JetBlue Plus, JetBlue Business, Wells Fargo Choice Privileges Select, and Wyndham Earner Business detail pages.

## Note
This conflicts slightly with the still-open [#508](https://github.com/CreditOdds/creditodds/pull/508) (Wyndham Earner Business + `foreign_transaction_fee` field). Both touch the Wyndham YAML and `lib/api.ts`, but the changes are additive (different fields), so they should resolve cleanly when one merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)