### PR TITLE
Fix Amplify build: normalize current_categories entries before use

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -150,7 +150,7 @@ function findCategoryMatch(card: Card, categories: string[], includeMerchantSpec
     }
 
     if (inferred === 'quarterly_rotating') {
-      const current = r.current_categories || [];
+      const current = (r.current_categories || []).map(c => typeof c === 'string' ? c : c.category);
       const eligible = r.eligible_categories || [];
       const inCurrent = categories.find(c => current.includes(c));
       const inEligible = !inCurrent ? categories.find(c => eligible.includes(c)) : undefined;

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -977,7 +977,10 @@ export default function CardClient({
                                 <div className="cj-cell-detail">
                                   {r.current_period}:{" "}
                                   {r.current_categories
-                                    .map((c) => categoryLabels[c] || c)
+                                    .map((c) => {
+                                      const id = typeof c === "string" ? c : c.category;
+                                      return categoryLabels[id] || id;
+                                    })
                                     .join(", ")}
                                 </div>
                               )}

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -676,15 +676,44 @@ export default function CardClient({
           )}
         </div>
         {card.slug && (
-          <a
-            href={`https://github.com/CreditOdds/creditodds/edit/main/data/cards/${card.slug}.yaml`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="cj-term-link"
-          >
-            <PencilSquareIcon className="cj-term-icon" />
-            edit
-          </a>
+          <>
+            <a
+              href={`https://github.com/CreditOdds/creditodds/edit/main/data/cards/${card.slug}.yaml`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="cj-term-link"
+            >
+              <PencilSquareIcon className="cj-term-icon" />
+              edit
+            </a>
+            <a
+              href={`https://github.com/CreditOdds/creditodds/issues/new?${new URLSearchParams({
+                title: `Card data issue: ${card.card_name}`,
+                labels: 'card-data',
+                body: [
+                  `**Card:** ${card.card_name}`,
+                  `**Page:** https://creditodds.com/card/${card.slug}`,
+                  `**Source:** https://github.com/CreditOdds/creditodds/blob/main/data/cards/${card.slug}.yaml`,
+                  '',
+                  '### What\'s wrong?',
+                  '<!-- e.g. wrong reward rate, missing benefit, outdated annual fee, incorrect credit frequency -->',
+                  '',
+                  '### What should it say?',
+                  '<!-- the correct value, ideally with a link to the issuer\'s page -->',
+                  '',
+                  '### Source / proof',
+                  '<!-- link to the issuer page or screenshot showing the correct info -->',
+                ].join('\n'),
+              }).toString()}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="cj-term-link"
+              title="Report an issue with this card's data"
+            >
+              <ExclamationTriangleIcon className="cj-term-icon" />
+              report issue
+            </a>
+          </>
         )}
         </div>
       </div>

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -22,7 +22,7 @@ import {
   CardWireEntry,
 } from "@/lib/api";
 import { getValuationDetails } from "@/lib/valuations";
