### PR TITLE
Multi-year benefit amortization: flexible frequency_years

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -22,7 +22,7 @@ import {
   CardWireEntry,
 } from "@/lib/api";
 import { getValuationDetails } from "@/lib/valuations";
-import { formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
+import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
 import { NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { Article } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -276,7 +276,10 @@ export default function CardClient({
       const matches = unit === 'usd' ? isUsd : b.value_unit === unit;
       if (!matches) return sum;
       if (b.frequency === "ongoing") return sum;
-      if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
+      if (b.frequency === "multi_year") {
+        const years = b.frequency_years || DEFAULT_MULTI_YEAR_CYCLE;
+        return sum + Math.round(b.value / years);
+      }
       return sum + b.value;
     }, 0);
   const totalCredits = sumByUnit('usd');

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -12,7 +12,7 @@ import {
   InformationCircleIcon,
 } from '@heroicons/react/24/outline';
 import { Card, Reward } from '@/lib/api';
-import { formatBenefitValue, isMonetaryBenefit } from '@/lib/cardDisplayUtils';
+import { amortizedAnnualValue, formatBenefitValue } from '@/lib/cardDisplayUtils';
 import { cardMatchesSearch } from '@/lib/searchAliases';
 import {
   categoryLabels,
@@ -525,11 +525,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                   {card.benefits && card.benefits.length > 0 && (() => {
                     const credits = card.benefits.filter(b => b.value > 0);
                     const perks = card.benefits.filter(b => b.value === 0);
-                    const totalAnnual = credits.reduce((sum, b) => {
-                      if (!isMonetaryBenefit(b)) return sum;
-                      if (b.frequency === 'multi_year') return sum + Math.round(b.value / 4);
-                      return sum + b.value;
-                    }, 0);
+                    const totalAnnual = credits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0);
                     return (
                       <div className="px-4 py-2.5 text-sm">
                         <span className="text-gray-500 font-medium block mb-1">Benefits</span>
@@ -814,11 +810,10 @@ export default function CompareClient({ allCards }: CompareClientProps) {
               {activeCards.some(c => c.benefits && c.benefits.length > 0) && (() => {
                 const totalCredits = activeCards.map(c => {
                   if (!c.benefits) return 0;
-                  return c.benefits.filter(b => b.value > 0).reduce((sum, b) => {
-                    if (!isMonetaryBenefit(b)) return sum;
-                    if (b.frequency === 'multi_year') return sum + Math.round(b.value / 4);
-                    return sum + b.value;
-                  }, 0);
+                  return c.benefits.filter(b => b.value > 0).reduce(
+                    (sum, b) => sum + amortizedAnnualValue(b),
+                    0
+                  );
                 });
                 const bestSet = getBestIndices(totalCredits.map(v => v || null), 'max');
                 return (

--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -5,16 +5,7 @@ import {
   CheckCircleIcon,
 } from "@heroicons/react/24/outline";
 import { CardBenefit } from "@/lib/api";
-import { formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
-
-const frequencyLabels: Record<string, string> = {
-  monthly: "/mo",
-  quarterly: "/qtr",
-  semi_annual: "/6 mo",
-  annual: "/yr",
-  multi_year: "every 4 yr",
-  ongoing: "",
-};
+import { amortizedAnnualValue, formatBenefitValue, frequencyLabel } from "@/lib/cardDisplayUtils";
 
 const categoryIcons: Record<string, string> = {
   dining: "🍽️",
@@ -43,11 +34,7 @@ export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) 
   const credits = benefits.filter((b) => b.value > 0);
   const perks = benefits.filter((b) => b.value === 0);
   // Only sum USD-valued credits — points/miles can't be meaningfully added in dollars.
-  const totalAnnualValue = credits.reduce((sum, b) => {
-    if (!isMonetaryBenefit(b)) return sum;
-    if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
-    return sum + b.value;
-  }, 0);
+  const totalAnnualValue = credits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0);
 
   return (
     <div className="py-6">
@@ -105,7 +92,7 @@ export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) 
                       {formatBenefitValue(benefit)}
                     </span>
                     <span className="text-sm text-gray-400 font-medium">
-                      {frequencyLabels[benefit.frequency]}
+                      {frequencyLabel(benefit)}
                     </span>
                   </div>
                   <p className="text-sm text-gray-600 leading-relaxed">

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -4,20 +4,11 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import CardImage from "@/components/ui/CardImage";
 import { Card, CardBenefit, WalletCard } from "@/lib/api";
-import { formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
+import { amortizedAnnualValue, formatBenefitValue, frequencyLabel } from "@/lib/cardDisplayUtils";
 import {
   CheckCircleIcon,
   GiftIcon,
 } from "@heroicons/react/24/outline";
-
-const frequencyLabels: Record<string, string> = {
-  monthly: "/mo",
-  quarterly: "/qtr",
-  semi_annual: "/6 mo",
-  annual: "/yr",
-  multi_year: "every 4 yr",
-  ongoing: "",
-};
 
 const categoryIcons: Record<string, string> = {
   dining: "🍽️",
@@ -75,11 +66,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
   }, [cardsWithBenefits]);
 
   const totalAnnualValue = useMemo(() => {
-    return allCredits.reduce((sum, b) => {
-      if (!isMonetaryBenefit(b)) return sum;
-      if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
-      return sum + b.value;
-    }, 0);
+    return allCredits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0);
   }, [allCredits]);
 
   if (cardsWithBenefits.length === 0) {
@@ -154,7 +141,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
                   </Link>
                   <div className="text-right flex-shrink-0">
                     <p className="text-lg font-bold text-emerald-700">{formatBenefitValue(credit)}</p>
-                    <p className="text-xs text-gray-400">{frequencyLabels[credit.frequency]}</p>
+                    <p className="text-xs text-gray-400">{frequencyLabel(credit)}</p>
                   </div>
                   {credit.enrollment_required && (
                     <span className="hidden sm:inline-flex flex-shrink-0 items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 border border-amber-200">
@@ -193,11 +180,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
           {cardsWithBenefits.map(({ walletCard, cardData, benefits }) => {
             const credits = benefits.filter(b => b.value > 0);
             const perks = benefits.filter(b => b.value === 0);
-            const cardTotal = credits.reduce((sum, b) => {
-              if (!isMonetaryBenefit(b)) return sum;
-              if (b.frequency === "multi_year") return sum + Math.round(b.value / 4);
-              return sum + b.value;
-            }, 0);
+            const cardTotal = credits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0);
 
             return (
               <div key={walletCard.id} className="bg-white shadow rounded-lg overflow-hidden">
@@ -234,7 +217,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
                           </div>
                           <div className="flex items-baseline gap-1 flex-shrink-0">
                             <span className="text-sm font-bold text-emerald-700">{formatBenefitValue(b)}</span>
-                            <span className="text-xs text-gray-400">{frequencyLabels[b.frequency]}</span>
+                            <span className="text-xs text-gray-400">{frequencyLabel(b)}</span>
                           </div>
                         </div>
                       ))}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -52,6 +52,11 @@ export interface CardBenefit {
   value_unit?: 'usd' | 'points' | 'miles';
   description: string;
   frequency: 'monthly' | 'quarterly' | 'semi_annual' | 'annual' | 'multi_year' | 'ongoing';
+  // For frequency: 'multi_year' — number of years between recurrences. Defaults
+  // to 4 if missing (preserves legacy behavior). Use 5 for Global Entry / TSA
+  // PreCheck (the actual renewal cycle), 2 for biennial perks, etc. Used by
+  // amortizedAnnualValue() to compute the per-year contribution.
+  frequency_years?: number;
   category: 'dining' | 'dining_travel' | 'travel' | 'hotel' | 'entertainment' | 'shopping' | 'fitness' | 'lounge' | 'security' | 'gas' | 'streaming' | 'grocery' | 'rideshare' | 'car_rental' | 'other';
   enrollment_required?: boolean;
 }

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -108,6 +108,46 @@ export function formatBenefitValue(benefit: CardBenefit): string {
   return `$${v}`;
 }
 
+// Default cycle length for `multi_year` benefits when `frequency_years` is
+// missing — covers existing Global Entry/TSA PreCheck entries that didn't
+// specify a cycle. New entries should set `frequency_years` explicitly.
+export const DEFAULT_MULTI_YEAR_CYCLE = 4;
+
+// Per-year USD contribution of a benefit, used to roll up "Total Annual
+// Credits" across all monetary benefits on a card. `multi_year` divides by
+// `frequency_years` (default 4); `ongoing` returns 0 because we can't
+// estimate a per-year credit amount for it; everything else returns the raw
+// value (the unit caller is responsible for treating annual/monthly/etc.
+// consistently in its own context).
+export function amortizedAnnualValue(benefit: CardBenefit): number {
+  if (!isMonetaryBenefit(benefit)) return 0;
+  if (benefit.frequency === 'ongoing') return 0;
+  if (benefit.frequency === 'multi_year') {
+    const years = benefit.frequency_years || DEFAULT_MULTI_YEAR_CYCLE;
+    return Math.round(benefit.value / years);
+  }
+  return benefit.value;
+}
+
+// Human-readable frequency label shown next to a benefit's value in the UI
+// (e.g. "$120 every 5 yr" for Global Entry on a 5-year cycle, "$300 /yr" for
+// an annual travel credit). Multi-year is dynamic so the label matches the
+// benefit's `frequency_years` instead of always saying "every 4 yr".
+export function frequencyLabel(benefit: CardBenefit): string {
+  switch (benefit.frequency) {
+    case 'monthly': return '/mo';
+    case 'quarterly': return '/qtr';
+    case 'semi_annual': return '/6 mo';
+    case 'annual': return '/yr';
+    case 'multi_year': {
+      const years = benefit.frequency_years || DEFAULT_MULTI_YEAR_CYCLE;
+      return `every ${years} yr`;
+    }
+    case 'ongoing': return '';
+    default: return '';
+  }
+}
+
 // Cents-per-point estimates by program (driven by data/valuations.yaml)
 export function getCentsPerPoint(card: Card): number | null {
   if (!card.signup_bonus) return null;

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -23,6 +23,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Priority Pass Select"
     value: 0

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -16,6 +16,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
 tags:
   - travel

--- a/data/cards/capital-one-venture-business.yaml
+++ b/data/cards/capital-one-venture-business.yaml
@@ -40,6 +40,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Free Employee Cards"
     value: 0

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -11,6 +11,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Lifestyle Collection Experience Credit"
     value: 0

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -30,6 +30,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Hertz President's Circle Status"
     value: 0

--- a/data/cards/chase-aeroplan.yaml
+++ b/data/cards/chase-aeroplan.yaml
@@ -43,6 +43,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees every 4 years"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "No Foreign Transaction Fees"
     value: 0

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -19,6 +19,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Sapphire Lounge by The Club Access"
     value: 0

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -15,6 +15,7 @@ benefits:
     value: 100
     description: "Statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "First Checked Bag Free"
     value: 0

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -28,6 +28,7 @@ benefits:
     value: 100
     description: "Statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Priority Pass Select"
     value: 0

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -16,6 +16,7 @@ benefits:
     value: 100
     description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "TakeOff 15"
     value: 0

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -21,6 +21,7 @@ benefits:
     value: 100
     description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "TakeOff 15"
     value: 0

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -56,6 +56,7 @@ benefits:
     value: 100
     description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Priority Pass Select"
     value: 0

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -71,6 +71,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "CLEAR Plus Credit"
     value: 209

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -77,6 +77,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "travel"
     enrollment_required: false
   - name: "Equinox Credit"

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -39,6 +39,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "2 Free Checked Bags"
     value: 0

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -34,6 +34,7 @@ benefits:
     value: 120
     description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "First Checked Bag Free"
     value: 0

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -47,6 +47,7 @@ benefits:
     value: 100
     description: "Statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "2 Free Checked Bags"
     value: 0

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -11,6 +11,7 @@ benefits:
     value: 100
     description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Airport Lounge Access"
     value: 0

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -16,6 +16,7 @@ benefits:
     value: 100
     description: "Statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
+    frequency_years: 5
     category: "security"
   - name: "Priority Pass Select"
     value: 0

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -291,7 +291,8 @@ Return ONLY valid JSON in this exact shape — no markdown, no commentary:
       "value": <number or 0 if perk has no monetary value>,
       "value_unit": "usd" | "points" | "miles" | "percent",
       "description": "<one short sentence>",
-      "frequency": "monthly" | "quarterly" | "semi_annual" | "annual" | "multi_year" | "ongoing" | "per_purchase" | "per_flight" | "per_trip" | "per_visit" | "per_rental" | "per_claim" | "every_4_years" | "one_time",
+      "frequency": "monthly" | "quarterly" | "semi_annual" | "annual" | "multi_year" | "ongoing" | "per_purchase" | "per_flight" | "per_trip" | "per_visit" | "per_rental" | "per_claim" | "one_time",
+      "frequency_years": <number, REQUIRED when frequency is "multi_year"; e.g. 5 for Global Entry / TSA PreCheck (5-year renewal cycle), 4 for benefits with explicit 4-year cycle, 2 for biennial perks>,
       "category": "dining" | "dining_travel" | "travel" | "hotel" | "entertainment" | "shopping" | "fitness" | "lounge" | "security" | "gas" | "streaming" | "grocery" | "rideshare" | "car_rental" | "telecom" | "statement_credit" | "rewards" | "other",
       "enrollment_required": <true|false>
     }
@@ -381,6 +382,11 @@ WRONG for a "5% rebate" benefit.
 - "foreign_transaction_fee": true if the card charges one, false if not. null only if the page truly doesn't say.
 - For ELITE-NIGHT-CREDIT or TIER-QUALIFYING-NIGHT type benefits, use \`value: 0\` and OMIT \`value_unit\` — non-monetary count perks. The count goes in the description (e.g. "5 elite night credits each year").
 - For elite STATUS perks (e.g. "Automatic Diamond Status"), use \`value: 0\` and put the tier name in the description.
+- When you set \`frequency: "multi_year"\` you MUST also set \`frequency_years\` to the actual cycle length. Examples:
+    Global Entry credit ($120, renews every 5 years) → \`frequency: "multi_year"\`, \`frequency_years: 5\`.
+    TSA PreCheck credit ($85, every 5 years) → same — 5.
+    A biennial fitness credit ($200 every 2 years) → \`frequency_years: 2\`.
+  The frontend uses \`frequency_years\` to amortize the credit per year (so a $120/5yr Global Entry contributes $24/yr to the card's total annual credits).
 - STRIKETHROUGH TEXT in [STRIKETHROUGH: ...] markers is expired/old; ignore those values.
 
 # CALIBRATION
@@ -787,6 +793,9 @@ function renderBenefitBlock(b, indent = '  ') {
   }
   if (b.frequency) {
     lines.push(`${fieldIndent}frequency: ${ymlString(b.frequency)}`);
+  }
+  if (b.frequency === 'multi_year' && typeof b.frequency_years === 'number' && b.frequency_years > 0) {
+    lines.push(`${fieldIndent}frequency_years: ${b.frequency_years}`);
   }
   if (b.category) {
     lines.push(`${fieldIndent}category: ${ymlString(b.category)}`);


### PR DESCRIPTION
## Summary
Surfaced while reviewing #945. The frontend hardcoded multi_year credits to /4 in **6 spots** — worked roughly for Global Entry (\$120/4 = \$30/yr) but Global Entry / TSA PreCheck are actually **5-year** cycles, and future benefits may run on 2- or 3-year cycles.

## Three pieces

**1. Schema** — added optional \`frequency_years?: number\` to \`CardBenefit\`. Defaults to 4 if missing (preserves legacy behavior).

**2. Helpers** — \`amortizedAnnualValue(b)\` and \`frequencyLabel(b)\` in \`cardDisplayUtils.tsx\`. Replaced 6 inline \`/4\` instances + 3 \`frequencyLabels[freq]\` lookups across CardBenefits, WalletBenefits, CardClient, and CompareClient. Label now reads "every N yr" instead of always "every 4 yr".

**3. Migration** — added \`frequency_years: 5\` to all 19 existing card YAMLs with a Global Entry / TSA PreCheck multi_year credit. Both programs are 5-year cycles. Per-card per-year contribution shifts from \$30 to \$24 — small downward, more accurate.

Also: extractor prompt updated to require \`frequency_years\` whenever \`multi_year\` is used; \`every_4_years\` frequency removed (redundant); YAML writer includes the field in appended benefit blocks.

## Test plan
- [x] \`node --check scripts/check-card-rewards-and-benefits.js\`
- [x] \`npx tsc --noEmit\` in apps/web-next
- [x] \`node scripts/build-cards.js\` validates all 160 cards
- [ ] Some descriptions still say "every 4 years" — inaccurate, separate cleanup pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)