### PR TITLE
Add car_rental as a benefit category

### DIFF
--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -30,6 +30,7 @@ const categoryIcons: Record<string, string> = {
   streaming: "📺",
   grocery: "🛒",
   rideshare: "🚗",
+  car_rental: "🚙",
   other: "✨",
 };
 

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -33,6 +33,7 @@ const categoryIcons: Record<string, string> = {
   streaming: "📺",
   grocery: "🛒",
   rideshare: "🚗",
+  car_rental: "🚙",
   other: "✨",
 };
 

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -52,7 +52,7 @@ export interface CardBenefit {
   value_unit?: 'usd' | 'points' | 'miles';
   description: string;
   frequency: 'monthly' | 'quarterly' | 'semi_annual' | 'annual' | 'multi_year' | 'ongoing';
-  category: 'dining' | 'dining_travel' | 'travel' | 'hotel' | 'entertainment' | 'shopping' | 'fitness' | 'lounge' | 'security' | 'gas' | 'streaming' | 'grocery' | 'rideshare' | 'other';
+  category: 'dining' | 'dining_travel' | 'travel' | 'hotel' | 'entertainment' | 'shopping' | 'fitness' | 'lounge' | 'security' | 'gas' | 'streaming' | 'grocery' | 'rideshare' | 'car_rental' | 'other';
   enrollment_required?: boolean;
 }
 

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -292,7 +292,7 @@ Return ONLY valid JSON in this exact shape — no markdown, no commentary:
       "value_unit": "usd" | "points" | "miles" | "percent",
       "description": "<one short sentence>",
       "frequency": "monthly" | "quarterly" | "semi_annual" | "annual" | "multi_year" | "ongoing" | "per_purchase" | "per_flight" | "per_trip" | "per_visit" | "per_rental" | "per_claim" | "every_4_years" | "one_time",
-      "category": "dining" | "dining_travel" | "travel" | "hotel" | "entertainment" | "shopping" | "fitness" | "lounge" | "security" | "gas" | "streaming" | "grocery" | "rideshare" | "telecom" | "statement_credit" | "rewards" | "other",
+      "category": "dining" | "dining_travel" | "travel" | "hotel" | "entertainment" | "shopping" | "fitness" | "lounge" | "security" | "gas" | "streaming" | "grocery" | "rideshare" | "car_rental" | "telecom" | "statement_credit" | "rewards" | "other",
       "enrollment_required": <true|false>
     }
   ],


### PR DESCRIPTION
## Summary
Surfaced while reviewing #944 (Citi AAdvantage Executive World Elite), which proposed an Avis/Budget Car Rental Credit. Adding \`car_rental\` matches the existing \`rideshare\` / \`lounge\` / \`hotel\` / \`gas\` / \`streaming\` pattern of specific subcategories.

## Changes
- \`apps/web-next/src/lib/api.ts\` — added \`car_rental\` to benefit category union.
- \`apps/web-next/src/components/ui/CardBenefits.tsx\` and \`WalletBenefits.tsx\` — added 🚙 icon (distinct from rideshare's 🚗).
- \`scripts/check-card-rewards-and-benefits.js\` — added \`car_rental\` to extractor prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)