### PR TITLE
Quality fixes for the rewards/benefits checker

### DIFF
--- a/data/benefit-policy.yaml
+++ b/data/benefit-policy.yaml
@@ -66,6 +66,21 @@ exclude:
 
   # Misc network/platform features
   - "Group 5 Boarding"   # (Southwest's; default boarding group, not a perk)
+  - "Roadside Dispatch"
+  - "Emergency Cash Disbursement"
+  - "Emergency Cash"
+  - "Emergency Card Replacement"
+  - "Card Replacement"
+
+  # Welcome/signup bonus belongs in `signup_bonus:`, not `benefits[]`
+  - "Welcome Bonus"
+  - "Welcome Offer"
+  - "Sign-Up Bonus"
+  - "Signup Bonus"
+  - "New Cardmember Bonus"
+  - "New Cardmember Offer"
+  - "New Account Bonus"
+  - "Introductory Bonus"
 
 # ────────────────────────────────────────────────────────────────────────────
 # 2. Borderline — surface in the weekly review issue, do NOT auto-PR.
@@ -87,6 +102,8 @@ borderline:
   - "Purchase Protection"
   - "Extended Warranty"
   - "Lost Luggage Reimbursement"
+  - "Lost Baggage Reimbursement"
+  - "Lost Baggage"
   - "Baggage Delay Insurance"
   - "Baggage Insurance Plan"
   - "Travel Accident Insurance"

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -308,6 +308,8 @@ Rules:
 - DO NOT include "Pay Over Time", "ExtendPay", "0% intro APR" entries — those are financing features, not benefits.
 - DO NOT include earning multipliers (e.g. "10% bonus on points earned") — describe earn rates only in "rewards".
 - DO NOT include "Free Employee Cards" or other generic business-card platform features.
