### PR TITLE
wallet: show acquired date input for all cards, not just annual-fee cards

### DIFF
--- a/apps/web-next/src/components/wallet/AddToWalletModal.tsx
+++ b/apps/web-next/src/components/wallet/AddToWalletModal.tsx
@@ -159,33 +159,31 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
                   </button>
                 </div>
 
-                {(selectedCard.annual_fee ?? 0) > 0 && (
-                  <div className="cj-modal-section">
-                    <label className="cj-modal-label">When did you get this card? <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional — used to track renewals)</span></label>
-                    <div className="cj-modal-grid">
-                      <select
-                        value={acquiredMonth || ''}
-                        onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
-                        className="cj-modal-select"
-                      >
-                        <option value="">Month</option>
-                        {months.map((m) => (
-                          <option key={m.value} value={m.value}>{m.label}</option>
-                        ))}
-                      </select>
-                      <select
-                        value={acquiredYear || ''}
-                        onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
-                        className="cj-modal-select"
-                      >
-                        <option value="">Year</option>
-                        {years.map((y) => (
-                          <option key={y} value={y}>{y}</option>
-                        ))}
-                      </select>
-                    </div>
+                <div className="cj-modal-section">
+                  <label className="cj-modal-label">When did you get this card? <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional)</span></label>
+                  <div className="cj-modal-grid">
+                    <select
+                      value={acquiredMonth || ''}
+                      onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
+                      className="cj-modal-select"
+                    >
+                      <option value="">Month</option>
+                      {months.map((m) => (
+                        <option key={m.value} value={m.value}>{m.label}</option>
+                      ))}
+                    </select>
+                    <select
+                      value={acquiredYear || ''}
+                      onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
+                      className="cj-modal-select"
+                    >
+                      <option value="">Year</option>
+                      {years.map((y) => (
+                        <option key={y} value={y}>{y}</option>
+                      ))}
+                    </select>
                   </div>
-                )}
+                </div>
               </>
             )}
           </div>

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -193,33 +193,31 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, o
               </div>
             </div>
 
-            {(annualFee ?? 0) > 0 && (
-              <div className="cj-modal-section">
-                <label className="cj-modal-label">When did you get this card? <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(used to track renewals)</span></label>
-                <div className="cj-modal-grid">
-                  <select
-                    value={acquiredMonth || ''}
-                    onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
-                    className="cj-modal-select"
-                  >
-                    <option value="">Month</option>
-                    {months.map((m) => (
-                      <option key={m.value} value={m.value}>{m.label}</option>
-                    ))}
-                  </select>
-                  <select
-                    value={acquiredYear || ''}
-                    onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
-                    className="cj-modal-select"
-                  >
-                    <option value="">Year</option>
-                    {years.map((y) => (
-                      <option key={y} value={y}>{y}</option>
-                    ))}
-                  </select>
-                </div>
+            <div className="cj-modal-section">
+              <label className="cj-modal-label">When did you get this card? <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional)</span></label>
+              <div className="cj-modal-grid">
+                <select
+                  value={acquiredMonth || ''}
+                  onChange={(e) => setAcquiredMonth(e.target.value ? Number(e.target.value) : undefined)}
+                  className="cj-modal-select"
+                >
+                  <option value="">Month</option>
+                  {months.map((m) => (
+                    <option key={m.value} value={m.value}>{m.label}</option>
+                  ))}
+                </select>
+                <select
+                  value={acquiredYear || ''}
+                  onChange={(e) => setAcquiredYear(e.target.value ? Number(e.target.value) : undefined)}
+                  className="cj-modal-select"
+                >
+                  <option value="">Year</option>
+                  {years.map((y) => (
+                    <option key={y} value={y}>{y}</option>
+                  ))}
+                </select>
               </div>
-            )}
+            </div>
           </div>
 
           <div className="cj-modal-footer">


### PR DESCRIPTION
## Summary
- Remove the `annual_fee > 0` gate around the "When did you get this card?" date input in both wallet modals (Edit + Add). The backend already accepts `acquired_month` / `acquired_year` for any card.
- Soften helper text from "(used to track renewals)" to just "(optional)" since the field now applies to fee-free cards too (useful for SUB windows, 5/24 tracking, general history).

## Test plan
- [x] Confirmed via dev preview: with `annualFee={0}`, the EditWalletCardModal renders the "When did you get this card? (optional)" label and both Month + Year selects.
- [ ] Sanity check: open a no-fee card from the profile/wallet, verify date inputs appear and save round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)