### PR TITLE
wallet: allow multiple instances of the same card

### DIFF
--- a/apps/api/migrations/027_drop_user_cards_unique_index.sql
+++ b/apps/api/migrations/027_drop_user_cards_unique_index.sql
@@ -1,0 +1,5 @@
+-- Allow multiple instances of the same card in a user's wallet (e.g. two Citi Custom Cash
+-- with different acquired dates, or a downgrade where the source card is also retained).
+-- Per-card identity is provided by user_cards.id (auto-increment PK); ratings remain
+-- one-per-(user_id, card_id) via card_ratings, which is the desired behavior.
+ALTER TABLE user_cards DROP INDEX unique_user_card;

--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -1,11 +1,35 @@
 // User Wallet API - Manage cards in user's wallet
+//
+// Routes:
+//   GET    /wallet         — list every card instance in the user's wallet
+//   POST   /wallet         — add a new instance (duplicates of the same card_id are allowed)
+//   PUT    /wallet/{id}    — update acquired_month / acquired_year on a specific instance
+//   DELETE /wallet/{id}    — remove a specific instance
+//
+// Per-card identity is `user_cards.id` (auto-increment). Ratings live in `card_ratings`
+// keyed by (user_id, card_id) — one rating per card type, shared across duplicates.
 const mysql = require("../db");
 
 const responseHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "Content-Type,Authorization",
-  "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+  "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
 };
+
+function validateAcquiredDate(acquired_month, acquired_year) {
+  if (acquired_month !== undefined && acquired_month !== null) {
+    if (acquired_month < 1 || acquired_month > 12) {
+      return "acquired_month must be between 1 and 12";
+    }
+  }
+  if (acquired_year !== undefined && acquired_year !== null) {
+    const currentYear = new Date().getFullYear();
+    if (acquired_year < 1950 || acquired_year > currentYear) {
+      return `acquired_year must be between 1950 and ${currentYear}`;
+    }
+  }
+  return null;
+}
 
 exports.UserWalletHandler = async (event) => {
   console.info("received:", event);
@@ -29,13 +53,14 @@ exports.UserWalletHandler = async (event) => {
     };
   }
 
+  const walletRowId = event.pathParameters?.id ? Number(event.pathParameters.id) : null;
   let response = {};
 
   try {
     switch (event.httpMethod) {
-      case "GET":
-        // Get all cards in user's wallet with card details + the user's rating
-        // (preloaded so the edit modal doesn't flash an empty rating while fetching).
+      case "GET": {
+        // Get all card instances in the user's wallet, with the shared
+        // (per-card-type) rating preloaded so the edit modal doesn't flash empty stars.
         const walletCards = await mysql.query(`
           SELECT
             uc.id,
@@ -52,7 +77,7 @@ exports.UserWalletHandler = async (event) => {
           LEFT JOIN card_ratings cr
             ON cr.card_id = uc.card_id AND cr.user_id = uc.user_id
           WHERE uc.user_id = ?
-          ORDER BY uc.created_at DESC
+          ORDER BY uc.created_at ASC, uc.id ASC
         `, [userId]);
         await mysql.end();
 
@@ -62,9 +87,11 @@ exports.UserWalletHandler = async (event) => {
           body: JSON.stringify(walletCards),
         };
         break;
+      }
 
-      case "POST":
-        // Add card to wallet
+      case "POST": {
+        // Add a new card instance to the wallet. Duplicates of the same card_id are allowed —
+        // each row has its own auto-increment `id`.
         const addBody = JSON.parse(event.body || "{}");
         const { card_id, acquired_month, acquired_year } = addBody;
 
@@ -77,32 +104,16 @@ exports.UserWalletHandler = async (event) => {
           break;
         }
 
-        // Validate month if provided
-        if (acquired_month !== undefined && acquired_month !== null) {
-          if (acquired_month < 1 || acquired_month > 12) {
-            response = {
-              statusCode: 400,
-              headers: responseHeaders,
-              body: JSON.stringify({ error: "acquired_month must be between 1 and 12" }),
-            };
-            break;
-          }
+        const dateError = validateAcquiredDate(acquired_month, acquired_year);
+        if (dateError) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: dateError }),
+          };
+          break;
         }
 
