### PR TITLE
Track unique apply + referral clicks

### DIFF
--- a/apps/api/migrations/025_create_card_apply_clicks.sql
+++ b/apps/api/migrations/025_create_card_apply_clicks.sql
@@ -1,0 +1,18 @@
+-- Per-row event log for outbound apply clicks. Replaces card_apply_click_counts
+-- as the source of truth going forward; card_apply_click_counts is kept for
+-- historical totals only (no per-user info, no uniqueness possible).
+CREATE TABLE IF NOT EXISTS card_apply_clicks (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  card_id INT NOT NULL,
+  click_source ENUM('direct', 'referral') NOT NULL DEFAULT 'direct',
+  user_id VARCHAR(128) NULL,
+  ip_hash CHAR(64) NULL,
+  user_agent VARCHAR(500) NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_card_id_created_at (card_id, created_at),
+  INDEX idx_created_at (created_at),
+  INDEX idx_click_source (click_source),
+  INDEX idx_user_id (user_id),
+  INDEX idx_ip_hash (ip_hash),
+  CONSTRAINT fk_card_apply_clicks_card FOREIGN KEY (card_id) REFERENCES cards(card_id) ON DELETE CASCADE
+);

--- a/apps/api/migrations/026a_add_user_id_to_referral_stats.sql
+++ b/apps/api/migrations/026a_add_user_id_to_referral_stats.sql
@@ -1,0 +1,1 @@
+ALTER TABLE referral_stats ADD COLUMN user_id VARCHAR(128) NULL;

--- a/apps/api/migrations/026b_add_ip_hash_to_referral_stats.sql
+++ b/apps/api/migrations/026b_add_ip_hash_to_referral_stats.sql
@@ -1,0 +1,1 @@
+ALTER TABLE referral_stats ADD COLUMN ip_hash CHAR(64) NULL;

--- a/apps/api/migrations/026c_index_referral_stats_user_id.sql
+++ b/apps/api/migrations/026c_index_referral_stats_user_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_referral_stats_user_id ON referral_stats (user_id);

--- a/apps/api/migrations/026d_index_referral_stats_ip_hash.sql
+++ b/apps/api/migrations/026d_index_referral_stats_ip_hash.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_referral_stats_ip_hash ON referral_stats (ip_hash);

--- a/apps/api/src/click-identity.js
+++ b/apps/api/src/click-identity.js
@@ -1,0 +1,60 @@
+// Helpers for tagging anonymous click events with stable identity:
+//   - hashIp: SHA-256(pepper + ip), giving a stable per-IP token without
+//     storing raw addresses. The pepper is a static server-side secret;
+//     rotating it resets all uniqueness chains by design.
+//   - getOptionalUserId: tries to extract a Firebase uid from the
+//     Authorization header. Returns null on missing/invalid token — these
+//     endpoints accept anonymous callers, so failure is not fatal.
+
+const crypto = require("crypto");
+
+let firebaseAdmin = null;
+function getFirebaseAdmin() {
+  if (firebaseAdmin) return firebaseAdmin;
+  try {
+    const admin = require("firebase-admin");
+    if (!admin.apps.length) {
+      admin.initializeApp({
+        projectId: process.env.FIREBASE_PROJECT_ID || "creditodds",
+      });
+    }
+    firebaseAdmin = admin;
+    return admin;
+  } catch (err) {
+    console.warn("firebase-admin not available:", err.message);
+    return null;
+  }
+}
+
+function hashIp(ip) {
+  if (!ip) return null;
+  const pepper = process.env.IP_HASH_PEPPER;
+  if (!pepper) {
+    console.warn("IP_HASH_PEPPER not set; skipping ip hash");
+    return null;
+  }
+  return crypto.createHash("sha256").update(pepper + ip).digest("hex");
+}
+
+async function getOptionalUserId(event) {
+  const authHeader =
+    event.headers?.Authorization || event.headers?.authorization;
+  if (!authHeader) return null;
+  const token = authHeader.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : authHeader;
+  if (!token) return null;
+
+  const admin = getFirebaseAdmin();
+  if (!admin) return null;
+
+  try {
+    const decoded = await admin.auth().verifyIdToken(token);
+    return decoded.uid || null;
+  } catch (err) {
+    console.warn("Firebase token verification failed:", err.message);
+    return null;
+  }
+}
+
+module.exports = { hashIp, getOptionalUserId };

