### PR TITLE
Fix Iberia Visa apply link

### DIFF
--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -47,4 +47,4 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: true
-apply_link: https://creditcards.chase.com/travel-credit-cards/iberia
+apply_link: https://creditcards.chase.com/travel-credit-cards/avios/iberia


### PR DESCRIPTION
## Summary
- Chase moved the Iberia Visa Signature card page from `/travel-credit-cards/iberia` to `/travel-credit-cards/avios/iberia`. The old URL still 302s to the new one, but the apply-link health check's headless Playwright fails to resolve the redirect target (`ERR_NAME_NOT_RESOLVED`).
- Updated `data/cards/iberia-visa-signature-card.yaml` to point directly at the canonical URL — verified `200 OK`.

Closes #1063.

## Test plan
- [ ] Re-run **check-apply-links** workflow on this branch — Iberia should drop out of the broken-link list
- [ ] On `/card/iberia-visa-signature-card`, "Apply" link opens to the new Chase URL
🤖 Generated with [Claude Code](https://claude.com/claude-code)