### PR TITLE
Widen article and news detail pages on desktop

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3660,12 +3660,12 @@
 
 /* ---------- Article detail (news/[id], articles/[slug]) ---------- */
 .landing-v2 .article-layout {
-  max-width: 820px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 16px 28px 72px;
 }
 .landing-v2 .article-layout.wide {
-  max-width: 1080px;
+  max-width: 1180px;
 }
 .landing-v2 .article-tags {
   display: flex;


### PR DESCRIPTION
## Summary
- Bump \`.article-layout\` max-width from 820px → 960px (and the rarely-used \`.wide\` variant from 1080px → 1180px) so article and news detail pages use more of the desktop viewport.
- Both \`/articles/[slug]\` and \`/news/[id]\` share this class, so both get the wider column.

## Test plan
- [x] Verified at 1440px viewport in dev that the article column is wider while still capped (no edge-to-edge sprawl).
- [ ] Spot-check on a real article and a news post after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)