### PR TITLE
Wallet: add Nearby beta tab

### DIFF
--- a/apps/api/src/handlers/nearby-recommendations.js
+++ b/apps/api/src/handlers/nearby-recommendations.js
@@ -1,0 +1,185 @@
+// Nearby Recommendations — fetches a small list of nearby businesses from
+// Google Places API (New) so the wallet UI can suggest the best card per
+// place. Field-masked to stay on the Pro SKU. The response is intentionally
+// thin (id, name, types, location) — category mapping and best-card picking
+// happen on the frontend where the user's wallet + card data already live.
+
+// Lambda runtime is Node 22 (see template.yml), so global fetch is available.
+
+const responseHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Methods": "POST,OPTIONS",
+};
+
+const PLACES_ENDPOINT = "https://places.googleapis.com/v1/places:searchNearby";
+
+// Curated subset of Place types relevant to credit-card categories. Keeps
+// results signal-heavy (no parks, schools, churches) and lets the API
+// filter server-side. See data/places-types.md for the full mapping.
+const INCLUDED_TYPES = [
+  "restaurant",
+  "cafe",
+  "coffee_shop",
+  "bar",
+  "fast_food_restaurant",
+  "bakery",
+  "meal_takeaway",
+  "supermarket",
+  "grocery_store",
+  "gas_station",
+  "pharmacy",
+  "drugstore",
+  "department_store",
+  "clothing_store",
+  "shopping_mall",
+  "home_goods_store",
+  "hardware_store",
+  "lodging",
+  "hotel",
+  "car_rental",
+  "movie_theater",
+];
+
+const RADIUS_METERS = 1000;
+const MAX_RESULTS = 10;
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 min
+const GRID_PRECISION = 3; // ~110m squares
+const DAILY_USER_CAP = 30;
+
+// In-memory caches scoped to a warm Lambda container. They reset on cold
+// start, which is fine for a beta — the worst case is one extra Places
+// call per cold start. Move to DynamoDB / Redis if abuse becomes an issue.
+const placesCache = new Map(); // key: "lat,lng" -> { expiresAt, data }
+const userUsage = new Map();   // key: userId -> { dayKey, count }
+
+function gridKey(lat, lng) {
+  return `${Number(lat).toFixed(GRID_PRECISION)},${Number(lng).toFixed(GRID_PRECISION)}`;
+}
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function bumpUserUsage(userId) {
+  const today = todayKey();
+  const cur = userUsage.get(userId);
+  if (!cur || cur.dayKey !== today) {
+    userUsage.set(userId, { dayKey: today, count: 1 });
+    return 1;
+  }
+  cur.count += 1;
+  return cur.count;
+}
+
+function err(statusCode, message) {
+  return {
+    statusCode,
+    headers: responseHeaders,
+    body: JSON.stringify({ error: message }),
+  };
+}
+
+async function searchNearby(lat, lng, apiKey) {
+  const res = await fetch(PLACES_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Goog-Api-Key": apiKey,
+      // Field mask is required and controls billing tier.
+      "X-Goog-FieldMask":
+        "places.id,places.displayName,places.location,places.types,places.primaryType,places.formattedAddress",
+    },
+    body: JSON.stringify({
+      includedTypes: INCLUDED_TYPES,
+      maxResultCount: MAX_RESULTS,
+      rankPreference: "DISTANCE",
+      locationRestriction: {
+        circle: {
+          center: { latitude: lat, longitude: lng },
+          radius: RADIUS_METERS,
+        },
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Places API ${res.status}: ${text.slice(0, 200)}`);
+  }
+
+  const data = await res.json();
+  const places = Array.isArray(data.places) ? data.places : [];
+  return places.map((p) => ({
+    id: p.id,
+    name: p.displayName?.text || "",
+    primaryType: p.primaryType || null,
+    types: Array.isArray(p.types) ? p.types : [],
+    address: p.formattedAddress || null,
+    lat: p.location?.latitude ?? null,
+    lng: p.location?.longitude ?? null,
+  }));
+}
+
+exports.NearbyRecommendationsHandler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 200, headers: responseHeaders, body: "" };
+  }
+  if (event.httpMethod !== "POST") {
+    return err(405, `Method ${event.httpMethod} not allowed`);
+  }
+
+  const userId = event.requestContext?.authorizer?.principalId;
+  if (!userId) return err(401, "Unauthorized");
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) {
+    console.error("GOOGLE_PLACES_API_KEY not set");
+    return err(503, "Nearby recommendations are not configured");
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body || "{}");
+  } catch {
+    return err(400, "Invalid JSON body");
+  }
+
+  const lat = Number(body.lat);
+  const lng = Number(body.lng);
+  if (
+    !Number.isFinite(lat) || !Number.isFinite(lng) ||
+    lat < -90 || lat > 90 || lng < -180 || lng > 180
+  ) {
+    return err(400, "lat and lng must be valid coordinates");
+  }
+
+  const usage = bumpUserUsage(userId);
+  if (usage > DAILY_USER_CAP) {
+    return err(429, `Daily limit of ${DAILY_USER_CAP} nearby lookups reached`);
+  }
+
+  const cacheKey = gridKey(lat, lng);
+  const cached = placesCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) {
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ places: cached.data, cached: true }),
+    };
+  }
+
+  try {
+    const places = await searchNearby(lat, lng, apiKey);
+    placesCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, data: places });
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ places, cached: false }),
+    };
+  } catch (e) {
+    console.error("Places fetch failed:", e);
+    return err(502, "Failed to fetch nearby places");
+  }
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -32,7 +32,12 @@ Parameters:
   CardsJsonUrl:
     Type: String
     Description: CloudFront URL for cards.json
-    Default: https://d2hxvzw7msbtvt.cloudfront.net/cards.json 
+    Default: https://d2hxvzw7msbtvt.cloudfront.net/cards.json
+  GooglePlacesApiKey:
+    Type: String
+    Description: Google Places API (New) key for the wallet "Nearby" beta feature
+    NoEcho: true
+    Default: ""
 
 # Resources declares the AWS resources that you want to include in the stack
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
@@ -1008,6 +1013,35 @@ Resources:
             Method: OPTIONS
             RestApiId:
               Ref: CreditCardOddsAPI
+
+  NearbyRecommendationsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/nearby-recommendations.NearbyRecommendationsHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 15
+      Description: "Beta: returns nearby businesses (Google Places) for the wallet 'best card to use here' feature"
+      Environment:
+        Variables:
+          GOOGLE_PLACES_API_KEY: !Ref GooglePlacesApiKey
+      Events:
+        PostNearby:
+          Type: Api
+          Properties:
+            Path: /nearby-recommendations
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        NearbyOptions:
+          Type: Api
+          Properties:
+            Path: /nearby-recommendations
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
 
   CardWireFunction:
     Type: AWS::Serverless::Function

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -29,6 +29,7 @@ const ReferralModal = dynamic(() => import("@/components/forms/ReferralModal"), 
 const AddToWalletModal = dynamic(() => import("@/components/wallet/AddToWalletModal"), { ssr: false, loading: () => null });
 const EditWalletCardModal = dynamic(() => import("@/components/wallet/EditWalletCardModal"), { ssr: false, loading: () => null });
 const BestCardByCategory = dynamic(() => import("@/components/wallet/BestCardByCategory"), { ssr: false, loading: () => null });
+const NearbyBestCard = dynamic(() => import("@/components/wallet/NearbyBestCard"), { ssr: false, loading: () => null });
 const WalletBenefits = dynamic(() => import("@/components/wallet/WalletBenefits"), { ssr: false, loading: () => null });
 const SubmitRecordModal = dynamic(() => import("@/components/forms/SubmitRecordModal"), { ssr: false, loading: () => null });
 const SubmitRecordCardPicker = dynamic(() => import("@/components/forms/SubmitRecordCardPicker"), { ssr: false, loading: () => null });
@@ -70,7 +71,7 @@ interface Profile {
   referrals_count: number;
 }
 
-type TabKey = 'cards' | 'rewards' | 'benefits' | 'applications' | 'referrals' | 'settings';
+type TabKey = 'cards' | 'rewards' | 'nearby' | 'benefits' | 'applications' | 'referrals' | 'settings';
 
 const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -300,10 +301,11 @@ export default function ProfileClient() {
   const tabs: { key: TabKey; num: string; label: string; count: string }[] = [
     { key: 'cards', num: '01', label: 'Cards', count: walletCards.length ? `${walletCards.length} cards` : '' },
     { key: 'rewards', num: '02', label: 'Rewards', count: '' },
-    { key: 'benefits', num: '03', label: 'Benefits', count: '' },
-    { key: 'applications', num: '04', label: 'Applications', count: records.length ? `${records.length} records` : '' },
-    { key: 'referrals', num: '05', label: 'Referrals', count: activeReferralsCount ? `${activeReferralsCount} links` : '' },
-    { key: 'settings', num: '06', label: 'Settings', count: '' },
+    { key: 'nearby', num: '03', label: 'Nearby', count: 'beta' },
+    { key: 'benefits', num: '04', label: 'Benefits', count: '' },
+    { key: 'applications', num: '05', label: 'Applications', count: records.length ? `${records.length} records` : '' },
+    { key: 'referrals', num: '06', label: 'Referrals', count: activeReferralsCount ? `${activeReferralsCount} links` : '' },
+    { key: 'settings', num: '07', label: 'Settings', count: '' },
   ];
 
   return (
@@ -425,6 +427,11 @@ export default function ProfileClient() {
             {activeTab === 'rewards' && (
               !walletLoaded ? <LoadingPanel /> :
               <BestCardByCategory walletCards={walletCards} allCards={allCards} />
+            )}
+
+            {activeTab === 'nearby' && (
+              !walletLoaded ? <LoadingPanel /> :
+              <NearbyBestCard walletCards={walletCards} allCards={allCards} />
             )}
 
             {activeTab === 'benefits' && (

--- a/apps/web-next/src/components/wallet/NearbyBestCard.tsx
+++ b/apps/web-next/src/components/wallet/NearbyBestCard.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import Link from 'next/link';
+import CardImage from '@/components/ui/CardImage';
+import { Card, NearbyPlace, WalletCard, getNearbyPlaces } from '@/lib/api';
+import { useAuth } from '@/auth/AuthProvider';
+import { categoryLabels, formatRewardWithUsdEquivalent } from '@/lib/cardDisplayUtils';
+import { mapPlaceToCategory } from '@/lib/placeTypeMapping';
+import { pickBestCardForCategory } from '@/lib/pickBestCardForCategory';
+
+interface NearbyBestCardProps {
+  walletCards: WalletCard[];
+  allCards: Card[];
+}
+
+interface Row {
+  place: NearbyPlace;
+  category: string;
+  categoryLabel: string;
+  pick: ReturnType<typeof pickBestCardForCategory>;
+}
+
+type Status = 'idle' | 'locating' | 'fetching' | 'ready' | 'error';
+
+export default function NearbyBestCard({ walletCards, allCards }: NearbyBestCardProps) {
+  const { getToken } = useAuth();
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [places, setPlaces] = useState<NearbyPlace[]>([]);
+  const [cached, setCached] = useState(false);
+
+  const rows = useMemo<Row[]>(() => {
+    return places.map((place) => {
+      const match = mapPlaceToCategory({
+        name: place.name,
+        primaryType: place.primaryType ?? undefined,
+        types: place.types,
+      });
+      const pick = pickBestCardForCategory(walletCards, allCards, match.category);
+      return {
+        place,
+        category: match.category,
+        categoryLabel: categoryLabels[match.category] || match.category,
+        pick,
+      };
+    });
+  }, [places, walletCards, allCards]);
+
+  const handleFind = useCallback(async () => {
+    setErrorMessage(null);
+    if (!('geolocation' in navigator)) {
+      setStatus('error');
+      setErrorMessage('Your browser does not support location lookup.');
+      return;
+    }
+
+    setStatus('locating');
+    let coords: GeolocationCoordinates;
+    try {
+      coords = await new Promise<GeolocationCoordinates>((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(
+          (pos) => resolve(pos.coords),
+          (err) => reject(err),
+          { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 },
+        );
+      });
+    } catch (e) {
+      setStatus('error');
+      const msg = e instanceof GeolocationPositionError && e.code === 1
+        ? 'Location permission denied. Allow location access to see nearby places.'
+        : 'Could not determine your location. Try again in a moment.';
+      setErrorMessage(msg);
+      return;
+    }
+
+    setStatus('fetching');
+    try {
+      const token = await getToken();
+      if (!token) {
+        setStatus('error');
+        setErrorMessage('You need to be signed in to use this feature.');
+        return;
+      }
+      const result = await getNearbyPlaces(coords.latitude, coords.longitude, token);
+      setPlaces(result.places);
+      setCached(result.cached);
+      setStatus('ready');
+    } catch (e) {
+      setStatus('error');
+      setErrorMessage(e instanceof Error ? e.message : 'Something went wrong.');
+    }
+  }, [getToken]);
+
+  if (walletCards.length === 0) {
+    return (
+      <div className="cj-verdict">
+        <b>Add cards to your wallet first.</b> The Nearby beta picks the best of <em>your</em> cards
+        for each spot — it needs to know what you carry.
+      </div>
+    );
+  }
+
+  return (
+    <section className="cj-section">
+      <div className="cj-table-label">
+        <span style={{ display: 'inline-block', padding: '2px 6px', background: 'var(--accent-2)', color: 'var(--accent)', borderRadius: 2, fontSize: 9.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', marginRight: 8, verticalAlign: '1px' }}>
+          Beta
+        </span>
+        Find the best card to use at nearby places. We share your location with our server to look up
+        businesses within 1km — never stored or logged.
+      </div>
+
+      {status === 'idle' && (
+        <div style={{ marginTop: 12 }}>
+          <button type="button" className="cj-inline-cta" onClick={handleFind}>
+            find nearby places
+          </button>
+        </div>
+      )}
+
+      {(status === 'locating' || status === 'fetching') && (
+        <div className="cj-verdict" style={{ marginTop: 12 }}>
+          {status === 'locating' ? 'Getting your location…' : 'Looking up nearby places…'}
+        </div>
+      )}
+
+      {status === 'error' && errorMessage && (
+        <div className="cj-verdict" style={{ marginTop: 12, background: '#fef9e8', borderLeftColor: '#a8792a', color: '#5c4318' }}>
+          <b style={{ color: '#a8792a' }}>{errorMessage}</b>
+          <div style={{ marginTop: 8 }}>
+            <button type="button" className="cj-inline-cta" onClick={handleFind}>
+              try again
+            </button>
+          </div>
+        </div>
+      )}
+
+      {status === 'ready' && rows.length === 0 && (
+        <div className="cj-verdict" style={{ marginTop: 12 }}>
+          No relevant businesses found within 1km. Try again from a different spot.
+        </div>
+      )}
+
+      {status === 'ready' && rows.length > 0 && (
+        <>
+          <div style={{ marginTop: 12, marginBottom: 8, fontSize: 11, color: 'var(--muted-2)' }}>
+            {rows.length} place{rows.length === 1 ? '' : 's'} nearby{cached ? ' · cached' : ''} ·{' '}
+            <button
+              type="button"
+              onClick={handleFind}
+              style={{ background: 'transparent', border: 0, padding: 0, color: 'var(--accent)', cursor: 'pointer', fontWeight: 600 }}
+            >
+              refresh
+            </button>
+          </div>
+          <table className="cj-table">
+            <thead>
+              <tr>
+                <th>Place</th>
+                <th>Best card</th>
+                <th className="cj-tr">Earn</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.place.id}>
+                  <td>
+                    <div className="cj-cell-primary">{row.place.name}</div>
+                    <div className="cj-cell-detail">
+                      {row.categoryLabel}
+                      {row.place.address ? ` · ${row.place.address.split(',')[0]}` : ''}
+                    </div>
+                  </td>
+                  <td>
+                    {row.pick ? <PickCell pick={row.pick.primary} /> : <span className="cj-cell-detail">—</span>}
+                  </td>
+                  <td className="cj-tr">
+                    {row.pick ? (
+                      <span className="cj-eff-pct">
+                        {formatRewardWithUsdEquivalent(row.pick.primary.reward, row.pick.primary.card)}
+                      </span>
+                    ) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="cj-verdict" style={{ marginTop: 16, fontSize: 12 }}>
+            Recommendations are based on the place&apos;s category from Google Maps. Actual reward
+            categories depend on the merchant&apos;s billing code, so the issuer&apos;s coding may differ.
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function PickCell({ pick }: { pick: NonNullable<ReturnType<typeof pickBestCardForCategory>>['primary'] }) {
+  const { card, reward, slotNote } = pick;
+  const note = slotNote ?? reward.note;
+  const href = card.slug ? `/card/${card.slug}` : undefined;
+  const inner = (
+    <div className="cj-rew-best">
+      <span className="cj-rew-thumb">
+        <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="32px" />
+      </span>
+      <div style={{ minWidth: 0 }}>
+        <div className="cj-cell-primary">{card.card_name}</div>
+        {note && <div className="cj-cell-detail">{note}</div>}
+      </div>
+    </div>
+  );
+  return href ? (
+    <Link href={href} style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
+      {inner}
+    </Link>
+  ) : inner;
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -347,6 +347,43 @@ export async function removeFromWallet(cardId: number, token: string): Promise<{
   return res.json();
 }
 
+// Nearby Recommendations (Beta) — POST lat/lng, get back a slim list of
+// nearby businesses. Category mapping + best-card picking happen client-side.
+export interface NearbyPlace {
+  id: string;
+  name: string;
+  primaryType: string | null;
+  types: string[];
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+}
+
+export interface NearbyResponse {
+  places: NearbyPlace[];
+  cached: boolean;
+}
+
+export async function getNearbyPlaces(
+  lat: number,
+  lng: number,
+  token: string,
+): Promise<NearbyResponse> {
+  const res = await fetch(`${API_BASE}/nearby-recommendations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ lat, lng }),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to fetch nearby places: ${res.status} ${errorText}`);
+  }
+  return res.json();
+}
+
 // Recent records for ticker (no auth required)
 export interface RecentRecord {
   record_id: number;

--- a/apps/web-next/src/lib/pickBestCardForCategory.ts
+++ b/apps/web-next/src/lib/pickBestCardForCategory.ts
@@ -1,0 +1,102 @@
+import { Card, Reward, WalletCard } from '@/lib/api';
+import { getRewardUsdRate } from '@/lib/cardDisplayUtils';
+
+export interface CategoryPick {
+  card: Card;
+  reward: Reward;
+  usdRate: number;
+  rotating?: boolean;
+  staleRotation?: boolean;
+  slotNote?: string;
+}
+
+function currentQuarterLabel(now: Date = new Date()): string {
+  const q = Math.floor(now.getUTCMonth() / 3) + 1;
+  return `Q${q} ${now.getUTCFullYear()}`;
+}
+
+function isStaleRotation(reward: Reward, expected: string): boolean {
+  if (reward.mode !== 'quarterly_rotating') return false;
+  const cur = reward.current_period;
+  if (!cur) return true;
+  return cur.trim().toUpperCase() !== expected.toUpperCase();
+}
+
+// Returns the highest-earning card in the user's wallet for a given reward
+// category, plus an optional alternative when the primary pick is conditional
+// (merchant-specific or note-restricted). Mirrors the per-category logic in
+// BestCardByCategory.tsx so the Nearby feature can reuse it row-by-row.
+export function pickBestCardForCategory(
+  walletCards: WalletCard[],
+  allCards: Card[],
+  category: string,
+): { primary: CategoryPick; alternative?: CategoryPick } | null {
+  if (!category) return null;
+
+  const walletCardData = walletCards
+    .map((wc) => allCards.find((c) => c.card_name === wc.card_name))
+    .filter((c): c is Card => c !== undefined && !!c.rewards && c.rewards.length > 0);
+
+  if (walletCardData.length === 0) return null;
+
+  const expectedQuarter = currentQuarterLabel();
+  const picks: CategoryPick[] = [];
+
+  for (const card of walletCardData) {
+    const permanentRates = new Map<string, number>();
+    for (const reward of card.rewards!) {
+      if (reward.mode === 'quarterly_rotating') continue;
+      const r = getRewardUsdRate(reward, card);
+      const prev = permanentRates.get(reward.category) ?? 0;
+      if (r > prev) permanentRates.set(reward.category, r);
+    }
+
+    for (const reward of card.rewards!) {
+      const usdRate = getRewardUsdRate(reward, card);
+
+      if (
+        reward.mode === 'quarterly_rotating' &&
+        reward.current_categories &&
+        reward.current_categories.length > 0
+      ) {
+        const stale = isStaleRotation(reward, expectedQuarter);
+        for (const entry of reward.current_categories) {
+          const cat = typeof entry === 'string' ? entry : entry.category;
+          const slotNote = typeof entry === 'string' ? undefined : entry.note;
+          if (cat !== category) continue;
+          const perm = permanentRates.get(cat) ?? 0;
+          if (perm >= usdRate) continue;
+          picks.push({ card, reward, usdRate, rotating: true, staleRotation: stale, slotNote });
+        }
+        continue;
+      }
+
+      if (reward.category === category) {
+        picks.push({ card, reward, usdRate });
+      }
+    }
+  }
+
+  // If nothing matches the requested category, fall back to everything_else
+  // so we always surface at least the user's best baseline card.
+  if (picks.length === 0 && category !== 'everything_else') {
+    return pickBestCardForCategory(walletCards, allCards, 'everything_else');
+  }
+
+  if (picks.length === 0) return null;
+
+  picks.sort((a, b) => b.usdRate - a.usdRate);
+  const primary = picks[0];
+
+  let alternative: CategoryPick | undefined;
+  const isConditional = (r: Reward) =>
+    r.merchant_specific === true || (!!r.note && r.note.trim().length > 0);
+
+  if (isConditional(primary.reward)) {
+    alternative = picks.find(
+      (p) => !isConditional(p.reward) && p.card.card_name !== primary.card.card_name,
+    );
+  }
+
+  return { primary, alternative };
+}

--- a/apps/web-next/src/lib/placeTypeMapping.ts
+++ b/apps/web-next/src/lib/placeTypeMapping.ts
@@ -1,0 +1,111 @@
+// Maps Google Places API "primaryType" / "types" values to the reward
+// categories defined in cardDisplayUtils.tsx (categoryLabels). The mapping
+// is intentionally small — anything that doesn't match falls through to
+// `everything_else`, which is also the catch-all that every wallet card
+// usually rewards at 1x.
+//
+// Reference for Google place types:
+// https://developers.google.com/maps/documentation/places/web-service/place-types
+
+// Brand overrides — tested against placeName.toLowerCase() with substring
+// match. Used to bias toward a more specific category when a generic
+// place type would lose information (Whole Foods is a grocery store but
+// also Amazon-branded; Costco is a grocery+merchandise hybrid but a
+// dedicated Costco card is the right pick for the user).
+const BRAND_TO_CATEGORY: Array<{ match: string; category: string }> = [
+  { match: 'whole foods', category: 'amazon' },
+  { match: 'amazon fresh', category: 'amazon' },
+  { match: 'amazon go', category: 'amazon' },
+  { match: 'rei', category: 'rei' },
+];
+
+const PRIMARY_TYPE_TO_CATEGORY: Record<string, string> = {
+  // dining
+  restaurant: 'dining',
+  cafe: 'dining',
+  coffee_shop: 'dining',
+  bar: 'dining',
+  meal_takeaway: 'dining',
+  meal_delivery: 'dining',
+  bakery: 'dining',
+  fast_food_restaurant: 'dining',
+  ice_cream_shop: 'dining',
+  pizza_restaurant: 'dining',
+  sandwich_shop: 'dining',
+  // groceries
+  supermarket: 'groceries',
+  grocery_store: 'groceries',
+  grocery_or_supermarket: 'groceries',
+  // gas
+  gas_station: 'gas',
+  // drugstores
+  pharmacy: 'drugstores',
+  drugstore: 'drugstores',
+  // transit
+  transit_station: 'transit',
+  bus_station: 'transit',
+  subway_station: 'transit',
+  train_station: 'transit',
+  taxi_stand: 'transit',
+  light_rail_station: 'transit',
+  // hotels
+  lodging: 'hotels',
+  hotel: 'hotels',
+  motel: 'hotels',
+  resort_hotel: 'hotels',
+  bed_and_breakfast: 'hotels',
+  // airlines / travel
+  airport: 'airlines',
+  travel_agency: 'travel',
+  // car rentals
+  car_rental: 'car_rentals',
+  // entertainment
+  movie_theater: 'entertainment',
+  amusement_park: 'entertainment',
+  bowling_alley: 'entertainment',
+  zoo: 'entertainment',
+  aquarium: 'entertainment',
+  stadium: 'entertainment',
+  night_club: 'entertainment',
+  // home improvement
+  home_goods_store: 'home_improvement',
+  hardware_store: 'home_improvement',
+};
+
+export interface PlaceCategoryMatch {
+  category: string;
+  matchedBy: 'brand' | 'primaryType' | 'type' | 'fallback';
+  matchedValue?: string;
+}
+
+export function mapPlaceToCategory(place: {
+  name?: string;
+  primaryType?: string;
+  types?: string[];
+}): PlaceCategoryMatch {
+  const lowerName = (place.name || '').toLowerCase();
+  for (const { match, category } of BRAND_TO_CATEGORY) {
+    if (lowerName.includes(match)) {
+      return { category, matchedBy: 'brand', matchedValue: match };
+    }
+  }
+  if (place.primaryType && PRIMARY_TYPE_TO_CATEGORY[place.primaryType]) {
+    return {
+      category: PRIMARY_TYPE_TO_CATEGORY[place.primaryType],
+      matchedBy: 'primaryType',
+      matchedValue: place.primaryType,
+    };
+  }
+  if (place.types) {
+    for (const t of place.types) {
+      if (PRIMARY_TYPE_TO_CATEGORY[t]) {
+        return {
+          category: PRIMARY_TYPE_TO_CATEGORY[t],
+          matchedBy: 'type',
+          matchedValue: t,
+        };
+      }
+    }
+  }
+  return { category: 'everything_else', matchedBy: 'fallback' };
+}


### PR DESCRIPTION
## Summary
- New **Nearby (beta)** tab in the profile that asks for the user's location, fetches nearby businesses from Google Places API (New), maps each to a reward category, and recommends the best card from the user's wallet for that spot.
- New `NearbyRecommendationsFunction` Lambda + `POST /nearby-recommendations` route. Calls Places `searchNearby` with a field-masked **Pro-tier** response. 10-min in-memory grid cache + 30/day per-user cap.
- Reuses the existing `BestCardByCategory` logic via a new `pickBestCardForCategory` helper (handles quarterly rotators, conditional rewards, `everything_else` fallback).
- Place-type → category map in `placeTypeMapping.ts` with a few brand overrides (Whole Foods → amazon, REI → rei).

## Cost & guardrails (already configured on GCP)
- Places API (New) enabled on `creditodds` project.
- API key restricted to Places API only.
- **SearchNearby daily quota set to 300** — caps monthly usage at ~9k calls (under the 10k free tier).
- App-side: 10-min cache by 110m grid + 30/day per-user cap.

## Deployment status
- ✅ **Already deployed** to `CreditCardOddsAPI` stack in `us-east-2` (deployed before this PR was opened).
- ✅ Endpoint smoke-tested: `OPTIONS 200`, `POST 403` (auth gate working).
- API key written to `apps/api/samconfig.toml` (gitignored).

## Test plan
- [ ] Sign in at `/profile`
- [ ] Click `03 Nearby · beta` tab
- [ ] Click "find nearby places", grant location permission
- [ ] Confirm a list of nearby businesses renders with a recommended card per row
- [ ] Confirm "refresh" works
- [ ] Confirm wallet-empty state renders correctly when wallet is empty
- [ ] Verify category mapping looks reasonable for nearby spots (restaurant → dining, gas station → gas, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)