### PR TITLE
Best Card Here: fix CSS cascade so mobile layout actually applies

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4219,12 +4219,9 @@
   }
 }
 
-/* ===== Best Card Here tape (desktop) ===== */
-.landing-v2.profile-v2 .cj-tape-bch .cj-bch-head,
-.landing-v2.profile-v2 .cj-tape-bch .cj-bch-row {
-  grid-template-columns: 56px minmax(0, 1.4fr) 96px minmax(0, 1.2fr) minmax(0, 1.1fr) 70px;
-  gap: 0 14px;
-}
+/* ===== Best Card Here tape ===== */
+
+/* Shared row chrome (applies at all sizes) */
 .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row {
   cursor: pointer;
   width: 100%;
@@ -4244,26 +4241,52 @@
   min-width: 0;
 }
 .landing-v2.profile-v2 .cj-tape-bch .cj-bch-card.cj-bch-next { opacity: 0.85; }
-.landing-v2.profile-v2 .cj-tape-bch .cj-bch-card-text { min-width: 0; }
+.landing-v2.profile-v2 .cj-tape-bch .cj-bch-card-text { min-width: 0; flex: 1; }
 .landing-v2.profile-v2 .cj-tape-bch .cj-bch-card-text .cj-cell-primary {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .landing-v2.profile-v2 .cj-tape-bch .cj-bch-earn-val { font-size: 14px; }
-.landing-v2.profile-v2 .cj-tape-bch .cj-bch-mob-meta { display: none; }
+
+/* Desktop layout — gated to ≥641px so it doesn't override the mobile rules
+   inside the @media (max-width: 640px) block above. */
+@media (min-width: 641px) {
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-head,
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row {
+    grid-template-columns: 56px minmax(0, 1.4fr) 96px minmax(0, 1.2fr) minmax(0, 1.1fr) 70px;
+    gap: 0 14px;
+  }
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-mob-meta { display: none; }
+  .landing-v2.profile-v2 .cj-bch-detail {
+    padding: 14px 18px 16px 78px;
+    border-top: 1px solid var(--line);
+    background: #fbfaff;
+    font-size: 12.5px;
+    color: var(--ink-2);
+    line-height: 1.6;
+  }
+  .landing-v2.profile-v2 .cj-bch-detail-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px 28px;
+    margin-bottom: 12px;
+  }
+}
+
+/* Mobile detail block (defaults; mobile @media block above further tunes) */
 .landing-v2.profile-v2 .cj-bch-detail {
-  padding: 14px 18px 16px 78px;
   border-top: 1px solid var(--line);
   background: #fbfaff;
   font-size: 12.5px;
   color: var(--ink-2);
   line-height: 1.6;
+  padding: 12px 14px;
 }
 .landing-v2.profile-v2 .cj-bch-detail-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px 28px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
   margin-bottom: 12px;
 }
 


### PR DESCRIPTION
## What was broken
The mobile fix in [#1089](https://github.com/CreditOdds/creditodds/pull/1089) didn't take effect because of a CSS source-order bug:

\`\`\`css
@media (max-width: 640px) {
  .cj-tape-bch .cj-bch-row { grid-template-columns: 1fr auto; ... }   /* mobile */
}

.cj-tape-bch .cj-bch-row { grid-template-columns: 56px 1.4fr 96px ...; }  /* desktop */
\`\`\`

Both selectors have identical specificity. The desktop rule lives **after** the @media block in source order, so on mobile *both* rules match and the desktop one wins the tiebreak. Merchant column collapsed to ~47px and \"Illy Café\" wrapped to \"Illy\" / \"Café\".

## Fix
Wrap the desktop \`grid-template-columns\` inside \`@media (min-width: 641px)\` so it physically can't apply on mobile. Move the always-on row chrome (cursor / border / background) above the breakpoints.

## Verified via getComputedStyle
- **Mobile (375px)**: \`gridTemplateColumns: "313.891px 19.1094px"\` — merchant gets 314px ✓
- **Desktop (1280px)**: \`gridTemplateColumns: "56px 362.484px 96px 310.703px 284.812px 70px"\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)