### PR TITLE
Landing: square the search chips, add explore-all link

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -294,6 +294,10 @@ function Hero({ cards }: { cards: LandingCard[] }) {
               );
             })}
           </div>
+
+          <Link href="/explore" className="explore-all">
+            Or explore all cards →
+          </Link>
         </div>
       </div>
     </section>

--- a/apps/web-next/src/app/landing-v3.css
+++ b/apps/web-next/src/app/landing-v3.css
@@ -128,9 +128,9 @@
 .landing-v3 .quick-tags .qt {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 10px 5px 5px;
-  border-radius: 999px;
+  gap: 8px;
+  padding: 6px 10px 6px 6px;
+  border-radius: 8px;
   border: 1px solid var(--line-2);
   background: var(--card);
   font-size: 12px;
@@ -144,12 +144,28 @@
 }
 .landing-v3 .quick-tags .qt-thumb {
   position: relative;
-  width: 26px;
-  height: 17px;
-  border-radius: 3px;
+  width: 28px;
+  height: 18px;
+  border-radius: 4px;
   overflow: hidden;
   background: var(--paper-2);
   flex-shrink: 0;
+}
+
+.landing-v3 .explore-all {
+  display: block;
+  width: fit-content;
+  margin: 14px auto 0;
+  font-size: 12.5px;
+  color: var(--muted);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--line-2);
+  padding-bottom: 1px;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.landing-v3 .explore-all:hover {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
 }
 
 /* ---------- Search dropdown (live results) ---------- */


### PR DESCRIPTION
## Summary
- Drop the search-bar quick chips from full pills (`border-radius: 999px`) to 8px rounded rectangles so the inner card thumbnail (now 4px radius, 28×18) no longer fights the outer pill geometry.
- Add a quiet centered "Or explore all cards →" link beneath the chips for users who'd rather browse than type, styled with a dashed underline that solidifies on hover.

## Test plan
- [ ] Landing hero renders chips as soft rectangles, not pills
- [ ] "Or explore all cards →" link appears centered below the chips
- [ ] Link routes to `/explore`
- [ ] Mobile (chip row scrolls horizontally) still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)