### PR TITLE
Render partial stars on card rating display

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useId } from "react";
 import dynamic from "next/dynamic";
 import CardImage from "@/components/ui/CardImage";
 import Link from "next/link";
@@ -82,22 +82,30 @@ function getStableReferralIndex(cardKey: string, referralCount: number): number 
 }
 
 function StarIcon({
-  filled,
+  fill = 1,
   size = 14,
 }: {
-  filled: boolean;
+  fill?: number;
   size?: number;
 }) {
+  const gradientId = useId();
+  const pct = Math.max(0, Math.min(1, fill)) * 100;
+  const path =
+    "M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z";
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 20 20"
-      fill={filled ? "currentColor" : "none"}
-      stroke="currentColor"
-      strokeWidth={filled ? 0 : 1.4}
-    >
-      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+    <svg width={size} height={size} viewBox="0 0 20 20">
+      <defs>
+        <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
+          <stop offset={`${pct}%`} stopColor="currentColor" stopOpacity={1} />
+          <stop offset={`${pct}%`} stopColor="currentColor" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <path
+        d={path}
+        fill={`url(#${gradientId})`}
+        stroke="currentColor"
+        strokeWidth={1.2}
+      />
     </svg>
   );
 }
@@ -1328,7 +1336,7 @@ export default function CardClient({
                 {[1, 2, 3, 4, 5].map((s) => (
                   <StarIcon
                     key={s}
-                    filled={s <= Math.round(ratings.average ?? 0)}
+                    fill={(ratings.average ?? 0) - (s - 1)}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- A 4.5-rated card was showing 5 full stars because `StarIcon` was driven by `Math.round(ratings.average)`.
- `StarIcon` now takes a `fill` prop (0–1) and renders a half/partial star using an SVG linear gradient with two stops at the same offset.
- Call site passes `(ratings.average ?? 0) - (s - 1)` per star (clamped inside the icon).

## Test plan
- [x] Verified on `/card/discover-it-cash-back` (4.5 average): DOM shows 5 star SVGs with gradient stops `[100%, 100%, 100%, 100%, 50%]`.
- [ ] Spot-check a 4.0 rating (e.g. Citi Double Cash) renders 4 full + 1 empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)