-import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
+import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, frequencyLabel, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
 import { NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { Article } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -1009,7 +1009,7 @@ export default function CardClient({
                     <thead>
                       <tr>
                         <th>Credit</th>
-                        <th className="cj-tr">Annual</th>
+                        <th className="cj-tr">Value</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -1021,6 +1021,9 @@ export default function CardClient({
                           </td>
                           <td className="cj-tr">
                             {formatBenefitValue(b)}
+                            {frequencyLabel(b) && (
+                              <span className="cj-cell-detail"> {frequencyLabel(b)}</span>
+                            )}
                           </td>
                         </tr>
                       ))}

--- a/apps/web-next/src/components/wallet/BestCardByCategory.tsx
+++ b/apps/web-next/src/components/wallet/BestCardByCategory.tsx
@@ -1,97 +1,156 @@
 'use client';
 
 import { useMemo } from 'react';
+import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
 import { Card, WalletCard, Reward } from '@/lib/api';
-import { formatRewardWithUsdEquivalent, getRewardUsdRate } from '@/lib/cardDisplayUtils';
+import { categoryLabels, formatRewardWithUsdEquivalent, getRewardUsdRate } from '@/lib/cardDisplayUtils';
 
-const categoryLabels: Record<string, string> = {
-  dining: "Dining",
-  groceries: "Groceries",
-  travel: "Travel",
-  gas: "Gas",
-  streaming: "Streaming",
-  transit: "Transit",
-  drugstores: "Drugstores",
-  home_improvement: "Home Improvement",
-  online_shopping: "Online Shopping",
-  hotels: "Hotels",
-  airlines: "Airlines",
-  car_rentals: "Car Rentals",
-  entertainment: "Entertainment",
-  rotating: "Rotating Categories",
-  travel_portal: "Travel (via Portal)",
-  hotels_portal: "Hotels (via Portal)",
-  flights_portal: "Flights (via Portal)",
-  hotels_car_portal: "Hotels & Car Rentals (via Portal)",
-  amazon: "Amazon.com",
-  rei: "REI",
-};
+const canonicalOrder = Object.keys(categoryLabels).filter(c => c !== 'everything_else');
 
-const canonicalOrder = Object.keys(categoryLabels);
+// Returns the canonical "QN YYYY" label for the current quarter (UTC), used to
+// detect rotating rewards whose `current_period` hasn't been refreshed yet.
+function currentQuarterLabel(now: Date = new Date()): string {
+  const q = Math.floor(now.getUTCMonth() / 3) + 1;
+  return `Q${q} ${now.getUTCFullYear()}`;
+}
+
+function isStaleRotation(reward: Reward, expected: string): boolean {
+  if (reward.mode !== 'quarterly_rotating') return false;
+  const cur = reward.current_period;
+  if (!cur) return true;
+  return cur.trim().toUpperCase() !== expected.toUpperCase();
+}
+
+// A reward is "conditional" if it carries a note OR is flagged merchant_specific.
+// We use this to surface an unrestricted alternative when the top earner is gated
+// (e.g. Marriott Bonvoy 6x at Marriott properties vs. a 3x general-hotels card).
+function isConditional(reward: Reward) {
+  return reward.merchant_specific === true || (!!reward.note && reward.note.trim().length > 0);
+}
 
 interface BestCardByCategoryProps {
   walletCards: WalletCard[];
   allCards: Card[];
 }
 
+interface Pick {
+  card: Card;
+  reward: Reward;
+  usdRate: number;
+  // True when this pick was slotted into a category via the reward's
+  // current_categories (rotating-bonus expansion) rather than declared directly.
+  rotating?: boolean;
+  // True when the rotating reward's current_period doesn't match the actual
+  // current quarter — the listed bonus categories may be outdated.
+  staleRotation?: boolean;
+  // Slot-specific note from current_categories[i].note. Falls back to reward.note in render.
+  slotNote?: string;
+}
+
 interface CategoryBest {
   category: string;
   label: string;
-  card: Card;
-  reward: Reward;
+  primary: Pick;
+  alternative?: Pick;
 }
 
 export default function BestCardByCategory({ walletCards, allCards }: BestCardByCategoryProps) {
-  const categoryBests = useMemo(() => {
+  const categoryBests = useMemo<CategoryBest[]>(() => {
     if (walletCards.length === 0 || allCards.length === 0) return [];
 
-    // Join wallet cards to full card data
     const walletCardData = walletCards
       .map(wc => allCards.find(c => c.card_name === wc.card_name))
       .filter((c): c is Card => c !== undefined && !!c.rewards && c.rewards.length > 0);
 
     if (walletCardData.length === 0) return [];
 
-    // For each category, find the card with the highest reward value
-    const bestByCategory = new Map<string, { card: Card; reward: Reward; usdRate: number }>();
+    const expectedQuarter = currentQuarterLabel();
+
+    // Collect every (card, reward) pair per category, then sort by USD rate.
+    const picksByCategory = new Map<string, Pick[]>();
+    const push = (cat: string, pick: Pick) => {
+      const list = picksByCategory.get(cat) ?? [];
+      list.push(pick);
+      picksByCategory.set(cat, list);
+    };
 
     for (const card of walletCardData) {
+      // Index each card's permanent (non-rotating) per-category rates so
+      // we can suppress rotating slots that are already covered at >= rate
+      // by a permanent reward on the same card (e.g. Freedom Flex's
+      // permanent 5% travel_portal vs. its rotating travel_portal slot).
+      const permanentRates = new Map<string, number>();
+      for (const reward of card.rewards!) {
+        if (reward.mode === 'quarterly_rotating') continue;
+        const r = getRewardUsdRate(reward, card);
+        const prev = permanentRates.get(reward.category) ?? 0;
+        if (r > prev) permanentRates.set(reward.category, r);
+      }
+
       for (const reward of card.rewards!) {
         if (reward.category === 'everything_else') continue;
         const usdRate = getRewardUsdRate(reward, card);
 
-        const existing = bestByCategory.get(reward.category);
-        if (!existing || usdRate > existing.usdRate) {
-          bestByCategory.set(reward.category, { card, reward, usdRate });
+        // Quarterly rotating rewards: slot the bonus rate under each of this
+        // quarter's actual categories (e.g. groceries, gas) so users see the
+        // card competing where it currently earns the bonus. Skip the
+        // umbrella "rotating" row in that case to avoid duplication.
+        if (
+          reward.mode === 'quarterly_rotating' &&
+          reward.current_categories &&
+          reward.current_categories.length > 0
+        ) {
+          const stale = isStaleRotation(reward, expectedQuarter);
+          for (const entry of reward.current_categories) {
+            const cat = typeof entry === 'string' ? entry : entry.category;
+            const slotNote = typeof entry === 'string' ? undefined : entry.note;
+            if (!cat || cat === 'everything_else') continue;
+            // Same card already earns >= rate permanently in this category — skip.
+            const perm = permanentRates.get(cat) ?? 0;
+            if (perm >= usdRate) continue;
+            push(cat, { card, reward, usdRate, rotating: true, staleRotation: stale, slotNote });
+          }
+          continue;
         }
+
+        push(reward.category, { card, reward, usdRate });
       }
     }
 
-    // Sort by canonical order
+    const buildEntry = (category: string): CategoryBest | null => {
+      const picks = picksByCategory.get(category);
+      if (!picks || picks.length === 0) return null;
+      picks.sort((a, b) => b.usdRate - a.usdRate);
+      const primary = picks[0];
+
+      let alternative: Pick | undefined;
+      if (isConditional(primary.reward)) {
+        // Find the best unrestricted pick from a *different* card.
+        alternative = picks.find(p => !isConditional(p.reward) && p.card.card_name !== primary.card.card_name);
+      }
+
+      return {
+        category,
+        label: categoryLabels[category] || category,
+        primary,
+        alternative,
+      };
+    };
+
+    const seen = new Set<string>();
     const results: CategoryBest[] = [];
     for (const category of canonicalOrder) {
-      const best = bestByCategory.get(category);
-      if (best) {
-        results.push({
-          category,
-          label: categoryLabels[category] || category,
-          card: best.card,
-          reward: best.reward,
-        });
+      const entry = buildEntry(category);
+      if (entry) {
+        results.push(entry);
+        seen.add(category);
       }
     }
-
-    // Add any categories not in canonical order
-    for (const [category, best] of bestByCategory) {
-      if (!canonicalOrder.includes(category)) {
-        results.push({
-          category,
-          label: categoryLabels[category] || category,
-          card: best.card,
-          reward: best.reward,
-        });
-      }
+    for (const category of picksByCategory.keys()) {
+      if (seen.has(category)) continue;
+      const entry = buildEntry(category);
+      if (entry) results.push(entry);
     }
 
     return results;
@@ -106,7 +165,7 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
           Best Card by Category
           <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 align-middle">Experimental</span>
         </h2>
-        <p className="text-sm text-gray-500 mt-1">Which card in your wallet earns the most for each spending category</p>
+        <p className="text-sm text-gray-500 mt-1">Which card in your wallet earns the most for each spending category. When the top earner is brand- or merchant-restricted, we also surface the best unrestricted option.</p>
       </div>
 
       {/* Desktop table */}
@@ -120,33 +179,28 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {categoryBests.map(({ category, label, card, reward }) => (
-              <tr key={category}>
-                <td className="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900">
+            {categoryBests.map(({ category, label, primary, alternative }) => (
+              <tr key={category} className="align-top">
+                <td className="px-4 py-3 text-sm font-medium text-gray-900">
                   {label}
                 </td>
-                <td className="px-4 py-3 whitespace-nowrap">
-                  <div className="flex items-center gap-3">
-                    <div className="flex-shrink-0 h-8 w-12 relative">
-                      <CardImage
-                        cardImageLink={card.card_image_link}
-                        alt={card.card_name}
-                        fill
-                        className="object-contain"
-                        sizes="48px"
-                      />
+                <td className="px-4 py-3">
+                  <PickRow pick={primary} />
+                  {alternative && (
+                    <div className="mt-2 pt-2 border-t border-dashed border-gray-200">
+                      <div className="text-[11px] uppercase tracking-wide text-gray-400 mb-1">All {label.toLowerCase()}</div>
+                      <PickRow pick={alternative} />
                     </div>
-                    <span className="text-sm text-gray-900">{card.card_name}</span>
-                  </div>
+                  )}
                 </td>
-                <td className="px-4 py-3 whitespace-nowrap">
-                  <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${
-                    reward.unit === 'percent'
-                      ? 'bg-green-100 text-green-800'
-                      : 'bg-indigo-100 text-indigo-800'
-                  }`}>
-                    {formatRewardWithUsdEquivalent(reward, card)}
-                  </span>
+                <td className="px-4 py-3">
+                  <RateBadge pick={primary} />
+                  {alternative && (
+                    <div className="mt-2 pt-2 border-t border-dashed border-gray-200">
+                      <div className="invisible text-[11px] mb-1">.</div>
+                      <RateBadge pick={alternative} />
+                    </div>
+                  )}
                 </td>
               </tr>
             ))}
@@ -156,30 +210,119 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
 
       {/* Mobile layout */}
       <div className="sm:hidden divide-y divide-gray-200">
-        {categoryBests.map(({ category, label, card, reward }) => (
-          <div key={category} className="flex items-center justify-between py-3">
-            <span className="text-sm font-medium text-gray-900">{label}</span>
-            <div className="flex items-center gap-2">
-              <div className="flex-shrink-0 h-6 w-10 relative">
-                <CardImage
-                  cardImageLink={card.card_image_link}
-                  alt={card.card_name}
-                  fill
-                  className="object-contain"
-                  sizes="40px"
-                />
+        {categoryBests.map(({ category, label, primary, alternative }) => (
+          <div key={category} className="py-3">
+            <div className="text-sm font-medium text-gray-900 mb-2">{label}</div>
+            <MobilePickRow pick={primary} />
+            {alternative && (
+              <div className="mt-2 pt-2 border-t border-dashed border-gray-200">
+                <div className="text-[11px] uppercase tracking-wide text-gray-400 mb-1">All {label.toLowerCase()}</div>
+                <MobilePickRow pick={alternative} />
               </div>
-              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${
-                reward.unit === 'percent'
-                  ? 'bg-green-100 text-green-800'
-                  : 'bg-indigo-100 text-indigo-800'
-              }`}>
-                {formatRewardWithUsdEquivalent(reward, card)}
-              </span>
-            </div>
+            )}
           </div>
         ))}
       </div>
     </div>
+  );
+}
+
+function PickRow({ pick }: { pick: Pick }) {
+  const { card, reward, rotating, staleRotation, slotNote } = pick;
+  const note = slotNote ?? reward.note;
+  const href = card.slug ? `/card/${card.slug}` : undefined;
+  return (
+    <div className={`flex items-start gap-3 ${staleRotation ? 'opacity-60' : ''}`}>
+      <div className="flex-shrink-0 h-8 w-12 relative">
+        <CardImage
+          cardImageLink={card.card_image_link}
+          alt={card.card_name}
+          fill
+          className="object-contain"
+          sizes="48px"
+        />
+      </div>
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {href ? (
+            <Link href={href} className="text-sm text-gray-900 hover:text-indigo-600 hover:underline">
+              {card.card_name}
+            </Link>
+          ) : (
+            <span className="text-sm text-gray-900">{card.card_name}</span>
+          )}
+          {rotating && (
+            <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide ${
+              staleRotation ? 'bg-amber-100 text-amber-800' : 'bg-purple-100 text-purple-800'
+            }`}>
+              Rotating{reward.current_period ? ` · ${reward.current_period}` : ''}
+            </span>
+          )}
+          {staleRotation && (
+            <span className="text-[11px] text-amber-700">may be outdated</span>
+          )}
+        </div>
+        {note && (
+          <div className="text-xs text-gray-500 mt-0.5">{note}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MobilePickRow({ pick }: { pick: Pick }) {
+  const { card, reward, rotating, staleRotation, slotNote } = pick;
+  const note = slotNote ?? reward.note;
+  const href = card.slug ? `/card/${card.slug}` : undefined;
+  return (
+    <div className={`flex items-start justify-between gap-2 ${staleRotation ? 'opacity-60' : ''}`}>
+      <div className="flex items-start gap-2 min-w-0">
+        <div className="flex-shrink-0 h-6 w-10 relative">
+          <CardImage
+            cardImageLink={card.card_image_link}
+            alt={card.card_name}
+            fill
+            className="object-contain"
+            sizes="40px"
+          />
+        </div>
+        <div className="min-w-0">
+          {href ? (
+            <Link href={href} className="block text-xs text-gray-900 truncate hover:text-indigo-600 hover:underline">
+              {card.card_name}
+            </Link>
+          ) : (
+            <div className="text-xs text-gray-900 truncate">{card.card_name}</div>
+          )}
+          {rotating && (
+            <span className={`inline-flex items-center mt-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide ${
+              staleRotation ? 'bg-amber-100 text-amber-800' : 'bg-purple-100 text-purple-800'
+            }`}>
+              Rotating{reward.current_period ? ` · ${reward.current_period}` : ''}
+            </span>
+          )}
+          {staleRotation && (
+            <div className="text-[10px] text-amber-700 mt-0.5">may be outdated</div>
+          )}
+          {note && (
+            <div className="text-[11px] text-gray-500 mt-0.5">{note}</div>
+          )}
+        </div>
+      </div>
+      <RateBadge pick={pick} />
+    </div>
+  );
+}
+
+function RateBadge({ pick }: { pick: Pick }) {
+  const { card, reward } = pick;
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap ${
+      reward.unit === 'percent'
+        ? 'bg-green-100 text-green-800'
+        : 'bg-indigo-100 text-indigo-800'
+    }`}>
+      {formatRewardWithUsdEquivalent(reward, card)}
+    </span>
   );
 }

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -18,7 +18,12 @@ export interface Reward {
   mode?: 'quarterly_rotating' | 'user_choice' | 'auto_top_spend';
   eligible_categories?: string[];
   choices?: number;
-  current_categories?: string[];
+  // Active categories for the current rotating period. Each entry is either
+  // a category id (e.g. "amazon") or an object with a category id plus a
+  // slot-specific note (e.g. {category: "amazon", note: "Amazon.com"}).
+  // Slot notes let us describe each Q-period category precisely instead of
+  // forcing every slotted row to share the umbrella `note`.
+  current_categories?: Array<string | { category: string; note?: string }>;
   current_period?: string;
   // Spend caps. When set, `value` is earned only on spend up to `spend_cap`
   // within `cap_period` (default 'annual'); spend above that earns

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T18:48:37.556Z",
+  "generated_at": "2026-05-04T14:21:27.403Z",
   "count": 160,
   "categories": [
     {
@@ -1930,8 +1930,8 @@
       "signup_bonus": {
         "value": 250,
         "type": "cash",
-        "spend_requirement": 15000,
-        "timeframe_months": 12
+        "spend_requirement": 3000,
+        "timeframe_months": 3
       },
       "apr": {
         "purchase_intro": {
@@ -2988,9 +2988,10 @@
           "unit": "percent",
           "mode": "quarterly_rotating",
           "current_categories": [
-            "amazon",
-            "travel_portal",
-            "everything_else"
+            {
+              "category": "amazon",
+              "note": "Amazon.com (Q2 2026 rotation)"
+            }
           ],
           "current_period": "Q2 2026",
           "note": "Q2 2026: Amazon, Chase Travel, and donations to Feeding America",
@@ -8575,11 +8576,11 @@
           "category": "travel"
         },
         {
-          "name": "Global Entry / TSA PreCheck Credit",
-          "value": 100,
-          "description": "Statement credit for Global Entry or TSA PreCheck application fee",
+          "name": "Global Entry / TSA PreCheck / NEXUS Credit",
+          "value": 120,
+          "description": "Statement credit reimbursing the application fee for Global Entry, TSA PreCheck, or NEXUS (up to $120 every 4 years)",
           "frequency": "multi_year",
-          "frequency_years": 5,
+          "frequency_years": 4,
           "category": "security"
         },
         {

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -13,10 +13,12 @@ rewards:
     value: 5
     unit: "percent"
     mode: "quarterly_rotating"
+    # Chase Travel (travel_portal) is a permanent 5% on this card, so it is
+    # intentionally NOT listed here. Donations to Feeding America don't map to
+    # a spending category — kept in the umbrella note for context.
     current_categories:
-      - "amazon"
-      - "travel_portal"
-      - "everything_else"
+      - category: "amazon"
+        note: "Amazon.com (Q2 2026 rotation)"
     current_period: "Q2 2026"
     note: "Q2 2026: Amazon, Chase Travel, and donations to Feeding America"
     spend_cap: 1500

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -110,8 +110,21 @@
           },
           "current_categories": {
             "type": "array",
-            "items": { "type": "string" },
-            "description": "Currently active categories (quarterly_rotating mode)"
+            "items": {
+              "oneOf": [
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "required": ["category"],
+                  "properties": {
+                    "category": { "type": "string" },
+                    "note": { "type": "string", "description": "Slot-specific note shown when this card is surfaced under this category" }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "description": "Currently active categories (quarterly_rotating mode). Each entry is a category id or {category, note}."
           },
           "current_period": {
             "type": "string",

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -43,11 +43,11 @@ benefits:
     description: "$200 in United TravelBank cash automatically deposited after account opening and each anniversary, for future United-operated flights"
     frequency: "annual"
     category: "travel"
-  - name: "Global Entry / TSA PreCheck Credit"
-    value: 100
-    description: "Statement credit for Global Entry or TSA PreCheck application fee"
+  - name: "Global Entry / TSA PreCheck / NEXUS Credit"
+    value: 120
+    description: "Statement credit reimbursing the application fee for Global Entry, TSA PreCheck, or NEXUS (up to $120 every 4 years)"
     frequency: "multi_year"
-    frequency_years: 5
+    frequency_years: 4
     category: "security"
   - name: "2 Free Checked Bags"
     value: 0

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -79,7 +79,12 @@ function validateCard(card, schema, categoryIds) {
         }
       }
       if (reward.current_categories) {
-        for (const cat of reward.current_categories) {
+        for (const entry of reward.current_categories) {
+          const cat = typeof entry === 'string' ? entry : entry && entry.category;
+          if (!cat) {
+            errors.push(`Invalid current_category entry for ${reward.category}: missing category id`);
+            continue;
+          }
           if (reward.eligible_categories && !reward.eligible_categories.includes(cat)) {
             // current_categories should be a subset of eligible_categories when both are present
             errors.push(`current_category '${cat}' not in eligible_categories for ${reward.category}`);


### PR DESCRIPTION
## Summary
- Amplify build failed with a type error after #1049 widened `Reward.current_categories` to accept `string | {category, note}`. Two existing consumers (`CardClient.tsx`, `best-card-for/[slug]/page.tsx`) still indexed/`.includes()`-checked the entries as raw strings.
- Fix normalizes each entry to its category id at the use site (cleaner than narrowing the type back).

## Test plan
- [x] `next build` completes
- [ ] Card detail page renders the rotating-categories detail row with the new YAML shape
- [ ] `/best-card-for/[slug]` still matches rotating-bonus categories correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)