### PR TITLE
Profile v4: comprehensive mobile pass

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3874,9 +3874,146 @@
   color: #fff;
 }
 
+/* Mobile / responsive utility classes */
+.landing-v2.profile-v2 .cj-mob-only { display: none; }
+.landing-v2.profile-v2 .cj-mob-hide { display: block; }
+
 /* Mobile: rail moves below main, no border-right on main */
 @media (max-width: 1023px) {
   .landing-v2.profile-v2 .cj-main { border-right: 0; }
+}
+
+/* ===== Mobile (≤640px) — comprehensive overrides ===== */
+@media (max-width: 640px) {
+  .landing-v2.profile-v2 .cj-mob-only { display: block; }
+  .landing-v2.profile-v2 .cj-mob-hide { display: none !important; }
+
+  /* Snapshot — slightly smaller H1, tighter padding */
+  .landing-v2.profile-v2 .cj-snapshot { padding: 10px 0 12px; }
+  .landing-v2.profile-v2 .cj-snapshot-h1 { font-size: 24px !important; }
+  .landing-v2.profile-v2 .cj-snapshot-meta { font-size: 10.5px; }
+
+  /* Readoff — last odd cell spans full width so 5 cells lay out evenly (2/2/1-full) */
+  .landing-v2.profile-v2 .cj-readoff > .cj-readoff-cell:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+  .landing-v2.profile-v2 .cj-readoff-v { font-size: 18px; }
+  .landing-v2.profile-v2 .cj-readoff-cell { padding: 8px 10px; }
+
+  /* Tabs — tighter so 6 wrap onto two lines comfortably */
+  .landing-v2.profile-v2 .cj-main-tab {
+    padding: 8px 12px 8px 0;
+    margin-right: 14px;
+    font-size: 12.5px;
+  }
+
+  /* Wallet tape — drop the head, simplify rows: thumb · name+issuer · fee · caret */
+  .landing-v2.profile-v2 .cj-wallet-toolbar { gap: 10px; }
+  .landing-v2.profile-v2 .cj-wallet-head { display: none; }
+  .landing-v2.profile-v2 .cj-wallet-crow {
+    grid-template-columns: 36px minmax(0, 1fr) auto auto;
+    grid-template-areas:
+      "thumb name fee caret"
+      "thumb issuer fee caret";
+    gap: 0 10px;
+    padding: 10px 12px;
+    align-items: center;
+  }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-thumb { grid-area: thumb; align-self: center; }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-name {
+    grid-area: name;
+    align-self: end;
+    line-height: 1.15;
+    font-size: 13.5px;
+  }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-issuer {
+    grid-area: issuer;
+    align-self: start;
+    font-size: 10.5px;
+    color: var(--muted);
+  }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-renew { display: none; }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-fee {
+    grid-area: fee;
+    align-self: center;
+    font-size: 13px;
+  }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-caret { grid-area: caret; align-self: center; }
+  .landing-v2.profile-v2 .cj-cw-marks { margin-left: 6px; }
+  .landing-v2.profile-v2 .cj-cw-mark { width: 16px; height: 16px; }
+
+  /* Wallet detail expand — left padding aligned with thumb shrunk to row padding */
+  .landing-v2.profile-v2 .cj-wallet-detail { padding: 14px 12px; }
+  .landing-v2.profile-v2 .cj-wd-cta { font-size: 11px !important; padding: 5px 8px !important; }
+
+  /* Records tape — head hidden, columns collapsed to: card+detail · pill */
+  .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-head { display: none; }
+  .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 10px 12px;
+  }
+  .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row > div:nth-child(1),
+  .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row > div:nth-child(2),
+  .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row > div:nth-child(4),
+  .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row > div:nth-child(5) {
+    display: none;
+  }
+
+  /* Referrals tape — drop impressions/clicks columns; show as detail under card */
+  .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-head { display: none; }
+  .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-row {
+    grid-template-columns: 36px minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 10px 12px;
+  }
+  .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-row > div:nth-child(3),
+  .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-row > div:nth-child(4) {
+    display: none;
+  }
+
+  /* Benefits credits tape — drop cadence column; cadence shown in detail line */
+  .landing-v2.profile-v2 .cj-tape.cj-tape-credits .cj-tape-head { display: none; }
+  .landing-v2.profile-v2 .cj-tape.cj-tape-credits .cj-tape-row {
+    grid-template-columns: 36px minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 10px 12px;
+  }
+  .landing-v2.profile-v2 .cj-tape.cj-tape-credits .cj-tape-row > div:nth-child(3) {
+    display: none;
+  }
+
+  /* Rewards table — tighter, stacked best-cell */
+  .landing-v2.profile-v2 .cj-table { font-size: 12px; }
+  .landing-v2.profile-v2 .cj-table th { padding: 8px 8px; font-size: 11px; }
+  .landing-v2.profile-v2 .cj-table td { padding: 9px 8px; }
+  .landing-v2.profile-v2 .cj-rew-best { gap: 8px; }
+  .landing-v2.profile-v2 .cj-rew-thumb,
+  .landing-v2.profile-v2 .cj-rew-thumb-empty {
+    width: 24px;
+    height: 16px;
+  }
+  .landing-v2.profile-v2 .cj-eff-pct { font-size: 13px; }
+
+  /* Settings list — keep 2-col, tighten */
+  .landing-v2.profile-v2 .cj-settings-list { padding: 12px 0; gap: 10px; }
+  .landing-v2.profile-v2 .cj-settings-k { font-size: 12px; }
+  .landing-v2.profile-v2 .cj-settings-v { font-size: 12px; word-break: break-word; }
+
+  /* Verdict block — slimmer */
+  .landing-v2.profile-v2 .cj-verdict { padding: 14px 16px; font-size: 13px; }
+
+  /* Apply block — smaller display values */
+  .landing-v2.profile-v2 .cj-apply { padding: 16px; }
+  .landing-v2.profile-v2 .cj-apply-v { font-size: 18px; }
+
+  /* Modal — full-width on mobile */
+  .landing-v2.profile-v2 .cj-modal-card {
+    border-radius: 0;
+    border-left: 0;
+    border-right: 0;
+    max-width: 100%;
+  }
 }
 
 /* ===== Application rule card ===== */

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -816,6 +816,11 @@ function ApplicationsTab(props: ApplicationsTabProps) {
                 </div>
                 <div className="cj-tape-event">
                   <span className="cj-tape-field">{r.card_name}</span>
+                  <div className="cj-tape-detail cj-mob-only">
+                    {new Date(r.date_applied || r.submit_datetime).toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' })}
+                    {' · '}score {r.credit_score}
+                    {' · '}${(r.listed_income / 1000).toFixed(0)}k
+                  </div>
                 </div>
                 <div className="cj-tape-res">{r.credit_score}</div>
                 <div className="cj-tape-res">${(r.listed_income / 1000).toFixed(0)}k</div>
@@ -948,6 +953,9 @@ function ReferralsTab(props: ReferralsTabProps) {
                   <a href={r.referral_link} target="_blank" rel="noreferrer" style={{ color: 'var(--muted)', textDecoration: 'underline', textDecorationColor: 'var(--line-2)' }}>
                     {r.referral_link.length > 40 ? r.referral_link.slice(0, 40) + '…' : r.referral_link}
                   </a>
+                </div>
+                <div className="cj-tape-detail cj-mob-only">
+                  {(r.impressions ?? 0).toLocaleString()} impr · {r.clicks ?? 0} click{(r.clicks ?? 0) === 1 ? '' : 's'}
                 </div>
               </div>
               <div className="cj-tape-res">{(r.impressions ?? 0).toLocaleString()}</div>

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -117,6 +117,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
                     {b.cardName}
                     {b.enrollment_required ? ' · enrollment required' : ''}
                   </div>
+                  <div className="cj-tape-detail cj-mob-only">{frequencyLabel(b)}</div>
                 </div>
                 <div className="cj-tape-when">{frequencyLabel(b)}</div>
                 <div className="cj-tape-res">


### PR DESCRIPTION
## Summary
At 375px the desktop tape grids overflowed (wallet rows hit ~390px, records ~386px) — text and outcome pills were being clipped or running off-screen. This pass adds a single `@media (max-width: 640px)` block that restructures every tape and table so the page reads cleanly without losing data.

- **Wallet tape**: head hidden, rows now `grid-template-areas: thumb name fee caret / thumb issuer fee caret`. Renewal lives only in the expand (still one tap away).
- **Records / Referrals / Benefits credits tapes**: side-column cells hidden on mobile and re-surfaced as a `cj-mob-only` detail line under the card name.
- **Rewards table**: smaller font/padding, thumbs shrunk to 24×16.
- **Readoff strip**: last odd cell spans full width so the trailing cell isn't half-width when there are 5 cells in 2-col.
- **Tabs**: tighter padding so 6 wrap onto two lines comfortably.
- **Modal**: edge-to-edge on mobile (no side borders / rounded corners).
- New `.cj-mob-only` / `.cj-mob-hide` utility classes scoped to `.profile-v2`.

## Test plan
- [ ] On mobile (375px), `/profile` Cards tab — rows fit without clipping; tap to expand still works
- [ ] Records tab — card name + outcome pill align cleanly; mobile detail line shows date · score · income
- [ ] Referrals tab — card + status pill align; mobile detail line shows impressions · clicks
- [ ] Benefits tab — credits show value on the right with cadence in the detail line
- [ ] Rewards tab — table doesn't horizontal-scroll; thumbs visible
- [ ] Settings tab — key + value rows wrap cleanly
- [ ] Snapshot / tabs / readoff at 375px don't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)