### PR TITLE
Update Discover it Cash Back to Q2 2026 categories

### DIFF
--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -13,8 +13,8 @@ rewards:
     value: 5
     unit: percent
     mode: quarterly_rotating
-    current_categories: [groceries, online_shopping]
-    current_period: "Q1 2026"
+    current_categories: [restaurants, home_improvement]
+    current_period: "Q2 2026"
     note: "Up to $1,500/quarter when activated"
   - category: everything_else
     value: 1


### PR DESCRIPTION
## Summary
- Updates Discover it Cash Back rotating bonus from Q1 2026 (groceries + online shopping) to Q2 2026 (restaurants + home improvement stores)

## Test plan
- [ ] Verify card page renders updated Q2 2026 categories after build-cards sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)