### PR TITLE
profile: clean up record edit/delete button layout

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3749,7 +3749,61 @@
 }
 .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-head,
 .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row {
-  grid-template-columns: 100px 56px 1fr 80px 70px 80px;
+  grid-template-columns: 100px 56px 1fr 80px 70px 80px 60px;
+}
+
+/* Per-row action buttons (edit / delete) — own column to the right of the
+   outcome pill so the pill has clean breathing room. Buttons are subtle by
+   default and brighten on row hover; the delete button shifts to a danger
+   tone on its own hover. */
+.landing-v2.profile-v2 .cj-tape-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  opacity: 0.55;
+  transition: opacity 120ms ease;
+}
+.landing-v2.profile-v2 .cj-tape-row:hover .cj-tape-actions,
+.landing-v2.profile-v2 .cj-tape-row:focus-within .cj-tape-actions {
+  opacity: 1;
+}
+.landing-v2.profile-v2 .cj-tape-action-btn {
+  background: transparent;
+  border: 0;
+  padding: 4px;
+  border-radius: 4px;
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+.landing-v2.profile-v2 .cj-tape-action-btn:hover {
+  color: var(--ink);
+  background: var(--paper-2);
+}
+.landing-v2.profile-v2 .cj-tape-action-btn-danger:hover {
+  color: var(--warn);
+  background: var(--warn-2);
+}
+.landing-v2.profile-v2 .cj-tape-action-btn:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+.landing-v2.profile-v2 .cj-tape-action-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.landing-v2.profile-v2 .cj-tape-action-icon {
+  width: 14px;
+  height: 14px;
+}
+.landing-v2.profile-v2 .cj-tape-action-spinner {
+  font-size: 14px;
+  line-height: 1;
 }
 .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-head,
 .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-row {
@@ -4266,10 +4320,10 @@
   .landing-v2.profile-v2 .cj-wallet-detail { padding: 14px 4px; }
   .landing-v2.profile-v2 .cj-wd-cta { font-size: 11px !important; padding: 5px 8px !important; }
 
-  /* Records tape — head hidden, columns collapsed to: card+detail · pill */
+  /* Records tape — head hidden, columns collapsed to: card+detail · pill · actions */
   .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-head { display: none; }
   .landing-v2.profile-v2 .cj-tape.cj-tape-records .cj-tape-row {
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     gap: 10px;
     padding: 14px 12px;
   }
@@ -4283,6 +4337,8 @@
     font-size: 16px;
     font-weight: 500;
   }
+  /* Mobile has no hover, so always show the actions at full opacity. */
+  .landing-v2.profile-v2 .cj-tape-actions { opacity: 1; }
 
   /* Referrals tape — drop impressions/clicks columns; show as detail under card */
   .landing-v2.profile-v2 .cj-tape.cj-tape-refs .cj-tape-head { display: none; }

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -988,6 +988,7 @@ function ApplicationsTab(props: ApplicationsTabProps) {
               <div className="cj-tape-res">Score</div>
               <div className="cj-tape-res">Income</div>
               <div className="cj-tape-res">Outcome</div>
+              <div className="cj-tape-actions" aria-hidden="true"></div>
             </div>
             {records.map((r) => (
               <div key={r.record_id} className="cj-tape-row">
@@ -1013,22 +1014,30 @@ function ApplicationsTab(props: ApplicationsTabProps) {
                   <span className={'cj-pill ' + (r.result ? 'cj-pill-app' : 'cj-pill-den')}>
                     {r.result ? 'approved' : 'denied'}
                   </span>
+                </div>
+                <div className="cj-tape-actions">
                   <button
                     type="button"
                     onClick={() => onEditRecord(r.record_id)}
-                    style={{ marginLeft: 6, fontSize: 11, color: 'var(--muted)', background: 'transparent', border: 0, cursor: 'pointer', display: 'inline-flex', alignItems: 'center' }}
+                    className="cj-tape-action-btn"
                     aria-label="Edit record"
+                    title="Edit record"
                   >
-                    <PencilIcon style={{ width: 12, height: 12 }} />
+                    <PencilIcon className="cj-tape-action-icon" />
                   </button>
                   <button
                     type="button"
                     onClick={() => onDeleteRecord(r.record_id)}
                     disabled={deletingRecordId === r.record_id}
-                    style={{ marginLeft: 6, fontSize: 11, color: 'var(--muted)', background: 'transparent', border: 0, cursor: 'pointer' }}
+                    className="cj-tape-action-btn cj-tape-action-btn-danger"
                     aria-label="Delete record"
+                    title="Delete record"
                   >
-                    {deletingRecordId === r.record_id ? '…' : '×'}
+                    {deletingRecordId === r.record_id ? (
+                      <span className="cj-tape-action-spinner">…</span>
+                    ) : (
+                      <TrashIcon className="cj-tape-action-icon" />
+                    )}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
The pencil + × were stuffed into the same cell as the approved/denied pill, so the pill wrapped them to a second line. Also the × was a plain text glyph and didn't match the pencil's icon weight — the pair looked mismatched and amateurish.

**Fix:**
- Give the actions their own 60px grid column to the right of the outcome pill (pill now sits cleanly on its own line)
- Replace the text × with the heroicons \`TrashIcon\` so both buttons match in stroke and size
- Ghost-button styling: 55% opacity by default, fades to full on row hover; mobile is always at full opacity (no hover)
- Delete button gets a danger-tone hover only (red bg + warn color)
- Bigger icons (14px from 12px) for a real hit target
- \`:focus-visible\` ring for keyboard nav

Visual flow on each row is now:
\`Date · Card thumb · Card name · Score · Income · [Outcome pill] · [✏ 🗑]\`

Mobile collapses to: \`[Card name + detail line] · [Outcome pill] · [✏ 🗑]\` (3 cells, no overlap).

## Test plan
- [ ] Open /profile → Applications tab → confirm icons sit to the right of the pill, not below it
- [ ] Hover a record row → both icons brighten; hover the trash icon → red tint
- [ ] Tab through — focus ring visible on each button
- [ ] Click pencil → SubmitRecordModal opens in edit mode; click trash → delete confirm
- [ ] Resize to mobile width — actions stay visible inline with the pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)