### PR TITLE
Profile mobile: Variant B App Tabs

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3341,9 +3341,9 @@
   .landing-v2.profile-v2 .cj-snapshot-h1 { font-size: 32px !important; }
 }
 .landing-v2.profile-v2 .cj-snapshot-h1 em {
-  font-style: italic;
-  color: var(--accent);
-  font-weight: 400;
+  font-style: normal;
+  color: var(--ink);
+  font-weight: 500;
 }
 .landing-v2.profile-v2 .cj-snapshot-meta {
   font-size: 11.5px;
@@ -4061,67 +4061,209 @@
   .landing-v2.profile-v2 .cj-main { border-right: 0; }
 }
 
-/* ===== Mobile (≤640px) — comprehensive overrides ===== */
+/* "Best card here." mobile-only feature.
+   Default (desktop): hide the full BestCardHere shell; show the banner. */
+.landing-v2.profile-v2 .cj-bch-shell { display: none; }
+.landing-v2.profile-v2 .cj-bch-desktop-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 18px 20px;
+  background: linear-gradient(180deg, var(--accent-2) 0%, var(--paper) 100%);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  margin: 12px 0 0;
+}
+.landing-v2.profile-v2 .cj-bch-desktop-banner-icon {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.landing-v2.profile-v2 .cj-bch-desktop-banner-text { min-width: 0; }
+.landing-v2.profile-v2 .cj-bch-desktop-banner-title {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.landing-v2.profile-v2 .cj-bch-desktop-banner-title em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+}
+.landing-v2.profile-v2 .cj-bch-desktop-banner-pill {
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--accent);
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.landing-v2.profile-v2 .cj-bch-desktop-banner-sub {
+  font-size: 13px;
+  color: var(--ink-2, #3a2f55);
+  line-height: 1.5;
+  margin-top: 4px;
+  max-width: 64ch;
+}
+
+/* Bottom tab bar (Variant B · App Tabs) — hidden by default; shown ≤640px */
+.landing-v2.profile-v2 .cj-mob-tabbar { display: none; }
+.landing-v2.profile-v2 .cj-mob-more { padding-top: 0; }
+.landing-v2.profile-v2 .cj-mob-more-h { display: none; }
+.landing-v2.profile-v2 .cj-mob-news,
+.landing-v2.profile-v2 .cj-mob-news-list,
+.landing-v2.profile-v2 .cj-mob-news-row,
+.landing-v2.profile-v2 .cj-mob-news-hero,
+.landing-v2.profile-v2 .cj-mob-news-filter { display: none; }
+/* Variant B Cards-tab hero — hidden by default; shown only ≤640px on Cards tab */
+.landing-v2.profile-v2 .cj-mob-cards-hero { display: none; }
+
+/* ===== Mobile (≤640px) — Profile v4 Mobile (Variant B · App Tabs) =====
+   Bottom tab bar with 5 icons (Cards / Rewards / News / Benefits / More).
+   The top tab strip is hidden and replaced by the bottom bar.
+   Variant A's editorial hero + magazine-style card rows still apply.
+   Pulled from creditodds/project/profile-v4-mobile.css (mB-* tokens),
+   re-applied to the existing cj-* shell so JSX stays small. */
 @media (max-width: 640px) {
   .landing-v2.profile-v2 .cj-mob-only { display: block; }
   .landing-v2.profile-v2 .cj-mob-hide { display: none !important; }
 
-  /* Snapshot — slightly smaller H1, tighter padding */
-  .landing-v2.profile-v2 .cj-snapshot { padding: 10px 0 12px; }
-  .landing-v2.profile-v2 .cj-snapshot-h1 { font-size: 24px !important; }
-  .landing-v2.profile-v2 .cj-snapshot-meta { font-size: 10.5px; }
+  /* Main column — give content edge breathing room */
+  .landing-v2.profile-v2 .cj-main { padding: 18px 18px 60px; }
 
-  /* Readoff — last odd cell spans full width so 5 cells lay out evenly (2/2/1-full) */
+  /* Snapshot — editorial hero: big H1 split with italic em, handle below */
+  .landing-v2.profile-v2 .cj-snapshot { padding: 18px 0 4px; }
+  .landing-v2.profile-v2 .cj-snapshot-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .landing-v2.profile-v2 .cj-snapshot-h1 {
+    font-size: 38px !important;
+    line-height: 0.98 !important;
+    letter-spacing: -0.03em;
+  }
+  .landing-v2.profile-v2 .cj-snapshot-meta {
+    font-size: 12.5px;
+    color: var(--muted);
+    letter-spacing: 0.02em;
+  }
+
+  /* Readoff — 2x2 stat grid with generous values, last cell spans full width */
+  .landing-v2.profile-v2 .cj-readoff { margin-top: 18px; }
   .landing-v2.profile-v2 .cj-readoff > .cj-readoff-cell:last-child:nth-child(odd) {
     grid-column: 1 / -1;
   }
-  .landing-v2.profile-v2 .cj-readoff-v { font-size: 18px; }
-  .landing-v2.profile-v2 .cj-readoff-cell { padding: 8px 10px; }
+  .landing-v2.profile-v2 .cj-readoff-cell { padding: 14px 14px 16px; }
+  .landing-v2.profile-v2 .cj-readoff-k {
+    font-size: 11.5px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .landing-v2.profile-v2 .cj-readoff-v {
+    font-size: 24px;
+    margin-top: 6px;
+  }
+  .landing-v2.profile-v2 .cj-readoff-foot {
+    font-size: 11.5px;
+    margin-top: 5px;
+  }
 
-  /* Tabs — tighter so 6 wrap onto two lines comfortably */
+  /* Sticky tab strip — bigger numbered tabs, horizontal scroll on overflow */
+  .landing-v2.profile-v2 .cj-main-tabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+    margin: 14px -18px 18px;
+    padding: 0 14px;
+  }
+  .landing-v2.profile-v2 .cj-main-tabs::-webkit-scrollbar { display: none; }
   .landing-v2.profile-v2 .cj-main-tab {
-    padding: 8px 12px 8px 0;
-    margin-right: 14px;
-    font-size: 12.5px;
+    flex: 0 0 auto;
+    padding: 14px 14px 12px;
+    margin-right: 0;
+    font-size: 14px;
   }
+  .landing-v2.profile-v2 .cj-main-tab-num { font-size: 10.5px; }
+  .landing-v2.profile-v2 .cj-main-tab-count { display: none; }
 
-  /* Wallet tape — drop the head, simplify rows: thumb · name+issuer · fee · caret */
-  .landing-v2.profile-v2 .cj-wallet-toolbar { gap: 10px; }
+  /* Wallet rows — magazine-style stacked: 56px thumb · name+issuer+renewal · fee right */
+  .landing-v2.profile-v2 .cj-wallet-toolbar { gap: 10px; flex-wrap: wrap; }
   .landing-v2.profile-v2 .cj-wallet-head { display: none; }
+  .landing-v2.profile-v2 .cj-wallet-tape { border-left: 0; border-right: 0; }
   .landing-v2.profile-v2 .cj-wallet-crow {
-    grid-template-columns: 36px minmax(0, 1fr) auto auto;
+    grid-template-columns: 56px minmax(0, 1fr) auto;
     grid-template-areas:
-      "thumb name fee caret"
-      "thumb issuer fee caret";
-    gap: 0 10px;
-    padding: 10px 12px;
-    align-items: center;
+      "thumb name   fee"
+      "thumb issuer fee"
+      "thumb renew  fee";
+    gap: 2px 14px;
+    padding: 18px 4px;
+    align-items: start;
   }
-  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-thumb { grid-area: thumb; align-self: center; }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-thumb {
+    grid-area: thumb;
+    align-self: start;
+    width: 56px;
+    height: 36px;
+  }
   .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-name {
     grid-area: name;
-    align-self: end;
+    align-self: start;
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.015em;
     line-height: 1.15;
-    font-size: 13.5px;
   }
   .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-issuer {
     grid-area: issuer;
-    align-self: start;
-    font-size: 10.5px;
+    margin-top: 4px;
+    font-size: 12.5px;
     color: var(--muted);
   }
-  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-renew { display: none; }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-renew {
+    grid-area: renew;
+    display: block;
+    margin-top: 8px;
+    font-size: 12px;
+    color: var(--muted);
+    letter-spacing: 0.01em;
+  }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-renew::before {
+    content: 'renewal · ';
+    color: var(--muted-2);
+  }
   .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-fee {
     grid-area: fee;
-    align-self: center;
-    font-size: 13px;
+    align-self: start;
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 18px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
   }
-  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-caret { grid-area: caret; align-self: center; }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-caret { display: none; }
   .landing-v2.profile-v2 .cj-cw-marks { margin-left: 6px; }
   .landing-v2.profile-v2 .cj-cw-mark { width: 16px; height: 16px; }
 
-  /* Wallet detail expand — left padding aligned with thumb shrunk to row padding */
-  .landing-v2.profile-v2 .cj-wallet-detail { padding: 14px 12px; }
+  /* Wallet detail expand — flush with the main column edge */
+  .landing-v2.profile-v2 .cj-wallet-detail { padding: 14px 4px; }
   .landing-v2.profile-v2 .cj-wd-cta { font-size: 11px !important; padding: 5px 8px !important; }
 
   /* Records tape — head hidden, columns collapsed to: card+detail · pill */
@@ -4129,7 +4271,7 @@
   .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row {
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 10px;
-    padding: 10px 12px;
+    padding: 14px 12px;
   }
   .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row > div:nth-child(1),
   .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row > div:nth-child(2),
@@ -4137,53 +4279,183 @@
   .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row > div:nth-child(5) {
     display: none;
   }
+  .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-event .cj-tape-field {
+    font-size: 16px;
+    font-weight: 500;
+  }
 
   /* Referrals tape — drop impressions/clicks columns; show as detail under card */
   .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-head { display: none; }
   .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-row {
-    grid-template-columns: 36px minmax(0, 1fr) auto;
-    gap: 10px;
-    padding: 10px 12px;
+    grid-template-columns: 44px minmax(0, 1fr) auto;
+    gap: 12px;
+    padding: 14px 12px;
   }
   .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-row > div:nth-child(3),
   .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-row > div:nth-child(4) {
     display: none;
   }
 
-  /* Benefits credits tape — drop cadence column; cadence shown in detail line */
+  /* Benefits credits tape — bigger thumb, drop cadence column */
   .landing-v2.profile-v2 .cj-tape.cj-tape-credits .cj-tape-head { display: none; }
   .landing-v2.profile-v2 .cj-tape.cj-tape-credits .cj-tape-row {
-    grid-template-columns: 36px minmax(0, 1fr) auto;
-    gap: 10px;
-    padding: 10px 12px;
+    grid-template-columns: 44px minmax(0, 1fr) auto;
+    gap: 12px;
+    padding: 14px 12px;
   }
   .landing-v2.profile-v2 .cj-tape.cj-tape-credits .cj-tape-row > div:nth-child(3) {
     display: none;
   }
 
-  /* Rewards table — tighter, stacked best-cell */
-  .landing-v2.profile-v2 .cj-table { font-size: 12px; }
-  .landing-v2.profile-v2 .cj-table th { padding: 8px 8px; font-size: 11px; }
-  .landing-v2.profile-v2 .cj-table td { padding: 9px 8px; }
-  .landing-v2.profile-v2 .cj-rew-best { gap: 8px; }
+  /* Rewards table — readable type, stacked best-cell */
+  .landing-v2.profile-v2 .cj-table { font-size: 13px; }
+  .landing-v2.profile-v2 .cj-table th { padding: 10px 8px; font-size: 11px; }
+  .landing-v2.profile-v2 .cj-table td { padding: 12px 8px; }
+  .landing-v2.profile-v2 .cj-rew-best { gap: 10px; }
   .landing-v2.profile-v2 .cj-rew-thumb,
   .landing-v2.profile-v2 .cj-rew-thumb-empty {
-    width: 24px;
-    height: 16px;
+    width: 32px;
+    height: 20px;
   }
-  .landing-v2.profile-v2 .cj-eff-pct { font-size: 13px; }
+  .landing-v2.profile-v2 .cj-eff-pct { font-size: 16px; }
 
-  /* Settings list — keep 2-col, tighten */
-  .landing-v2.profile-v2 .cj-settings-list { padding: 12px 0; gap: 10px; }
+  /* Settings list — keep 2-col, generous padding */
+  .landing-v2.profile-v2 .cj-settings-list { padding: 14px 0; gap: 12px; }
   .landing-v2.profile-v2 .cj-settings-k { font-size: 12px; }
-  .landing-v2.profile-v2 .cj-settings-v { font-size: 12px; word-break: break-word; }
+  .landing-v2.profile-v2 .cj-settings-v { font-size: 13px; word-break: break-word; }
 
-  /* Verdict block — slimmer */
-  .landing-v2.profile-v2 .cj-verdict { padding: 14px 16px; font-size: 13px; }
+  /* Verdict block — keep readable */
+  .landing-v2.profile-v2 .cj-verdict { padding: 16px 18px; font-size: 14px; }
 
-  /* Apply block — smaller display values */
-  .landing-v2.profile-v2 .cj-apply { padding: 16px; }
-  .landing-v2.profile-v2 .cj-apply-v { font-size: 18px; }
+  /* Rail — when stacked below main on mobile, present "Wallet" hero like the design's mB-apply */
+  .landing-v2.profile-v2 .cj-rail { padding: 8px 18px 32px; }
+  .landing-v2.profile-v2 .cj-apply { padding: 18px; }
+  .landing-v2.profile-v2 .cj-apply-v { font-size: 22px; }
+
+  /* News for you + view all news → hidden on mobile (the News tab covers this) */
+  .landing-v2.profile-v2 .cj-rail-block-news,
+  .landing-v2.profile-v2 .cj-rail-cta-news { display: none; }
+
+  /* Upcoming renewals rail block → hidden on mobile except on the More tab.
+     The More mobile pill stays active for any of these desktop activeTab values. */
+  .landing-v2.profile-v2 .cj-rail-block-renewals { display: none; }
+  .landing-v2.profile-v2[data-tab="more"] .cj-rail-block-renewals,
+  .landing-v2.profile-v2[data-tab="applications"] .cj-rail-block-renewals,
+  .landing-v2.profile-v2[data-tab="referrals"] .cj-rail-block-renewals,
+  .landing-v2.profile-v2[data-tab="settings"] .cj-rail-block-renewals { display: block; }
+
+  /* ====== Variant B Cards-tab hero ======
+     Replace the editorial Welcome+readoff with the design's dark Wallet hero
+     + 3-cell snap pills + "Cards held" section header. */
+  .landing-v2.profile-v2 .cj-snapshot { display: none; }
+  .landing-v2.profile-v2 .cj-mob-cards-hero { display: block; margin: 8px 0 4px; }
+
+  .landing-v2.profile-v2 .cj-mob-wallet {
+    background: var(--ink);
+    color: #fff;
+    padding: 22px 20px;
+    border-radius: 8px;
+    margin-bottom: 14px;
+  }
+  .landing-v2.profile-v2 .cj-mob-wallet-k {
+    font-size: 12px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.65);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .landing-v2.profile-v2 .cj-mob-wallet-v {
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 28px;
+    font-weight: 500;
+    letter-spacing: -0.025em;
+    margin-top: 6px;
+    line-height: 1.05;
+  }
+  .landing-v2.profile-v2 .cj-mob-wallet-sub {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.65);
+    margin-top: 6px;
+    letter-spacing: 0.01em;
+  }
+  .landing-v2.profile-v2 .cj-mob-wallet-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    margin-top: 18px;
+  }
+  .landing-v2.profile-v2 .cj-mob-wallet-btn {
+    background: var(--accent);
+    color: #fff;
+    border: 0;
+    padding: 13px;
+    border-radius: 5px;
+    font-family: inherit;
+    font-size: 13.5px;
+    font-weight: 600;
+    cursor: pointer;
+    letter-spacing: 0.02em;
+  }
+  .landing-v2.profile-v2 .cj-mob-wallet-btn.outline {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+  }
+  .landing-v2.profile-v2 .cj-mob-wallet-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  .landing-v2.profile-v2 .cj-mob-snap {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+    margin-bottom: 18px;
+  }
+  .landing-v2.profile-v2 .cj-mob-snap-cell {
+    background: var(--paper);
+    border: 1px solid var(--line);
+    padding: 12px 12px 14px;
+    border-radius: 6px;
+  }
+  .landing-v2.profile-v2 .cj-mob-snap-k {
+    font-size: 10.5px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+  }
+  .landing-v2.profile-v2 .cj-mob-snap-v {
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 20px;
+    font-weight: 500;
+    letter-spacing: -0.015em;
+    margin-top: 4px;
+    line-height: 1;
+  }
+  .landing-v2.profile-v2 .cj-mob-snap-v.accent { color: var(--accent); }
+  .landing-v2.profile-v2 .cj-mob-snap-v.warn { color: var(--warn); }
+
+  .landing-v2.profile-v2 .cj-mob-section-h {
+    margin: 4px 0 6px;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .landing-v2.profile-v2 .cj-mob-section-h h2 {
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 22px;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    margin: 0;
+    color: var(--ink);
+  }
+  .landing-v2.profile-v2 .cj-mob-section-sub {
+    font-size: 12px;
+    color: var(--muted);
+    letter-spacing: 0.01em;
+  }
 
   /* Modal — full-width on mobile */
   .landing-v2.profile-v2 .cj-modal-card {
@@ -4191,6 +4463,71 @@
     border-left: 0;
     border-right: 0;
     max-width: 100%;
+  }
+
+  /* Show BestCardHere on mobile, hide the desktop banner */
+  .landing-v2.profile-v2 .cj-bch-shell { display: block; }
+  .landing-v2.profile-v2 .cj-bch-desktop-banner { display: none; }
+
+  /* ====== Variant B Rewards-tab hero ======
+     Restyle the existing BestCardHere wrapper as the design's purple gradient
+     hero with a 60px pin icon (CSS pseudo-element) + bigger headline. */
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell {
+    background: linear-gradient(180deg, var(--accent-2) 0%, var(--paper) 80%);
+    padding: 26px 20px 22px;
+    margin: -18px -18px 14px;
+    border-bottom: 1px solid var(--line);
+  }
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell::before {
+    content: '';
+    display: block;
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background-color: var(--accent);
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s7-7 7-13a7 7 0 0 0-14 0c0 6 7 13 7 13z"/><circle cx="12" cy="9" r="2.5"/></svg>');
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 28px;
+    margin-bottom: 8px;
+    box-shadow: 0 8px 24px -8px rgba(109, 63, 232, 0.5);
+  }
+  /* BETA pill (rounded full on mobile) + pilot/feedback line on its own row */
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-bch-head {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-bch-head > span:first-of-type {
+    border-radius: 999px !important;
+    padding: 4px 10px !important;
+    font-size: 10.5px !important;
+  }
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-section-h2 {
+    flex: 1 0 100%;
+    font-size: 32px !important;
+    line-height: 1.02 !important;
+    letter-spacing: -0.025em;
+    margin-top: 4px !important;
+  }
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-section-num {
+    margin-left: 0 !important;
+    font-size: 11px;
+    order: 1;
+  }
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell > p {
+    font-size: 14.5px !important;
+    line-height: 1.5 !important;
+    margin: 12px 0 16px !important;
+    max-width: 36ch;
+    color: var(--ink-2, #3a2f55);
+  }
+  /* Merchant tape outside the hero — paper-2 background to match the design */
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-tape-bch {
+    margin: 0 -2px;
+    background: transparent;
+    border: 0;
   }
 
   /* Best Card Here tape — drop dist/category columns, stack best/runner-up under merchant + earn */
@@ -4201,9 +4538,68 @@
       "merchant earn"
       "best     best"
       "next     next";
-    gap: 8px 12px;
-    padding: 12px 14px;
+    gap: 10px 12px;
+    padding: 16px 14px;
     align-items: center;
+    background: var(--paper);
+    border: 1px solid var(--line-2);
+    border-radius: 8px;
+    margin-bottom: 12px;
+  }
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row.is-open { background: var(--accent-2); }
+  /* Distance + category as a top-row eyebrow inside each merchant card */
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-merchant .cj-tape-detail {
+    font-size: 11.5px;
+    color: var(--muted);
+    margin-top: 4px;
+  }
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-tape-field {
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 20px;
+    font-weight: 500;
+    letter-spacing: -0.015em;
+    line-height: 1.15;
+  }
+  /* "Best" pick block — paper-2 footer with thumb + name + earn rate */
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-best {
+    margin: 8px -14px 0;
+    padding: 12px 14px 0;
+    border-top: 1px solid var(--line);
+  }
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-best .cj-bch-card-text .cj-cell-primary {
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 17px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+  /* "Next" runner-up — dashed top border, smaller */
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-next {
+    margin: 6px -14px -6px;
+    padding: 10px 14px;
+    border-top: 1px dashed var(--line);
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+  /* Earn rate — large purple */
+  .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-earn .cj-bch-earn-val {
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 24px !important;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    color: var(--accent);
+  }
+
+  /* "Wallet-wide" divider becomes a flat eyebrow on mobile */
+  .landing-v2.profile-v2 .cj-walletwide-divider {
+    margin: 24px 0 8px !important;
+  }
+  .landing-v2.profile-v2 .cj-walletwide-rule { display: none; }
+  .landing-v2.profile-v2 .cj-walletwide-label {
+    font-size: 12.5px !important;
+    letter-spacing: 0.08em;
+  }
+  .landing-v2.profile-v2 .cj-walletwide-label::after {
+    content: ' rewards';
   }
   .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-dist,
   .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-cat { display: none; }
@@ -4212,11 +4608,223 @@
   .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-best { grid-area: best; }
   .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-next { grid-area: next; }
   .landing-v2.profile-v2 .cj-tape-bch .cj-bch-mob-meta { display: inline; }
-  .landing-v2.profile-v2 .cj-bch-detail { padding: 12px 14px; }
+  .landing-v2.profile-v2 .cj-bch-detail { padding: 14px 16px; }
   .landing-v2.profile-v2 .cj-bch-detail-grid {
     grid-template-columns: minmax(0, 1fr) !important;
     gap: 12px !important;
   }
+
+  /* ====== Variant B mobile chrome ====== */
+
+  /* Hide the desktop top tab strip — bottom tab bar takes over on mobile */
+  .landing-v2.profile-v2 .cj-main-tabs { display: none; }
+
+  /* Leave room for the fixed bottom tab bar (~64px + safe area) */
+  .landing-v2.profile-v2 .cj-main { padding-bottom: 96px; }
+
+  /* Bottom tab bar — fixed to viewport, blur background, 5 grid columns */
+  .landing-v2.profile-v2 .cj-mob-tabbar {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    background: rgba(255, 255, 255, 0.94);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    border-top: 1px solid var(--line);
+    padding: 8px 6px calc(env(safe-area-inset-bottom, 0px) + 10px);
+  }
+  .landing-v2.profile-v2 .cj-mob-tab {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    background: transparent;
+    border: 0;
+    padding: 8px 4px;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--muted);
+    cursor: pointer;
+    letter-spacing: 0.02em;
+    position: relative;
+    font-family: inherit;
+  }
+  .landing-v2.profile-v2 .cj-mob-tab.active { color: var(--accent); }
+  .landing-v2.profile-v2 .cj-mob-tab-icon {
+    width: 26px;
+    height: 26px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .landing-v2.profile-v2 .cj-mob-tab-beta {
+    position: absolute;
+    top: 4px;
+    right: 22%;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 1.5px solid var(--paper);
+  }
+
+  /* "More" tab — restore section headers + reset borders so stacked tabs read as one page */
+  .landing-v2.profile-v2 .cj-mob-more { padding-top: 4px; }
+  .landing-v2.profile-v2 .cj-mob-more-h {
+    display: block;
+    font-family: 'Inter', sans-serif;
+    font-size: 11.5px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    margin: 18px 0 10px;
+    padding-top: 14px;
+    border-top: 1px solid var(--line);
+  }
+  .landing-v2.profile-v2 .cj-mob-more > .cj-mob-more-h:first-child {
+    border-top: 0;
+    margin-top: 0;
+    padding-top: 0;
+  }
+  .landing-v2.profile-v2 .cj-mob-more .cj-section { padding: 0; }
+
+  /* News tab (mobile-only) — show the elements that were hidden by default */
+  .landing-v2.profile-v2 .cj-mob-news,
+  .landing-v2.profile-v2 .cj-mob-news-hero,
+  .landing-v2.profile-v2 .cj-mob-news-list { display: block; }
+  .landing-v2.profile-v2 .cj-mob-news-filter { display: flex; }
+  .landing-v2.profile-v2 .cj-mob-news-row { display: grid; }
+
+  .landing-v2.profile-v2 .cj-mob-news-hero {
+    margin: 0 -18px;
+    padding: 22px 18px 18px;
+    border-bottom: 1px solid var(--line);
+    background: var(--paper);
+  }
+  .landing-v2.profile-v2 .cj-mob-news-eyebrow {
+    font-size: 11px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-h {
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 28px;
+    font-weight: 500;
+    letter-spacing: -0.025em;
+    line-height: 1.05;
+    margin: 6px 0 8px;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-h em {
+    font-style: italic;
+    font-weight: 400;
+    color: var(--accent);
+  }
+  .landing-v2.profile-v2 .cj-mob-news-sub {
+    font-size: 13.5px;
+    color: var(--ink-2, #3a2f55);
+    line-height: 1.45;
+    max-width: 36ch;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-filter {
+    gap: 8px;
+    padding: 14px 18px 0;
+    margin: 0 -18px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-filter::-webkit-scrollbar { display: none; }
+  .landing-v2.profile-v2 .cj-mob-news-chip {
+    flex: 0 0 auto;
+    padding: 7px 14px;
+    border-radius: 999px;
+    border: 1px solid var(--line-2);
+    background: var(--paper);
+    font: inherit;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--ink-2, #3a2f55);
+    cursor: pointer;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-chip.active {
+    background: var(--ink);
+    border-color: var(--ink);
+    color: #fff;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-list {
+    margin: 0 -18px;
+    padding: 8px 0 12px;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-row {
+    grid-template-columns: 48px 1fr;
+    gap: 14px;
+    padding: 16px 18px;
+    border-top: 1px solid var(--line);
+    align-items: flex-start;
+    text-decoration: none;
+    color: inherit;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-row:first-of-type { border-top: 0; }
+  .landing-v2.profile-v2 .cj-mob-news-thumb {
+    position: relative;
+    width: 48px;
+    height: 30px;
+    border-radius: 4px;
+    overflow: hidden;
+    background: var(--paper-2);
+    border: 1px solid var(--line);
+  }
+  .landing-v2.profile-v2 .cj-mob-news-meta {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-size: 11px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-tag { color: var(--accent); }
+  .landing-v2.profile-v2 .cj-mob-news-tag--fee-change,
+  .landing-v2.profile-v2 .cj-mob-news-tag--discontinued { color: var(--warn); }
+  .landing-v2.profile-v2 .cj-mob-news-tag--benefit-change,
+  .landing-v2.profile-v2 .cj-mob-news-tag--new-card { color: #0f8a5f; }
+  .landing-v2.profile-v2 .cj-mob-news-title {
+    font-family: 'Inter Tight', sans-serif;
+    font-size: 17px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    line-height: 1.25;
+    margin-top: 6px;
+    color: var(--ink);
+    text-wrap: pretty;
+  }
+  .landing-v2.profile-v2 .cj-mob-news-card {
+    font-size: 12.5px;
+    color: var(--muted);
+    margin-top: 4px;
+  }
+}
+
+/* ===== Smaller phones (≤380px) — pull H1 down so it doesn't blow out ===== */
+@media (max-width: 380px) {
+  .landing-v2.profile-v2 .cj-snapshot-h1 { font-size: 32px !important; }
+  .landing-v2.profile-v2 .cj-readoff-v { font-size: 21px; }
+  .landing-v2.profile-v2 .cj-wallet-crow {
+    grid-template-columns: 48px minmax(0, 1fr) auto;
+    gap: 2px 12px;
+  }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-thumb { width: 48px; height: 30px; }
+  .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-name { font-size: 17px; }
 }
 
 /* ===== Best Card Here tape ===== */

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -9,7 +9,7 @@ import { useAuth } from "@/auth/AuthProvider";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import { getAllCards, getProfile, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, deleteAccount, WalletCard, Card } from "@/lib/api";
 import "../landing.css";
-import { getNews, NewsItem, tagLabels } from "@/lib/news";
+import { getNews, NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
 import ProfileLoader from "./ProfileLoader";
 import { amortizedAnnualValue } from "@/lib/cardDisplayUtils";
@@ -71,7 +71,7 @@ interface Profile {
   referrals_count: number;
 }
 
-type TabKey = 'cards' | 'rewards' | 'benefits' | 'applications' | 'referrals' | 'settings';
+type TabKey = 'cards' | 'rewards' | 'benefits' | 'applications' | 'referrals' | 'settings' | 'news' | 'more';
 
 const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -308,7 +308,7 @@ export default function ProfileClient() {
   ];
 
   return (
-    <div className="landing-v2 profile-v2">
+    <div className="landing-v2 profile-v2" data-tab={activeTab}>
       {/* Terminal strip — dark bar with breadcrumb + status */}
       <div className="cj-terminal">
         <nav className="cj-crumbs" aria-label="Breadcrumb">
@@ -325,7 +325,9 @@ export default function ProfileClient() {
 
       <div className="cj-layout">
         <main className="cj-main">
-          {/* Snapshot header — tight welcome row */}
+          {/* Snapshot — welcome row + 5-cell stat readoff. Desktop: visible on
+              every tab. Mobile: hidden via CSS — the Cards-tab dark Wallet hero
+              below replaces it on mobile. */}
           <div className="cj-snapshot">
             <div className="cj-snapshot-row">
               <h1 className="cj-snapshot-h1">
@@ -385,6 +387,58 @@ export default function ProfileClient() {
             </div>
           </div>
 
+          {/* Mobile-only (Variant B · App Tabs) Cards-tab hero — dark Wallet card +
+              3-cell snap pills. Hidden ≥641px; the editorial cj-snapshot above takes over. */}
+          {activeTab === 'cards' && (
+            <div className="cj-mob-cards-hero">
+              <div className="cj-mob-wallet">
+                <div className="cj-mob-wallet-k">Wallet</div>
+                <div className="cj-mob-wallet-v">
+                  {walletCards.length} card{walletCards.length === 1 ? '' : 's'} · ${totalAnnualFees.toLocaleString()}/yr
+                </div>
+                <div className="cj-mob-wallet-actions">
+                  <button type="button" className="cj-mob-wallet-btn" onClick={() => setShowWalletModal(true)}>
+                    + add a card
+                  </button>
+                  <button
+                    type="button"
+                    className="cj-mob-wallet-btn outline"
+                    onClick={() => setShowRecordCardPicker(true)}
+                    disabled={eligibleRecordCards.length === 0}
+                  >
+                    submit a record
+                  </button>
+                </div>
+              </div>
+              <div className="cj-mob-snap">
+                <div className="cj-mob-snap-cell">
+                  <div className="cj-mob-snap-k">Active</div>
+                  <div className="cj-mob-snap-v">{walletCards.length - inactiveCount}</div>
+                </div>
+                <div className="cj-mob-snap-cell">
+                  <div className="cj-mob-snap-k">Annual fees</div>
+                  <div className={'cj-mob-snap-v' + (totalAnnualFees > 0 ? ' warn' : '')}>
+                    ${totalAnnualFees.toLocaleString()}
+                  </div>
+                </div>
+                <div className="cj-mob-snap-cell">
+                  <div className="cj-mob-snap-k">Credits</div>
+                  <div className="cj-mob-snap-v accent">
+                    {annualCreditsTotals.total >= 1000
+                      ? `$${(annualCreditsTotals.total / 1000).toFixed(1)}k`
+                      : `$${annualCreditsTotals.total}`}
+                  </div>
+                </div>
+              </div>
+              <div className="cj-mob-section-h">
+                <h2>Cards held</h2>
+                <div className="cj-mob-section-sub">
+                  {walletCards.length - inactiveCount} active{inactiveCount > 0 ? ` · ${inactiveCount} archived` : ''}
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* Tab row */}
           <div className="cj-main-tabs">
             {tabs.map((it) => (
@@ -426,14 +480,33 @@ export default function ProfileClient() {
             {activeTab === 'rewards' && (
               !walletLoaded ? <LoadingPanel /> : (
                 <section className="cj-section">
+                  {/* Best Card Here is mobile-only — relies on geolocation
+                      and the merchant-card layout doesn't fit a desktop column.
+                      Desktop sees a banner pointing them to mobile. */}
                   <BestCardHere walletCards={walletCards} allCards={allCards} />
-                  <div style={{
+                  <div className="cj-bch-desktop-banner" aria-hidden="false">
+                    <span className="cj-bch-desktop-banner-icon" aria-hidden="true">
+                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M12 22s7-7 7-13a7 7 0 0 0-14 0c0 6 7 13 7 13z" />
+                        <circle cx="12" cy="9" r="2.5" />
+                      </svg>
+                    </span>
+                    <div className="cj-bch-desktop-banner-text">
+                      <div className="cj-bch-desktop-banner-title">
+                        Best card <em>here.</em> <span className="cj-bch-desktop-banner-pill">Beta · mobile</span>
+                      </div>
+                      <div className="cj-bch-desktop-banner-sub">
+                        Wallet-aware merchant lookup. Open this page on your phone to see the best card to swipe at the businesses around you.
+                      </div>
+                    </div>
+                  </div>
+                  <div className="cj-walletwide-divider" style={{
                     display: 'flex',
                     alignItems: 'center',
                     gap: 12,
                     margin: '36px 0 18px',
                   }}>
-                    <span style={{
+                    <span className="cj-walletwide-label" style={{
                       fontSize: 10.5,
                       color: 'var(--muted)',
                       textTransform: 'uppercase',
@@ -442,7 +515,7 @@ export default function ProfileClient() {
                     }}>
                       Wallet-wide
                     </span>
-                    <span style={{ flex: 1, height: 1, background: 'var(--line)' }} />
+                    <span className="cj-walletwide-rule" style={{ flex: 1, height: 1, background: 'var(--line)' }} />
                   </div>
                   <BestCardByCategory walletCards={walletCards} allCards={allCards} />
                 </section>
@@ -494,6 +567,55 @@ export default function ProfileClient() {
                 onLogout={() => { logout().then(() => router.push("/")); }}
               />
             )}
+
+            {/* Mobile-only: News tab (Variant B) — wallet-filtered news with chip filters */}
+            {activeTab === 'news' && (
+              <MobileNewsView
+                relevantNews={relevantNews}
+                walletCardsCount={walletCards.length}
+              />
+            )}
+
+            {/* Mobile-only: More tab (Variant B) — stacks Applications + Referrals + Settings */}
+            {activeTab === 'more' && (
+              <section className="cj-section cj-mob-more">
+                <div className="cj-mob-more-h">Applications</div>
+                <ApplicationsTab
+                  recordsLoaded={recordsLoaded}
+                  walletLoaded={walletLoaded}
+                  records={records}
+                  walletCards={walletCards}
+                  applicationRules={applicationRules}
+                  cardsMissingDates={cardsMissingDates}
+                  onPickCard={() => setShowRecordCardPicker(true)}
+                  onDeleteRecord={handleDeleteRecord}
+                  deletingRecordId={deletingRecordId}
+                  eligibleRecordCards={eligibleRecordCards}
+                />
+                <div className="cj-mob-more-h">Referrals</div>
+                <ReferralsTab
+                  referralsLoaded={referralsLoaded}
+                  referrals={referrals}
+                  eligibleReferralCards={eligibleReferralCards}
+                  onAddReferral={() => setShowReferralModal(true)}
+                  onArchive={handleArchiveReferral}
+                  archivingReferralId={archivingReferralId}
+                />
+                <div className="cj-mob-more-h">Account</div>
+                <SettingsTab
+                  profile={profile}
+                  email={authState.user?.email}
+                  handle={handle}
+                  confirmingDelete={confirmingDelete}
+                  setConfirmingDelete={setConfirmingDelete}
+                  deleteConfirmText={deleteConfirmText}
+                  setDeleteConfirmText={setDeleteConfirmText}
+                  deletingAccount={deletingAccount}
+                  onDeleteAccount={handleDeleteAccount}
+                  onLogout={() => { logout().then(() => router.push("/")); }}
+                />
+              </section>
+            )}
           </div>
         </main>
 
@@ -518,7 +640,7 @@ export default function ProfileClient() {
           </div>
 
           {upcomingRenewals.length > 0 && (
-            <div className="cj-rail-block">
+            <div className="cj-rail-block cj-rail-block-renewals">
               <div className="cj-rail-label">Upcoming renewals</div>
               <ul className="cj-rail-list">
                 {upcomingRenewals.map((r) => (
@@ -536,7 +658,7 @@ export default function ProfileClient() {
             </div>
           )}
 
-          <div className="cj-rail-block">
+          <div className="cj-rail-block cj-rail-block-news">
             <div className="cj-rail-label">News for you</div>
             {relevantNews.length > 0 ? (
               <ul className="cj-rail-list">
@@ -568,9 +690,12 @@ export default function ProfileClient() {
             )}
           </div>
 
-          <Link href="/news" className="cj-rail-cta">view all news</Link>
+          <Link href="/news" className="cj-rail-cta cj-rail-cta-news">view all news</Link>
         </aside>
       </div>
+
+      {/* Mobile bottom tab bar — Variant B (App Tabs). Hidden ≥641px via CSS. */}
+      <MobileTabBar activeTab={activeTab} onSelect={setActiveTab} />
 
       <V2Footer />
 
@@ -1113,5 +1238,158 @@ function SettingsTab(props: SettingsTabProps) {
         </div>
       </div>
     </section>
+  );
+}
+
+/* ========== Mobile-only: News view (Variant B) — wallet-filtered news with chip filters ========== */
+type NewsFilter = 'all' | NewsTag;
+
+function MobileNewsView({ relevantNews, walletCardsCount }: { relevantNews: NewsItem[]; walletCardsCount: number }) {
+  const [filter, setFilter] = useState<NewsFilter>('all');
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return relevantNews;
+    return relevantNews.filter((n) => n.tags?.includes(filter));
+  }, [relevantNews, filter]);
+
+  const tagCount = (t: NewsTag) => relevantNews.filter((n) => n.tags?.includes(t)).length;
+  const allChips: { key: NewsFilter; label: string }[] = [
+    { key: 'all', label: `all · ${relevantNews.length}` },
+    { key: 'fee-change', label: 'fee changes' },
+    { key: 'benefit-change', label: 'benefit changes' },
+    { key: 'bonus-change', label: 'bonus offers' },
+    { key: 'new-card', label: 'new cards' },
+    { key: 'limited-time', label: 'limited time' },
+  ];
+  const chips = allChips.filter((c) => c.key === 'all' || tagCount(c.key as NewsTag) > 0);
+
+  return (
+    <section className="cj-mob-news">
+      <div className="cj-mob-news-hero">
+        <div className="cj-mob-news-eyebrow">News · last 60 days</div>
+        <h1 className="cj-mob-news-h">Filtered to <em>your wallet.</em></h1>
+        <p className="cj-mob-news-sub">
+          Devalues, benefit changes, and transfer-partner news for the {walletCardsCount} card{walletCardsCount === 1 ? '' : 's'} you carry —
+          so you only see what matters.
+        </p>
+      </div>
+      <div className="cj-mob-news-filter">
+        {chips.map((c) => (
+          <button
+            key={c.key}
+            type="button"
+            className={'cj-mob-news-chip' + (filter === c.key ? ' active' : '')}
+            onClick={() => setFilter(c.key)}
+          >
+            {c.label}
+          </button>
+        ))}
+      </div>
+      {filtered.length === 0 ? (
+        <div className="cj-verdict" style={{ margin: '14px 18px' }}>
+          {walletCardsCount === 0
+            ? <><b>No cards in your wallet yet.</b> Add cards to see news for them.</>
+            : <><b>No matching news.</b> Try a different filter.</>}
+        </div>
+      ) : (
+        <div className="cj-mob-news-list">
+          {filtered.map((n) => (
+            <Link key={n.id} href={`/news/${n.id}`} className="cj-mob-news-row">
+              <span className="cj-mob-news-thumb">
+                <CardImage cardImageLink={n.card_image_link || n.card_image_links?.[0]} alt={n.card_names?.[0] || ''} fill sizes="48px" className="object-contain" />
+              </span>
+              <div>
+                <div className="cj-mob-news-meta">
+                  <span>{new Date(n.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+                  <span style={{ color: 'var(--muted-2)' }}>·</span>
+                  {n.tags?.[0] && (
+                    <span className={`cj-mob-news-tag cj-mob-news-tag--${n.tags[0]}`}>
+                      {(tagLabels[n.tags[0]] || n.tags[0]).replace(/^[^\w]+\s*/, '').toLowerCase()}
+                    </span>
+                  )}
+                </div>
+                <div className="cj-mob-news-title">{n.title}</div>
+                {n.card_names?.[0] && <div className="cj-mob-news-card">{n.card_names[0]}</div>}
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/* ========== Mobile-only: Bottom tab bar (Variant B · App Tabs) ========== */
+function MobileTabBar({ activeTab, onSelect }: { activeTab: TabKey; onSelect: (k: TabKey) => void }) {
+  // Map the desktop's 6 tabs to the 5 in-profile mobile tabs:
+  //   cards → cards | rewards → rewards | news → news (wallet-filtered) |
+  //   benefits → benefits | applications/referrals/settings → more
+  const mobileSelected: TabKey =
+    (['applications', 'referrals', 'settings'] as TabKey[]).includes(activeTab) ? 'more' : activeTab;
+
+  return (
+    <nav className="cj-mob-tabbar" aria-label="Mobile navigation">
+      <button
+        type="button"
+        className={'cj-mob-tab' + (mobileSelected === 'cards' ? ' active' : '')}
+        onClick={() => onSelect('cards')}
+      >
+        <span className="cj-mob-tab-icon">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="2" y="6" width="20" height="13" rx="2" /><path d="M2 10h20" />
+          </svg>
+        </span>
+        Cards
+      </button>
+      <button
+        type="button"
+        className={'cj-mob-tab' + (mobileSelected === 'rewards' ? ' active' : '')}
+        onClick={() => onSelect('rewards')}
+      >
+        <span className="cj-mob-tab-icon">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="11" r="7" /><path d="M9 17l-2 5 5-3 5 3-2-5" />
+          </svg>
+        </span>
+        Rewards
+        <span className="cj-mob-tab-beta" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        className={'cj-mob-tab' + (mobileSelected === 'news' ? ' active' : '')}
+        onClick={() => onSelect('news')}
+      >
+        <span className="cj-mob-tab-icon">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="4" width="18" height="16" rx="2" /><path d="M7 8h10M7 12h10M7 16h6" />
+          </svg>
+        </span>
+        News
+      </button>
+      <button
+        type="button"
+        className={'cj-mob-tab' + (mobileSelected === 'benefits' ? ' active' : '')}
+        onClick={() => onSelect('benefits')}
+      >
+        <span className="cj-mob-tab-icon">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="8" width="18" height="13" rx="1" /><path d="M3 12h18M12 8v13" />
+          </svg>
+        </span>
+        Benefits
+      </button>
+      <button
+        type="button"
+        className={'cj-mob-tab' + (mobileSelected === 'more' ? ' active' : '')}
+        onClick={() => onSelect('more')}
+      >
+        <span className="cj-mob-tab-icon">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="6" cy="12" r="1.5" /><circle cx="12" cy="12" r="1.5" /><circle cx="18" cy="12" r="1.5" />
+          </svg>
+        </span>
+        More
+      </button>
+    </nav>
   );
 }

--- a/apps/web-next/src/components/wallet/BestCardHere.tsx
+++ b/apps/web-next/src/components/wallet/BestCardHere.tsx
@@ -287,15 +287,46 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
       .filter((x): x is { merchant: Merchant; picks: { best: WalletPick; next?: WalletPick } } => x !== null);
   }, [merchants, walletCards, allCards]);
 
+  const feedbackUrl = `https://github.com/CreditOdds/creditodds/issues/new?${new URLSearchParams({
+    title: 'Feedback: Best Card Here (Beta)',
+    labels: 'feedback,best-card-here',
+    body: [
+      '**Feature:** Best Card Here (Beta)',
+      `**Page:** https://creditodds.com/profile (Rewards tab)`,
+      `**Wallet size:** ${cardsCount} card${cardsCount === 1 ? '' : 's'}`,
+      ...(location ? [`**Last lookup:** ${merchants.length} merchant${merchants.length === 1 ? '' : 's'} returned`] : []),
+      '',
+      '### Feedback type',
+      '<!-- delete the ones that don\'t apply -->',
+      '- Bug',
+      '- Suggestion',
+      '- Praise',
+      '',
+      '### What happened or what would you like to see?',
+      '',
+      '',
+      '### Steps to reproduce (if a bug)',
+      '',
+    ].join('\n'),
+  }).toString()}`;
+
   return (
-    <div style={{ paddingBottom: 8 }}>
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' }}>
+    <div className="cj-bch-shell" style={{ paddingBottom: 8 }}>
+      <div className="cj-bch-head" style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' }}>
         <BetaPill />
         <h2 className="cj-section-h2" style={{ margin: 0, fontSize: 26 }}>
           Best card <em className="cj-section-accent">here.</em>
         </h2>
         <span className="cj-section-num" style={{ marginLeft: 'auto' }}>
-          pilot · <a href="#" style={{ color: 'var(--accent)', textDecoration: 'none' }}>send feedback →</a>
+          pilot ·{' '}
+          <a
+            href={feedbackUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--accent)', textDecoration: 'none' }}
+          >
+            send feedback →
+          </a>
         </span>
       </div>
       <p style={{


### PR DESCRIPTION
## Summary

Mobile-only redesign of the Profile page implementing Variant B (App Tabs) from the design system. Desktop layout untouched.

- **Bottom tab bar** (fixed, blur background): Cards / Rewards / News / Benefits / More — replaces the top tab strip on mobile. News links out to the existing `/news` route; More consolidates Applications + Referrals + Settings on one stacked page.
- **Cards tab**: dark Wallet hero card (count · total fees · `+ add a card` / `submit a record`) + 3-cell snap pills (Active / Annual fees / Credits) + "Cards held" section header above the magazine-style 56px-thumb card list.
- **Rewards tab**: Best Card Here is now a purple-gradient hero with a 60px pin icon + "Best card *here.*" + send-feedback link that opens a pre-populated GitHub issue. Mobile-only — desktop sees a compact "try on mobile" banner. Merchant rows render as rounded cards with paper-2 best-pick footer and dashed runner-up.
- **News tab**: wallet-filtered news with horizontal-scroll chip filters and link rows.
- **Rail cleanup**: "News for you" + "view all news" hidden on mobile (the News tab covers this); "Upcoming renewals" hidden on mobile except on the More tab via `[data-tab]` selectors.
- **Polish**: removed italic styling from welcome-back name; readoff snapshot now renders on every desktop tab; gradient hero pulls flush against the dark Profile terminal strip on mobile.

## Test plan

- [ ] Sign in on mobile (≤640px), verify bottom tab bar present + active state highlights correctly when tapping each tab
- [ ] Cards tab mobile: dark Wallet hero, 3-cell pills, card list renders with 56px thumbs
- [ ] Rewards tab mobile: gradient hero with pin icon, "send feedback" link opens GitHub issue with pre-populated context
- [ ] Rewards tab desktop: shows compact "try on mobile" banner instead of the full feature
- [ ] News tab mobile: filter chips work, taps navigate to `/news/[id]`
- [ ] More tab mobile: Applications + Referrals + Settings sections all render with their headers
- [ ] More tab mobile: Upcoming renewals appears in the rail; other tabs hide it
- [ ] Desktop ≥641px: all tabs still show the welcome row + 5-cell readoff
- [ ] Run `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)