### PR TITLE
Backend: shared MySQL module, drop aws-sdk, add records submitter_id index

### DIFF
--- a/apps/api/migrations/023_create_records_submitter_id_index.sql
+++ b/apps/api/migrations/023_create_records_submitter_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_records_submitter_active ON records (submitter_id, active)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.799.0",
     "firebase-admin": "^13.6.0",
     "mysql2": "^3.16.2",
     "serverless-mysql": "^1.5.4",

--- a/apps/api/src/db.js
+++ b/apps/api/src/db.js
@@ -1,0 +1,10 @@
+// Shared serverless-mysql client used by every Lambda handler.
+// Centralizing config keeps credential rotation and connection tuning in one place.
+module.exports = require("serverless-mysql")({
+  config: {
+    host: process.env.ENDPOINT,
+    database: process.env.DATABASE,
+    user: process.env.USERNAME,
+    password: process.env.PASSWORD,
+  },
+});

--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -1,13 +1,6 @@
 // Comprehensive admin handler
 const yup = require("yup");
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 // Fallback admin user IDs (Firebase UIDs) - used if custom claims not set
 const FALLBACK_ADMIN_IDS = ['zXOyHmGl7HStyAqEdLsgXLA5inS2'];

--- a/apps/api/src/handlers/all-cards.js
+++ b/apps/api/src/handlers/all-cards.js
@@ -1,15 +1,6 @@
 // Fetch cards from CloudFront CDN
 const https = require('https');
-
-// MySQL client for fetching card stats (approval rates, etc.)
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
 

--- a/apps/api/src/handlers/card-apply-click.js
+++ b/apps/api/src/handlers/card-apply-click.js
@@ -1,12 +1,5 @@
 // Track outbound apply clicks per card and return aggregated counts
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":

--- a/apps/api/src/handlers/card-by-id.js
+++ b/apps/api/src/handlers/card-by-id.js
@@ -1,14 +1,6 @@
 // Fetch card details from CloudFront CDN and MySQL
 const https = require('https');
-
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
 

--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -1,11 +1,4 @@
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":

--- a/apps/api/src/handlers/card-view.js
+++ b/apps/api/src/handlers/card-view.js
@@ -1,12 +1,5 @@
 // Track card page views and return view counts
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":

--- a/apps/api/src/handlers/card-wire.js
+++ b/apps/api/src/handlers/card-wire.js
@@ -1,11 +1,4 @@
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":

--- a/apps/api/src/handlers/check-odds.js
+++ b/apps/api/src/handlers/check-odds.js
@@ -1,13 +1,5 @@
 const https = require('https');
-
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
 

--- a/apps/api/src/handlers/delete-account.js
+++ b/apps/api/src/handlers/delete-account.js
@@ -1,13 +1,5 @@
 // Delete account handler - removes user data but keeps records (data points)
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
-
+const mysql = require("../db");
 const admin = require('firebase-admin');
 
 // Initialize Firebase Admin SDK

--- a/apps/api/src/handlers/get-card-graphs.js
+++ b/apps/api/src/handlers/get-card-graphs.js
@@ -1,14 +1,6 @@
 // Create MySQL client and set shared const values outside of the handler.
 const https = require('https');
-
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
 
