### PR TITLE
Citi Double Cash: add travel_portal 5% (Citi Travel bonus)

### DIFF
--- a/data/cards/citi-double-cash.yaml
+++ b/data/cards/citi-double-cash.yaml
@@ -9,6 +9,10 @@ tags:
   - rewards
 reward_type: "cashback"
 rewards:
+  - category: travel_portal
+    value: 5
+    unit: percent
+    note: "Hotels, car rentals, and attractions booked through Citi Travel portal (2% base + 3% bonus)"
   - category: everything_else
     value: 2
     unit: percent


### PR DESCRIPTION
Triaged from weekly review issue #1034. Citi Double Cash's apply page advertises **3% bonus on hotels, car rentals, and attractions** booked through the Citi Travel portal — on top of the 2% base. Net **5% effective** on those bookings.

```yaml
- category: travel_portal
  value: 5
  unit: percent
  note: "Hotels, car rentals, and attractions booked through Citi Travel portal (2% base + 3% bonus)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)