### PR TITLE
Post-walkthrough cleanups: policy, GE descriptions, rotating-period check

### DIFF
--- a/data/benefit-policy.yaml
+++ b/data/benefit-policy.yaml
@@ -28,6 +28,8 @@ exclude:
   - "$0 Fraud Liability"
   - "Zero Fraud Liability"
   - "0 Liability"
+  - "Fraud Liability Protection"
+  - "Fraud Protection"
 
   # Issuer platform features available to all the issuer's cardholders
   - "Eno Virtual Card Numbers"
@@ -44,6 +46,9 @@ exclude:
   - "Chase Pay Over Time"
   - "0% intro APR on Disney Vacations"
   - "0% APR on Disney Vacations"
+  - "Citi Flex Pay"                 # buy-now-pay-later financing feature
+  - "Flex Pay"
+  - "My Chase Plan"
 
   # Redemption mechanics — describes how rewards are earned/redeemed,
   # not a perk you "get" from holding the card
@@ -54,6 +59,11 @@ exclude:
   - "Real-Time Rewards"
   - "Cash-Back Deals"
   - "Ultimate Rewards Transfer Bonus"
+  - "Points Transfer Partners"      # describes the transfer network, not a perk
+  - "Transfer Partners"
+  - "Pay with Miles"                # specific Delta-style miles-for-flights mechanic
+  - "Pay with Miles Discount"
+  - "MileagePlus Pay with Points"
 
   # Generic business-card platform features (not card-differentiators)
   - "Free Employee Cards"
@@ -107,6 +117,18 @@ exclude:
   - "Bill Pay"
   - "Refer-a-Friend"
   - "Refer a Friend"
+  - "Referral Bonus"                # active recruiting, not a passive benefit
+  - "Refer Friends Bonus"
+  - "Refer Friends"
+  - "Friend Referral"
+  - "Automatic Payments Statement Credit"   # one-time enrollment carrot
+  - "Autopay Enrollment Credit"
+  - "DisneyStore.com Discount"      # store discount, not a free perk
+  - "DisneyStore Discount"
+  - "Disney Park Merchandise Discount"
+  - "Disney Park Dining Discount"
+  - "Disney Guided Tour Discount"
+  - "The Cultivist Membership Discount"  # discount on a paid membership
 
   # Issuer-platform "deals" portals — available to all cardholders of that
   # issuer, not card-specific perks. Treated like Amex Offers.

--- a/data/cards/atmos-rewards-summit.yaml
+++ b/data/cards/atmos-rewards-summit.yaml
@@ -59,7 +59,7 @@ benefits:
     enrollment_required: false
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120
-    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fees, once every 4 years"
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fees, once"
     frequency: "every_4_years"
     category: "travel"
     enrollment_required: false

--- a/data/cards/chase-aeroplan.yaml
+++ b/data/cards/chase-aeroplan.yaml
@@ -41,7 +41,7 @@ benefits:
     category: "travel"
   - name: "Global Entry / TSA PreCheck / NEXUS Credit"
     value: 120
-    description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees every 4 years"
+    description: "Up to $120 statement credit for Global Entry, TSA PreCheck, or NEXUS application fees"
     frequency: "multi_year"
     frequency_years: 5
     category: "security"

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -14,7 +14,7 @@ benefits:
     category: "travel"
   - name: "Global Entry / TSA PreCheck Credit"
     value: 100
-    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     frequency_years: 5
     category: "security"

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -19,7 +19,7 @@ benefits:
     category: "travel"
   - name: "Global Entry / TSA PreCheck Credit"
     value: 100
-    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     frequency_years: 5
     category: "security"

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -13,7 +13,7 @@ rewards:
     value: 5
     unit: percent
     mode: quarterly_rotating
-    current_categories: [restaurants, home_improvement]
+    current_categories: [dining, home_improvement]
     current_period: "Q2 2026"
     note: "Up to $1,500/quarter when activated"
   - category: everything_else

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -55,7 +55,7 @@ benefits:
     category: "hotel"
   - name: "Global Entry / TSA PreCheck Credit"
     value: 100
-    description: "Up to $100 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     frequency_years: 5
     category: "security"

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -69,7 +69,7 @@ benefits:
     enrollment_required: true
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120
-    description: "Up to $120 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     frequency_years: 5
     category: "security"

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -76,7 +76,7 @@ benefits:
     enrollment_required: true
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120
-    description: "Up to $120 statement credit every 4 years for Global Entry or TSA PreCheck application fee"
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
     frequency: "multi_year"
     frequency_years: 5
     category: "travel"

--- a/data/cards/usaa-eagle-navigator.yaml
+++ b/data/cards/usaa-eagle-navigator.yaml
@@ -32,7 +32,7 @@ apr:
 benefits:
   - name: "Global Entry / TSA PreCheck Credit"
     value: 100
-    description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fees, once every 4 years"
+    description: "Up to $100 statement credit for Global Entry or TSA PreCheck application fees, once"
     frequency: "every_4_years"
     category: "travel"
     enrollment_required: false

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -55,7 +55,7 @@ benefits:
     enrollment_required: false
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120
-    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fees, once every 4 years"
+    description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fees, once"
     frequency: "every_4_years"
     category: "travel"
     enrollment_required: false

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -133,6 +133,43 @@ function validateCard(card, schema, categoryIds) {
   return errors;
 }
 
