### PR TITLE
Card wire: inline change chips + right-rail block, retire top-rate metric

### DIFF
--- a/apps/api/src/handlers/card-wire.js
+++ b/apps/api/src/handlers/card-wire.js
@@ -49,6 +49,7 @@ exports.CardWireHandler = async (event) => {
          FROM card_wire cw
          JOIN cards c ON c.card_id = cw.card_id
          WHERE cw.card_id = ?
+           AND cw.field != 'reward_top_rate'
          ORDER BY cw.changed_at DESC
          LIMIT ?`,
         [parseInt(cardId, 10), limit]
@@ -59,6 +60,7 @@ exports.CardWireHandler = async (event) => {
                 cw.field, cw.old_value, cw.new_value, cw.changed_at
          FROM card_wire cw
          JOIN cards c ON c.card_id = cw.card_id
+         WHERE cw.field != 'reward_top_rate'
          ORDER BY cw.changed_at DESC
          LIMIT ?`,
         [limit]

--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -35,26 +35,11 @@ async function fetchCardsFromCDN() {
 
 // Extract metric values from a CDN card for change detection
 function extractMetrics(cdnCard) {
-  let rewardTopRate = null;
-  let rewardTopUnit = null;
-  if (cdnCard.rewards && cdnCard.rewards.length > 0) {
-    const topReward = cdnCard.rewards.reduce(
-      (best, r) => (r.value > (best?.value || 0) ? r : best),
-      null
-    );
-    if (topReward) {
-      rewardTopRate = topReward.value;
-      rewardTopUnit = topReward.unit;
-    }
-  }
-
   return {
     accepting_applications: cdnCard.accepting_applications === false ? 0 : 1,
     annual_fee: cdnCard.annual_fee ?? null,
     signup_bonus_value: cdnCard.signup_bonus?.value ?? null,
     signup_bonus_type: cdnCard.signup_bonus?.type ?? null,
-    reward_top_rate: rewardTopRate,
-    reward_top_unit: rewardTopUnit,
     apr_min: cdnCard.apr?.regular?.min ?? null,
     apr_max: cdnCard.apr?.regular?.max ?? null,
   };
@@ -66,7 +51,6 @@ async function detectAndRecordChanges(cardId, oldMetrics, newMetrics) {
     { field: "accepting_applications", old: oldMetrics.accepting_applications, new: newMetrics.accepting_applications },
     { field: "annual_fee", old: oldMetrics.annual_fee, new: newMetrics.annual_fee },
     { field: "signup_bonus_value", old: oldMetrics.signup_bonus_value, new: newMetrics.signup_bonus_value },
-    { field: "reward_top_rate", old: oldMetrics.reward_top_rate, new: newMetrics.reward_top_rate },
     { field: "apr_min", old: oldMetrics.apr_min, new: newMetrics.apr_min },
     { field: "apr_max", old: oldMetrics.apr_max, new: newMetrics.apr_max },
   ];
@@ -118,7 +102,6 @@ async function syncCardsToDatabase(cdnCards) {
     const existingCards = await mysql.query(
       `SELECT card_id, card_name, bank, accepting_applications, annual_fee,
               signup_bonus_value, signup_bonus_type,
-              reward_top_rate, reward_top_unit,
               apr_min, apr_max
        FROM cards`
     );
@@ -184,8 +167,6 @@ async function syncCardsToDatabase(cdnCards) {
               card_referral_link = ?,
               signup_bonus_value = ?,
               signup_bonus_type = ?,
-              reward_top_rate = ?,
-              reward_top_unit = ?,
               apr_min = ?,
               apr_max = ?
             WHERE card_id = ?`,
@@ -194,7 +175,6 @@ async function syncCardsToDatabase(cdnCards) {
               cdnCard.image || null, cdnCard.release_date || null, tagsJson,
               newMetrics.annual_fee, cdnCard.apply_link || null, cdnCard.card_referral_link || null,
               newMetrics.signup_bonus_value, newMetrics.signup_bonus_type,
-              newMetrics.reward_top_rate, newMetrics.reward_top_unit,
               newMetrics.apr_min, newMetrics.apr_max,
               existingCard.card_id,
             ]
@@ -208,15 +188,14 @@ async function syncCardsToDatabase(cdnCards) {
           await mysql.query(
             `INSERT INTO cards (card_id, card_name, bank, accepting_applications, card_image_link,
               release_date, tags, annual_fee, apply_link, card_referral_link,
-              signup_bonus_value, signup_bonus_type, reward_top_rate, reward_top_unit,
+              signup_bonus_value, signup_bonus_type,
               apr_min, apr_max, active)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
             [
               nextId, name, bank, acceptingApplications,
               cdnCard.image || null, cdnCard.release_date || null, tagsJson,
               newMetrics.annual_fee, cdnCard.apply_link || null, cdnCard.card_referral_link || null,
               newMetrics.signup_bonus_value, newMetrics.signup_bonus_type,
-              newMetrics.reward_top_rate, newMetrics.reward_top_unit,
               newMetrics.apr_min, newMetrics.apr_max,
             ]
           );

--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -15,13 +15,12 @@ interface Props {
   bonusTypeMap: Record<string, string>;
 }
 
-type FilterKey = 'all' | 'fee' | 'bonus' | 'reward' | 'apr' | 'apps';
+type FilterKey = 'all' | 'fee' | 'bonus' | 'apr' | 'apps';
 
 const FILTERS: { key: FilterKey; label: string }[] = [
   { key: 'all', label: 'All' },
   { key: 'fee', label: 'Annual fee' },
   { key: 'bonus', label: 'Sign-up bonus' },
-  { key: 'reward', label: 'Rewards' },
   { key: 'apr', label: 'APR' },
   { key: 'apps', label: 'Applications' },
 ];
@@ -30,7 +29,6 @@ const FIELD_LABELS: Record<string, string> = {
   accepting_applications: 'Applications',
   annual_fee: 'Annual fee',
   signup_bonus_value: 'Sign-up bonus',
-  reward_top_rate: 'Top reward',
   apr_min: 'APR min',
   apr_max: 'APR max',
 };
@@ -40,7 +38,6 @@ const HIGHER_IS_BAD = new Set(['annual_fee', 'apr_min', 'apr_max']);
 function fieldGroup(field: string): FilterKey {
   if (field === 'annual_fee') return 'fee';
   if (field === 'signup_bonus_value') return 'bonus';
-  if (field === 'reward_top_rate') return 'reward';
   if (field === 'apr_min' || field === 'apr_max') return 'apr';
   if (field === 'accepting_applications') return 'apps';
   return 'all';
@@ -69,7 +66,7 @@ function formatValue(
     }
     return value;
   }
-  if (field === 'reward_top_rate' || field === 'apr_min' || field === 'apr_max') {
+  if (field === 'apr_min' || field === 'apr_max') {
     if (!Number.isNaN(num)) return `${num}%`;
     return value;
   }

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -128,6 +128,102 @@ function bucketize(
   );
 }
 
+// Returns 'pos' (good for the cardholder), 'neg' (worse), or null.
+// `annual_fee`, `apr_min`, `apr_max` are inverted — lower is better.
+function wireDirection(
+  field: string,
+  oldVal: string | null,
+  newVal: string | null,
+): "pos" | "neg" | null {
+  if (oldVal === null || newVal === null) return null;
+  if (field === "accepting_applications") {
+    const o = oldVal === "true" || oldVal === "1";
+    const n = newVal === "true" || newVal === "1";
+    if (o === n) return null;
+    return n ? "pos" : "neg";
+  }
+  const o = Number(oldVal);
+  const n = Number(newVal);
+  if (Number.isNaN(o) || Number.isNaN(n) || o === n) return null;
+  const lowerIsBetter = field === "annual_fee" || field.startsWith("apr_");
+  const wentUp = n > o;
+  if (lowerIsBetter) return wentUp ? "neg" : "pos";
+  return wentUp ? "pos" : "neg";
+}
+
+function WireChip({
+  entry,
+  label,
+  format,
+}: {
+  entry: CardWireEntry | undefined;
+  label: string;
+  format: (val: string | null) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  if (!entry) return null;
+
+  const date = new Date(entry.changed_at).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "2-digit",
+  });
+
+  const dir = wireDirection(entry.field, entry.old_value, entry.new_value);
+  const dirClass = dir ? ` cj-wire-${dir}` : "";
+  const oN = Number(entry.old_value);
+  const nN = Number(entry.new_value);
+  const arrow =
+    !Number.isNaN(oN) && !Number.isNaN(nN) && nN !== oN
+      ? nN > oN
+        ? "▲"
+        : "▼"
+      : "•";
+
+  return (
+    <span className="cj-wire-chip-wrap" ref={wrapRef}>
+      <button
+        type="button"
+        className={`cj-wire-chip${dirClass}`}
+        aria-expanded={open}
+        aria-label={`${label} changed ${date}`}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {arrow} {date}
+      </button>
+      {open && (
+        <span className="cj-wire-chip-pop" role="dialog">
+          <span className="cj-wire-chip-pop-k">{label} changed</span>
+          <span className="cj-wire-chip-pop-row">
+            <span className="cj-wire-chip-old">{format(entry.old_value)}</span>
+            <span className={`cj-wire-chip-arrow${dirClass}`}>→</span>
+            <span className={`cj-wire-chip-new${dirClass}`}>{format(entry.new_value)}</span>
+          </span>
+          <span className="cj-wire-chip-pop-foot">{date}</span>
+        </span>
+      )}
+    </span>
+  );
+}
+
 interface CardClientProps {
   card: Card;
   graphData: GraphData[];
@@ -389,29 +485,33 @@ export default function CardClient({
     return `${n} yr${n === 1 ? "" : "s"}`;
   })();
 
-  // Combine news + wire into a single tape, newest first.
-  type TapeNews = { kind: "news"; date: string; raw: NewsItem };
-  type TapeWire = { kind: "wire"; date: string; raw: CardWireEntry };
-  const tapeEntries: (TapeNews | TapeWire)[] = useMemo(() => {
-    const arr: (TapeNews | TapeWire)[] = [
-      ...news.map<TapeNews>((n) => ({ kind: "news", date: n.date, raw: n })),
-      ...wire.map<TapeWire>((w) => ({
-        kind: "wire",
-        date: w.changed_at,
-        raw: w,
-      })),
-    ];
-    return arr
-      .sort(
-        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-      )
-      .slice(0, 12);
-  }, [news, wire]);
+  // Bottom tape is news-only — wire diffs live in the right rail.
+  const newsEntries = useMemo(
+    () =>
+      [...news]
+        .sort(
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+        )
+        .slice(0, 12),
+    [news],
+  );
+
+  // Wire entries for the right-rail block, newest first.
+  const wireEntries = useMemo(
+    () =>
+      [...wire]
+        .sort(
+          (a, b) =>
+            new Date(b.changed_at).getTime() -
+            new Date(a.changed_at).getTime(),
+        )
+        .slice(0, 8),
+    [wire],
+  );
 
   const fieldLabel: Record<string, string> = {
     annual_fee: "Annual fee",
     signup_bonus_value: "Signup bonus",
-    reward_top_rate: "Top reward",
     apr_min: "APR min",
     apr_max: "APR max",
   };
@@ -420,9 +520,22 @@ export default function CardClient({
     if (field === "annual_fee") return `$${Number(val).toLocaleString()}`;
     if (field === "signup_bonus_value") return Number(val).toLocaleString();
     if (field.startsWith("apr_")) return `${val}%`;
-    if (field === "reward_top_rate") return `${val}x`;
     return val;
   };
+
+  // Latest wire entry per field — drives inline change chips on the readoff
+  // values. Only the most recent diff per field is surfaced inline; the full
+  // history still lives in section 04.
+  const latestWireByField = useMemo(() => {
+    const map: Record<string, CardWireEntry> = {};
+    for (const w of wire) {
+      const prev = map[w.field];
+      if (!prev || new Date(w.changed_at) > new Date(prev.changed_at)) {
+        map[w.field] = w;
+      }
+    }
+    return map;
+  }, [wire]);
 
   // ---------- Render ----------
   return (
@@ -577,9 +690,9 @@ export default function CardClient({
           <a href="#odds" className="cj-toc-link">
             <span className="cj-toc-num">03</span>Approval odds
           </a>
-          {tapeEntries.length > 0 && (
+          {newsEntries.length > 0 && (
             <a href="#wire" className="cj-toc-link">
-              <span className="cj-toc-num">04</span>News &amp; wire
+              <span className="cj-toc-num">04</span>News
             </a>
           )}
           {articles.length > 0 && (
@@ -661,6 +774,11 @@ export default function CardClient({
                 </div>
                 <div className="cj-readoff-foot">
                   {card.annual_fee === 0 ? "No fee" : "Per year"}
+                  <WireChip
+                    entry={latestWireByField.annual_fee}
+                    label="Annual fee"
+                    format={(v) => formatWireValue(v, "annual_fee")}
+                  />
                 </div>
               </div>
               <div
@@ -672,6 +790,11 @@ export default function CardClient({
                 </div>
                 <div className="cj-readoff-foot">
                   {bonusDisplay ? bonusDisplay.sub : "No current offer"}
+                  <WireChip
+                    entry={latestWireByField.signup_bonus_value}
+                    label="Signup bonus"
+                    format={(v) => formatWireValue(v, "signup_bonus_value")}
+                  />
                 </div>
               </div>
               <div className="cj-readoff-cell">
@@ -1164,12 +1287,12 @@ export default function CardClient({
             )}
           </section>
 
-          {/* 04 News & wire */}
-          {tapeEntries.length > 0 && (
+          {/* 04 News */}
+          {newsEntries.length > 0 && (
             <section id="wire" className="cj-section">
-              <div className="cj-section-num">04 · news &amp; wire</div>
+              <div className="cj-section-num">04 · news</div>
               <h2 className="cj-section-h2">
-                News &amp; <em className="cj-section-accent">wire</em>
+                In the <em className="cj-section-accent">news</em>
               </h2>
               <div className="cj-tape">
                 <div className="cj-tape-head">
@@ -1177,64 +1300,28 @@ export default function CardClient({
                   <div>Event</div>
                   <div className="cj-tape-res">Source</div>
                 </div>
-                {tapeEntries.map((t, i) => {
-                  const dateText = new Date(t.date).toLocaleDateString(
+                {newsEntries.map((n, i) => {
+                  const dateText = new Date(n.date).toLocaleDateString(
                     "en-US",
                     { year: "numeric", month: "short", day: "numeric" },
                   );
-                  if (t.kind === "news") {
-                    const n = t.raw;
-                    const tag = n.tags[0] as NewsTag | undefined;
-                    return (
-                      <Link
-                        key={`n-${n.id}-${i}`}
-                        href={`/news/${n.id}`}
-                        className="cj-tape-row"
-                      >
-                        <div className="cj-tape-when">{dateText}</div>
-                        <div className="cj-tape-event">
-                          <span className="cj-tape-field">{n.title}</span>
-                        </div>
-                        <div className="cj-tape-res">
-                          <span className="cj-news-tag">
-                            {tag ? tagLabels[tag] : "NEWS"}
-                          </span>
-                        </div>
-                      </Link>
-                    );
-                  }
-                  const w = t.raw;
-                  const isUp =
-                    w.old_value !== null &&
-                    w.new_value !== null &&
-                    Number(w.new_value) > Number(w.old_value);
-                  const isDn =
-                    w.old_value !== null &&
-                    w.new_value !== null &&
-                    Number(w.new_value) < Number(w.old_value);
+                  const tag = n.tags[0] as NewsTag | undefined;
                   return (
-                    <div key={`w-${w.id}`} className="cj-tape-row">
+                    <Link
+                      key={`n-${n.id}-${i}`}
+                      href={`/news/${n.id}`}
+                      className="cj-tape-row"
+                    >
                       <div className="cj-tape-when">{dateText}</div>
                       <div className="cj-tape-event">
-                        <span className="cj-tape-field">
-                          {fieldLabel[w.field] || w.field}
-                        </span>
-                        <span className="cj-tape-change">
-                          <span className="cj-tape-old">
-                            {formatWireValue(w.old_value, w.field)}
-                          </span>
-                          {" → "}
-                          <span
-                            className={`cj-tape-new${isUp ? " cj-pos" : isDn ? " cj-neg" : ""}`}
-                          >
-                            {formatWireValue(w.new_value, w.field)}
-                          </span>
-                        </span>
+                        <span className="cj-tape-field">{n.title}</span>
                       </div>
                       <div className="cj-tape-res">
-                        <span className="cj-pill">WIRE</span>
+                        <span className="cj-news-tag">
+                          {tag ? tagLabels[tag] : "NEWS"}
+                        </span>
                       </div>
-                    </div>
+                    </Link>
                   );
                 })}
               </div>
@@ -1321,6 +1408,43 @@ export default function CardClient({
               </div>
             )}
           </div>
+
+          {wireEntries.length > 0 && (
+            <div className="cj-rail-block cj-wire-rail">
+              <div className="cj-rail-label">Card wire</div>
+              <ul className="cj-wire-rail-list">
+                {wireEntries.map((w) => {
+                  const dir = wireDirection(w.field, w.old_value, w.new_value);
+                  const dirClass = dir ? ` cj-wire-${dir}` : "";
+                  const date = new Date(w.changed_at).toLocaleDateString(
+                    "en-US",
+                    { month: "short", day: "numeric" },
+                  );
+                  return (
+                    <li key={w.id} className="cj-wire-rail-row">
+                      <div className="cj-wire-rail-meta">
+                        <span className="cj-wire-rail-date">{date}</span>
+                        <span className="cj-wire-rail-field">
+                          {fieldLabel[w.field] || w.field}
+                        </span>
+                      </div>
+                      <div className="cj-wire-rail-change">
+                        <span className="cj-wire-rail-old">
+                          {formatWireValue(w.old_value, w.field)}
+                        </span>
+                        <span className={`cj-wire-rail-arrow${dirClass}`}>
+                          →
+                        </span>
+                        <span className={`cj-wire-rail-new${dirClass}`}>
+                          {formatWireValue(w.new_value, w.field)}
+                        </span>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
 
           {ratings.average !== null && ratings.count > 0 && (
             <div className="cj-rating">

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4184,6 +4184,183 @@
 }
 .landing-v2 .cj-readoff-v.cj-accent { color: var(--accent); }
 
+/* Wire chip — inline "changed [date]" badge that opens a popover with the
+   most recent old → new diff for a field. Lets the readoff cell escape its
+   overflow:hidden when the popover is open. */
+.landing-v2 .cj-readoff-cell:has(.cj-wire-chip[aria-expanded="true"]),
+.landing-v2 td:has(.cj-wire-chip[aria-expanded="true"]) {
+  overflow: visible;
+  position: relative;
+  z-index: 5;
+}
+.landing-v2 .cj-wire-chip-wrap {
+  position: relative;
+  display: inline-block;
+  margin-left: 6px;
+  vertical-align: baseline;
+}
+.landing-v2 .cj-wire-chip {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-2);
+  border: 1px solid transparent;
+  padding: 2px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  line-height: 1.2;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.landing-v2 .cj-wire-chip:hover {
+  border-color: var(--accent);
+}
+.landing-v2 .cj-wire-chip[aria-expanded="true"] {
+  background: var(--accent);
+  color: var(--paper);
+}
+/* Direction-tinted chips — green when the change benefits the cardholder
+   (bigger SUB, lower fee), red for the opposite. Triangle inside the chip
+   indicates raw value direction (up vs. down). */
+.landing-v2 .cj-wire-chip.cj-wire-pos {
+  background: #e0f6ea;
+  color: #0f8a5f;
+}
+.landing-v2 .cj-wire-chip.cj-wire-pos:hover { border-color: #0f8a5f; }
+.landing-v2 .cj-wire-chip.cj-wire-pos[aria-expanded="true"] {
+  background: #0f8a5f;
+  color: var(--paper);
+}
+.landing-v2 .cj-wire-chip.cj-wire-neg {
+  background: var(--warn-2);
+  color: var(--warn);
+}
+.landing-v2 .cj-wire-chip.cj-wire-neg:hover { border-color: var(--warn); }
+.landing-v2 .cj-wire-chip.cj-wire-neg[aria-expanded="true"] {
+  background: var(--warn);
+  color: var(--paper);
+}
+.landing-v2 .cj-wire-chip-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 30;
+  min-width: 200px;
+  max-width: min(280px, calc(100vw - 32px));
+  padding: 10px 12px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: 'Inter', sans-serif;
+  text-align: left;
+  white-space: normal;
+}
+.landing-v2 .cj-wire-chip-pop-k {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-weight: 500;
+}
+.landing-v2 .cj-wire-chip-pop-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+}
+.landing-v2 .cj-wire-chip-old {
+  color: var(--muted);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+.landing-v2 .cj-wire-chip-arrow { color: var(--muted); }
+.landing-v2 .cj-wire-chip-new { color: var(--accent); font-weight: 600; }
+/* Direction colors — green for changes that benefit the cardholder
+   (bigger SUB, lower fee), red for the opposite. Applied to both the
+   chip popover arrow/new value and the rail row. */
+.landing-v2 .cj-wire-chip-arrow.cj-wire-pos,
+.landing-v2 .cj-wire-chip-new.cj-wire-pos,
+.landing-v2 .cj-wire-rail-arrow.cj-wire-pos,
+.landing-v2 .cj-wire-rail-new.cj-wire-pos {
+  color: #0f8a5f;
+}
+.landing-v2 .cj-wire-chip-arrow.cj-wire-neg,
+.landing-v2 .cj-wire-chip-new.cj-wire-neg,
+.landing-v2 .cj-wire-rail-arrow.cj-wire-neg,
+.landing-v2 .cj-wire-rail-new.cj-wire-neg {
+  color: var(--warn);
+}
+.landing-v2 .cj-wire-chip-pop-foot {
+  font-size: 11px;
+  color: var(--muted);
+  font-family: 'JetBrains Mono', monospace;
+}
+@media (max-width: 640px) {
+  .landing-v2 .cj-wire-chip-pop {
+    left: auto;
+    right: 0;
+  }
+}
+
+/* Right-rail "Recent changes" block — compact list of wire diffs
+   sitting under the welcome-bonus apply card. */
+.landing-v2 .cj-wire-rail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.landing-v2 .cj-wire-rail-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 0;
+  border-top: 1px dashed var(--line);
+}
+.landing-v2 .cj-wire-rail-row:first-of-type {
+  border-top: 1px solid var(--line);
+}
+.landing-v2 .cj-wire-rail-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 11px;
+}
+.landing-v2 .cj-wire-rail-date {
+  font-family: 'JetBrains Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.landing-v2 .cj-wire-rail-field {
+  color: var(--ink);
+  font-weight: 500;
+}
+.landing-v2 .cj-wire-rail-change {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12.5px;
+}
+.landing-v2 .cj-wire-rail-old {
+  color: var(--muted);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+.landing-v2 .cj-wire-rail-arrow {
+  color: var(--muted);
+}
+.landing-v2 .cj-wire-rail-new {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 .landing-v2 .cj-two-up {
   display: grid;
   grid-template-columns: minmax(0, 1fr);

--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -56,7 +56,6 @@ const fieldLabels = {
   accepting_applications: 'Applications',
   annual_fee: 'Annual Fee',
   signup_bonus_value: 'Sign-up Bonus',
-  reward_top_rate: 'Top Reward Rate',
   apr_min: 'APR Min',
   apr_max: 'APR Max',
 };
@@ -77,7 +76,7 @@ function formatValue(field, value) {
   if (field === 'signup_bonus_value') {
     return !isNaN(num) ? `${num.toLocaleString()} pts` : value;
   }
-  if (field === 'reward_top_rate' || field === 'apr_min' || field === 'apr_max') {
+  if (field === 'apr_min' || field === 'apr_max') {
     return !isNaN(num) ? `${num}%` : value;
   }
   return value;


### PR DESCRIPTION
## Summary
- Promote per-card wire history out of the bottom news combo: inline "Δ date" chips on Annual fee + Sign-up bonus, and a new "Card wire" block in the right rail under the welcome bonus.
- Chips and rail rows are tinted green/red based on whether the change benefits the cardholder; triangle (▲/▼) shows raw value direction. CSS `:has()` lets the chip popover escape the readoff cell's `overflow: hidden` only while open.
- Retire the context-free top-reward-rate metric from user-facing surfaces. The earn-rates table already shows the highest rate in its first row, and Explore's "Top reward" cell pairs rate with category context (the actually-useful version, untouched here).

### Removed
- Wire chip + `fieldLabel` / `formatWireValue` entries in `CardClient.tsx`
- "Rewards" filter chip and field mappings in `CardWireV2Client.tsx` (the global wire page)
- `fieldLabels` + `formatValue` branch in `scripts/post-card-wire.js`
- `extractMetrics`, `trackedFields`, SELECT/UPDATE/INSERT references in `update-cards-github.js` so future syncs stop accumulating rows
- WHERE filter in `card-wire.js` so existing rows stop reaching the UI

### Untouched (intentional)
- DB columns `cards.reward_top_rate` / `cards.reward_top_unit` and historical `card_wire` rows — vestigial, zero-cost; a DROP migration is risk-with-no-reward.
- Explore's `TopRewardCell` (`.ct-top-reward*`) — that's the category-included display, not the bare metric.

## Test plan
- [x] Verified live on `/card/american-express-gold-card`: Sign-up bonus chip renders green ▲ ("60,000 → 100,000"), popover anchors right on mobile, rail "Card wire" block lists recent diffs.
- [x] Earn-rates table no longer renders any wire chip on the top row.
- [x] No new console errors (Firebase/news.json noise is pre-existing local env config).
- [ ] After merge: confirm Amplify deploy picks up the frontend.
- [ ] After backend deploy: confirm `/card-wire` API drops `reward_top_rate` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)