@@ -69,7 +61,7 @@ exports.getCardGraphsHandler = async (event) => {
 
           // Get card_id from cards table (with fuzzy matching for card suffix)
           // Order by exact match first, then by card_id to get the oldest (original) entry
-          let cardResult = await mysql.query(
+          const cardResult = await mysql.query(
             `SELECT card_id FROM cards
              WHERE card_name = ? OR card_name = ? OR ? LIKE CONCAT(card_name, '%')
              ORDER BY
@@ -80,9 +72,9 @@ exports.getCardGraphsHandler = async (event) => {
              LIMIT 1`,
             [card_name, card_name.replace(/ Card$/, ''), card_name, card_name, card_name.replace(/ Card$/, '')]
           );
-          await mysql.end();
 
           if (!cardResult || cardResult.length === 0) {
+            await mysql.end();
             response = {
               statusCode: 404,
               body: `Card not found: ${card_name}`,
@@ -92,70 +84,59 @@ exports.getCardGraphsHandler = async (event) => {
           }
 
           const card_id = cardResult[0].card_id;
-          let resultsData = await mysql.query(
+          const rawResults = await mysql.query(
             "SELECT * FROM records WHERE card_id = ? AND admin_review = 1",
             [card_id]
           );
-
           await mysql.end();
 
-          resultsData = JSON.parse(JSON.stringify(resultsData));
+          const resultsData = JSON.parse(JSON.stringify(rawResults));
 
           //Credit Score vs Income
-          acceptedFinal = resultsData
-            .filter(function (element) {
-              return (
-                element.result == 1 &&
-                element.credit_score != null &&
-                element.listed_income != null
-              );
-            })
+          const chartOneAccepted = resultsData
+            .filter((element) => (
+              element.result == 1 &&
+              element.credit_score != null &&
+              element.listed_income != null
+            ))
             .map((x) => [x.credit_score, x.listed_income]);
-          rejectedFinal = resultsData
-            .filter(function (element) {
-              return (
-                element.result == 0 &&
-                element.credit_score != null &&
-                element.listed_income != null
-              );
-            })
+          const chartOneRejected = resultsData
+            .filter((element) => (
+              element.result == 0 &&
+              element.credit_score != null &&
+              element.listed_income != null
+            ))
             .map((x) => [x.credit_score, x.listed_income]);
-          let chartOne = [acceptedFinal, rejectedFinal];
+          const chartOne = [chartOneAccepted, chartOneRejected];
 
           //Credit Score vs Length of Credit
-          acceptedFinal = resultsData
-            .filter(function (element) {
-              return (
-                element.result == 1 &&
-                element.credit_score != null &&
-                element.length_credit != null
-              );
-            })
+          const chartTwoAccepted = resultsData
+            .filter((element) => (
+              element.result == 1 &&
+              element.credit_score != null &&
+              element.length_credit != null
+            ))
             .map((x) => [x.length_credit, x.credit_score]);
-          rejectedFinal = resultsData
-            .filter(function (element) {
-              return (
-                element.result == 0 &&
-                element.credit_score != null &&
-                element.length_credit != null
-              );
-            })
+          const chartTwoRejected = resultsData
+            .filter((element) => (
+              element.result == 0 &&
+              element.credit_score != null &&
+              element.length_credit != null
+            ))
             .map((x) => [x.length_credit, x.credit_score]);
-          let chartTwo = [acceptedFinal, rejectedFinal];
+          const chartTwo = [chartTwoAccepted, chartTwoRejected];
 
           //Income vs Starting Credit Limit (approved only, with valid values)
-          let chartThreeData = resultsData
-            .filter(function (element) {
-              return (
-                element.result == 1 &&
-                element.starting_credit_limit != null &&
-                element.starting_credit_limit > 0 &&
-                element.listed_income != null &&
-                element.listed_income > 0
-              );
-            })
+          const chartThreeData = resultsData
+            .filter((element) => (
+              element.result == 1 &&
+              element.starting_credit_limit != null &&
+              element.starting_credit_limit > 0 &&
+              element.listed_income != null &&
+              element.listed_income > 0
+            ))
             .map((x) => [x.listed_income, x.starting_credit_limit]);
-          let chartThree = [chartThreeData];
+          const chartThree = [chartThreeData];
 
           response = {
             statusCode: 200,

--- a/apps/api/src/handlers/leaderboard.js
+++ b/apps/api/src/handlers/leaderboard.js
@@ -1,12 +1,5 @@
 // Leaderboard handler - returns top contributors by data points submitted
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":

--- a/apps/api/src/handlers/recent-records.js
+++ b/apps/api/src/handlers/recent-records.js
@@ -1,12 +1,5 @@
 // Returns the most recent approved records for the ticker
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/handlers/referral-stats.js
+++ b/apps/api/src/handlers/referral-stats.js
@@ -1,12 +1,5 @@
 // Track referral impressions and clicks
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":

--- a/apps/api/src/handlers/refresh-card-stats.js
+++ b/apps/api/src/handlers/refresh-card-stats.js
@@ -1,14 +1,7 @@
 // Recomputes per-card stats and upserts them into the card_stats table.
 // Triggered by EventBridge on a schedule; also callable via HTTP for ops use.
 
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/handlers/run-migration.js
+++ b/apps/api/src/handlers/run-migration.js
@@ -1,13 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 exports.RunMigrationHandler = async (event) => {
   const migrationFile = event.migration || event.queryStringParameters?.migration;

--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -1,13 +1,5 @@
 const https = require("https");
-
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const CARDS_URL = process.env.CardsJsonUrl || "https://d2hxvzw7msbtvt.cloudfront.net/cards.json";
 

--- a/apps/api/src/handlers/user-profile.js
+++ b/apps/api/src/handlers/user-profile.js
@@ -1,12 +1,5 @@
 // Create clients and set shared const values outside of the handler.
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":

--- a/apps/api/src/handlers/user-records.js
+++ b/apps/api/src/handlers/user-records.js
@@ -1,12 +1,5 @@
 // Create clients and set shared const values outside of the handler.
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 // Yup Schema Validation for Record Submit
 const yup = require("yup");

--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -1,12 +1,5 @@
 // Create clients and set shared const values outside of the handler.
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":

--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -1,12 +1,5 @@
 // User Wallet API - Manage cards in user's wallet
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.ENDPOINT,
-    database: process.env.DATABASE,
-    user: process.env.USERNAME,
-    password: process.env.PASSWORD,
-  },
-});
+const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
## Summary
- **Shared DB module** ([apps/api/src/db.js](apps/api/src/db.js)): replaces the duplicated `serverless-mysql({config:{...}})` block in 19 handlers with `require("../db")`. Centralizes credential rotation. Net -148 LOC.
- **Drop `aws-sdk@^2.799.0`**: it was in `apps/api/package.json` but never imported in `src/`.
- **Index `records(submitter_id, active)`** ([migration 023](apps/api/migrations/023_create_records_submitter_id_index.sql)): supports the GET `/records`, profile counts, and leaderboard scans. **Already applied to prod** via the temporary `RunMigrationFunction` pattern (deploy → invoke → unwire → redeploy). The matching `idx_referrals_submitter_id` was already present in the original schema, so no second migration was needed.
- **Fix `get-card-graphs.js`**: `acceptedFinal` and `rejectedFinal` were implicit globals (no `const`/`let`/`var`) — would leak across Lambda invocations on warm-container reuse. Now scoped per-chart with `const`. Also removed a redundant mid-handler `mysql.end()` that forced a reconnect before the second query.

## Deploy state
The refactor + index were deployed to `CreditCardOddsAPI` (us-east-2) as part of running the migration. Stack is `UPDATE_COMPLETE`.

## Test plan
- [x] All 21 handlers pass `node --check` and `require()` cleanly
- [x] `sam build` succeeds
- [x] `sam deploy` succeeds (already done)
- [x] Migration 023 invocation returned 200, `Records: 0  Duplicates: 0  Warnings: 0`
- [x] `RunMigrationFunction` and its IAM role deleted on follow-up deploy
- [ ] Spot-check `/graphs?card_name=...` and `/records` in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)