--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -458,13 +458,16 @@ exports.AdminReferralsHandler = async (event) => {
             c.bank,
             c.card_referral_link,
             COALESCE(stats.impressions, 0) as impressions,
-            COALESCE(stats.clicks, 0) as clicks
+            COALESCE(stats.clicks, 0) as clicks,
+            COALESCE(stats.unique_clicks, 0) as unique_clicks
           FROM referrals r
           JOIN cards c ON r.card_id = c.card_id
           LEFT JOIN (
             SELECT referral_id,
               SUM(CASE WHEN event_type = 'impression' THEN 1 ELSE 0 END) as impressions,
-              SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks
+              SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks,
+              COUNT(DISTINCT CASE WHEN event_type = 'click'
+                THEN COALESCE(user_id, ip_hash) END) as unique_clicks
             FROM referral_stats
             GROUP BY referral_id
           ) stats ON r.referral_id = stats.referral_id
@@ -723,13 +726,16 @@ exports.AdminUserLookupHandler = async (event) => {
       mysql.query(`
         SELECT r.*, c.card_name, c.card_image_link, c.bank,
           COALESCE(stats.impressions, 0) as impressions,
-          COALESCE(stats.clicks, 0) as clicks
+          COALESCE(stats.clicks, 0) as clicks,
+          COALESCE(stats.unique_clicks, 0) as unique_clicks
         FROM referrals r
         JOIN cards c ON r.card_id = c.card_id
         LEFT JOIN (
           SELECT referral_id,
             SUM(CASE WHEN event_type = 'impression' THEN 1 ELSE 0 END) as impressions,
-            SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks
+            SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks,
+            COUNT(DISTINCT CASE WHEN event_type = 'click'
+              THEN COALESCE(user_id, ip_hash) END) as unique_clicks
           FROM referral_stats
           GROUP BY referral_id
         ) stats ON r.referral_id = stats.referral_id

--- a/apps/api/src/handlers/card-apply-click.js
+++ b/apps/api/src/handlers/card-apply-click.js
@@ -1,5 +1,18 @@
-// Track outbound apply clicks per card and return aggregated counts
+// Track outbound apply clicks per card and return aggregated counts.
+//
+// Click model (current):
+//   Every click writes one row to card_apply_clicks with click_source,
+//   user_id (Firebase uid, when signed in), ip_hash (sha256(pepper + ip)),
+//   user_agent, and created_at. Uniqueness is computed at read time as
+//   COUNT(DISTINCT COALESCE(user_id, ip_hash)).
+//
+// Click model (legacy):
+//   The card_apply_click_counts table holds aggregated totals predating the
+//   per-row log. It has no per-user info, so no uniqueness can be derived
+//   from it. We keep summing it into total counts for historical continuity,
+//   but uniques only reflect new (post-rollout) clicks.
 const mysql = require("../db");
+const { hashIp, getOptionalUserId } = require("../click-identity");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":
@@ -10,22 +23,6 @@ const responseHeaders = {
 };
 
 const VALID_CLICK_SOURCES = new Set(["direct", "referral"]);
-const ENSURE_TABLE_SQL = `
-  CREATE TABLE IF NOT EXISTS card_apply_click_counts (
-    card_id INT NOT NULL,
-    click_date DATE NOT NULL,
-    click_source ENUM('direct', 'referral') NOT NULL DEFAULT 'direct',
-    click_count INT NOT NULL DEFAULT 0,
-    PRIMARY KEY (card_id, click_date, click_source),
-    INDEX idx_click_date (click_date),
-    INDEX idx_click_source (click_source),
-    CONSTRAINT fk_card_apply_click_card FOREIGN KEY (card_id) REFERENCES cards(card_id) ON DELETE CASCADE
-  )
-`;
-
-async function ensureCardApplyClickTable() {
-  await mysql.query(ENSURE_TABLE_SQL);
-}
 
 exports.CardApplyClickHandler = async (event) => {
   console.info("received:", event);
@@ -74,12 +71,21 @@ exports.CardApplyClickHandler = async (event) => {
           break;
         }
 
-        await ensureCardApplyClickTable();
+        const ip = event.requestContext?.identity?.sourceIp || null;
+        const ipHash = hashIp(ip);
+        const userId = await getOptionalUserId(event);
+
         await mysql.query(
-          `INSERT INTO card_apply_click_counts (card_id, click_date, click_source, click_count)
-           VALUES (?, CURDATE(), ?, 1)
-           ON DUPLICATE KEY UPDATE click_count = click_count + 1`,
-          [card_id, click_source]
+          `INSERT INTO card_apply_clicks
+             (card_id, click_source, user_id, ip_hash, user_agent)
+           VALUES (?, ?, ?, ?, ?)`,
+          [
+            card_id,
+            click_source,
+            userId,
+            ipHash,
+            userAgent ? userAgent.substring(0, 500) : null,
+          ]
         );
         await mysql.end();
 
@@ -113,40 +119,87 @@ exports.CardApplyClickHandler = async (event) => {
           break;
         }
 
-        const params = [];
-        const where = [];
-
+        let days = null;
         if (period && period !== "0") {
-          const days = Math.min(Math.max(parseInt(period, 10) || 30, 1), 365);
-          where.push("click_date >= CURDATE() - INTERVAL ? DAY");
-          params.push(days);
+          days = Math.min(Math.max(parseInt(period, 10) || 30, 1), 365);
         }
 
+        // --- legacy aggregate (no per-user info) ---
+        const legacyParams = [];
+        const legacyWhere = [];
+        if (days !== null) {
+          legacyWhere.push("click_date >= CURDATE() - INTERVAL ? DAY");
+          legacyParams.push(days);
+        }
         if (clickSource) {
-          where.push("click_source = ?");
-          params.push(clickSource);
+          legacyWhere.push("click_source = ?");
+          legacyParams.push(clickSource);
         }
+        const legacyWhereClause = legacyWhere.length > 0 ? `WHERE ${legacyWhere.join(" AND ")}` : "";
 
-        const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
-        await ensureCardApplyClickTable();
+        // --- new per-row log (uniques computable) ---
+        const newParams = [];
+        const newWhere = [];
+        if (days !== null) {
+          newWhere.push("created_at >= NOW() - INTERVAL ? DAY");
+          newParams.push(days);
+        }
+        if (clickSource) {
+          newWhere.push("click_source = ?");
+          newParams.push(clickSource);
+        }
+        const newWhereClause = newWhere.length > 0 ? `WHERE ${newWhere.join(" AND ")}` : "";
 
         if (breakdown === "source") {
-          const rows = await mysql.query(
-            `SELECT card_id, click_source, SUM(click_count) AS clicks
-             FROM card_apply_click_counts
-             ${whereClause}
-             GROUP BY card_id, click_source`,
-            params
-          );
+          const [legacyRows, newRows] = await Promise.all([
+            mysql.query(
+              `SELECT card_id, click_source, SUM(click_count) AS clicks
+                 FROM card_apply_click_counts
+                 ${legacyWhereClause}
+                 GROUP BY card_id, click_source`,
+              legacyParams
+            ),
+            mysql.query(
+              `SELECT card_id, click_source,
+                      COUNT(*) AS clicks,
+                      COUNT(DISTINCT COALESCE(user_id, ip_hash)) AS unique_clicks
+                 FROM card_apply_clicks
+                 ${newWhereClause}
+                 GROUP BY card_id, click_source`,
+              newParams
+            ),
+          ]);
           await mysql.end();
 
           const clicks = {};
-          for (const row of rows) {
-            const id = row.card_id;
-            if (!clicks[id]) clicks[id] = { direct: 0, referral: 0, total: 0 };
+          const ensure = (id) => {
+            if (!clicks[id]) {
+              clicks[id] = {
+                direct: 0,
+                referral: 0,
+                total: 0,
+                unique_direct: 0,
+                unique_referral: 0,
+                unique_total: 0,
+              };
+            }
+            return clicks[id];
+          };
+
+          for (const row of legacyRows) {
+            const e = ensure(row.card_id);
             const count = Number(row.clicks);
-            clicks[id][row.click_source] = count;
-            clicks[id].total += count;
+            e[row.click_source] += count;
+            e.total += count;
+          }
+          for (const row of newRows) {
+            const e = ensure(row.card_id);
+            const count = Number(row.clicks);
+            const uniq = Number(row.unique_clicks);
+            e[row.click_source] += count;
+            e.total += count;
+            e[`unique_${row.click_source}`] += uniq;
+            e.unique_total += uniq;
           }
 
           response = {
@@ -157,24 +210,40 @@ exports.CardApplyClickHandler = async (event) => {
           break;
         }
 
-        const rows = await mysql.query(
-          `SELECT card_id, SUM(click_count) AS clicks
-           FROM card_apply_click_counts
-           ${whereClause}
-           GROUP BY card_id`,
-          params
-        );
+        const [legacyRows, newRows] = await Promise.all([
+          mysql.query(
+            `SELECT card_id, SUM(click_count) AS clicks
+               FROM card_apply_click_counts
+               ${legacyWhereClause}
+               GROUP BY card_id`,
+            legacyParams
+          ),
+          mysql.query(
+            `SELECT card_id,
+                    COUNT(*) AS clicks,
+                    COUNT(DISTINCT COALESCE(user_id, ip_hash)) AS unique_clicks
+               FROM card_apply_clicks
+               ${newWhereClause}
+               GROUP BY card_id`,
+            newParams
+          ),
+        ]);
         await mysql.end();
 
         const clicks = {};
-        for (const row of rows) {
-          clicks[row.card_id] = Number(row.clicks);
+        const uniqueClicks = {};
+        for (const row of legacyRows) {
+          clicks[row.card_id] = (clicks[row.card_id] || 0) + Number(row.clicks);
+        }
+        for (const row of newRows) {
+          clicks[row.card_id] = (clicks[row.card_id] || 0) + Number(row.clicks);
+          uniqueClicks[row.card_id] = Number(row.unique_clicks);
         }
 
         response = {
           statusCode: 200,
           headers: responseHeaders,
-          body: JSON.stringify({ clicks }),
+          body: JSON.stringify({ clicks, unique_clicks: uniqueClicks }),
         };
       } catch (error) {
         console.error("Error fetching card apply clicks:", error);

--- a/apps/api/src/handlers/referral-stats.js
+++ b/apps/api/src/handlers/referral-stats.js
@@ -1,5 +1,6 @@
 // Track referral impressions and clicks
 const mysql = require("../db");
+const { hashIp, getOptionalUserId } = require("../click-identity");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":
@@ -46,13 +47,24 @@ exports.ReferralStatsHandler = async (event) => {
           break;
         }
 
-        // Get IP and user agent from request
+        // Get IP and user agent from request. ip_address is kept null going
+        // forward; ip_hash (sha256(pepper + ip)) is the stable per-IP token
+        // we use for unique-click counting. user_id is the Firebase uid when
+        // the caller is signed in, otherwise null.
         const ipAddress = event.requestContext?.identity?.sourceIp || null;
         const userAgent = event.headers?.['User-Agent'] || event.headers?.['user-agent'] || null;
+        const ipHash = hashIp(ipAddress);
+        const userId = await getOptionalUserId(event);
 
         await mysql.query(
-          "INSERT INTO referral_stats (referral_id, event_type, ip_address, user_agent) VALUES (?, ?, ?, ?)",
-          [referral_id, event_type, ipAddress, userAgent ? userAgent.substring(0, 500) : null]
+          "INSERT INTO referral_stats (referral_id, event_type, ip_hash, user_id, user_agent) VALUES (?, ?, ?, ?, ?)",
+          [
+            referral_id,
+            event_type,
+            ipHash,
+            userId,
+            userAgent ? userAgent.substring(0, 500) : null,
+          ]
         );
         await mysql.end();
 

--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -52,7 +52,9 @@ exports.UserReferralsHandler = async (event) => {
               SELECT
                 referral_id,
                 SUM(CASE WHEN event_type = 'impression' THEN 1 ELSE 0 END) as impressions,
-                SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks
+                SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks,
+                COUNT(DISTINCT CASE WHEN event_type = 'click'
+                  THEN COALESCE(user_id, ip_hash) END) as unique_clicks
               FROM referral_stats
               WHERE referral_id IN (?)
               GROUP BY referral_id
@@ -74,7 +76,8 @@ exports.UserReferralsHandler = async (event) => {
           for (const stat of statsResults) {
             statsMap[stat.referral_id] = {
               impressions: stat.impressions || 0,
-              clicks: stat.clicks || 0
+              clicks: stat.clicks || 0,
+              unique_clicks: stat.unique_clicks || 0
             };
           }
 
@@ -94,9 +97,10 @@ exports.UserReferralsHandler = async (event) => {
 
           // Add stats, card_referral_link, and archived_at to submitted referrals
           for (const referral of submitted) {
-            const stats = statsMap[referral.referral_id] || { impressions: 0, clicks: 0 };
+            const stats = statsMap[referral.referral_id] || { impressions: 0, clicks: 0, unique_clicks: 0 };
             referral.impressions = stats.impressions;
             referral.clicks = stats.clicks;
+            referral.unique_clicks = stats.unique_clicks;
             referral.card_referral_link = cardLinkMap[referral.card_id] || null;
             referral.archived_at = archivedMap[referral.referral_id] || null;
             referral.archived_reason = archivedReasonMap[referral.referral_id] || null;

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -38,6 +38,10 @@ Parameters:
     Description: Google Places API (New) key for the wallet "Best Card Here" feature
     NoEcho: true
     Default: ""
+  IpHashPepper:
+    Type: String
+    Description: Server-side pepper used to hash visitor IPs into stable per-IP tokens for unique-click counting. Treat as a long-lived secret; rotating resets all uniqueness chains.
+    NoEcho: true
 
 # Resources declares the AWS resources that you want to include in the stack
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
@@ -396,6 +400,8 @@ Resources:
           DATABASE: !Ref DATABASE
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
+          IP_HASH_PEPPER: !Ref IpHashPepper
+          FIREBASE_PROJECT_ID: creditodds
       Events:
         TrackEvent:
           Type: Api
@@ -516,6 +522,8 @@ Resources:
           DATABASE: !Ref DATABASE
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
+          IP_HASH_PEPPER: !Ref IpHashPepper
+          FIREBASE_PROJECT_ID: creditodds
       Events:
         TrackClick:
           Type: Api

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -554,7 +554,7 @@ const APPLY_CLICK_RANGES = [
   { label: 'All', days: 0 },
 ];
 
-type ApplyClickSortKey = 'total' | 'direct' | 'referral';
+type ApplyClickSortKey = 'total' | 'direct' | 'referral' | 'unique_total';
 
 interface ApplyClickRow {
   cardId: number;
@@ -563,6 +563,7 @@ interface ApplyClickRow {
   direct: number;
   referral: number;
   total: number;
+  unique_total: number;
 }
 
 function ApplyClicksTab() {
@@ -612,6 +613,7 @@ function ApplyClicksTab() {
       direct: counts.direct,
       referral: counts.referral,
       total: counts.total,
+      unique_total: counts.unique_total,
     };
   });
 
@@ -622,9 +624,10 @@ function ApplyClicksTab() {
       acc.direct += row.direct;
       acc.referral += row.referral;
       acc.total += row.total;
+      acc.unique_total += row.unique_total;
       return acc;
     },
-    { direct: 0, referral: 0, total: 0 }
+    { direct: 0, referral: 0, total: 0, unique_total: 0 }
   );
 
   const rangeLabel =
@@ -661,8 +664,9 @@ function ApplyClicksTab() {
       </div>
 
       {/* Summary stat cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         <StatCard title={`Total Clicks (${rangeLabel})`} value={totals.total} />
+        <StatCard title="Unique Visitors" value={totals.unique_total} />
         <StatCard title="Direct Apply" value={totals.direct} />
         <StatCard title="Referral Apply" value={totals.referral} />
       </div>
@@ -713,6 +717,11 @@ function ApplyClicksTab() {
                     active={sortKey === 'total'}
                     onClick={() => setSortKey('total')}
                   />
+                  <SortableHeader
+                    label="Unique"
+                    active={sortKey === 'unique_total'}
+                    onClick={() => setSortKey('unique_total')}
+                  />
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
@@ -744,6 +753,9 @@ function ApplyClicksTab() {
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm font-semibold text-gray-900 tabular-nums">
                       {row.total.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700 tabular-nums">
+                      {row.unique_total.toLocaleString()}
                     </td>
                   </tr>
                 ))}
@@ -1006,7 +1018,7 @@ function ReferralsTab({
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
                   <div>{referral.impressions} views</div>
-                  <div>{referral.clicks} clicks</div>
+                  <div>{referral.clicks} clicks{typeof referral.unique_clicks === 'number' ? ` (${referral.unique_clicks} unique)` : ''}</div>
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900 font-mono text-xs">
                   {referral.submitter_id || 'Unknown'}
@@ -1409,7 +1421,7 @@ function UserLookupTab({
                         </td>
                         <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
                           <div>{referral.impressions} views</div>
-                          <div>{referral.clicks} clicks</div>
+                          <div>{referral.clicks} clicks{typeof referral.unique_clicks === 'number' ? ` (${referral.unique_clicks} unique)` : ''}</div>
                         </td>
                         <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
                           {new Date(referral.submit_datetime).toLocaleDateString()}

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -62,6 +62,7 @@ interface Referral {
   archived_reason?: string | null;
   impressions?: number;
   clicks?: number;
+  unique_clicks?: number;
 }
 
 interface Profile {

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1,5 +1,23 @@
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
 
+// Best-effort Firebase ID token grab for fire-and-forget click trackers.
+// Returns null on the server, when Firebase isn't initialized, or when the
+// user is signed out. Never throws — these endpoints accept anonymous calls,
+// so the token is just a hint to the backend that this click belongs to a
+// known uid (used for unique-click counting).
+async function getAnonymousAuthToken(): Promise<string | null> {
+  if (typeof window === 'undefined') return null;
+  try {
+    const { getFirebaseAuth } = await import('@/auth/firebase');
+    const auth = getFirebaseAuth();
+    const user = auth?.currentUser;
+    if (!user) return null;
+    return await user.getIdToken();
+  } catch {
+    return null;
+  }
+}
+
 export interface CardReferral {
   referral_id: number;
   referral_link: string;
@@ -471,9 +489,12 @@ export async function trackCardApplyClick(
   cardId: number,
   clickSource: CardApplyClickSource = 'direct'
 ): Promise<void> {
+  const token = await getAnonymousAuthToken();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
   await fetch(`${API_BASE}/card-apply-click`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     keepalive: true,
     body: JSON.stringify({
       card_id: cardId,
@@ -487,14 +508,21 @@ export interface CardApplyClickBreakdown {
   direct: number;
   referral: number;
   total: number;
+  // Unique-click counts use COUNT(DISTINCT COALESCE(user_id, ip_hash)) on
+  // the per-row click log. Only post-rollout clicks contribute (legacy
+  // aggregated counts have no per-user info), so for old cards the totals
+  // can exceed unique_total significantly until the new log fills in.
+  unique_direct: number;
+  unique_referral: number;
+  unique_total: number;
 }
 
 // Aggregated apply-click counts per card, broken down by click source.
 // `period` is in days; pass 0 for all-time. Used by the admin dashboard.
 // Normalizes the response so older API deployments (which return
-// `{[id]: number}` instead of `{[id]: {direct, referral, total}}`) still
-// produce sane totals — direct/referral will both be 0 until the backend
-// catches up.
+// `{[id]: number}` instead of `{[id]: {direct, referral, total, ...}}`)
+// still produce sane totals — direct/referral and unique fields default
+// to 0 until the backend catches up.
 export async function getCardApplyClicksBreakdown(
   period: number = 30
 ): Promise<Record<number, CardApplyClickBreakdown>> {
@@ -509,14 +537,26 @@ export async function getCardApplyClicksBreakdown(
   for (const [id, value] of Object.entries(raw)) {
     const cardId = Number(id);
     if (typeof value === 'number') {
-      normalized[cardId] = { direct: 0, referral: 0, total: value };
+      normalized[cardId] = {
+        direct: 0,
+        referral: 0,
+        total: value,
+        unique_direct: 0,
+        unique_referral: 0,
+        unique_total: 0,
+      };
     } else {
       const direct = value.direct ?? 0;
       const referral = value.referral ?? 0;
+      const uniqueDirect = value.unique_direct ?? 0;
+      const uniqueReferral = value.unique_referral ?? 0;
       normalized[cardId] = {
         direct,
         referral,
         total: value.total ?? direct + referral,
+        unique_direct: uniqueDirect,
+        unique_referral: uniqueReferral,
+        unique_total: value.unique_total ?? uniqueDirect + uniqueReferral,
       };
     }
   }
@@ -553,16 +593,19 @@ export async function getAllCardWire(limit = 100): Promise<CardWireEntry[]> {
   return data.changes || [];
 }
 
-// Track referral impressions and clicks (no auth required)
+// Track referral impressions and clicks. Auth is optional — if the user is
+// signed in we attach their Firebase ID token so the backend can record the
+// uid for unique-click counting; anonymous calls still work.
 export async function trackReferralEvent(
   referralId: number,
   eventType: 'impression' | 'click'
 ): Promise<void> {
+  const token = await getAnonymousAuthToken();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
   await fetch(`${API_BASE}/referral-stats`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers,
     keepalive: true,
     body: JSON.stringify({
       referral_id: referralId,
@@ -902,6 +945,7 @@ export interface AdminReferral {
   archived_at: string | null;
   impressions: number;
   clicks: number;
+  unique_clicks?: number;
 }
 
 export interface AdminReferralsResponse {


### PR DESCRIPTION
## Summary
- **Apply clicks** were a pure aggregated counter (`card_apply_click_counts`) with no per-user info — unique vs repeat was impossible to derive. New clicks now write to a per-row log (`card_apply_clicks`) with `user_id` (Firebase uid when signed in), `ip_hash` (sha256 of `IP_HASH_PEPPER + ip`), and `user_agent`. Legacy aggregate counts still sum into totals for historical continuity; uniques only reflect post-rollout clicks (no backfill).
- **Referral clicks** already stored raw IP per row but never surfaced uniqueness. Added `user_id` + `ip_hash` columns, stopped writing raw `ip_address`, and `user-referrals` + admin endpoints now expose `unique_clicks`.
- **Uniqueness** is defined as `COUNT(DISTINCT COALESCE(user_id, ip_hash))` — a signed-in user always counts as themselves across networks/devices; anonymous users dedupe by hashed IP. Same IP → same hash forever (static pepper), so "did this person come back six months later" works. NAT inflates the household-as-1 effect, which is consistent over time and the standard analytics tradeoff.
- **Click endpoints stay anonymous-friendly** — auth is optional. Frontend attaches Firebase ID token when present; handler verifies best-effort and falls back to `ip_hash` if missing/invalid.
- Admin Apply Clicks tab gains a "Unique Visitors" stat card + "Unique" sortable column. Admin Referrals tabs and per-user pane show "N clicks (M unique)".

## Deployment notes
- Run migrations in order: `025`, `026a`, `026b`, `026c`, `026d`. All single-statement per the project's migration convention.
- Provide a new SAM parameter `IpHashPepper` (long-lived secret — rotating it resets all uniqueness chains by design).
- Backend deploy: `cd apps/api && sam build && sam deploy` — passes `IP_HASH_PEPPER` and `FIREBASE_PROJECT_ID` to `CardApplyClickFunction` + `ReferralStatsFunction`.

## Test plan
- [ ] Run migrations 025–026d via `RunMigrationHandler`.
- [ ] Deploy SAM with new `IpHashPepper` param.
- [ ] Sign-out, click an Apply button → row appears in `card_apply_clicks` with `user_id IS NULL`, `ip_hash` populated.
- [ ] Sign in, click another Apply button → row has `user_id = <uid>`, `ip_hash` populated.
- [ ] Click the same Apply button twice in same session → `total = 2`, `unique_total = 1` in admin.
- [ ] Same flow on `referral-stats` POST: rows in `referral_stats` have `user_id`/`ip_hash`, raw `ip_address` is null.
- [ ] Admin → Apply Clicks tab: "Unique Visitors" card + "Unique" sortable column populate.
- [ ] Admin → Referrals: each row shows "N clicks (M unique)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)