### PR TITLE
referrals: fix /profile hiding referrals on cards without card_referral_link

### DIFF
--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -26,115 +26,67 @@ exports.UserReferralsHandler = async (event) => {
       break;
     case "GET":
       try {
-        // Run stored procedure query
-        let results = await mysql.query(
-          "call creditodds.all_card_referrals(?)",
-          [event.requestContext.authorizer.sub]
+        const userId = event.requestContext.authorizer.sub;
+
+        // Inline replacement for the legacy `creditodds.all_card_referrals` stored procedure.
+        // Source-controlling the query here makes it grep-able and removes a hidden filter
+        // that was hiding some users' approved referrals (the procedure required a join the
+        // user's wallet/records still satisfied at submit time but might not now).
+        // The client only reads response[0] (submitted), so we no longer compute the
+        // "open eligible cards" list — that's already derived client-side from records + wallet.
+        const submittedRaw = await mysql.query(
+          `SELECT
+             r.referral_id, r.card_id, r.referral_link, r.admin_approved,
+             r.submit_datetime, r.archived_at, r.archived_reason,
+             c.card_name, c.card_image_link, c.card_referral_link
+           FROM referrals r
+           JOIN cards c ON r.card_id = c.card_id
+           WHERE r.submitter_id = ?
+           ORDER BY r.submit_datetime DESC`,
+          [userId]
         );
-        results = JSON.parse(JSON.stringify(results[0]));
+        const submitted = JSON.parse(JSON.stringify(submittedRaw));
 
-        //Splits response into already submitted referrals and cards user hasn't submitted referrals for (open)
-        const submitted = results.filter(function (element) {
-          return element.referral_link != null;
-        });
-        const open = results.filter(function (element) {
-          return element.referral_link == null;
-        });
-
-        // Get impression/click counts, card_referral_link, and archived status for submitted referrals
+        // Stats join, only if there's anything to look up
         if (submitted.length > 0) {
-          const referralIds = submitted.map(r => r.referral_id).filter(id => id);
-          const cardIds = submitted.map(r => r.card_id).filter(id => id);
+          const referralIds = submitted.map(r => r.referral_id);
+          const statsResults = await mysql.query(
+            `SELECT
+               referral_id,
+               SUM(CASE WHEN event_type = 'impression' THEN 1 ELSE 0 END) as impressions,
+               SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks,
+               COUNT(DISTINCT CASE WHEN event_type = 'click'
+                 THEN COALESCE(user_id, ip_hash) END) as unique_clicks
+             FROM referral_stats
+             WHERE referral_id IN (?)
+             GROUP BY referral_id`,
+            [referralIds]
+          );
 
-          // Fetch stats, card referral links, and archived status in parallel
-          const [statsResults, cardResults, archivedResults] = await Promise.all([
-            referralIds.length > 0 ? mysql.query(`
-              SELECT
-                referral_id,
-                SUM(CASE WHEN event_type = 'impression' THEN 1 ELSE 0 END) as impressions,
-                SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) as clicks,
-                COUNT(DISTINCT CASE WHEN event_type = 'click'
-                  THEN COALESCE(user_id, ip_hash) END) as unique_clicks
-              FROM referral_stats
-              WHERE referral_id IN (?)
-              GROUP BY referral_id
-            `, [referralIds]) : [],
-            cardIds.length > 0 ? mysql.query(`
-              SELECT card_id, card_referral_link
-              FROM cards
-              WHERE card_id IN (?)
-            `, [cardIds]) : [],
-            referralIds.length > 0 ? mysql.query(`
-              SELECT referral_id, archived_at, archived_reason
-              FROM referrals
-              WHERE referral_id IN (?)
-            `, [referralIds]) : []
-          ]);
-
-          // Create a map of stats by referral_id
           const statsMap = {};
           for (const stat of statsResults) {
             statsMap[stat.referral_id] = {
               impressions: stat.impressions || 0,
               clicks: stat.clicks || 0,
-              unique_clicks: stat.unique_clicks || 0
+              unique_clicks: stat.unique_clicks || 0,
             };
           }
-
-          // Create a map of card_referral_link by card_id
-          const cardLinkMap = {};
-          for (const card of cardResults) {
-            cardLinkMap[card.card_id] = card.card_referral_link;
-          }
-
-          // Create maps of archived_at and archived_reason by referral_id
-          const archivedMap = {};
-          const archivedReasonMap = {};
-          for (const row of archivedResults) {
-            archivedMap[row.referral_id] = row.archived_at;
-            archivedReasonMap[row.referral_id] = row.archived_reason;
-          }
-
-          // Add stats, card_referral_link, and archived_at to submitted referrals
           for (const referral of submitted) {
             const stats = statsMap[referral.referral_id] || { impressions: 0, clicks: 0, unique_clicks: 0 };
             referral.impressions = stats.impressions;
             referral.clicks = stats.clicks;
             referral.unique_clicks = stats.unique_clicks;
-            referral.card_referral_link = cardLinkMap[referral.card_id] || null;
-            referral.archived_at = archivedMap[referral.referral_id] || null;
-            referral.archived_reason = archivedReasonMap[referral.referral_id] || null;
           }
         }
 
-        // Also include cards with only archived referrals in the "open" list
-        const archivedCardIds = new Set(
-          submitted.filter(r => r.archived_at).map(r => r.card_id)
-        );
-        const activeCardIds = new Set(
-          submitted.filter(r => !r.archived_at).map(r => r.card_id)
-        );
-        // Cards that only have archived referrals (no active one) should appear in open
-        for (const cardId of archivedCardIds) {
-          if (!activeCardIds.has(cardId)) {
-            const archivedRef = submitted.find(r => r.card_id === cardId && r.archived_at);
-            if (archivedRef && !open.some(o => o.card_id === cardId)) {
-              open.push({
-                card_id: archivedRef.card_id,
-                card_name: archivedRef.card_name,
-                card_image_link: archivedRef.card_image_link,
-              });
-            }
-          }
-        }
-
-        // Run clean up function
         await mysql.end();
 
+        // Response shape kept as [submitted, open] for backwards compatibility with the
+        // existing client; open is always [] now since the client computes it itself.
         response = {
           statusCode: 200,
           headers: responseHeaders,
-          body: JSON.stringify([submitted, open]),
+          body: JSON.stringify([submitted, []]),
         };
       } catch (error) {
         response = {


### PR DESCRIPTION
## Summary
Fixes user report: an approved Marriott Bonvoy Boundless referral was visible on the card page and in admin, but missing from the user's own /profile.

## Root cause
Inspected the legacy stored procedure \`creditodds.all_card_referrals\` (not in source control; queried via \`SHOW CREATE PROCEDURE\`):

\`\`\`sql
SELECT
    c.card_id, c.card_name, c.card_image_link, c.card_referral_link,
    r.referral_link, r.referral_id, r.admin_approved
FROM cards c
LEFT JOIN referrals r ON c.card_id = r.card_id AND r.submitter_id = _id
WHERE c.card_referral_link IS NOT NULL;
\`\`\`

Starting from \`cards\` (LEFT JOIN to referrals) and filtering by \`c.card_referral_link IS NOT NULL\` means: **any card whose row in \`cards\` has no \`card_referral_link\` set silently drops the user's submitted row** — even if it's approved and being shown on the public card page. Marriott Bonvoy Boundless has no \`card_referral_link\`, so the user's referral was being filtered out at the procedure level.

\`card-by-id.js\` and \`admin.js\` both query the \`referrals\` table directly with no card-side filter, which is why those paths found the row fine. Only \`/profile\` was broken.

## Fix
Replace the procedure call with an inline query: \`FROM referrals r JOIN cards c ON r.card_id = c.card_id WHERE r.submitter_id = ?\`. Anchored on referrals, no card-side filter. Same shape \`card-by-id.js\` and \`admin.js\` already use.

Also dropped the second array of "open eligible cards" — the client computes it itself from records + wallet via \`getEligibleReferralCards\`, so the procedure's LEFT JOIN was doing work nobody read. Response stays \`[submitted, []]\` for backwards compat with the existing client unpack at \`ProfileClient.tsx:236\`.

Bonus: handler is now grep-able and self-contained instead of calling a procedure that lives only in the database.

## Test plan
- [ ] Backend deploys cleanly (\`sam build && sam deploy\`)
- [ ] Affected user (zXOyHmGl7HStyAqEdLsgXLA5inS2) sees their Marriott Bonvoy Boundless referral on /profile after deploy
- [ ] Other users with referrals still see all of them
- [ ] Submitting a new referral still appears immediately (PR #1106 cache-bust still in place)
- [ ] \"Add a referral\" modal still shows eligible cards (computed client-side, unaffected)

## Follow-up (optional)
The stored procedure \`creditodds.all_card_referrals\` is now unused. We can drop it in a separate migration once we confirm nothing else calls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)