### PR TITLE
Capped reward rates: structured spend_cap / cap_period / rate_after_cap

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -22,7 +22,7 @@ import {
   CardWireEntry,
 } from "@/lib/api";
 import { getValuationDetails } from "@/lib/valuations";
-import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
+import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
 import { NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { Article } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -762,6 +762,11 @@ export default function CardClient({
                               </div>
                               {r.note && (
                                 <div className="cj-cell-detail">{r.note}</div>
+                              )}
+                              {r.spend_cap && (
+                                <div className="cj-cell-detail">
+                                  {formatRewardCapCaveat(r)}
+                                </div>
                               )}
                               {r.current_categories && r.current_period && (
                                 <div className="cj-cell-detail">

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -22,6 +22,7 @@ import {
   formatBonusRequirement,
   formatAnnualFee,
   formatRewardWithUsdEquivalent,
+  formatRewardCapCaveat,
   getRewardUsdRate,
   RewardTypeBadge,
 } from '@/lib/cardDisplayUtils';
@@ -718,6 +719,9 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                               </span>
                             )}
                           </span>
+                          {!isFallback && reward?.spend_cap && (
+                            <div className="text-xs text-gray-500 mt-0.5">{formatRewardCapCaveat(reward)}</div>
+                          )}
                           {!isFallback && reward?.mode === 'quarterly_rotating' && (
                             <div className="text-xs text-gray-400 mt-0.5">Rotating</div>
                           )}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -20,6 +20,13 @@ export interface Reward {
   choices?: number;
   current_categories?: string[];
   current_period?: string;
+  // Spend caps. When set, `value` is earned only on spend up to `spend_cap`
+  // within `cap_period` (default 'annual'); spend above that earns
+  // `rate_after_cap` (default 1, in the same unit). Example: Blue Business
+  // Plus is `value: 2, unit: points_per_dollar, spend_cap: 50000`.
+  spend_cap?: number;
+  cap_period?: 'monthly' | 'quarterly' | 'semi_annual' | 'annual' | 'billing_cycle' | 'lifetime';
+  rate_after_cap?: number;
 }
 
 export interface SignupBonus {

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -252,6 +252,28 @@ export function formatRewardWithUsdEquivalent(reward: Reward | undefined, card: 
   return `${raw} (~${formatPercent(usdRate)}%)`;
 }
 
+// Render the structured cap/post-cap caveat for a reward (e.g.
+// "on first $50K/yr, then 1x" for Blue Business Plus). Returns an empty
+// string when the reward isn't capped. Used as a small caveat next to or
+// below the headline rate so users can see the limit without parsing
+// the prose `note`.
+export function formatRewardCapCaveat(reward: Reward): string {
+  if (!reward.spend_cap || reward.spend_cap <= 0) return '';
+  const cap = `$${reward.spend_cap.toLocaleString()}`;
+  const periodLabels: Record<string, string> = {
+    monthly: '/mo',
+    quarterly: '/qtr',
+    semi_annual: '/6 mo',
+    annual: '/yr',
+    billing_cycle: '/billing cycle',
+    lifetime: ' lifetime',
+  };
+  const period = periodLabels[reward.cap_period || 'annual'] || '/yr';
+  const after = reward.rate_after_cap ?? 1;
+  const afterStr = reward.unit === 'percent' ? `${after}%` : `${after}x`;
+  return `on first ${cap}${period}, then ${afterStr}`;
+}
+
 export function RewardTypeBadge({ type }: { type?: string }) {
   if (!type) return null;
   const colors: Record<string, string> = {

--- a/data/cards/amazon-business-prime-american-express-card.yaml
+++ b/data/cards/amazon-business-prime-american-express-card.yaml
@@ -10,7 +10,10 @@ rewards:
   - category: amazon
     value: 5
     unit: percent
-    note: "U.S. purchases at Amazon.com, Amazon Business, AWS, and Whole Foods Market, on first $120,000/year then 1%"
+    note: "U.S. purchases at Amazon.com, Amazon Business, AWS, and Whole Foods Market"
+    spend_cap: 120000
+    cap_period: annual
+    rate_after_cap: 1
   - category: dining
     value: 2
     unit: percent

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -16,7 +16,10 @@ rewards:
       - gas
       - dining
       - transit
-    note: "Automatically on your top 2 spending categories each billing cycle from 6 eligible (airfare, U.S. advertising, U.S. gas, U.S. restaurants, U.S. computer/cloud, transit), on the first $150,000/year"
+    note: "Automatically on your top 2 spending categories each billing cycle from 6 eligible (airfare, U.S. advertising, U.S. gas, U.S. restaurants, U.S. computer/cloud, transit) — combined cap"
+    spend_cap: 150000
+    cap_period: annual
+    rate_after_cap: 1
   - category: travel_portal
     value: 3
     unit: points_per_dollar

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -14,11 +14,17 @@ rewards:
     value: 3
     unit: percent
     choices: 1
-    note: "3% in choice category, up to $2,500/quarter"
+    note: "3% in choice category; cap is combined with groceries/wholesale-club row"
+    spend_cap: 2500
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: groceries
     value: 2
     unit: percent
-    note: "Also includes wholesale clubs, up to $2,500/quarter combined"
+    note: "Also includes wholesale clubs; cap is combined with choice category"
+    spend_cap: 2500
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: percent

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -14,11 +14,17 @@ rewards:
     value: 3
     unit: percent
     choices: 1
-    note: "3% in choice category (gas, online shopping, dining, travel, drugstores, home improvement), up to $2,500/quarter"
+    note: "3% in choice category (gas, online shopping, dining, travel, drugstores, home improvement); cap is combined with groceries/wholesale-club row"
+    spend_cap: 2500
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: groceries
     value: 2
     unit: percent
-    note: "Also includes wholesale clubs, up to $2,500/quarter combined with choice category"
+    note: "Also includes wholesale clubs; cap is combined with choice category"
+    spend_cap: 2500
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: percent

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -25,7 +25,10 @@ rewards:
     eligible_categories:
       - "dining"
       - "groceries"
-    note: "Choose dining (default) or groceries as your 3x category annually; grocery earns 3x on up to $25,000/year, then 1x."
+    note: "Choose dining (default) or groceries as your 3x category annually (cap applies when groceries is selected)"
+    spend_cap: 25000
+    cap_period: annual
+    rate_after_cap: 1
   - category: "travel"
     value: 2
     unit: "points_per_dollar"

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -46,7 +46,10 @@ rewards:
   - category: dining
     value: 3
     unit: points_per_dollar
-    note: "Choose dining or groceries, up to $25,000/year"
+    note: "Choose dining or groceries as the 3x category"
+    spend_cap: 25000
+    cap_period: annual
+    rate_after_cap: 1
   - category: travel
     value: 2
     unit: points_per_dollar

--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -10,7 +10,9 @@ rewards:
   - category: everything_else
     value: 2
     unit: percent
-    note: "On first $50,000 in purchases per calendar year, then 1%"
+    spend_cap: 50000
+    cap_period: annual
+    rate_after_cap: 1
 signup_bonus:
   value: 250
   type: cash

--- a/data/cards/blue-business-plus-credit-card-from-american-express.yaml
+++ b/data/cards/blue-business-plus-credit-card-from-american-express.yaml
@@ -10,7 +10,9 @@ rewards:
   - category: everything_else
     value: 2
     unit: points_per_dollar
-    note: "On first $50,000 in purchases per calendar year, then 1x"
+    spend_cap: 50000
+    cap_period: annual
+    rate_after_cap: 1
 signup_bonus:
   value: 15000
   type: points

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -13,15 +13,24 @@ rewards:
   - category: "groceries"
     value: 3
     unit: "percent"
-    note: "U.S. supermarkets, up to $6,000 per year then 1%"
+    note: "U.S. supermarkets"
+    spend_cap: 6000
+    cap_period: annual
+    rate_after_cap: 1
   - category: "gas"
     value: 3
     unit: "percent"
-    note: "U.S. gas stations, up to $6,000 per year then 1%"
+    note: "U.S. gas stations"
+    spend_cap: 6000
+    cap_period: annual
+    rate_after_cap: 1
   - category: "online_shopping"
     value: 3
     unit: "percent"
-    note: "U.S. online retail purchases, up to $6,000 per year then 1%"
+    note: "U.S. online retail purchases"
+    spend_cap: 6000
+    cap_period: annual
+    rate_after_cap: 1
   - category: "everything_else"
     value: 1
     unit: "percent"

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -11,7 +11,10 @@ rewards:
   - category: groceries
     value: 6
     unit: percent
-    note: "U.S. supermarkets, up to $6,000 per year then 1%"
+    note: "U.S. supermarkets"
+    spend_cap: 6000
+    cap_period: annual
+    rate_after_cap: 1
   - category: streaming
     value: 6
     unit: percent

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -18,7 +18,10 @@ rewards:
       - "travel_portal"
       - "everything_else"
     current_period: "Q2 2026"
-    note: "Q2 2026: Amazon, Chase Travel, and donations to Feeding America (up to $1,500)"
+    note: "Q2 2026: Amazon, Chase Travel, and donations to Feeding America"
+    spend_cap: 1500
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: "travel_portal"
     value: 5
     unit: "percent"

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -13,15 +13,24 @@ rewards:
   - category: online_shopping
     value: 5
     unit: percent
-    note: "Office supply stores, internet, cable, and phone services (first $25,000/year)"
+    note: "Office supply stores, internet, cable, and phone services"
+    spend_cap: 25000
+    cap_period: annual
+    rate_after_cap: 1
   - category: gas
     value: 2
     unit: percent
-    note: "Gas stations and restaurants (first $25,000/year)"
+    note: "Gas stations and restaurants (combined cap with dining)"
+    spend_cap: 25000
+    cap_period: annual
+    rate_after_cap: 1
   - category: dining
     value: 2
     unit: percent
-    note: "Gas stations and restaurants (first $25,000/year)"
+    note: "Gas stations and restaurants (combined cap with gas)"
+    spend_cap: 25000
+    cap_period: annual
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: percent

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -15,7 +15,10 @@ rewards:
   - category: travel
     value: 3
     unit: points_per_dollar
-    note: "Travel, shipping, internet/cable/phone, advertising on search engines and social media (first $150,000/year combined)"
+    note: "Travel, shipping, internet/cable/phone, advertising on search engines and social media (combined)"
+    spend_cap: 150000
+    cap_period: annual
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: points_per_dollar

--- a/data/cards/citi-custom-cash.yaml
+++ b/data/cards/citi-custom-cash.yaml
@@ -22,7 +22,10 @@ rewards:
       - "drugstores"
       - "home_improvement"
       - "entertainment"
-    note: "Automatically on your top eligible spend category each billing cycle, up to $500/month"
+    note: "Automatically on your top eligible spend category each billing cycle"
+    spend_cap: 500
+    cap_period: monthly
+    rate_after_cap: 1
   - category: "hotels_car_portal"
     value: 4
     unit: "points_per_dollar"

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -15,7 +15,10 @@ rewards:
     mode: quarterly_rotating
     current_categories: [dining, home_improvement]
     current_period: "Q2 2026"
-    note: "Up to $1,500/quarter when activated"
+    note: "Activation required each quarter"
+    spend_cap: 1500
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: percent

--- a/data/cards/discover-it-for-students-card.yaml
+++ b/data/cards/discover-it-for-students-card.yaml
@@ -16,7 +16,10 @@ rewards:
     mode: quarterly_rotating
     current_categories: [dining, home_improvement]
     current_period: "Q2 2026"
-    note: "Up to $1,500/quarter when activated"
+    note: "Activation required each quarter"
+    spend_cap: 1500
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: percent

--- a/data/cards/nhl-discover-it.yaml
+++ b/data/cards/nhl-discover-it.yaml
@@ -15,7 +15,10 @@ rewards:
     mode: quarterly_rotating
     current_categories: [dining, home_improvement]
     current_period: "Q2 2026"
-    note: "Up to $1,500/quarter when activated"
+    note: "Activation required each quarter"
+    spend_cap: 1500
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: percent

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -116,6 +116,21 @@
           "current_period": {
             "type": "string",
             "description": "Current rotation period label, e.g. Q1 2026"
+          },
+          "spend_cap": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Maximum dollar spend that earns the headline `value` rate (e.g. 50000 for 'first $50K/yr'). Once exceeded, the cardholder earns `rate_after_cap` (or 1 if unspecified). Combined with `cap_period`."
+          },
+          "cap_period": {
+            "type": "string",
+            "enum": ["monthly", "quarterly", "semi_annual", "annual", "billing_cycle", "lifetime"],
+            "description": "Time window over which `spend_cap` resets. Defaults to 'annual'."
+          },
+          "rate_after_cap": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Reward rate (in the same `unit`) earned on spend above `spend_cap`. Defaults to 1 (i.e. 1% or 1x) when unspecified."
           }
         }
       },

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -92,6 +92,23 @@ function validateCard(card, schema, categoryIds) {
       if (reward.choices !== undefined && (typeof reward.choices !== 'number' || reward.choices < 1 || !Number.isInteger(reward.choices))) {
         errors.push(`Invalid reward choices for ${reward.category}: must be a positive integer`);
       }
+      // Cap fields. spend_cap is the dollar threshold; cap_period is the
+      // window over which it resets; rate_after_cap is the rate earned on
+      // spend above the cap (defaults to 1 if unspecified).
+      if (reward.spend_cap !== undefined && (typeof reward.spend_cap !== 'number' || reward.spend_cap <= 0)) {
+        errors.push(`Invalid spend_cap for ${reward.category}: must be a positive number`);
+      }
+      const validCapPeriods = ['monthly', 'quarterly', 'semi_annual', 'annual', 'billing_cycle', 'lifetime'];
+      if (reward.cap_period !== undefined && !validCapPeriods.includes(reward.cap_period)) {
+        errors.push(`Invalid cap_period for ${reward.category}: ${reward.cap_period} (must be one of ${validCapPeriods.join(', ')})`);
+      }
+      if (reward.rate_after_cap !== undefined && (typeof reward.rate_after_cap !== 'number' || reward.rate_after_cap < 0)) {
+        errors.push(`Invalid rate_after_cap for ${reward.category}: must be a non-negative number`);
+      }
+      // Sanity: cap_period or rate_after_cap without spend_cap doesn't make sense.
+      if ((reward.cap_period !== undefined || reward.rate_after_cap !== undefined) && reward.spend_cap === undefined) {
+        errors.push(`${reward.category}: cap_period/rate_after_cap requires spend_cap to be set`);
+      }
     }
   }
 

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -283,7 +283,15 @@ Return ONLY valid JSON in this exact shape — no markdown, no commentary:
 
 {
   "rewards": [
-    { "category": "<category id>", "value": <number>, "unit": "percent" | "points_per_dollar", "note": "<optional>" }
+    {
+      "category": "<category id>",
+      "value": <number>,
+      "unit": "percent" | "points_per_dollar",
+      "note": "<optional>",
+      "spend_cap": <optional number>,
+      "cap_period": "monthly" | "quarterly" | "semi_annual" | "annual" | "billing_cycle" | "lifetime",
+      "rate_after_cap": <optional number>
+    }
   ],
   "benefits": [
     {
@@ -350,6 +358,27 @@ bag"), an elite status tier, or a clearly free recurring service.
 - "Priority Pass" ONLY counts as a benefit if access is FREE (unlimited or
   N free visits per year). If the page says "with pay-per-visit pricing"
   or "members rate" or similar, OMIT it.
+
+# REWARDS — capped earn rates (CRITICAL)
+When an apply page describes a capped earn rate — "X on first \$Y per
+year, then Z" — \`value\` MUST be the headline rate (X), and the cap
+goes in the structured fields:
+  spend_cap: <Y>           ← the dollar threshold
+  cap_period: "annual"     ← or quarterly / monthly / billing_cycle / lifetime
+  rate_after_cap: <Z>      ← rate above the cap, in the same unit (defaults to 1)
+
+DO NOT propose dropping \`value\` to the post-cap rate. Examples:
+  Blue Business Plus "2x on first \$50K, then 1x" →
+    value: 2, unit: points_per_dollar, spend_cap: 50000,
+    cap_period: annual, rate_after_cap: 1
+  Blue Cash Preferred "6% at U.S. supermarkets up to \$6,000/yr, then 1%" →
+    value: 6, unit: percent, spend_cap: 6000,
+    cap_period: annual, rate_after_cap: 1
+  Citi Custom Cash "5% on top eligible category up to \$500/month" →
+    value: 5, unit: percent, spend_cap: 500,
+    cap_period: monthly, rate_after_cap: 1
+  Chase Freedom Flex rotating "5% up to \$1,500/quarter when activated" →
+    value: 5, unit: percent, spend_cap: 1500, cap_period: quarterly
 
 # DO NOT INCLUDE — earn / redemption / finance mechanics
 - "rewards" describes per-CATEGORY EARN RATES on spend (e.g. "5% on dining"). Use category ids that already appear in the example cards below.
@@ -523,6 +552,16 @@ function diffRewards(current, proposed) {
   // ("4% Bilt Cash on everyday purchases") that the model treats as the
   // earn rate. Drop those silently rather than overwriting the human-curated
   // earn rate with the wrong unit.
+  //
+  // Capped-rate guard: if the existing reward has a `spend_cap` (or its note
+  // mentions one) and the LLM proposes a value LOWER than current, the LLM
+  // is probably misreading the post-cap rate (e.g. "1x after $50K") as the
+  // headline. Skip those proposals — the schema's `rate_after_cap` already
+  // captures the post-cap rate.
+  const noteMentionsCap = (r) =>
+    typeof r?.note === 'string' &&
+    /(\bfirst\s+\$\d|\bup\s+to\s+\$\d|\bcap\b|then\s+\d+\s*(x|%)|combined\b)/i.test(r.note);
+
   const cur = new Map((current || []).map(r => [r.category, r]));
   const prop = new Map((proposed || []).map(r => [r.category, r]));
   const added = [];
@@ -535,7 +574,20 @@ function diffRewards(current, proposed) {
     } else if (c.unit !== p.unit) {
       // Unit mismatch — skip; almost always an LLM misread.
       continue;
-    } else if (c.value !== p.value) {
+    } else if (
+      p.value < c.value &&
+      (c.spend_cap !== undefined || noteMentionsCap(c))
+    ) {
+      // Downward proposal on a capped reward — the LLM is likely reading the
+      // post-cap rate as the headline. Skip; if there's a real change to the
+      // cap or rate_after_cap, those will get picked up in the field-merge.
+      continue;
+    } else if (
+      c.value !== p.value ||
+      c.spend_cap !== p.spend_cap ||
+      c.cap_period !== p.cap_period ||
+      c.rate_after_cap !== p.rate_after_cap
+    ) {
       changed.push({ from: c, to: p });
     }
   }


### PR DESCRIPTION
## Summary
The auto-checker keeps proposing reward downgrades on capped cards (Blue Business Plus 2x→1x, Marriott Bonvoy Bold 3x→2x, etc.) because the LLM reads "first \$50K, then 1x" and stores the post-cap rate as the headline. We've been closing these weekly. **This is the structural fix** — we model the cap explicitly.

## Schema additions (rewards items)
\`\`\`yaml
- category: everything_else
  value: 2
  unit: points_per_dollar
  spend_cap: 50000          # $ threshold
  cap_period: annual         # monthly | quarterly | semi_annual | annual | billing_cycle | lifetime
  rate_after_cap: 1          # earn rate above the cap, same unit
\`\`\`

## Wired through
- **TS** \`Reward\` interface
- **\`build-cards.js\`** validation (sanity check: cap_period/rate_after_cap require spend_cap)
- **Auto-checker prompt** — explicit "REWARDS — capped earn rates (CRITICAL)" section with examples
- **Auto-checker \`diffRewards\`** — capped-rate guard: proposals to lower \`value\` on a capped reward are silently rejected. Kills the recurring false positive.
- **Frontend** — \`formatRewardCapCaveat()\` renders "on first \$50,000/yr, then 1x" on the card detail rewards table and compare-page cells

## Migrated 16 existing cards
Amazon Business Prime, Amex Biz Gold (top-2 combined), Blue Business Plus / Cash, Blue Cash Everyday / Preferred, Bilt Palladium / Obsidian, BoA Cash Rewards (2 cards × 2 rows), Chase Freedom Flex (rotating quarter), Chase Ink Business Cash / Preferred (combined caps), Citi Custom Cash (monthly), Discover It Cash Back / Students / NHL (quarterly).

Combined-cap cards (where one cap applies across multiple rows) keep the cap on each row and document the combined relationship in row notes — schema doesn't yet model shared caps, but the data is correct.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`build-cards\` validates all 160 cards
- [x] Combined-cap rows on Chase Ink Cash, BoA Cash Rewards build correctly
- [ ] After merge: spot-check card detail page for Blue Biz Plus, Citi Custom Cash, Chase Freedom Flex

🤖 Generated with [Claude Code](https://claude.com/claude-code)