### PR TITLE
Revert sub-annual amortization multiplier (annual-total convention)

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -278,25 +278,28 @@ export default function CardClient({
   );
 
   const creditBenefits = (card.benefits || []).filter((b) => b.value > 0);
-  // Sub-annual frequencies multiply by occurrence count to get a per-year
-  // total (e.g. $15/mo Uber Cash = $180/yr). Mirrors the math in
-  // amortizedAnnualValue() but supports unit-filtering for points/miles.
+  // Mirrors amortizedAnnualValue() but supports unit filtering so we can
+  // roll up USD / points / miles totals separately. Convention: `value` is
+  // the annual total; `frequency` is just a display hint (monthly/quarterly
+  // /semi_annual all return value as-is). Only multi_year amortizes by
+  // dividing across `frequency_years`.
   const sumByUnit = (unit: 'usd' | 'points' | 'miles') =>
     creditBenefits.reduce((sum, b) => {
       const isUsd = !b.value_unit || b.value_unit === 'usd';
       const matches = unit === 'usd' ? isUsd : b.value_unit === unit;
       if (!matches) return sum;
       switch (b.frequency) {
-        case 'monthly':     return sum + b.value * 12;
-        case 'quarterly':   return sum + b.value * 4;
-        case 'semi_annual': return sum + b.value * 2;
-        case 'annual':      return sum + b.value;
+        case 'monthly':
+        case 'quarterly':
+        case 'semi_annual':
+        case 'annual':
+          return sum + b.value;
         case 'multi_year': {
           const years = b.frequency_years || DEFAULT_MULTI_YEAR_CYCLE;
           return sum + Math.round(b.value / years);
         }
         // ongoing / per_purchase / per_flight / one_time / etc. — usage
-        // unknown, can't roll up.
+        // frequency unknown, can't roll up annually.
         default: return sum;
       }
     }, 0);

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -120,39 +120,44 @@ export const DEFAULT_MULTI_YEAR_CYCLE = 4;
 // Per-year USD contribution of a benefit, used to roll up "Total Annual
 // Credits" across all monetary benefits on a card.
 //
-// The repo convention for recurring credits is to store the PER-OCCURRENCE
-// value plus the matching `frequency`. So Hilton Aspire's "$200 every 6
-// months" lives as `value: 200, frequency: semi_annual` (NOT value: 400 /
-// annual). To compute the per-year contribution we multiply by the number
-// of occurrences in a year for sub-annual frequencies.
+// CONVENTION: `value` is always the ANNUAL TOTAL — the dollar amount the
+// cardholder gets in a typical 12-month period. `frequency` is a display
+// hint (renders "$15/mo", "$50/qtr", "$200/6 mo", etc.) and is NOT used as
+// a multiplier. This matches every existing hand-curated card YAML:
 //
-// Frequencies handled:
-//   - `monthly`     — value × 12
-//   - `quarterly`   — value × 4
-//   - `semi_annual` — value × 2
-//   - `annual`      — value × 1
-//   - `multi_year`  — value ÷ frequency_years (default 4)
-//   - `ongoing`     — 0 (no quantifiable per-year amount)
-//   - everything else (per_purchase, per_flight, one_time, etc.) — 0,
-//     since we can't estimate how often a user will trigger them.
+//   Amex Platinum Uber Cash:   value: 200,  frequency: monthly  → $200/yr
+//   Amex Platinum Equinox:     value: 300,  frequency: monthly  → $300/yr
+//   Hilton Aspire Flight:      value: 200,  frequency: quarterly → $200/yr
+//   Amex Biz Plat Indeed:      value: 360,  frequency: quarterly → $360/yr
+//   Hilton Aspire Resort:      value: 800,  frequency: semi_annual (covered
+//     by `frequency_years` for multi-year, by raw value otherwise — annual)
 //
-// Older bug: this used to return `value` for monthly/quarterly/semi_annual,
-// which silently undercounted every recurring credit on the site (e.g. the
-// Platinum's $15/mo Uber Cash counted as $15/yr instead of $180/yr).
+// Cycle handling:
+//   - monthly / quarterly / semi_annual / annual → value (the annual total)
+//   - multi_year → value ÷ frequency_years (default 4) — value is the
+//     amount per cycle, e.g. $120 every 5 years for Global Entry → $24/yr.
+//   - ongoing → 0 (no quantifiable per-year amount)
+//   - per_purchase / per_flight / per_trip / etc. → 0 (usage unknown)
+//
+// History: an earlier (incorrect) version of this function multiplied
+// monthly/quarterly/semi_annual values by their occurrence count, which
+// inflated the wallet/profile annual totals 12×/4×/2× across most cards
+// because the YAMLs already store the annual total. Reverted.
 export function amortizedAnnualValue(benefit: CardBenefit): number {
   if (!isMonetaryBenefit(benefit)) return 0;
   switch (benefit.frequency) {
-    case 'monthly': return benefit.value * 12;
-    case 'quarterly': return benefit.value * 4;
-    case 'semi_annual': return benefit.value * 2;
-    case 'annual': return benefit.value;
+    case 'monthly':
+    case 'quarterly':
+    case 'semi_annual':
+    case 'annual':
+      return benefit.value;
     case 'multi_year': {
       const years = benefit.frequency_years || DEFAULT_MULTI_YEAR_CYCLE;
       return Math.round(benefit.value / years);
     }
     case 'ongoing': return 0;
     // per_purchase, per_flight, per_trip, per_visit, per_rental, per_claim,
-    // one_time — usage-frequency unknown, can't roll up.
+    // one_time — usage frequency unknown, can't roll up annually.
     default: return 0;
   }
 }

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -67,14 +67,14 @@ benefits:
     category: "security"
     enrollment_required: false
   - name: "Hotel Credit"
-    value: 250
-    description: "Up to $250 in statement credit every 6 months for hotel stays booked through the Robinhood Banking app."
+    value: 500
+    description: "Up to $500 in statement credits each year ($250 every 6 months) for hotel stays booked through the Robinhood Banking app."
     frequency: "semi_annual"
     category: "hotel"
     enrollment_required: false
   - name: "Travel Credit"
-    value: 150
-    description: "$150 in statement credit every 6 months for travel purchases."
+    value: 300
+    description: "$300 in statement credits each year ($150 every 6 months) for travel purchases."
     frequency: "semi_annual"
     category: "travel"
     enrollment_required: false

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -360,11 +360,29 @@ bag"), an elite status tier, or a clearly free recurring service.
 - DO NOT include the welcome/signup bonus as a benefit. Names like "Welcome Bonus", "New Cardmember Bonus", "Sign-Up Bonus", "Introductory Bonus" must NOT appear in the \`benefits[]\` array.
 - DO NOT include "Roadside Dispatch", "Emergency Cash Disbursement", or "Emergency Card Replacement" — Visa/Mastercard network-tier features on every card.
 
-# FIELD RULES — value + value_unit
+# FIELD RULES — value + value_unit + frequency
 The \`value\` is a number, paired with a \`value_unit\` that says what the
 number means. CRITICAL: never put a percentage in \`value\` without setting
 \`value_unit: "percent"\` — \`value: 5\` with no unit means "$5", which is
 WRONG for a "5% rebate" benefit.
+
+\`value\` is the ANNUAL TOTAL the cardholder gets in a typical year. The
+\`frequency\` field is just a display hint (renders as "$15/mo", "$50/qtr",
+"$200/6 mo", etc.) — it is NOT used as a multiplier. Examples that match
+the existing repo convention:
+  Amex Platinum Uber Cash ("$15/month"):
+    value: 200, frequency: monthly      ← value is the annual total ($200)
+  Hilton Aspire flight credit ("$50/quarter"):
+    value: 200, frequency: quarterly    ← annual total ($50 × 4 = $200)
+  Hilton Aspire resort credit ("$400 semi-annually"):
+    value: 800, frequency: semi_annual  ← annual total ($400 × 2 = $800)
+  Amex Biz Plat Indeed credit ("$90/quarter"):
+    value: 360, frequency: quarterly    ← annual total
+DO NOT store the per-occurrence value with a sub-annual frequency — the
+frontend would treat \`value: 15, frequency: monthly\` as $15/yr, not
+$180/yr. The only frequency that does cycle math is \`multi_year\`, where
+\`value\` is the amount per cycle and \`frequency_years\` is the cycle
+length (Global Entry: value=120, frequency=multi_year, frequency_years=5).
 
 - \`value_unit: "usd"\` — dollar credits/rebates. Default. Examples:
   "$300 travel credit" → value=300, value_unit=usd (or omitted).


### PR DESCRIPTION
## Bug
#1013 inflated wallet/profile **Total Annual Credits** values 12×/4×/2× for most cards.

User-reported examples (numbers I pulled from the YAMLs):
- Amex Platinum Equinox Credit: rendering as **\$3,600/yr** (actual: \$300/yr)
- Amex Platinum Digital Entertainment: **\$2,880/yr** (actual: \$240/yr)
- Amex Platinum Uber Cash: **\$2,400/yr** (actual: \$200/yr)
- Amex Business Platinum Indeed: **\$1,440/yr** (actual: \$360/yr)

## Root cause
I assumed the repo stored per-occurrence values for sub-annual frequencies. It doesn't — every hand-curated YAML stores the **annual total**:

\`\`\`yaml
# Amex Platinum's actual YAML:
- name: "Uber Cash"
  value: 200      # annual total
  description: "\$15/month in Uber Cash..."
  frequency: "monthly"
\`\`\`

## Fix
1. \`amortizedAnnualValue()\` returns \`value\` for monthly/quarterly/semi_annual/annual (annual-total convention). multi_year still divides by \`frequency_years\` — that one was correct.
2. Same revert in \`CardClient\`'s \`sumByUnit\` (points/miles roll-up).
3. \`data/cards/robinhood-platinum.yaml\` — fixes the 2 entries I changed to per-occurrence during the walkthrough (Hotel Credit, Travel Credit). Restored to annual-total with per-occurrence noted in description.
4. \`scripts/check-card-rewards-and-benefits.js\` prompt — explicit guidance for future LLM extractions to use annual-total convention with examples.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`build-cards\` validates all 160 cards
- [ ] After merge: spot-check wallet/profile totals on cards with sub-annual benefits

🤖 Generated with [Claude Code](https://claude.com/claude-code)