+- DO NOT include the welcome/signup bonus as a benefit. The card's signup bonus is captured separately in the YAML's \`signup_bonus:\` block. Names like "Welcome Bonus", "New Cardmember Bonus", "Sign-Up Bonus", "Introductory Bonus" must NOT appear in the \`benefits[]\` array.
+- DO NOT include "Roadside Dispatch", "Emergency Cash Disbursement", or "Emergency Card Replacement" — those are Visa/Mastercard network-tier features available on every card on the network.
 - STRIKETHROUGH TEXT in [STRIKETHROUGH: ...] markers is expired/old; ignore those values.
 
 EXAMPLES — what good extraction looks like for our team:
@@ -428,15 +430,74 @@ function diffRewards(current, proposed) {
   return { added, removed, changed };
 }
 
+// Tokenize a benefit name into meaningful words for fuzzy duplicate detection.
+// Drops short words and a small stop-list of glue words that show up across
+// many benefits (Annual, Statement, Credit, etc.) and would otherwise
+// produce false positives.
+const BENEFIT_NAME_STOP_WORDS = new Set([
+  'annual', 'statement', 'credit', 'credits', 'free', 'on', 'and', 'the', 'a',
+  'of', 'for', 'in', 'with', 'plan', 'membership', 'rewards', 'reward',
+]);
+// Normalize synonyms so the tokenizer treats "cell"/"cellular" and
+// "phone"/"telephone" as the same word — apply pages frequently use both.
+const BENEFIT_NAME_ALIASES = new Map([
+  ['cellular', 'cell'],
+  ['telephone', 'phone'],
+  ['baggage', 'luggage'],
+  ['waiver', 'damage'],
+  ['cdw', 'damage'],
+]);
+function tokenizeBenefitName(name) {
+  return new Set(
+    String(name || '')
+      .toLowerCase()
+      .replace(/[^\w\s]/g, ' ')
+      .split(/\s+/)
+      .map(t => BENEFIT_NAME_ALIASES.get(t) || t)
+      .filter(t => t.length > 2 && !BENEFIT_NAME_STOP_WORDS.has(t))
+  );
+}
+
+// Two benefit names are likely the same benefit if they share at least 2
+// meaningful tokens, OR if one's meaningful-token set is fully contained in
+// the other (handles cases like "Cell Phone Protection" vs
+// "Cellular Telephone Protection" → "phone" + "protection" overlap; Set logic
+// would also catch "Cell Phone Protection" vs "Cell Phone Protection Plus").
+function looksLikeSameBenefit(a, b) {
+  if (a.toLowerCase() === b.toLowerCase()) return true;
+  const ta = tokenizeBenefitName(a);
+  const tb = tokenizeBenefitName(b);
+  if (ta.size === 0 || tb.size === 0) return false;
+  const shared = [...ta].filter(t => tb.has(t)).length;
+  if (shared >= 2) return true;
+  // If one set is a subset of the other AND has at least 1 meaningful token,
+  // call it a match (e.g. {"phone","protection"} ⊂ {"phone","protection","plus"})
+  const aSubsetOfB = [...ta].every(t => tb.has(t));
+  const bSubsetOfA = [...tb].every(t => ta.has(t));
+  if ((aSubsetOfB || bSubsetOfA) && shared >= 1) return true;
+  return false;
+}
+
 function diffBenefits(current, proposed, policy, removedFromThisCard) {
   // Each proposed benefit is routed by classifyBenefit(); only "auto" routes
   // into the YAML. Existing benefits aren't touched (the human curated those).
-  const currentNames = new Set((current || []).map(b => b.name));
+  const currentNames = (current || []).map(b => b.name);
   const auto = [];
   const review = [];
   const skipped = [];
   for (const b of proposed || []) {
-    if (currentNames.has(b.name)) continue; // already there
+    // Exact-name dedup
+    if (currentNames.includes(b.name)) {
+      skipped.push({ ...b, tier: 'duplicate_exact' });
+      continue;
+    }
+    // Fuzzy dedup — skip a proposal that probably refers to an existing benefit
+    // (the human curated the existing wording; we won't replace it).
+    const fuzzyMatch = currentNames.find(n => looksLikeSameBenefit(n, b.name));
+    if (fuzzyMatch) {
+      skipped.push({ ...b, tier: 'duplicate_fuzzy', fuzzyMatch });
+      continue;
+    }
     const tier = classifyBenefit(b.name, policy, removedFromThisCard);
     if (tier === 'auto') auto.push(b);
     else if (tier === 'borderline') review.push({ ...b, tier });
@@ -502,8 +563,13 @@ function applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff) {
   // Re-serialize. We use full re-dump to avoid the regex-based field-replacement
   // hairiness in check-card-pages.js — the diff size is small per card so a
   // re-dump is fine and gives stable formatting.
+  // forceQuotes:true matches the existing repo style (most YAMLs already
+  // double-quote string values) and keeps the diff stable — without it,
+  // js-yaml strips quotes from already-quoted simple strings like `bank: "Chase"`,
+  // producing huge cosmetic diffs across every card the script touches.
   const newYaml = yaml.dump(data, {
     quotingType: '"',
+    forceQuotes: true,
     lineWidth: -1,
     sortKeys: false,
     noRefs: true,


### PR DESCRIPTION
## Five issues from the first all-cards run

All surfaced on [#593 Wells Fargo Autograph Journey](https://github.com/CreditOdds/creditodds/pull/593) but apply across the 83 PRs from run 25243468203.

### 1. Welcome bonus contamination
Extractor included the welcome bonus as a row in `benefits[]` (`name: Welcome Bonus, value: 60000, value_unit: points`) even though the YAML has a dedicated `signup_bonus:` block.

**Fix**: tightened the extractor prompt to explicitly forbid this; added "Welcome Bonus", "New Cardmember Bonus", "Sign-Up Bonus", "Introductory Bonus" etc. to `policy.exclude` as a backup filter.

### 2. Duplicate benefits with different wording
"Cellular Telephone Protection" proposed alongside existing "Cell Phone Protection". Same benefit, different wording.

**Fix**: fuzzy-duplicate check that tokenizes both names (with a small alias map: `cell`↔`cellular`, `phone`↔`telephone`, `baggage`↔`luggage`, `waiver`↔`damage`/`cdw`) and skips a proposal if it shares ≥2 meaningful tokens with — or is a token-subset of — an existing benefit. Verified: 8/8 test cases.

### 3. Network-tier perks
"Roadside Dispatch", "Emergency Cash Disbursement", "Emergency Card Replacement" are baseline Visa/Mastercard features.

**Fix**: added to `policy.exclude` and the prompt's DO-NOT list.

### 4. Missing borderline alias
Policy had "Lost Luggage Reimbursement" but apply pages also say "Lost Baggage Reimbursement".

**Fix**: added the alias to `policy.borderline`.

### 5. YAML quote-stripping
`yaml.dump`'s default behavior strips quotes from simple strings (`bank: "Chase"` → `bank: Chase`), polluting every diff with cosmetic noise across every line of every modified YAML.

**Fix**: `forceQuotes: true` to match the existing repo style.

## After merging
I'll close all 83 existing PRs (they have these issues baked in) and re-trigger the workflow. Future runs should produce smaller, cleaner PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)