### PR TITLE
Restore nearby-recommendations handler PR #1088 forgot to re-add

### DIFF
--- a/apps/api/src/handlers/nearby-recommendations.js
+++ b/apps/api/src/handlers/nearby-recommendations.js
@@ -1,0 +1,185 @@
+// Nearby Recommendations — fetches a small list of nearby businesses from
+// Google Places API (New) so the wallet UI can suggest the best card per
+// place. Field-masked to stay on the Pro SKU. The response is intentionally
+// thin (id, name, types, location) — category mapping and best-card picking
+// happen on the frontend where the user's wallet + card data already live.
+
+// Lambda runtime is Node 22 (see template.yml), so global fetch is available.
+
+const responseHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Methods": "POST,OPTIONS",
+};
+
+const PLACES_ENDPOINT = "https://places.googleapis.com/v1/places:searchNearby";
+
+// Curated subset of Place types relevant to credit-card categories. Keeps
+// results signal-heavy (no parks, schools, churches) and lets the API
+// filter server-side. See data/places-types.md for the full mapping.
+const INCLUDED_TYPES = [
+  "restaurant",
+  "cafe",
+  "coffee_shop",
+  "bar",
+  "fast_food_restaurant",
+  "bakery",
+  "meal_takeaway",
+  "supermarket",
+  "grocery_store",
+  "gas_station",
+  "pharmacy",
+  "drugstore",
+  "department_store",
+  "clothing_store",
+  "shopping_mall",
+  "home_goods_store",
+  "hardware_store",
+  "lodging",
+  "hotel",
+  "car_rental",
+  "movie_theater",
+];
+
+const RADIUS_METERS = 1000;
+const MAX_RESULTS = 10;
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 min
+const GRID_PRECISION = 3; // ~110m squares
+const DAILY_USER_CAP = 30;
+
+// In-memory caches scoped to a warm Lambda container. They reset on cold
+// start, which is fine for a beta — the worst case is one extra Places
+// call per cold start. Move to DynamoDB / Redis if abuse becomes an issue.
+const placesCache = new Map(); // key: "lat,lng" -> { expiresAt, data }
+const userUsage = new Map();   // key: userId -> { dayKey, count }
+
+function gridKey(lat, lng) {
+  return `${Number(lat).toFixed(GRID_PRECISION)},${Number(lng).toFixed(GRID_PRECISION)}`;
+}
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function bumpUserUsage(userId) {
+  const today = todayKey();
+  const cur = userUsage.get(userId);
+  if (!cur || cur.dayKey !== today) {
+    userUsage.set(userId, { dayKey: today, count: 1 });
+    return 1;
+  }
+  cur.count += 1;
+  return cur.count;
+}
+
+function err(statusCode, message) {
+  return {
+    statusCode,
+    headers: responseHeaders,
+    body: JSON.stringify({ error: message }),
+  };
+}
+
+async function searchNearby(lat, lng, apiKey) {
+  const res = await fetch(PLACES_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Goog-Api-Key": apiKey,
+      // Field mask is required and controls billing tier.
+      "X-Goog-FieldMask":
+        "places.id,places.displayName,places.location,places.types,places.primaryType,places.formattedAddress",
+    },
+    body: JSON.stringify({
+      includedTypes: INCLUDED_TYPES,
+      maxResultCount: MAX_RESULTS,
+      rankPreference: "DISTANCE",
+      locationRestriction: {
+        circle: {
+          center: { latitude: lat, longitude: lng },
+          radius: RADIUS_METERS,
+        },
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Places API ${res.status}: ${text.slice(0, 200)}`);
+  }
+
+  const data = await res.json();
+  const places = Array.isArray(data.places) ? data.places : [];
+  return places.map((p) => ({
+    id: p.id,
+    name: p.displayName?.text || "",
+    primaryType: p.primaryType || null,
+    types: Array.isArray(p.types) ? p.types : [],
+    address: p.formattedAddress || null,
+    lat: p.location?.latitude ?? null,
+    lng: p.location?.longitude ?? null,
+  }));
+}
+
+exports.NearbyRecommendationsHandler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 200, headers: responseHeaders, body: "" };
+  }
+  if (event.httpMethod !== "POST") {
+    return err(405, `Method ${event.httpMethod} not allowed`);
+  }
+
+  const userId = event.requestContext?.authorizer?.principalId;
+  if (!userId) return err(401, "Unauthorized");
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) {
+    console.error("GOOGLE_PLACES_API_KEY not set");
+    return err(503, "Nearby recommendations are not configured");
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body || "{}");
+  } catch {
+    return err(400, "Invalid JSON body");
+  }
+
+  const lat = Number(body.lat);
+  const lng = Number(body.lng);
+  if (
+    !Number.isFinite(lat) || !Number.isFinite(lng) ||
+    lat < -90 || lat > 90 || lng < -180 || lng > 180
+  ) {
+    return err(400, "lat and lng must be valid coordinates");
+  }
+
+  const usage = bumpUserUsage(userId);
+  if (usage > DAILY_USER_CAP) {
+    return err(429, `Daily limit of ${DAILY_USER_CAP} nearby lookups reached`);
+  }
+
+  const cacheKey = gridKey(lat, lng);
+  const cached = placesCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) {
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ places: cached.data, cached: true }),
+    };
+  }
+
+  try {
+    const places = await searchNearby(lat, lng, apiKey);
+    placesCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, data: places });
+    return {
+      statusCode: 200,
+      headers: responseHeaders,
+      body: JSON.stringify({ places, cached: false }),
+    };
+  } catch (e) {
+    console.error("Places fetch failed:", e);
+    return err(502, "Failed to fetch nearby places");
+  }
+};


### PR DESCRIPTION
## Summary
The deployed \`NearbyRecommendationsFunction\` Lambda is throwing \`Runtime.ImportModuleError: Cannot find module 'nearby-recommendations'\` on every invocation, breaking the wallet's "Best Card Here" feature with a "Load failed" error.

## Root cause
A two-PR chain from 5/7:

1. **PR #1087** ("Tear down /nearby-recommendations Lambda") deleted \`apps/api/src/handlers/nearby-recommendations.js\` plus the SAM template entry plus the \`GooglePlacesApiKey\` CFN parameter.
2. **PR #1088** ("Best Card Here: wire real Places API backend") restored the SAM template entry, the CFN parameter, the frontend \`getNearbyPlaces()\` call — **but forgot to restore the handler source file**. The merge commit \`3802979c\` only touches \`template.yml\`, \`BestCardHere.tsx\`, \`api.ts\`, \`placeTypeMapping.ts\`.

The deployed Lambda kept working only because its in-AWS package still had the pre-teardown code from before #1087. A redeploy today rebuilt from source, found no handler in \`src/handlers/\`, and shipped an empty package. CloudWatch shows the import error firing on every invocation since 14:59 UTC.

## Fix
Restore \`apps/api/src/handlers/nearby-recommendations.js\` verbatim from \`d67c61d3^\` (the commit before #1087's deletion) — 185 lines, no behavioural change. After this merges, a backend redeploy will ship the code to the live Lambda and Best Card Here will work again.

## Test plan
- [ ] Merge this PR
- [ ] \`cd apps/api && sam build && sam deploy --parameter-overrides ...\` (manual backend deploy per CLAUDE.md)
- [ ] Open the wallet → Rewards tab → confirm Best Card Here resolves nearby merchants instead of "Load failed"
- [ ] Check CloudWatch \`/aws/lambda/CreditCardOddsAPI-NearbyRecommendationsFunction-*\` — no more \`Runtime.ImportModuleError\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)