### PR TITLE
Amex Gold: 60th-anniversary updates (5x Amex Travel hotels + Hertz status)

### DIFF
--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -31,6 +31,12 @@ benefits:
     frequency: "semi_annual"
     category: "dining"
     enrollment_required: true
+  - name: "Hertz Elite Status"
+    value: 0
+    description: "Complimentary Hertz elite status for Amex Gold cardholders"
+    frequency: "ongoing"
+    category: "car_rental"
+    enrollment_required: true
 tags:
   - travel
   - dining
@@ -47,6 +53,10 @@ rewards:
   - category: airlines
     value: 3
     unit: points_per_dollar
+  - category: hotels_portal
+    value: 5
+    unit: points_per_dollar
+    note: "Hotels prepaid through Amex Travel"
   - category: everything_else
     value: 1
     unit: points_per_dollar


### PR DESCRIPTION
## Summary
Card-page updates from the 2026-05-02 Amex Gold 60th-anniversary news (merged in #923, source CNBC Select).

## Changes
1. **\`hotels_portal: 5\` reward** — new 5x earn rate on hotels prepaid through Amex Travel.
2. **Hertz Elite Status benefit** — \`value: 0\`, ongoing, \`category: car_rental\` (using the category we added in #998).

## Skipped
- "Expanded dining partnerships" — too vague to model concretely
- "Limited-time anniversary promotions worth up to 2× annual fee" — explicitly time-bound, not a structural change

Annual fee stays at \$325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)