### PR TITLE
Profile news rail: color-coded category chips, drop emojis

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3786,7 +3786,20 @@
   font-size: 10.5px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: #eef2ff;
+  line-height: 1.2;
 }
+.landing-v2.profile-v2 .cj-news-tag--new-card { background: #ecfdf5; color: #047857; }
+.landing-v2.profile-v2 .cj-news-tag--discontinued { background: #fef2f2; color: #b91c1c; }
+.landing-v2.profile-v2 .cj-news-tag--bonus-change { background: #eff6ff; color: #1d4ed8; }
+.landing-v2.profile-v2 .cj-news-tag--fee-change { background: #fffbeb; color: #b45309; }
+.landing-v2.profile-v2 .cj-news-tag--benefit-change { background: #f5f3ff; color: #6d28d9; }
+.landing-v2.profile-v2 .cj-news-tag--limited-time { background: #fff7ed; color: #c2410c; }
+.landing-v2.profile-v2 .cj-news-tag--policy-change { background: #f8fafc; color: #334155; }
+.landing-v2.profile-v2 .cj-news-tag--general { background: #eef2ff; color: #4338ca; }
 
 /* Apply block (dark "add a card" CTA) */
 .landing-v2.profile-v2 .cj-apply {

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -524,7 +524,9 @@ export default function ProfileClient() {
                         {new Date(n.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                       </span>
                       {n.tags?.[0] && (
-                        <span className="cj-news-tag">{tagLabels[n.tags[0]]?.toLowerCase() || n.tags[0]}</span>
+                        <span className={`cj-news-tag cj-news-tag--${n.tags[0]}`}>
+                          {(tagLabels[n.tags[0]] || n.tags[0]).replace(/^[^\w]+\s*/, '').toLowerCase()}
+                        </span>
                       )}
                     </div>
                     <Link href={`/news/${n.id}`} className="cj-rail-row-link">{n.title}</Link>


### PR DESCRIPTION
## Summary
- Replace emoji-prefixed category labels in the profile "News for you" rail with plain text
- Render each category as a light-tinted pill with per-category color (new-card → green, discontinued → red, bonus-change → blue, fee-change → amber, benefit-change → violet, limited-time → orange, policy-change → slate, general → indigo)

## Test plan
- [ ] Visit `/profile` with wallet cards that have associated news; confirm chips show colored backgrounds and no emojis

🤖 Generated with [Claude Code](https://claude.com/claude-code)