### PR TITLE
Profile v4: card-journal cj-* shell with sticky tabs and re-skinned modals

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -12,6 +12,7 @@
   --card: #ffffff;
   --accent: #6d3fe8;
   --accent-2: #f0e9ff;
+  --accent-deep: #4a25b5;
   --warn: #d23a62;
   --warn-2: #ffe6ed;
   --gold: #a8792a;
@@ -3083,193 +3084,1245 @@
   margin: 0;
 }
 
-/* ---------- Profile (/profile) ---------- */
+/* ---------- Profile v4 (/profile) — card-journal cj-* shell ---------- */
 .landing-v2.profile-v2 {
   background: var(--paper);
-}
-.landing-v2.profile-v2 .profile-wrap {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding-inline: 16px;
-  padding-top: 20px;
-  padding-bottom: 64px;
-}
-.landing-v2.profile-v2 .profile-hero {
-  padding: 0;
-  margin-bottom: 28px;
-}
-@media (min-width: 640px) {
-  .landing-v2.profile-v2 .profile-wrap {
-    padding-inline: 24px;
-  }
-}
-@media (min-width: 1024px) {
-  .landing-v2.profile-v2 .profile-wrap {
-    padding-inline: 32px;
-    padding-top: 32px;
-  }
-}
-.landing-v2.profile-v2 .profile-hero .eyebrow {
-  margin-bottom: 14px;
-}
-.landing-v2.profile-v2 .profile-greeting {
-  font-family: 'Inter Tight', sans-serif;
-  font-weight: 500;
-  letter-spacing: -0.03em;
-  font-size: clamp(32px, 3.6vw, 52px);
-  line-height: 1;
-  margin: 10px 0 8px;
-  color: var(--ink);
-  text-wrap: balance;
-}
-.landing-v2.profile-v2 .profile-greeting em {
-  font-style: normal;
-  color: var(--accent);
-  font-weight: 400;
-}
-.landing-v2.profile-v2 .profile-email {
-  font-family: 'Inter', sans-serif;
-  font-size: 12px;
-  color: var(--muted);
-  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'ss01', 'cv11';
 }
 
