### PR TITLE
Card wire: re-skin to match card/profile cj-* editorial shell

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -17,12 +17,12 @@ interface Props {
 
 type FilterKey = 'all' | 'fee' | 'bonus' | 'apr' | 'apps';
 
-const FILTERS: { key: FilterKey; label: string }[] = [
-  { key: 'all', label: 'All' },
-  { key: 'fee', label: 'Annual fee' },
-  { key: 'bonus', label: 'Sign-up bonus' },
-  { key: 'apr', label: 'APR' },
-  { key: 'apps', label: 'Applications' },
+const FILTERS: { key: FilterKey; num: string; label: string }[] = [
+  { key: 'all', num: '01', label: 'All' },
+  { key: 'fee', num: '02', label: 'Annual fee' },
+  { key: 'bonus', num: '03', label: 'Sign-up bonus' },
+  { key: 'apr', num: '04', label: 'APR' },
+  { key: 'apps', num: '05', label: 'Applications' },
 ];
 
 const FIELD_LABELS: Record<string, string> = {
@@ -105,9 +105,27 @@ function formatDay(ts: string): string {
   });
 }
 
+function formatDayShort(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
 export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Props) {
   const [filter, setFilter] = useState<FilterKey>('all');
   const [page, setPage] = useState(1);
+
+  const counts = useMemo(() => {
+    const c: Record<FilterKey, number> = { all: entries.length, fee: 0, bonus: 0, apr: 0, apps: 0 };
+    for (const e of entries) {
+      const g = fieldGroup(e.field);
+      if (g !== 'all') c[g]++;
+    }
+    return c;
+  }, [entries]);
 
   const filtered = useMemo(() => {
     if (filter === 'all') return entries;
@@ -118,19 +136,8 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
   const safePage = Math.min(page, totalPages);
   const visible = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
 
-  const daysCovered = useMemo(() => {
-    const days = new Set<string>();
-    for (const e of entries) {
-      const d = new Date(e.changed_at);
-      if (!Number.isNaN(d.getTime())) {
-        days.add(d.toISOString().slice(0, 10));
-      }
-    }
-    return days.size;
-  }, [entries]);
-
   const latestTs = entries[0]?.changed_at;
-  const latestLabel = latestTs ? formatDay(latestTs) : '—';
+  const latestShort = latestTs ? formatDayShort(latestTs) : '—';
 
   const grouped = useMemo(() => {
     const groups: { date: string; entries: CardWireEntry[] }[] = [];
@@ -154,114 +161,106 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
   }
 
   return (
-    <div className="landing-v2">
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          The wire. <em>Every change.</em>
-        </h1>
-        <p className="page-sub">
-          A chronological feed of every credit-card change we track — annual fees,
-          sign-up bonuses, reward rates, APR shifts, and application status.
-        </p>
-        <div className="wire-hero-meta">
-          <span>
-            <b>{entries.length.toLocaleString()}</b> changes
+    <div className="landing-v2 wire-v2">
+      {/* Terminal strip — dark bar with breadcrumb + status */}
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <Link href="/news" className="cj-crumb">News</Link>
+          <span className="cj-sep">/</span>
+          <span className="cj-crumb cj-crumb-current" aria-current="page">
+            Wire
           </span>
-          <span>·</span>
+        </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
           <span>
-            <b>{daysCovered}</b> days covered
-          </span>
-          <span>·</span>
-          <span>Last update · <b>{latestLabel}</b></span>
-        </div>
-      </section>
-
-      <div className="wrap">
-        <div className="filter-bar" style={{ paddingTop: 20 }}>
-          {FILTERS.map((f) => (
-            <button
-              key={f.key}
-              type="button"
-              className={'filter-chip ' + (filter === f.key ? 'active' : '')}
-              onClick={() => {
-                setFilter(f.key);
-                setPage(1);
-              }}
-            >
-              {f.label}
-            </button>
-          ))}
-          <div style={{ flex: 1 }} />
-          <span
-            style={{
-              fontSize: 13,
-              fontWeight: 500,
-              color: 'var(--muted)',
-            }}
-          >
-            <span style={{ fontFamily: "'Inter', sans-serif" }}>{filtered.length}</span> change{filtered.length === 1 ? '' : 's'}
+            <span className="cj-status-dot" />
+            live · last update {latestShort}
           </span>
         </div>
-
-        {filtered.length === 0 ? (
-          <div
-            style={{
-              padding: '80px 0',
-              textAlign: 'center',
-              color: 'var(--muted)',
-              fontFamily: "'Inter', sans-serif",
-              fontSize: 13,
-            }}
-          >
-            No changes match this filter yet.
-          </div>
-        ) : (
-          <div className="wire-table-wrap">
-            <table className="wire-table">
-              <thead>
-                <tr>
-                  <th>Card</th>
-                  <th className="hide-sm">Field</th>
-                  <th className="hide-sm">Change</th>
-                </tr>
-              </thead>
-              <tbody>
-                {grouped.map((group) => (
-                  <GroupRows
-                    key={group.date}
-                    date={group.date}
-                    entries={group.entries}
-                    slugMap={slugMap}
-                    bonusTypeMap={bonusTypeMap}
-                  />
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-
-        {totalPages > 1 && (
-          <div className="wire-pager">
-            <button
-              type="button"
-              onClick={() => goPage(safePage - 1)}
-              disabled={safePage === 1}
-            >
-              ← Previous
-            </button>
-            <span>
-              Page {safePage} of {totalPages}
-            </span>
-            <button
-              type="button"
-              onClick={() => goPage(safePage + 1)}
-              disabled={safePage === totalPages}
-            >
-              Next →
-            </button>
-          </div>
-        )}
       </div>
+
+      <main className="cj-main wire-main">
+        {/* Snapshot — title + sub + readoff */}
+        <div className="cj-snapshot wire-snapshot">
+          <h1 className="cj-snapshot-h1">
+            The wire. <em>Every change.</em>
+          </h1>
+          <p className="wire-snapshot-sub">
+            A chronological feed of every credit-card change we track — annual
+            fees, sign-up bonuses, APR shifts, and application status.
+          </p>
+        </div>
+
+        {/* Sticky filter tabs — same shell as profile cj-main-tabs */}
+        <div className="cj-main-tabs wire-tabs">
+          {FILTERS.map((f) => {
+            const count = counts[f.key];
+            return (
+              <button
+                key={f.key}
+                type="button"
+                className={'cj-main-tab' + (filter === f.key ? ' active' : '')}
+                onClick={() => {
+                  setFilter(f.key);
+                  setPage(1);
+                }}
+              >
+                <span className="cj-main-tab-num">{f.num}</span>
+                {f.label}
+                {count > 0 && (
+                  <span className="cj-main-tab-count">· {count}</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="cj-main-content">
+          {filtered.length === 0 ? (
+            <div className="wire-empty">No changes match this filter yet.</div>
+          ) : (
+            <div className="wire-feed" role="table" aria-label="Card wire change feed">
+              <div className="wire-feed-head" role="row">
+                <span role="columnheader">Card</span>
+                <span role="columnheader" className="hide-sm">Field</span>
+                <span role="columnheader" className="hide-sm">Change</span>
+              </div>
+              {grouped.map((group) => (
+                <GroupRows
+                  key={group.date}
+                  date={group.date}
+                  entries={group.entries}
+                  slugMap={slugMap}
+                  bonusTypeMap={bonusTypeMap}
+                />
+              ))}
+            </div>
+          )}
+
+          {totalPages > 1 && (
+            <div className="wire-pager">
+              <button
+                type="button"
+                onClick={() => goPage(safePage - 1)}
+                disabled={safePage === 1}
+              >
+                ← Previous
+              </button>
+              <span>
+                Page {safePage} of {totalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => goPage(safePage + 1)}
+                disabled={safePage === totalPages}
+              >
+                Next →
+              </button>
+            </div>
+          )}
+        </div>
+      </main>
       <V2Footer />
     </div>
   );
@@ -280,14 +279,12 @@ function GroupRows({
 }) {
   return (
     <>
-      <tr className="wire-date-row">
-        <td colSpan={3}>
-          {date}
-          <span className="wire-date-count">
-            {entries.length} change{entries.length === 1 ? '' : 's'}
-          </span>
-        </td>
-      </tr>
+      <div className="wire-day" role="row">
+        <span className="wire-day-date">{date}</span>
+        <span className="wire-day-count">
+          {entries.length} change{entries.length === 1 ? '' : 's'}
+        </span>
+      </div>
       {entries.map((entry) => {
         const slug = slugMap[entry.card_name];
         const bonusType = bonusTypeMap[entry.card_name];
@@ -296,9 +293,9 @@ function GroupRows({
         const oldFmt = formatValue(entry.field, entry.old_value, bonusType);
         const newFmt = formatValue(entry.field, entry.new_value, bonusType);
         const dir = changeDirection(entry.field, entry.old_value, entry.new_value);
-        const cardContent = (
+        const cardInner = (
           <span className="wire-card">
-            <span className="wc-thumb">
+            <span className="wire-thumb">
               <CardImage
                 cardImageLink={entry.card_image_link}
                 alt=""
@@ -307,37 +304,37 @@ function GroupRows({
                 style={{ objectFit: 'cover' }}
               />
             </span>
-            <span className="wc-name">{entry.card_name}</span>
-          </span>
-        );
-        const changeBlock = (
-          <span className={'wire-change ' + dir}>
-            <span className="old">{oldFmt}</span>
-            <span className="arrow">→</span>
-            <span className="new">{newFmt}</span>
+            <span className="wire-card-name">{entry.card_name}</span>
           </span>
         );
         const fieldChip = (
           <span className={'wire-field-chip ' + group}>{label}</span>
         );
+        const changeBlock = (
+          <span className={'wire-change ' + dir}>
+            <span className="old">{oldFmt}</span>
+            <span className="arrow" aria-hidden="true">→</span>
+            <span className="new">{newFmt}</span>
+          </span>
+        );
         return (
-          <tr key={entry.id}>
-            <td>
+          <div key={entry.id} className="wire-row" role="row">
+            <span className="wire-row-card" role="cell">
               {slug ? (
-                <Link href={`/card/${slug}`} style={{ textDecoration: 'none' }}>
-                  {cardContent}
+                <Link href={`/card/${slug}`} className="wire-card-link">
+                  {cardInner}
                 </Link>
               ) : (
-                cardContent
+                cardInner
               )}
-              <div className="wire-mobile-summary">
+              <div className="wire-row-mobile">
                 {fieldChip}
                 {changeBlock}
               </div>
-            </td>
-            <td className="hide-sm">{fieldChip}</td>
-            <td className="hide-sm">{changeBlock}</td>
-          </tr>
+            </span>
+            <span className="wire-row-field hide-sm" role="cell">{fieldChip}</span>
+            <span className="wire-row-change hide-sm" role="cell">{changeBlock}</span>
+          </div>
         );
       })}
     </>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2666,174 +2666,293 @@
   }
 }
 
-/* ---------- Card Wire (live feed) ---------- */
-.landing-v2 .wire-hero-meta {
+/* ---------- Card Wire v2 (/card-wire) — card-journal cj-* shell ---------- */
+.landing-v2.wire-v2 {
+  background: var(--paper);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'ss01', 'cv11';
+}
+.landing-v2.wire-v2 .wire-main {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px 18px 48px;
+  min-width: 0;
+}
+@media (min-width: 768px) {
+  .landing-v2.wire-v2 .wire-main { padding: 28px 24px 64px; }
+}
+@media (min-width: 1024px) {
+  .landing-v2.wire-v2 .wire-main { padding: 32px 32px 80px; }
+}
+
+/* Snapshot — title + sub */
+.landing-v2.wire-v2 .wire-snapshot {
+  padding: 6px 0 16px;
+}
+.landing-v2.wire-v2 .wire-snapshot .cj-snapshot-h1 {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  font-size: 32px;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin: 0;
+  color: var(--ink);
+}
+@media (min-width: 768px) {
+  .landing-v2.wire-v2 .wire-snapshot .cj-snapshot-h1 { font-size: 44px; }
+}
+.landing-v2.wire-v2 .wire-snapshot .cj-snapshot-h1 em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+}
+.landing-v2.wire-v2 .wire-snapshot-sub {
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  max-width: 620px;
+  margin: 12px 0 16px;
+}
+.landing-v2.wire-v2 .wire-snapshot .cj-readoff {
+  margin-top: 4px;
+}
+@media (min-width: 1024px) {
+  .landing-v2.wire-v2 .wire-snapshot .cj-readoff {
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+  }
+}
+
+/* Sticky tab row — sits below the global navbar (h-14 mobile / h-16 desktop) */
+.landing-v2.wire-v2 .wire-tabs {
   display: flex;
-  align-items: center;
-  gap: 14px;
-  margin-top: 18px;
   flex-wrap: wrap;
+  gap: 0;
+  border-bottom: 1px solid var(--line);
+  margin: 8px 0 20px;
+  position: sticky;
+  top: 56px;
+  z-index: 20;
+  background: var(--paper);
+  box-shadow: 0 1px 0 var(--line);
+}
+@media (min-width: 640px) {
+  .landing-v2.wire-v2 .wire-tabs { top: 64px; }
+}
+.landing-v2.wire-v2 .wire-tabs .cj-main-tab {
+  padding: 10px 18px 10px 0;
+  margin-right: 22px;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  font-family: inherit;
   font-size: 13px;
   font-weight: 500;
   color: var(--muted);
-}
-.landing-v2 .wire-hero-meta b {
-  color: var(--ink);
-  font-weight: 600;
-}
-.landing-v2 .wire-table-wrap {
-  padding: 24px 0 24px;
-  overflow-x: auto;
-}
-.landing-v2 .wire-table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  background: var(--card);
-  border: 1px solid var(--line-2);
-  border-radius: 14px;
-  overflow: hidden;
-  font-size: 13px;
-}
-.landing-v2 .wire-table thead th {
-  text-align: left;
-  font-size: 13px;
-  color: var(--muted);
-  font-weight: 600;
-  padding: 14px 16px;
-  background: var(--paper-2);
-  border-bottom: 1px solid var(--line);
+  cursor: pointer;
   white-space: nowrap;
+  letter-spacing: 0.01em;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
 }
-.landing-v2 .wire-table tbody td {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--line);
+.landing-v2.wire-v2 .wire-tabs .cj-main-tab:hover { color: var(--ink); }
+.landing-v2.wire-v2 .wire-tabs .cj-main-tab.active {
   color: var(--ink);
-  vertical-align: middle;
+  border-bottom-color: var(--accent);
+  font-weight: 600;
 }
-.landing-v2 .wire-table tbody tr:last-child td {
-  border-bottom: 0;
+.landing-v2.wire-v2 .wire-tabs .cj-main-tab-num {
+  font-size: 10px;
+  color: var(--muted-2);
+  font-weight: 500;
 }
-.landing-v2 .wire-table tbody tr:not(.wire-date-row):hover {
-  background: color-mix(in oklab, var(--accent) 4%, transparent);
+.landing-v2.wire-v2 .wire-tabs .cj-main-tab.active .cj-main-tab-num { color: var(--accent); }
+.landing-v2.wire-v2 .wire-tabs .cj-main-tab-count {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 500;
+  margin-left: 2px;
 }
-.landing-v2 .wire-table tr.wire-date-row td {
-  background: var(--paper-2);
-  padding: 8px 16px;
-  border-bottom: 1px dashed var(--line-2);
+
+/* Empty state */
+.landing-v2.wire-v2 .wire-empty {
+  padding: 80px 0;
+  text-align: center;
+  color: var(--muted);
+  font-family: 'Inter', sans-serif;
   font-size: 13px;
+  border: 1px solid var(--line-2);
+  background: var(--paper-2);
+}
+
+/* Feed — grid-based rows, day strips inline */
+.landing-v2.wire-v2 .wire-feed {
+  border: 1px solid var(--line-2);
+  background: var(--paper);
+}
+.landing-v2.wire-v2 .wire-feed-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) 130px minmax(0, 1.4fr);
+  padding: 8px 14px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  gap: 12px;
+}
+.landing-v2.wire-v2 .wire-day {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 8px 14px;
+  background: var(--paper-2);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px dashed var(--line-2);
+  font-family: 'Inter', sans-serif;
+  font-size: 11.5px;
   font-weight: 500;
   color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
-.landing-v2 .wire-table tr.wire-date-row td .wire-date-count {
+.landing-v2.wire-v2 .wire-day:first-child {
+  border-top: 0;
+}
+.landing-v2.wire-v2 .wire-day-date {
+  color: var(--ink);
+  font-weight: 600;
+}
+.landing-v2.wire-v2 .wire-day-count {
   color: var(--muted-2);
-  margin-left: 8px;
+  font-size: 11px;
 }
-.landing-v2 .wire-card {
+
+.landing-v2.wire-v2 .wire-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) 130px minmax(0, 1.4fr);
+  padding: 9px 14px;
+  border-top: 1px solid var(--line);
+  align-items: center;
+  font-size: 12.5px;
+  gap: 12px;
+  background: var(--paper);
+}
+.landing-v2.wire-v2 .wire-row:hover { background: var(--paper-2); }
+
+.landing-v2.wire-v2 .wire-card {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  text-decoration: none;
-  color: inherit;
   min-width: 0;
 }
-.landing-v2 .wire-card .wc-thumb {
-  width: 40px;
-  height: 26px;
-  border-radius: 4px;
-  flex-shrink: 0;
+.landing-v2.wire-v2 .wire-card-link {
+  text-decoration: none;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.landing-v2.wire-v2 .wire-thumb {
   position: relative;
+  width: 36px;
+  height: 22px;
+  border-radius: 3px;
   overflow: hidden;
   background: var(--paper-2);
   border: 1px solid var(--line);
+  flex: 0 0 auto;
 }
-.landing-v2 .wire-card .wc-name {
+.landing-v2.wire-v2 .wire-card-name {
   font-weight: 500;
   color: var(--ink);
-  font-size: 13px;
-  line-height: 1.3;
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 14px;
   letter-spacing: -0.005em;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  white-space: nowrap;
   overflow: hidden;
-  max-width: 320px;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
-.landing-v2 .wire-card:hover .wc-name {
-  color: var(--accent);
-}
-.landing-v2 .wire-field-chip {
+.landing-v2.wire-v2 .wire-card-link:hover .wire-card-name { color: var(--accent); }
+
+.landing-v2.wire-v2 .wire-field-chip {
   display: inline-flex;
   align-items: center;
   padding: 3px 8px;
-  border-radius: 4px;
-  font-size: 12px;
+  border-radius: 3px;
+  font-size: 11px;
   font-weight: 600;
+  letter-spacing: 0.02em;
   white-space: nowrap;
+  text-transform: uppercase;
 }
-.landing-v2 .wire-field-chip.fee {
+.landing-v2.wire-v2 .wire-field-chip.fee {
   background: color-mix(in oklab, var(--gold) 15%, var(--paper));
   color: var(--gold);
 }
-.landing-v2 .wire-field-chip.bonus {
+.landing-v2.wire-v2 .wire-field-chip.bonus {
   background: var(--accent-2);
   color: var(--accent);
 }
-.landing-v2 .wire-field-chip.reward {
-  background: color-mix(in oklab, #0c8450 14%, var(--paper));
-  color: #0c8450;
-}
-.landing-v2 .wire-field-chip.apr {
+.landing-v2.wire-v2 .wire-field-chip.apr {
   background: color-mix(in oklab, var(--accent) 12%, var(--paper));
   color: var(--accent);
 }
-.landing-v2 .wire-field-chip.apps {
+.landing-v2.wire-v2 .wire-field-chip.apps {
   background: var(--warn-2);
   color: var(--warn);
 }
-.landing-v2 .wire-field-chip.other {
+.landing-v2.wire-v2 .wire-field-chip.all {
   background: var(--paper-2);
   color: var(--ink-2);
   border: 1px solid var(--line);
 }
-.landing-v2 .wire-change {
+
+.landing-v2.wire-v2 .wire-change {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   font-family: 'Inter', sans-serif;
-  font-size: 13px;
+  font-size: 12.5px;
+  min-width: 0;
 }
-.landing-v2 .wire-change .old {
+.landing-v2.wire-v2 .wire-change .old {
   color: var(--muted);
   text-decoration: line-through;
   text-decoration-color: color-mix(in oklab, var(--muted) 60%, transparent);
 }
-.landing-v2 .wire-change .arrow {
+.landing-v2.wire-v2 .wire-change .arrow {
   color: var(--muted-2);
-  font-size: 11px;
+  font-size: 10.5px;
 }
-.landing-v2 .wire-change .new {
+.landing-v2.wire-v2 .wire-change .new {
   font-weight: 600;
   color: var(--ink);
+  font-variant-numeric: tabular-nums;
 }
-.landing-v2 .wire-change.pos .new {
-  color: #0c8450;
-}
-.landing-v2 .wire-change.neg .new {
-  color: var(--warn);
-}
-.landing-v2 .wire-pager {
+.landing-v2.wire-v2 .wire-change.pos .new { color: #0c8450; }
+.landing-v2.wire-v2 .wire-change.neg .new { color: var(--warn); }
+
+.landing-v2.wire-v2 .wire-row-mobile { display: none; }
+
+/* Pager */
+.landing-v2.wire-v2 .wire-pager {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 0 60px;
+  padding: 16px 0 8px;
   font-family: 'Inter', sans-serif;
   font-size: 11.5px;
   color: var(--muted);
 }
-.landing-v2 .wire-pager button {
-  padding: 8px 14px;
-  border-radius: 6px;
+.landing-v2.wire-v2 .wire-pager button {
+  padding: 6px 12px;
+  border-radius: 3px;
   border: 1px solid var(--line-2);
   background: var(--paper);
   color: var(--ink);
@@ -2841,61 +2960,49 @@
   font-family: inherit;
   font-size: 12px;
   font-weight: 500;
+  letter-spacing: 0.02em;
 }
-.landing-v2 .wire-pager button:hover:not(:disabled) {
+.landing-v2.wire-v2 .wire-pager button:hover:not(:disabled) {
+  background: var(--ink);
+  color: #fff;
   border-color: var(--ink);
 }
-.landing-v2 .wire-pager button:disabled {
+.landing-v2.wire-v2 .wire-pager button:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.landing-v2 .wire-mobile-summary {
-  display: none;
-}
+
+/* Mobile — single-column row, chip + change inline below the card name */
 @media (max-width: 640px) {
-  .landing-v2 .wire-table-wrap {
-    margin-left: -14px;
-    margin-right: -14px;
-    padding-top: 16px;
-    padding-bottom: 48px;
-    overflow-x: hidden;
+  .landing-v2.wire-v2 .wire-feed-head {
+    grid-template-columns: 1fr;
+    padding: 8px 12px;
   }
-  .landing-v2 .wire-table {
-    border-radius: 0;
-    border-left: 0;
-    border-right: 0;
-    font-size: 12px;
-  }
-  .landing-v2 .wire-table thead th.hide-sm,
-  .landing-v2 .wire-table tbody td.hide-sm {
-    display: none;
-  }
-  .landing-v2 .wire-table thead th {
-    padding: 10px 12px;
-    font-size: 10px;
-  }
-  .landing-v2 .wire-table tbody td {
+  .landing-v2.wire-v2 .wire-feed-head .hide-sm { display: none; }
+  .landing-v2.wire-v2 .wire-row {
+    grid-template-columns: 1fr;
     padding: 12px;
+    gap: 8px;
   }
-  .landing-v2 .wire-card .wc-name {
-    max-width: none;
-    white-space: normal;
-    font-size: 13px;
-  }
-  .landing-v2 .wire-mobile-summary {
+  .landing-v2.wire-v2 .wire-row .hide-sm { display: none; }
+  .landing-v2.wire-v2 .wire-row-mobile {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 8px;
-    margin-top: 8px;
-    margin-left: 50px;
+    margin-top: 6px;
+    padding-left: 46px;
   }
-  .landing-v2 .wire-mobile-summary .wire-field-chip {
-    font-size: 9.5px;
+  .landing-v2.wire-v2 .wire-row-mobile .wire-field-chip {
+    font-size: 10px;
     padding: 2px 6px;
   }
-  .landing-v2 .wire-mobile-summary .wire-change {
-    font-size: 11px;
+  .landing-v2.wire-v2 .wire-row-mobile .wire-change {
+    font-size: 12px;
+  }
+  .landing-v2.wire-v2 .wire-card-name {
+    white-space: normal;
+    font-size: 13.5px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Re-skin `/card-wire` to use the same `cj-*` shell as `/card/[name]` and `/profile`: dark terminal strip with breadcrumb + live status, Inter Tight headline with italic accent, sticky numbered tab row, grid-based "tape" feed grouped by date
- Per-tab counts on the filter row (`01 All · 46`, `02 Annual fee · 2`, …); active tab gets the accent underline
- Removed the readoff stat boxes (Changes / Days covered / Cards moved / Last update) so the page goes straight from intro into the feed
- Removed the When timestamp column — the date-strip grouping carries that signal already
- Mobile: row collapses to a single column with the field chip + change inline below the card name

## Test plan
- [ ] Visit `/card-wire` and confirm terminal strip + headline render with v2 palette
- [ ] Click each filter tab; counts update and active state shows the purple underline
- [ ] Resize to mobile and confirm rows collapse to one column with chip+change inline
- [ ] Click a card row; navigates to `/card/[slug]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)