### PR TITLE
Add balance transfer cards explainer article

### DIFF
--- a/data/articles/balance-transfer-cards-explained.yaml
+++ b/data/articles/balance-transfer-cards-explained.yaml
@@ -1,0 +1,159 @@
+id: "balance-transfer-cards-explained"
+slug: "balance-transfer-cards-explained"
+title: "Balance Transfer Cards: How They Work, What They Cost, and How Much Credit You'll Get"
+date: "2026-05-02"
+author: "CreditOdds"
+summary: "A practical guide to 0% balance transfer cards in 2026 — fees, intro periods, credit limits, and the mistakes that quietly cost people thousands."
+tags:
+  - guide
+  - beginner
+  - strategy
+related_cards:
+  - citi-simplicity-card
+  - wells-fargo-reflect
+  - bankamericard
+  - citi-diamond-preferred
+seo_title: "Balance Transfer Credit Cards Explained (2026) | CreditOdds"
+seo_description: "How balance transfer cards work, what fees to expect, typical credit limits ($1K–$25K), and the FAQ most guides skip. Updated for May 2026."
+estimated_value: "$300–$2,000+ in interest saved"
+content: |
+  If you're carrying a credit card balance at 22% APR, the math is brutal. A $5,000 balance making minimum payments will run you well over a thousand dollars in interest before it's gone. A balance transfer card is one of the few legitimate escape hatches — done right, you can wipe out the interest entirely and just pay down the principal.
+
+  Done wrong, you can end up paying more than you started with. Here's what actually matters.
+
+  ## What a Balance Transfer Card Actually Is
+
+  A balance transfer card is a credit card that lets you move debt from one or more existing cards onto it, and charges 0% interest on that transferred balance for an introductory period — typically **12 to 21 months** in 2026.
+
+  The pitch is simple: stop paying interest, knock down the principal, escape.
+
+  The catch is that balance transfer cards are not rewards cards. They generally earn no points, no cash back, and have no signup bonus. They're a financial tool, not a daily driver.
+
+  ## How the Mechanics Work
+
+  Here's what actually happens when you open one:
+
+  1. **You apply and get approved**, and the issuer assigns a credit limit.
+  2. **You request a balance transfer** — usually online or by phone — telling the new issuer which card to pay off and how much.
+  3. **The new issuer pays your old card directly**, and that amount shows up as a balance on the new card.
+  4. **You pay a balance transfer fee** of typically 3% to 5% of the transferred amount, added right onto the new balance.
+  5. **You make monthly payments to the new card**, with no interest accruing during the intro period.
+  6. **When the intro period ends**, any remaining balance starts accruing interest at the regular APR — which is often 17% to 28%+.
+
+  Critically, **you must usually complete the transfer within 60 days of account opening** to lock in the 0% rate. Miss that window and you'll pay the regular APR on the transfer.
+
+  ## How Much Credit Will You Actually Get?
+
+  This is the question most guides dodge, and the honest answer is: **it depends, but a useful range is $1,000 to $10,000 for most approved applicants, with $25,000+ possible for strong credit profiles.**
+
+  Some specifics worth knowing:
+
+  - **Minimums are low.** Cards like the Wells Fargo Reflect have a stated minimum credit limit of $1,000. If your credit is thin, that's what you might get — and a $1,000 limit only helps you transfer a few hundred dollars after the fee and the issuer's transfer cap.
+  - **Most approved applicants land in the $3,000–$10,000 range.** This is the sweet spot for typical-to-good credit, decent income, and no recent delinquencies.
+  - **High limits exist but require strong credit.** Wells Fargo Reflect, Citi Diamond Preferred, and BankAmericard have all been reported issuing limits up to $25,000+ for excellent-credit applicants with high income.
+  - **You can't transfer your full credit limit.** Issuers typically cap balance transfers at **75% to 95% of your credit limit** so the transfer fee fits inside the limit. On a $10,000 limit, expect to be able to transfer roughly $8,000–$9,500.
+  - **Some issuers cap transfers in dollars, not percentages.** Citi, for example, caps balance transfers at $15,000 over a rolling period regardless of your limit.
+
+  The practical takeaway: **you can't reliably plan to consolidate $15,000 of debt onto one card**. If you have a large balance to move, you may need two cards, or you may need to transfer in stages.
+
+  ### What Determines Your Limit
+
+  Issuers don't publish the formula, but the inputs are roughly:
+
+  - Credit score (FICO 720+ helps significantly)
+  - Reported income
+  - Existing total credit limits across all your cards
+  - Debt-to-income ratio
+  - Payment history and recent delinquencies
+  - Length of credit history
+
+  One quirk worth knowing: **issuers will not approve you for a high limit just because you ask**. The limit is set at approval based on their underwriting model. You can request an increase later (often after 6 months of on-time payments), but counting on that to consolidate a large debt is risky.
+
+  ## What These Cards Actually Cost
+
+  The 0% rate is real, but balance transfer cards are not free. Three costs to model before you apply:
+
+  ### 1. The Transfer Fee
+
+  Almost every card charges a balance transfer fee — typically **3% to 5% of the transferred amount**, with a $5–$10 minimum. On a $5,000 transfer:
+
+  - 3% fee = $150
+  - 5% fee = $250
+
+  This fee is added to your transferred balance. So a $5,000 transfer at 3% means you owe $5,150 on day one. The fee is essentially the price of the 0% intro period.
+
+  ### 2. The Regular APR (After the Intro)
+
+  When the intro period ends, the regular APR kicks in on whatever balance remains. Most balance transfer cards have regular APRs in the **17% to 28%** range. If you don't pay off the balance during the intro, you're back where you started — sometimes worse, because you also paid the transfer fee.
+
+  ### 3. The Purchase Trap
+
+  Most balance transfer cards do **not** give you 0% on new purchases — or if they do, it's for a shorter period. New purchases often start accruing interest immediately at the regular APR.
+
+  And here's the trap: card issuers are required by law (the CARD Act) to apply payments above the minimum to the highest-APR balance first, but **the minimum payment itself is applied however the issuer wants** — usually to the lowest-APR balance. That means new purchases at 24% APR can sit there accruing interest the entire time you're paying down your 0% transfer.
+
+  **Rule of thumb: don't use a balance transfer card for new purchases. Treat it as a debt payoff tool only.**
+
+  ## Notable 2026 Balance Transfer Cards
+
+  A few cards consistently lead the category. None of these earn rewards — that's not the point.
+
+  | Card | 0% Intro on BT | 0% Intro on Purchases | Annual Fee |
+  |---|---|---|---|
+  | Wells Fargo Reflect | 21 months | 21 months | $0 |
+  | Citi Simplicity | 21 months | 12 months | $0 |
+  | Citi Diamond Preferred | 21 months | 12 months | $0 |
+  | BankAmericard | 18 months | 18 months | $0 |
+
+  All four charge a balance transfer fee in the 3%–5% range and have regular APRs that climb above 17% after the intro period.
+
+  ## How to Use One Without Getting Burned
+
+  A simple checklist that separates people who escape debt from people who get deeper:
+
+  1. **Calculate your monthly payoff number.** Take your transfer balance + fee, divide by the number of intro months, and that's the minimum you need to pay every month to be at zero when the clock runs out. If you can't afford that, the card probably won't solve your problem.
+  2. **Set up autopay for that exact number.** Don't rely on the minimum payment — minimums are calibrated to keep you in debt, not get you out.
+  3. **Don't put new purchases on the card.** Use a different card for spending and pay it off in full every month.
+  4. **Transfer within the deadline** (typically 60 days). Missing it usually voids the 0% rate.
+  5. **Don't close the card you're paying off.** Closing it tanks your credit utilization ratio and can drop your score.
+  6. **Don't apply if you can't stop the bleeding.** A balance transfer is a refinancing tool, not a fix for overspending. If the card you're transferring from is going to refill, you're going to end up worse.
+
+  ## FAQ
+
+  ### How much can I usually transfer?
+  Most approved applicants get a credit limit somewhere between **$3,000 and $10,000**, and you can typically transfer 75–95% of that limit. Excellent credit and strong income can push limits to $25,000+, but those approvals are not the norm.
+
+  ### Will applying for a balance transfer card hurt my credit score?
+  Yes, but mildly and usually temporarily. The hard inquiry typically costs **5–10 points**, and opening a new account drops your average account age. However, your credit utilization ratio almost always *improves* once the transfer settles (because you've added a new credit limit), which often nets out positive after a few months.
+
+  ### Can I transfer a balance from one Citi card to another Citi card?
+  No. Issuers do not let you transfer balances between their own cards. Balance transfers must come from a different bank. (This is the main reason people end up with cards from multiple issuers.)
+
+  ### What happens if I don't pay it off before the intro period ends?
+  The remaining balance starts accruing interest at the regular APR — usually 17% to 28%. Importantly, **most balance transfer cards do not use deferred interest**, meaning you only pay interest going forward on what's left, not retroactively on the original full balance. (Deferred interest is a different product, more common with store financing.)
+
+  ### Is the balance transfer fee always worth it?
+  The breakeven is straightforward: if you'd pay more in interest on your old card during the intro period than the transfer fee costs, the transfer wins. Example: $5,000 at 22% APR for 21 months would cost roughly $1,000+ in interest. A 3% transfer fee is $150. The transfer saves around $850.
+
+  ### Can I transfer balances from a personal loan or student loan?
+  Sometimes. Citi and a few other issuers allow transfers from non-credit-card debt, but most issuers limit transfers to other credit card balances. Check the specific card's terms before assuming.
+
+  ### How long does a balance transfer take?
+  Anywhere from **a few days to three weeks**. Until the transfer fully posts to your old card, **keep paying the minimum on the old card** — otherwise you'll get hit with a late fee and possibly a penalty APR.
+
+  ### Should I close the old card after the balance transfers?
+  Usually no. Closing it reduces your total available credit and shortens your average account age, both of which can drop your score. Leave it open with a $0 balance unless it has an annual fee that isn't worth paying.
+
+  ### Can I do a second balance transfer onto the same card later?
+  Yes, but the introductory promo typically only applies to transfers made within the first 60 days. Transfers after that window will be at the regular APR — meaning you're paying full interest on them.
+
+  ### Will a balance transfer card help me build credit?
+  Indirectly. Paying down debt improves your utilization ratio, which is the single biggest score factor after payment history. The card itself isn't designed to build credit — it's designed to get you out of it.
+
+  ## The Bottom Line
+
+  A balance transfer card is one of the highest-leverage financial moves available to most people in credit card debt, but only if two things are true: you have a realistic plan to pay off the balance during the intro period, and you can stop adding new debt.
+
+  If both of those are true, you can save hundreds to thousands of dollars in interest. If either is false, the transfer fee is just an extra cost on top of debt you'd have ended up carrying anyway.
+
+  Pick a card with an intro period long enough to actually pay it off, do the monthly math before you apply, and treat the card as a single-purpose tool — not a new credit line to spend on.


### PR DESCRIPTION
## Summary
- New evergreen guide: [balance-transfer-cards-explained.yaml](data/articles/balance-transfer-cards-explained.yaml)
- Covers how 0% balance transfer cards work, fees (3–5%), typical credit limits ($1K–$25K with most approved applicants in the $3K–$10K range), the new-purchase trap, and a 10-question FAQ
- Links to the four no-annual-fee BT cards already in our catalog: Citi Simplicity, Wells Fargo Reflect, BankAmericard, Citi Diamond Preferred

## Test plan
- [ ] Verify article renders at /articles/balance-transfer-cards-explained
- [ ] Check related-cards section pulls in the four linked cards
- [ ] Confirm FAQ markdown renders correctly (no broken headings)
- [ ] Verify SEO title (60 chars) and description (142 chars) fit metadata limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)