### PR TITLE
profile: preload user rating with wallet to fix edit-modal flash

### DIFF
--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -34,7 +34,8 @@ exports.UserWalletHandler = async (event) => {
   try {
     switch (event.httpMethod) {
       case "GET":
-        // Get all cards in user's wallet with card details
+        // Get all cards in user's wallet with card details + the user's rating
+        // (preloaded so the edit modal doesn't flash an empty rating while fetching).
         const walletCards = await mysql.query(`
           SELECT
             uc.id,
@@ -44,9 +45,12 @@ exports.UserWalletHandler = async (event) => {
             uc.created_at,
             c.card_name,
             c.bank,
-            c.card_image_link
+            c.card_image_link,
+            cr.rating AS user_rating
           FROM user_cards uc
           JOIN cards c ON uc.card_id = c.card_id
+          LEFT JOIN card_ratings cr
+            ON cr.card_id = uc.card_id AND cr.user_id = uc.user_id
           WHERE uc.user_id = ?
           ORDER BY uc.created_at DESC
         `, [userId]);

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -58,13 +58,18 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, o
       setAcquiredMonth(card.acquired_month);
       setAcquiredYear(card.acquired_year);
       setError(null);
-      setUserRating(null);
-      (async () => {
-        const token = await getToken();
-        if (!token) return;
-        const rating = await getUserCardRating(card.card_name, token);
-        setUserRating(rating);
-      })();
+      const preloaded = card.user_rating;
+      setUserRating(preloaded ?? null);
+      // Fall back to a fetch only when the wallet payload didn't include the rating
+      // (e.g. older API deployments before user_rating was added to GET /wallet).
+      if (preloaded === undefined) {
+        (async () => {
+          const token = await getToken();
+          if (!token) return;
+          const rating = await getUserCardRating(card.card_name, token);
+          setUserRating(rating);
+        })();
+      }
     }
   }, [card, getToken]);
 

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -326,6 +326,7 @@ export interface WalletCard {
   acquired_month?: number;
   acquired_year?: number;
   created_at: string;
+  user_rating?: number | null;
 }
 
 export async function getWallet(token: string): Promise<WalletCard[]> {


### PR DESCRIPTION
## Summary
- \`GET /wallet\` now \`LEFT JOIN\`s \`card_ratings\` and returns \`user_rating\` per card
- \`EditWalletCardModal\` seeds rating state synchronously from \`card.user_rating\` so existing ratings appear instantly (no flash of "Rate this card")
- Frontend keeps the existing \`getUserCardRating\` fetch as a fallback when \`user_rating\` is \`undefined\`, so deploying frontend before backend is safe

## Test plan
- [ ] After backend deploy, open profile → edit a previously-rated wallet card → stars are filled immediately
- [ ] Edit a wallet card with no rating yet → label still reads "Rate this card"
- [ ] Submit a new rating → persists; reopening modal shows it preloaded next time

🤖 Generated with [Claude Code](https://claude.com/claude-code)