### PR TITLE
Best: cross-promo banner to /best-card-for above stat bar

### DIFF
--- a/apps/web-next/src/app/best/BestV2Client.tsx
+++ b/apps/web-next/src/app/best/BestV2Client.tsx
@@ -65,6 +65,17 @@ export default function BestV2Client({
       </section>
 
       <div className="wrap">
+        <Link href="/best-card-for" className="best-cross-promo">
+          <span className="bcp-kicker">By store</span>
+          <span className="bcp-text">
+            <strong>Shopping somewhere specific?</strong> See the best card to use at
+            every major U.S. retailer we track — Amazon, Costco, Whole Foods, and more.
+          </span>
+          <span className="bcp-arrow" aria-hidden>
+            →
+          </span>
+        </Link>
+
         <div className="best-hero-stats">
           <div className="bhs">
             <div className="k">Issuers covered</div>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2900,6 +2900,64 @@
 }
 
 /* ---------- Best cards index ---------- */
+.landing-v2 .best-cross-promo {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin: 24px 0 0;
+  padding: 14px 18px;
+  background: var(--card);
+  border: 1px solid var(--line-2);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.landing-v2 .best-cross-promo:hover {
+  border-color: var(--ink);
+  background: var(--paper-2);
+}
+.landing-v2 .best-cross-promo .bcp-kicker {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.landing-v2 .best-cross-promo .bcp-text {
+  font-size: 14px;
+  color: var(--ink);
+  line-height: 1.45;
+  flex: 1;
+}
+.landing-v2 .best-cross-promo .bcp-text strong {
+  font-weight: 600;
+}
+.landing-v2 .best-cross-promo .bcp-arrow {
+  font-size: 18px;
+  color: var(--muted);
+  transition: color 0.15s ease, transform 0.15s ease;
+  flex-shrink: 0;
+}
+.landing-v2 .best-cross-promo:hover .bcp-arrow {
+  color: var(--accent);
+  transform: translateX(2px);
+}
+@media (max-width: 640px) {
+  .landing-v2 .best-cross-promo {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 12px 14px;
+  }
+  .landing-v2 .best-cross-promo .bcp-arrow {
+    display: none;
+  }
+}
+
 .landing-v2 .best-hero-stats {
   display: grid;
   grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
## Summary
- Adds a small \"By store\" cross-promo banner above the stat bar on `/best` that links to `/best-card-for`, surfacing the per-retailer rankings that were otherwise only reachable via the navbar.
- Editorial v2 styling — purple left-border accent, kicker + headline + arrow on desktop; stacks (and hides arrow) under 640px.

## Test plan
- [x] Desktop: banner sits between hero and stat grid with a 24px gap, links to `/best-card-for`
- [x] Mobile (375px): kicker stacks above text, arrow hidden, no overflow