### PR TITLE
Profile: card-shuffle loader (riffle + deal, 50/50)

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -6489,3 +6489,152 @@
 .landing-v2.store-v2 .store-back-link:hover {
   color: var(--accent);
 }
+
+/* ============================================================
+   Profile Loader — card-shuffle replacements for the spinner.
+   Two variants: riffle (A) and deal (C). Pure CSS keyframes.
+   ============================================================ */
+.pl-host {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 22px;
+  padding: 32px 16px;
+  width: 100%;
+}
+.pl-caption {
+  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--ink-2);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+.pl-caption::after {
+  content: '';
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pl-pulse 1.4s ease-in-out infinite;
+}
+@keyframes pl-pulse {
+  0%, 100% { opacity: 0.25; transform: scale(0.85); }
+  50%      { opacity: 1;    transform: scale(1.15); }
+}
+
+.pl-card {
+  position: absolute;
+  width: 88px;
+  height: 56px;
+  border-radius: 6px;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.18) inset,
+    0 8px 20px -8px rgba(26, 19, 48, 0.45),
+    0 0 0 1px rgba(0, 0, 0, 0.04);
+  background: linear-gradient(135deg, var(--ink-2), var(--ink));
+  overflow: hidden;
+  will-change: transform;
+}
+.pl-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    -45deg,
+    transparent 0 4px,
+    rgba(255, 255, 255, 0.05) 4px 5px
+  );
+}
+.pl-card::after {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 9px;
+  width: 12px;
+  height: 9px;
+  border-radius: 1.5px;
+  background: linear-gradient(135deg, #d8c97a, #8a6f1e);
+  opacity: 0.85;
+}
+.pl-card .pl-stripe {
+  position: absolute;
+  left: 8px;
+  bottom: 9px;
+  height: 5px;
+  width: 38px;
+  border-radius: 1px;
+  background: rgba(255, 255, 255, 0.18);
+}
+.pl-card .pl-stripe.short { width: 22px; bottom: 17px; }
+
+.pl-card.t-accent { background: linear-gradient(135deg, #8a5fff, #4a25b5); }
+.pl-card.t-csr    { background: linear-gradient(135deg, #1a3a6a, #0e2244); }
+.pl-card.t-bilt   { background: linear-gradient(135deg, #1f1f1f, #0b0b0b); }
+.pl-card.t-amex   { background: linear-gradient(135deg, #c9a558, #8a6a26); }
+.pl-card.t-amex .pl-stripe { background: rgba(0, 0, 0, 0.18); }
+.pl-card.t-cap1   { background: linear-gradient(135deg, #c4a86d, #7a5e2f); }
+.pl-card.t-cap1 .pl-stripe { background: rgba(0, 0, 0, 0.18); }
+.pl-card.t-citi   { background: linear-gradient(135deg, #1a4eaf, #0a2a66); }
+
+/* Variant A — Riffle shuffle (1.8s loop, 6 cards). */
+.pl-riffle {
+  position: relative;
+  width: 200px;
+  height: 92px;
+}
+.pl-riffle .pl-card {
+  left: 56px;
+  top: 18px;
+}
+.pl-riffle .pl-card.r-l1 { animation: rfl-left  1.8s cubic-bezier(.45,.05,.55,.95) infinite; animation-delay: 0.00s; z-index: 6; }
+.pl-riffle .pl-card.r-r1 { animation: rfl-right 1.8s cubic-bezier(.45,.05,.55,.95) infinite; animation-delay: 0.10s; z-index: 5; }
+.pl-riffle .pl-card.r-l2 { animation: rfl-left  1.8s cubic-bezier(.45,.05,.55,.95) infinite; animation-delay: 0.20s; z-index: 4; }
+.pl-riffle .pl-card.r-r2 { animation: rfl-right 1.8s cubic-bezier(.45,.05,.55,.95) infinite; animation-delay: 0.30s; z-index: 3; }
+.pl-riffle .pl-card.r-l3 { animation: rfl-left  1.8s cubic-bezier(.45,.05,.55,.95) infinite; animation-delay: 0.40s; z-index: 2; }
+.pl-riffle .pl-card.r-r3 { animation: rfl-right 1.8s cubic-bezier(.45,.05,.55,.95) infinite; animation-delay: 0.50s; z-index: 1; }
+
+@keyframes rfl-left {
+  0%        { transform: translate(0, 0)        rotate(0deg); }
+  18%       { transform: translate(-58px, -2px) rotate(-4deg); }
+  55%       { transform: translate(-58px, -2px) rotate(-4deg); }
+  85%, 100% { transform: translate(0, 0)        rotate(0deg); }
+}
+@keyframes rfl-right {
+  0%        { transform: translate(0, 0)       rotate(0deg); }
+  18%       { transform: translate(58px, 2px)  rotate(4deg); }
+  55%       { transform: translate(58px, 2px)  rotate(4deg); }
+  85%, 100% { transform: translate(0, 0)       rotate(0deg); }
+}
+
+/* Variant C — Deal & tuck (5.6s loop, 4 cards). */
+.pl-deal {
+  position: relative;
+  width: 140px;
+  height: 80px;
+}
+.pl-deal .pl-card {
+  left: 26px;
+  top: 12px;
+  animation: deal 5.6s linear infinite;
+}
+.pl-deal .pl-card.d-1 { animation-delay: 0.0s; }
+.pl-deal .pl-card.d-2 { animation-delay: -1.4s; }
+.pl-deal .pl-card.d-3 { animation-delay: -2.8s; }
+.pl-deal .pl-card.d-4 { animation-delay: -4.2s; }
+
+@keyframes deal {
+  0%   { transform: translate(0, 0)       rotate(0deg); z-index: 4; }
+  20%  { transform: translate(0, 0)       rotate(0deg); z-index: 4; }
+  28%  { transform: translate(70px, -6px) rotate(8deg); z-index: 4; }
+  36%  { transform: translate(70px, 18px) rotate(0deg); z-index: 0; }
+  44%  { transform: translate(0,    18px) rotate(0deg); z-index: 1; }
+  52%  { transform: translate(0,    12px) rotate(0deg); z-index: 1; }
+  76%  { transform: translate(0,     6px) rotate(0deg); z-index: 2; }
+  100% { transform: translate(0,     0)   rotate(0deg); z-index: 3; }
+}

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -11,6 +11,7 @@ import { getAllCards, getProfile, getRecords, getReferrals, deleteRecord, archiv
 import "../landing.css";
 import { getNews, NewsItem, tagLabels } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
+import ProfileLoader from "./ProfileLoader";
 import { amortizedAnnualValue } from "@/lib/cardDisplayUtils";
 import { TrashIcon, DocumentTextIcon, LinkIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { calculateApplicationRules, countCardsMissingDates } from "@/lib/applicationRules";
@@ -595,11 +596,7 @@ export default function ProfileClient() {
 }
 
 function LoadingPanel() {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '48px 0' }}>
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
-    </div>
-  );
+  return <ProfileLoader />;
 }
 
 /* ========== Cards tab ========== */

--- a/apps/web-next/src/app/profile/ProfileLoader.tsx
+++ b/apps/web-next/src/app/profile/ProfileLoader.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Tone = 'accent' | 'csr' | 'amex' | 'bilt' | 'citi' | 'cap1';
+
+function Card({ tone, klass }: { tone: Tone; klass: string }) {
+  return (
+    <div className={`pl-card t-${tone} ${klass}`}>
+      <span className="pl-stripe short" />
+      <span className="pl-stripe" />
+    </div>
+  );
+}
+
+function LoaderRiffle({ caption }: { caption: string }) {
+  return (
+    <div className="pl-host">
+      <div className="pl-riffle" role="status" aria-label={caption}>
+        <Card tone="accent" klass="r-l1" />
+        <Card tone="csr" klass="r-r1" />
+        <Card tone="amex" klass="r-l2" />
+        <Card tone="bilt" klass="r-r2" />
+        <Card tone="citi" klass="r-l3" />
+        <Card tone="cap1" klass="r-r3" />
+      </div>
+      <p className="pl-caption">{caption}</p>
+    </div>
+  );
+}
+
+function LoaderDeal({ caption }: { caption: string }) {
+  return (
+    <div className="pl-host">
+      <div className="pl-deal" role="status" aria-label={caption}>
+        <Card tone="accent" klass="d-1" />
+        <Card tone="csr" klass="d-2" />
+        <Card tone="amex" klass="d-3" />
+        <Card tone="bilt" klass="d-4" />
+      </div>
+      <p className="pl-caption">{caption}</p>
+    </div>
+  );
+}
+
+export default function ProfileLoader() {
+  const [variant, setVariant] = useState<'riffle' | 'deal'>('riffle');
+  useEffect(() => {
+    setVariant(Math.random() < 0.5 ? 'riffle' : 'deal');
+  }, []);
+  return variant === 'riffle' ? (
+    <LoaderRiffle caption="Shuffling your wallet" />
+  ) : (
+    <LoaderDeal caption="Loading your wallet" />
+  );
+}

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -86,7 +86,7 @@ function MobileNavLink({
       href={href}
       onClick={onClick}
       className={classNames(
-        "block rounded-[8px] border px-4 py-3 text-sm font-medium transition-colors",
+        "block rounded-[3px] border px-4 py-3 text-sm font-medium transition-colors",
         active
           ? "border-[#ddd7ec] bg-[#f7f5fc] text-[#1a1330] [box-shadow:inset_3px_0_0_0_#6d3fe8]"
           : "border-transparent text-[#3a2f55] hover:border-[#ece8f5] hover:bg-[#f7f5fc] hover:text-[#1a1330]"
@@ -145,7 +145,7 @@ export default function Navbar() {
                     <Link
                       href="/profile"
                       className={classNames(
-                        "inline-flex items-center gap-2 rounded-[8px] px-4 py-2 text-[13px] font-semibold tracking-[-0.005em] transition-colors",
+                        "inline-flex items-center gap-2 rounded-[3px] px-4 py-2 text-[13px] font-semibold tracking-[-0.005em] transition-colors",
                         isProfileActive
                           ? "bg-[#3a2f55] text-white"
                           : "bg-[#1a1330] text-white hover:bg-[#3a2f55]"
@@ -158,10 +158,10 @@ export default function Navbar() {
                     <Menu as="div" className="relative z-10">
                       {({ open: menuOpen }) => (
                         <>
-                          <Menu.Button className="inline-flex h-9 w-9 items-center justify-center rounded-[8px] border border-[#ddd7ec] bg-white p-0 text-sm transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
+                          <Menu.Button className="inline-flex h-9 w-9 items-center justify-center rounded-[3px] border border-[#ddd7ec] bg-white p-0 text-sm transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
                             <span className="sr-only">Open user menu</span>
                             <Image
-                              className="h-8 w-8 rounded-full"
+                              className="h-8 w-8 rounded-[2px]"
                               src="https://d3ay3etzd1512y.cloudfront.net/other/profile_pic.svg"
                               alt=""
                               width={32}
@@ -180,14 +180,14 @@ export default function Navbar() {
                           >
                             <Menu.Items
                               static
-                              className="absolute right-0 mt-2 w-48 origin-top-right rounded-[12px] border border-[#ece8f5] bg-white p-1.5 shadow-lg focus:outline-none"
+                              className="absolute right-0 mt-2 w-48 origin-top-right rounded-[4px] border border-[#ece8f5] bg-white p-1.5 shadow-lg focus:outline-none"
                             >
                               <Menu.Item>
                                 {({ active }) => (
                                   <Link
                                     href="/profile"
                                     className={classNames(
-                                      "block rounded-[8px] px-3 py-2 text-sm text-[#3a2f55] transition-colors",
+                                      "block rounded-[3px] px-3 py-2 text-sm text-[#3a2f55] transition-colors",
                                       active && "bg-[#f7f5fc] text-[#1a1330]"
                                     )}
                                   >
@@ -200,7 +200,7 @@ export default function Navbar() {
                                   <button
                                     onClick={logout}
                                     className={classNames(
-                                      "block w-full rounded-[8px] px-3 py-2 text-left text-sm text-[#3a2f55] transition-colors",
+                                      "block w-full rounded-[3px] px-3 py-2 text-left text-sm text-[#3a2f55] transition-colors",
                                       active && "bg-[#f7f5fc] text-[#1a1330]"
                                     )}
                                   >
@@ -218,13 +218,13 @@ export default function Navbar() {
                   <>
                     <Link
                       href="/login"
-                      className="inline-flex items-center rounded-[8px] border border-[#ddd7ec] bg-white px-4 py-2 text-[13px] font-semibold tracking-[-0.005em] text-[#1a1330] transition-colors hover:border-[#1a1330]"
+                      className="inline-flex items-center rounded-[3px] border border-[#ddd7ec] bg-white px-4 py-2 text-[13px] font-semibold tracking-[-0.005em] text-[#1a1330] transition-colors hover:border-[#1a1330]"
                     >
                       Sign In
                     </Link>
                     <Link
                       href="/register"
-                      className="inline-flex items-center rounded-[8px] border border-[#1a1330] bg-[#1a1330] px-4 py-2 text-[13px] font-semibold tracking-[-0.005em] text-white transition-colors hover:bg-[#3a2f55] hover:border-[#3a2f55]"
+                      className="inline-flex items-center rounded-[3px] border border-[#1a1330] bg-[#1a1330] px-4 py-2 text-[13px] font-semibold tracking-[-0.005em] text-white transition-colors hover:bg-[#3a2f55] hover:border-[#3a2f55]"
                     >
                       Sign Up
                     </Link>
@@ -233,7 +233,7 @@ export default function Navbar() {
               </div>
 
               <div className="flex items-center lg:hidden">
-                <Disclosure.Button className="inline-flex h-9 w-9 items-center justify-center rounded-[8px] border border-[#ddd7ec] bg-white text-[#1a1330] transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
+                <Disclosure.Button className="inline-flex h-9 w-9 items-center justify-center rounded-[3px] border border-[#ddd7ec] bg-white text-[#1a1330] transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
                   <span className="sr-only">Open main menu</span>
                   {open ? (
                     <XMarkIcon className="h-5 w-5" aria-hidden="true" />
@@ -258,14 +258,14 @@ export default function Navbar() {
               ))}
             </div>
 
-            <div className="mt-4 rounded-[8px] border border-[#ece8f5] bg-white p-3">
+            <div className="mt-4 rounded-[3px] border border-[#ece8f5] bg-white p-3">
               {authState.isAuthenticated ? (
                 <div className="space-y-2">
                   <Link
                     href="/profile"
                     onClick={() => close()}
                     className={classNames(
-                      "flex items-center gap-2 rounded-[8px] px-4 py-3 text-sm font-semibold transition-colors",
+                      "flex items-center gap-2 rounded-[3px] px-4 py-3 text-sm font-semibold transition-colors",
                       isProfileActive
                         ? "bg-[#3a2f55] text-white"
                         : "bg-[#1a1330] text-white hover:bg-[#3a2f55]"
@@ -279,7 +279,7 @@ export default function Navbar() {
                       close();
                       logout();
                     }}
-                    className="block w-full rounded-[8px] border border-[#ddd7ec] px-4 py-3 text-left text-sm font-medium text-[#1a1330] transition-colors hover:border-[#1a1330]"
+                    className="block w-full rounded-[3px] border border-[#ddd7ec] px-4 py-3 text-left text-sm font-medium text-[#1a1330] transition-colors hover:border-[#1a1330]"
                   >
                     Sign Out
                   </button>
@@ -289,14 +289,14 @@ export default function Navbar() {
                   <Link
                     href="/login"
                     onClick={() => close()}
-                    className="block rounded-[8px] border border-[#ddd7ec] px-4 py-3 text-sm font-semibold text-[#1a1330] transition-colors hover:border-[#1a1330]"
+                    className="block rounded-[3px] border border-[#ddd7ec] px-4 py-3 text-sm font-semibold text-[#1a1330] transition-colors hover:border-[#1a1330]"
                   >
                     Sign In
                   </Link>
                   <Link
                     href="/register"
                     onClick={() => close()}
-                    className="block rounded-[8px] border border-[#1a1330] bg-[#1a1330] px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#3a2f55] hover:border-[#3a2f55]"
+                    className="block rounded-[3px] border border-[#1a1330] bg-[#1a1330] px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#3a2f55] hover:border-[#3a2f55]"
                   >
                     Sign Up
                   </Link>


### PR DESCRIPTION
## Summary
- Replace the indigo \`animate-spin\` in profile \`LoadingPanel\` with one of two card-shuffle animations from the Profile Loader design bundle.
- 50/50 random pick on every mount between **A — Riffle shuffle** (1.8s, 6 cards split + interleave) and **C — Deal & tuck** (5.6s, 4-card stack peeling under).
- Variant choice is set inside \`useEffect\` after mount so SSR and client hydrate with the same value (avoids \`Math.random()\` mismatch).
- All animations are pure CSS keyframes — no JS animation, no new deps. Loader styles live in \`landing.css\` under a \`pl-*\` namespace.

## Test plan
- [ ] Sign in, hit \`/profile\` — Cards / Records / Referrals tabs each show one of the two loaders while data fetches
- [ ] Reload several times — variant alternates roughly 50/50
- [ ] No hydration warnings introduced (the existing headlessui id-mismatch warning is preexisting)
- [ ] Mobile renders the loader without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)