### PR TITLE
profile: add 'Report an issue' link to Wallet-wide rankings

### DIFF
--- a/apps/web-next/src/components/wallet/BestCardByCategory.tsx
+++ b/apps/web-next/src/components/wallet/BestCardByCategory.tsx
@@ -135,6 +135,31 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
     return results;
   }, [walletCards, allCards]);
 
+  const reportUrl = `https://github.com/CreditOdds/creditodds/issues/new?${new URLSearchParams({
+    title: 'Wallet-wide rankings: issue report',
+    labels: 'feedback,wallet-wide-rankings',
+    body: [
+      '**Feature:** Wallet-wide rankings (Best card by category)',
+      '**Page:** https://creditodds.com/profile (Rewards tab)',
+      `**Wallet size:** ${walletCards.length} card${walletCards.length === 1 ? '' : 's'}`,
+      `**Categories shown:** ${categoryBests.length}`,
+      '',
+      '### Issue type',
+      "<!-- delete the ones that don't apply -->",
+      '- Wrong card picked for a category',
+      '- Missing category',
+      '- Wrong earn rate / USD value',
+      '- Other bug',
+      '- Suggestion',
+      '',
+      '### Which category is affected?',
+      '',
+      '',
+      '### What did you expect to see vs. what was shown?',
+      '',
+    ].join('\n'),
+  }).toString()}`;
+
   if (categoryBests.length === 0) {
     return (
       <div className="cj-verdict">
@@ -145,8 +170,18 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
 
   return (
     <section className="cj-section">
-      <div className="cj-table-label">
-        Derived from rewards on the cards you hold. When the top earner is brand- or merchant-restricted, an unrestricted alternative is shown below it.
+      <div className="cj-table-label" style={{ display: 'flex', alignItems: 'flex-start', gap: 12, justifyContent: 'space-between', flexWrap: 'wrap' }}>
+        <span style={{ flex: '1 1 320px', minWidth: 0 }}>
+          Derived from rewards on the cards you hold. When the top earner is brand- or merchant-restricted, an unrestricted alternative is shown below it.
+        </span>
+        <a
+          href={reportUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'var(--accent)', textDecoration: 'none', whiteSpace: 'nowrap', fontWeight: 600 }}
+        >
+          Report an issue →
+        </a>
       </div>
       <table className="cj-table">
         <thead>


### PR DESCRIPTION
## Summary
- Adds a "Report an issue →" link in the top-right of the Wallet-wide rankings section on `/profile` (Rewards tab).
- Opens a pre-filled GitHub issue with wallet size, category count, an issue-type checklist (wrong card / missing category / wrong rate / etc.), and prompts for the affected category + expected vs. actual.
- Mirrors the existing "send feedback" pattern on the Best Card Here component.

## Test plan
- [ ] On `/profile`, switch to the Rewards tab and confirm the link renders top-right of the rankings table label.
- [ ] Click it and verify the GitHub issue page opens with title, labels, and body templated with the current wallet size and category count.
- [ ] Empty wallet: confirm no link renders (early return on `categoryBests.length === 0` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)