### PR TITLE
Profile mobile polish: lean Wallet hero, Earn tab, bigger BCH CTA

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4344,6 +4344,19 @@
   .landing-v2.profile-v2[data-tab="referrals"] .cj-rail-block-renewals,
   .landing-v2.profile-v2[data-tab="settings"] .cj-rail-block-renewals { display: block; }
 
+  /* Whole rail → hidden on mobile except on the More tab group.
+     Removes empty whitespace under the card list on Cards/Earn/News/Benefits. */
+  .landing-v2.profile-v2 .cj-rail { display: none; }
+  .landing-v2.profile-v2[data-tab="more"] .cj-rail,
+  .landing-v2.profile-v2[data-tab="applications"] .cj-rail,
+  .landing-v2.profile-v2[data-tab="referrals"] .cj-rail,
+  .landing-v2.profile-v2[data-tab="settings"] .cj-rail { display: block; }
+
+  /* Cards held toolbar → hide redundant count text + 'add a card' button on mobile.
+     The wallet hero above already exposes both. Keep the archived toggle. */
+  .landing-v2.profile-v2 .cj-wallet-toolbar > .cj-table-label,
+  .landing-v2.profile-v2 .cj-wallet-toolbar > .cj-inline-cta { display: none; }
+
   /* ====== Variant B Cards-tab hero ======
      Replace the editorial Welcome+readoff with the design's dark Wallet hero
      + 3-cell snap pills + "Cards held" section header. */
@@ -4469,65 +4482,147 @@
   .landing-v2.profile-v2 .cj-bch-shell { display: block; }
   .landing-v2.profile-v2 .cj-bch-desktop-banner { display: none; }
 
-  /* ====== Variant B Rewards-tab hero ======
-     Restyle the existing BestCardHere wrapper as the design's purple gradient
-     hero with a 60px pin icon (CSS pseudo-element) + bigger headline. */
+  /* ====== Variant B Earn-tab hero ======
+     Two-column layout: pin + BETA pill on the left, headline on the right. */
   .landing-v2.profile-v2 .cj-section .cj-bch-shell {
     background: linear-gradient(180deg, var(--accent-2) 0%, var(--paper) 80%);
-    padding: 26px 20px 22px;
+    padding: 22px 20px 22px;
     margin: -18px -18px 14px;
     border-bottom: 1px solid var(--line);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px 16px;
+    align-items: flex-start;
   }
