### PR TITLE
tools: multi-source valuation chart, YAML data, breadcrumb

### DIFF
--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -42,6 +43,8 @@ export default async function AmexMRToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'Amex Membership Rewards to USD', url: 'https://creditodds.com/tools/amex-membership-rewards-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="Amex Membership Rewards to USD" toolSlug="amex-membership-rewards-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -39,6 +40,8 @@ export default async function BiltToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'Bilt Rewards Points to USD', url: 'https://creditodds.com/tools/bilt-rewards-points-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="Bilt Rewards Points to USD" toolSlug="bilt-rewards-points-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -39,6 +40,8 @@ export default async function CapitalOneMilesToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'Capital One Miles to USD', url: 'https://creditodds.com/tools/capital-one-miles-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="Capital One Miles to USD" toolSlug="capital-one-miles-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -40,6 +41,8 @@ export default async function ChaseURToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'Chase Ultimate Rewards to USD', url: 'https://creditodds.com/tools/chase-ultimate-rewards-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="Chase Ultimate Rewards to USD" toolSlug="chase-ultimate-rewards-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -39,6 +40,8 @@ export default async function CitiThankYouToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'Citi ThankYou Points to USD', url: 'https://creditodds.com/tools/citi-thankyou-points-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="Citi ThankYou Points to USD" toolSlug="citi-thankyou-points-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/ConverterClient.tsx
@@ -3,7 +3,7 @@ import RewardValueConverter from '@/components/tools/RewardValueConverter';
 export default function ConverterClient() {
   return (
     <RewardValueConverter
-      fallbackCpp={1.1}
+      fallbackCpp={1.20}
       inputLabel="Delta SkyMiles"
       unitLabel="mile"
       valuationSlug="delta-skymiles"

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
@@ -6,15 +6,18 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
+import ValuationChart from '@/components/tools/ValuationChart';
+import { loadValuation } from '@/lib/valuationData';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
 export const metadata: Metadata = {
   title: 'Delta SkyMiles to USD (Converter/Calculator) | CreditOdds',
-  description: 'Convert Delta SkyMiles to their estimated USD value. Free calculator using the standard 1.1 cents per mile valuation.',
+  description: 'Convert Delta SkyMiles to their estimated USD value. Free calculator using the multi-source 1.20 cents per mile median valuation.',
   openGraph: {
     title: 'Delta SkyMiles to USD | CreditOdds',
-    description: 'Convert Delta SkyMiles to USD using the 1.1 cents per mile valuation.',
+    description: 'Convert Delta SkyMiles to USD using the multi-source 1.20 cents per mile median valuation.',
     url: 'https://creditodds.com/tools/delta-skymiles-to-usd',
     type: 'website',
   },
@@ -23,6 +26,7 @@ export const metadata: Metadata = {
 
 export default async function DeltaSkyMilesToUsdPage() {
   const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+  const valuation = loadValuation('delta-skymiles');
 
   const cards = allCards.filter(c =>
     c.card_name.toLowerCase().includes('delta') && c.accepting_applications
@@ -40,6 +44,8 @@ export default async function DeltaSkyMilesToUsdPage() {
         { name: 'Delta SkyMiles to USD', url: 'https://creditodds.com/tools/delta-skymiles-to-usd' },
       ]} />
 
+      <ToolBreadcrumb toolName="Delta SkyMiles to USD" toolSlug="delta-skymiles-to-usd" />
+
       <section className="page-hero wrap">
         <h1 className="page-title">
           Delta SkyMiles to USD Converter.
@@ -50,36 +56,48 @@ export default async function DeltaSkyMilesToUsdPage() {
       </section>
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>
-        <ConverterClient />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+          <div>
+            <ConverterClient />
 
-        {cards.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Delta Credit Cards</h2>
-            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {cards.map(card => (
-                <Link
-                  key={card.slug}
-                  href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
-                >
-                  <div className="h-10 w-16 flex-shrink-0 relative">
-                    <CardImage
-                      cardImageLink={card.card_image_link}
-                      alt={card.card_name}
-                      fill
-                      className="object-contain"
-                      sizes="64px"
-                    />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
-                    <p className="text-xs text-gray-500">{card.bank}</p>
-                  </div>
-                </Link>
-              ))}
-            </div>
+            {cards.length > 0 && (
+              <div className="mt-8">
+                <h2 className="text-lg font-semibold text-gray-900">Delta Credit Cards</h2>
+                <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                  {cards.map(card => (
+                    <Link
+                      key={card.slug}
+                      href={`/card/${card.slug}`}
+                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                    >
+                      <div className="h-10 w-16 flex-shrink-0 relative">
+                        <CardImage
+                          cardImageLink={card.card_image_link}
+                          alt={card.card_name}
+                          fill
+                          className="object-contain"
+                          sizes="64px"
+                        />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                        <p className="text-xs text-gray-500">{card.bank}</p>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
-        )}
+
+          {valuation && (
+            <ValuationChart
+              programName={valuation.program}
+              unit={valuation.unit}
+              dataPoints={valuation.data_points}
+            />
+          )}
+        </div>
 
         <PaginatedNewsList news={news} heading="Delta News" />
       </div>

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -39,6 +40,8 @@ export default async function HiltonHonorsToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'Hilton Honors Points to USD', url: 'https://creditodds.com/tools/hilton-honors-points-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="Hilton Honors Points to USD" toolSlug="hilton-honors-points-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -39,6 +40,8 @@ export default async function IHGToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'IHG One Rewards Points to USD', url: 'https://creditodds.com/tools/ihg-one-rewards-points-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="IHG One Rewards Points to USD" toolSlug="ihg-one-rewards-points-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -40,6 +41,8 @@ export default async function MarriottBonvoyToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'Marriott Bonvoy Points to USD', url: 'https://creditodds.com/tools/marriott-bonvoy-points-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="Marriott Bonvoy Points to USD" toolSlug="marriott-bonvoy-points-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/app/tools/page.tsx
+++ b/apps/web-next/src/app/tools/page.tsx
@@ -47,9 +47,9 @@ const categories: ToolCategory[] = [
   {
     label: 'Airline Miles',
     tools: [
-      { name: 'United MileagePlus', description: 'Convert United MileagePlus miles to dollars.', href: '/tools/united-miles-to-usd', cpp: 1.2, unit: 'mile', logo: '/logos/united.jpg' },
-      { name: 'Delta SkyMiles', description: 'Convert Delta SkyMiles to dollars.', href: '/tools/delta-skymiles-to-usd', cpp: 1.1, unit: 'mile', logo: '/logos/delta.jpg' },
-      { name: 'Southwest Rapid Rewards', description: 'Convert Southwest points to dollars.', href: '/tools/southwest-rapid-rewards-to-usd', cpp: 1.4, unit: 'point', logo: '/logos/southwest.jpg' },
+      { name: 'United MileagePlus', description: 'Convert United MileagePlus miles to dollars.', href: '/tools/united-miles-to-usd', cpp: 1.21, unit: 'mile', logo: '/logos/united.jpg' },
+      { name: 'Delta SkyMiles', description: 'Convert Delta SkyMiles to dollars.', href: '/tools/delta-skymiles-to-usd', cpp: 1.20, unit: 'mile', logo: '/logos/delta.jpg' },
+      { name: 'Southwest Rapid Rewards', description: 'Convert Southwest points to dollars.', href: '/tools/southwest-rapid-rewards-to-usd', cpp: 1.30, unit: 'point', logo: '/logos/southwest.jpg' },
     ],
   },
   {

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/ConverterClient.tsx
@@ -3,7 +3,7 @@ import RewardValueConverter from '@/components/tools/RewardValueConverter';
 export default function ConverterClient() {
   return (
     <RewardValueConverter
-      fallbackCpp={1.4}
+      fallbackCpp={1.30}
       inputLabel="Southwest Rapid Rewards Points"
       unitLabel="point"
       valuationSlug="southwest-rapid-rewards"

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
@@ -6,15 +6,18 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
+import ValuationChart from '@/components/tools/ValuationChart';
+import { loadValuation } from '@/lib/valuationData';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
 export const metadata: Metadata = {
   title: 'Southwest Rapid Rewards to USD (Converter/Calculator) | CreditOdds',
-  description: 'Convert Southwest Rapid Rewards points to their estimated USD value. Free calculator using the standard 1.4 cents per point valuation.',
+  description: 'Convert Southwest Rapid Rewards points to their estimated USD value. Free calculator using the multi-source 1.30 cents per point median valuation.',
   openGraph: {
     title: 'Southwest Rapid Rewards to USD | CreditOdds',
-    description: 'Convert Southwest Rapid Rewards points to USD using the 1.4 cents per point valuation.',
+    description: 'Convert Southwest Rapid Rewards points to USD using the multi-source 1.30 cents per point median valuation.',
     url: 'https://creditodds.com/tools/southwest-rapid-rewards-to-usd',
     type: 'website',
   },
@@ -23,6 +26,7 @@ export const metadata: Metadata = {
 
 export default async function SouthwestRRToUsdPage() {
   const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+  const valuation = loadValuation('southwest-rapid-rewards');
 
   const cards = allCards.filter(c =>
     c.card_name.toLowerCase().includes('southwest') && c.accepting_applications
@@ -40,6 +44,8 @@ export default async function SouthwestRRToUsdPage() {
         { name: 'Southwest Rapid Rewards to USD', url: 'https://creditodds.com/tools/southwest-rapid-rewards-to-usd' },
       ]} />
 
+      <ToolBreadcrumb toolName="Southwest Rapid Rewards to USD" toolSlug="southwest-rapid-rewards-to-usd" />
+
       <section className="page-hero wrap">
         <h1 className="page-title">
           Southwest Rapid Rewards to USD Converter.
@@ -50,36 +56,48 @@ export default async function SouthwestRRToUsdPage() {
       </section>
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>
-        <ConverterClient />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+          <div>
+            <ConverterClient />
 
-        {cards.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">Southwest Credit Cards</h2>
-            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {cards.map(card => (
-                <Link
-                  key={card.slug}
-                  href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
-                >
-                  <div className="h-10 w-16 flex-shrink-0 relative">
-                    <CardImage
-                      cardImageLink={card.card_image_link}
-                      alt={card.card_name}
-                      fill
-                      className="object-contain"
-                      sizes="64px"
-                    />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
-                    <p className="text-xs text-gray-500">{card.bank}</p>
-                  </div>
-                </Link>
-              ))}
-            </div>
+            {cards.length > 0 && (
+              <div className="mt-8">
+                <h2 className="text-lg font-semibold text-gray-900">Southwest Credit Cards</h2>
+                <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                  {cards.map(card => (
+                    <Link
+                      key={card.slug}
+                      href={`/card/${card.slug}`}
+                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                    >
+                      <div className="h-10 w-16 flex-shrink-0 relative">
+                        <CardImage
+                          cardImageLink={card.card_image_link}
+                          alt={card.card_name}
+                          fill
+                          className="object-contain"
+                          sizes="64px"
+                        />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                        <p className="text-xs text-gray-500">{card.bank}</p>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
-        )}
+
+          {valuation && (
+            <ValuationChart
+              programName={valuation.program}
+              unit={valuation.unit}
+              dataPoints={valuation.data_points}
+            />
+          )}
+        </div>
 
         <PaginatedNewsList news={news} heading="Southwest News" />
       </div>

--- a/apps/web-next/src/app/tools/united-miles-to-usd/ConverterClient.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/ConverterClient.tsx
@@ -3,7 +3,7 @@ import RewardValueConverter from '@/components/tools/RewardValueConverter';
 export default function ConverterClient() {
   return (
     <RewardValueConverter
-      fallbackCpp={1.2}
+      fallbackCpp={1.21}
       inputLabel="United MileagePlus Miles"
       unitLabel="mile"
       valuationSlug="united-mileageplus"

--- a/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
@@ -6,15 +6,18 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
+import ValuationChart from '@/components/tools/ValuationChart';
+import { loadValuation } from '@/lib/valuationData';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
 export const metadata: Metadata = {
   title: 'United Miles to USD (Converter/Calculator) | CreditOdds',
-  description: 'Convert United MileagePlus miles to their estimated USD value. Free calculator using the standard 1.2 cents per mile valuation.',
+  description: 'Convert United MileagePlus miles to their estimated USD value. Free calculator using the multi-source 1.21 cents per mile median valuation.',
   openGraph: {
     title: 'United Miles to USD | CreditOdds',
-    description: 'Convert United MileagePlus miles to USD using the 1.2 cents per mile valuation.',
+    description: 'Convert United MileagePlus miles to USD using the multi-source 1.21 cents per mile median valuation.',
     url: 'https://creditodds.com/tools/united-miles-to-usd',
     type: 'website',
   },
@@ -23,6 +26,7 @@ export const metadata: Metadata = {
 
 export default async function UnitedMilesToUsdPage() {
   const [allCards, allNews] = await Promise.all([getAllCards(), getNews()]);
+  const valuation = loadValuation('united-mileageplus');
 
   const cards = allCards.filter(c =>
     c.card_name.toLowerCase().includes('united') && c.accepting_applications
@@ -40,6 +44,8 @@ export default async function UnitedMilesToUsdPage() {
         { name: 'United Miles to USD', url: 'https://creditodds.com/tools/united-miles-to-usd' },
       ]} />
 
+      <ToolBreadcrumb toolName="United Miles to USD" toolSlug="united-miles-to-usd" />
+
       <section className="page-hero wrap">
         <h1 className="page-title">
           United Miles to USD Converter.
@@ -50,36 +56,48 @@ export default async function UnitedMilesToUsdPage() {
       </section>
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>
-        <ConverterClient />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+          <div>
+            <ConverterClient />
 
-        {cards.length > 0 && (
-          <div className="mt-12">
-            <h2 className="text-lg font-semibold text-gray-900">United Credit Cards</h2>
-            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {cards.map(card => (
-                <Link
-                  key={card.slug}
-                  href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
-                >
-                  <div className="h-10 w-16 flex-shrink-0 relative">
-                    <CardImage
-                      cardImageLink={card.card_image_link}
-                      alt={card.card_name}
-                      fill
-                      className="object-contain"
-                      sizes="64px"
-                    />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
-                    <p className="text-xs text-gray-500">{card.bank}</p>
-                  </div>
-                </Link>
-              ))}
-            </div>
+            {cards.length > 0 && (
+              <div className="mt-8">
+                <h2 className="text-lg font-semibold text-gray-900">United Credit Cards</h2>
+                <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                  {cards.map(card => (
+                    <Link
+                      key={card.slug}
+                      href={`/card/${card.slug}`}
+                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                    >
+                      <div className="h-10 w-16 flex-shrink-0 relative">
+                        <CardImage
+                          cardImageLink={card.card_image_link}
+                          alt={card.card_name}
+                          fill
+                          className="object-contain"
+                          sizes="64px"
+                        />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-indigo-600 group-hover:text-indigo-900 truncate">{card.card_name}</p>
+                        <p className="text-xs text-gray-500">{card.bank}</p>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
-        )}
+
+          {valuation && (
+            <ValuationChart
+              programName={valuation.program}
+              unit={valuation.unit}
+              dataPoints={valuation.data_points}
+            />
+          )}
+        </div>
 
         <PaginatedNewsList news={news} heading="United News" />
       </div>

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
@@ -6,6 +6,7 @@ import { getAllCards } from '@/lib/api';
 import { getNews } from '@/lib/news';
 import ConverterClient from './ConverterClient';
 import PaginatedNewsList from '@/components/tools/PaginatedNewsList';
+import ToolBreadcrumb from '@/components/tools/ToolBreadcrumb';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../../landing.css';
 
@@ -39,6 +40,8 @@ export default async function HyattToUsdPage() {
         { name: 'Tools', url: 'https://creditodds.com/tools' },
         { name: 'World of Hyatt Points to USD', url: 'https://creditodds.com/tools/world-of-hyatt-points-to-usd' },
       ]} />
+
+      <ToolBreadcrumb toolName="World of Hyatt Points to USD" toolSlug="world-of-hyatt-points-to-usd" />
 
       <section className="page-hero wrap">
         <h1 className="page-title">

--- a/apps/web-next/src/components/tools/ToolBreadcrumb.tsx
+++ b/apps/web-next/src/components/tools/ToolBreadcrumb.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+
+interface ToolBreadcrumbProps {
+  toolName: string;
+  toolSlug: string;
+}
+
+export default function ToolBreadcrumb({ toolName, toolSlug }: ToolBreadcrumbProps) {
+  const issueUrl = `https://github.com/CreditOdds/creditodds/issues/new?${new URLSearchParams({
+    title: `Tool page issue: ${toolName}`,
+    labels: 'tool-data',
+    body: [
+      `**Tool:** ${toolName}`,
+      `**Page:** https://creditodds.com/tools/${toolSlug}`,
+      '',
+      "### What's wrong?",
+      '<!-- e.g. wrong cents-per-point value, broken calculator, outdated valuation, missing context -->',
+      '',
+      '### What should it say?',
+      "<!-- the correct value or behavior, ideally with a link to a source -->",
+      '',
+      '### Source / proof',
+      '<!-- link to the source or screenshot showing the correct info -->',
+    ].join('\n'),
+  }).toString()}`;
+
+  return (
+    <div className="cj-terminal">
+      <nav className="cj-crumbs" aria-label="Breadcrumb">
+        <Link href="/tools" className="cj-crumb">Tools</Link>
+        <span className="cj-sep">/</span>
+        <span className="cj-crumb cj-crumb-current" aria-current="page">{toolName}</span>
+      </nav>
+      <span className="cj-spacer" />
+      <div className="cj-term-actions">
+        <a
+          href={issueUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="cj-term-link"
+          title="Report an issue with this tool"
+        >
+          <ExclamationTriangleIcon className="cj-term-icon" />
+          report issue
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/tools/ValuationChart.tsx
+++ b/apps/web-next/src/components/tools/ValuationChart.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useMemo } from 'react';
+import Highcharts from 'highcharts';
+import 'highcharts/highcharts-more';
+import HighchartsReact from 'highcharts-react-official';
+import type { ValuationDataPoint } from '@/lib/valuationData';
+
+interface ValuationChartProps {
+  programName: string;
+  unit: 'mile' | 'point';
+  dataPoints: ValuationDataPoint[];
+}
+
+function median(nums: number[]): number {
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export default function ValuationChart({ programName, unit, dataPoints }: ValuationChartProps) {
+  const { rangeData, medianData, scatterSeries, summaryRows, yMin, yMax } = useMemo(() => {
+    const byYear = new Map<number, ValuationDataPoint[]>();
+    for (const p of dataPoints) {
+      if (!byYear.has(p.year)) byYear.set(p.year, []);
+      byYear.get(p.year)!.push(p);
+    }
+
+    const years = Array.from(byYear.keys()).sort((a, b) => a - b);
+
+    const range: [number, number, number][] = [];
+    const med: [number, number][] = [];
+    const summary: { year: number; high: number; low: number; median: number; n: number }[] = [];
+
+    for (const year of years) {
+      const points = byYear.get(year)!;
+      const nums = points.map(p => p.cpp);
+      const x = Date.UTC(year, 5, 30);
+      const high = Math.max(...nums);
+      const low = Math.min(...nums);
+      const m = median(nums);
+      range.push([x, low, high]);
+      med.push([x, m]);
+      summary.push({ year, high, low, median: m, n: nums.length });
+    }
+
+    const sourcesByYear = new Map<string, [number, number, string?][]>();
+    for (const p of dataPoints) {
+      if (!sourcesByYear.has(p.source)) sourcesByYear.set(p.source, []);
+      sourcesByYear.get(p.source)!.push([Date.UTC(p.year, 5, 30), p.cpp, p.url]);
+    }
+
+    const series = Array.from(sourcesByYear.entries()).map(([source, data]) => ({
+      name: source,
+      type: 'scatter' as const,
+      color: '#9CA3AF',
+      marker: { radius: 4, symbol: 'circle' },
+      data: data.map(([x, y, url]) => ({ x, y, url })),
+      tooltip: {
+        pointFormat: `<b>{series.name}</b>: {point.y}¢<br/>`,
+      },
+    }));
+
+    const allValues = dataPoints.map(p => p.cpp);
+    const min = Math.min(...allValues);
+    const max = Math.max(...allValues);
+    const padding = Math.max(0.2, (max - min) * 0.5);
+
+    return {
+      rangeData: range,
+      medianData: med,
+      scatterSeries: series,
+      summaryRows: summary,
+      yMin: Math.max(0, Math.floor((min - padding) * 10) / 10),
+      yMax: Math.ceil((max + padding) * 10) / 10,
+    };
+  }, [dataPoints]);
+
+  const chartOptions = useMemo<Highcharts.Options>(() => ({
+    chart: {
+      height: 380,
+      backgroundColor: 'transparent',
+    },
+    title: { text: undefined },
+    xAxis: {
+      type: 'datetime',
+      labels: { format: '{value:%Y}' },
+      tickInterval: 365 * 24 * 3600 * 1000,
+    },
+    yAxis: {
+      title: { text: `Cents per ${unit}` },
+      min: yMin,
+      max: yMax,
+      tickInterval: 0.1,
+      labels: { format: '{value}¢' },
+      gridLineColor: '#E5E7EB',
+    },
+    tooltip: {
+      shared: true,
+      useHTML: true,
+      xDateFormat: '%Y',
+      headerFormat: '<b>{point.key}</b><br/>',
+    },
+    plotOptions: {
+      arearange: {
+        fillOpacity: 0.18,
+        lineWidth: 0,
+        marker: { enabled: false },
+        enableMouseTracking: true,
+      },
+      line: {
+        marker: { enabled: true, radius: 4 },
+        lineWidth: 2.5,
+      },
+      scatter: {
+        jitter: { x: 6 * 24 * 3600 * 1000, y: 0 },
+        cursor: 'pointer',
+        events: {
+          click: function (e) {
+            const point = e.point as Highcharts.Point & { url?: string };
+            if (point.url) window.open(point.url, '_blank', 'noopener,noreferrer');
+          },
+        },
+      },
+    },
+    legend: {
+      align: 'center',
+      verticalAlign: 'bottom',
+      itemStyle: { fontSize: '12px' },
+    },
+    credits: { enabled: false },
+    series: [
+      {
+        name: 'High–Low range',
+        type: 'arearange',
+        color: '#7C3AED',
+        data: rangeData,
+        zIndex: 0,
+        tooltip: {
+          pointFormat: '<span style="color:{series.color}">●</span> Range: {point.low}¢–{point.high}¢<br/>',
+        },
+      },
+      {
+        name: 'Median',
+        type: 'line',
+        color: '#7C3AED',
+        data: medianData,
+        zIndex: 2,
+        tooltip: {
+          pointFormat: '<span style="color:{series.color}">●</span> <b>Median: {point.y}¢</b><br/>',
+        },
+      },
+      ...scatterSeries.map(s => ({ ...s, zIndex: 1, showInLegend: false })),
+    ],
+  }), [rangeData, medianData, scatterSeries, unit, yMin, yMax]);
+
+  const sourceCount = new Set(dataPoints.map(p => p.source)).size;
+  const sourceList = Array.from(new Set(dataPoints.map(p => p.source))).join(', ');
+
+  return (
+    <div className="mt-6 bg-white rounded-lg shadow p-6">
+      <div className="flex flex-col gap-1 mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">{programName} valuation, by year</h2>
+        <p className="text-sm text-gray-600">
+          High, low, and median cents-per-{unit} across major published valuations. Each gray dot is one source's published number for that year — click a dot to view the source.
+        </p>
+      </div>
+
+      <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+
+      <div className="mt-6 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium text-gray-700">Year</th>
+              <th className="px-3 py-2 text-right font-medium text-gray-700">Median</th>
+              <th className="px-3 py-2 text-right font-medium text-gray-700">High</th>
+              <th className="px-3 py-2 text-right font-medium text-gray-700">Low</th>
+              <th className="px-3 py-2 text-right font-medium text-gray-700">Sources</th>
+            </tr>
+          </thead>
+          <tbody>
+            {summaryRows.map(row => (
+              <tr key={row.year} className="border-t border-gray-200">
+                <td className="px-3 py-2 text-gray-900 font-medium">{row.year}</td>
+                <td className="px-3 py-2 text-right text-gray-900">{row.median.toFixed(2)}¢</td>
+                <td className="px-3 py-2 text-right text-gray-700">{row.high.toFixed(2)}¢</td>
+                <td className="px-3 py-2 text-right text-gray-700">{row.low.toFixed(2)}¢</td>
+                <td className="px-3 py-2 text-right text-gray-500">{row.n}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-4 text-xs text-gray-500">
+        {sourceCount > 0 ? `Sources: ${sourceList}.` : ''} Only directly cited values from each source's published page or article are included.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/valuationData.ts
+++ b/apps/web-next/src/lib/valuationData.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+export interface ValuationDataPoint {
+  year: number;
+  source: string;
+  cpp: number;
+  url?: string;
+}
+
+export interface ValuationFile {
+  slug: string;
+  program: string;
+  unit: 'mile' | 'point';
+  data_points: ValuationDataPoint[];
+}
+
+const VALUATIONS_DIR = path.join(process.cwd(), '..', '..', 'data', 'valuations');
+
+export function loadValuation(slug: string): ValuationFile | null {
+  const filePath = path.join(VALUATIONS_DIR, `${slug}.yaml`);
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const parsed = yaml.load(raw) as ValuationFile;
+  return parsed;
+}

--- a/apps/web-next/src/lib/valuations.ts
+++ b/apps/web-next/src/lib/valuations.ts
@@ -12,8 +12,8 @@ export interface Valuation {
 const valuations: Valuation[] = [
   { program: "Chase Ultimate Rewards", slug: "chase-ultimate-rewards", cpp: 1.25, match: ["chase sapphire", "freedom"], toolSlug: "chase-ultimate-rewards" },
   { program: "Amex Membership Rewards", slug: "amex-membership-rewards", cpp: 1.2, match: ["american express", "amex", "gold card", "platinum card"], exclude: ["delta", "hilton", "skymiles"], toolSlug: "amex-membership-rewards" },
-  { program: "Delta SkyMiles", slug: "delta-skymiles", cpp: 1.1, match: ["delta", "skymiles"], toolSlug: "delta-skymiles" },
-  { program: "United MileagePlus", slug: "united-mileageplus", cpp: 1.2, match: ["united"], toolSlug: "united-miles" },
+  { program: "Delta SkyMiles", slug: "delta-skymiles", cpp: 1.20, match: ["delta", "skymiles"], toolSlug: "delta-skymiles" },
+  { program: "United MileagePlus", slug: "united-mileageplus", cpp: 1.21, match: ["united"], toolSlug: "united-miles" },
   { program: "Hilton Honors", slug: "hilton-honors", cpp: 0.5, match: ["hilton"], toolSlug: "hilton-honors-points" },
   { program: "World of Hyatt", slug: "world-of-hyatt", cpp: 2.0, match: ["hyatt"], toolSlug: "world-of-hyatt-points" },
   { program: "IHG One Rewards", slug: "ihg-one-rewards", cpp: 0.5, match: ["ihg"], toolSlug: "ihg-one-rewards-points" },
@@ -22,7 +22,7 @@ const valuations: Valuation[] = [
   { program: "Bilt Rewards", slug: "bilt-rewards", cpp: 1.5, match: ["bilt"], toolSlug: "bilt-rewards-points" },
   { program: "Citi ThankYou", slug: "citi-thankyou", cpp: 1.0, match: ["citi"], toolSlug: "citi-thankyou-points" },
   { program: "Wells Fargo Rewards", slug: "wells-fargo-rewards", cpp: 1.0, match: ["wells fargo"] },
-  { program: "Southwest Rapid Rewards", slug: "southwest-rapid-rewards", cpp: 1.4, match: ["southwest"], toolSlug: "southwest-rapid-rewards" },
+  { program: "Southwest Rapid Rewards", slug: "southwest-rapid-rewards", cpp: 1.30, match: ["southwest"], toolSlug: "southwest-rapid-rewards" },
 ];
 
 const DEFAULT_CPP = 1.0;

--- a/data/valuations/README.md
+++ b/data/valuations/README.md
@@ -1,0 +1,36 @@
+# Valuation Data
+
+Each YAML file in this directory holds historical published valuations for one points/miles program. The files power the multi-source valuation chart on the corresponding `/tools/[slug]` page.
+
+## Adding a new data point
+
+To add a citation (e.g. a new monthly TPG valuation), open the relevant YAML file and append an entry to `data_points`:
+
+```yaml
+- year: 2026
+  source: TPG
+  cpp: 1.35
+  url: https://thepointsguy.com/loyalty-programs/monthly-valuations/
+```
+
+Open a PR. The chart picks up the new point on next deploy.
+
+## Rules
+
+- **Only directly cited values.** No inferred or rough estimates. Each entry must have a `url` pointing to the source's actual published article showing that number for that year.
+- **`cpp` is in cents** (e.g. `1.35` means 1.35¢ per mile).
+- **`source`** should match the publisher name as users know it (e.g. `TPG`, `NerdWallet`, `Frequent Miler`, `Bankrate`, `One Mile at a Time`, `WalletHub`).
+- **`year`** is the year the source published the value. If TPG publishes monthly, pick the latest publication for that year; multiple monthly snapshots within one year are fine — they just become multiple points stacked on the chart.
+
+## Schema
+
+```yaml
+slug: united-mileageplus           # matches the filename
+program: United MileagePlus        # human-readable program name
+unit: mile                         # 'mile' or 'point'
+data_points:
+  - year: 2023
+    source: TPG
+    cpp: 1.35
+    url: https://...
+```

--- a/data/valuations/delta-skymiles.yaml
+++ b/data/valuations/delta-skymiles.yaml
@@ -1,0 +1,43 @@
+slug: delta-skymiles
+program: Delta SkyMiles
+unit: mile
+
+# Only directly cited values from each source's published page or article.
+# See data/valuations/README.md for instructions on adding a new data point.
+data_points:
+  - year: 2025
+    source: TPG
+    cpp: 1.15
+    url: https://thepointsguy.com/loyalty-programs/monthly-valuations/
+    # September 2025 monthly valuation
+  - year: 2025
+    source: Frequent Miler
+    cpp: 1.10
+    url: https://frequentmiler.com/what-are-delta-miles-worth/
+    # FM noted RRV was unchanged from prior year
+
+  - year: 2026
+    source: TPG
+    cpp: 1.20
+    url: https://thepointsguy.com/loyalty-programs/monthly-valuations/
+    # April 2026 valuation
+  - year: 2026
+    source: NerdWallet
+    cpp: 1.20
+    url: https://www.nerdwallet.com/travel/learn/how-much-are-my-delta-skymiles-worth
+  - year: 2026
+    source: Bankrate
+    cpp: 1.20
+    url: https://www.bankrate.com/credit-cards/travel/delta-miles-value/
+  - year: 2026
+    source: Frequent Miler
+    cpp: 1.10
+    url: https://frequentmiler.com/what-are-delta-miles-worth/
+  - year: 2026
+    source: One Mile at a Time
+    cpp: 1.30
+    url: https://onemileatatime.com/how-much-are-delta-skymiles-worth/
+  - year: 2026
+    source: WalletHub
+    cpp: 1.14
+    url: https://wallethub.com/delta-miles-value-calculator

--- a/data/valuations/southwest-rapid-rewards.yaml
+++ b/data/valuations/southwest-rapid-rewards.yaml
@@ -1,0 +1,53 @@
+slug: southwest-rapid-rewards
+program: Southwest Rapid Rewards
+unit: point
+
+# Only directly cited values from each source's published page or article.
+# See data/valuations/README.md for instructions on adding a new data point.
+data_points:
+  - year: 2021
+    source: TPG
+    cpp: 1.50
+    url: https://thepointsguy.com/news/southwest-2021-devaluation/
+    # TPG's pre-2021-devaluation valuation cited in the devaluation article
+
+  - year: 2023
+    source: TPG
+    cpp: 1.40
+    url: https://thepointsguy.com/loyalty-programs/southwest-rapid-rewards-points-worth-less-in-2024/
+    # TPG cites "1.4 cents apiece" as their valuation prior to the Jan 2024 change
+  - year: 2023
+    source: NerdWallet
+    cpp: 1.50
+    url: https://www.nerdwallet.com/travel/news/southwest-points-worth-2025-devaluation
+    # NerdWallet article notes points "remained at 1.5 cents per point as of September 2023"
+
+  - year: 2024
+    source: TPG
+    cpp: 1.30
+    url: https://thepointsguy.com/loyalty-programs/southwest-rapid-rewards-points-worth-less-in-2024/
+    # Post-Jan-2024 TPG revision: "your points will soon be worth 1.3 cents each"
+
+  - year: 2025
+    source: TPG
+    cpp: 1.35
+    url: https://thepointsguy.com/loyalty-programs/monthly-valuations/
+    # TPG's August 2025 monthly valuation
+
+  - year: 2026
+    source: TPG
+    cpp: 1.30
+    url: https://thepointsguy.com/loyalty-programs/monthly-valuations/
+    # April 2026 valuation
+  - year: 2026
+    source: NerdWallet
+    cpp: 1.30
+    url: https://www.nerdwallet.com/travel/learn/how-much-are-my-southwest-rapid-rewards-points-worth
+  - year: 2026
+    source: Bankrate
+    cpp: 1.50
+    url: https://www.bankrate.com/credit-cards/travel/frequent-flyer-guide-southwest-rapid-rewards/
+  - year: 2026
+    source: Frequent Miler
+    cpp: 1.30
+    url: https://frequentmiler.com/how-much-are-southwest-rapid-rewards-points-worth/

--- a/data/valuations/united-mileageplus.yaml
+++ b/data/valuations/united-mileageplus.yaml
@@ -1,0 +1,86 @@
+slug: united-mileageplus
+program: United MileagePlus
+unit: mile
+
+# Only directly cited values from each source's published page or article.
+# See data/valuations/README.md for instructions on adding a new data point.
+data_points:
+  - year: 2023
+    source: TPG
+    cpp: 1.35
+    url: https://thepointsguy.com/loyalty-programs/monthly-valuations/
+  - year: 2023
+    source: NerdWallet
+    cpp: 1.20
+    url: https://www.nerdwallet.com/travel/learn/how-much-are-my-united-miles-worth
+  - year: 2023
+    source: Frequent Miler
+    cpp: 1.40
+    url: https://frequentmiler.com/reasonable-redemption-values-rrvs/
+  - year: 2023
+    source: One Mile at a Time
+    cpp: 1.30
+    url: https://onemileatatime.com/insights/united-mileageplus-miles-value/
+
+  - year: 2024
+    source: TPG
+    cpp: 1.40
+    url: https://thepointsguy.com/loyalty-programs/united-miles-high-valuation/
+  - year: 2024
+    source: NerdWallet
+    cpp: 1.20
+    url: https://www.nerdwallet.com/travel/learn/how-much-are-my-united-miles-worth
+  - year: 2024
+    source: Frequent Miler
+    cpp: 1.40
+    url: https://frequentmiler.com/reasonable-redemption-values-rrvs/
+  - year: 2024
+    source: Bankrate
+    cpp: 0.90
+    url: https://www.bankrate.com/credit-cards/travel/value-of-united-miles/
+
+  - year: 2025
+    source: TPG
+    cpp: 1.30
+    url: https://thepointsguy.com/loyalty-programs/monthly-valuations/
+  - year: 2025
+    source: NerdWallet
+    cpp: 1.20
+    url: https://www.nerdwallet.com/travel/learn/how-much-are-my-united-miles-worth
+  - year: 2025
+    source: Frequent Miler
+    cpp: 1.40
+    url: https://frequentmiler.com/reasonable-redemption-values-rrvs/
+  - year: 2025
+    source: Bankrate
+    cpp: 0.90
+    url: https://www.bankrate.com/credit-cards/travel/value-of-united-miles/
+  - year: 2025
+    source: One Mile at a Time
+    cpp: 1.10
+    url: https://onemileatatime.com/insights/united-mileageplus-miles-value/
+
+  - year: 2026
+    source: TPG
+    cpp: 1.35
+    url: https://thepointsguy.com/loyalty-programs/monthly-valuations/
+  - year: 2026
+    source: NerdWallet
+    cpp: 1.20
+    url: https://www.nerdwallet.com/travel/learn/how-much-are-my-united-miles-worth
+  - year: 2026
+    source: Frequent Miler
+    cpp: 1.40
+    url: https://frequentmiler.com/reasonable-redemption-values-rrvs/
+  - year: 2026
+    source: Bankrate
+    cpp: 0.90
+    url: https://www.bankrate.com/credit-cards/travel/value-of-united-miles/
+  - year: 2026
+    source: One Mile at a Time
+    cpp: 1.10
+    url: https://onemileatatime.com/insights/united-mileageplus-miles-value/
+  - year: 2026
+    source: WalletHub
+    cpp: 1.21
+    url: https://wallethub.com/answers/rp/united-miles-value-1000540-2140717652/


### PR DESCRIPTION
## Summary
- New purple breadcrumb bar on every `/tools/[slug]` page (matching `/card/[slug]` and `/profile`), with a "report issue" link that opens a prefilled GitHub issue for the tool.
- Multi-source valuation chart on the United, Delta, and Southwest converter pages: high/low/median trend across major published valuations, plus a per-source scatter — clicking any dot opens the source article.
- Valuation history now lives in `data/valuations/*.yaml`. Contributors can add a new TPG/NerdWallet/Frequent Miler/etc. citation via PR — see `data/valuations/README.md` for the schema.
- Calculator cpp updated to the 2026 multi-source median for the three programs: United 1.21¢/mile, Delta 1.20¢/mile, Southwest 1.30¢/point. This propagates through `lib/valuations.ts` to card SUB valuations across the rest of the site.

## Files of note
- `data/valuations/{united-mileageplus,delta-skymiles,southwest-rapid-rewards}.yaml` — initial seeded data, all directly cited
- `apps/web-next/src/components/tools/ValuationChart.tsx` — generic Highcharts component (arearange + median line + scatter)
- `apps/web-next/src/components/tools/ToolBreadcrumb.tsx` — shared breadcrumb bar
- `apps/web-next/src/lib/valuationData.ts` — server-side YAML loader

## Test plan
- [ ] /tools/united-miles-to-usd renders chart with 4 years of data, calc shows 1.21¢/mile
- [ ] /tools/delta-skymiles-to-usd renders chart, calc shows 1.20¢/mile
- [ ] /tools/southwest-rapid-rewards-to-usd renders chart, calc shows 1.30¢/point
- [ ] All 12 `/tools/[slug]` pages show the purple breadcrumb with "Tools / [Name]" and a "report issue" link
- [ ] Clicking "report issue" opens a prefilled GitHub issue
- [ ] Clicking a gray dot in any chart opens the source URL in a new tab
- [ ] Tool pages list at /tools shows the updated cpp values

🤖 Generated with [Claude Code](https://claude.com/claude-code)