### PR TITLE
Benefits: headline the spendable per-cycle amount, not the annual total

### DIFF
--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -100,6 +100,19 @@ export interface CardBenefit {
   // PreCheck (the actual renewal cycle), 2 for biennial perks, etc. Used by
   // amortizedAnnualValue() to compute the per-year contribution.
   frequency_years?: number;
+  // OPTIONAL spendable-per-cycle override for sub-annual frequencies. The UI
+  // headlines whichever cadence has the smallest spendable denomination, so a
+  // user doesn't think they can spend the full annual total in a single cycle
+  // (Amex Platinum Uber Cash is $200/yr but you can only spend $15/month).
+  //
+  // - When omitted, the headline is auto-derived as round(value / N), where N
+  //   is 12/4/2 for monthly/quarterly/semi_annual. This is correct for benefits
+  //   that distribute evenly (e.g. $300 Equinox = $25/mo).
+  // - Set this when the per-cycle spend doesn't match value/N — e.g. $15/mo +
+  //   $20 December (set value_per_cycle: 15), or "$12.95/mo + tax" Walmart+
+  //   where value=155 (set value_per_cycle: 13).
+  // The annual rollup (Total Annual Credits) still uses `value` unchanged.
+  value_per_cycle?: number;
   category: 'dining' | 'dining_travel' | 'travel' | 'hotel' | 'entertainment' | 'shopping' | 'fitness' | 'lounge' | 'security' | 'gas' | 'streaming' | 'grocery' | 'rideshare' | 'car_rental' | 'other';
   enrollment_required?: boolean;
 }

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -136,8 +136,31 @@ export function isMonetaryBenefit(benefit: { value_unit?: string }): boolean {
   return !benefit.value_unit || benefit.value_unit === 'usd';
 }
 
