### PR TITLE
Profile Benefits: show cadence words + amortize multi-year credits

### DIFF
--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import Link from "next/link";
 import CardImage from "@/components/ui/CardImage";
 import { Card, CardBenefit, WalletCard } from "@/lib/api";
-import { amortizedAnnualValue, formatBenefitValue, frequencyLabel } from "@/lib/cardDisplayUtils";
+import { amortizedAnnualValue, cadenceLabel, formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
 
 interface CardWithBenefits {
   walletCard: WalletCard;
@@ -100,31 +100,40 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
               <div>Cadence</div>
               <div className="cj-tape-res">Value</div>
             </div>
-            {allCredits.map((b, i) => (
-              <Link
-                key={`${b.cardName}-${b.name}-${i}`}
-                href={`/card/${b.cardSlug}`}
-                className="cj-tape-row"
-              >
-                <div>
-                  <span className="cj-tape-thumb">
-                    <CardImage cardImageLink={b.cardImage} alt={b.cardName} fill sizes="36px" className="object-contain" />
-                  </span>
-                </div>
-                <div className="cj-tape-event">
-                  <span className="cj-tape-field">{b.name}</span>
-                  <div className="cj-tape-detail">
-                    {b.cardName}
-                    {b.enrollment_required ? ' · enrollment required' : ''}
+            {allCredits.map((b, i) => {
+              const cadence = cadenceLabel(b);
+              const annual = amortizedAnnualValue(b);
+              const isMultiYear = b.frequency === 'multi_year';
+              const showAmortized = isMultiYear && isMonetaryBenefit(b) && annual > 0;
+              return (
+                <Link
+                  key={`${b.cardName}-${b.name}-${i}`}
+                  href={`/card/${b.cardSlug}`}
+                  className="cj-tape-row"
+                >
+                  <div>
+                    <span className="cj-tape-thumb">
+                      <CardImage cardImageLink={b.cardImage} alt={b.cardName} fill sizes="36px" className="object-contain" />
+                    </span>
                   </div>
-                  <div className="cj-tape-detail cj-mob-only">{frequencyLabel(b)}</div>
-                </div>
-                <div className="cj-tape-when">{frequencyLabel(b)}</div>
-                <div className="cj-tape-res">
-                  <b>{formatBenefitValue(b)}</b>
-                </div>
-              </Link>
-            ))}
+                  <div className="cj-tape-event">
+                    <span className="cj-tape-field">{b.name}</span>
+                    <div className="cj-tape-detail">
+                      {b.cardName}
+                      {b.enrollment_required ? ' · enrollment required' : ''}
+                    </div>
+                    <div className="cj-tape-detail cj-mob-only">{cadence}</div>
+                  </div>
+                  <div className="cj-tape-when">{cadence}</div>
+                  <div className="cj-tape-res">
+                    <b>{formatBenefitValue(b)}</b>
+                    {showAmortized && (
+                      <div className="cj-tape-detail">~${annual.toLocaleString()}/yr</div>
+                    )}
+                  </div>
+                </Link>
+              );
+            })}
           </div>
         </>
       )}

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -219,6 +219,32 @@ export function frequencyLabel(benefit: CardBenefit): string {
   }
 }
 
+// Human-readable cadence word — describes how often the benefit is RECEIVED,
+// not when its value is realized. Use this where the cadence is its own
+// column/field (e.g. wallet benefits table). For inline labels next to a
+// value, prefer frequencyLabel().
+//
+//   monthly      → "Monthly"
+//   quarterly    → "Quarterly"
+//   semi_annual  → "Semi-annual"
+//   annual       → "Yearly"
+//   multi_year   → "Every 5 years" (uses frequency_years, default 4)
+//   ongoing      → "Ongoing"
+export function cadenceLabel(benefit: CardBenefit): string {
+  switch (benefit.frequency) {
+    case 'monthly': return 'Monthly';
+    case 'quarterly': return 'Quarterly';
+    case 'semi_annual': return 'Semi-annual';
+    case 'annual': return 'Yearly';
+    case 'multi_year': {
+      const years = benefit.frequency_years || DEFAULT_MULTI_YEAR_CYCLE;
+      return years === 1 ? 'Yearly' : `Every ${years} years`;
+    }
+    case 'ongoing': return 'Ongoing';
+    default: return '';
+  }
+}
+
 // Cents-per-point estimates by program (driven by data/valuations.yaml)
 export function getCentsPerPoint(card: Card): number | null {
   if (!card.signup_bonus) return null;


### PR DESCRIPTION
## Summary
- Cadence column on Profile > Benefits now shows the actual cadence (\"Monthly\", \"Quarterly\", \"Semi-annual\", \"Yearly\", \"Every N years\", \"Ongoing\") instead of every row reading \"/yr\".
- Multi-year credits (CLEAR, Global Entry, etc.) now also show their amortized annual contribution as a \"~\$X/yr\" subline, matching how they roll into the Total Annual Credits stat.
- Added \`cadenceLabel(benefit)\` helper in \`cardDisplayUtils.tsx\` (existing \`frequencyLabel\` left untouched for the inline-with-value case on the card detail page).

## Test plan
- [ ] Profile > Benefits tab: verify Cadence column shows the cadence word for each credit type.
- [ ] Add a card with a multi-year benefit (e.g. CLEAR or Global Entry) and confirm Value cell shows raw value plus \"~\$X/yr\" subline.
- [ ] Verify Total Annual Credits stat at the top still matches the sum of amortized per-row values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)