### PR TITLE
Remove duplicate Card news block from card detail right rail

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1333,35 +1333,6 @@ export default function CardClient({
             Compare cards
           </Link>
 
-          {news.length > 0 && (
-            <div className="cj-rail-block">
-              <div className="cj-rail-label">Card news</div>
-              {news.slice(0, 3).map((n) => {
-                const tag = n.tags[0] as NewsTag | undefined;
-                return (
-                  <div key={n.id} className="cj-news-item">
-                    <Link href={`/news/${n.id}`}>
-                      <div className="cj-news-meta">
-                        <span className="cj-news-date">
-                          {new Date(n.date).toLocaleDateString("en-US", {
-                            month: "short",
-                            day: "numeric",
-                          })}
-                        </span>
-                        {tag && (
-                          <span className="cj-news-tag">
-                            {tagLabels[tag]}
-                          </span>
-                        )}
-                      </div>
-                      <div className="cj-news-title">{n.title}</div>
-                    </Link>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
           {similarCards.length > 0 && (
             <div className="cj-rail-block">
               <div className="cj-rail-label">Alternatives</div>


### PR DESCRIPTION
## Summary

The card detail page rendered news in two places — the right-rail "Card news" block and the bottom "News & wire" tape section. Drops the right-rail copy and keeps the bottom section as the single source.

## Test plan

- [ ] Visit any card detail page and confirm the right rail no longer shows a "Card news" block
- [ ] Confirm the bottom "04 · News & wire" section still renders when news/wire data is present
- [ ] Right rail still shows "Alternatives" as before