### PR TITLE
Mobile: full-width bank tables/news + tighter hero spacing

### DIFF
--- a/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
+++ b/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
@@ -85,7 +85,7 @@ export default function BankCardsTable({ cards, trendingViews }: BankCardsTableP
       </div>
 
       {/* Cards table */}
-      <div className="overflow-hidden sm:shadow sm:ring-1 sm:ring-black sm:ring-opacity-5 sm:rounded-lg">
+      <div className="-mx-4 sm:mx-0 overflow-hidden sm:shadow sm:ring-1 sm:ring-black sm:ring-opacity-5 sm:rounded-lg">
         <table className="min-w-full divide-y divide-gray-300">
           <thead className="bg-gray-50">
             <tr>

--- a/apps/web-next/src/app/bank/[name]/page.tsx
+++ b/apps/web-next/src/app/bank/[name]/page.tsx
@@ -102,7 +102,7 @@ export default async function BankPage({ params }: BankPageProps) {
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>
         <BankCardsTable cards={cards} trendingViews={trendingViews} />
 
-        <div className="mt-8 bg-white sm:shadow sm:ring-1 sm:ring-black sm:ring-opacity-5 sm:rounded-lg overflow-hidden">
+        <div className="-mx-4 sm:mx-0 mt-8 bg-white sm:shadow sm:ring-1 sm:ring-black sm:ring-opacity-5 sm:rounded-lg overflow-hidden">
           <div className="px-4 py-4 border-b border-gray-200">
             <div className="flex items-center gap-2">
               <NewspaperIcon className="h-5 w-5 text-indigo-600" />

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2306,10 +2306,10 @@
     /* aligned with Navbar px-4/sm:px-6 — see main .wrap rule */
   }
   .landing-v2 .hero {
-    padding-block: 20px 28px;
+    padding-block: 4px 28px;
   }
   .landing-v2 .page-hero {
-    padding-block: 20px 24px;
+    padding-block: 4px 24px;
   }
   .landing-v2 .sec {
     padding-block: 72px;


### PR DESCRIPTION
## Summary
- Bank page table and news card now extend edge-to-edge on mobile (added `-mx-4 sm:mx-0` to negate the `.wrap` 16px horizontal padding)
- Reduced mobile top padding on `.hero` and `.page-hero` from 20px to 4px so page titles sit closer to the navbar (less dead space at the top of every page)

## Test plan
- [x] Verified bank page table is 375px wide at x:0 on mobile (375px viewport)
- [x] Verified news card is 375px wide at x:0 on mobile
- [x] Verified landing page hero gap is visibly tighter
- [x] Verified bank page hero (`Chase.`) gap is visibly tighter
- [ ] Spot-check on real iOS Safari after Amplify deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)