### PR TITLE
docs: note CreditCardOddsAPI pipeline + builder are deleted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,31 @@
 - Frontend: Deployed via AWS Amplify (automatic on push)
 - Cards data: Run `npm run build-cards` in web-next to rebuild cards.json
 
+### Backend CI/CD: there is none — `sam deploy` is the only path
+
+The `CreditCardOddsAPI` CodePipeline + `CreditCardOddsAPI-Builder` CodeBuild
+project were **deleted on 2026-05-08**. They had been pointing at the
+obsolete pre-monorepo `CreditCardOdds/creditcardodds-api` repo (different
+GitHub org from this monorepo). Triggering the pipeline pulled that stale
+template — missing 20+ Lambdas added since the migration — and CloudFormation
+deleted those functions from production. Recovery required a manual
+`aws cloudformation deploy` with full param overrides + a freshly generated
+`IpHashPepper` (the previous value lived only on the deployer's machine
+and was wiped from the stack when the broken template was applied).
+
+If you want CI/CD back, build a new pipeline pointing at this monorepo:
+- New CodeStar connection authorized for the `CreditOdds` GitHub org
+- Source: `CreditOdds/creditodds` (branch `main`), with a path filter so
+  it only triggers on `apps/api/**` changes
+- CodeBuild project with `BuildSpec: apps/api/buildspec.yml`
+- Deploy stage's `ParameterOverrides` must wire in `IpHashPepper`,
+  `GooglePlacesApiKey`, and the DB creds (DB creds live in SSM at
+  `/creditodds/db/{endpoint,database,username,password}`)
+
+Until then: `cd apps/api && sam build && sam deploy`. The first time on a
+new machine you'll need `--parameter-overrides` for the NoEcho params; the
+stack remembers them after that.
+
 ## Database
 
 - MySQL database hosted on AWS


### PR DESCRIPTION
## Summary
Document the foot-gun that took down 20+ Lambdas earlier today, and the deletion that prevents recurrence.

## What happened
The \`CreditCardOddsAPI\` CodePipeline's Source action was still pointing at \`CreditCardOdds/creditcardodds-api\` — the **pre-monorepo standalone API repo** (different GitHub org from \`CreditOdds/creditodds\`). When triggered, it pulled that stale template (~Jan vintage) which is missing 20+ Lambdas added since the monorepo migration. CloudFormation then deleted those functions from the live \`CreditCardOddsAPI\` stack.

Triggering the pipeline today wiped: \`RefreshCardStatsFunction\`, \`CheckOddsFunction\`, \`LeaderboardFunction\`, \`RecentRecordsFunction\`, all admin functions, \`DeleteAccountFunction\`, \`UserWalletFunction\`, \`CardRatingsFunction\`, \`CardWireFunction\`, etc. Those endpoints were down for ~10 minutes. Recovery: \`aws cloudformation deploy\` with full param overrides + a regenerated \`IpHashPepper\` (existing value was wiped when the stack lost the param definition).

## Fix
- **Deleted** the CodePipeline \`CreditCardOddsAPI\`
- **Deleted** the CodeBuild project \`CreditCardOddsAPI-Builder\`
- IAM roles, CodeStar connection, and the unrelated \`CreditCardOdds-FrontEnd\` pipeline are intact
- This PR adds the post-mortem + reconstruction recipe to CLAUDE.md so future sessions can rebuild CI/CD correctly if wanted

## Test plan
- [ ] Read the new \`Backend CI/CD: there is none\` section in CLAUDE.md and confirm the reconstruction recipe is right
- [ ] Confirm \`sam deploy\` is still the documented manual path

🤖 Generated with [Claude Code](https://claude.com/claude-code)