+// Smallest spendable denomination per cycle — what we headline in the UI.
+//
+// Why not just `benefit.value`? Because `value` is the ANNUAL TOTAL by
+// convention (see amortizedAnnualValue), and headlining "$200/yr" for a
+// monthly benefit misleads users into thinking they can spend the full $200
+// in a single month. Amex Platinum Uber Cash is $15/mo + $20 in December =
+// $200/yr — you can't expense $200 of Uber rides in January.
+//
+// Order of precedence:
+//   1. `value_per_cycle` if set (explicit YAML override for non-uniform cases
+//      like Uber Cash $15/mo with December bonus, or Walmart+ "$12.95/mo + tax")
+//   2. round(value / 12 | 4 | 2) for monthly | quarterly | semi_annual
+//   3. `value` itself for annual / multi_year / ongoing / per-event
+export function spendableValue(benefit: CardBenefit): number {
+  if (typeof benefit.value_per_cycle === 'number') return benefit.value_per_cycle;
+  switch (benefit.frequency) {
+    case 'monthly': return Math.round(benefit.value / 12);
+    case 'quarterly': return Math.round(benefit.value / 4);
+    case 'semi_annual': return Math.round(benefit.value / 2);
+    default: return benefit.value;
+  }
+}
+
 export function formatBenefitValue(benefit: CardBenefit): string {
-  const v = benefit.value.toLocaleString();
+  const v = spendableValue(benefit).toLocaleString();
   if (benefit.value_unit === 'points') return `${v} points`;
   if (benefit.value_unit === 'miles') return `${v} miles`;
   return `$${v}`;
@@ -195,21 +218,19 @@ export function amortizedAnnualValue(benefit: CardBenefit): number {
 
 // Human-readable frequency label shown next to a benefit's value in the UI.
 //
-// Because `value` is the ANNUAL TOTAL (see amortizedAnnualValue), all
-// sub-annual frequencies render as "/yr" — e.g. Amex Platinum Uber Cash
-// (value: 200, frequency: monthly) shows as "$200/yr", with the cadence
-// ("$15/month...") communicated in the description. Showing "$200/mo" was
-// the bug — that read as $2,400/yr to the user.
+// Pairs with spendableValue() — sub-annual frequencies render at their actual
+// cadence so a $300 Equinox monthly credit reads "$25/mo" (not "$300/yr"
+// which the user might think is spendable in a single month). The annual
+// total is still surfaced via "Total Annual Credits" at the top of the card.
 //
 // `multi_year` is dynamic — "every N yr" using the benefit's
 // `frequency_years` field (default 4 for legacy Global Entry entries).
 export function frequencyLabel(benefit: CardBenefit): string {
   switch (benefit.frequency) {
-    case 'monthly':
-    case 'quarterly':
-    case 'semi_annual':
-    case 'annual':
-      return '/yr';
+    case 'monthly': return '/mo';
+    case 'quarterly': return '/qtr';
+    case 'semi_annual': return ' / 6 mo';
+    case 'annual': return '/yr';
     case 'multi_year': {
       const years = benefit.frequency_years || DEFAULT_MULTI_YEAR_CYCLE;
       return `every ${years} yr`;

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T16:03:11.547Z",
+  "generated_at": "2026-05-08T15:45:09.860Z",
   "count": 161,
   "categories": [
     {
@@ -564,6 +564,7 @@
         {
           "name": "Walmart+ Credit",
           "value": 155,
+          "value_per_cycle": 13,
           "description": "Up to $12.95/month plus applicable taxes toward one monthly Walmart+ membership",
           "frequency": "monthly",
           "category": "shopping",
@@ -8090,6 +8091,7 @@
         {
           "name": "Uber Cash",
           "value": 200,
+          "value_per_cycle": 15,
           "description": "$15/month in Uber Cash for Uber Eats or rides ($20 in December)",
           "frequency": "monthly",
           "category": "dining_travel",
@@ -8138,6 +8140,7 @@
         {
           "name": "Walmart+ Credit",
           "value": 155,
+          "value_per_cycle": 13,
           "description": "Monthly credit covering Walmart+ membership ($12.95/month)",
           "frequency": "monthly",
           "category": "shopping",
@@ -8497,6 +8500,7 @@
         {
           "name": "Rideshare Credit",
           "value": 150,
+          "value_per_cycle": 12,
           "description": "Up to $12 monthly from January through November and $18 in December after annual opt-in",
           "frequency": "monthly",
           "category": "rideshare"

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -48,6 +48,7 @@ benefits:
     enrollment_required: true
   - name: "Walmart+ Credit"
     value: 155
+    value_per_cycle: 13
     description: "Up to $12.95/month plus applicable taxes toward one monthly Walmart+ membership"
     frequency: "monthly"
     category: "shopping"

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -28,6 +28,7 @@ signup_bonus:
 benefits:
   - name: "Uber Cash"
     value: 200
+    value_per_cycle: 15
     description: "$15/month in Uber Cash for Uber Eats or rides ($20 in December)"
     frequency: "monthly"
     category: "dining_travel"
@@ -64,6 +65,7 @@ benefits:
     enrollment_required: true
   - name: "Walmart+ Credit"
     value: 155
+    value_per_cycle: 13
     description: "Monthly credit covering Walmart+ membership ($12.95/month)"
     frequency: "monthly"
     category: "shopping"

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -64,6 +64,7 @@ benefits:
     category: "hotel"
   - name: "Rideshare Credit"
     value: 150
+    value_per_cycle: 12
     description: "Up to $12 monthly from January through November and $18 in December after annual opt-in"
     frequency: "monthly"
     category: "rideshare"

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -301,6 +301,7 @@ Return ONLY valid JSON in this exact shape — no markdown, no commentary:
       "description": "<one short sentence>",
       "frequency": "monthly" | "quarterly" | "semi_annual" | "annual" | "multi_year" | "ongoing" | "per_purchase" | "per_flight" | "per_trip" | "per_visit" | "per_rental" | "per_claim" | "one_time",
       "frequency_years": <number, REQUIRED when frequency is "multi_year"; e.g. 5 for Global Entry / TSA PreCheck (5-year renewal cycle), 4 for benefits with explicit 4-year cycle, 2 for biennial perks>,
+      "value_per_cycle": <optional number — the SPENDABLE amount per single cycle, ONLY when round(value / N) doesn't match the real per-cycle spend; e.g. Amex Platinum Uber Cash is $15/mo + $20 December → value: 200, value_per_cycle: 15. Skip when value/N already matches (e.g. $300 Equinox monthly → value: 300, no override needed since 300/12 = 25)>,
       "category": "dining" | "dining_travel" | "travel" | "hotel" | "entertainment" | "shopping" | "fitness" | "lounge" | "security" | "gas" | "streaming" | "grocery" | "rideshare" | "car_rental" | "telecom" | "statement_credit" | "rewards" | "other",
       "enrollment_required": <true|false>
     }
@@ -418,22 +419,26 @@ number means. CRITICAL: never put a percentage in \`value\` without setting
 WRONG for a "5% rebate" benefit.
 
 \`value\` is the ANNUAL TOTAL the cardholder gets in a typical year. The
-\`frequency\` field is just a display hint (renders as "$15/mo", "$50/qtr",
-"$200/6 mo", etc.) — it is NOT used as a multiplier. Examples that match
-the existing repo convention:
-  Amex Platinum Uber Cash ("$15/month"):
-    value: 200, frequency: monthly      ← value is the annual total ($200)
+\`frequency\` field tells the UI what cadence to headline ("$15/mo",
+"$50/qtr", "$400 / 6 mo"); the per-cycle dollar is auto-derived as
+round(value / N). Examples that match the existing repo convention:
+  Amex Platinum Uber Cash ("$15/month + $20 December"):
+    value: 200, frequency: monthly, value_per_cycle: 15
+                                  ← override needed: 200/12 ≈ 17, real is 15
+  Amex Platinum Equinox ("$25/month"):
+    value: 300, frequency: monthly      ← no override: 300/12 = 25 exactly
   Hilton Aspire flight credit ("$50/quarter"):
-    value: 200, frequency: quarterly    ← annual total ($50 × 4 = $200)
+    value: 200, frequency: quarterly    ← no override: 200/4 = 50 exactly
   Hilton Aspire resort credit ("$400 semi-annually"):
-    value: 800, frequency: semi_annual  ← annual total ($400 × 2 = $800)
+    value: 800, frequency: semi_annual  ← no override: 800/2 = 400 exactly
   Amex Biz Plat Indeed credit ("$90/quarter"):
-    value: 360, frequency: quarterly    ← annual total
-DO NOT store the per-occurrence value with a sub-annual frequency — the
-frontend would treat \`value: 15, frequency: monthly\` as $15/yr, not
-$180/yr. The only frequency that does cycle math is \`multi_year\`, where
-\`value\` is the amount per cycle and \`frequency_years\` is the cycle
-length (Global Entry: value=120, frequency=multi_year, frequency_years=5).
+    value: 360, frequency: quarterly    ← no override: 360/4 = 90 exactly
+DO NOT store the per-occurrence value in \`value\` with a sub-annual frequency
+— the frontend treats \`value\` as the annual total. Use \`value_per_cycle\`
+ONLY when the actual spendable per-cycle amount differs from round(value / N).
+The only frequency that does cycle math is \`multi_year\`, where \`value\`
+is the amount per cycle and \`frequency_years\` is the cycle length
+(Global Entry: value=120, frequency=multi_year, frequency_years=5).
 
 - \`value_unit: "usd"\` — dollar credits/rebates. Default. Examples:
   "$300 travel credit" → value=300, value_unit=usd (or omitted).


### PR DESCRIPTION
## Summary
Headlining \"$200/yr\" for Amex Platinum Uber Cash misled users — you can't spend $200 in a single month, only $15. Switch the per-benefit headline on card pages and the wallet-benefits panel to the actual spendable per-cycle amount.

**Before:** \`$200/yr\` (Uber Cash, Walmart+ Credit, Equinox, etc.)
**After:** \`$15/mo\` Uber Cash, \`$13/mo\` Walmart+, \`$25/mo\` Equinox, \`$50/qtr\` Hilton Aspire flight, \`$400 / 6 mo\` Hilton Aspire resort.

Total Annual Credits at the top of the section is unchanged — it still uses \`amortizedAnnualValue\` (which reads \`value\`, the annual total).

## How the per-cycle amount is computed
1. \`value_per_cycle\` if present in YAML (explicit override)
2. \`round(value / N)\` for sub-annual frequencies (N = 12 / 4 / 2)
3. \`value\` itself for annual / multi_year / ongoing

Most existing YAMLs distribute evenly so the auto-derive is correct — no YAML change needed for them.

## Where the per-cycle amount needed an explicit override
Audit found these benefits where \`round(value / N)\` doesn't match the real cadence; added \`value_per_cycle\`:

| Card | Benefit | value | auto-derived | actual | override |
|---|---|---|---|---|---|
| Amex Platinum | Uber Cash | 200 | $17/mo | $15/mo + $20 Dec | 15 |
| Amex Platinum | Walmart+ | 155 | $13/mo | $12.95/mo + tax | 13 |
| Amex Biz Gold | Walmart+ | 155 | $13/mo | $12.95/mo + tax | 13 |
| United Club Infinite | Rideshare | 150 | $13/mo | $12 Jan–Nov + $18 Dec | 12 |

## Auditor prompt updated
\`scripts/check-card-rewards-and-benefits.js\` (the LLM-driven YAML auditor) is updated to teach it about \`value_per_cycle\` — when to set it (only when round(value/N) ≠ real cadence), when to skip (most cards distribute evenly).

## Test plan
- [ ] Open a card with monthly credits (e.g. Amex Platinum) — Uber Cash now reads \`$15/mo\`, Walmart+ reads \`$13/mo\`, Equinox reads \`$25/mo\`
- [ ] Open a card with quarterly credits (e.g. Hilton Aspire) — flight reads \`$50/qtr\`
- [ ] Open a card with semi-annual credits (e.g. Hilton Aspire resort, Saks Platinum) — reads \`$400 / 6 mo\` and \`$50 / 6 mo\`
- [ ] Confirm \"Total Annual Credits\" at the top of the benefits section is unchanged
- [ ] Confirm the wallet \"Annual credits\" total (\`apps/web-next/src/components/wallet/WalletBenefits.tsx\`) is unchanged
- [ ] Confirm card detail pages still pass typecheck (\`npx tsc --noEmit\` ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)