### PR TITLE
Fix Amplify build; drop non-functional X on Cardy popup

### DIFF
--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -136,7 +136,7 @@ export default async function CardPage({ params }: CardPageProps) {
     const cardsBySlug = new Map(allCards.map(c => [c.slug, c]));
     const frequentlyComparedCards = comparePartners
       .map(p => cardsBySlug.get(p.slug))
-      .filter((c): c is Card => Boolean(c) && c.active !== false)
+      .filter((c): c is Card => c !== undefined && c.active !== false)
       .slice(0, 3);
 
     return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} frequentlyComparedCards={frequentlyComparedCards} />;

--- a/apps/web-next/src/components/ui/CardyComparePopup.tsx
+++ b/apps/web-next/src/components/ui/CardyComparePopup.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { XMarkIcon } from '@heroicons/react/24/outline';
 import CardyCharacter from './CardyCharacter';
 import CardImage from './CardImage';
 
@@ -97,15 +96,7 @@ export default function CardyComparePopup({ currentSlug, currentName, currentIma
           100% { opacity: 1; transform: translateY(0) scale(1); }
         }
       `}</style>
-      <button
-        onClick={dismiss}
-        aria-label="Dismiss"
-        className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 p-1"
-      >
-        <XMarkIcon className="h-4 w-4" />
-      </button>
-
-      <div className="flex items-center justify-center gap-2 pr-4">
+      <div className="flex items-center justify-center gap-2">
         <div className="flex flex-col items-center gap-1 min-w-0 flex-1">
           <div className="relative w-full aspect-[1.6/1] max-w-[120px] bg-gray-50 rounded-md overflow-hidden ring-1 ring-gray-200">
             <CardImage


### PR DESCRIPTION
## Summary
- **Amplify build fix**: \`Boolean(c) && c.active !== false\` doesn't narrow \`c\` from \`Card | undefined\` to \`Card\` in TypeScript, so [card/[name]/page.tsx:139](apps/web-next/src/app/card/[name]/page.tsx#L139) failed type-checking on Amplify (TS18048 \"'c' is possibly 'undefined'\"). Replaced with an explicit \`c !== undefined\` guard.
- **Cardy popup X removed**: per user feedback the X dismiss in the top-right of the compare popup wasn't visibly doing anything — only "Not now" registered. Dropped the X (and its unused \`XMarkIcon\` import) so the only dismiss path is "Not now".

## Why the build failed
The "Often compared with" page wiring in PR #1054 used a \`Boolean(c)\` truthy check inside a type predicate. TS only narrows on identity comparisons (\`!== undefined\`, \`!= null\`) — not on \`Boolean(...)\`. Local builds passed where strict mode wasn't enforced; Amplify's \`next build\` runs full \`tsc\` and caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)