+// Compute the current calendar quarter as a "Q<N> YYYY" string. Used to
+// surface stale `current_period` values on rotating-category cards
+// (Discover It, Chase Freedom Flex, etc.) so we don't silently keep
+// last quarter's bonus categories live on the site.
+function currentQuarterLabel(now = new Date()) {
+  const month = now.getUTCMonth(); // 0-indexed
+  const quarter = Math.floor(month / 3) + 1; // 1..4
+  return `Q${quarter} ${now.getUTCFullYear()}`;
+}
+
+// Walk the loaded cards looking for rotating-category rewards whose
+// `current_period` doesn't match the current calendar quarter. Returns an
+// array of { file, cardName, currentPeriod } entries — non-fatal warnings.
+function findStaleRotatingPeriods(cardsWithFiles) {
+  const expected = currentQuarterLabel();
+  const stale = [];
+  for (const { file, card } of cardsWithFiles) {
+    if (!card.rewards) continue;
+    for (const reward of card.rewards) {
+      if (reward.mode !== 'quarterly_rotating') continue;
+      if (!reward.current_period) {
+        // Card declares quarterly rotation but has no current_period set —
+        // worth flagging so the team fills it in once the new quarter's
+        // categories are announced.
+        stale.push({ file, cardName: card.name, currentPeriod: '(missing)', expected });
+        continue;
+      }
+      // Tolerate trivial whitespace / Q vs. q variations.
+      const norm = String(reward.current_period).trim().toUpperCase();
+      if (norm !== expected.toUpperCase()) {
+        stale.push({ file, cardName: card.name, currentPeriod: reward.current_period, expected });
+      }
+    }
+  }
+  return stale;
+}
+
 function buildCards() {
   console.log('Building cards.json from YAML files...\n');
 
@@ -140,6 +177,7 @@ function buildCards() {
   const categories = loadCategories();
   const categoryIds = new Set(categories.map(c => c.id));
   const cards = [];
+  const cardsWithFiles = [];
   const errors = [];
 
   // Read all YAML files in the cards directory
@@ -169,6 +207,7 @@ function buildCards() {
       delete card.check_ignore;
 
       cards.push(card);
+      cardsWithFiles.push({ file, card });
       console.log(`  OK: ${card.name}`);
     } catch (err) {
       errors.push({ file, errors: [err.message] });
@@ -187,6 +226,23 @@ function buildCards() {
       }
     }
     process.exit(1);
+  }
+
+  // Non-fatal warning: rotating-category cards whose current_period is stale.
+  // This protects against the failure mode where a card silently keeps last
+  // quarter's bonus categories live on the site after the new quarter starts —
+  // surfaced manually multiple times (e.g. Discover It Cash Back).
+  const staleRotations = findStaleRotatingPeriods(cardsWithFiles);
+  if (staleRotations.length > 0) {
+    console.warn(
+      `\n⚠️  ${staleRotations.length} card(s) have stale or missing rotating-category period (expected ${currentQuarterLabel()}):`
+    );
+    for (const { file, cardName, currentPeriod, expected } of staleRotations) {
+      console.warn(`  - ${cardName} (${file}): current_period="${currentPeriod}", expected "${expected}"`);
+    }
+    console.warn(
+      `  These won't fail the build — fix the YAML when you have the new quarter's categories.\n`
+    );
   }
 
   // Sort cards by name


### PR DESCRIPTION
## Summary
Follow-ups gathered during the manual PR walkthrough.

## 1. Policy excludes (`data/benefit-policy.yaml`)
Patterns the LLM kept proposing as benefits — now silenced:
- **Redemption mechanics**: Points Transfer Partners, Pay with Miles
- **Financing**: Citi Flex Pay, My Chase Plan
- **Federal-law standards**: Fraud Liability Protection
- **Active-recruitment**: Referral Bonus, Refer Friends Bonus
- **Enrollment carrots**: Automatic Payments Statement Credit
- **Discount-style "perks"**: Disney Park Merchandise/Dining/Guided Tour, DisneyStore.com, The Cultivist

## 2. Global Entry description cleanup (9 files)
PR #1000 moved Global Entry credits to `frequency: multi_year` + `frequency_years: 5`. Some descriptions still said "every 4 years" inline (legacy LLM phrasing) — contradicting the structured field. Stripped from all 9.

## 3. Discover It Cash Back: `restaurants` → `dining`
Manual edit had set `current_categories: [restaurants, ...]` but `restaurants` isn't in `data/categories.yaml` — was breaking `build:cards` on main. Renamed to canonical `dining`.

## 4. Rotating-category staleness check (`scripts/build-cards.js`)
Non-fatal warning when a card with `mode: quarterly_rotating` has a `current_period` that doesn't match the current quarter (or is missing). Covers the failure mode where new-quarter categories silently never get updated.

**First run flagged 2 cards**: Discover It for Students and NHL Discover It both have no `current_period` set — needs the actual Q2 2026 bonus categories filled in (separate work, not in this PR).

## Test plan
- [x] `node --check scripts/build-cards.js`
- [x] `node scripts/build-cards.js` validates all 160 cards (no errors, 2 expected staleness warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)