### PR TITLE
Track compare events; show "Often compared with" on card pages

### DIFF
--- a/apps/api/migrations/024_create_card_compare_pair_counts.sql
+++ b/apps/api/migrations/024_create_card_compare_pair_counts.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS card_compare_pair_counts (
+  slug_a VARCHAR(190) NOT NULL,
+  slug_b VARCHAR(190) NOT NULL,
+  compare_count INT NOT NULL DEFAULT 0,
+  last_seen_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (slug_a, slug_b),
+  INDEX idx_compare_slug_a (slug_a, compare_count DESC),
+  INDEX idx_compare_slug_b (slug_b, compare_count DESC),
+  CONSTRAINT chk_compare_pair_ordered CHECK (slug_a < slug_b)
+)

--- a/apps/api/src/handlers/card-compare-event.js
+++ b/apps/api/src/handlers/card-compare-event.js
@@ -1,0 +1,160 @@
+// Track and read compare-pair counts. POST { slugs: [a, b, c?] } increments
+// the count for every unordered pair of slugs in the comparison; GET ?slug=X
+// returns the top partner slugs most often compared with X (descending count).
+//
+// Pairs are stored with slug_a < slug_b so (A,B) and (B,A) collapse into a
+// single row — see migration 024_create_card_compare_pair_counts.sql.
+
+const mysql = require("../db");
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+const SLUG_RE = /^[a-z0-9-]{1,190}$/;
+const MAX_SLUGS = 5;
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 20;
+
+function unorderedPairs(slugs) {
+  const out = [];
+  for (let i = 0; i < slugs.length; i++) {
+    for (let j = i + 1; j < slugs.length; j++) {
+      const [a, b] = slugs[i] < slugs[j] ? [slugs[i], slugs[j]] : [slugs[j], slugs[i]];
+      out.push([a, b]);
+    }
+  }
+  return out;
+}
+
+exports.CardCompareEventHandler = async (event) => {
+  console.info("received:", event);
+
+  let response = {};
+
+  switch (event.httpMethod) {
+    case "OPTIONS":
+      response = {
+        statusCode: 200,
+        headers: responseHeaders,
+        body: JSON.stringify({ statusText: "OK" }),
+      };
+      break;
+
+    case "POST":
+      try {
+        const body = event.body ? JSON.parse(event.body) : {};
+        const raw = Array.isArray(body.slugs) ? body.slugs : [];
+        const slugs = [...new Set(raw.filter((s) => typeof s === "string" && SLUG_RE.test(s)))];
+
+        if (slugs.length < 2 || slugs.length > MAX_SLUGS) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "slugs must contain 2-" + MAX_SLUGS + " unique valid card slugs" }),
+          };
+          break;
+        }
+
+        // Filter out obvious bots — same heuristic as card-view
+        const userAgent = event.headers?.["User-Agent"] || event.headers?.["user-agent"] || "";
+        if (/bot|crawler|spider|scraper/i.test(userAgent)) {
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({ success: true, skipped: "bot" }),
+          };
+          break;
+        }
+
+        const pairs = unorderedPairs(slugs);
+        for (const [a, b] of pairs) {
+          await mysql.query(
+            `INSERT INTO card_compare_pair_counts (slug_a, slug_b, compare_count, last_seen_at)
+             VALUES (?, ?, 1, NOW())
+             ON DUPLICATE KEY UPDATE compare_count = compare_count + 1, last_seen_at = NOW()`,
+            [a, b]
+          );
+        }
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ success: true, pairs: pairs.length }),
+        };
+      } catch (error) {
+        console.error("Error tracking compare event:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to track compare event" }),
+        };
+      }
+      break;
+
+    case "GET":
+      try {
+        const slug = event.queryStringParameters?.slug;
+        if (!slug || !SLUG_RE.test(slug)) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "slug query parameter required" }),
+          };
+          break;
+        }
+
+        const limitRaw = parseInt(event.queryStringParameters?.limit, 10);
+        const limit = Number.isFinite(limitRaw)
+          ? Math.min(Math.max(limitRaw, 1), MAX_LIMIT)
+          : DEFAULT_LIMIT;
+
+        // Pull from both columns since the pair is stored with slug_a < slug_b.
+        // UNION ALL because the same partner can't appear twice (slug != partner).
+        const rows = await mysql.query(
+          `SELECT partner, compare_count
+           FROM (
+             SELECT slug_b AS partner, compare_count FROM card_compare_pair_counts WHERE slug_a = ?
+             UNION ALL
+             SELECT slug_a AS partner, compare_count FROM card_compare_pair_counts WHERE slug_b = ?
+           ) AS partners
+           ORDER BY compare_count DESC
+           LIMIT ?`,
+          [slug, slug, limit]
+        );
+        await mysql.end();
+
+        const partners = rows.map((r) => ({ slug: r.partner, count: Number(r.compare_count) }));
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ slug, partners }),
+        };
+      } catch (error) {
+        console.error("Error fetching compare partners:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to fetch compare partners" }),
+        };
+      }
+      break;
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: `CardCompareEvent only accepts GET, POST, OPTIONS — you tried: ${event.httpMethod}`,
+      };
+      break;
+  }
+
+  console.info(`response from: ${event.path} statusCode: ${response.statusCode}`);
+  return response;
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -454,6 +454,49 @@ Resources:
             RestApiId:
               Ref: CreditCardOddsAPI
 
