### PR TITLE
Card page: clarify "Often compared with" rows are compare links

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1566,8 +1566,10 @@ export default function CardClient({
                 <Link
                   key={c.slug}
                   href={`/compare?cards=${card.slug},${c.slug}`}
-                  className="cj-sim-row"
+                  className="cj-sim-row cj-sim-row--vs"
+                  aria-label={`Compare ${card.card_name} vs ${c.card_name}`}
                 >
+                  <span className="cj-sim-vs">vs</span>
                   <div className="cj-sim-img">
                     <CardImage
                       cardImageLink={c.card_image_link}
@@ -1581,6 +1583,7 @@ export default function CardClient({
                     <div className="cj-sim-name">{c.card_name}</div>
                     <div className="cj-sim-meta">{c.bank}</div>
                   </div>
+                  <span className="cj-sim-arrow" aria-hidden="true">→</span>
                 </Link>
               ))}
             </div>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4847,6 +4847,37 @@
 }
 .landing-v2 .cj-sim-row:hover { background: var(--paper-2); }
 
+/* "Often compared with" rows: prefix each row with "versus" so the compare action is obvious */
+.landing-v2 .cj-sim-row--vs {
+  grid-template-columns: auto 48px 1fr auto;
+  gap: 10px;
+  padding: 10px 0;
+}
+.landing-v2 .cj-sim-vs {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  font-style: italic;
+  color: var(--muted);
+}
+.landing-v2 .cj-sim-arrow {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 14px;
+  color: var(--muted);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.15s ease, transform 0.15s ease, color 0.15s ease;
+  padding-right: 2px;
+}
+.landing-v2 .cj-sim-row--vs:hover .cj-sim-arrow {
+  opacity: 1;
+  transform: translateX(0);
+  color: var(--accent);
+}
+.landing-v2 .cj-sim-row--vs:hover .cj-sim-vs {
+  color: var(--accent);
+}
+
 .landing-v2 .cj-rating {
   padding: 14px 16px;
   border: 1px solid var(--line-2);


### PR DESCRIPTION
## Summary
- "Often compared with" rows in the card page right rail now lead with an italic *vs* label and reveal a `→` arrow on hover, making it obvious each row opens a side-by-side compare against the current card.
- Section label kept as "Often compared with"; the row layout is now: *vs* + card image + name/bank + arrow.

## Test plan
- [x] Visit a card page with frequently-compared cards (e.g. `/card/chase-sapphire-preferred`)
- [x] Right rail shows "Often compared with" with new "vs" prefix on each row
- [x] Hover reveals the purple arrow and turns the "vs" purple
- [x] Clicking still routes to `/compare?cards={current},{other}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)