-        // Validate year if provided
-        if (acquired_year !== undefined && acquired_year !== null) {
-          const currentYear = new Date().getFullYear();
-          if (acquired_year < 1950 || acquired_year > currentYear) {
-            response = {
-              statusCode: 400,
-              headers: responseHeaders,
-              body: JSON.stringify({ error: `acquired_year must be between 1950 and ${currentYear}` }),
-            };
-            break;
-          }
-        }
-
-        // Check if card exists
         const cardExists = await mysql.query(
           "SELECT card_id FROM cards WHERE card_id = ?",
           [card_id]
@@ -117,13 +128,9 @@ exports.UserWalletHandler = async (event) => {
           break;
         }
 
-        // Insert or update (upsert) - if card already in wallet, update acquired date
-        await mysql.query(`
+        const insertResult = await mysql.query(`
           INSERT INTO user_cards (user_id, card_id, acquired_month, acquired_year)
           VALUES (?, ?, ?, ?)
-          ON DUPLICATE KEY UPDATE
-            acquired_month = VALUES(acquired_month),
-            acquired_year = VALUES(acquired_year)
         `, [userId, card_id, acquired_month || null, acquired_year || null]);
         await mysql.end();
 
@@ -132,30 +139,82 @@ exports.UserWalletHandler = async (event) => {
           headers: responseHeaders,
           body: JSON.stringify({
             message: "Card added to wallet",
+            id: insertResult.insertId,
             card_id,
             acquired_month: acquired_month || null,
-            acquired_year: acquired_year || null
+            acquired_year: acquired_year || null,
           }),
         };
         break;
+      }
 
-      case "DELETE":
-        // Remove card from wallet
-        const deleteBody = JSON.parse(event.body || "{}");
-        const cardIdToDelete = deleteBody.card_id;
-
-        if (!cardIdToDelete) {
+      case "PUT": {
+        // Update acquired_month / acquired_year on a specific wallet row.
+        if (!walletRowId || !Number.isFinite(walletRowId)) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "card_id is required" }),
+            body: JSON.stringify({ error: "wallet row id is required in path" }),
+          };
+          break;
+        }
+
+        const editBody = JSON.parse(event.body || "{}");
+        const { acquired_month, acquired_year } = editBody;
+
+        const dateError = validateAcquiredDate(acquired_month, acquired_year);
+        if (dateError) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: dateError }),
+          };
+          break;
+        }
+
+        const updateResult = await mysql.query(`
+          UPDATE user_cards
+          SET acquired_month = ?, acquired_year = ?
+          WHERE id = ? AND user_id = ?
+        `, [acquired_month || null, acquired_year || null, walletRowId, userId]);
+        await mysql.end();
+
+        if (updateResult.affectedRows === 0) {
+          response = {
+            statusCode: 404,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "Wallet card not found" }),
+          };
+        } else {
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({
+              message: "Wallet card updated",
+              id: walletRowId,
+              acquired_month: acquired_month || null,
+              acquired_year: acquired_year || null,
+            }),
+          };
+        }
+        break;
+      }
+
+      case "DELETE": {
+        // Remove a specific wallet row. Always keyed by row id so duplicates of
+        // the same card_id can be removed independently.
+        if (!walletRowId || !Number.isFinite(walletRowId)) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "wallet row id is required in path" }),
           };
           break;
         }
 
         const deleteResult = await mysql.query(
-          "DELETE FROM user_cards WHERE user_id = ? AND card_id = ?",
-          [userId, cardIdToDelete]
+          "DELETE FROM user_cards WHERE id = ? AND user_id = ?",
+          [walletRowId, userId]
         );
         await mysql.end();
 
@@ -163,7 +222,7 @@ exports.UserWalletHandler = async (event) => {
           response = {
             statusCode: 404,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "Card not found in wallet" }),
+            body: JSON.stringify({ error: "Wallet card not found" }),
           };
         } else {
           response = {
@@ -173,6 +232,7 @@ exports.UserWalletHandler = async (event) => {
           };
         }
         break;
+      }
 
       default:
         response = {

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -351,7 +351,7 @@ Resources:
             Method: PUT
             RestApiId:
               Ref: CreditCardOddsAPI
-        RemoveFromWallet:
+        RemoveFromWalletItem:
           Type: Api
           Properties:
             Path: /wallet/{id}

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -344,10 +344,17 @@ Resources:
             Method: POST
             RestApiId:
               Ref: CreditCardOddsAPI
+        UpdateWalletCard:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}
+            Method: PUT
+            RestApiId:
+              Ref: CreditCardOddsAPI
         RemoveFromWallet:
           Type: Api
           Properties:
-            Path: /wallet
+            Path: /wallet/{id}
             Method: DELETE
             RestApiId:
               Ref: CreditCardOddsAPI
@@ -355,6 +362,15 @@ Resources:
           Type: Api
           Properties:
             Path: /wallet
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+        WalletItemOptions:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}
             Method: OPTIONS
             RestApiId:
               Ref: CreditCardOddsAPI

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -17,10 +17,12 @@ import { TrashIcon, DocumentTextIcon, LinkIcon, ExclamationTriangleIcon, PencilI
 import { calculateApplicationRules, countCardsMissingDates } from "@/lib/applicationRules";
 import {
   createCardLookups,
+  dedupeWalletByCardName,
   getEligibleRecordCards,
   getEligibleReferralCards,
   getRelevantNews,
   getTotalAnnualFees,
+  getWalletDisplayNames,
   getWalletVisibility,
   isCardInactive,
 } from "./profileSelectors";
@@ -152,10 +154,14 @@ export default function ProfileClient() {
   );
 
   // Total annual credits from wallet card benefits (for the snapshot stat)
+  const walletDisplayNames = useMemo(() => getWalletDisplayNames(walletCards), [walletCards]);
+
   const annualCreditsTotals = useMemo(() => {
+    // Dedupe by card_name — duplicates of the same card don't double its credits.
+    const uniqueWalletCards = dedupeWalletByCardName(walletCards);
     let total = 0;
     let cardsWithCredits = 0;
-    for (const wc of walletCards) {
+    for (const wc of uniqueWalletCards) {
       const card = cardLookups.byName.get(wc.card_name);
       if (!card?.benefits?.length) continue;
       let cardTotal = 0;
@@ -183,7 +189,7 @@ export default function ProfileClient() {
       const days = daysUntil(renewal.sortKey);
       if (days < 0) continue;
       list.push({
-        name: wc.card_name,
+        name: walletDisplayNames.get(wc.id) ?? wc.card_name,
         renewal: renewal.display,
         fee,
         sortKey: renewal.sortKey,
@@ -193,7 +199,7 @@ export default function ProfileClient() {
     list.sort((a, b) => a.sortKey - b.sortKey);
     return list.slice(0, 3);
     // Intentionally re-uses isInactiveCard via cardLookups — eslint disable not needed
-  }, [walletCards, cardLookups]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [walletCards, cardLookups, walletDisplayNames]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const nextRenewal = upcomingRenewals[0];
 
@@ -459,6 +465,7 @@ export default function ProfileClient() {
                 walletLoaded={walletLoaded}
                 walletCards={walletCards}
                 visibleWalletCards={visibleWalletCards}
+                walletDisplayNames={walletDisplayNames}
                 inactiveCount={inactiveCount}
                 showArchived={showArchived}
                 setShowArchived={setShowArchived}
@@ -715,6 +722,7 @@ export default function ProfileClient() {
         card={editingCard}
         cardSlug={editingCard ? allCards.find(c => c.card_name === editingCard.card_name)?.slug : undefined}
         annualFee={editingCard ? (cardLookups.byName.get(editingCard.card_name)?.annual_fee ?? 0) : 0}
+        displayName={editingCard ? walletDisplayNames.get(editingCard.id) : undefined}
         onClose={() => setEditingCard(null)}
         onSuccess={loadData}
       />
@@ -777,6 +785,7 @@ interface CardsTabProps {
   walletLoaded: boolean;
   walletCards: WalletCard[];
   visibleWalletCards: WalletCard[];
+  walletDisplayNames: Map<number, string>;
   inactiveCount: number;
   showArchived: boolean;
   setShowArchived: (v: boolean) => void;
@@ -794,7 +803,7 @@ interface CardsTabProps {
 
 function CardsTab(props: CardsTabProps) {
   const {
-    walletLoaded, walletCards, visibleWalletCards, inactiveCount, showArchived, setShowArchived,
+    walletLoaded, walletCards, visibleWalletCards, walletDisplayNames, inactiveCount, showArchived, setShowArchived,
     openWalletId, setOpenWalletId, cardLookups, cardsWithRecords, cardsWithActiveReferrals,
     totalAnnualFees, onAdd, onEdit, onSubmitRecord, onAddReferral,
   } = props;
@@ -866,7 +875,7 @@ function CardsTab(props: CardsTabProps) {
                   <CardImage cardImageLink={c.card_image_link} alt={c.card_name} fill sizes="36px" className="object-contain" />
                 </span>
                 <div className="cj-cw-name">
-                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{c.card_name}</span>
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{walletDisplayNames.get(c.id) ?? c.card_name}</span>
                   <span className="cj-cw-marks">
                     {hasRecord && (
                       <span className="cj-cw-mark" title="record submitted" aria-label="record submitted">

--- a/apps/web-next/src/app/profile/profileSelectors.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.ts
@@ -114,8 +114,76 @@ export function isCardInactive(cardName: string, lookups: CardLookups) {
 }
 
 export function getEligibleRecordCards<T extends NamedCardRecord>(walletCards: WalletCard[], records: T[]) {
+  // Dedupe by card_name — records are keyed by card_name, so showing two copies of the
+  // same card in the picker would be confusing and the second pick would be a no-op.
   const cardsWithRecords = new Set(records.map((record) => record.card_name));
-  return walletCards.filter((walletCard) => !cardsWithRecords.has(walletCard.card_name));
+  const seen = new Set<string>();
+  const result: WalletCard[] = [];
+  for (const walletCard of walletCards) {
+    if (cardsWithRecords.has(walletCard.card_name)) continue;
+    if (seen.has(walletCard.card_name)) continue;
+    seen.add(walletCard.card_name);
+    result.push(walletCard);
+  }
+  return result;
+}
+
+/**
+ * Returns one wallet row per unique card_name. Used by consumers that aggregate by card
+ * type (benefits, best-card-by-category, best-card-here, referrals) — duplicates would
+ * double-count credits or pit a card against itself.
+ *
+ * Keeps the oldest instance (earliest acquired_year/month, then earliest created_at).
+ */
+export function dedupeWalletByCardName(walletCards: WalletCard[]): WalletCard[] {
+  const byName = new Map<string, WalletCard>();
+  for (const card of walletCards) {
+    const existing = byName.get(card.card_name);
+    if (!existing) {
+      byName.set(card.card_name, card);
+      continue;
+    }
+    if (compareWalletCardsByAge(card, existing) < 0) {
+      byName.set(card.card_name, card);
+    }
+  }
+  return Array.from(byName.values());
+}
+
+function compareWalletCardsByAge(a: WalletCard, b: WalletCard): number {
+  // Earlier first. Cards with no acquired date sort after dated cards.
+  const aDated = a.acquired_year ? a.acquired_year * 12 + (a.acquired_month ?? 0) : Infinity;
+  const bDated = b.acquired_year ? b.acquired_year * 12 + (b.acquired_month ?? 0) : Infinity;
+  if (aDated !== bDated) return aDated - bDated;
+  return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+}
+
+/**
+ * Map of wallet row id -> display name. When the user holds more than one of the same
+ * card type, instances get an "A", "B", "C"… suffix in chronological order. Single-copy
+ * cards keep the plain card_name.
+ */
+export function getWalletDisplayNames(walletCards: WalletCard[]): Map<number, string> {
+  const groups = new Map<string, WalletCard[]>();
+  for (const card of walletCards) {
+    const list = groups.get(card.card_name) ?? [];
+    list.push(card);
+    groups.set(card.card_name, list);
+  }
+
+  const display = new Map<number, string>();
+  for (const [name, list] of groups) {
+    if (list.length === 1) {
+      display.set(list[0].id, name);
+      continue;
+    }
+    const sorted = [...list].sort(compareWalletCardsByAge);
+    sorted.forEach((card, idx) => {
+      const suffix = String.fromCharCode(65 + idx); // A, B, C…
+      display.set(card.id, `${name} ${suffix}`);
+    });
+  }
+  return display;
 }
 
 // Tags relevant to existing cardholders (exclude signup bonus / new card news)

--- a/apps/web-next/src/components/wallet/AddToWalletModal.tsx
+++ b/apps/web-next/src/components/wallet/AddToWalletModal.tsx
@@ -45,9 +45,10 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
     }
   }, [show]);
 
+  const existingCardIdSet = new Set(existingCardIds);
+
   const filteredCards = cards.filter(card => {
     if (!card.db_card_id) return false;
-    if (existingCardIds.includes(card.db_card_id)) return false;
     if (!search) return true;
     const s = search.toLowerCase();
     return card.card_name.toLowerCase().includes(s) || card.bank.toLowerCase().includes(s);
@@ -115,22 +116,27 @@ export default function AddToWalletModal({ show, onClose, onSuccess, existingCar
 
                 <div className="cj-modal-section">
                   <div className="cj-modal-list">
-                    {filteredCards.slice(0, 20).map((card) => (
-                      <button
-                        key={card.card_id}
-                        type="button"
-                        onClick={() => setSelectedCard(card)}
-                        className="cj-modal-list-row"
-                      >
-                        <span className="cj-modal-thumb">
-                          <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="56px" />
-                        </span>
-                        <div style={{ minWidth: 0 }}>
-                          <div className="cj-modal-list-name">{card.card_name}</div>
-                          <div className="cj-modal-list-meta">{card.bank}</div>
-                        </div>
-                      </button>
-                    ))}
+                    {filteredCards.slice(0, 20).map((card) => {
+                      const alreadyHeld = card.db_card_id !== undefined && existingCardIdSet.has(card.db_card_id);
+                      return (
+                        <button
+                          key={card.card_id}
+                          type="button"
+                          onClick={() => setSelectedCard(card)}
+                          className="cj-modal-list-row"
+                        >
+                          <span className="cj-modal-thumb">
+                            <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="56px" />
+                          </span>
+                          <div style={{ minWidth: 0 }}>
+                            <div className="cj-modal-list-name">{card.card_name}</div>
+                            <div className="cj-modal-list-meta">
+                              {card.bank}{alreadyHeld ? ' · already in your wallet' : ''}
+                            </div>
+                          </div>
+                        </button>
+                      );
+                    })}
                     {filteredCards.length === 0 && (
                       <div className="cj-modal-list-empty">no cards match</div>
                     )}

--- a/apps/web-next/src/components/wallet/BestCardByCategory.tsx
+++ b/apps/web-next/src/components/wallet/BestCardByCategory.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
 import { Card, WalletCard, Reward } from '@/lib/api';
 import { categoryLabels, formatRewardWithUsdEquivalent, getRewardUsdRate } from '@/lib/cardDisplayUtils';
+import { dedupeWalletByCardName } from '@/app/profile/profileSelectors';
 
 const canonicalOrder = Object.keys(categoryLabels).filter(c => c !== 'everything_else');
 
@@ -49,7 +50,9 @@ export default function BestCardByCategory({ walletCards, allCards }: BestCardBy
   const categoryBests = useMemo<CategoryBest[]>(() => {
     if (walletCards.length === 0 || allCards.length === 0) return [];
 
-    const walletCardData = walletCards
+    // Dedupe by card_name — a card can't beat itself in a category ranking.
+    const uniqueWalletCards = dedupeWalletByCardName(walletCards);
+    const walletCardData = uniqueWalletCards
       .map(wc => allCards.find(c => c.card_name === wc.card_name))
       .filter((c): c is Card => c !== undefined && !!c.rewards && c.rewards.length > 0);
 

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
 import { XMarkIcon, TrashIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
-import { addToWallet, removeFromWallet, WalletCard, getUserCardRating, submitCardRating } from '@/lib/api';
+import { updateWalletCard, removeFromWallet, WalletCard, getUserCardRating, submitCardRating } from '@/lib/api';
 import { useAuth } from '@/auth/AuthProvider';
 
 interface EditWalletCardModalProps {
@@ -12,6 +12,9 @@ interface EditWalletCardModalProps {
   card: WalletCard | null;
   cardSlug?: string;
   annualFee?: number;
+  // Optional override for the display name when the user holds multiple of the same card
+  // (e.g. "Citi Custom Cash A" vs "Citi Custom Cash B"). Falls back to card.card_name.
+  displayName?: string;
   onClose: () => void;
   onSuccess: () => void;
 }
@@ -39,7 +42,7 @@ const months = [
   { value: 10, label: 'October' }, { value: 11, label: 'November' }, { value: 12, label: 'December' },
 ];
 
-export default function EditWalletCardModal({ show, card, cardSlug, annualFee, onClose, onSuccess }: EditWalletCardModalProps) {
+export default function EditWalletCardModal({ show, card, cardSlug, annualFee, displayName, onClose, onSuccess }: EditWalletCardModalProps) {
   const { getToken } = useAuth();
   const [acquiredMonth, setAcquiredMonth] = useState<number | undefined>();
   const [acquiredYear, setAcquiredYear] = useState<number | undefined>();
@@ -79,7 +82,8 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, o
     setError(null);
     try {
       const token = await getToken();
-      await addToWallet(card.card_id, acquiredMonth, acquiredYear, token || undefined);
+      if (!token) throw new Error('Authentication required');
+      await updateWalletCard(card.id, acquiredMonth, acquiredYear, token);
       onSuccess();
       onClose();
     } catch (err) {
@@ -91,13 +95,13 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, o
 
   const handleDelete = async () => {
     if (!card) return;
-    if (!confirm(`Remove "${card.card_name}" from your wallet?`)) return;
+    if (!confirm(`Remove "${displayName ?? card.card_name}" from your wallet?`)) return;
     setDeleting(true);
     setError(null);
     try {
       const token = await getToken();
       if (!token) throw new Error('Authentication required');
-      await removeFromWallet(card.card_id, token);
+      await removeFromWallet(card.id, token);
       onSuccess();
       onClose();
     } catch (err) {
@@ -158,7 +162,7 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, o
                   <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="56px" />
                 </span>
                 <div style={{ minWidth: 0 }}>
-                  <div className="cj-modal-card-name">{card.card_name}</div>
+                  <div className="cj-modal-card-name">{displayName ?? card.card_name}</div>
                   <div className="cj-modal-card-meta">
                     {card.bank}{acquiredLabel ? ` · ${acquiredLabel}` : ''}
                   </div>

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import CardImage from "@/components/ui/CardImage";
 import { Card, CardBenefit, WalletCard } from "@/lib/api";
 import { amortizedAnnualValue, cadenceLabel, formatBenefitValue, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
+import { dedupeWalletByCardName } from "@/app/profile/profileSelectors";
 
 interface CardWithBenefits {
   walletCard: WalletCard;
@@ -25,8 +26,10 @@ interface DecoratedBenefit extends CardBenefit {
 
 export default function WalletBenefits({ walletCards, allCards }: WalletBenefitsProps) {
   const cardsWithBenefits = useMemo(() => {
+    // Dedupe by card_name — holding two of the same card doesn't double its credits.
+    const uniqueWalletCards = dedupeWalletByCardName(walletCards);
     const result: CardWithBenefits[] = [];
-    for (const wc of walletCards) {
+    for (const wc of uniqueWalletCards) {
       const cardData = allCards.find(c => c.card_name === wc.card_name);
       if (cardData?.benefits && cardData.benefits.length > 0) {
         result.push({ walletCard: wc, cardData, benefits: cardData.benefits });

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -347,7 +347,7 @@ export async function addToWallet(
   acquiredMonth?: number,
   acquiredYear?: number,
   token?: string
-): Promise<{ message: string; card_id: number }> {
+): Promise<{ message: string; id: number; card_id: number }> {
   if (!token) throw new Error('Authentication required');
   const res = await fetch(`${API_BASE}/wallet`, {
     method: 'POST',
@@ -368,14 +368,36 @@ export async function addToWallet(
   return res.json();
 }
 
-export async function removeFromWallet(cardId: number, token: string): Promise<{ message: string }> {
-  const res = await fetch(`${API_BASE}/wallet`, {
-    method: 'DELETE',
+export async function updateWalletCard(
+  walletRowId: number,
+  acquiredMonth: number | undefined,
+  acquiredYear: number | undefined,
+  token: string
+): Promise<{ message: string; id: number }> {
+  const res = await fetch(`${API_BASE}/wallet/${walletRowId}`, {
+    method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ card_id: cardId }),
+    body: JSON.stringify({
+      acquired_month: acquiredMonth || null,
+      acquired_year: acquiredYear || null,
+    }),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to update wallet card: ${errorText}`);
+  }
+  return res.json();
+}
+
+export async function removeFromWallet(walletRowId: number, token: string): Promise<{ message: string }> {
+  const res = await fetch(`${API_BASE}/wallet/${walletRowId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   });
   if (!res.ok) {
     const errorText = await res.text().catch(() => 'Unknown error');


### PR DESCRIPTION
## Summary

- Drops the `user_cards (user_id, card_id)` unique index so users can hold multiple copies of the same card (e.g. two Citi Custom Cash with different acquired dates, or a downgrade where the source card is also retained).
- Backend: `POST /wallet` always inserts; new `PUT /wallet/{id}` edits acquired month/year; `DELETE` switches to `/wallet/{id}` so duplicates can be removed independently.
- Frontend: Cards tab + edit modal show "A"/"B"/"C" suffixes when the user holds duplicates (chronological by acquired date). Benefits, Best card by category, and the annual-credits stat dedupe by name so duplicates don't double-count credits or compete with themselves. Annual fees and 5/24-style application rules continue to count each instance.

Per-consumer rule sheet:
- **Dedupe by name:** WalletBenefits, BestCardByCategory, annual credits total, eligible referrals, eligible records, StorePersonalRow.
- **Count each instance:** total annual fees, application rules (5/24, 2/90, 1/6), upcoming renewals, missing-dates count.

Ratings stay one-per-(user_id, card_id) via `card_ratings` — instances share the same star rating, which matches the desired UX.

Out of scope (future work): per-instance "product change vs. new application" flag, migrate-this-card flow (Built MC → WF Autograph), per-instance nicknames.

## Deploy order

This needs all three steps in order — the frontend depends on the new `/wallet/{id}` routes, and the backend code's `INSERT` will start failing for users with existing duplicates the moment the migration runs.

1. `cd apps/api && sam build && sam deploy` — adds `PUT /wallet/{id}`, `DELETE /wallet/{id}`, OPTIONS preflight
2. Run migration `027_drop_user_cards_unique_index.sql` via the `RunMigrationHandler` workflow
3. Merge to main → Amplify auto-deploys the frontend

## Test plan

- [ ] After backend deploy + migration: add the same card twice in the Cards tab → both rows render with "A" / "B" suffixes
- [ ] Edit acquired date on instance A → instance B's date is unchanged
- [ ] Rate instance A → instance B reflects the same rating (shared per card type)
- [ ] Remove instance A → instance B remains
- [ ] WalletBenefits + BestCardByCategory only count the card once
- [ ] Total annual fees doubles when you hold two of an annual-fee card
- [ ] 5/24 / 2/90 / 1/6 rules count each instance as a separate application

🤖 Generated with [Claude Code](https://claude.com/claude-code)