+  CardCompareEventFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/card-compare-event.CardCompareEventHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Track card-compare events and return frequent compare partners
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        TrackCompare:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /card-compare-event
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        GetComparePartners:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /card-compare-event
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        CardCompareEventOptions:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /card-compare-event
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+
   CardApplyClickFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -233,6 +233,7 @@ interface CardClientProps {
   ratings: { count: number; average: number | null };
   similarCards?: Card[];
   wire?: CardWireEntry[];
+  frequentlyComparedCards?: Card[];
 }
 
 export default function CardClient({
@@ -243,6 +244,7 @@ export default function CardClient({
   ratings,
   similarCards = [],
   wire = [],
+  frequentlyComparedCards = [],
 }: CardClientProps) {
   // ---------- State + chrome ----------
   const [showModal, setShowModal] = useState(false);
@@ -1525,6 +1527,33 @@ export default function CardClient({
             <ScaleIcon className="cj-rail-cta-icon" />
             Compare cards
           </Link>
+
+          {frequentlyComparedCards.length > 0 && (
+            <div className="cj-rail-block">
+              <div className="cj-rail-label">Often compared with</div>
+              {frequentlyComparedCards.map((c) => (
+                <Link
+                  key={c.slug}
+                  href={`/compare?cards=${card.slug},${c.slug}`}
+                  className="cj-sim-row"
+                >
+                  <div className="cj-sim-img">
+                    <CardImage
+                      cardImageLink={c.card_image_link}
+                      alt={c.card_name}
+                      width={48}
+                      height={30}
+                      style={{ width: 48, height: 30, objectFit: "contain" }}
+                    />
+                  </div>
+                  <div className="cj-sim-body">
+                    <div className="cj-sim-name">{c.card_name}</div>
+                    <div className="cj-sim-meta">{c.bank}</div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
 
           {similarCards.length > 0 && (
             <div className="cj-rail-block">

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Card, CardBenefit, getCard, getCardGraphs, getAllCards, getCardRatings, getCardWire, GraphData, CardWireEntry } from "@/lib/api";
+import { Card, CardBenefit, getCard, getCardGraphs, getAllCards, getCardRatings, getCardWire, getComparePartners, GraphData, CardWireEntry } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import CardClient from "./CardClient";
@@ -88,7 +88,7 @@ export default async function CardPage({ params }: CardPageProps) {
   try {
     // Fetch all data in parallel — chain getCard → getCardRatings together
     // so ratings fetches concurrently with graphs/news/articles instead of after them all
-    const [cardWithRatingsAndWire, graphData, allNews, allArticles, allCards] = await Promise.all([
+    const [cardWithRatingsAndWire, graphData, allNews, allArticles, allCards, comparePartners] = await Promise.all([
       getCard(slug).then(async (card) => ({
         card,
         ratings: await getCardRatings(card.card_name).catch(() => ({ count: 0, average: null })),
@@ -98,6 +98,7 @@ export default async function CardPage({ params }: CardPageProps) {
       getNews().catch(() => [] as NewsItem[]),
       getArticles().catch(() => [] as Article[]),
       getAllCards().catch(() => [] as Card[]),
+      getComparePartners(slug, 4).catch(() => []),
     ]);
 
     const { card, ratings, wire } = cardWithRatingsAndWire;
@@ -130,7 +131,15 @@ export default async function CardPage({ params }: CardPageProps) {
     // Find similar cards based on reward type, bank, tags, and category
     const similarCards = getSimilarCards(card, allCards);
 
-    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} />;
+    // Resolve compare-partner slugs into full Card objects (drop any that no
+    // longer exist in cards.json). Hard cap at 3 for the rail UI.
+    const cardsBySlug = new Map(allCards.map(c => [c.slug, c]));
+    const frequentlyComparedCards = comparePartners
+      .map(p => cardsBySlug.get(p.slug))
+      .filter((c): c is Card => Boolean(c) && c.active !== false)
+      .slice(0, 3);
+
+    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} frequentlyComparedCards={frequentlyComparedCards} />;
   } catch {
     notFound();
   }

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -11,7 +11,7 @@ import {
   ScaleIcon,
   InformationCircleIcon,
 } from '@heroicons/react/24/outline';
-import { Card, Reward } from '@/lib/api';
+import { Card, Reward, trackCardCompareEvent } from '@/lib/api';
 import { amortizedAnnualValue, formatBenefitValue } from '@/lib/cardDisplayUtils';
 import { cardMatchesSearch } from '@/lib/searchAliases';
 import {
@@ -250,6 +250,22 @@ export default function CompareClient({ allCards }: CompareClientProps) {
       router.replace('/compare', { scroll: false });
     }
   }, [slots, router]);
+
+  // Track each unique multi-card combination the user actually views,
+  // debounced so quick swaps don't all log. We dedupe per session via a ref —
+  // re-selecting the same set of cards in a session won't double-count.
+  const trackedCombosRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const activeSlugs = slots.filter((s): s is string => Boolean(s));
+    if (activeSlugs.length < 2) return;
+    const key = [...activeSlugs].sort().join('|');
+    if (trackedCombosRef.current.has(key)) return;
+    const t = setTimeout(() => {
+      trackedCombosRef.current.add(key);
+      trackCardCompareEvent(activeSlugs);
+    }, 1500);
+    return () => clearTimeout(t);
+  }, [slots]);
 
   // Merge CDN card data with detailed card data (which has median stats)
   const selectedCards = useMemo(() => {

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -380,6 +380,44 @@ export async function getCardViewCounts(period: 'trending' | 'all-time' = 'trend
   return data.views || {};
 }
 
+// Track a multi-card comparison so we can rank "frequently compared" partners
+// per card. Slugs are deduplicated and unordered server-side; fire-and-forget.
+export async function trackCardCompareEvent(slugs: string[]): Promise<void> {
+  const unique = [...new Set(slugs.filter(Boolean))];
+  if (unique.length < 2) return;
+  try {
+    await fetch(`${API_BASE}/card-compare-event`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: true,
+      body: JSON.stringify({ slugs: unique }),
+    });
+  } catch {
+    // ignore
+  }
+}
+
+export interface ComparePartner {
+  slug: string;
+  count: number;
+}
+
+// Pull the top N most-frequently-compared partner cards for a given card slug.
+// Used to populate "Often compared with" chips on the card detail page.
+export async function getComparePartners(slug: string, limit = 5): Promise<ComparePartner[]> {
+  try {
+    const res = await fetch(
+      `${API_BASE}/card-compare-event?slug=${encodeURIComponent(slug)}&limit=${limit}`,
+      { next: { revalidate: 600 } },
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data.partners) ? data.partners : [];
+  } catch {
+    return [];
+  }
+}
+
 export type CardApplyClickSource = 'direct' | 'referral';
 
 export async function trackCardApplyClick(


### PR DESCRIPTION
## Summary
Part 2 of the compare-promotion work (Part 1 was the [Cardy popup](https://github.com/CreditOdds/creditodds/pull/1053)). Logs every multi-card comparison rendered on /compare and uses that aggregate to populate an "Often compared with" rail block under the Compare CTA on every card detail page. Cardy's "Compare them" CTA feeds into the same pipeline, so accepted nudges directly improve future suggestions.

## Pieces
- **Migration 024** — \`card_compare_pair_counts\` with a \`slug_a < slug_b\` check constraint so (A,B) and (B,A) collapse into one row. Single-statement per the migration-runner contract.
- **Lambda \`card-compare-event\`** — POST upserts every unordered pair from \`{slugs:[...]}\`; GET \`?slug=X&limit=N\` returns top partners by count (descending). Bot UA filter, slug regex validation, max 5 slugs per call.
- **SAM template** — new \`CardCompareEventFunction\` (auth NONE), same shape as \`CardViewFunction\`.
- **\`lib/api.ts\`** — \`trackCardCompareEvent\` (fire-and-forget, dedupes client-side) and \`getComparePartners\` (server-side fetch, 10-min ISR).
- **CompareClient** — 1.5s-debounced track call, deduped per session via a \`Set\` ref so quick swaps don't pollute counts.
- **Card detail page** — passes top 3 active partners to \`CardClient\`; rail block renders only when there's data, so it stays hidden until counts accumulate.

## Deploy steps
1. \`cd apps/api && sam build && sam deploy\` — ships the new Lambda + API route
2. Apply migration 024 via the \`RunMigrationHandler\` wire-deploy-invoke-remove cycle
3. Frontend auto-deploys via Amplify on merge

Frontend is safe to ship ahead of the backend — \`getComparePartners\` swallows errors and the rail block hides itself when the array is empty.

## Test plan
- [ ] After deploy, visit \`/compare?cards=A,B\` → DevTools shows POST to \`/card-compare-event\` with \`{slugs:[A,B]}\` ~1.5s after load
- [ ] Adjust a slot to \`/compare?cards=A,B,C\` → second POST fires with \`[A,B,C]\` (different combo)
- [ ] Same combo viewed twice in one session → only one POST
- [ ] After enough events, \`/card/A\` shows "Often compared with" block in the right rail
- [ ] Clicking a partner chip → lands on \`/compare?cards=A,partner\`
- [ ] DB: \`SELECT * FROM card_compare_pair_counts WHERE slug_a='cap-one-venture-x' OR slug_b='cap-one-venture-x' ORDER BY compare_count DESC\` returns expected rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)