-  .landing-v2.profile-v2 .cj-section .cj-bch-shell::before {
-    content: '';
-    display: block;
-    width: 60px;
-    height: 60px;
+  /* Pin + BETA pill stacked, left side */
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-bch-icon-col {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-bch-pin {
+    width: 56px;
+    height: 56px;
     border-radius: 50%;
-    background-color: var(--accent);
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s7-7 7-13a7 7 0 0 0-14 0c0 6 7 13 7 13z"/><circle cx="12" cy="9" r="2.5"/></svg>');
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: 28px;
-    margin-bottom: 8px;
+    background: var(--accent);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     box-shadow: 0 8px 24px -8px rgba(109, 63, 232, 0.5);
   }
-  /* BETA pill (rounded full on mobile) + pilot/feedback line on its own row */
-  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-bch-head {
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 8px;
-    align-items: center;
-  }
-  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-bch-head > span:first-of-type {
+  /* The existing inline-style BetaPill becomes pill-shaped on mobile */
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-bch-icon-col > span:nth-child(2) {
     border-radius: 999px !important;
     padding: 4px 10px !important;
     font-size: 10.5px !important;
   }
+  /* Headline + feedback line on the right */
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-bch-head {
+    flex: 1 1 200px;
+    min-width: 0;
+    flex-direction: column;
+    align-items: flex-start !important;
+    gap: 6px !important;
+  }
   .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-section-h2 {
-    flex: 1 0 100%;
-    font-size: 32px !important;
+    font-size: 30px !important;
     line-height: 1.02 !important;
     letter-spacing: -0.025em;
-    margin-top: 4px !important;
   }
   .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-section-num {
     margin-left: 0 !important;
-    font-size: 11px;
-    order: 1;
+    font-size: 11.5px;
+  }
+  /* Description + state divs span full width below the icon/head row */
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell > p,
+  .landing-v2.profile-v2 .cj-section .cj-bch-shell > div:not(.cj-bch-icon-col):not(.cj-bch-head) {
+    flex: 1 0 100%;
+    min-width: 0;
   }
   .landing-v2.profile-v2 .cj-section .cj-bch-shell > p {
     font-size: 14.5px !important;
     line-height: 1.5 !important;
-    margin: 12px 0 16px !important;
+    margin: 4px 0 0 !important;
     max-width: 36ch;
     color: var(--ink-2, #3a2f55);
+  }
+  /* Big "Find Best Near Me" CTA (replaces the bordered LocationBlock pre-enable) */
+  .landing-v2.profile-v2 .cj-bch-cta-wrap {
+    margin-top: 12px;
+  }
+  .landing-v2.profile-v2 .cj-bch-cta-prompt {
+    font-size: 13.5px;
+    color: var(--ink-2, #3a2f55);
+    line-height: 1.5;
+    margin: 0 0 12px;
+  }
+  .landing-v2.profile-v2 .cj-bch-cta-btn {
+    width: 100%;
+    padding: 16px;
+    background: var(--accent);
+    color: #fff;
+    border: 0;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    box-shadow: 0 8px 24px -8px rgba(109, 63, 232, 0.5);
+  }
+  .landing-v2.profile-v2 .cj-bch-cta-btn:hover { filter: brightness(1.05); }
+  /* Post-enable location pill — small, inline */
+  .landing-v2.profile-v2 .cj-bch-loc {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--paper);
+    border: 1px solid var(--line-2);
+    border-radius: 6px;
+    margin-top: 12px;
+    font-size: 12.5px;
+  }
+  .landing-v2.profile-v2 .cj-bch-loc-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: #1f8a5b;
+    flex: 0 0 auto;
+  }
+  .landing-v2.profile-v2 .cj-bch-loc-text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .landing-v2.profile-v2 .cj-bch-loc-label {
+    color: var(--ink);
+    font-weight: 600;
+  }
+  .landing-v2.profile-v2 .cj-bch-loc-coords {
+    color: var(--muted);
+    font-size: 11.5px;
+  }
+  .landing-v2.profile-v2 .cj-bch-loc-update {
+    background: transparent;
+    border: 0;
+    font: inherit;
+    font-size: 11.5px;
+    color: var(--accent);
+    cursor: pointer;
+    padding: 4px 0 4px 8px;
+    letter-spacing: 0.02em;
   }
   /* Merchant tape outside the hero — paper-2 background to match the design */
   .landing-v2.profile-v2 .cj-section .cj-bch-shell .cj-tape-bch {
     margin: 0 -2px;
     background: transparent;
     border: 0;
+    flex: 1 0 100%;
   }
 
   /* Best Card Here tape — drop dist/category columns, stack best/runner-up under merchant + earn */

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -301,7 +301,7 @@ export default function ProfileClient() {
 
   const tabs: { key: TabKey; num: string; label: string; count: string }[] = [
     { key: 'cards', num: '01', label: 'Cards', count: walletCards.length ? `${walletCards.length} cards` : '' },
-    { key: 'rewards', num: '02', label: 'Rewards', count: '' },
+    { key: 'rewards', num: '02', label: 'Earn', count: '' },
     { key: 'benefits', num: '03', label: 'Benefits', count: '' },
     { key: 'applications', num: '04', label: 'Applications', count: records.length ? `${records.length} records` : '' },
     { key: 'referrals', num: '05', label: 'Referrals', count: activeReferralsCount ? `${activeReferralsCount} links` : '' },
@@ -394,9 +394,6 @@ export default function ProfileClient() {
             <div className="cj-mob-cards-hero">
               <div className="cj-mob-wallet">
                 <div className="cj-mob-wallet-k">Wallet</div>
-                <div className="cj-mob-wallet-v">
-                  {walletCards.length} card{walletCards.length === 1 ? '' : 's'} · ${totalAnnualFees.toLocaleString()}/yr
-                </div>
                 <div className="cj-mob-wallet-actions">
                   <button type="button" className="cj-mob-wallet-btn" onClick={() => setShowWalletModal(true)}>
                     + add a card
@@ -433,9 +430,6 @@ export default function ProfileClient() {
               </div>
               <div className="cj-mob-section-h">
                 <h2>Cards held</h2>
-                <div className="cj-mob-section-sub">
-                  {walletCards.length - inactiveCount} active{inactiveCount > 0 ? ` · ${inactiveCount} archived` : ''}
-                </div>
               </div>
             </div>
           )}
@@ -1348,11 +1342,13 @@ function MobileTabBar({ activeTab, onSelect }: { activeTab: TabKey; onSelect: (k
         onClick={() => onSelect('rewards')}
       >
         <span className="cj-mob-tab-icon">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="11" r="7" /><path d="M9 17l-2 5 5-3 5 3-2-5" />
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="19" y1="5" x2="5" y2="19" />
+            <circle cx="6.5" cy="6.5" r="2.5" />
+            <circle cx="17.5" cy="17.5" r="2.5" />
           </svg>
         </span>
-        Rewards
+        Earn
         <span className="cj-mob-tab-beta" aria-hidden="true" />
       </button>
       <button

--- a/apps/web-next/src/components/wallet/BestCardHere.tsx
+++ b/apps/web-next/src/components/wallet/BestCardHere.tsx
@@ -100,79 +100,30 @@ function BetaPill() {
 
 interface LocationBlockProps {
   location: Location | null;
-  cardsCount: number;
   onEnable: () => void;
   onClear: () => void;
 }
 
-function LocationBlock({ location, cardsCount, onEnable, onClear }: LocationBlockProps) {
+function LocationBlock({ location, onEnable, onClear }: LocationBlockProps) {
   if (!location) {
     return (
-      <div style={{
-        marginTop: 10,
-        padding: '20px 22px',
-        border: '1px solid var(--line-2)',
-        background: 'var(--paper-2)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        flexWrap: 'wrap',
-        gap: 16,
-      }}>
-        <div style={{ minWidth: 0 }}>
-          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
-            Use your location to find the best card to swipe
-          </div>
-          <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 4, lineHeight: 1.5, maxWidth: '52ch' }}>
-            We&apos;ll look up nearby businesses and cross-reference your {cardsCount} card{cardsCount === 1 ? '' : 's'} to surface
-            the highest earn at each merchant. Your location is used in-session and never stored.
-          </div>
-        </div>
-        <button
-          type="button"
-          className="cj-inline-cta"
-          style={{ padding: '8px 14px', fontSize: 12 }}
-          onClick={onEnable}
-        >
-          enable location
+      <div className="cj-bch-cta-wrap">
+        <p className="cj-bch-cta-prompt">Tap to find the best card to swipe at the businesses around you.</p>
+        <button type="button" className="cj-bch-cta-btn" onClick={onEnable}>
+          Find Best Near Me
         </button>
       </div>
     );
   }
   return (
-    <div style={{
-      marginTop: 10,
-      padding: '12px 16px',
-      border: '1px solid var(--line-2)',
-      background: 'var(--paper)',
-      display: 'flex',
-      alignItems: 'center',
-      gap: 14,
-      fontSize: 12.5,
-      flexWrap: 'wrap',
-    }}>
-      <span style={{
-        display: 'inline-block',
-        width: 7, height: 7,
-        borderRadius: '50%',
-        background: '#1f8a5b',
-      }} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <span style={{ color: 'var(--ink)', fontWeight: 600 }}>{location.label}</span>
-        <span style={{ color: 'var(--muted)', marginLeft: 10 }}>
-          {location.coords} · accuracy ±{location.accuracy}m
-        </span>
+    <div className="cj-bch-loc">
+      <span className="cj-bch-loc-dot" />
+      <div className="cj-bch-loc-text">
+        <span className="cj-bch-loc-label">{location.label}</span>
+        <span className="cj-bch-loc-coords">{location.coords} · ±{location.accuracy}m</span>
       </div>
-      <button
-        type="button"
-        onClick={onClear}
-        style={{
-          background: 'transparent', border: 0, font: 'inherit',
-          fontSize: 11.5, color: 'var(--muted)', cursor: 'pointer',
-          letterSpacing: '0.02em', padding: 0,
-        }}
-      >
-        update location
+      <button type="button" className="cj-bch-loc-update" onClick={onClear}>
+        update
       </button>
     </div>
   );
@@ -312,8 +263,16 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
 
   return (
     <div className="cj-bch-shell" style={{ paddingBottom: 8 }}>
-      <div className="cj-bch-head" style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' }}>
+      <div className="cj-bch-icon-col" aria-hidden="true">
+        <span className="cj-bch-pin">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 22s7-7 7-13a7 7 0 0 0-14 0c0 6 7 13 7 13z" />
+            <circle cx="12" cy="9" r="2.5" />
+          </svg>
+        </span>
         <BetaPill />
+      </div>
+      <div className="cj-bch-head" style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' }}>
         <h2 className="cj-section-h2" style={{ margin: 0, fontSize: 26 }}>
           Best card <em className="cj-section-accent">here.</em>
         </h2>
@@ -343,7 +302,6 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
 
       <LocationBlock
         location={location}
-        cardsCount={cardsCount}
         onEnable={enable}
         onClear={clear}
       />


### PR DESCRIPTION
## Summary

Round of mobile-only polish on top of #1094.

**Cards tab**
- Wallet hero is now just the **WALLET** eyebrow + two action buttons. The big "X cards · \$Y/yr" line is gone — that info already lives in the snap pills below.
- "Cards held" header drops the "X active · Y archived" subtitle (also redundant with the snap pills).
- `cj-wallet-toolbar` on mobile: hide the duplicate count text and "+ add a card" button (wallet hero owns that action). Archived toggle stays.
- Empty `cj-rail` hidden on Cards / Earn / News / Benefits via `[data-tab]` selectors — kills ~100px of trailing whitespace below the card list. Still shown on the More tab group where Upcoming Renewals lives.

**Earn (renamed from Rewards)**
- Mobile bottom tab bar: label is now **Earn**, icon is a **%** (line + two circles), Beta dot still present.
- Desktop top tab strip: "02 Earn" replaces "02 Rewards".

**Best Card Here mobile hero**
- Header restructured: 56px purple pin icon + BETA pill stacked on the **left**, "Best card *here.*" headline + "pilot · send feedback →" line on the **right**.
- Bordered LocationBlock pre-enable state replaced with a small prompt ("Tap to find the best card to swipe…") + a full-width 16px purple **"Find Best Near Me"** CTA with shadow.
- Pin icon switched from CSS `::before` to a JSX `<svg>` so the icon column participates in flex layout.
- Post-enable LocationBlock: cleaner inline pill (green dot + label + coords + "update" link).
- `cardsCount` prop removed from `LocationBlock` (was only used in the deleted descriptive copy).

## Test plan

- [ ] Cards tab on mobile: wallet hero shows only WALLET label + the two buttons; snap pills show Active / Annual fees / Credits; Cards held has no subtitle; no duplicate "+ add a card" button under it
- [ ] Cards tab archived toggle ("show N archived") still works
- [ ] No empty whitespace below the card list on Cards / Earn / News / Benefits
- [ ] Bottom tab bar label is "Earn" with a % icon
- [ ] Earn tab on mobile: pin + BETA on the left, headline on the right, big purple "Find Best Near Me" CTA below
- [ ] Tapping "Find Best Near Me" still triggers geolocation flow
- [ ] After geolocation grants: post-enable pill shows label · coords · update link
- [ ] Desktop top tab strip shows "Earn" at position 02
- [ ] Desktop Earn tab still shows the "Best card *here.* — Beta · mobile" banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)