### PR TITLE
Hide referral UI for no-fee wallet cards

### DIFF
--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -842,7 +842,7 @@ function CardsTab(props: CardsTabProps) {
                         <DocumentTextIcon style={{ width: 11, height: 11 }} />
                       </span>
                     )}
-                    {hasReferral && (
+                    {fee > 0 && hasReferral && (
                       <span className="cj-cw-mark" title="referral active" aria-label="referral active">
                         <LinkIcon style={{ width: 11, height: 11 }} />
                       </span>
@@ -885,12 +885,12 @@ function CardsTab(props: CardsTabProps) {
                       </button>
                     )}
                     {hasRecord && <span className="cj-wd-done">✓ record submitted</span>}
-                    {!hasReferral && (
+                    {fee > 0 && !hasReferral && (
                       <button type="button" className="cj-wd-cta" onClick={onAddReferral}>
                         + add referral link
                       </button>
                     )}
-                    {hasReferral && <span className="cj-wd-done">✓ referral link active</span>}
+                    {fee > 0 && hasReferral && <span className="cj-wd-done">✓ referral link active</span>}
                   </div>
                 </div>
               )}

--- a/apps/web-next/src/app/profile/profileSelectors.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.ts
@@ -55,6 +55,7 @@ export function getEligibleReferralCards(
     if (excluded.has(w.card_name) || seen.has(w.card_name)) continue;
     seen.add(w.card_name);
     const card = lookups.byName.get(w.card_name);
+    if (!card?.annual_fee) continue;
     result.push({
       card_id: String(w.card_id),
       card_name: w.card_name,
@@ -67,6 +68,7 @@ export function getEligibleReferralCards(
     if (excluded.has(r.card_name) || seen.has(r.card_name)) continue;
     const card = lookups.byName.get(r.card_name);
     if (!card) continue;
+    if (!card.annual_fee) continue;
     const dbId = card.db_card_id ?? Number(card.card_id);
     if (!Number.isFinite(dbId)) continue;
     seen.add(r.card_name);


### PR DESCRIPTION
## Summary
- Cards with no annual fee don't have referral links, so the profile wallet now hides the referral chip, the "+ add referral link" CTA, and the "✓ referral link active" badge when `annual_fee` is 0.
- `getEligibleReferralCards` skips no-fee cards so they no longer appear in the referral picker.

## Test plan
- [ ] Open profile → Cards: a no-fee wallet card shows no referral chip and, when expanded, no add/active referral text.
- [ ] Fee > 0 cards still show the referral CTA / active badge as before.
- [ ] Referrals tab "+ add a referral" picker omits no-fee cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)