### PR TITLE
Card page: tighten mobile gap between main and right rail

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4030,11 +4030,11 @@
 }
 
 .landing-v2 .cj-main {
-  padding: 28px 20px 56px;
+  padding: 28px 20px 12px;
   border-right: 1px solid var(--line);
   min-width: 0;
 }
-@media (min-width: 768px) { .landing-v2 .cj-main { padding: 32px 32px 64px; } }
+@media (min-width: 768px) { .landing-v2 .cj-main { padding: 32px 32px 16px; } }
 @media (min-width: 1024px) { .landing-v2 .cj-main { padding: 32px 40px 64px; } }
 
 .landing-v2 .cj-section {
@@ -4676,7 +4676,7 @@
 
 /* Right rail */
 .landing-v2 .cj-rail {
-  padding: 28px 20px 56px;
+  padding: 4px 20px 56px;
 }
 @media (min-width: 1024px) {
   .landing-v2 .cj-rail {


### PR DESCRIPTION
## Summary
- On mobile, the right rail (Welcome bonus, Card wire, Alternatives) stacks below the main column. The rail's vertical padding was tuned for the desktop sticky-sidebar layout, which combined with `.cj-main`'s bottom padding to create ~112px of empty space between the news/reading sections and the Welcome bonus box.
- Trim `.cj-main` bottom padding to 12px (mobile) / 16px (tablet) and `.cj-rail` top padding to 4px on viewports below 1024px. Desktop layout (≥1024px) is unchanged.

## Test plan
- [x] Verified on mobile viewport (375×812): visible gap from Reading section box to Welcome bonus dropped from ~112px to ~44px
- [x] Verified desktop (≥1024px): `.cj-main` padding-bottom remains 64px, `.cj-rail` remains sticky with 32px top padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)