### PR TITLE
referrals: rebuild submit modal in v2 + revert misscoped no-fee filter

### DIFF
--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -714,6 +714,7 @@ export default function ProfileClient() {
         show={!!editingCard}
         card={editingCard}
         cardSlug={editingCard ? allCards.find(c => c.card_name === editingCard.card_name)?.slug : undefined}
+        annualFee={editingCard ? (cardLookups.byName.get(editingCard.card_name)?.annual_fee ?? 0) : 0}
         onClose={() => setEditingCard(null)}
         onSuccess={loadData}
       />
@@ -872,7 +873,7 @@ function CardsTab(props: CardsTabProps) {
                         <DocumentTextIcon style={{ width: 11, height: 11 }} />
                       </span>
                     )}
-                    {fee > 0 && hasReferral && (
+                    {hasReferral && (
                       <span className="cj-cw-mark" title="referral active" aria-label="referral active">
                         <LinkIcon style={{ width: 11, height: 11 }} />
                       </span>
@@ -915,12 +916,12 @@ function CardsTab(props: CardsTabProps) {
                       </button>
                     )}
                     {hasRecord && <span className="cj-wd-done">✓ record submitted</span>}
-                    {fee > 0 && !hasReferral && (
+                    {!hasReferral && (
                       <button type="button" className="cj-wd-cta" onClick={onAddReferral}>
                         + add referral link
                       </button>
                     )}
-                    {fee > 0 && hasReferral && <span className="cj-wd-done">✓ referral link active</span>}
+                    {hasReferral && <span className="cj-wd-done">✓ referral link active</span>}
                   </div>
                 </div>
               )}

--- a/apps/web-next/src/app/profile/profileSelectors.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.ts
@@ -55,7 +55,6 @@ export function getEligibleReferralCards(
     if (excluded.has(w.card_name) || seen.has(w.card_name)) continue;
     seen.add(w.card_name);
     const card = lookups.byName.get(w.card_name);
-    if (!card?.annual_fee) continue;
     result.push({
       card_id: String(w.card_id),
       card_name: w.card_name,
@@ -68,7 +67,6 @@ export function getEligibleReferralCards(
     if (excluded.has(r.card_name) || seen.has(r.card_name)) continue;
     const card = lookups.byName.get(r.card_name);
     if (!card) continue;
-    if (!card.annual_fee) continue;
     const dbId = card.db_card_id ?? Number(card.card_id);
     if (!Number.isFinite(dbId)) continue;
     seen.add(r.card_name);

--- a/apps/web-next/src/components/forms/ReferralModal.tsx
+++ b/apps/web-next/src/components/forms/ReferralModal.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { useState } from "react";
-import { Dialog, DialogBackdrop, DialogPanel, DialogTitle, Listbox, ListboxButton, ListboxOption, ListboxOptions, Label } from "@headlessui/react";
+import { useState } from 'react';
+import { XMarkIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import CardImage from '@/components/ui/CardImage';
-import { LinkIcon, CheckIcon, ChevronUpDownIcon } from "@heroicons/react/24/outline";
-import { useFormik } from "formik";
-import * as Yup from "yup";
-import { useAuth } from "@/auth/AuthProvider";
-import { toast } from "react-toastify";
+import { useAuth } from '@/auth/AuthProvider';
+import { toast } from 'react-toastify';
 
 interface OpenReferral {
   card_id: string;
@@ -25,225 +22,222 @@ interface ReferralModalProps {
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
 
-function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(" ");
+function validateUrl(value: string): string | null {
+  if (!value) return 'Required';
+  if (value.length < 10) return 'Referral URL must be at least 10 characters';
+  if (value.length > 500) return 'Referral URL cannot be more than 500 characters';
+  if (!/^https?:\/\//.test(value)) return 'URL must start with https://';
+  return null;
 }
 
 export default function ReferralModal({ show, handleClose, openReferrals, onSuccess }: ReferralModalProps) {
   const { getToken } = useAuth();
-
-  const defaultCard: OpenReferral = {
-    card_id: "",
-    card_name: "Select a card...",
-    card_image_link: "",
-  };
-
-  const [selected, setSelected] = useState<OpenReferral>(defaultCard);
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<OpenReferral | null>(null);
+  const [referralLink, setReferralLink] = useState('');
+  const [touched, setTouched] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const formik = useFormik({
-    initialValues: {
-      referral_link: "",
-    },
-    validationSchema: Yup.object({
-      referral_link: Yup.string()
-        .min(10, "Referral URL must be at least 10 characters")
-        .max(500, "Referral URL cannot be more than 500 characters")
-        .matches(/^https?:\/\//, "URL must start with https://")
-        .required("Required"),
-    }),
-    onSubmit: async (values) => {
-      if (!selected.card_id) {
-        toast.error("Please select a card");
-        return;
-      }
+  const validationError = validateUrl(referralLink);
 
-      setSubmitting(true);
-      try {
-        const token = await getToken();
-        if (!token) {
-          throw new Error('Not authenticated');
-        }
-
-        const response = await fetch(`${API_BASE}/referrals`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            card_id: selected.card_id,
-            referral_link: values.referral_link,
-          }),
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(errorText || 'Failed to submit referral');
-        }
-
-        toast.success("Your referral was submitted!", {
-          position: "top-right",
-          autoClose: 5000,
-        });
-
-        formik.resetForm();
-        setSelected(defaultCard);
-        onSuccess();
-        handleClose();
-      } catch (error) {
-        console.error("Error submitting referral:", error);
-        toast.error(error instanceof Error ? error.message : "Failed to submit referral");
-      } finally {
-        setSubmitting(false);
-      }
-    },
+  const filtered = openReferrals.filter(card => {
+    if (!search) return true;
+    const s = search.toLowerCase();
+    return card.card_name.toLowerCase().includes(s);
   });
 
-  const handleModalClose = () => {
-    formik.resetForm();
-    setSelected(defaultCard);
+  const reset = () => {
+    setSearch('');
+    setSelected(null);
+    setReferralLink('');
+    setTouched(false);
+    setError(null);
+    setSubmitting(false);
+  };
+
+  const close = () => {
+    reset();
     handleClose();
   };
 
-  return (
-    <Dialog open={show} onClose={handleModalClose} className="relative z-10">
-      <DialogBackdrop className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+  const submit = async () => {
+    setTouched(true);
+    if (!selected || validationError) return;
 
-      <div className="fixed inset-0 z-10 overflow-y-auto">
-        <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-          <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-3xl sm:p-6">
-            <div>
-              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-indigo-100">
-                <LinkIcon className="h-6 w-6 text-indigo-600" aria-hidden="true" />
-              </div>
-              <div className="mt-3 text-center sm:mt-5">
-                <DialogTitle as="h3" className="text-lg font-medium leading-6 text-gray-900">
-                  Submit a referral
-                </DialogTitle>
-                <div className="mt-4">
-                  <Listbox value={selected} onChange={setSelected}>
-                    <Label className="block text-sm font-medium text-gray-700 text-left">
-                      Select card
-                    </Label>
-                    <div className="relative mt-1">
-                      <ListboxButton className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
-                        <span className="flex items-center">
-                          {selected.card_image_link && (
-                            <div className="h-8 w-12 flex-shrink-0 relative">
+    setSubmitting(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error('Not authenticated');
+
+      const response = await fetch(`${API_BASE}/referrals`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          card_id: selected.card_id,
+          referral_link: referralLink,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || 'Failed to submit referral');
+      }
+
+      toast.success('Your referral was submitted!', { position: 'top-right', autoClose: 5000 });
+      onSuccess();
+      close();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to submit referral';
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!show) return null;
+
+  return (
+    <div className="cj-modal-root" role="dialog" aria-modal="true">
+      <div className="cj-modal-backdrop" onClick={close} />
+      <div className="cj-modal-shell">
+        <div className="cj-modal-card" style={{ maxWidth: 520 }}>
+          <div className="cj-modal-head">
+            <span className="cj-status-dot" />
+            <span className="cj-modal-title">submit a referral link</span>
+            <button type="button" className="cj-modal-close" onClick={close} aria-label="Close">
+              <XMarkIcon style={{ width: 16, height: 16 }} />
+            </button>
+          </div>
+
+          <div className="cj-modal-body">
+            {error && <div className="cj-modal-error">{error}</div>}
+
+            {!selected ? (
+              <>
+                {openReferrals.length === 0 ? (
+                  <div className="cj-modal-section">
+                    <div className="cj-modal-list-empty">
+                      No eligible cards. Add a card with an annual fee to your wallet to submit a referral.
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="cj-modal-section">
+                      <label className="cj-modal-label">Search</label>
+                      <div className="cj-modal-search">
+                        <MagnifyingGlassIcon className="cj-modal-search-icon" />
+                        <input
+                          type="text"
+                          placeholder="card name…"
+                          value={search}
+                          onChange={(e) => setSearch(e.target.value)}
+                          className="cj-modal-search-input"
+                          autoFocus
+                        />
+                      </div>
+                    </div>
+
+                    <div className="cj-modal-section">
+                      <div className="cj-modal-list">
+                        {filtered.slice(0, 20).map((card) => (
+                          <button
+                            key={card.card_id}
+                            type="button"
+                            onClick={() => setSelected(card)}
+                            className="cj-modal-list-row"
+                          >
+                            <span className="cj-modal-thumb">
                               <CardImage
-                                cardImageLink={selected.card_image_link}
-                                alt=""
+                                cardImageLink={card.card_image_link}
+                                alt={card.card_name}
                                 fill
                                 className="object-contain"
-                                sizes="48px"
+                                sizes="56px"
                               />
+                            </span>
+                            <div style={{ minWidth: 0 }}>
+                              <div className="cj-modal-list-name">{card.card_name}</div>
                             </div>
-                          )}
-                          <span className="ml-3 block truncate">{selected.card_name}</span>
-                        </span>
-                        <span className="pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2">
-                          <ChevronUpDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
-                        </span>
-                      </ListboxButton>
-
-                      <ListboxOptions className="absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
-                        {openReferrals.map((card) => (
-                          <ListboxOption
-                            key={card.card_id}
-                            className={({ active }) =>
-                              classNames(
-                                active ? "bg-indigo-600 text-white" : "text-gray-900",
-                                "relative cursor-default select-none py-2 pl-3 pr-9"
-                              )
-                            }
-                            value={card}
-                          >
-                            {({ selected: isSelected, active }) => (
-                              <>
-                                <div className="flex items-center">
-                                  {card.card_image_link && (
-                                    <div className="h-8 w-12 flex-shrink-0 relative">
-                                      <CardImage
-                                        cardImageLink={card.card_image_link}
-                                        alt=""
-                                        fill
-                                        className="object-contain"
-                                        sizes="48px"
-                                      />
-                                    </div>
-                                  )}
-                                  <span
-                                    className={classNames(
-                                      isSelected ? "font-semibold" : "font-normal",
-                                      "ml-3 block truncate"
-                                    )}
-                                  >
-                                    {card.card_name}
-                                  </span>
-                                </div>
-                                {isSelected && (
-                                  <span
-                                    className={classNames(
-                                      active ? "text-white" : "text-indigo-600",
-                                      "absolute inset-y-0 right-0 flex items-center pr-4"
-                                    )}
-                                  >
-                                    <CheckIcon className="h-5 w-5" aria-hidden="true" />
-                                  </span>
-                                )}
-                              </>
-                            )}
-                          </ListboxOption>
+                          </button>
                         ))}
-                      </ListboxOptions>
+                        {filtered.length === 0 && (
+                          <div className="cj-modal-list-empty">no cards match</div>
+                        )}
+                      </div>
                     </div>
-                  </Listbox>
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                <div className="cj-modal-section">
+                  <div className="cj-modal-card-row">
+                    <span className="cj-modal-thumb">
+                      <CardImage
+                        cardImageLink={selected.card_image_link}
+                        alt={selected.card_name}
+                        fill
+                        className="object-contain"
+                        sizes="56px"
+                      />
+                    </span>
+                    <div style={{ minWidth: 0 }}>
+                      <div className="cj-modal-card-name">{selected.card_name}</div>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    className="cj-modal-back"
+                    onClick={() => { setSelected(null); setReferralLink(''); setTouched(false); }}
+                  >
+                    ← choose a different card
+                  </button>
                 </div>
-              </div>
-            </div>
 
-            <form onSubmit={formik.handleSubmit} className="mt-4">
-              <label htmlFor="referral_link" className="block text-sm font-medium text-gray-700 text-left">
-                Referral URL
-              </label>
-              <div className="mt-1">
-                <input
-                  type="text"
-                  name="referral_link"
-                  id="referral_link"
-                  className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                  placeholder={selected.card_id ? "Paste your full referral URL" : "Select a card first"}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
-                  value={formik.values.referral_link}
-                  disabled={!selected.card_id}
-                />
-              </div>
-              {formik.touched.referral_link && formik.errors.referral_link && (
-                <p className="mt-2 text-sm text-red-600">{formik.errors.referral_link}</p>
-              )}
+                <div className="cj-modal-section">
+                  <label className="cj-modal-label" htmlFor="referral_link">Referral URL</label>
+                  <input
+                    id="referral_link"
+                    type="url"
+                    inputMode="url"
+                    placeholder="https://…"
+                    value={referralLink}
+                    onChange={(e) => setReferralLink(e.target.value)}
+                    onBlur={() => setTouched(true)}
+                    className="cj-modal-input"
+                  />
+                  {touched && validationError && (
+                    <div style={{ marginTop: 6, fontSize: 11.5, color: 'var(--warn)' }}>{validationError}</div>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
 
-              <div className="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-                <button
-                  type="submit"
-                  disabled={submitting}
-                  className="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 sm:col-start-2 sm:text-sm"
-                >
-                  {submitting ? "Submitting..." : "Submit"}
-                </button>
+          {selected && (
+            <div className="cj-modal-footer">
+              <span style={{ fontSize: 11, color: 'var(--muted)' }}>{/* spacer */}</span>
+              <div className="cj-modal-actions">
+                <button type="button" className="cj-modal-btn" onClick={close}>cancel</button>
                 <button
                   type="button"
-                  className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:col-start-1 sm:mt-0 sm:text-sm"
-                  onClick={handleModalClose}
+                  className="cj-modal-btn cj-modal-btn-primary"
+                  onClick={submit}
+                  disabled={submitting || !!validationError}
                 >
-                  Cancel
+                  {submitting ? 'submitting…' : 'submit'}
                 </button>
               </div>
-            </form>
-          </DialogPanel>
+            </div>
+          )}
         </div>
       </div>
-    </Dialog>
+    </div>
   );
 }

--- a/apps/web-next/src/components/forms/ReferralModal.tsx
+++ b/apps/web-next/src/components/forms/ReferralModal.tsx
@@ -123,7 +123,7 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
                 {openReferrals.length === 0 ? (
                   <div className="cj-modal-section">
                     <div className="cj-modal-list-empty">
-                      No eligible cards. Add a card with an annual fee to your wallet to submit a referral.
+                      No eligible cards. Add a card to your wallet or submit a record to submit a referral.
                     </div>
                   </div>
                 ) : (

--- a/apps/web-next/src/components/wallet/AddToWalletModal.tsx
+++ b/apps/web-next/src/components/wallet/AddToWalletModal.tsx
@@ -159,31 +159,33 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
                   </button>
                 </div>
 
-                <div className="cj-modal-section">
-                  <label className="cj-modal-label">When did you get this card? <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional)</span></label>
-                  <div className="cj-modal-grid">
-                    <select
-                      value={acquiredMonth || ''}
-                      onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
-                      className="cj-modal-select"
-                    >
-                      <option value="">Month</option>
-                      {months.map((m) => (
-                        <option key={m.value} value={m.value}>{m.label}</option>
-                      ))}
-                    </select>
-                    <select
-                      value={acquiredYear || ''}
-                      onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
-                      className="cj-modal-select"
-                    >
-                      <option value="">Year</option>
-                      {years.map((y) => (
-                        <option key={y} value={y}>{y}</option>
-                      ))}
-                    </select>
+                {(selectedCard.annual_fee ?? 0) > 0 && (
+                  <div className="cj-modal-section">
+                    <label className="cj-modal-label">When did you get this card? <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional — used to track renewals)</span></label>
+                    <div className="cj-modal-grid">
+                      <select
+                        value={acquiredMonth || ''}
+                        onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
+                        className="cj-modal-select"
+                      >
+                        <option value="">Month</option>
+                        {months.map((m) => (
+                          <option key={m.value} value={m.value}>{m.label}</option>
+                        ))}
+                      </select>
+                      <select
+                        value={acquiredYear || ''}
+                        onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
+                        className="cj-modal-select"
+                      >
+                        <option value="">Year</option>
+                        {years.map((y) => (
+                          <option key={y} value={y}>{y}</option>
+                        ))}
+                      </select>
+                    </div>
                   </div>
-                </div>
+                )}
               </>
             )}
           </div>

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -11,6 +11,7 @@ interface EditWalletCardModalProps {
   show: boolean;
   card: WalletCard | null;
   cardSlug?: string;
+  annualFee?: number;
   onClose: () => void;
   onSuccess: () => void;
 }
@@ -38,7 +39,7 @@ const months = [
   { value: 10, label: 'October' }, { value: 11, label: 'November' }, { value: 12, label: 'December' },
 ];
 
-export default function EditWalletCardModal({ show, card, cardSlug, onClose, onSuccess }: EditWalletCardModalProps) {
+export default function EditWalletCardModal({ show, card, cardSlug, annualFee, onClose, onSuccess }: EditWalletCardModalProps) {
   const { getToken } = useAuth();
   const [acquiredMonth, setAcquiredMonth] = useState<number | undefined>();
   const [acquiredYear, setAcquiredYear] = useState<number | undefined>();
@@ -192,31 +193,33 @@ export default function EditWalletCardModal({ show, card, cardSlug, onClose, onS
               </div>
             </div>
 
-            <div className="cj-modal-section">
-              <label className="cj-modal-label">When did you get this card?</label>
-              <div className="cj-modal-grid">
-                <select
-                  value={acquiredMonth || ''}
-                  onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
-                  className="cj-modal-select"
-                >
-                  <option value="">Month</option>
-                  {months.map((m) => (
-                    <option key={m.value} value={m.value}>{m.label}</option>
-                  ))}
-                </select>
-                <select
-                  value={acquiredYear || ''}
-                  onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
-                  className="cj-modal-select"
-                >
-                  <option value="">Year</option>
-                  {years.map((y) => (
-                    <option key={y} value={y}>{y}</option>
-                  ))}
-                </select>
+            {(annualFee ?? 0) > 0 && (
+              <div className="cj-modal-section">
+                <label className="cj-modal-label">When did you get this card? <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(used to track renewals)</span></label>
+                <div className="cj-modal-grid">
+                  <select
+                    value={acquiredMonth || ''}
+                    onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
+                    className="cj-modal-select"
+                  >
+                    <option value="">Month</option>
+                    {months.map((m) => (
+                      <option key={m.value} value={m.value}>{m.label}</option>
+                    ))}
+                  </select>
+                  <select
+                    value={acquiredYear || ''}
+                    onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
+                    className="cj-modal-select"
+                  >
+                    <option value="">Year</option>
+                    {years.map((y) => (
+                      <option key={y} value={y}>{y}</option>
+                    ))}
+                  </select>
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
           <div className="cj-modal-footer">


### PR DESCRIPTION
## Summary
Two related fixes to the referral flow on /profile:

### 1. Modal rebuild (v2 styling)
The submit-referral modal was the only profile-area modal still on the pre-v2 styling — rounded white card with an icon bubble, big indigo button, Headless UI Dialog. Two visible problems:

- **Tabs bleeding through the modal**: Headless UI's portal renders the dialog *outside* \`.landing-v2.profile-v2\`, so the v2 \`cj-modal-*\` z-50 backdrop styles couldn't apply, and the dialog sat at z-10 — below the cj-terminal tab strip.
- **Old look-and-feel**: rounded card, icon bubble, indigo branding — clashed with the rest of the redesigned profile.

Rebuilt to match the [AddToWalletModal](apps/web-next/src/components/wallet/AddToWalletModal.tsx) pattern: \`cj-modal-root\` + \`cj-modal-card\`, search field + filtered list, two-step flow (pick card → enter URL), inline validation, \`cj-modal-btn\` footer. Dropped Headless UI Dialog (no portal) and formik/yup (single field, four rules — \`validateUrl\` helper is enough).

### 2. Revert PR #1099's referral filter; apply to renewal pickers instead
PR #1099 hid the referral UI for no-fee wallet cards, but the actual intent was to hide the **renewal date picker** for no-fee cards (no-fee cards don't have annual fee renewals to track, so asking when you got the card is meaningless). The referral filter was misscoped collateral.

- \`profileSelectors.getEligibleReferralCards\`: drop \`!annual_fee\` exclusions for both wallet and records loops. All wallet/record cards are eligible for referrals again.
- \`ProfileClient.CardsTab\`: drop \`fee>0\` gating from the referral chip, the "+ add referral link" CTA, and the "✓ referral link active" badge in the wallet detail row.
- \`AddToWalletModal\`: hide the "When did you get this card?" month/year pickers when the selected card has \`annual_fee === 0\`. Label clarified to "(optional — used to track renewals)".
- \`EditWalletCardModal\`: same treatment via a new \`annualFee\` prop passed from \`ProfileClient\`.

Existing referrals on no-fee cards (legacy Blue Cash Everyday, etc.) continue to display normally — no migration needed.

## Test plan
- [ ] Profile → Referrals → "+ add a referral" opens the v2 modal (purple bordered, no tab bleed-through)
- [ ] Searching narrows the card list
- [ ] All wallet cards (including no-fee) appear in the dropdown
- [ ] Submitting a valid URL adds the referral and closes the modal
- [ ] Profile → Cards: a no-fee card now shows the "+ add referral link" CTA again
- [ ] AddToWalletModal: pick a no-fee card → no month/year pickers shown
- [ ] AddToWalletModal: pick a fee card → month/year pickers visible
- [ ] EditWalletCardModal: opening a no-fee wallet card hides the month/year pickers
- [ ] EditWalletCardModal: opening a fee wallet card still shows them

🤖 Generated with [Claude Code](https://claude.com/claude-code)