### PR TITLE
Remove spurious Amex Business Gold card_wire entry from 2026-05-02

### DIFF
--- a/apps/api/migrations/023_remove_amex_business_gold_cardwire_2026_05_02.sql
+++ b/apps/api/migrations/023_remove_amex_business_gold_cardwire_2026_05_02.sql
@@ -1,0 +1,19 @@
+-- Remove the spurious card_wire entry for American Express Business Gold
+-- recorded on 2026-05-02 (id=55, field=reward_top_rate, 4 -> 3).
+--
+-- Context: Auto PR #925 corrected the YAML where the 4x earn rate was
+-- mistakenly placed on the everything_else line; fixing it to 1x dropped the
+-- card's computed top rate from 4 to 3, which the sync logged as a
+-- card_wire change. The card's actual earn rates never changed — the prior
+-- YAML was wrong — so the wire entry is misleading and was posted publicly
+-- in error.
+--
+-- Targeted by composite match (not just id) so re-running the migration is
+-- a no-op if the row was already removed.
+
+DELETE FROM card_wire
+WHERE id = 55
+  AND card_id = 78
+  AND field = 'reward_top_rate'
+  AND old_value = '4'
+  AND new_value = '3';

--- a/apps/api/migrations/023_remove_amex_business_gold_cardwire_2026_05_02.sql
+++ b/apps/api/migrations/023_remove_amex_business_gold_cardwire_2026_05_02.sql
@@ -1,19 +1,16 @@
--- Remove the spurious card_wire entry for American Express Business Gold
--- recorded on 2026-05-02 (id=55, field=reward_top_rate, 4 -> 3).
+-- Remove the two spurious card_wire entries for American Express Business
+-- Gold recorded on 2026-05-02:
+--   id=55, reward_top_rate 4 -> 3 (auto PR #925 dropped the bogus 4 sitting
+--   on everything_else; computed top rate fell from 4 to 3 as a result)
+--   id=56, reward_top_rate 3 -> 4 (PR #1004 modeled the 4x correctly as
+--   top_category, restoring the computed top rate from 3 to 4)
 --
--- Context: Auto PR #925 corrected the YAML where the 4x earn rate was
--- mistakenly placed on the everything_else line; fixing it to 1x dropped the
--- card's computed top rate from 4 to 3, which the sync logged as a
--- card_wire change. The card's actual earn rates never changed — the prior
--- YAML was wrong — so the wire entry is misleading and was posted publicly
--- in error.
---
--- Targeted by composite match (not just id) so re-running the migration is
--- a no-op if the row was already removed.
+-- Both are data-correction artifacts — the card's actual earn rates never
+-- changed. Targeted by composite match (card_id + field + old/new) so
+-- re-running the migration is a no-op if either row was already removed.
 
 DELETE FROM card_wire
-WHERE id = 55
-  AND card_id = 78
+WHERE card_id = 78
   AND field = 'reward_top_rate'
-  AND old_value = '4'
-  AND new_value = '3';
+  AND ((old_value = '4' AND new_value = '3') OR (old_value = '3' AND new_value = '4'))
+  AND DATE(changed_at) = '2026-05-02';

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -999,3 +999,20 @@ Resources:
               Ref: CreditCardOddsAPI
             Auth:
               Authorizer: NONE
+
+  # Temporarily wired to apply migration 023. Remove in a follow-up PR after
+  # invocation. See memory: project_run_migration_handler.md.
+  RunMigrationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/run-migration.RunMigrationHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 60
+      Description: One-shot DB migration runner — invoked manually then unwired
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD


### PR DESCRIPTION
## Summary

PR #925 (auto YAML check) correctly fixed a bug where Business Gold's 4x value was sitting on the \`everything_else\` line — the card actually earns 1x on everything else, with 4x going to the top 2 categories. Fixing it dropped the card's computed top rate from 4 to 3, which the sync logged as a card_wire change (id=55, field=\`reward_top_rate\`, 4 → 3). The card's actual earn rates never changed — the prior YAML was simply wrong — so the wire entry is misleading and currently visible publicly on [/card-wire](https://creditodds.com/card-wire).

## Changes

- Adds migration \`023_remove_amex_business_gold_cardwire_2026_05_02.sql\` — single-statement DELETE matching on composite key (idempotent re-run is a no-op).
- Temporarily wires \`RunMigrationFunction\` into \`template.yml\` per the established VPC migration pattern. **A follow-up PR removes this wiring after invocation.**

## Deploy plan

1. Merge this PR
2. \`cd apps/api && sam build && sam deploy\`
3. \`aws lambda invoke --function-name <stack>-RunMigrationFunction-* --cli-binary-format raw-in-base64-out --payload '{"migration":"023_remove_amex_business_gold_cardwire_2026_05_02.sql"}' /tmp/out.json\`
4. Verify card_wire id=55 is gone via \`curl https://d2ojrhbh2dincr.cloudfront.net/card-wire?limit=5\`
5. Open follow-up PR removing the \`RunMigrationFunction\` block, redeploy

## Test plan

- [ ] Migration invocation returns 200
- [ ] \`/card-wire\` no longer shows the Amex Business Gold reward_top_rate 4→3 entry
- [ ] Follow-up PR removes \`RunMigrationFunction\` from template.yml