### PR TITLE
Cardy popup: suggest comparing the two cards just visited

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -26,6 +26,7 @@ import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, fr
 import { NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { Article } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
+import CardyComparePopup from "@/components/ui/CardyComparePopup";
 import { CreditCardSchema, BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { categoryLabels, CategoryIcon } from "@/lib/cardDisplayUtils";
@@ -1578,6 +1579,7 @@ export default function CardClient({
         card={card}
         onSuccess={handleSubmitSuccess}
       />
+      <CardyComparePopup currentSlug={card.slug} currentName={card.card_name} currentImage={card.card_image_link} />
       <V2Footer />
     </div>
   );

--- a/apps/web-next/src/components/ui/CardyCharacter.tsx
+++ b/apps/web-next/src/components/ui/CardyCharacter.tsx
@@ -1,0 +1,75 @@
+// Shared "Cardy" character — the cartoon credit-card mascot used by
+// onboarding prompts (DataPointPrompt) and compare suggestions
+// (CardyComparePopup). Keep visuals consistent across surfaces.
+
+interface CardyCharacterProps {
+  size?: 'sm' | 'md';
+}
+
+export default function CardyCharacter({ size = 'md' }: CardyCharacterProps) {
+  const isSm = size === 'sm';
+  return (
+    <div
+      className={`relative rounded-xl bg-gradient-to-br from-indigo-500 to-indigo-700 shadow-lg ${
+        isSm ? 'w-16 h-[42px]' : 'w-28 h-[72px]'
+      }`}
+    >
+      <div
+        className={`absolute rounded-sm bg-yellow-300/80 ${
+          isSm ? 'top-1.5 left-1.5 w-3.5 h-2.5' : 'top-3 left-3 w-6 h-[18px]'
+        }`}
+      >
+        <div className="absolute inset-0.5 border border-yellow-500/40 rounded-[1px]" />
+      </div>
+      <div
+        className={`absolute flex ${
+          isSm ? 'top-1.5 right-2 gap-1' : 'top-3 right-4 gap-2'
+        }`}
+      >
+        <div
+          className={`rounded-full bg-white flex items-center justify-center ${
+            isSm ? 'w-1.5 h-1.5' : 'w-2.5 h-2.5'
+          }`}
+        >
+          <div
+            className={`rounded-full bg-indigo-900 ${
+              isSm ? 'w-[3px] h-[3px]' : 'w-1 h-1'
+            }`}
+          />
+        </div>
+        <div
+          className={`rounded-full bg-white flex items-center justify-center ${
+            isSm ? 'w-1.5 h-1.5' : 'w-2.5 h-2.5'
+          }`}
+        >
+          <div
+            className={`rounded-full bg-indigo-900 ${
+              isSm ? 'w-[3px] h-[3px]' : 'w-1 h-1'
+            }`}
+          />
+        </div>
+      </div>
+      <div
+        className={`absolute border-b-2 border-white/80 rounded-b-full ${
+          isSm ? 'bottom-1.5 right-2.5 w-2.5 h-1' : 'bottom-3 right-5 w-4 h-2'
+        }`}
+      />
+      <div
+        className={`absolute flex flex-col ${
+          isSm ? 'bottom-1.5 left-1.5 gap-[1px]' : 'bottom-3 left-3 gap-0.5'
+        }`}
+      >
+        <div
+          className={`bg-indigo-400/40 rounded-full ${
+            isSm ? 'w-4 h-[1px]' : 'w-8 h-0.5'
+          }`}
+        />
+        <div
+          className={`bg-indigo-400/40 rounded-full ${
+            isSm ? 'w-3 h-[1px]' : 'w-6 h-0.5'
+          }`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/ui/CardyComparePopup.tsx
+++ b/apps/web-next/src/components/ui/CardyComparePopup.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import CardyCharacter from './CardyCharacter';
+import CardImage from './CardImage';
+
+const VISITS_KEY = 'ccd_session_card_visits';
+const DISMISSED_KEY = 'ccd_session_compare_popup_dismissed';
+
+interface CardyComparePopupProps {
+  currentSlug: string;
+  currentName: string;
+  currentImage?: string | null;
+}
+
+interface VisitedCard {
+  slug: string;
+  name: string;
+  image?: string | null;
+}
+
+function readVisits(): VisitedCard[] {
+  try {
+    const raw = sessionStorage.getItem(VISITS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(v => v?.slug && v?.name) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeVisits(visits: VisitedCard[]) {
+  try {
+    sessionStorage.setItem(VISITS_KEY, JSON.stringify(visits));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export default function CardyComparePopup({ currentSlug, currentName, currentImage }: CardyComparePopupProps) {
+  const [visible, setVisible] = useState(false);
+  const [previousCard, setPreviousCard] = useState<VisitedCard | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const visits = readVisits();
+    // Move current card to the end (most recent), de-duped.
+    const filtered = visits.filter(v => v.slug !== currentSlug);
+    const updated = [...filtered, { slug: currentSlug, name: currentName, image: currentImage ?? null }].slice(-10);
+    writeVisits(updated);
+
+    if (sessionStorage.getItem(DISMISSED_KEY) === 'true') return;
+
+    // Need at least one prior unique card to suggest a comparison.
+    const priorUniques = filtered;
+    if (priorUniques.length === 0) return;
+
+    // Suggest the most recently visited prior card.
+    const prev = priorUniques[priorUniques.length - 1];
+    setPreviousCard(prev);
+
+    // Small delay so it doesn't feel jarring on page load.
+    const timer = setTimeout(() => setVisible(true), 1200);
+    return () => clearTimeout(timer);
+  }, [currentSlug, currentName, currentImage]);
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      sessionStorage.setItem(DISMISSED_KEY, 'true');
+    } catch {
+      // ignore
+    }
+  };
+
+  if (!visible || !previousCard) return null;
+
+  const compareHref = `/compare?cards=${previousCard.slug},${currentSlug}`;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Compare these cards"
+      className="fixed bottom-4 right-4 z-40 w-[320px] max-w-[calc(100vw-2rem)] rounded-2xl bg-white shadow-2xl ring-1 ring-gray-200 p-4 animate-[cardy-pop_220ms_ease-out]"
+      style={{
+        // Keyframes inline so the component is self-contained.
+        // Tailwind doesn't have a built-in pop animation that matches.
+      }}
+    >
+      <style jsx>{`
+        @keyframes cardy-pop {
+          0% { opacity: 0; transform: translateY(12px) scale(0.96); }
+          100% { opacity: 1; transform: translateY(0) scale(1); }
+        }
+      `}</style>
+      <button
+        onClick={dismiss}
+        aria-label="Dismiss"
+        className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 p-1"
+      >
+        <XMarkIcon className="h-4 w-4" />
+      </button>
+
+      <div className="flex items-center justify-center gap-2 pr-4">
+        <div className="flex flex-col items-center gap-1 min-w-0 flex-1">
+          <div className="relative w-full aspect-[1.6/1] max-w-[120px] bg-gray-50 rounded-md overflow-hidden ring-1 ring-gray-200">
+            <CardImage
+              cardImageLink={previousCard.image ?? undefined}
+              alt={previousCard.name}
+              fill
+              className="object-contain p-1"
+              sizes="120px"
+            />
+          </div>
+          <div className="text-[11px] font-medium text-gray-700 text-center leading-tight line-clamp-2">
+            {previousCard.name}
+          </div>
+        </div>
+        <div className="text-xs font-bold text-gray-400 uppercase tracking-wider px-1">vs</div>
+        <div className="flex flex-col items-center gap-1 min-w-0 flex-1">
+          <div className="relative w-full aspect-[1.6/1] max-w-[120px] bg-gray-50 rounded-md overflow-hidden ring-1 ring-gray-200">
+            <CardImage
+              cardImageLink={currentImage ?? undefined}
+              alt={currentName}
+              fill
+              className="object-contain p-1"
+              sizes="120px"
+            />
+          </div>
+          <div className="text-[11px] font-medium text-gray-700 text-center leading-tight line-clamp-2">
+            {currentName}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-start gap-2">
+        <div className="flex-shrink-0 mt-0.5">
+          <CardyCharacter size="sm" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-indigo-600 leading-tight">
+            Cardy says
+          </p>
+          <p className="text-sm text-gray-900 leading-snug">
+            Compare these two side by side?
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        <Link
+          href={compareHref}
+          onClick={dismiss}
+          className="flex-1 text-center rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-semibold px-3 py-2 transition-colors"
+        >
+          Compare them
+        </Link>
+        <button
+          onClick={dismiss}
+          className="rounded-lg bg-white text-gray-700 text-sm font-medium px-3 py-2 ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        >
+          Not now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/ui/DataPointPrompt.tsx
+++ b/apps/web-next/src/components/ui/DataPointPrompt.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import CardImage from '@/components/ui/CardImage';
+import CardyCharacter from '@/components/ui/CardyCharacter';
 import Downshift from 'downshift';
 import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react';
 import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline';
@@ -322,32 +323,10 @@ export default function DataPointPrompt() {
 
               {step === 1 && (
                 <>
-                  {/* Credit card character */}
+                  {/* Cardy character */}
                   <div className="flex justify-center mb-4">
                     <div className="relative">
-                      {/* Card body */}
-                      <div className="w-28 h-[72px] rounded-xl bg-gradient-to-br from-indigo-500 to-indigo-700 shadow-lg relative">
-                        {/* Chip */}
-                        <div className="absolute top-3 left-3 w-6 h-[18px] rounded-sm bg-yellow-300/80">
-                          <div className="absolute inset-0.5 border border-yellow-500/40 rounded-[1px]" />
-                        </div>
-                        {/* Eyes */}
-                        <div className="absolute top-3 right-4 flex gap-2">
-                          <div className="w-2.5 h-2.5 rounded-full bg-white flex items-center justify-center">
-                            <div className="w-1 h-1 rounded-full bg-indigo-900" />
-                          </div>
-                          <div className="w-2.5 h-2.5 rounded-full bg-white flex items-center justify-center">
-                            <div className="w-1 h-1 rounded-full bg-indigo-900" />
-                          </div>
-                        </div>
-                        {/* Smile */}
-                        <div className="absolute bottom-3 right-5 w-4 h-2 border-b-2 border-white/80 rounded-b-full" />
-                        {/* Stripe lines */}
-                        <div className="absolute bottom-3 left-3 flex flex-col gap-0.5">
-                          <div className="w-8 h-0.5 bg-indigo-400/40 rounded-full" />
-                          <div className="w-6 h-0.5 bg-indigo-400/40 rounded-full" />
-                        </div>
-                      </div>
+                      <CardyCharacter />
                       {/* Speech bubble */}
                       <div className="absolute -top-14 -right-4 bg-indigo-50 border border-indigo-200 rounded-lg px-3 py-1.5 text-xs text-indigo-700 font-medium whitespace-nowrap">
                         Hi there! 👋


### PR DESCRIPTION
## Summary
- After a user views their second unique card-detail page in a session, Cardy (the existing onboarding mascot) appears in the bottom-right with side-by-side images of the two cards and a one-tap **Compare them** link to /compare?cards=a,b.
- Tracking is purely client-side via sessionStorage — no backend or analytics dependency. Once dismissed (X or "Not now"), it stays gone for the rest of the session.
- Extracts the mascot markup from DataPointPrompt into a shared <CardyCharacter /> component so onboarding and the compare nudge stay visually consistent.

This is part 1 of two compare-promotion features. Part 2 (logging compare events to a new table and showing "Often compared with" chips on each card page) needs a migration + new Lambda + the wire-then-deploy migration cycle, so it'll come in a follow-up PR.

## Test plan
- [ ] Open /card/X — no popup appears (only one card visited)
- [ ] Navigate to /card/Y — Cardy popup appears bottom-right ~1.2s after load with X and Y images side-by-side, "VS" between them, "Compare them" CTA
- [ ] Click "Compare them" — lands on /compare?cards=X,Y with both cards selected
- [ ] Click "Not now" or X — popup hides; navigating to /card/Z does not bring it back this session
- [ ] Refresh tab (still same browser session) — dismissal persists; visiting more cards doesn't re-fire
- [ ] Open in fresh incognito — popup re-arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)