### PR TITLE
Card page: surface apply box above earn section on mobile

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -538,6 +538,56 @@ export default function CardClient({
   }, [wire]);
 
   // ---------- Render ----------
+  const applyBlock = (
+    <div className="cj-apply">
+      <div className="cj-apply-k">Welcome bonus</div>
+      <div className="cj-apply-v">
+        {bonusDisplay?.value ?? "No current offer"}
+      </div>
+      {bonusDisplay && (
+        <div className="cj-apply-sub">{bonusDisplay.sub}</div>
+      )}
+      {card.signup_bonus?.note && (
+        <div className="cj-apply-note">{card.signup_bonus.note}</div>
+      )}
+      {card.accepting_applications ? (
+        <>
+          {card.apply_link && (
+            <a
+              href={withApplySource(card.apply_link)}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => handleCardApplyClick("direct")}
+              className="cj-apply-btn"
+            >
+              Apply now
+            </a>
+          )}
+          {randomReferralUrl && (
+            <a
+              href={randomReferralUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleReferralClick}
+              className="cj-apply-btn-outline"
+            >
+              Apply with referral
+            </a>
+          )}
+          {!card.apply_link && !randomReferralUrl && (
+            <div className="cj-apply-closed">
+              Apply link not available yet
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="cj-apply-closed">
+          Not accepting applications
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <div className="landing-v2 card-journal">
       <CreditCardSchema card={card} ratings={ratings} />
@@ -826,6 +876,9 @@ export default function CardClient({
               </div>
             </div>
           </section>
+
+          {/* Mobile-only welcome offer / apply box, shown above section 02 */}
+          <div className="cj-apply-mobile">{applyBlock}</div>
 
           {/* 02 Earn & credits */}
           <section id="earn" className="cj-section">
@@ -1361,53 +1414,7 @@ export default function CardClient({
 
         {/* Right rail */}
         <aside className="cj-rail">
-          <div className="cj-apply">
-            <div className="cj-apply-k">Welcome bonus</div>
-            <div className="cj-apply-v">
-              {bonusDisplay?.value ?? "No current offer"}
-            </div>
-            {bonusDisplay && (
-              <div className="cj-apply-sub">{bonusDisplay.sub}</div>
-            )}
-            {card.signup_bonus?.note && (
-              <div className="cj-apply-note">{card.signup_bonus.note}</div>
-            )}
-            {card.accepting_applications ? (
-              <>
-                {card.apply_link && (
-                  <a
-                    href={withApplySource(card.apply_link)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() => handleCardApplyClick("direct")}
-                    className="cj-apply-btn"
-                  >
-                    Apply now
-                  </a>
-                )}
-                {randomReferralUrl && (
-                  <a
-                    href={randomReferralUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={handleReferralClick}
-                    className="cj-apply-btn-outline"
-                  >
-                    Apply with referral
-                  </a>
-                )}
-                {!card.apply_link && !randomReferralUrl && (
-                  <div className="cj-apply-closed">
-                    Apply link not available yet
-                  </div>
-                )}
-              </>
-            ) : (
-              <div className="cj-apply-closed">
-                Not accepting applications
-              </div>
-            )}
-          </div>
+          {applyBlock}
 
           {wireEntries.length > 0 && (
             <div className="cj-rail-block cj-wire-rail">

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4695,6 +4695,19 @@
   border-radius: 4px;
   margin-bottom: 20px;
 }
+/* Mobile: render the apply box inline above section 02. Hidden on desktop. */
+.landing-v2 .cj-apply-mobile {
+  padding: 20px 0 8px;
+  border-bottom: 1px solid var(--line);
+}
+.landing-v2 .cj-apply-mobile .cj-apply { margin-bottom: 0; }
+@media (min-width: 1024px) {
+  .landing-v2 .cj-apply-mobile { display: none; }
+}
+/* On mobile the rail copy is suppressed so it doesn't appear twice. */
+@media (max-width: 1023.98px) {
+  .landing-v2 .cj-rail > .cj-apply { display: none; }
+}
 .landing-v2 .cj-readoff-cell.cj-readoff-bonus {
   background: #fef9e8;
 }


### PR DESCRIPTION
## Summary
- On mobile, render the Welcome-bonus / Apply CTA inline between the Overview and Earn & credits sections so the offer and Apply buttons appear in-flow where users are scrolling, instead of being buried at the bottom of the right rail.
- Desktop (>=1024px) layout is unchanged — the rail copy still shows there.
- Implemented by extracting the apply box JSX into a single `applyBlock` const and rendering it twice (inline `.cj-apply-mobile` for <1024px, rail copy for >=1024px), with each occurrence hidden in the other breakpoint via CSS so it never renders twice.

## Test plan
- [x] Mobile (375px): apply box appears between overview readoff cells and "02 · earn & credits"; rail copy hidden.
- [x] Desktop (1280px): rail copy renders as before; mobile inline copy hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)