### PR TITLE
Card page: 'Apply now' label when no welcome bonus

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -545,12 +545,14 @@ export default function CardClient({
   // ---------- Render ----------
   const applyBlock = (
     <div className="cj-apply">
-      <div className="cj-apply-k">Welcome bonus</div>
-      <div className="cj-apply-v">
-        {bonusDisplay?.value ?? "No current offer"}
+      <div className="cj-apply-k">
+        {bonusDisplay ? "Welcome bonus" : "Apply now"}
       </div>
       {bonusDisplay && (
-        <div className="cj-apply-sub">{bonusDisplay.sub}</div>
+        <>
+          <div className="cj-apply-v">{bonusDisplay.value}</div>
+          <div className="cj-apply-sub">{bonusDisplay.sub}</div>
+        </>
       )}
       {card.signup_bonus?.note && (
         <div className="cj-apply-note">{card.signup_bonus.note}</div>


### PR DESCRIPTION
## Summary
- Replaces the "Welcome bonus / No current offer" copy in the purple apply box with a single "Apply now" label when a card has no SUB.
- Cards with a welcome bonus are unchanged (label, value, sub-line render exactly as before).
- Apply CTA and referral link logic untouched.

## Test plan
- [x] Card without SUB (Apple Card): box reads "Apply now" + Apply now button — no "No current offer" line
- [x] Card with SUB (Chase Sapphire Preferred): box reads "Welcome bonus / 75K pts / After \$5,000 in 3 mo · ≈ \$938" + button

🤖 Generated with [Claude Code](https://claude.com/claude-code)