-.landing-v2.profile-v2 .profile-tabs {
+/* Layout — terminal strip + 2-col grid (main + 300px right rail) */
+.landing-v2.profile-v2 .cj-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+@media (min-width: 1024px) {
+  .landing-v2.profile-v2 .cj-layout {
+    grid-template-columns: minmax(0, 1fr) 300px;
+  }
+}
+.landing-v2.profile-v2 .cj-main {
+  padding: 24px 18px 32px;
+  min-width: 0;
+}
+@media (min-width: 768px) {
+  .landing-v2.profile-v2 .cj-main { padding: 28px 24px 48px; }
+}
+@media (min-width: 1024px) {
+  .landing-v2.profile-v2 .cj-main {
+    padding: 28px 32px 64px;
+    border-right: 1px solid var(--line);
+  }
+}
+.landing-v2.profile-v2 .cj-main-content { min-width: 0; }
+
+/* Terminal strip — dark bar with breadcrumb + status */
+.landing-v2.profile-v2 .cj-terminal {
+  background: var(--ink);
+  color: #fff;
+  padding: 10px 18px;
   display: flex;
-  gap: 2px;
-  border-bottom: 1px solid var(--line);
-  margin: 32px 0;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scrollbar-width: none;
+  align-items: center;
+  gap: 14px;
+  font-family: 'Inter', sans-serif;
+  font-size: 11.5px;
+  flex-wrap: wrap;
 }
-.landing-v2.profile-v2 .profile-tabs::-webkit-scrollbar {
-  display: none;
+@media (min-width: 768px) {
+  .landing-v2.profile-v2 .cj-terminal { padding: 10px 24px; }
 }
-.landing-v2.profile-v2 .profile-tab {
+.landing-v2.profile-v2 .cj-terminal .cj-spacer { flex: 1; }
+.landing-v2.profile-v2 .cj-terminal .cj-crumbs {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 14px 18px;
-  font-size: 14px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.landing-v2.profile-v2 .cj-terminal .cj-crumb-current { color: #fff; }
+.landing-v2.profile-v2 .cj-terminal .cj-status-dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: #64d88a;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+/* Snapshot header — tight welcome row */
+.landing-v2.profile-v2 .cj-snapshot {
+  padding: 10px 0 12px;
+}
+.landing-v2.profile-v2 .cj-snapshot-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.landing-v2.profile-v2 .cj-snapshot-h1 {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  font-size: 28px !important;
+  letter-spacing: -0.03em;
+  line-height: 1 !important;
+  margin: 0 !important;
+  color: var(--ink);
+}
+@media (min-width: 768px) {
+  .landing-v2.profile-v2 .cj-snapshot-h1 { font-size: 32px !important; }
+}
+.landing-v2.profile-v2 .cj-snapshot-h1 em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+}
+.landing-v2.profile-v2 .cj-snapshot-meta {
+  font-size: 11.5px;
   font-weight: 500;
   color: var(--muted);
-  cursor: pointer;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+
+/* Compact readoff — 5-up grid that scales to 2-up on narrow */
+.landing-v2.profile-v2 .cj-readoff {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+  margin-top: 14px;
+  border: 1px solid var(--line);
+}
+@media (min-width: 640px) {
+  .landing-v2.profile-v2 .cj-readoff { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+@media (min-width: 1024px) {
+  .landing-v2.profile-v2 .cj-readoff { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+}
+.landing-v2.profile-v2 .cj-readoff-cell {
+  background: var(--paper);
+  padding: 9px 12px;
+  min-width: 0;
+  overflow: hidden;
+}
+.landing-v2.profile-v2 .cj-readoff-k {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+}
+.landing-v2.profile-v2 .cj-readoff-v {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 19px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  margin-top: 4px;
+  line-height: 1;
+  color: var(--ink);
+}
+.landing-v2.profile-v2 .cj-readoff-foot {
+  font-family: 'Inter', sans-serif;
+  font-size: 11.5px;
+  color: var(--muted);
+  margin-top: 5px;
+}
+.landing-v2.profile-v2 .cj-readoff-v.cj-accent { color: var(--accent); }
+.landing-v2.profile-v2 .cj-readoff-v.cj-warn { color: var(--warn); }
+.landing-v2.profile-v2 .cj-readoff-bonus { background: #fef9e8; }
+.landing-v2.profile-v2 .cj-readoff-bonus .cj-readoff-k { color: #92722a; }
+
+/* Main column tab row — sticky below the global navbar (h-14 mobile / h-16 desktop) */
+.landing-v2.profile-v2 .cj-main-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0;
+  border-bottom: 1px solid var(--line);
+  margin: 8px 0 24px;
+  position: sticky;
+  top: 56px;
+  z-index: 20;
+  background: var(--paper);
+  box-shadow: 0 1px 0 var(--line);
+}
+@media (min-width: 640px) {
+  .landing-v2.profile-v2 .cj-main-tabs { top: 64px; }
+}
+.landing-v2.profile-v2 .cj-main-tab {
+  padding: 10px 18px 10px 0;
+  margin-right: 22px;
+  background: transparent;
   border: 0;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
-  white-space: nowrap;
-  background: none;
   font-family: inherit;
-  letter-spacing: -0.005em;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+  white-space: nowrap;
+  letter-spacing: 0.01em;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
 }
-.landing-v2.profile-v2 .profile-tab:hover:not(.active) {
-  color: var(--ink);
-}
-.landing-v2.profile-v2 .profile-tab.active {
+.landing-v2.profile-v2 .cj-main-tab:hover { color: var(--ink); }
+.landing-v2.profile-v2 .cj-main-tab.active {
   color: var(--ink);
   border-bottom-color: var(--accent);
   font-weight: 600;
 }
-.landing-v2.profile-v2 .profile-tab svg {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-.landing-v2.profile-v2 .profile-tab .tab-count {
-  font-family: 'Inter', sans-serif;
-  font-size: 11px;
+.landing-v2.profile-v2 .cj-main-tab-num {
+  font-size: 10px;
   color: var(--muted-2);
-  padding: 2px 6px;
-  border-radius: 4px;
-  background: var(--paper-2);
-  border: 1px solid var(--line);
+  font-weight: 500;
+}
+.landing-v2.profile-v2 .cj-main-tab.active .cj-main-tab-num { color: var(--accent); }
+.landing-v2.profile-v2 .cj-main-tab-count {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 500;
   margin-left: 2px;
 }
-.landing-v2.profile-v2 .profile-tab.active .tab-count {
-  background: var(--accent-2);
-  color: var(--accent);
-  border-color: transparent;
+
+/* Section block — no border-bottom inside tabs */
+.landing-v2.profile-v2 .cj-main-content .cj-section {
+  padding: 0;
+  border-bottom: 0;
 }
 
-/* Re-skin the bg-white card containers that wrap tab panels so they match the
-   v2 aesthetic without rewriting every internal element.  */
-.landing-v2.profile-v2 .bg-white.shadow,
-.landing-v2.profile-v2 .bg-white.shadow-sm {
-  background: var(--card);
-  border: 1px solid var(--line-2);
-  border-radius: 14px;
-  box-shadow: none;
-}
-.landing-v2.profile-v2 .bg-gray-50 {
-  background: var(--paper-2);
-}
-.landing-v2.profile-v2 .divide-gray-200 > * + * {
-  border-color: var(--line);
-}
-.landing-v2.profile-v2 .border-gray-200 {
-  border-color: var(--line);
-}
-.landing-v2.profile-v2 .text-indigo-600,
-.landing-v2.profile-v2 .text-indigo-500 {
-  color: var(--accent);
-}
-.landing-v2.profile-v2 .bg-indigo-600 {
-  background: var(--ink);
-}
-.landing-v2.profile-v2 .bg-indigo-600:hover,
-.landing-v2.profile-v2 .hover\:bg-indigo-700:hover {
-  background: var(--ink-2);
-}
-.landing-v2.profile-v2 .border-b-2.border-indigo-600 {
-  border-color: var(--accent);
-}
-.landing-v2.profile-v2 .hover\:text-indigo-900:hover {
-  color: var(--accent);
-}
-
-/* Stats row — reuse best-hero-stats but shorter */
-.landing-v2.profile-v2 .profile-stats {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1px;
-  background: var(--line);
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  overflow: hidden;
-  margin-top: 6px;
-}
-@media (max-width: 760px) {
-  .landing-v2.profile-v2 .profile-stats {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-.landing-v2.profile-v2 .profile-stats .pstat {
-  background: var(--card);
-  padding: 14px 18px;
+/* Wallet toolbar — count + show-archived toggle + add a card */
+.landing-v2.profile-v2 .cj-wallet-toolbar {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  align-items: center;
+  gap: 14px;
+  margin: 0 0 10px;
+  flex-wrap: wrap;
 }
-.landing-v2.profile-v2 .profile-stats .pstat .k {
+.landing-v2.profile-v2 .cj-wallet-toolbar-spacer { flex: 1; }
+.landing-v2.profile-v2 .cj-table-label {
   font-size: 13px;
   font-weight: 500;
   color: var(--muted);
+  margin: 0 0 8px;
 }
-.landing-v2.profile-v2 .profile-stats .pstat .v {
+.landing-v2.profile-v2 .cj-archived-toggle {
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--muted);
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  padding: 4px 0;
+}
+.landing-v2.profile-v2 .cj-archived-toggle:hover { color: var(--accent); }
+.landing-v2.profile-v2 .cj-inline-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  font-family: inherit;
+}
+.landing-v2.profile-v2 .cj-inline-cta:hover { background: var(--accent-deep); }
+
+/* Compact wallet rows */
+.landing-v2.profile-v2 .cj-wallet-tape { border: 1px solid var(--line-2); }
+.landing-v2.profile-v2 .cj-wallet-head {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1.6fr) 110px 90px 80px 22px;
+  padding: 8px 14px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  gap: 12px;
+}
+.landing-v2.profile-v2 .cj-wallet-head .cj-tr { text-align: right; }
+
+.landing-v2.profile-v2 .cj-wallet-crow {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1.6fr) 110px 90px 80px 22px;
+  padding: 9px 14px;
+  border-top: 1px solid var(--line);
+  align-items: center;
+  font-size: 12.5px;
+  gap: 12px;
+  cursor: pointer;
+  background: var(--paper);
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  color: inherit;
+}
+.landing-v2.profile-v2 .cj-wallet-crow:first-of-type { border-top: 0; }
+.landing-v2.profile-v2 .cj-wallet-crow:hover { background: var(--paper-2); }
+.landing-v2.profile-v2 .cj-wallet-crow.is-open { background: var(--accent-2); }
+.landing-v2.profile-v2 .cj-wallet-crow.is-archived { opacity: 0.55; }
+.landing-v2.profile-v2 .cj-wallet-crow .cj-cw-thumb {
+  position: relative;
+  width: 36px;
+  height: 22px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--paper-2);
+  flex-shrink: 0;
+}
+.landing-v2.profile-v2 .cj-wallet-crow .cj-cw-name {
+  font-weight: 500;
+  color: var(--ink);
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 14px;
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+}
+.landing-v2.profile-v2 .cj-wallet-crow .cj-cw-issuer {
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 11.5px;
+}
+.landing-v2.profile-v2 .cj-wallet-crow .cj-cw-renew {
+  color: var(--ink-2);
+  font-variant-numeric: tabular-nums;
+  font-size: 11.5px;
+}
+.landing-v2.profile-v2 .cj-wallet-crow .cj-cw-fee {
+  text-align: right;
+  font-weight: 600;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.landing-v2.profile-v2 .cj-wallet-crow .cj-cw-fee.cj-cw-zero { color: var(--muted); font-weight: 500; }
+.landing-v2.profile-v2 .cj-wallet-crow .cj-cw-caret {
+  font-size: 10px;
+  color: var(--muted);
+  transition: transform 0.15s ease;
+  text-align: right;
+}
+.landing-v2.profile-v2 .cj-wallet-crow.is-open .cj-cw-caret { transform: rotate(90deg); color: var(--accent); }
+
+/* Per-row record/referral indicators */
+.landing-v2.profile-v2 .cj-cw-marks {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+.landing-v2.profile-v2 .cj-cw-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: rgba(34, 134, 76, 0.10);
+  color: #1f8a5b;
+  border: 1px solid rgba(34, 134, 76, 0.25);
+}
+
+/* Wallet detail (expanded inline) */
+.landing-v2.profile-v2 .cj-wallet-detail {
+  padding: 18px 14px 18px 62px;
+  border-top: 1px solid var(--line);
+  background: #fbfaff;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+}
+.landing-v2.profile-v2 .cj-wallet-detail .cj-wd-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 28px;
+  padding: 4px 0 12px;
+  border-bottom: 1px dashed var(--line);
+}
+@media (min-width: 768px) {
+  .landing-v2.profile-v2 .cj-wallet-detail .cj-wd-meta {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+.landing-v2.profile-v2 .cj-wallet-detail .cj-wd-k {
+  font-size: 10px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  display: block;
+  margin-bottom: 4px;
+}
+.landing-v2.profile-v2 .cj-wallet-detail .cj-wd-v {
+  font-size: 14px;
+  color: var(--ink);
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  line-height: 1.2;
+}
+.landing-v2.profile-v2 .cj-wallet-detail .cj-wd-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding-top: 2px;
+}
+.landing-v2.profile-v2 .cj-wallet-detail .cj-wd-actions a,
+.landing-v2.profile-v2 .cj-wallet-detail .cj-wd-actions button {
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--ink-2);
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  padding: 5px 9px;
+  text-decoration: none;
+  cursor: pointer;
+  font-family: inherit;
+  letter-spacing: 0.02em;
+}
+.landing-v2.profile-v2 .cj-wallet-detail .cj-wd-actions a:hover,
+.landing-v2.profile-v2 .cj-wallet-detail .cj-wd-actions button:not(.cj-wd-cta):hover {
+  background: var(--ink);
+  color: #fff;
+  border-color: var(--ink);
+}
+.landing-v2.profile-v2 .cj-wd-cta {
+  font: inherit !important;
+  font-size: 11.5px !important;
+  background: var(--accent) !important;
+  color: #fff !important;
+  border: 1px solid var(--accent) !important;
+  border-radius: 3px !important;
+  padding: 5px 10px !important;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600 !important;
+  letter-spacing: 0.02em;
+}
+.landing-v2.profile-v2 .cj-wd-cta:hover {
+  background: var(--accent-deep) !important;
+  border-color: var(--accent-deep) !important;
+}
+.landing-v2.profile-v2 .cj-wd-done {
+  font-size: 11px;
+  color: #0f8a5f;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  align-self: center;
+  padding: 5px 0;
+}
+.landing-v2.profile-v2 .cj-wallet-arch-strip {
+  padding: 10px 14px;
+  border-top: 1px solid var(--line);
+  font-size: 11.5px;
+  color: var(--muted);
+  background: var(--paper-2);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* Tape variants used by Benefits / Records / Referrals tabs */
+.landing-v2.profile-v2 .cj-tape { border: 1px solid var(--line-2); }
+.landing-v2.profile-v2 .cj-tape-head {
+  display: grid;
+  grid-template-columns: 110px 56px 1fr 90px;
+  padding: 8px 14px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--muted);
+  gap: 10px;
+}
+.landing-v2.profile-v2 .cj-tape-row {
+  display: grid;
+  grid-template-columns: 110px 56px 1fr 90px;
+  padding: 9px 14px;
+  border-top: 1px solid var(--line);
+  align-items: center;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+}
+.landing-v2.profile-v2 .cj-tape-row:first-of-type { border-top: 0; }
+.landing-v2.profile-v2 .cj-tape-when { color: var(--muted); }
+.landing-v2.profile-v2 .cj-tape-res { text-align: right; }
+.landing-v2.profile-v2 .cj-tape-event .cj-tape-field {
+  font-weight: 500;
+  color: var(--ink);
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+}
+.landing-v2.profile-v2 .cj-tape-event .cj-tape-detail {
+  font-size: 10.5px;
+  color: var(--muted);
+  margin-top: 1px;
+}
+.landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-head,
+.landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row {
+  grid-template-columns: 100px 56px 1fr 80px 70px 80px;
+}
+.landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-head,
+.landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-row {
+  grid-template-columns: 56px 1fr 70px 70px 80px;
+}
+.landing-v2.profile-v2 .cj-tape.cj-tape-credits .cj-tape-head,
+.landing-v2.profile-v2 .cj-tape.cj-tape-credits .cj-tape-row {
+  grid-template-columns: 56px 1fr 140px 80px;
+}
+.landing-v2.profile-v2 .cj-tape-row-perk {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+}
+.landing-v2.profile-v2 .cj-tape-row:hover { background: var(--paper-2); }
+.landing-v2.profile-v2 .cj-tape-thumb {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 22px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--paper-2);
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
+/* Pills (override landing-v2 defaults) */
+.landing-v2.profile-v2 .cj-pill {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 2px;
+  background: var(--paper-2);
+  color: var(--muted);
+  display: inline-block;
+  letter-spacing: 0.02em;
+}
+.landing-v2.profile-v2 .cj-pill.cj-pill-app { background: #e0f6ea; color: #0f8a5f; }
+.landing-v2.profile-v2 .cj-pill.cj-pill-den { background: var(--warn-2); color: var(--warn); }
+.landing-v2.profile-v2 .cj-pill.cj-pill-pen { background: var(--accent-2); color: var(--accent); }
+
+/* Verdict block (used at bottom of Applications tab) */
+.landing-v2.profile-v2 .cj-verdict {
+  margin-top: 16px;
+  padding: 16px 20px;
+  background: var(--accent-2);
+  border-left: 3px solid var(--accent);
+  font-size: 13.5px;
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+.landing-v2.profile-v2 .cj-verdict b { color: var(--accent); }
+
+/* Rewards table — best-in-wallet cell with thumb */
+.landing-v2.profile-v2 .cj-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  border: 1px solid var(--line-2);
+}
+.landing-v2.profile-v2 .cj-table thead tr { background: var(--paper-2); }
+.landing-v2.profile-v2 .cj-table th {
+  text-align: left;
+  padding: 9px 12px;
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 600;
+}
+.landing-v2.profile-v2 .cj-table th.cj-tr { text-align: right; }
+.landing-v2.profile-v2 .cj-table td { padding: 10px 12px; vertical-align: top; }
+.landing-v2.profile-v2 .cj-table td.cj-tr { text-align: right; }
+.landing-v2.profile-v2 .cj-table tbody tr { border-top: 1px solid var(--line); }
+.landing-v2.profile-v2 .cj-table tbody tr:first-child { border-top: 0; }
+.landing-v2.profile-v2 .cj-cell-primary { font-weight: 500; }
+.landing-v2.profile-v2 .cj-cell-detail {
+  font-family: 'Inter', sans-serif;
+  font-size: 10.5px;
+  color: var(--muted);
+  margin-top: 1px;
+}
+.landing-v2.profile-v2 .cj-eff-pct {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--accent);
+}
+.landing-v2.profile-v2 .cj-eff-pct.cj-warn { color: var(--warn); }
+.landing-v2.profile-v2 .cj-rew-best {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.landing-v2.profile-v2 .cj-rew-thumb {
+  position: relative;
+  width: 32px;
+  height: 22px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--paper-2);
+  flex: 0 0 auto;
+}
+.landing-v2.profile-v2 .cj-rew-thumb-empty {
+  width: 32px;
+  height: 22px;
+  border-radius: 3px;
+  border: 1px dashed var(--line-2);
+  background: repeating-linear-gradient(135deg, transparent 0 4px, var(--paper-2) 4px 5px);
+  flex: 0 0 auto;
+}
+
+/* Settings list */
+.landing-v2.profile-v2 .cj-settings-list {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  padding: 14px 0;
+  border-top: 1px dashed var(--line);
+  align-items: baseline;
+  font-size: 13px;
+}
+@media (min-width: 768px) {
+  .landing-v2.profile-v2 .cj-settings-list {
+    grid-template-columns: 200px 1fr auto;
+    gap: 16px;
+  }
+}
+.landing-v2.profile-v2 .cj-settings-list:first-of-type { border-top: 1px solid var(--line); }
+.landing-v2.profile-v2 .cj-settings-k { color: var(--muted); font-weight: 500; }
+.landing-v2.profile-v2 .cj-settings-v { color: var(--ink); font-family: 'Inter', sans-serif; }
+.landing-v2.profile-v2 .cj-settings-edit {
+  font-size: 11.5px;
+  color: var(--accent);
+  text-decoration: none;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  letter-spacing: 0.02em;
+  padding: 0;
+}
+
+/* Right rail — apply block, dashed lists, news */
+.landing-v2.profile-v2 .cj-rail {
+  padding: 24px 18px 48px;
+  align-self: start;
+  min-width: 0;
+}
+@media (min-width: 1024px) {
+  .landing-v2.profile-v2 .cj-rail { padding: 32px 24px 64px; }
+}
+.landing-v2.profile-v2 .cj-rail-block { margin-bottom: 24px; }
+.landing-v2.profile-v2 .cj-rail-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.landing-v2.profile-v2 .cj-rail-list { list-style: none; margin: 0; padding: 0; }
+.landing-v2.profile-v2 .cj-rail-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 0;
+  border-top: 1px dashed var(--line);
+}
+.landing-v2.profile-v2 .cj-rail-row:first-of-type { border-top: 1px solid var(--line); }
+.landing-v2.profile-v2 .cj-rail-row-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 11px;
+}
+.landing-v2.profile-v2 .cj-rail-row-date {
+  font-family: 'Inter', monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.landing-v2.profile-v2 .cj-rail-row-field {
+  color: var(--ink);
+  font-weight: 500;
+}
+.landing-v2.profile-v2 .cj-rail-row-detail {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.landing-v2.profile-v2 .cj-rail-row-link {
+  color: var(--ink-2);
+  text-decoration: none;
+  line-height: 1.35;
+  font-weight: 500;
+  font-size: 11.5px;
+}
+.landing-v2.profile-v2 .cj-rail-row-link:hover { color: var(--accent); }
+.landing-v2.profile-v2 .cj-news-tag {
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Apply block (dark "add a card" CTA) */
+.landing-v2.profile-v2 .cj-apply {
+  padding: 20px;
+  background: var(--ink);
+  color: #fff;
+  border-radius: 4px;
+  margin-bottom: 20px;
+}
+.landing-v2.profile-v2 .cj-apply-k {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted-2);
+}
+.landing-v2.profile-v2 .cj-apply-v {
   font-family: 'Inter Tight', sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.02em;
+  margin-top: 4px;
+}
+.landing-v2.profile-v2 .cj-apply-sub {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: var(--muted-2);
+  margin-top: 2px;
+}
+.landing-v2.profile-v2 .cj-apply-btn {
+  margin-top: 14px;
+  width: 100%;
+  padding: 11px;
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+  display: block;
+  font-family: inherit;
+}
+.landing-v2.profile-v2 .cj-apply-btn:hover { filter: brightness(1.1); }
+.landing-v2.profile-v2 .cj-apply-btn-outline {
+  margin-top: 8px;
+  width: 100%;
+  padding: 11px;
+  background: transparent;
+  color: #fff;
+  border: 1px solid var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+  display: block;
+  font-family: inherit;
+}
+.landing-v2.profile-v2 .cj-apply-btn-outline:hover { border-color: #fff; }
+
+.landing-v2.profile-v2 .cj-rail-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  margin-bottom: 20px;
+  letter-spacing: 0.01em;
+  font-family: inherit;
+  cursor: pointer;
+}
+.landing-v2.profile-v2 .cj-rail-cta:hover {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: #fff;
+}
+
+/* Mobile: rail moves below main, no border-right on main */
+@media (max-width: 1023px) {
+  .landing-v2.profile-v2 .cj-main { border-right: 0; }
+}
+
+/* ===== Application rule card ===== */
+.landing-v2.profile-v2 .cj-rule {
+  border: 1px solid var(--line-2);
+  background: var(--paper);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 180px;
+}
+.landing-v2.profile-v2 .cj-rule-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.landing-v2.profile-v2 .cj-rule-name {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   color: var(--ink);
   line-height: 1.1;
 }
-.landing-v2.profile-v2 .profile-stats .pstat .v.accent {
+.landing-v2.profile-v2 .cj-rule-period {
+  font-size: 10.5px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+.landing-v2.profile-v2 .cj-rule-num {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.landing-v2.profile-v2 .cj-rule-num-current {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 32px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 1;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.landing-v2.profile-v2 .cj-rule-num-current.is-warn { color: var(--warn); }
+.landing-v2.profile-v2 .cj-rule-num-current.is-at { color: var(--gold); }
+.landing-v2.profile-v2 .cj-rule-num-current.is-ok { color: var(--accent); }
+.landing-v2.profile-v2 .cj-rule-num-limit {
+  font-size: 13px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.landing-v2.profile-v2 .cj-rule-bar {
+  display: flex;
+  gap: 4px;
+  margin-top: auto;
+}
+.landing-v2.profile-v2 .cj-rule-seg {
+  flex: 1;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+}
+.landing-v2.profile-v2 .cj-rule-seg.is-fill { background: var(--accent); border-color: var(--accent); }
+.landing-v2.profile-v2 .cj-rule-seg.is-fill-at { background: var(--gold); border-color: var(--gold); }
+.landing-v2.profile-v2 .cj-rule-seg.is-fill-over { background: var(--warn); border-color: var(--warn); }
+.landing-v2.profile-v2 .cj-rule-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.landing-v2.profile-v2 .cj-rule-status { display: inline-block; }
+.landing-v2.profile-v2 .cj-rule-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+@media (min-width: 640px) {
+  .landing-v2.profile-v2 .cj-rule-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (min-width: 1024px) {
+  .landing-v2.profile-v2 .cj-rule-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+.landing-v2.profile-v2 .cj-rule-grid .cj-rule {
+  border: 0;
+  background: var(--paper);
+}
+
+/* ===== Modal — cj-* styled ===== */
+.landing-v2.profile-v2 .cj-modal-root {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  overflow-y: auto;
+}
+.landing-v2.profile-v2 .cj-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 19, 48, 0.55);
+  backdrop-filter: blur(2px);
+}
+.landing-v2.profile-v2 .cj-modal-shell {
+  position: relative;
+  display: flex;
+  min-height: 100%;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0;
+}
+@media (min-width: 640px) {
+  .landing-v2.profile-v2 .cj-modal-shell {
+    align-items: center;
+    padding: 32px 16px;
+  }
+}
+.landing-v2.profile-v2 .cj-modal-card {
+  position: relative;
+  width: 100%;
+  max-width: 440px;
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  box-shadow: 0 20px 60px -20px rgba(26, 19, 48, 0.4);
+  border-radius: 0;
+  overflow: hidden;
+}
+@media (min-width: 640px) {
+  .landing-v2.profile-v2 .cj-modal-card { border-radius: 4px; }
+}
+.landing-v2.profile-v2 .cj-modal-head {
+  background: var(--ink);
+  color: #fff;
+  padding: 10px 18px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 11.5px;
+}
+.landing-v2.profile-v2 .cj-modal-title {
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+}
+.landing-v2.profile-v2 .cj-modal-close {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  color: var(--muted-2);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 4px;
+}
+.landing-v2.profile-v2 .cj-modal-close:hover { color: #fff; }
+.landing-v2.profile-v2 .cj-modal-body {
+  padding: 20px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.landing-v2.profile-v2 .cj-modal-section { }
+.landing-v2.profile-v2 .cj-modal-section + .cj-modal-section {
+  border-top: 1px dashed var(--line);
+  padding-top: 18px;
+}
+.landing-v2.profile-v2 .cj-modal-label {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.landing-v2.profile-v2 .cj-modal-card-row {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  gap: 12px;
+  align-items: center;
+}
+.landing-v2.profile-v2 .cj-modal-thumb {
+  position: relative;
+  display: block;
+  width: 56px;
+  height: 36px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--paper-2);
+}
+.landing-v2.profile-v2 .cj-modal-card-name {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  line-height: 1.2;
+}
+.landing-v2.profile-v2 .cj-modal-card-meta {
+  font-size: 11.5px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+.landing-v2.profile-v2 .cj-modal-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 10px;
+  font-size: 11.5px;
   color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.02em;
 }
-.landing-v2.profile-v2 .profile-stats .pstat .v.warn {
+.landing-v2.profile-v2 .cj-modal-link:hover { color: var(--accent-deep); }
+.landing-v2.profile-v2 .cj-modal-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.landing-v2.profile-v2 .cj-modal-input,
+.landing-v2.profile-v2 .cj-modal-select {
+  width: 100%;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  appearance: none;
+  -webkit-appearance: none;
+}
+.landing-v2.profile-v2 .cj-modal-select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%236b6384' stroke-width='1.5'%3E%3Cpath d='M3 4.5l3 3 3-3'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px;
+  padding-right: 28px;
+}
+.landing-v2.profile-v2 .cj-modal-input:focus,
+.landing-v2.profile-v2 .cj-modal-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-2);
+}
+.landing-v2.profile-v2 .cj-modal-stars {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.landing-v2.profile-v2 .cj-modal-star {
+  background: transparent;
+  border: 0;
+  padding: 4px;
+  cursor: pointer;
+  border-radius: 3px;
+  color: var(--line-2);
+  transition: color 0.1s ease;
+}
+.landing-v2.profile-v2 .cj-modal-star:hover { background: var(--paper-2); }
+.landing-v2.profile-v2 .cj-modal-star.is-active { color: var(--accent); }
+.landing-v2.profile-v2 .cj-modal-star-label {
+  margin-left: 8px;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+}
+.landing-v2.profile-v2 .cj-modal-error {
+  padding: 10px 12px;
+  background: var(--warn-2);
+  border-left: 3px solid var(--warn);
+  font-size: 12px;
   color: var(--warn);
+  font-weight: 500;
 }
+.landing-v2.profile-v2 .cj-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  background: var(--paper-2);
+  border-top: 1px solid var(--line);
+  flex-wrap: wrap;
+}
+.landing-v2.profile-v2 .cj-modal-danger {
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--warn);
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+}
+.landing-v2.profile-v2 .cj-modal-danger:hover { text-decoration: underline; }
+.landing-v2.profile-v2 .cj-modal-actions {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+}
+.landing-v2.profile-v2 .cj-modal-btn {
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 7px 14px;
+  border-radius: 3px;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--line-2);
+  color: var(--ink-2);
+  letter-spacing: 0.02em;
+}
+.landing-v2.profile-v2 .cj-modal-btn:hover { background: var(--paper); border-color: var(--ink-2); color: var(--ink); }
+.landing-v2.profile-v2 .cj-modal-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+.landing-v2.profile-v2 .cj-modal-btn-primary:hover {
+  background: var(--accent-deep);
+  border-color: var(--accent-deep);
+  color: #fff;
+}
+.landing-v2.profile-v2 .cj-modal-btn:disabled,
+.landing-v2.profile-v2 .cj-modal-btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Modal — search field + scrollable card list */
+.landing-v2.profile-v2 .cj-modal-search {
+  position: relative;
+}
+.landing-v2.profile-v2 .cj-modal-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  color: var(--muted);
+  pointer-events: none;
+}
+.landing-v2.profile-v2 .cj-modal-search-input {
+  width: 100%;
+  padding: 8px 10px 8px 32px;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+}
+.landing-v2.profile-v2 .cj-modal-search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-2);
+}
+.landing-v2.profile-v2 .cj-modal-list {
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--line-2);
+}
+.landing-v2.profile-v2 .cj-modal-list-row {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--line);
+  background: var(--paper);
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  cursor: pointer;
+  color: inherit;
+}
+.landing-v2.profile-v2 .cj-modal-list-row:first-of-type { border-top: 0; }
+.landing-v2.profile-v2 .cj-modal-list-row:hover { background: var(--paper-2); }
+.landing-v2.profile-v2 .cj-modal-list-row .cj-modal-thumb {
+  width: 56px;
+  height: 36px;
+}
+.landing-v2.profile-v2 .cj-modal-list-name {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--ink);
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.landing-v2.profile-v2 .cj-modal-list-meta {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.landing-v2.profile-v2 .cj-modal-list-empty {
+  padding: 28px 12px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+}
+.landing-v2.profile-v2 .cj-modal-list-foot {
+  padding: 8px 12px;
+  text-align: center;
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--paper-2);
+  border-top: 1px solid var(--line);
+}
+.landing-v2.profile-v2 .cj-modal-back {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--accent);
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  font-weight: 500;
+  margin-top: 10px;
+}
+.landing-v2.profile-v2 .cj-modal-back:hover { color: var(--accent-deep); }
 
 /* ---------- Long-form content (about / how / terms / privacy) ---------- */
 .landing-v2 .page-body {

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, Fragment } from "react";
 import { useRouter } from "next/navigation";
 import CardImage from "@/components/ui/CardImage";
 import Link from "next/link";
@@ -9,9 +9,10 @@ import { useAuth } from "@/auth/AuthProvider";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import { getAllCards, getProfile, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, deleteAccount, WalletCard, Card } from "@/lib/api";
 import "../landing.css";
-import { getNews, NewsItem, tagLabels, tagColors, NewsTag } from "@/lib/news";
+import { getNews, NewsItem, tagLabels } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
-import { PlusIcon, WalletIcon, TrashIcon, DocumentTextIcon, LinkIcon, NewspaperIcon, ChartBarIcon, ExclamationTriangleIcon, ArchiveBoxIcon, Cog6ToothIcon, GiftIcon, TrophyIcon } from "@heroicons/react/24/outline";
+import { amortizedAnnualValue } from "@/lib/cardDisplayUtils";
+import { TrashIcon, DocumentTextIcon, LinkIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { calculateApplicationRules, countCardsMissingDates } from "@/lib/applicationRules";
 import {
   createCardLookups,
@@ -23,48 +24,19 @@ import {
   isCardInactive,
 } from "./profileSelectors";
 
-// Lazy load modals - only loaded when user opens them
-const ReferralModal = dynamic(() => import("@/components/forms/ReferralModal"), {
-  ssr: false,
-  loading: () => null,
-});
-
-const AddToWalletModal = dynamic(() => import("@/components/wallet/AddToWalletModal"), {
-  ssr: false,
-  loading: () => null,
-});
-
-const EditWalletCardModal = dynamic(() => import("@/components/wallet/EditWalletCardModal"), {
-  ssr: false,
-  loading: () => null,
-});
-
-const BestCardByCategory = dynamic(() => import("@/components/wallet/BestCardByCategory"), {
-  ssr: false,
-  loading: () => null,
-});
-
-const WalletBenefits = dynamic(() => import("@/components/wallet/WalletBenefits"), {
-  ssr: false,
-  loading: () => null,
-});
-
-const SubmitRecordModal = dynamic(() => import("@/components/forms/SubmitRecordModal"), {
-  ssr: false,
-  loading: () => null,
-});
-
-const SubmitRecordCardPicker = dynamic(() => import("@/components/forms/SubmitRecordCardPicker"), {
-  ssr: false,
-  loading: () => null,
-});
-
+const ReferralModal = dynamic(() => import("@/components/forms/ReferralModal"), { ssr: false, loading: () => null });
+const AddToWalletModal = dynamic(() => import("@/components/wallet/AddToWalletModal"), { ssr: false, loading: () => null });
+const EditWalletCardModal = dynamic(() => import("@/components/wallet/EditWalletCardModal"), { ssr: false, loading: () => null });
+const BestCardByCategory = dynamic(() => import("@/components/wallet/BestCardByCategory"), { ssr: false, loading: () => null });
+const WalletBenefits = dynamic(() => import("@/components/wallet/WalletBenefits"), { ssr: false, loading: () => null });
+const SubmitRecordModal = dynamic(() => import("@/components/forms/SubmitRecordModal"), { ssr: false, loading: () => null });
+const SubmitRecordCardPicker = dynamic(() => import("@/components/forms/SubmitRecordCardPicker"), { ssr: false, loading: () => null });
 const RuleProgressChart = dynamic(() => import("@/components/charts/RuleProgressChart"), {
   ssr: false,
-  loading: () => <div className="bg-white rounded-lg border border-gray-200 p-4 h-[250px] animate-pulse" />,
+  loading: () => <div className="cj-rule" style={{ opacity: 0.4 }} />,
 });
 
-interface Record {
+interface RecordItem {
   record_id: number;
   card_name: string;
   card_image_link?: string;
@@ -97,16 +69,30 @@ interface Profile {
   referrals_count: number;
 }
 
+type TabKey = 'cards' | 'rewards' | 'benefits' | 'applications' | 'referrals' | 'settings';
+
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatRenewal(month?: number, year?: number): { display: string; sortKey: number } | null {
+  if (!month || !year) return null;
+  const renewalYear = year + 1;
+  const date = new Date(renewalYear, month - 1, 1);
+  return { display: `${MONTHS_SHORT[month - 1]} ${renewalYear}`, sortKey: date.getTime() };
+}
+
+function daysUntil(timestamp: number): number {
+  return Math.ceil((timestamp - Date.now()) / (1000 * 60 * 60 * 24));
+}
+
 export default function ProfileClient() {
   const { authState, getToken, logout } = useAuth();
   const router = useRouter();
   const [profile, setProfile] = useState<Profile | null>(null);
-  const [records, setRecords] = useState<Record[]>([]);
+  const [records, setRecords] = useState<RecordItem[]>([]);
   const [referrals, setReferrals] = useState<Referral[]>([]);
   const [walletCards, setWalletCards] = useState<WalletCard[]>([]);
   const [allCards, setAllCards] = useState<Card[]>([]);
   const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
-  const [profileLoaded, setProfileLoaded] = useState(false);
   const [walletLoaded, setWalletLoaded] = useState(false);
   const [recordsLoaded, setRecordsLoaded] = useState(false);
   const [referralsLoaded, setReferralsLoaded] = useState(false);
@@ -115,8 +101,9 @@ export default function ProfileClient() {
   const [deletingRecordId, setDeletingRecordId] = useState<number | null>(null);
   const [archivingReferralId, setArchivingReferralId] = useState<number | null>(null);
   const [deletingAccount, setDeletingAccount] = useState(false);
-  const [showInactiveCards, setShowInactiveCards] = useState(false);
-  const [activeTab, setActiveTab] = useState<'wallet' | 'best-for' | 'benefits' | 'records' | 'referrals' | 'applications' | 'settings'>('wallet');
+  const [showArchived, setShowArchived] = useState(false);
+  const [openWalletId, setOpenWalletId] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState<TabKey>('cards');
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [editingCard, setEditingCard] = useState<WalletCard | null>(null);
@@ -124,62 +111,88 @@ export default function ProfileClient() {
   const [showRecordCardPicker, setShowRecordCardPicker] = useState(false);
   const cardLookups = useMemo(() => createCardLookups(allCards), [allCards]);
 
-  // Allow referrals for any card the user has in wallet or has submitted a record for,
-  // excluding cards with an existing active referral.
   const eligibleReferralCards = useMemo(
-    () => getEligibleReferralCards(
-      records,
-      walletCards,
-      referrals.filter((r) => !r.archived_at),
-      cardLookups,
-    ),
+    () => getEligibleReferralCards(records, walletCards, referrals.filter((r) => !r.archived_at), cardLookups),
     [records, walletCards, referrals, cardLookups]
   );
 
-  // Calculate total annual fees for wallet cards
   const totalAnnualFees = useMemo(
     () => getTotalAnnualFees(walletCards, cardLookups),
     [walletCards, cardLookups]
   );
 
-  // Filter wallet cards based on active status
   const { activeWalletCards, inactiveCount } = useMemo(
-    () => getWalletVisibility(walletCards, cardLookups, showInactiveCards),
-    [walletCards, cardLookups, showInactiveCards]
+    () => getWalletVisibility(walletCards, cardLookups, showArchived),
+    [walletCards, cardLookups, showArchived]
   );
 
-  // Helper to check if a card is inactive
   const isInactiveCard = (cardName: string) => isCardInactive(cardName, cardLookups);
 
-  // Track which cards have records or referrals
-  const cardsWithRecords = useMemo(() =>
-    new Set(records.map(r => r.card_name)), [records]);
-  const cardsWithReferrals = useMemo(() =>
-    new Set(referrals.map(r => r.card_name)), [referrals]);
+  const cardsWithRecords = useMemo(() => new Set(records.map(r => r.card_name)), [records]);
+  const cardsWithActiveReferrals = useMemo(
+    () => new Set(referrals.filter(r => !r.archived_at).map(r => r.card_name)),
+    [referrals]
+  );
 
-  // Get cards eligible for record submission (in wallet, no record yet)
   const eligibleRecordCards = useMemo(
     () => getEligibleRecordCards(walletCards, records),
     [walletCards, records]
   );
 
-  // Calculate application rules from wallet cards
-  const applicationRules = useMemo(() => {
-    return calculateApplicationRules(walletCards);
-  }, [walletCards]);
+  const applicationRules = useMemo(() => calculateApplicationRules(walletCards), [walletCards]);
+  const cardsMissingDates = useMemo(() => countCardsMissingDates(walletCards), [walletCards]);
 
-  // Count cards missing acquisition dates
-  const cardsMissingDates = useMemo(() => {
-    return countCardsMissingDates(walletCards);
-  }, [walletCards]);
-
-  // Filter news to cards in user's wallet (only match by card slug, not bank)
   const relevantNews = useMemo(
     () => getRelevantNews(walletCards, newsItems, cardLookups),
     [walletCards, newsItems, cardLookups]
   );
 
-  // Fetch public data client-side on mount — runs immediately, overlaps with Firebase auth
+  // Total annual credits from wallet card benefits (for the snapshot stat)
+  const annualCreditsTotals = useMemo(() => {
+    let total = 0;
+    let cardsWithCredits = 0;
+    for (const wc of walletCards) {
+      const card = cardLookups.byName.get(wc.card_name);
+      if (!card?.benefits?.length) continue;
+      let cardTotal = 0;
+      for (const b of card.benefits) {
+        if (b.value > 0) cardTotal += amortizedAnnualValue(b);
+      }
+      if (cardTotal > 0) {
+        total += cardTotal;
+        cardsWithCredits += 1;
+      }
+    }
+    return { total: Math.round(total), cardsWithCredits };
+  }, [walletCards, cardLookups]);
+
+  // Upcoming renewals — top 3 by date
+  const upcomingRenewals = useMemo(() => {
+    const list: { name: string; renewal: string; fee: number; sortKey: number; daysOut: number }[] = [];
+    for (const wc of walletCards) {
+      if (isInactiveCard(wc.card_name)) continue;
+      const card = cardLookups.byName.get(wc.card_name);
+      const fee = card?.annual_fee ?? 0;
+      if (fee <= 0) continue;
+      const renewal = formatRenewal(wc.acquired_month, wc.acquired_year);
+      if (!renewal) continue;
+      const days = daysUntil(renewal.sortKey);
+      if (days < 0) continue;
+      list.push({
+        name: wc.card_name,
+        renewal: renewal.display,
+        fee,
+        sortKey: renewal.sortKey,
+        daysOut: days,
+      });
+    }
+    list.sort((a, b) => a.sortKey - b.sortKey);
+    return list.slice(0, 3);
+    // Intentionally re-uses isInactiveCard via cardLookups — eslint disable not needed
+  }, [walletCards, cardLookups]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const nextRenewal = upcomingRenewals[0];
+
   useEffect(() => {
     Promise.all([getAllCards(), getNews()])
       .then(([cards, news]) => { setAllCards(cards); setNewsItems(news); })
@@ -195,16 +208,8 @@ export default function ProfileClient() {
     if (authState.isAuthenticated) {
       loadData();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authState.isAuthenticated, authState.isLoading, router]);
-
-  // If the user empties their wallet while on the "Best for" tab (which is
-  // hidden when walletCards is empty), bounce them back to the wallet tab so
-  // they don't end up on a tab that no longer exists in the nav.
-  useEffect(() => {
-    if (activeTab === 'best-for' && walletLoaded && walletCards.length === 0) {
-      setActiveTab('wallet');
-    }
-  }, [activeTab, walletLoaded, walletCards.length]);
 
   const loadData = async () => {
     const token = await getToken();
@@ -213,121 +218,62 @@ export default function ProfileClient() {
       return;
     }
 
-    // Fire all fetches independently — each sets its own loaded state when done
     const loadProfile = async () => {
-      try {
-        const result = await getProfile(token);
-        setProfile(result);
-      } catch (error) {
-        console.error("Profile error:", error);
-      }
-      setProfileLoaded(true);
+      try { setProfile(await getProfile(token)); } catch (e) { console.error("Profile error:", e); }
     };
-
     const loadWallet = async () => {
-      try {
-        const result = await getWallet(token);
-        setWalletCards(result || []);
-      } catch (error) {
-        console.error("Wallet error:", error);
-        setWalletCards([]);
-      }
+      try { setWalletCards(await getWallet(token) || []); } catch (e) { console.error("Wallet error:", e); setWalletCards([]); }
       setWalletLoaded(true);
     };
-
     const loadRecords = async () => {
-      try {
-        const result = await getRecords(token);
-        setRecords(result || []);
-      } catch (error) {
-        console.error("Records error:", error);
-        setRecords([]);
-      }
+      try { setRecords(await getRecords(token) || []); } catch (e) { console.error("Records error:", e); setRecords([]); }
       setRecordsLoaded(true);
     };
-
     const loadReferrals = async () => {
       try {
-        const referralsData = await getReferrals(token);
-        if (Array.isArray(referralsData) && referralsData.length >= 1) {
-          setReferrals(referralsData[0] || []);
-        } else {
-          setReferrals([]);
-        }
-      } catch (error) {
-        console.error("Referrals error:", error);
-        setReferrals([]);
-      }
+        const r = await getReferrals(token);
+        setReferrals(Array.isArray(r) && r.length >= 1 ? (r[0] || []) : []);
+      } catch (e) { console.error("Referrals error:", e); setReferrals([]); }
       setReferralsLoaded(true);
     };
 
-    loadProfile();
-    loadWallet();
-    loadRecords();
-    loadReferrals();
-  };
-
-  const formatAcquiredDate = (month?: number, year?: number) => {
-    if (!month && !year) return null;
-    const monthName = month ? new Date(2000, month - 1).toLocaleString('default', { month: 'short' }) : '';
-    if (month && year) return `${monthName} ${year}`;
-    if (year) return `${year}`;
-    return monthName;
+    loadProfile(); loadWallet(); loadRecords(); loadReferrals();
   };
 
   const handleDeleteRecord = async (recordId: number) => {
-    if (!confirm("Are you sure you want to delete this record?")) {
-      return;
-    }
-
+    if (!confirm("Delete this record?")) return;
     setDeletingRecordId(recordId);
     try {
       const token = await getToken();
-      if (!token) {
-        console.error("No auth token available");
-        return;
-      }
+      if (!token) return;
       await deleteRecord(recordId, token);
-      // Remove the record from local state
       setRecords(records.filter(r => r.record_id !== recordId));
-    } catch (error) {
-      console.error("Error deleting record:", error);
+    } catch (e) {
+      console.error("Error deleting record:", e);
       alert("Failed to delete record. Please try again.");
-    } finally {
-      setDeletingRecordId(null);
-    }
+    } finally { setDeletingRecordId(null); }
   };
 
   const handleArchiveReferral = async (referralId: number) => {
-    if (!confirm("Archive this referral? It will stop being shown to visitors.")) {
-      return;
-    }
-
+    if (!confirm("Archive this referral?")) return;
     setArchivingReferralId(referralId);
     try {
       const token = await getToken();
       if (!token) return;
       await archiveReferral(referralId, token);
       setReferrals(referrals.filter(r => r.referral_id !== referralId));
-    } catch (error) {
-      console.error("Error archiving referral:", error);
+    } catch (e) {
+      console.error("Error archiving referral:", e);
       alert("Failed to archive referral. Please try again.");
-    } finally {
-      setArchivingReferralId(null);
-    }
+    } finally { setArchivingReferralId(null); }
   };
 
   const handleDeleteAccount = async () => {
     if (deleteConfirmText !== 'DELETE') return;
-
     setDeletingAccount(true);
     try {
       const token = await getToken();
-      if (!token) {
-        alert("No auth token available");
-        return;
-      }
-
+      if (!token) { alert("No auth token available"); return; }
       await deleteAccount(token);
       alert("Your account has been deleted. Thank you for contributing to CreditOdds.");
       await logout();
@@ -342,851 +288,801 @@ export default function ProfileClient() {
     }
   };
 
-  if (authState.isLoading) {
-    return <ProfileSkeleton />;
-  }
-
-  if (!authState.isAuthenticated) {
-    return null;
-  }
-
-  const tabs: { key: typeof activeTab; label: string; icon: typeof WalletIcon; count?: number }[] = [
-    { key: 'wallet', label: 'Wallet', icon: WalletIcon, count: walletCards.length },
-    // "Best for" only shows when the user has cards — empty state is uninformative.
-    ...(walletCards.length > 0
-      ? [{ key: 'best-for' as const, label: 'Best for', icon: TrophyIcon }]
-      : []),
-    { key: 'benefits', label: 'Benefits', icon: GiftIcon },
-    { key: 'records', label: 'Records', icon: DocumentTextIcon, count: records.length },
-    { key: 'referrals', label: 'Referrals', icon: LinkIcon, count: referrals.filter(r => !r.archived_at).length },
-    { key: 'applications', label: 'Applications', icon: ChartBarIcon },
-    { key: 'settings', label: 'Settings', icon: Cog6ToothIcon },
-  ];
+  if (authState.isLoading) return <ProfileSkeleton />;
+  if (!authState.isAuthenticated) return null;
 
   const displayName = authState.user?.displayName || authState.user?.email?.split('@')[0] || 'there';
+  const handle = profile?.username || authState.user?.email?.split('@')[0] || '';
+  const activeReferralsCount = referrals.filter(r => !r.archived_at).length;
+  const visibleWalletCards = activeWalletCards;
+
+  const tabs: { key: TabKey; num: string; label: string; count: string }[] = [
+    { key: 'cards', num: '01', label: 'Cards', count: walletCards.length ? `${walletCards.length} cards` : '' },
+    { key: 'rewards', num: '02', label: 'Rewards', count: '' },
+    { key: 'benefits', num: '03', label: 'Benefits', count: '' },
+    { key: 'applications', num: '04', label: 'Applications', count: records.length ? `${records.length} records` : '' },
+    { key: 'referrals', num: '05', label: 'Referrals', count: activeReferralsCount ? `${activeReferralsCount} links` : '' },
+    { key: 'settings', num: '06', label: 'Settings', count: '' },
+  ];
 
   return (
     <div className="landing-v2 profile-v2">
-      <div className="profile-wrap">
-        {/* Profile page hero */}
-        <section className="profile-hero">
-          <h1 className="profile-greeting">
-            Welcome back, <em>{displayName}.</em>
-          </h1>
-          {authState.user?.email && (
-            <p className="profile-email">{authState.user.email}</p>
-          )}
-          <div className="profile-stats">
-            <div className="pstat">
-              <span className="k">Cards in wallet</span>
-              <span className="v accent">{walletCards.length}</span>
-            </div>
-            <div className="pstat">
-              <span className="k">Annual fees</span>
-              <span className={'v ' + (totalAnnualFees > 0 ? 'warn' : '')}>
-                ${totalAnnualFees.toLocaleString()}
-              </span>
-            </div>
-            <div className="pstat">
-              <span className="k">Records submitted</span>
-              <span className="v">{records.length}</span>
-            </div>
-            <div className="pstat">
-              <span className="k">Active referrals</span>
-              <span className="v">{referrals.filter(r => !r.archived_at).length}</span>
-            </div>
-          </div>
-        </section>
-
-        {/* Tabs */}
-        <nav className="profile-tabs" aria-label="Profile sections">
-          {tabs.map((t) => {
-            const Icon = t.icon;
-            return (
-              <button
-                key={t.key}
-                type="button"
-                onClick={() => setActiveTab(t.key)}
-                className={'profile-tab ' + (activeTab === t.key ? 'active' : '')}
-              >
-                <Icon />
-                {t.label}
-                {typeof t.count === 'number' && (
-                  <span className="tab-count">{t.count}</span>
-                )}
-              </button>
-            );
-          })}
+      {/* Terminal strip — dark bar with breadcrumb + status */}
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <span className="cj-crumb cj-crumb-current">Profile</span>
         </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
+          <span>
+            <span className="cj-status-dot" />
+            verified{authState.user?.email ? ` · ${authState.user.email}` : ''}
+          </span>
+        </div>
+      </div>
 
-        {/* Main Content Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Tabs Content - Full width on mobile, 2/3 on desktop */}
-          <div className="col-span-1 lg:col-span-2">
-        {/* Tab Content */}
-        {activeTab === 'wallet' && (
-          !walletLoaded ? (
-          <div className="bg-white shadow rounded-lg p-6">
-            <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+      <div className="cj-layout">
+        <main className="cj-main">
+          {/* Snapshot header — tight welcome row */}
+          <div className="cj-snapshot">
+            <div className="cj-snapshot-row">
+              <h1 className="cj-snapshot-h1">
+                Welcome back, <em>{displayName}.</em>
+              </h1>
+              {handle && (
+                <div className="cj-snapshot-meta">@{handle}</div>
+              )}
+            </div>
+
+            <div className="cj-readoff">
+              <div className="cj-readoff-cell">
+                <div className="cj-readoff-k">Active cards</div>
+                <div className="cj-readoff-v">{walletCards.length - inactiveCount}</div>
+                <div className="cj-readoff-foot">
+                  {inactiveCount > 0 ? `+${inactiveCount} archived` : 'in wallet'}
+                </div>
+              </div>
+              <div className="cj-readoff-cell">
+                <div className="cj-readoff-k">Annual fees</div>
+                <div className={"cj-readoff-v " + (totalAnnualFees > 0 ? "cj-warn" : "")}>
+                  ${totalAnnualFees.toLocaleString()}
+                </div>
+                <div className="cj-readoff-foot">per year</div>
+              </div>
+              <div className="cj-readoff-cell">
+                <div className="cj-readoff-k">Annual credits</div>
+                <div className="cj-readoff-v cj-accent">
+                  ${annualCreditsTotals.total.toLocaleString()}
+                </div>
+                <div className="cj-readoff-foot">
+                  {annualCreditsTotals.cardsWithCredits > 0
+                    ? `across ${annualCreditsTotals.cardsWithCredits} card${annualCreditsTotals.cardsWithCredits === 1 ? '' : 's'}`
+                    : 'no credits yet'}
+                </div>
+              </div>
+              <div className="cj-readoff-cell cj-readoff-bonus">
+                <div className="cj-readoff-k">Next renewal</div>
+                <div className="cj-readoff-v">
+                  {nextRenewal ? nextRenewal.renewal.split(' ')[0] + ' ' + nextRenewal.renewal.split(' ')[1].slice(2) : '—'}
+                </div>
+                <div className="cj-readoff-foot">
+                  {nextRenewal ? `${nextRenewal.name.replace(/ Card$/, '')} · $${nextRenewal.fee}` : 'no fee renewals'}
+                </div>
+              </div>
+              <div className="cj-readoff-cell">
+                <div className="cj-readoff-k">Records</div>
+                <div className="cj-readoff-v">{records.length}</div>
+                <div className="cj-readoff-foot">
+                  {(() => {
+                    const approved = records.filter(r => r.result).length;
+                    const denied = records.length - approved;
+                    return records.length ? `${approved} approved · ${denied} denied` : 'submit a record';
+                  })()}
+                </div>
+              </div>
             </div>
           </div>
-          ) : (
-          <>
-          <div className="bg-white shadow rounded-lg p-6">
-          <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-gray-900">My Cards</h2>
+
+          {/* Tab row */}
+          <div className="cj-main-tabs">
+            {tabs.map((it) => (
               <button
-                onClick={() => setShowWalletModal(true)}
-                className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                key={it.key}
+                type="button"
+                className={'cj-main-tab' + (activeTab === it.key ? ' active' : '')}
+                onClick={() => setActiveTab(it.key)}
               >
-                <PlusIcon className="h-4 w-4 mr-1" />
-                Add Card
+                <span className="cj-main-tab-num">{it.num}</span>
+                {it.label}
+                {it.count && <span className="cj-main-tab-count">· {it.count}</span>}
               </button>
-            </div>
-
-          {/* Show inactive cards toggle */}
-          {inactiveCount > 0 && (
-            <div className="mb-4">
-              <label className="inline-flex items-center cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={showInactiveCards}
-                  onChange={(e) => setShowInactiveCards(e.target.checked)}
-                  className="sr-only peer"
-                />
-                <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-indigo-600"></div>
-                <span className="ms-3 text-sm text-gray-500">
-                  Show inactive cards ({inactiveCount})
-                </span>
-              </label>
-            </div>
-          )}
-
-          {activeWalletCards.length > 0 ? (
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-              {activeWalletCards.map((card) => {
-                            const inactive = isInactiveCard(card.card_name);
-                return (
-                  <button
-                    key={card.id}
-                    onClick={() => setEditingCard(card)}
-                    className={`relative text-left rounded-lg p-3 transition-colors cursor-pointer ${inactive ? 'bg-gray-100 opacity-60' : 'bg-gray-50 hover:bg-gray-100'}`}
-                  >
-                    <div className="aspect-[1.586/1] relative mb-2">
-                      <CardImage
-                        cardImageLink={card.card_image_link}
-                        alt={card.card_name}
-                        fill
-                        className={`object-contain ${inactive ? 'grayscale' : ''}`}
-                        sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 20vw"
-                      />
-                      {inactive && (
-                        <span className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gray-500 px-1.5 py-0.5 rounded-full text-xs font-medium text-white shadow-sm">
-                          Inactive
-                        </span>
-                      )}
-                      {/* Record and Referral indicators */}
-                      <div className="absolute top-0 left-0 flex gap-0.5">
-                        {cardsWithRecords.has(card.card_name) && (
-                          <span className="bg-green-500 p-0.5 rounded-full shadow-sm" title="Record submitted">
-                            <DocumentTextIcon className="h-3 w-3 text-white" />
-                          </span>
-                        )}
-                        {cardsWithReferrals.has(card.card_name) && (
-                          <span className="bg-green-500 p-0.5 rounded-full shadow-sm" title="Referral submitted">
-                            <LinkIcon className="h-3 w-3 text-white" />
-                          </span>
-                        )}
-                      </div>
-                      {(() => {
-                        const cardData = allCards.find(c => c.card_name === card.card_name);
-                        const annualFee = cardData?.annual_fee || 0;
-                        return annualFee > 0 ? (
-                          <span className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 bg-white px-1.5 py-0.5 rounded-full text-xs font-medium text-red-600 shadow-sm">
-                            ${annualFee}
-                          </span>
-                        ) : null;
-                      })()}
-                    </div>
-                    <p className="text-xs font-medium text-gray-900 truncate">{card.card_name}</p>
-                    <p className="text-xs text-gray-500">{card.bank}</p>
-                  </button>
-                );
-              })}
-            </div>
-          ) : walletCards.length > 0 ? (
-            <div className="text-center py-8">
-              <WalletIcon className="mx-auto h-12 w-12 text-gray-300" />
-              <p className="mt-2 text-gray-500">All {walletCards.length} cards are inactive.</p>
-              <p className="text-sm text-gray-400">Toggle &quot;Show inactive cards&quot; above to see them.</p>
-            </div>
-          ) : (
-            <div className="text-center py-8">
-              <WalletIcon className="mx-auto h-12 w-12 text-gray-300" />
-              <p className="mt-2 text-gray-500">No cards in your wallet yet.</p>
-              <p className="text-sm text-gray-400">Add the credit cards you own to track your collection.</p>
-            </div>
-          )}
+            ))}
           </div>
-          </>
-          )
-        )}
 
-        {/* Best For Tab */}
-        {activeTab === 'best-for' && (
-          !walletLoaded ? (
-          <div className="bg-white shadow rounded-lg p-6">
-            <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
-            </div>
-          </div>
-          ) : (
-          <BestCardByCategory walletCards={walletCards} allCards={allCards} />
-          )
-        )}
+          <div className="cj-main-content">
+            {activeTab === 'cards' && (
+              <CardsTab
+                walletLoaded={walletLoaded}
+                walletCards={walletCards}
+                visibleWalletCards={visibleWalletCards}
+                inactiveCount={inactiveCount}
+                showArchived={showArchived}
+                setShowArchived={setShowArchived}
+                openWalletId={openWalletId}
+                setOpenWalletId={setOpenWalletId}
+                cardLookups={cardLookups}
+                cardsWithRecords={cardsWithRecords}
+                cardsWithActiveReferrals={cardsWithActiveReferrals}
+                totalAnnualFees={totalAnnualFees}
+                onAdd={() => setShowWalletModal(true)}
+                onEdit={(c) => setEditingCard(c)}
+                onSubmitRecord={(c) => setSubmitRecordCard(c)}
+                onAddReferral={() => setShowReferralModal(true)}
+              />
+            )}
 
-        {/* Benefits Tab */}
-        {activeTab === 'benefits' && (
-          !walletLoaded ? (
-          <div className="bg-white shadow rounded-lg p-6">
-            <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
-            </div>
-          </div>
-          ) : (
-          <WalletBenefits walletCards={walletCards} allCards={allCards} />
-          )
-        )}
+            {activeTab === 'rewards' && (
+              !walletLoaded ? <LoadingPanel /> :
+              <BestCardByCategory walletCards={walletCards} allCards={allCards} />
+            )}
 
-        {/* Records Tab */}
-        {activeTab === 'records' && (
-          !recordsLoaded ? (
-          <div className="bg-white shadow rounded-lg p-6">
-            <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
-            </div>
+            {activeTab === 'benefits' && (
+              !walletLoaded ? <LoadingPanel /> :
+              <WalletBenefits walletCards={walletCards} allCards={allCards} />
+            )}
+
+            {activeTab === 'applications' && (
+              <ApplicationsTab
+                recordsLoaded={recordsLoaded}
+                walletLoaded={walletLoaded}
+                records={records}
+                walletCards={walletCards}
+                applicationRules={applicationRules}
+                cardsMissingDates={cardsMissingDates}
+                onPickCard={() => setShowRecordCardPicker(true)}
+                onDeleteRecord={handleDeleteRecord}
+                deletingRecordId={deletingRecordId}
+                eligibleRecordCards={eligibleRecordCards}
+              />
+            )}
+
+            {activeTab === 'referrals' && (
+              <ReferralsTab
+                referralsLoaded={referralsLoaded}
+                referrals={referrals}
+                eligibleReferralCards={eligibleReferralCards}
+                onAddReferral={() => setShowReferralModal(true)}
+                onArchive={handleArchiveReferral}
+                archivingReferralId={archivingReferralId}
+              />
+            )}
+
+            {activeTab === 'settings' && (
+              <SettingsTab
+                profile={profile}
+                email={authState.user?.email}
+                handle={handle}
+                confirmingDelete={confirmingDelete}
+                setConfirmingDelete={setConfirmingDelete}
+                deleteConfirmText={deleteConfirmText}
+                setDeleteConfirmText={setDeleteConfirmText}
+                deletingAccount={deletingAccount}
+                onDeleteAccount={handleDeleteAccount}
+                onLogout={() => { logout().then(() => router.push("/")); }}
+              />
+            )}
           </div>
-          ) : (
-          <div className="bg-white shadow rounded-lg overflow-hidden">
-            <div className="px-4 py-5 sm:px-6">
-              <h2 className="text-lg font-semibold text-gray-900">Your Records</h2>
-              <p className="mt-1 text-sm text-gray-500">Your submitted application data points</p>
+        </main>
+
+        <aside className="cj-rail">
+          <div className="cj-apply">
+            <div className="cj-apply-k">Wallet</div>
+            <div className="cj-apply-v">
+              {walletCards.length} card{walletCards.length === 1 ? '' : 's'}
             </div>
-          {records.length > 0 ? (
-            <div className="border-t border-gray-200">
-              {/* Mobile: Card layout */}
-              <div className="sm:hidden divide-y divide-gray-200">
-                {records.map((record, index) => (
-                  <div key={record.record_id || index} className="p-4">
-                    <div className="flex items-start gap-3">
-                      <div className="flex-shrink-0 h-12 w-20 relative">
-                        <CardImage
-                          className="object-contain"
-                          cardImageLink={record.card_image_link}
-                          alt={record.card_name}
-                          fill
-                          sizes="80px"
-                        />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-start justify-between">
-                          <p className="text-sm font-medium text-gray-900 truncate">{record.card_name}</p>
-                          <span
-                            className={`ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                              record.result
-                                ? "bg-green-100 text-green-800"
-                                : "bg-red-100 text-red-800"
-                            }`}
-                          >
-                            {record.result ? "Approved" : "Rejected"}
-                          </span>
-                        </div>
-                        <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
-                          <span>Score: <span className="font-medium text-gray-700">{record.credit_score}</span></span>
-                          <span>Income: <span className="font-medium text-gray-700">${record.listed_income?.toLocaleString()}</span></span>
-                        </div>
-                        <div className="mt-1 flex items-center justify-between">
-                          <span className="text-xs text-gray-400">
-                            {new Date(record.submit_datetime).toLocaleDateString()}
-                          </span>
-                          <button
-                            onClick={() => handleDeleteRecord(record.record_id)}
-                            disabled={deletingRecordId === record.record_id}
-                            className="text-xs text-red-600 hover:text-red-900 disabled:opacity-50"
-                          >
-                            {deletingRecordId === record.record_id ? "Deleting..." : "Delete"}
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-              {/* Desktop: Table layout */}
-              <div className="hidden sm:block overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500">
-                        Card
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500">
-                        Credit Score
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500">
-                        Income
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500">
-                        Result
-                      </th>
-                      <th className="relative px-6 py-3">
-                        <span className="sr-only">Delete</span>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
-                    {records.map((record, index) => (
-                      <tr key={record.record_id || index}>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="flex items-center">
-                            <div className="flex-shrink-0 h-10 w-16 relative">
-                              <CardImage
-                                className="object-contain"
-                                cardImageLink={record.card_image_link}
-                                alt={record.card_name}
-                                fill
-                                sizes="64px"
-                              />
-                            </div>
-                            <div className="ml-4">
-                              <div className="text-sm font-medium text-gray-900">
-                                {record.card_name}
-                              </div>
-                              <div className="text-sm text-gray-500">
-                                Submitted: {new Date(record.submit_datetime).toLocaleDateString()}
-                              </div>
-                              {record.date_applied && (
-                                <div className="text-sm text-gray-500">
-                                  Applied: {new Date(record.date_applied).toLocaleDateString()}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {record.credit_score}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          ${record.listed_income?.toLocaleString()}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <span
-                            className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                              record.result
-                                ? "bg-green-100 text-green-800"
-                                : "bg-red-100 text-red-800"
-                            }`}
-                          >
-                            {record.result ? "Approved" : "Rejected"}
-                          </span>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                          <button
-                            onClick={() => handleDeleteRecord(record.record_id)}
-                            disabled={deletingRecordId === record.record_id}
-                            className="text-red-600 hover:text-red-900 disabled:opacity-50"
-                          >
-                            {deletingRecordId === record.record_id ? "Deleting..." : "Delete"}
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          ) : (
-            <div className="border-t border-gray-200 px-4 py-5 sm:px-6">
-              <p className="text-gray-500">No records submitted yet.</p>
-            </div>
-          )}
-          <div className="border-t border-gray-200">
-            {eligibleRecordCards.length > 0 ? (
+            <button type="button" className="cj-apply-btn" onClick={() => setShowWalletModal(true)}>
+              + add a card
+            </button>
+            {eligibleRecordCards.length > 0 && (
               <button
+                type="button"
+                className="cj-apply-btn-outline"
                 onClick={() => setShowRecordCardPicker(true)}
-                className="block w-full bg-gray-50 text-sm font-medium text-gray-500 text-center px-4 py-4 hover:text-gray-700 sm:rounded-b-lg cursor-pointer"
               >
-                Submit a data point
+                submit a record
               </button>
-            ) : walletCards.length > 0 ? (
-              <div className="bg-gray-50 text-sm text-gray-400 text-center px-4 py-4 sm:rounded-b-lg">
-                You&apos;ve submitted records for all cards in your wallet
-              </div>
+            )}
+          </div>
+
+          {upcomingRenewals.length > 0 && (
+            <div className="cj-rail-block">
+              <div className="cj-rail-label">Upcoming renewals</div>
+              <ul className="cj-rail-list">
+                {upcomingRenewals.map((r) => (
+                  <li key={r.name} className="cj-rail-row">
+                    <div className="cj-rail-row-meta">
+                      <span className="cj-rail-row-date">{r.renewal.split(' ')[0]} {r.renewal.split(' ')[1].slice(2)}</span>
+                      <span className="cj-rail-row-field">{r.name.replace(/ Card$/, '')}</span>
+                    </div>
+                    <div className="cj-rail-row-detail">
+                      ${r.fee.toLocaleString()} · in {r.daysOut} day{r.daysOut === 1 ? '' : 's'}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="cj-rail-block">
+            <div className="cj-rail-label">News for you</div>
+            {relevantNews.length > 0 ? (
+              <ul className="cj-rail-list">
+                {relevantNews.slice(0, 5).map((n) => (
+                  <li key={n.id} className="cj-rail-row">
+                    <div className="cj-rail-row-meta">
+                      <span className="cj-rail-row-date">
+                        {new Date(n.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                      </span>
+                      {n.tags?.[0] && (
+                        <span className="cj-news-tag">{tagLabels[n.tags[0]]?.toLowerCase() || n.tags[0]}</span>
+                      )}
+                    </div>
+                    <Link href={`/news/${n.id}`} className="cj-rail-row-link">{n.title}</Link>
+                    {n.card_names && n.card_names[0] && (
+                      <div className="cj-rail-row-detail">{n.card_names[0]}</div>
+                    )}
+                  </li>
+                ))}
+              </ul>
             ) : (
-              <div className="bg-gray-50 text-sm text-gray-400 text-center px-4 py-4 sm:rounded-b-lg">
-                Add a card to your wallet to submit a data point
+              <div className="cj-rail-row-detail" style={{ paddingTop: 6 }}>
+                {walletCards.length === 0
+                  ? 'add cards to see news for them'
+                  : 'no recent news for your cards'}
               </div>
             )}
           </div>
-          </div>
-          )
+
+          <Link href="/news" className="cj-rail-cta">view all news</Link>
+        </aside>
+      </div>
+
+      <V2Footer />
+
+      {/* Modals */}
+      <ReferralModal
+        show={showReferralModal}
+        handleClose={() => setShowReferralModal(false)}
+        openReferrals={eligibleReferralCards}
+        onSuccess={loadData}
+      />
+      <AddToWalletModal
+        show={showWalletModal}
+        onClose={() => setShowWalletModal(false)}
+        onSuccess={loadData}
+        existingCardIds={walletCards.map(c => c.card_id)}
+      />
+      <EditWalletCardModal
+        show={!!editingCard}
+        card={editingCard}
+        cardSlug={editingCard ? allCards.find(c => c.card_name === editingCard.card_name)?.slug : undefined}
+        onClose={() => setEditingCard(null)}
+        onSuccess={loadData}
+      />
+      <SubmitRecordCardPicker
+        show={showRecordCardPicker}
+        onClose={() => setShowRecordCardPicker(false)}
+        cards={eligibleRecordCards}
+        onSelectCard={(card) => setSubmitRecordCard(card)}
+      />
+      {submitRecordCard && (
+        <SubmitRecordModal
+          show={!!submitRecordCard}
+          handleClose={() => setSubmitRecordCard(null)}
+          card={{
+            card_id: submitRecordCard.card_id,
+            card_name: submitRecordCard.card_name,
+            card_image_link: submitRecordCard.card_image_link,
+            bank: submitRecordCard.bank,
+          }}
+          onSuccess={loadData}
+        />
+      )}
+    </div>
+  );
+}
+
+function LoadingPanel() {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '48px 0' }}>
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+    </div>
+  );
+}
+
+/* ========== Cards tab ========== */
+interface CardsTabProps {
+  walletLoaded: boolean;
+  walletCards: WalletCard[];
+  visibleWalletCards: WalletCard[];
+  inactiveCount: number;
+  showArchived: boolean;
+  setShowArchived: (v: boolean) => void;
+  openWalletId: number | null;
+  setOpenWalletId: (v: number | null) => void;
+  cardLookups: ReturnType<typeof createCardLookups>;
+  cardsWithRecords: Set<string>;
+  cardsWithActiveReferrals: Set<string>;
+  totalAnnualFees: number;
+  onAdd: () => void;
+  onEdit: (c: WalletCard) => void;
+  onSubmitRecord: (c: WalletCard) => void;
+  onAddReferral: () => void;
+}
+
+function CardsTab(props: CardsTabProps) {
+  const {
+    walletLoaded, walletCards, visibleWalletCards, inactiveCount, showArchived, setShowArchived,
+    openWalletId, setOpenWalletId, cardLookups, cardsWithRecords, cardsWithActiveReferrals,
+    totalAnnualFees, onAdd, onEdit, onSubmitRecord, onAddReferral,
+  } = props;
+
+  if (!walletLoaded) return <LoadingPanel />;
+
+  if (walletCards.length === 0) {
+    return (
+      <div className="cj-verdict">
+        <b>No cards in your wallet yet.</b> Add the credit cards you own to track fees, renewals, and benefits.
+        <div style={{ marginTop: 12 }}>
+          <button type="button" className="cj-inline-cta" onClick={onAdd}>+ add a card</button>
+        </div>
+      </div>
+    );
+  }
+
+  const activeCount = walletCards.length - inactiveCount;
+
+  return (
+    <section className="cj-section">
+      <div className="cj-wallet-toolbar">
+        <div className="cj-table-label">
+          {activeCount} active{inactiveCount > 0 ? ` · ${inactiveCount} archived` : ''} · ${totalAnnualFees.toLocaleString()}/yr in fees
+        </div>
+        <span className="cj-wallet-toolbar-spacer" />
+        {inactiveCount > 0 && (
+          <button type="button" className="cj-archived-toggle" onClick={() => setShowArchived(!showArchived)}>
+            {showArchived ? 'hide archived' : `show ${inactiveCount} archived`}
+          </button>
         )}
+        <button type="button" className="cj-inline-cta" onClick={onAdd}>+ add a card</button>
+      </div>
 
-        {/* Referrals Tab */}
-        {activeTab === 'referrals' && (
-          !referralsLoaded ? (
-          <div className="bg-white shadow rounded-lg p-6">
-            <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
-            </div>
-          </div>
-          ) : (
-          <div className="bg-white shadow rounded-lg overflow-hidden">
-            <div className="px-4 py-5 sm:px-6">
-              <h2 className="text-lg font-semibold text-gray-900">Your Referrals</h2>
-            <p className="mt-1 max-w-2xl text-sm text-gray-500">
-              Submit your full referral URL for any card in your wallet or with a submitted record.
-            </p>
-          </div>
-          {(() => {
-            const activeReferrals = referrals.filter(r => !r.archived_at);
-            const adminArchived = referrals.filter(r => r.archived_at && r.archived_reason);
+      <div className="cj-wallet-tape">
+        <div className="cj-wallet-head">
+          <div></div>
+          <div>Card</div>
+          <div>Renewal</div>
+          <div className="cj-tr">Fee</div>
+          <div></div>
+          <div></div>
+        </div>
+        {visibleWalletCards.map((c) => {
+          const isOpen = openWalletId === c.id;
+          const card = cardLookups.byName.get(c.card_name);
+          const fee = card?.annual_fee ?? 0;
+          const archived = card?.active === false;
+          const renewal = formatRenewal(c.acquired_month, c.acquired_year);
+          const renewalDisplay = renewal ? renewal.display : '—';
+          const acquiredLabel = (() => {
+            if (!c.acquired_month && !c.acquired_year) return null;
+            const m = c.acquired_month ? MONTHS_SHORT[c.acquired_month - 1] : '';
+            return c.acquired_year ? `${m ? m + ' ' : ''}${c.acquired_year}` : m;
+          })();
+          const hasRecord = cardsWithRecords.has(c.card_name);
+          const hasReferral = cardsWithActiveReferrals.has(c.card_name);
+          const slug = card?.slug;
 
-            const renderReferralRow = (referral: Referral) => (
-              <tr key={referral.referral_id}>
-                <td className="px-4 py-3 whitespace-nowrap">
-                  <div className="flex items-center">
-                    <div className="flex-shrink-0 h-8 w-12 relative">
-                      <CardImage
-                        className="object-contain"
-                        cardImageLink={referral.card_image_link}
-                        alt={referral.card_name}
-                        fill
-                        sizes="48px"
-                      />
+          return (
+            <Fragment key={c.id}>
+              <button
+                type="button"
+                className={'cj-wallet-crow' + (isOpen ? ' is-open' : '') + (archived ? ' is-archived' : '')}
+                onClick={() => setOpenWalletId(isOpen ? null : c.id)}
+                aria-expanded={isOpen}
+              >
+                <span className="cj-cw-thumb">
+                  <CardImage cardImageLink={c.card_image_link} alt={c.card_name} fill sizes="36px" className="object-contain" />
+                </span>
+                <div className="cj-cw-name">
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{c.card_name}</span>
+                  <span className="cj-cw-marks">
+                    {hasRecord && (
+                      <span className="cj-cw-mark" title="record submitted" aria-label="record submitted">
+                        <DocumentTextIcon style={{ width: 11, height: 11 }} />
+                      </span>
+                    )}
+                    {hasReferral && (
+                      <span className="cj-cw-mark" title="referral active" aria-label="referral active">
+                        <LinkIcon style={{ width: 11, height: 11 }} />
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <div className="cj-cw-renew">{renewalDisplay}</div>
+                <div className={'cj-cw-fee' + (fee === 0 ? ' cj-cw-zero' : '')}>
+                  {fee === 0 ? '$0' : '$' + fee.toLocaleString()}
+                </div>
+                <div className="cj-cw-issuer">{c.bank}</div>
+                <div className="cj-cw-caret">›</div>
+              </button>
+              {isOpen && (
+                <div className="cj-wallet-detail">
+                  <div className="cj-wd-meta">
+                    <div>
+                      <div className="cj-wd-k">Issuer</div>
+                      <div className="cj-wd-v">{c.bank}</div>
                     </div>
-                    <div className="ml-3">
-                      <div className="text-sm font-medium text-gray-900">{referral.card_name}</div>
+                    <div>
+                      <div className="cj-wd-k">Opened</div>
+                      <div className="cj-wd-v">{acquiredLabel || '—'}</div>
+                    </div>
+                    <div>
+                      <div className="cj-wd-k">Renewal</div>
+                      <div className="cj-wd-v">{renewalDisplay}</div>
+                    </div>
+                    <div>
+                      <div className="cj-wd-k">Annual fee</div>
+                      <div className="cj-wd-v">{fee === 0 ? '$0 · no fee' : '$' + fee.toLocaleString()}</div>
                     </div>
                   </div>
-                </td>
-                <td className="px-4 py-3">
-                  <a href={referral.referral_link} target="_blank" rel="noreferrer"
-                    className="text-sm text-indigo-600 hover:text-indigo-900 truncate block max-w-[200px]">
-                    {referral.referral_link}
-                  </a>
-                </td>
-                <td className="px-4 py-3 whitespace-nowrap">
-                  {referral.admin_approved ? (
-                    <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                      Approved
-                    </span>
-                  ) : (
-                    <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                      Pending
-                    </span>
-                  )}
-                </td>
-                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
-                  <div>{referral.impressions ?? 0} views</div>
-                  <div>{referral.clicks ?? 0} clicks</div>
-                </td>
-                <td className="px-4 py-3 whitespace-nowrap text-right text-sm font-medium">
-                  <button
-                    onClick={() => handleArchiveReferral(referral.referral_id)}
-                    disabled={archivingReferralId === referral.referral_id}
-                    className="text-gray-500 hover:text-gray-700 disabled:opacity-50"
-                    title="Archive"
-                  >
-                    {archivingReferralId === referral.referral_id ? "..." : <ArchiveBoxIcon className="h-4 w-4 inline" />}
-                  </button>
-                </td>
-              </tr>
-            );
-
-            const renderReferralMobileCard = (referral: Referral) => (
-              <div key={referral.referral_id} className="p-4">
-                <div className="flex items-start gap-3">
-                  <div className="flex-shrink-0 h-12 w-20 relative">
-                    <CardImage
-                      className="object-contain"
-                      cardImageLink={referral.card_image_link}
-                      alt={referral.card_name}
-                      fill
-                      sizes="80px"
-                    />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-start justify-between">
-                      <p className="text-sm font-medium text-gray-900 truncate">{referral.card_name}</p>
-                      {referral.admin_approved ? (
-                        <span className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                          Approved
-                        </span>
-                      ) : (
-                        <span className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                          Pending
-                        </span>
-                      )}
-                    </div>
-                    <a href={referral.referral_link} target="_blank" rel="noreferrer"
-                      className="mt-1 text-xs text-indigo-600 hover:text-indigo-900 truncate block">
-                      {referral.referral_link}
-                    </a>
-                    <div className="mt-1 flex items-center justify-between">
-                      <div className="flex gap-3 text-xs text-gray-500">
-                        <span>{referral.impressions ?? 0} views</span>
-                        <span>{referral.clicks ?? 0} clicks</span>
-                      </div>
-                      <button
-                        onClick={() => handleArchiveReferral(referral.referral_id)}
-                        disabled={archivingReferralId === referral.referral_id}
-                        className="text-xs text-gray-500 hover:text-gray-700 disabled:opacity-50"
-                      >
-                        {archivingReferralId === referral.referral_id ? "..." : "Archive"}
+                  <div className="cj-wd-actions">
+                    {slug && <Link href={`/card/${slug}`}>view card page →</Link>}
+                    <button type="button" onClick={() => onEdit(c)}>edit</button>
+                    {!hasRecord && (
+                      <button type="button" className="cj-wd-cta" onClick={() => onSubmitRecord(c)}>
+                        + submit a record
                       </button>
-                    </div>
+                    )}
+                    {hasRecord && <span className="cj-wd-done">✓ record submitted</span>}
+                    {!hasReferral && (
+                      <button type="button" className="cj-wd-cta" onClick={onAddReferral}>
+                        + add referral link
+                      </button>
+                    )}
+                    {hasReferral && <span className="cj-wd-done">✓ referral link active</span>}
                   </div>
                 </div>
-              </div>
-            );
-
-            return (
-              <>
-                {activeReferrals.length > 0 ? (
-                  <div className="border-t border-gray-200">
-                    <div className="sm:hidden divide-y divide-gray-200">
-                      {activeReferrals.map(r => renderReferralMobileCard(r))}
-                    </div>
-                    <div className="hidden sm:block">
-                      <table className="min-w-full divide-y divide-gray-200">
-                        <thead className="bg-gray-50">
-                          <tr>
-                            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Card</th>
-                            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Referral Link</th>
-                            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Status</th>
-                            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Stats</th>
-                            <th className="relative px-4 py-3"><span className="sr-only">Actions</span></th>
-                          </tr>
-                        </thead>
-                        <tbody className="bg-white divide-y divide-gray-200">
-                          {activeReferrals.map(r => renderReferralRow(r))}
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="border-t border-gray-200 px-4 py-5 sm:px-6">
-                    <p className="text-gray-500">No active referrals.</p>
-                  </div>
-                )}
-
-                {adminArchived.length > 0 && (
-                  <div className="border-t border-gray-200 px-4 py-3 sm:px-6 bg-amber-50">
-                    <p className="text-sm text-amber-700">
-                      {adminArchived.length === 1
-                        ? `Your referral for ${adminArchived[0].card_name} was removed because the link was no longer working. You can submit a new one anytime.`
-                        : `${adminArchived.length} of your referrals were removed because the links were no longer working. You can submit new ones anytime.`}
-                    </p>
-                  </div>
-                )}
-
-                <div className="border-t border-gray-200">
-                  {eligibleReferralCards.length > 0 ? (
-                    <button
-                      onClick={() => setShowReferralModal(true)}
-                      className="block w-full bg-gray-50 text-sm font-medium text-gray-500 text-center px-4 py-4 hover:text-gray-700 sm:rounded-b-lg cursor-pointer"
-                    >
-                      Submit a referral
-                    </button>
-                  ) : (
-                    <div className="bg-gray-50 text-sm text-gray-400 text-center px-4 py-4 sm:rounded-b-lg">
-                      Add a card to your wallet or submit a data point to add your referral link
-                    </div>
-                  )}
-                </div>
-              </>
-            );
-          })()}
+              )}
+            </Fragment>
+          );
+        })}
+        {!showArchived && inactiveCount > 0 && (
+          <div className="cj-wallet-arch-strip">
+            <span>{inactiveCount} archived card{inactiveCount === 1 ? '' : 's'} hidden</span>
+            <button type="button" className="cj-archived-toggle" onClick={() => setShowArchived(true)}>
+              show archived →
+            </button>
           </div>
-          )
         )}
+      </div>
+    </section>
+  );
+}
 
-        {/* Applications Tab */}
-        {activeTab === 'applications' && (
-          <div className="bg-white shadow rounded-lg p-6">
-            <div className="mb-6">
-              <h2 className="text-lg font-semibold text-gray-900">Application Rules Tracker</h2>
-              <p className="mt-1 text-sm text-gray-500">
-                Track your credit card application velocity against common bank rules.
-              </p>
+/* ========== Applications tab ========== */
+interface ApplicationsTabProps {
+  recordsLoaded: boolean;
+  walletLoaded: boolean;
+  records: RecordItem[];
+  walletCards: WalletCard[];
+  applicationRules: ReturnType<typeof calculateApplicationRules>;
+  cardsMissingDates: number;
+  onPickCard: () => void;
+  onDeleteRecord: (id: number) => void;
+  deletingRecordId: number | null;
+  eligibleRecordCards: WalletCard[];
+}
+
+function ApplicationsTab(props: ApplicationsTabProps) {
+  const { recordsLoaded, walletLoaded, records, walletCards, applicationRules, cardsMissingDates, onPickCard, onDeleteRecord, deletingRecordId, eligibleRecordCards } = props;
+  if (!recordsLoaded || !walletLoaded) return <LoadingPanel />;
+
+  const approved = records.filter(r => r.result).length;
+  const denied = records.length - approved;
+
+  return (
+    <section className="cj-section">
+      {records.length > 0 ? (
+        <>
+          <div className="cj-table-label">Your applications, with the score and income at the time of each.</div>
+          <div className="cj-tape cj-tape-records">
+            <div className="cj-tape-head">
+              <div>Applied</div>
+              <div></div>
+              <div>Card</div>
+              <div className="cj-tape-res">Score</div>
+              <div className="cj-tape-res">Income</div>
+              <div className="cj-tape-res">Outcome</div>
             </div>
-
-            {/* Warning if cards missing dates */}
-            {cardsMissingDates > 0 && (
-              <div className="mb-6 rounded-md bg-yellow-50 p-4">
-                <div className="flex">
-                  <div className="flex-shrink-0">
-                    <ExclamationTriangleIcon className="h-5 w-5 text-yellow-400" aria-hidden="true" />
-                  </div>
-                  <div className="ml-3">
-                    <h3 className="text-sm font-medium text-yellow-800">Missing acquisition dates</h3>
-                    <div className="mt-2 text-sm text-yellow-700">
-                      <p>
-                        {cardsMissingDates} {cardsMissingDates === 1 ? 'card is' : 'cards are'} missing acquisition dates.
-                        For accurate rule tracking, please add when you got each card.
-                      </p>
-                    </div>
-                    <div className="mt-4">
-                      <div className="-mx-2 -my-1.5 flex">
-                        <button
-                          type="button"
-                          onClick={() => setActiveTab('wallet')}
-                          className="rounded-md bg-yellow-50 px-2 py-1.5 text-sm font-medium text-yellow-800 hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-600 focus:ring-offset-2 focus:ring-offset-yellow-50"
-                        >
-                          Go to Wallet
-                        </button>
-                      </div>
-                    </div>
-                  </div>
+            {records.map((r) => (
+              <div key={r.record_id} className="cj-tape-row">
+                <div className="cj-tape-when">
+                  {new Date(r.date_applied || r.submit_datetime).toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' })}
+                </div>
+                <div>
+                  <span className="cj-tape-thumb">
+                    <CardImage cardImageLink={r.card_image_link} alt={r.card_name} fill sizes="36px" className="object-contain" />
+                  </span>
+                </div>
+                <div className="cj-tape-event">
+                  <span className="cj-tape-field">{r.card_name}</span>
+                </div>
+                <div className="cj-tape-res">{r.credit_score}</div>
+                <div className="cj-tape-res">${(r.listed_income / 1000).toFixed(0)}k</div>
+                <div className="cj-tape-res">
+                  <span className={'cj-pill ' + (r.result ? 'cj-pill-app' : 'cj-pill-den')}>
+                    {r.result ? 'approved' : 'denied'}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onDeleteRecord(r.record_id)}
+                    disabled={deletingRecordId === r.record_id}
+                    style={{ marginLeft: 6, fontSize: 11, color: 'var(--muted)', background: 'transparent', border: 0, cursor: 'pointer' }}
+                    aria-label="Delete record"
+                  >
+                    {deletingRecordId === r.record_id ? '…' : '×'}
+                  </button>
                 </div>
               </div>
-            )}
-
-            {walletCards.length === 0 ? (
-              <div className="text-center py-12">
-                <ChartBarIcon className="mx-auto h-12 w-12 text-gray-300" />
-                <p className="mt-2 text-gray-500">Add cards to your wallet to track application rules.</p>
-                <button
-                  onClick={() => setActiveTab('wallet')}
-                  className="mt-4 inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                >
-                  Go to Wallet
+            ))}
+          </div>
+          <div className="cj-verdict">
+            <b>{records.length} record{records.length === 1 ? '' : 's'}.</b> {approved} approved, {denied} denied.{' '}
+            {eligibleRecordCards.length > 0 ? (
+              <>Submit a new record from <button type="button" onClick={onPickCard} style={{ background: 'transparent', border: 0, padding: 0, color: 'var(--accent)', cursor: 'pointer', fontWeight: 600 }}>any card in your wallet</button>.</>
+            ) : 'You’ve submitted records for every card in your wallet.'}
+          </div>
+        </>
+      ) : (
+        <div className="cj-verdict">
+          {walletCards.length === 0
+            ? <><b>No records yet.</b> Add a card to your wallet to submit a data point.</>
+            : <><b>No records yet.</b>{' '}
+                <button type="button" onClick={onPickCard} style={{ background: 'transparent', border: 0, padding: 0, color: 'var(--accent)', cursor: 'pointer', fontWeight: 600 }}>
+                  Submit a record →
                 </button>
-              </div>
-            ) : (
-              <>
-                {/* Rules Grid */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
-                  {applicationRules.map((rule) => (
-                    <RuleProgressChart key={rule.ruleName} rule={rule} />
-                  ))}
-                </div>
+              </>}
+        </div>
+      )}
 
-                {/* Rules Explanation */}
-                <div className="border-t border-gray-200 pt-6">
-                  <h3 className="text-sm font-medium text-gray-900 mb-4">Understanding Application Rules</h3>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600">
-                    <div>
-                      <p className="font-medium text-gray-700">Chase 5/24</p>
-                      <p>Chase will likely deny you if you&apos;ve opened 5+ cards (any bank) in 24 months.</p>
-                    </div>
-                    <div>
-                      <p className="font-medium text-gray-700">Amex 2/90</p>
-                      <p>American Express limits you to 2 credit card approvals within 90 days.</p>
-                    </div>
-                    <div>
-                      <p className="font-medium text-gray-700">Capital One 1/6</p>
-                      <p>Capital One typically approves only 1 card every 6 months.</p>
-                    </div>
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
-        )}
-
-        {/* Settings Tab */}
-        {activeTab === 'settings' && (
-          <div className="bg-white shadow rounded-lg p-6">
-            <div className="mb-6">
-              <h2 className="text-lg font-semibold text-gray-900">Settings</h2>
-              <p className="mt-1 text-sm text-gray-500">
-                Manage your account settings.
-              </p>
+      {walletCards.length > 0 && (
+        <>
+          <div className="cj-table-label" style={{ marginTop: 24 }}>Application rules</div>
+          {cardsMissingDates > 0 && (
+            <div className="cj-verdict" style={{ marginTop: 0, marginBottom: 16, background: '#fef9e8', borderLeftColor: '#a8792a', color: '#5c4318' }}>
+              <ExclamationTriangleIcon style={{ width: 16, height: 16, display: 'inline', marginRight: 6, verticalAlign: '-3px' }} />
+              <b style={{ color: '#a8792a' }}>{cardsMissingDates} card{cardsMissingDates === 1 ? '' : 's'} missing acquisition dates.</b>{' '}
+              For accurate rule tracking, edit each card to add when you got it.
             </div>
-
-            {/* Danger Zone */}
-            <div>
-              <h3 className="text-sm font-semibold text-red-600 mb-4">Danger zone</h3>
-              <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                  <div>
-                    <p className="text-sm font-medium text-gray-900">Delete your account</p>
-                    <p className="text-sm text-gray-500">
-                      Permanently delete your account, wallet, and referrals. Your submitted data points will be kept anonymously.
-                    </p>
-                  </div>
-                  {!confirmingDelete ? (
-                    <button
-                      onClick={() => setConfirmingDelete(true)}
-                      className="shrink-0 inline-flex items-center px-3 py-2 border border-red-300 text-sm font-medium rounded-md text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-                    >
-                      <TrashIcon className="h-4 w-4 mr-1.5" />
-                      Delete Account
-                    </button>
-                  ) : (
-                    <div className="shrink-0 flex flex-col gap-2">
-                      <label className="text-sm font-medium text-red-700">
-                        Type <span className="font-mono font-bold">DELETE</span> to confirm:
-                      </label>
-                      <div className="flex gap-2">
-                        <input
-                          type="text"
-                          value={deleteConfirmText}
-                          onChange={(e) => setDeleteConfirmText(e.target.value)}
-                          placeholder="DELETE"
-                          className="w-28 px-3 py-1.5 text-sm border border-red-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
-                          autoFocus
-                        />
-                        <button
-                          onClick={handleDeleteAccount}
-                          disabled={deleteConfirmText !== 'DELETE' || deletingAccount}
-                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-                        >
-                          {deletingAccount ? 'Deleting...' : 'Confirm'}
-                        </button>
-                        <button
-                          onClick={() => { setConfirmingDelete(false); setDeleteConfirmText(''); }}
-                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
+          )}
+          <div className="cj-rule-grid">
+            {applicationRules.map((rule) => (
+              <RuleProgressChart key={rule.ruleName} rule={rule} />
+            ))}
           </div>
-        )}
-          </div>
+        </>
+      )}
+    </section>
+  );
+}
 
-          {/* News Sidebar - Below content on mobile, 1/3 on desktop */}
-          <div className="col-span-1 lg:col-span-1">
-            <div className="bg-white shadow rounded-lg overflow-hidden sticky top-4">
-              <div className="px-4 py-4 border-b border-gray-200">
-                <div className="flex items-center gap-2">
-                  <NewspaperIcon className="h-5 w-5 text-indigo-600" />
-                  <h2 className="text-base font-semibold text-gray-900">Your Card News</h2>
-                </div>
-              </div>
-              {relevantNews.length > 0 ? (
-                <ul className="divide-y divide-gray-200 max-h-[600px] overflow-y-auto">
-                  {relevantNews.slice(0, 10).map((news) => (
-                    <li key={news.id} className="px-4 py-3 hover:bg-gray-50">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="text-xs text-gray-400">
-                          {new Date(news.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-                        </span>
-                        {news.tags.slice(0, 1).map((tag) => (
-                          <span
-                            key={tag}
-                            className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${tagColors[tag]}`}
-                          >
-                            {tagLabels[tag]}
-                          </span>
-                        ))}
-                      </div>
-                      <p className="text-sm font-medium text-gray-900">{news.title}</p>
-                      {news.summary && (
-                        <p className="mt-1 text-xs text-gray-500 line-clamp-3">{news.summary}</p>
-                      )}
-                      {news.card_slugs && news.card_names && news.card_slugs.length > 0 && (
-                        <div className="mt-1 text-xs">
-                          {news.card_slugs.map((s, i) => (
-                            <span key={s}>
-                              {i > 0 && <span className="text-gray-400">, </span>}
-                              <Link
-                                href={`/card/${s}`}
-                                className="text-indigo-600 hover:text-indigo-900"
-                              >
-                                {news.card_names![i]}
-                              </Link>
-                            </span>
-                          ))}
-                        </div>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <div className="px-4 py-8 text-center">
-                  <NewspaperIcon className="mx-auto h-8 w-8 text-gray-300" />
-                  <p className="mt-2 text-sm text-gray-500">No news for your cards</p>
-                  <Link
-                    href="/news"
-                    className="mt-2 inline-block text-xs text-indigo-600 hover:text-indigo-900"
-                  >
-                    View all news →
-                  </Link>
-                </div>
-              )}
-              {relevantNews.length > 0 && (
-                <div className="px-4 py-3 bg-gray-50 border-t border-gray-200">
-                  <Link
-                    href="/news"
-                    className="text-sm text-indigo-600 hover:text-indigo-900"
-                  >
-                    View all card news →
-                  </Link>
-                </div>
-              )}
-            </div>
+/* ========== Referrals tab ========== */
+interface ReferralsTabProps {
+  referralsLoaded: boolean;
+  referrals: Referral[];
+  eligibleReferralCards: ReturnType<typeof getEligibleReferralCards>;
+  onAddReferral: () => void;
+  onArchive: (id: number) => void;
+  archivingReferralId: number | null;
+}
+
+function ReferralsTab(props: ReferralsTabProps) {
+  const { referralsLoaded, referrals, eligibleReferralCards, onAddReferral, onArchive, archivingReferralId } = props;
+  if (!referralsLoaded) return <LoadingPanel />;
+
+  const active = referrals.filter(r => !r.archived_at);
+  const adminArchived = referrals.filter(r => r.archived_at && r.archived_reason);
+  const totalImpressions = active.reduce((s, r) => s + (r.impressions ?? 0), 0);
+  const totalClicks = active.reduce((s, r) => s + (r.clicks ?? 0), 0);
+  const ctr = totalImpressions > 0 ? ((totalClicks / totalImpressions) * 100).toFixed(1) : '0.0';
+
+  return (
+    <section className="cj-section">
+      <div className="cj-readoff" style={{ gridTemplateColumns: 'repeat(3, minmax(0, 1fr))' }}>
+        <div className="cj-readoff-cell">
+          <div className="cj-readoff-k">Active links</div>
+          <div className="cj-readoff-v">{active.length}</div>
+          <div className="cj-readoff-foot">
+            {adminArchived.length > 0 ? `${adminArchived.length} removed` : 'submit more anytime'}
           </div>
         </div>
-
-        {/* Referral Modal */}
-        <ReferralModal
-          show={showReferralModal}
-          handleClose={() => setShowReferralModal(false)}
-          openReferrals={eligibleReferralCards}
-          onSuccess={loadData}
-        />
-
-        {/* Add to Wallet Modal */}
-        <AddToWalletModal
-          show={showWalletModal}
-          onClose={() => setShowWalletModal(false)}
-          onSuccess={loadData}
-          existingCardIds={walletCards.map(c => c.card_id)}
-        />
-
-        {/* Edit Wallet Card Modal */}
-        <EditWalletCardModal
-          show={!!editingCard}
-          card={editingCard}
-          cardSlug={editingCard ? allCards.find(c => c.card_name === editingCard.card_name)?.slug : undefined}
-          onClose={() => setEditingCard(null)}
-          onSuccess={loadData}
-        />
-
-        {/* Card Picker for Submit Record */}
-        <SubmitRecordCardPicker
-          show={showRecordCardPicker}
-          onClose={() => setShowRecordCardPicker(false)}
-          cards={eligibleRecordCards}
-          onSelectCard={(card) => setSubmitRecordCard(card)}
-        />
-
-        {/* Submit Record Modal */}
-        {submitRecordCard && (
-          <SubmitRecordModal
-            show={!!submitRecordCard}
-            handleClose={() => setSubmitRecordCard(null)}
-            card={{
-              card_id: submitRecordCard.card_id,
-              card_name: submitRecordCard.card_name,
-              card_image_link: submitRecordCard.card_image_link,
-              bank: submitRecordCard.bank,
-            }}
-            onSuccess={loadData}
-          />
-        )}
-
+        <div className="cj-readoff-cell">
+          <div className="cj-readoff-k">Impressions</div>
+          <div className="cj-readoff-v">{totalImpressions.toLocaleString()}</div>
+          <div className="cj-readoff-foot">all time</div>
+        </div>
+        <div className="cj-readoff-cell">
+          <div className="cj-readoff-k">Clicks</div>
+          <div className="cj-readoff-v">{totalClicks}</div>
+          <div className="cj-readoff-foot">{ctr}% CTR</div>
+        </div>
       </div>
-      <V2Footer />
-    </div>
+
+      <div className="cj-wallet-toolbar" style={{ marginTop: 16 }}>
+        <div className="cj-table-label">Your referral links</div>
+        <span className="cj-wallet-toolbar-spacer" />
+        {eligibleReferralCards.length > 0 && (
+          <button type="button" className="cj-inline-cta" onClick={onAddReferral}>+ add a referral</button>
+        )}
+      </div>
+
+      {active.length > 0 ? (
+        <div className="cj-tape cj-tape-refs">
+          <div className="cj-tape-head">
+            <div></div>
+            <div>Card</div>
+            <div className="cj-tape-res">Impr.</div>
+            <div className="cj-tape-res">Clicks</div>
+            <div className="cj-tape-res">Status</div>
+          </div>
+          {active.map((r) => (
+            <div key={r.referral_id} className="cj-tape-row">
+              <div>
+                <span className="cj-tape-thumb">
+                  <CardImage cardImageLink={r.card_image_link} alt={r.card_name} fill sizes="36px" className="object-contain" />
+                </span>
+              </div>
+              <div className="cj-tape-event">
+                <span className="cj-tape-field">{r.card_name}</span>
+                <div className="cj-tape-detail">
+                  <a href={r.referral_link} target="_blank" rel="noreferrer" style={{ color: 'var(--muted)', textDecoration: 'underline', textDecorationColor: 'var(--line-2)' }}>
+                    {r.referral_link.length > 40 ? r.referral_link.slice(0, 40) + '…' : r.referral_link}
+                  </a>
+                </div>
+              </div>
+              <div className="cj-tape-res">{(r.impressions ?? 0).toLocaleString()}</div>
+              <div className="cj-tape-res">{r.clicks ?? 0}</div>
+              <div className="cj-tape-res" style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
+                <span className={'cj-pill ' + (r.admin_approved ? 'cj-pill-app' : 'cj-pill-pen')}>
+                  {r.admin_approved ? 'active' : 'in review'}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onArchive(r.referral_id)}
+                  disabled={archivingReferralId === r.referral_id}
+                  style={{ fontSize: 10.5, color: 'var(--muted)', background: 'transparent', border: 0, cursor: 'pointer', padding: 0 }}
+                >
+                  {archivingReferralId === r.referral_id ? 'archiving…' : 'archive'}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="cj-verdict">
+          {eligibleReferralCards.length > 0
+            ? <><b>No referrals yet.</b>{' '}
+                <button type="button" onClick={onAddReferral} style={{ background: 'transparent', border: 0, padding: 0, color: 'var(--accent)', cursor: 'pointer', fontWeight: 600 }}>
+                  Submit your first referral →
+                </button>
+              </>
+            : <><b>No eligible cards yet.</b> Add a card to your wallet or submit a record to add a referral link.</>}
+        </div>
+      )}
+
+      {adminArchived.length > 0 && (
+        <div className="cj-verdict" style={{ marginTop: 16, background: '#fef9e8', borderLeftColor: '#a8792a', color: '#5c4318' }}>
+          <b style={{ color: '#a8792a' }}>
+            {adminArchived.length === 1
+              ? `Your referral for ${adminArchived[0].card_name} was removed`
+              : `${adminArchived.length} referrals were removed`}
+          </b>{' '}
+          because the link{adminArchived.length === 1 ? ' was' : 's were'} no longer working. You can submit new ones anytime.
+        </div>
+      )}
+    </section>
+  );
+}
+
+/* ========== Settings tab ========== */
+interface SettingsTabProps {
+  profile: Profile | null;
+  email?: string | null;
+  handle: string;
+  confirmingDelete: boolean;
+  setConfirmingDelete: (v: boolean) => void;
+  deleteConfirmText: string;
+  setDeleteConfirmText: (v: string) => void;
+  deletingAccount: boolean;
+  onDeleteAccount: () => void;
+  onLogout: () => void;
+}
+
+function SettingsTab(props: SettingsTabProps) {
+  const { email, handle, confirmingDelete, setConfirmingDelete, deleteConfirmText, setDeleteConfirmText, deletingAccount, onDeleteAccount, onLogout } = props;
+
+  const rows = [
+    { k: 'Email', v: email || '—' },
+    { k: 'Username', v: handle ? `@${handle}` : '—' },
+  ];
+
+  return (
+    <section className="cj-section">
+      <div>
+        {rows.map((r, i) => (
+          <div key={i} className="cj-settings-list">
+            <div className="cj-settings-k">{r.k}</div>
+            <div className="cj-settings-v">{r.v}</div>
+            <span style={{ fontSize: 11, color: 'var(--muted-2)' }}>{/* read-only */}</span>
+          </div>
+        ))}
+        <div className="cj-settings-list">
+          <div className="cj-settings-k">Sign out</div>
+          <div className="cj-settings-v">end this session</div>
+          <button type="button" className="cj-settings-edit" onClick={onLogout}>sign out →</button>
+        </div>
+        <div className="cj-settings-list">
+          <div className="cj-settings-k" style={{ color: 'var(--warn)' }}>Delete account</div>
+          <div className="cj-settings-v" style={{ color: 'var(--warn)' }}>permanent · cannot be undone</div>
+          {!confirmingDelete ? (
+            <button
+              type="button"
+              className="cj-settings-edit"
+              style={{ color: 'var(--warn)' }}
+              onClick={() => setConfirmingDelete(true)}
+            >
+              <TrashIcon style={{ width: 11, height: 11, display: 'inline', marginRight: 4, verticalAlign: '-1px' }} />
+              delete →
+            </button>
+          ) : (
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+              <input
+                type="text"
+                value={deleteConfirmText}
+                onChange={(e) => setDeleteConfirmText(e.target.value)}
+                placeholder="type DELETE"
+                style={{ width: 110, padding: '4px 8px', fontSize: 12, border: '1px solid var(--warn)', borderRadius: 3, fontFamily: 'inherit' }}
+                autoFocus
+              />
+              <button
+                type="button"
+                onClick={onDeleteAccount}
+                disabled={deleteConfirmText !== 'DELETE' || deletingAccount}
+                style={{
+                  fontSize: 11.5,
+                  background: 'var(--warn)',
+                  color: '#fff',
+                  border: 0,
+                  borderRadius: 3,
+                  padding: '5px 10px',
+                  cursor: 'pointer',
+                  fontWeight: 600,
+                  opacity: deleteConfirmText !== 'DELETE' || deletingAccount ? 0.5 : 1,
+                }}
+              >
+                {deletingAccount ? 'deleting…' : 'confirm'}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setConfirmingDelete(false); setDeleteConfirmText(''); }}
+                style={{ fontSize: 11.5, background: 'transparent', border: '1px solid var(--line-2)', borderRadius: 3, padding: '5px 10px', cursor: 'pointer' }}
+              >
+                cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/apps/web-next/src/components/charts/RuleProgressChart.tsx
+++ b/apps/web-next/src/components/charts/RuleProgressChart.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-import { useMemo } from 'react';
-import Highcharts from 'highcharts';
-import HighchartsReact from 'highcharts-react-official';
 import { RuleResult } from '@/lib/applicationRules';
 
 interface RuleProgressChartProps {
@@ -10,114 +7,53 @@ interface RuleProgressChartProps {
 }
 
 export default function RuleProgressChart({ rule }: RuleProgressChartProps) {
-  const { ruleName, current, limit, periodDescription, isSafe } = rule;
+  const { ruleName, current, limit, periodDescription } = rule;
 
-  // Determine color based on status
-  const getBarColor = () => {
-    if (current > limit) return '#ef4444'; // red-500 - over limit
-    if (current === limit) return '#eab308'; // yellow-500 - at limit
-    return '#22c55e'; // green-500 - safe
-  };
+  const status: 'ok' | 'at' | 'over' =
+    current > limit ? 'over' : current === limit ? 'at' : 'ok';
 
-  const chartOptions = useMemo(
-    () => ({
-      chart: {
-        type: 'column',
-        height: 200,
-        backgroundColor: 'transparent',
-      },
-      title: {
-        text: ruleName,
-        style: {
-          fontSize: '14px',
-          fontWeight: '600',
-        },
-      },
-      subtitle: {
-        text: periodDescription,
-        style: {
-          fontSize: '12px',
-          color: '#6b7280',
-        },
-      },
-      xAxis: {
-        categories: [''],
-        visible: false,
-      },
-      yAxis: {
-        min: 0,
-        max: Math.max(limit + 1, current + 1),
-        title: {
-          text: null,
-        },
-        plotLines: [
-          {
-            value: limit,
-            color: '#9ca3af',
-            dashStyle: 'Dash' as const,
-            width: 2,
-            label: {
-              text: `Limit: ${limit}`,
-              align: 'right' as const,
-              style: {
-                fontSize: '11px',
-                color: '#6b7280',
-              },
-            },
-            zIndex: 5,
-          },
-        ],
-        gridLineWidth: 0,
-      },
-      legend: {
-        enabled: false,
-      },
-      tooltip: {
-        formatter: function () {
-          return `<b>${ruleName}</b><br/>Current: ${current} / ${limit}`;
-        },
-      },
-      plotOptions: {
-        column: {
-          borderRadius: 4,
-          dataLabels: {
-            enabled: true,
-            format: '{y}',
-            style: {
-              fontSize: '14px',
-              fontWeight: '600',
-            },
-          },
-        },
-      },
-      series: [
-        {
-          name: 'Current',
-          data: [current],
-          color: getBarColor(),
-        },
-      ],
-      credits: {
-        enabled: false,
-      },
-    }),
-    [ruleName, current, limit, periodDescription]
-  );
+  // Render `limit` segments. Filled in when index < current. If overflow
+  // (current > limit), append the overflow as warn-colored segments after.
+  const filledCount = Math.min(current, limit);
+  const overflowCount = Math.max(0, current - limit);
+  const totalSegs = limit + overflowCount;
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
-      <HighchartsReact highcharts={Highcharts} options={chartOptions} />
-      <div className="mt-2 text-center">
+    <div className="cj-rule">
+      <div className="cj-rule-head">
+        <div className="cj-rule-name">{ruleName}</div>
+        <div className="cj-rule-period">{periodDescription}</div>
+      </div>
+
+      <div className="cj-rule-num">
+        <span className={`cj-rule-num-current is-${status}`}>{current}</span>
+        <span className="cj-rule-num-limit">/ {limit}</span>
+      </div>
+
+      <div className="cj-rule-bar" aria-hidden="true">
+        {Array.from({ length: totalSegs }).map((_, i) => {
+          const isOverflow = i >= limit;
+          const isFilled = i < filledCount;
+          const cls = isOverflow
+            ? 'cj-rule-seg is-fill-over'
+            : isFilled
+            ? status === 'at'
+              ? 'cj-rule-seg is-fill-at'
+              : 'cj-rule-seg is-fill'
+            : 'cj-rule-seg';
+          return <span key={i} className={cls} />;
+        })}
+      </div>
+
+      <div className="cj-rule-foot">
         <span
-          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-            !isSafe
-              ? current > limit
-                ? 'bg-red-100 text-red-800'
-                : 'bg-yellow-100 text-yellow-800'
-              : 'bg-green-100 text-green-800'
-          }`}
+          className={
+            'cj-pill cj-rule-status ' +
+            (status === 'over' ? 'cj-pill-den' : status === 'at' ? '' : 'cj-pill-app')
+          }
+          style={status === 'at' ? { background: '#fef9e8', color: 'var(--gold)' } : undefined}
         >
-          {current > limit ? 'Over Limit' : current === limit ? 'At Limit' : 'Safe'}
+          {status === 'over' ? 'over limit' : status === 'at' ? 'at limit' : 'safe'}
         </span>
       </div>
     </div>

--- a/apps/web-next/src/components/wallet/AddToWalletModal.tsx
+++ b/apps/web-next/src/components/wallet/AddToWalletModal.tsx
@@ -14,18 +14,10 @@ interface AddToWalletModalProps {
 }
 
 const months = [
-  { value: 1, label: 'January' },
-  { value: 2, label: 'February' },
-  { value: 3, label: 'March' },
-  { value: 4, label: 'April' },
-  { value: 5, label: 'May' },
-  { value: 6, label: 'June' },
-  { value: 7, label: 'July' },
-  { value: 8, label: 'August' },
-  { value: 9, label: 'September' },
-  { value: 10, label: 'October' },
-  { value: 11, label: 'November' },
-  { value: 12, label: 'December' },
+  { value: 1, label: 'January' }, { value: 2, label: 'February' }, { value: 3, label: 'March' },
+  { value: 4, label: 'April' }, { value: 5, label: 'May' }, { value: 6, label: 'June' },
+  { value: 7, label: 'July' }, { value: 8, label: 'August' }, { value: 9, label: 'September' },
+  { value: 10, label: 'October' }, { value: 11, label: 'November' }, { value: 12, label: 'December' },
 ];
 
 export default function AddToWalletModal({ show, onClose, onSuccess, existingCardIds }: AddToWalletModalProps) {
@@ -38,52 +30,36 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Generate year options (current year back to 1990)
   const currentYear = new Date().getFullYear();
   const years = Array.from({ length: currentYear - 1989 }, (_, i) => currentYear - i);
 
   useEffect(() => {
     if (show) {
-      loadCards();
+      (async () => {
+        try {
+          setCards(await getAllCards());
+        } catch (err) {
+          console.error('Failed to load cards:', err);
+        }
+      })();
     }
   }, [show]);
 
-  const loadCards = async () => {
-    try {
-      const allCards = await getAllCards();
-      setCards(allCards);
-    } catch (err) {
-      console.error('Failed to load cards:', err);
-    }
-  };
-
   const filteredCards = cards.filter(card => {
-    // Exclude cards already in wallet or cards without db_card_id
     if (!card.db_card_id) return false;
     if (existingCardIds.includes(card.db_card_id)) return false;
-
     if (!search) return true;
-    const searchLower = search.toLowerCase();
-    return (
-      card.card_name.toLowerCase().includes(searchLower) ||
-      card.bank.toLowerCase().includes(searchLower)
-    );
+    const s = search.toLowerCase();
+    return card.card_name.toLowerCase().includes(s) || card.bank.toLowerCase().includes(s);
   });
 
   const handleSubmit = async () => {
     if (!selectedCard || !selectedCard.db_card_id) return;
-
     setLoading(true);
     setError(null);
-
     try {
       const token = await getToken();
-      await addToWallet(
-        selectedCard.db_card_id,
-        acquiredMonth,
-        acquiredYear,
-        token || undefined
-      );
+      await addToWallet(selectedCard.db_card_id, acquiredMonth, acquiredYear, token || undefined);
       onSuccess();
       handleClose();
     } catch (err) {
@@ -105,115 +81,91 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
   if (!show) return null;
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-        {/* Backdrop */}
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={handleClose} />
+    <div className="cj-modal-root" role="dialog" aria-modal="true">
+      <div className="cj-modal-backdrop" onClick={handleClose} />
+      <div className="cj-modal-shell">
+        <div className="cj-modal-card" style={{ maxWidth: 520 }}>
+          <div className="cj-modal-head">
+            <span className="cj-status-dot" />
+            <span className="cj-modal-title">add a card to your wallet</span>
+            <button type="button" className="cj-modal-close" onClick={handleClose} aria-label="Close">
+              <XMarkIcon style={{ width: 16, height: 16 }} />
+            </button>
+          </div>
 
-        {/* Modal */}
-        <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-          <div className="bg-white px-4 pb-4 pt-5 sm:p-6">
-            {/* Header */}
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-gray-900">Add Card to Wallet</h3>
-              <button
-                onClick={handleClose}
-                className="text-gray-400 hover:text-gray-500"
-              >
-                <XMarkIcon className="h-6 w-6" />
-              </button>
-            </div>
-
-            {error && (
-              <div className="mb-4 rounded-md bg-red-50 p-4">
-                <p className="text-sm text-red-700">{error}</p>
-              </div>
-            )}
+          <div className="cj-modal-body">
+            {error && <div className="cj-modal-error">{error}</div>}
 
             {!selectedCard ? (
               <>
-                {/* Search */}
-                <div className="relative mb-4">
-                  <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
-                  <input
-                    type="text"
-                    placeholder="Search cards..."
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    className="w-full rounded-md border-gray-300 pl-10 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                  />
+                <div className="cj-modal-section">
+                  <label className="cj-modal-label">Search</label>
+                  <div className="cj-modal-search">
+                    <MagnifyingGlassIcon className="cj-modal-search-icon" />
+                    <input
+                      type="text"
+                      placeholder="card name or issuer…"
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      className="cj-modal-search-input"
+                      autoFocus
+                    />
+                  </div>
                 </div>
 
-                {/* Card List */}
-                <div className="max-h-80 overflow-y-auto space-y-2">
-                  {filteredCards.slice(0, 20).map((card) => (
-                    <button
-                      key={card.card_id}
-                      onClick={() => setSelectedCard(card)}
-                      className="w-full flex items-center p-3 rounded-lg border border-gray-200 hover:border-indigo-500 hover:bg-indigo-50 transition-colors text-left"
-                    >
-                      <div className="h-10 w-16 flex-shrink-0 mr-3">
-                        <CardImage
-                          cardImageLink={card.card_image_link}
-                          alt={card.card_name}
-                          width={64}
-                          height={40}
-                          className="h-10 w-16 object-contain"
-                        />
+                <div className="cj-modal-section">
+                  <div className="cj-modal-list">
+                    {filteredCards.slice(0, 20).map((card) => (
+                      <button
+                        key={card.card_id}
+                        type="button"
+                        onClick={() => setSelectedCard(card)}
+                        className="cj-modal-list-row"
+                      >
+                        <span className="cj-modal-thumb">
+                          <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="56px" />
+                        </span>
+                        <div style={{ minWidth: 0 }}>
+                          <div className="cj-modal-list-name">{card.card_name}</div>
+                          <div className="cj-modal-list-meta">{card.bank}</div>
+                        </div>
+                      </button>
+                    ))}
+                    {filteredCards.length === 0 && (
+                      <div className="cj-modal-list-empty">no cards match</div>
+                    )}
+                    {filteredCards.length > 20 && (
+                      <div className="cj-modal-list-foot">
+                        showing first 20 — refine your search to see more
                       </div>
-                      <div>
-                        <div className="text-sm font-medium text-gray-900">{card.card_name}</div>
-                        <div className="text-xs text-gray-500">{card.bank}</div>
-                      </div>
-                    </button>
-                  ))}
-                  {filteredCards.length === 0 && (
-                    <p className="text-center text-gray-500 py-4">No cards found</p>
-                  )}
-                  {filteredCards.length > 20 && (
-                    <p className="text-center text-gray-400 text-sm py-2">
-                      Showing first 20 results. Refine your search for more.
-                    </p>
-                  )}
+                    )}
+                  </div>
                 </div>
               </>
             ) : (
               <>
-                {/* Selected Card */}
-                <div className="mb-6 p-4 bg-gray-50 rounded-lg">
-                  <div className="flex items-center">
-                    <div className="h-12 w-20 flex-shrink-0 mr-4">
-                      <CardImage
-                        cardImageLink={selectedCard.card_image_link}
-                        alt={selectedCard.card_name}
-                        width={80}
-                        height={48}
-                        className="h-12 w-20 object-contain"
-                      />
-                    </div>
-                    <div>
-                      <div className="font-medium text-gray-900">{selectedCard.card_name}</div>
-                      <div className="text-sm text-gray-500">{selectedCard.bank}</div>
+                <div className="cj-modal-section">
+                  <div className="cj-modal-card-row">
+                    <span className="cj-modal-thumb">
+                      <CardImage cardImageLink={selectedCard.card_image_link} alt={selectedCard.card_name} fill className="object-contain" sizes="56px" />
+                    </span>
+                    <div style={{ minWidth: 0 }}>
+                      <div className="cj-modal-card-name">{selectedCard.card_name}</div>
+                      <div className="cj-modal-card-meta">{selectedCard.bank}</div>
                     </div>
                   </div>
-                  <button
-                    onClick={() => setSelectedCard(null)}
-                    className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
-                  >
-                    Choose different card
+                  <button type="button" className="cj-modal-back" onClick={() => setSelectedCard(null)}>
+                    ← choose a different card
                   </button>
                 </div>
 
-                {/* Acquired Date (Optional) */}
-                <div className="mb-6">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    When did you get this card? (Optional)
-                  </label>
-                  <div className="grid grid-cols-2 gap-4">
+                <div className="cj-modal-section">
+                  <label className="cj-modal-label">When did you get this card? <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional)</span></label>
+                  <div className="cj-modal-grid">
                     <select
                       value={acquiredMonth || ''}
                       onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                      className="cj-modal-select"
                     >
                       <option value="">Month</option>
                       {months.map((m) => (
@@ -223,7 +175,7 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
                     <select
                       value={acquiredYear || ''}
                       onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                      className="cj-modal-select"
                     >
                       <option value="">Year</option>
                       {years.map((y) => (
@@ -232,26 +184,26 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
                     </select>
                   </div>
                 </div>
-
-                {/* Actions */}
-                <div className="flex justify-end gap-3">
-                  <button
-                    onClick={handleClose}
-                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    onClick={handleSubmit}
-                    disabled={loading}
-                    className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 disabled:opacity-50"
-                  >
-                    {loading ? 'Adding...' : 'Add to Wallet'}
-                  </button>
-                </div>
               </>
             )}
           </div>
+
+          {selectedCard && (
+            <div className="cj-modal-footer">
+              <span style={{ fontSize: 11, color: 'var(--muted)' }}>{/* spacer */}</span>
+              <div className="cj-modal-actions">
+                <button type="button" className="cj-modal-btn" onClick={handleClose}>cancel</button>
+                <button
+                  type="button"
+                  className="cj-modal-btn cj-modal-btn-primary"
+                  onClick={handleSubmit}
+                  disabled={loading}
+                >
+                  {loading ? 'adding…' : 'add to wallet'}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web-next/src/components/wallet/BestCardByCategory.tsx
+++ b/apps/web-next/src/components/wallet/BestCardByCategory.tsx
@@ -8,8 +8,6 @@ import { categoryLabels, formatRewardWithUsdEquivalent, getRewardUsdRate } from 
 
 const canonicalOrder = Object.keys(categoryLabels).filter(c => c !== 'everything_else');
 
-// Returns the canonical "QN YYYY" label for the current quarter (UTC), used to
-// detect rotating rewards whose `current_period` hasn't been refreshed yet.
 function currentQuarterLabel(now: Date = new Date()): string {
   const q = Math.floor(now.getUTCMonth() / 3) + 1;
   return `Q${q} ${now.getUTCFullYear()}`;
@@ -22,9 +20,6 @@ function isStaleRotation(reward: Reward, expected: string): boolean {
   return cur.trim().toUpperCase() !== expected.toUpperCase();
 }
 
-// A reward is "conditional" if it carries a note OR is flagged merchant_specific.
-// We use this to surface an unrestricted alternative when the top earner is gated
-// (e.g. Marriott Bonvoy 6x at Marriott properties vs. a 3x general-hotels card).
 function isConditional(reward: Reward) {
   return reward.merchant_specific === true || (!!reward.note && reward.note.trim().length > 0);
 }
@@ -38,13 +33,8 @@ interface Pick {
   card: Card;
   reward: Reward;
   usdRate: number;
-  // True when this pick was slotted into a category via the reward's
-  // current_categories (rotating-bonus expansion) rather than declared directly.
   rotating?: boolean;
-  // True when the rotating reward's current_period doesn't match the actual
-  // current quarter — the listed bonus categories may be outdated.
   staleRotation?: boolean;
-  // Slot-specific note from current_categories[i].note. Falls back to reward.note in render.
   slotNote?: string;
 }
 
@@ -67,7 +57,6 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
 
     const expectedQuarter = currentQuarterLabel();
 
-    // Collect every (card, reward) pair per category, then sort by USD rate.
     const picksByCategory = new Map<string, Pick[]>();
     const push = (cat: string, pick: Pick) => {
       const list = picksByCategory.get(cat) ?? [];
@@ -76,10 +65,6 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
     };
 
     for (const card of walletCardData) {
-      // Index each card's permanent (non-rotating) per-category rates so
-      // we can suppress rotating slots that are already covered at >= rate
-      // by a permanent reward on the same card (e.g. Freedom Flex's
-      // permanent 5% travel_portal vs. its rotating travel_portal slot).
       const permanentRates = new Map<string, number>();
       for (const reward of card.rewards!) {
         if (reward.mode === 'quarterly_rotating') continue;
@@ -92,10 +77,6 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
         if (reward.category === 'everything_else') continue;
         const usdRate = getRewardUsdRate(reward, card);
 
-        // Quarterly rotating rewards: slot the bonus rate under each of this
-        // quarter's actual categories (e.g. groceries, gas) so users see the
-        // card competing where it currently earns the bonus. Skip the
-        // umbrella "rotating" row in that case to avoid duplication.
         if (
           reward.mode === 'quarterly_rotating' &&
           reward.current_categories &&
@@ -106,7 +87,6 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
             const cat = typeof entry === 'string' ? entry : entry.category;
             const slotNote = typeof entry === 'string' ? undefined : entry.note;
             if (!cat || cat === 'everything_else') continue;
-            // Same card already earns >= rate permanently in this category — skip.
             const perm = permanentRates.get(cat) ?? 0;
             if (perm >= usdRate) continue;
             push(cat, { card, reward, usdRate, rotating: true, staleRotation: stale, slotNote });
@@ -126,7 +106,6 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
 
       let alternative: Pick | undefined;
       if (isConditional(primary.reward)) {
-        // Find the best unrestricted pick from a *different* card.
         alternative = picks.find(p => !isConditional(p.reward) && p.card.card_name !== primary.card.card_name);
       }
 
@@ -156,173 +135,97 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
     return results;
   }, [walletCards, allCards]);
 
-  if (categoryBests.length === 0) return null;
+  if (categoryBests.length === 0) {
+    return (
+      <div className="cj-verdict">
+        <b>No category data yet.</b> Add cards to your wallet to see which one earns the most for each spending category.
+      </div>
+    );
+  }
 
   return (
-    <div className="bg-white shadow rounded-lg p-6 mt-6">
-      <div className="mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">
-          Best Card by Category
-          <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 align-middle">Experimental</span>
-        </h2>
-        <p className="text-sm text-gray-500 mt-1">Which card in your wallet earns the most for each spending category. When the top earner is brand- or merchant-restricted, we also surface the best unrestricted option.</p>
+    <section className="cj-section">
+      <div className="cj-table-label">
+        Derived from rewards on the cards you hold. When the top earner is brand- or merchant-restricted, an unrestricted alternative is shown below it.
       </div>
-
-      {/* Desktop table */}
-      <div className="hidden sm:block overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Category</th>
-              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Best Card</th>
-              <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Rate</th>
+      <table className="cj-table">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Best in your wallet</th>
+            <th className="cj-tr">Earn</th>
+          </tr>
+        </thead>
+        <tbody>
+          {categoryBests.map(({ category, label, primary, alternative }) => (
+            <tr key={category}>
+              <td>
+                <div className="cj-cell-primary">{label}</div>
+              </td>
+              <td>
+                <PickCell pick={primary} />
+                {alternative && (
+                  <div style={{ marginTop: 6, paddingTop: 6, borderTop: '1px dashed var(--line)' }}>
+                    <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--muted-2)', fontWeight: 600, marginBottom: 4 }}>
+                      All {label.toLowerCase()}
+                    </div>
+                    <PickCell pick={alternative} />
+                  </div>
+                )}
+              </td>
+              <td className="cj-tr">
+                <RateCell pick={primary} />
+                {alternative && (
+                  <div style={{ marginTop: 6, paddingTop: 6, borderTop: '1px dashed var(--line)' }}>
+                    <div style={{ fontSize: 10, marginBottom: 4, visibility: 'hidden' }}>.</div>
+                    <RateCell pick={alternative} />
+                  </div>
+                )}
+              </td>
             </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {categoryBests.map(({ category, label, primary, alternative }) => (
-              <tr key={category} className="align-top">
-                <td className="px-4 py-3 text-sm font-medium text-gray-900">
-                  {label}
-                </td>
-                <td className="px-4 py-3">
-                  <PickRow pick={primary} />
-                  {alternative && (
-                    <div className="mt-2 pt-2 border-t border-dashed border-gray-200">
-                      <div className="text-[11px] uppercase tracking-wide text-gray-400 mb-1">All {label.toLowerCase()}</div>
-                      <PickRow pick={alternative} />
-                    </div>
-                  )}
-                </td>
-                <td className="px-4 py-3">
-                  <RateBadge pick={primary} />
-                  {alternative && (
-                    <div className="mt-2 pt-2 border-t border-dashed border-gray-200">
-                      <div className="invisible text-[11px] mb-1">.</div>
-                      <RateBadge pick={alternative} />
-                    </div>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Mobile layout */}
-      <div className="sm:hidden divide-y divide-gray-200">
-        {categoryBests.map(({ category, label, primary, alternative }) => (
-          <div key={category} className="py-3">
-            <div className="text-sm font-medium text-gray-900 mb-2">{label}</div>
-            <MobilePickRow pick={primary} />
-            {alternative && (
-              <div className="mt-2 pt-2 border-t border-dashed border-gray-200">
-                <div className="text-[11px] uppercase tracking-wide text-gray-400 mb-1">All {label.toLowerCase()}</div>
-                <MobilePickRow pick={alternative} />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
+          ))}
+        </tbody>
+      </table>
+    </section>
   );
 }
 
-function PickRow({ pick }: { pick: Pick }) {
+function PickCell({ pick }: { pick: Pick }) {
   const { card, reward, rotating, staleRotation, slotNote } = pick;
   const note = slotNote ?? reward.note;
   const href = card.slug ? `/card/${card.slug}` : undefined;
-  return (
-    <div className={`flex items-start gap-3 ${staleRotation ? 'opacity-60' : ''}`}>
-      <div className="flex-shrink-0 h-8 w-12 relative">
-        <CardImage
-          cardImageLink={card.card_image_link}
-          alt={card.card_name}
-          fill
-          className="object-contain"
-          sizes="48px"
-        />
-      </div>
-      <div className="min-w-0">
-        <div className="flex items-center gap-1.5 flex-wrap">
-          {href ? (
-            <Link href={href} className="text-sm text-gray-900 hover:text-indigo-600 hover:underline">
-              {card.card_name}
-            </Link>
-          ) : (
-            <span className="text-sm text-gray-900">{card.card_name}</span>
-          )}
+  const wrapper = (
+    <div className="cj-rew-best" style={staleRotation ? { opacity: 0.6 } : undefined}>
+      <span className="cj-rew-thumb">
+        <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="32px" />
+      </span>
+      <div style={{ minWidth: 0 }}>
+        <div className="cj-cell-primary" style={{ display: 'flex', gap: 6, alignItems: 'baseline', flexWrap: 'wrap' }}>
+          <span>{card.card_name}</span>
           {rotating && (
-            <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide ${
-              staleRotation ? 'bg-amber-100 text-amber-800' : 'bg-purple-100 text-purple-800'
-            }`}>
-              Rotating{reward.current_period ? ` · ${reward.current_period}` : ''}
+            <span style={{
+              fontSize: 9.5,
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              padding: '1px 5px',
+              borderRadius: 2,
+              background: staleRotation ? '#fef9e8' : 'var(--accent-2)',
+              color: staleRotation ? '#a8792a' : 'var(--accent)',
+            }}>
+              rotating{reward.current_period ? ` · ${reward.current_period}` : ''}
             </span>
           )}
-          {staleRotation && (
-            <span className="text-[11px] text-amber-700">may be outdated</span>
-          )}
         </div>
-        {note && (
-          <div className="text-xs text-gray-500 mt-0.5">{note}</div>
-        )}
+        {note && <div className="cj-cell-detail">{note}</div>}
+        {staleRotation && <div className="cj-cell-detail" style={{ color: '#a8792a' }}>may be outdated</div>}
       </div>
     </div>
   );
+  return href ? <Link href={href} style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>{wrapper}</Link> : wrapper;
 }
 
-function MobilePickRow({ pick }: { pick: Pick }) {
-  const { card, reward, rotating, staleRotation, slotNote } = pick;
-  const note = slotNote ?? reward.note;
-  const href = card.slug ? `/card/${card.slug}` : undefined;
-  return (
-    <div className={`flex items-start justify-between gap-2 ${staleRotation ? 'opacity-60' : ''}`}>
-      <div className="flex items-start gap-2 min-w-0">
-        <div className="flex-shrink-0 h-6 w-10 relative">
-          <CardImage
-            cardImageLink={card.card_image_link}
-            alt={card.card_name}
-            fill
-            className="object-contain"
-            sizes="40px"
-          />
-        </div>
-        <div className="min-w-0">
-          {href ? (
-            <Link href={href} className="block text-xs text-gray-900 truncate hover:text-indigo-600 hover:underline">
-              {card.card_name}
-            </Link>
-          ) : (
-            <div className="text-xs text-gray-900 truncate">{card.card_name}</div>
-          )}
-          {rotating && (
-            <span className={`inline-flex items-center mt-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide ${
-              staleRotation ? 'bg-amber-100 text-amber-800' : 'bg-purple-100 text-purple-800'
-            }`}>
-              Rotating{reward.current_period ? ` · ${reward.current_period}` : ''}
-            </span>
-          )}
-          {staleRotation && (
-            <div className="text-[10px] text-amber-700 mt-0.5">may be outdated</div>
-          )}
-          {note && (
-            <div className="text-[11px] text-gray-500 mt-0.5">{note}</div>
-          )}
-        </div>
-      </div>
-      <RateBadge pick={pick} />
-    </div>
-  );
-}
-
-function RateBadge({ pick }: { pick: Pick }) {
+function RateCell({ pick }: { pick: Pick }) {
   const { card, reward } = pick;
-  return (
-    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap ${
-      reward.unit === 'percent'
-        ? 'bg-green-100 text-green-800'
-        : 'bg-indigo-100 text-indigo-800'
-    }`}>
-      {formatRewardWithUsdEquivalent(reward, card)}
-    </span>
-  );
+  return <span className="cj-eff-pct">{formatRewardWithUsdEquivalent(reward, card)}</span>;
 }

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
 import { XMarkIcon, TrashIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
-import { addToWallet, removeFromWallet, WalletCard, getCardRatings, getUserCardRating, submitCardRating } from '@/lib/api';
+import { addToWallet, removeFromWallet, WalletCard, getUserCardRating, submitCardRating } from '@/lib/api';
 import { useAuth } from '@/auth/AuthProvider';
 
 interface EditWalletCardModalProps {
@@ -16,42 +16,26 @@ interface EditWalletCardModalProps {
 }
 
 const RATING_LABELS: Record<number, string> = {
-  1: 'Very Bad',
-  2: 'Bad',
-  3: 'Average',
-  4: 'Good',
-  5: 'Very Good',
-};
-
-const RATING_COLORS: Record<number, { bg: string; text: string; fill: string }> = {
-  1: { bg: 'bg-red-100', text: 'text-red-700', fill: 'text-red-400' },
-  2: { bg: 'bg-orange-100', text: 'text-orange-700', fill: 'text-orange-400' },
-  3: { bg: 'bg-yellow-100', text: 'text-yellow-700', fill: 'text-yellow-400' },
-  4: { bg: 'bg-green-100', text: 'text-green-700', fill: 'text-green-400' },
-  5: { bg: 'bg-emerald-100', text: 'text-emerald-700', fill: 'text-emerald-500' },
+  1: 'very bad',
+  2: 'bad',
+  3: 'average',
+  4: 'good',
+  5: 'very good',
 };
 
 function StarIcon({ filled, className }: { filled?: boolean; className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 20 20" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth={filled ? "0" : "1.5"} xmlns="http://www.w3.org/2000/svg">
+    <svg className={className} viewBox="0 0 20 20" fill={filled ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={filled ? '0' : '1.5'} xmlns="http://www.w3.org/2000/svg">
       <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
     </svg>
   );
 }
 
 const months = [
-  { value: 1, label: 'January' },
-  { value: 2, label: 'February' },
-  { value: 3, label: 'March' },
-  { value: 4, label: 'April' },
-  { value: 5, label: 'May' },
-  { value: 6, label: 'June' },
-  { value: 7, label: 'July' },
-  { value: 8, label: 'August' },
-  { value: 9, label: 'September' },
-  { value: 10, label: 'October' },
-  { value: 11, label: 'November' },
-  { value: 12, label: 'December' },
+  { value: 1, label: 'January' }, { value: 2, label: 'February' }, { value: 3, label: 'March' },
+  { value: 4, label: 'April' }, { value: 5, label: 'May' }, { value: 6, label: 'June' },
+  { value: 7, label: 'July' }, { value: 8, label: 'August' }, { value: 9, label: 'September' },
+  { value: 10, label: 'October' }, { value: 11, label: 'November' }, { value: 12, label: 'December' },
 ];
 
 export default function EditWalletCardModal({ show, card, cardSlug, onClose, onSuccess }: EditWalletCardModalProps) {
@@ -65,18 +49,15 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
   const [hoveredRating, setHoveredRating] = useState<number | null>(null);
   const [ratingSubmitting, setRatingSubmitting] = useState(false);
 
-  // Generate year options (current year back to 1990)
   const currentYear = new Date().getFullYear();
   const years = Array.from({ length: currentYear - 1989 }, (_, i) => currentYear - i);
 
-  // Reset form when card changes
   useEffect(() => {
     if (card) {
       setAcquiredMonth(card.acquired_month);
       setAcquiredYear(card.acquired_year);
       setError(null);
       setUserRating(null);
-      // Load user's rating
       (async () => {
         const token = await getToken();
         if (!token) return;
@@ -88,18 +69,11 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
 
   const handleSave = async () => {
     if (!card) return;
-
     setSaving(true);
     setError(null);
-
     try {
       const token = await getToken();
-      await addToWallet(
-        card.card_id,
-        acquiredMonth,
-        acquiredYear,
-        token || undefined
-      );
+      await addToWallet(card.card_id, acquiredMonth, acquiredYear, token || undefined);
       onSuccess();
       onClose();
     } catch (err) {
@@ -112,10 +86,8 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
   const handleDelete = async () => {
     if (!card) return;
     if (!confirm(`Remove "${card.card_name}" from your wallet?`)) return;
-
     setDeleting(true);
     setError(null);
-
     try {
       const token = await getToken();
       if (!token) throw new Error('Authentication required');
@@ -151,111 +123,82 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
 
   if (!show || !card) return null;
 
+  const activeRating = hoveredRating ?? userRating ?? 0;
+  const acquiredLabel = (() => {
+    if (!card.acquired_month && !card.acquired_year) return null;
+    const m = card.acquired_month ? new Date(2000, card.acquired_month - 1).toLocaleString('default', { month: 'short' }) : '';
+    return card.acquired_year ? `since ${m ? m + ' ' : ''}${card.acquired_year}` : `since ${m}`;
+  })();
+
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-        {/* Backdrop */}
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={handleClose} />
+    <div className="cj-modal-root" role="dialog" aria-modal="true">
+      <div className="cj-modal-backdrop" onClick={handleClose} />
+      <div className="cj-modal-shell">
+        <div className="cj-modal-card">
+          <div className="cj-modal-head">
+            <span className="cj-status-dot" />
+            <span className="cj-modal-title">edit card</span>
+            <button type="button" className="cj-modal-close" onClick={handleClose} aria-label="Close">
+              <XMarkIcon style={{ width: 16, height: 16 }} />
+            </button>
+          </div>
 
-        {/* Modal */}
-        <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-md">
-          <div className="bg-white px-4 pb-4 pt-5 sm:p-6">
-            {/* Header */}
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-gray-900">Edit Card</h3>
-              <button
-                onClick={handleClose}
-                className="text-gray-400 hover:text-gray-500"
-              >
-                <XMarkIcon className="h-6 w-6" />
-              </button>
-            </div>
+          <div className="cj-modal-body">
+            {error && <div className="cj-modal-error">{error}</div>}
 
-            {error && (
-              <div className="mb-4 rounded-md bg-red-50 p-4">
-                <p className="text-sm text-red-700">{error}</p>
-              </div>
-            )}
-
-            {/* Card Info */}
-            <div className="mb-6 p-4 bg-gray-50 rounded-lg">
-              <div className="flex items-center">
-                <div className="h-12 w-20 flex-shrink-0 mr-4">
-                  <CardImage
-                    cardImageLink={card.card_image_link}
-                    alt={card.card_name}
-                    width={80}
-                    height={48}
-                    className="h-12 w-20 object-contain"
-                  />
-                </div>
-                <div className="flex-1">
-                  <div className="font-medium text-gray-900">{card.card_name}</div>
-                  <div className="text-sm text-gray-500">{card.bank}</div>
-                  {(card.acquired_month || card.acquired_year) && (
-                    <div className="text-xs text-gray-400 mt-0.5">
-                      Since {card.acquired_month ? new Date(2000, card.acquired_month - 1).toLocaleString('default', { month: 'short' }) + ' ' : ''}{card.acquired_year || ''}
-                    </div>
-                  )}
+            <div className="cj-modal-section">
+              <div className="cj-modal-card-row">
+                <span className="cj-modal-thumb">
+                  <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="56px" />
+                </span>
+                <div style={{ minWidth: 0 }}>
+                  <div className="cj-modal-card-name">{card.card_name}</div>
+                  <div className="cj-modal-card-meta">
+                    {card.bank}{acquiredLabel ? ` · ${acquiredLabel}` : ''}
+                  </div>
                 </div>
               </div>
               {cardSlug && (
-                <Link
-                  href={`/card/${cardSlug}`}
-                  className="mt-3 inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-800"
-                >
-                  View card details
-                  <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                <Link href={`/card/${cardSlug}`} className="cj-modal-link">
+                  view card details <ArrowTopRightOnSquareIcon style={{ width: 11, height: 11 }} />
                 </Link>
               )}
             </div>
 
-            {/* Rating */}
-            <div className="mb-6">
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                {userRating ? 'Your rating (click to change):' : 'Rate this card:'}
-              </label>
-              <div className="flex items-center gap-1">
+            <div className="cj-modal-section">
+              <label className="cj-modal-label">{userRating ? 'Your rating' : 'Rate this card'}</label>
+              <div className="cj-modal-stars">
                 {[1, 2, 3, 4, 5].map((star) => {
-                  const active = (hoveredRating ?? userRating ?? 0) >= star;
-                  const colors = RATING_COLORS[hoveredRating ?? userRating ?? star];
+                  const active = activeRating >= star;
                   return (
                     <button
                       key={star}
+                      type="button"
                       onClick={() => handleRate(star)}
                       onMouseEnter={() => setHoveredRating(star)}
                       onMouseLeave={() => setHoveredRating(null)}
                       disabled={ratingSubmitting}
-                      className={`p-1.5 rounded-lg transition-colors ${
-                        active ? colors.bg : 'hover:bg-gray-100'
-                      } ${ratingSubmitting ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                      className={'cj-modal-star' + (active ? ' is-active' : '')}
                       title={RATING_LABELS[star]}
+                      aria-label={`Rate ${star} of 5`}
                     >
-                      <StarIcon
-                        filled={active}
-                        className={`h-6 w-6 ${active ? colors.fill : 'text-gray-300'}`}
-                      />
+                      <StarIcon filled={active} className="h-5 w-5" />
                     </button>
                   );
                 })}
-                {(hoveredRating ?? userRating) && (
-                  <span className={`ml-2 text-sm font-medium ${RATING_COLORS[hoveredRating ?? userRating!].text}`}>
-                    {RATING_LABELS[hoveredRating ?? userRating!]}
-                  </span>
+                {activeRating > 0 && (
+                  <span className="cj-modal-star-label">{RATING_LABELS[activeRating]}</span>
                 )}
               </div>
             </div>
 
-            {/* Acquired Date */}
-            <div className="mb-6">
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                When did you get this card?
-              </label>
-              <div className="grid grid-cols-2 gap-4">
+            <div className="cj-modal-section">
+              <label className="cj-modal-label">When did you get this card?</label>
+              <div className="cj-modal-grid">
                 <select
                   value={acquiredMonth || ''}
                   onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
-                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                  className="cj-modal-select"
                 >
                   <option value="">Month</option>
                   {months.map((m) => (
@@ -265,7 +208,7 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
                 <select
                   value={acquiredYear || ''}
                   onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
-                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                  className="cj-modal-select"
                 >
                   <option value="">Year</option>
                   {years.map((y) => (
@@ -274,32 +217,30 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
                 </select>
               </div>
             </div>
+          </div>
 
-            {/* Actions */}
-            <div className="flex items-center justify-between">
-              <button
-                onClick={handleDelete}
-                disabled={deleting || saving}
-                className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-red-600 hover:text-red-700 hover:bg-red-50 rounded-md disabled:opacity-50"
-              >
-                <TrashIcon className="h-4 w-4" />
-                {deleting ? 'Removing...' : 'Remove from Wallet'}
+          <div className="cj-modal-footer">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting || saving}
+              className="cj-modal-danger"
+            >
+              <TrashIcon style={{ width: 12, height: 12 }} />
+              {deleting ? 'removing…' : 'remove from wallet'}
+            </button>
+            <div className="cj-modal-actions">
+              <button type="button" className="cj-modal-btn" onClick={handleClose}>
+                cancel
               </button>
-              <div className="flex gap-3">
-                <button
-                  onClick={handleClose}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSave}
-                  disabled={saving || deleting}
-                  className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 disabled:opacity-50"
-                >
-                  {saving ? 'Saving...' : 'Save'}
-                </button>
-              </div>
+              <button
+                type="button"
+                className="cj-modal-btn cj-modal-btn-primary"
+                onClick={handleSave}
+                disabled={saving || deleting}
+              >
+                {saving ? 'saving…' : 'save'}
+              </button>
             </div>
           </div>
         </div>

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -1,32 +1,10 @@
 'use client';
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import Link from "next/link";
 import CardImage from "@/components/ui/CardImage";
 import { Card, CardBenefit, WalletCard } from "@/lib/api";
 import { amortizedAnnualValue, formatBenefitValue, frequencyLabel } from "@/lib/cardDisplayUtils";
-import {
-  CheckCircleIcon,
-  GiftIcon,
-} from "@heroicons/react/24/outline";
-
-const categoryIcons: Record<string, string> = {
-  dining: "🍽️",
-  dining_travel: "🚗",
-  travel: "✈️",
-  hotel: "🏨",
-  entertainment: "🎬",
-  shopping: "🛍️",
-  fitness: "💪",
-  lounge: "🛋️",
-  security: "🔒",
-  gas: "⛽",
-  streaming: "📺",
-  grocery: "🛒",
-  rideshare: "🚗",
-  car_rental: "🚙",
-  other: "✨",
-};
 
 interface CardWithBenefits {
   walletCard: WalletCard;
@@ -39,9 +17,13 @@ interface WalletBenefitsProps {
   allCards: Card[];
 }
 
-export default function WalletBenefits({ walletCards, allCards }: WalletBenefitsProps) {
-  const [viewMode, setViewMode] = useState<'by-card' | 'all-credits'>('all-credits');
+interface DecoratedBenefit extends CardBenefit {
+  cardName: string;
+  cardSlug: string;
+  cardImage?: string;
+}
 
+export default function WalletBenefits({ walletCards, allCards }: WalletBenefitsProps) {
   const cardsWithBenefits = useMemo(() => {
     const result: CardWithBenefits[] = [];
     for (const wc of walletCards) {
@@ -53,194 +35,123 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
     return result;
   }, [walletCards, allCards]);
 
-  const allCredits = useMemo(() => {
+  const allCredits = useMemo<DecoratedBenefit[]>(() => {
     return cardsWithBenefits.flatMap(c =>
-      c.benefits.filter(b => b.value > 0).map(b => ({ ...b, cardName: c.cardData.card_name, cardSlug: c.cardData.slug, cardImage: c.cardData.card_image_link }))
-    ).sort((a, b) => b.value - a.value);
+      c.benefits
+        .filter(b => b.value > 0)
+        .map(b => ({ ...b, cardName: c.cardData.card_name, cardSlug: c.cardData.slug, cardImage: c.cardData.card_image_link }))
+    ).sort((a, b) => amortizedAnnualValue(b) - amortizedAnnualValue(a));
   }, [cardsWithBenefits]);
 
-  const allPerks = useMemo(() => {
+  const allPerks = useMemo<DecoratedBenefit[]>(() => {
     return cardsWithBenefits.flatMap(c =>
-      c.benefits.filter(b => b.value === 0).map(b => ({ ...b, cardName: c.cardData.card_name, cardSlug: c.cardData.slug, cardImage: c.cardData.card_image_link }))
+      c.benefits
+        .filter(b => b.value === 0)
+        .map(b => ({ ...b, cardName: c.cardData.card_name, cardSlug: c.cardData.slug, cardImage: c.cardData.card_image_link }))
     );
   }, [cardsWithBenefits]);
 
-  const totalAnnualValue = useMemo(() => {
-    return allCredits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0);
-  }, [allCredits]);
+  const totalAnnualValue = useMemo(
+    () => Math.round(allCredits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0)),
+    [allCredits]
+  );
+
+  const enrollCount = useMemo(() => allCredits.filter(b => b.enrollment_required).length, [allCredits]);
 
   if (cardsWithBenefits.length === 0) {
     return (
-      <div className="bg-white shadow rounded-lg p-6">
-        <div className="text-center py-12">
-          <GiftIcon className="mx-auto h-12 w-12 text-gray-300" />
-          <p className="mt-2 text-gray-500">No cards with benefits in your wallet yet.</p>
-          <p className="mt-1 text-sm text-gray-400">Add premium cards to see their credits and perks here.</p>
-        </div>
+      <div className="cj-verdict">
+        <b>No cards with benefits yet.</b> Add premium cards to your wallet to see their credits and perks here.
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
-      {/* Summary Header */}
-      <div className="bg-gradient-to-br from-emerald-50 to-white shadow rounded-lg p-6 border border-emerald-100">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Your Card Benefits</h2>
-            <p className="mt-1 text-sm text-gray-500">
-              Credits and perks from {cardsWithBenefits.length} {cardsWithBenefits.length === 1 ? 'card' : 'cards'} in your wallet
-            </p>
+    <section className="cj-section">
+      <div className="cj-readoff" style={{ gridTemplateColumns: 'repeat(3, minmax(0, 1fr))' }}>
+        <div className="cj-readoff-cell cj-readoff-bonus">
+          <div className="cj-readoff-k">Total annual credits</div>
+          <div className="cj-readoff-v">${totalAnnualValue.toLocaleString()}</div>
+          <div className="cj-readoff-foot">
+            across {cardsWithBenefits.length} card{cardsWithBenefits.length === 1 ? '' : 's'}
           </div>
-          <div className="text-center sm:text-right">
-            <p className="text-sm font-semibold text-emerald-600">Total annual credits</p>
-            <p className="text-3xl font-extrabold text-emerald-700">${totalAnnualValue.toLocaleString()}</p>
+        </div>
+        <div className="cj-readoff-cell">
+          <div className="cj-readoff-k">Statement credits</div>
+          <div className="cj-readoff-v">{allCredits.length}</div>
+          <div className="cj-readoff-foot">
+            {enrollCount > 0 ? `${enrollCount} require enrollment` : 'no enrollment needed'}
           </div>
+        </div>
+        <div className="cj-readoff-cell">
+          <div className="cj-readoff-k">Additional perks</div>
+          <div className="cj-readoff-v">{allPerks.length}</div>
+          <div className="cj-readoff-foot">lounges, status, etc.</div>
         </div>
       </div>
 
-      {/* View Toggle */}
-      <div className="flex gap-2">
-        <button
-          onClick={() => setViewMode('all-credits')}
-          className={`px-3 py-1.5 text-sm font-medium rounded-md ${
-            viewMode === 'all-credits'
-              ? 'bg-indigo-100 text-indigo-700'
-              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-          }`}
-        >
-          All Credits
-        </button>
-        <button
-          onClick={() => setViewMode('by-card')}
-          className={`px-3 py-1.5 text-sm font-medium rounded-md ${
-            viewMode === 'by-card'
-              ? 'bg-indigo-100 text-indigo-700'
-              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-          }`}
-        >
-          By Card
-        </button>
-      </div>
-
-      {viewMode === 'all-credits' ? (
-        <div className="bg-white shadow rounded-lg divide-y divide-gray-100">
-          {/* Credits Table */}
-          <div className="p-6">
-            <h3 className="text-base font-semibold text-gray-700 mb-4">Statement credits</h3>
-            <div className="space-y-3">
-              {allCredits.map((credit, i) => (
-                <div key={`${credit.cardName}-${credit.name}-${i}`} className="flex items-center gap-4 rounded-lg border border-gray-100 bg-gray-50/50 px-4 py-3">
-                  <span className="text-xl flex-shrink-0">{categoryIcons[credit.category] || categoryIcons.other}</span>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold text-gray-900">{credit.name}</p>
-                    <p className="text-xs text-gray-500 truncate">{credit.description}</p>
-                  </div>
-                  <Link href={`/card/${credit.cardSlug}`} className="hidden sm:block flex-shrink-0">
-                    <CardImage cardImageLink={credit.cardImage} alt={credit.cardName} width={48} height={30} className="rounded object-contain" sizes="48px" />
-                  </Link>
-                  <div className="text-right flex-shrink-0">
-                    <p className="text-lg font-bold text-emerald-700">{formatBenefitValue(credit)}</p>
-                    <p className="text-xs text-gray-400">{frequencyLabel(credit)}</p>
-                  </div>
-                  {credit.enrollment_required && (
-                    <span className="hidden sm:inline-flex flex-shrink-0 items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 border border-amber-200">
-                      Enroll
-                    </span>
-                  )}
-                </div>
-              ))}
+      {allCredits.length > 0 && (
+        <>
+          <div className="cj-table-label" style={{ marginTop: 24 }}>Statement credits</div>
+          <div className="cj-tape cj-tape-credits">
+            <div className="cj-tape-head">
+              <div></div>
+              <div>Credit</div>
+              <div>Cadence</div>
+              <div className="cj-tape-res">Value</div>
             </div>
+            {allCredits.map((b, i) => (
+              <Link
+                key={`${b.cardName}-${b.name}-${i}`}
+                href={`/card/${b.cardSlug}`}
+                className="cj-tape-row"
+              >
+                <div>
+                  <span className="cj-tape-thumb">
+                    <CardImage cardImageLink={b.cardImage} alt={b.cardName} fill sizes="36px" className="object-contain" />
+                  </span>
+                </div>
+                <div className="cj-tape-event">
+                  <span className="cj-tape-field">{b.name}</span>
+                  <div className="cj-tape-detail">
+                    {b.cardName}
+                    {b.enrollment_required ? ' · enrollment required' : ''}
+                  </div>
+                </div>
+                <div className="cj-tape-when">{frequencyLabel(b)}</div>
+                <div className="cj-tape-res">
+                  <b>{formatBenefitValue(b)}</b>
+                </div>
+              </Link>
+            ))}
           </div>
-
-          {/* Perks */}
-          {allPerks.length > 0 && (
-            <div className="p-6">
-              <h3 className="text-base font-semibold text-gray-700 mb-4">Additional perks</h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {allPerks.map((perk, i) => (
-                  <div key={`${perk.cardName}-${perk.name}-${i}`} className="flex items-start gap-3 rounded-lg border border-gray-100 bg-gray-50/50 px-4 py-3">
-                    <CheckCircleIcon className="h-5 w-5 text-emerald-500 flex-shrink-0 mt-0.5" />
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold text-gray-900">{perk.name}</p>
-                      <p className="text-xs text-gray-500">{perk.description}</p>
-                      <Link href={`/card/${perk.cardSlug}`} className="text-xs text-indigo-600 hover:text-indigo-800 mt-1 inline-block">
-                        {perk.cardName}
-                      </Link>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      ) : (
-        /* By Card View */
-        <div className="space-y-4">
-          {cardsWithBenefits.map(({ walletCard, cardData, benefits }) => {
-            const credits = benefits.filter(b => b.value > 0);
-            const perks = benefits.filter(b => b.value === 0);
-            const cardTotal = credits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0);
-
-            return (
-              <div key={walletCard.id} className="bg-white shadow rounded-lg overflow-hidden">
-                <div className="p-4 sm:p-5 border-b border-gray-100 bg-gray-50/50">
-                  <div className="flex items-center gap-4">
-                    <Link href={`/card/${cardData.slug}`}>
-                      <CardImage cardImageLink={cardData.card_image_link} alt={cardData.card_name} width={64} height={40} className="rounded object-contain flex-shrink-0" sizes="64px" />
-                    </Link>
-                    <div className="flex-1 min-w-0">
-                      <Link href={`/card/${cardData.slug}`} className="text-sm font-semibold text-gray-900 hover:text-indigo-600 truncate block">
-                        {cardData.card_name}
-                      </Link>
-                      <p className="text-xs text-gray-500">{cardData.bank}</p>
-                    </div>
-                    <div className="text-right flex-shrink-0">
-                      <p className="text-lg font-bold text-emerald-700">${cardTotal.toLocaleString()}</p>
-                      <p className="text-xs text-gray-400">/yr in credits</p>
-                    </div>
-                  </div>
-                </div>
-                <div className="p-4 sm:p-5">
-                  {credits.length > 0 && (
-                    <div className="space-y-2">
-                      {credits.map((b, i) => (
-                        <div key={i} className="flex items-center justify-between py-1">
-                          <div className="flex items-center gap-2 min-w-0">
-                            <span className="text-base flex-shrink-0">{categoryIcons[b.category] || categoryIcons.other}</span>
-                            <span className="text-sm text-gray-700 truncate">{b.name}</span>
-                            {b.enrollment_required && (
-                              <span className="flex-shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 border border-amber-200">
-                                Enroll
-                              </span>
-                            )}
-                          </div>
-                          <div className="flex items-baseline gap-1 flex-shrink-0">
-                            <span className="text-sm font-bold text-emerald-700">{formatBenefitValue(b)}</span>
-                            <span className="text-xs text-gray-400">{frequencyLabel(b)}</span>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  {perks.length > 0 && (
-                    <div className={credits.length > 0 ? "mt-3 pt-3 border-t border-gray-100" : ""}>
-                      <div className="flex flex-wrap gap-2">
-                        {perks.map((p, i) => (
-                          <span key={i} className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-gray-100 text-xs text-gray-600">
-                            <CheckCircleIcon className="h-3.5 w-3.5 text-emerald-500" />
-                            {p.name}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+        </>
       )}
-    </div>
+
+      {allPerks.length > 0 && (
+        <>
+          <div className="cj-table-label" style={{ marginTop: 24 }}>Additional perks</div>
+          <div className="cj-tape">
+            {allPerks.map((p, i) => (
+              <Link
+                key={`${p.cardName}-${p.name}-${i}`}
+                href={`/card/${p.cardSlug}`}
+                className="cj-tape-row cj-tape-row-perk"
+              >
+                <div>
+                  <span className="cj-tape-thumb">
+                    <CardImage cardImageLink={p.cardImage} alt={p.cardName} fill sizes="36px" className="object-contain" />
+                  </span>
+                </div>
+                <div className="cj-tape-event">
+                  <span className="cj-tape-field">{p.name}</span>
+                  <div className="cj-tape-detail">{p.cardName}</div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </>
+      )}
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- Rebuilds `/profile` to match the Profile v4 design from claude.ai/design — terminal strip, tight welcome + 5-cell readoff, sticky tab row, 2-col layout with right rail (apply block, upcoming renewals, news for you).
- Re-skins the Cards / Rewards / Benefits / Applications / Referrals / Settings tabs in the cj-* tape + readoff style; rule charts are now a pure-CSS segmented meter (no Highcharts in that chunk).
- Edit-card and Add-card modals get a `cj-modal-*` shell (dark terminal-style head, dashed section dividers, paper-2 footer).
- Defines the `--accent-deep` token that was referenced but never declared, fixing the "+ button turns white on hover" bug across CTAs and modals.

## Test plan
- [ ] `/profile` loads on desktop: terminal strip → welcome + 5 stat cells → tab row → wallet tape → right rail
- [ ] Tab row stays pinned below the global navbar when scrolling the cards list
- [ ] Hovering tabs and using the wheel scrolls the page (not the tab bar)
- [ ] Clicking a card row expands inline detail; `+ submit a record` / `+ add referral link` show only when missing
- [ ] Hover state on `+ add a card`, `+ add a referral`, `+ submit a record`, modal save → deep purple, white text legible
- [ ] `+ add a card` and `edit card` modals render with the new `cj-modal-*` shell
- [ ] Rewards tab table shows card thumb + earn rate; alternative row appears for gated rewards
- [ ] Benefits tab shows 3-cell readoff + credits tape + perks tape
- [ ] Applications tab: records tape + segmented rule meters (safe / at limit / over limit)
- [ ] Referrals tab: 3-cell readoff + tape with status pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)