### PR TITLE
Apple Card: list 3% Apple Pay merchants in note

### DIFF
--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -9,7 +9,7 @@ rewards:
   - category: online_shopping
     value: 3
     unit: percent
-    note: "Apple purchases and select merchants"
+    note: "Apple purchases and select merchants via Apple Pay (Nike, Uber, Walgreens, Booking.com, ChargePoint, Duane Reade, Exxon Mobil, Hertz, Ace Hardware)"
   - category: dining
     value: 2
     unit: percent


### PR DESCRIPTION
## Summary
Triaged from weekly review issues #681/#767/#849/#920/#995. The Apple Card's 3% rate applies to Apple purchases AND a specific merchant list when paid through Apple Pay. Previous note was vague ("Apple purchases and select merchants") — this lists the merchants explicitly.

## Change
\`\`\`yaml
- category: online_shopping
  value: 3
  unit: percent
  note: "Apple purchases and select merchants via Apple Pay (Nike, Uber, Walgreens, Booking.com, ChargePoint, Duane Reade, Exxon Mobil, Hertz, Ace Hardware)"
\`\`\`

## Triage notes from those issues
- **A.1 Amex Business Gold top-2-categories** — already modeled correctly with \`top_category: 4 points_per_dollar, choices: 2\`. No action.
- **A.3 Amazon Prime online_shopping merge** — keep \`amazon\` category; don't expand. No action.
- **A.4 Capital One Savor travel_portal** — ignored.
- **B "missing from apply page" flags** — LLM extraction misses, not real removals. Trust the YAML.
- **C borderline insurance perks** — already in \`benefit-policy.yaml\` borderline, working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)