### PR TITLE
Fix silent data loss in rewards-and-benefits PR step

### DIFF
--- a/.github/workflows/check-card-rewards-and-benefits.yml
+++ b/.github/workflows/check-card-rewards-and-benefits.yml
@@ -76,7 +76,7 @@ jobs:
           git stash push -m "rewards-and-benefits-check" -- data/cards/
 
           DATE=$(date +%Y-%m-%d)
-          for FILE in $(git stash show stash@{0} --name-only -- data/cards/); do
+          for FILE in $(git stash show stash@{0} --name-only); do
             SLUG=$(basename "$FILE" .yaml)
             BRANCH="auto/${SLUG}-rewards-benefits-${DATE}"
 


### PR DESCRIPTION
## Summary

The `Open one PR per modified card` step in `check-card-rewards-and-benefits.yml` was silently discarding all detected card changes.

`git stash show stash@{0} --name-only -- data/cards/` failed at runtime with `Too many revisions specified: 'stash@{0}' 'data/cards/'` — `git stash show` parses both arguments as revisions rather than honoring the pathspec separator. Because the failure occurred inside `$(...)` in a `for`-loop, `bash -e` did not abort: the loop iterated zero times, `git stash drop` ran, and the job exited 0 — green run, no PRs, real changes lost.

The stash is already path-scoped to `data/cards/` via `git stash push -- data/cards/`, so the redundant pathspec on `git stash show` can simply be removed.

Observed in run #4 (2026-05-02):
```
Saved working directory and index state On main: rewards-and-benefits-check
Too many revisions specified: 'stash@{0}' 'data/cards/'
Dropped stash@{0} (d53006a3...)
```

## Test plan

- [ ] Manually dispatch the workflow on a card known to have changes; verify a PR is opened.
- [ ] Confirm idempotency guard still skips when the auto-branch already exists.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLTGaCRmCThV2zDTbKzpTc)_