### PR TITLE
Fix Amplify build: stop embedding full cards array in every store page

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/StorePersonalRow.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/StorePersonalRow.tsx
@@ -4,13 +4,12 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
 import { useAuth } from '@/auth/AuthProvider';
-import { getWallet, type Card, type WalletCard } from '@/lib/api';
+import { getAllCards, getWallet, type Card, type WalletCard } from '@/lib/api';
 import type { Store } from '@/lib/stores';
 import { rankCards, formatRate, type RankedPick } from '@/lib/storeRanking';
 
 interface Props {
   store: Store;
-  cards: Card[];
 }
 
 // Conditional matchModes: rate is contingent on user action or current
@@ -24,10 +23,30 @@ function isConditional(p: RankedPick): boolean {
   );
 }
 
-export default function StorePersonalRow({ store, cards }: Props) {
+export default function StorePersonalRow({ store }: Props) {
   const { authState, getToken } = useAuth();
   const [wallet, setWallet] = useState<WalletCard[] | null>(null);
+  const [cards, setCards] = useState<Card[] | null>(null);
   const [walletError, setWalletError] = useState(false);
+
+  // Fetch the cards list client-side. Previously this was passed in as a
+  // prop from the server page, which caused every prerendered /best-card-for
+  // page to serialize the entire cards array into its RSC payload —
+  // pushing the static bundle past Amplify's 220 MB limit (Aug 2026).
+  useEffect(() => {
+    let cancelled = false;
+    if (!authState.isAuthenticated) return;
+    getAllCards()
+      .then((c) => {
+        if (!cancelled) setCards(c);
+      })
+      .catch((err) => {
+        console.error('StorePersonalRow cards fetch failed', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [authState.isAuthenticated]);
 
   useEffect(() => {
     let cancelled = false;
@@ -64,7 +83,7 @@ export default function StorePersonalRow({ store, cards }: Props) {
     );
   }
 
-  if (!wallet && !walletError) {
+  if ((!wallet || !cards) && !walletError) {
     return (
       <div className="store-personal-row" aria-hidden="true">
         <div className="store-personal-row-eyebrow">From your wallet</div>
@@ -77,7 +96,7 @@ export default function StorePersonalRow({ store, cards }: Props) {
     );
   }
 
-  if (walletError || !wallet || wallet.length === 0) {
+  if (walletError || !wallet || wallet.length === 0 || !cards) {
     return (
       <div className="store-personal-row store-personal-row--cta">
         <div className="store-personal-row-copy">

--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -127,7 +127,7 @@ export default async function BestCardForStorePage({ params }: PageProps) {
           </p>
         ) : (
           <>
-          <StorePersonalRow store={store} cards={allCards} />
+          <StorePersonalRow store={store} />
           {picks.some(p => p.channel === 'online' || p.channel === 'in_store') && (
             <p className="store-channel-note">
               Picks without a tag earn at {store.name} both in-store and online. Watch for the


### PR DESCRIPTION
## Summary
Amplify has been failing since PR #1076 (the 100-stores expansion) with:

\`\`\`
CustomerError: build output (337,978,641 bytes) exceeds the max
allowed size of 230,686,720 bytes
\`\`\`

## Root cause
\`<StorePersonalRow store={store} cards={allCards} />\` passed the entire ~200 KB cards array as a prop to a client component. Next.js serializes that into the RSC payload of every prerendered store page. With 158 store pages × ~200 KB ≈ 30+ MB of duplication, plus the standalone bundle copies, the static build crossed Amplify's 220 MB cap.

## Fix
- Drop the \`cards\` prop from \`page.tsx\`.
- Have \`StorePersonalRow\` fetch \`getAllCards()\` itself on mount. It's already CDN-cached and only needed once per session, so the cost is essentially free per visitor.
- Update the loading skeleton to also wait for the cards fetch alongside the wallet fetch.

## Verification
Local \`next build\`:
- Before: 322 MB
- After: **130 MB** (well under the 220 MB cap)

## Test plan
- [ ] Amplify build job completes successfully on merge
- [ ] /best-card-for/marriott (signed-in) still shows the From-your-wallet row with correct picks
- [ ] Signed-out CTA still renders correctly
- [ ] No new console errors on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)