### PR TITLE
social: post best rankings once per month

### DIFF
--- a/.github/workflows/post-best-rankings.yml
+++ b/.github/workflows/post-best-rankings.yml
@@ -2,9 +2,9 @@ name: Post Best Rankings
 
 on:
   schedule:
-    # Days 3-9 and 17-23 at 3pm UTC (10am ET) — one category per day,
-    # spaced 2 days after the best-pages refresh on 1st/15th
-    - cron: '0 15 3-9,17-23 * *'
+    # Days 3-9 at 3pm UTC (10am ET) — one category per day, once per month.
+    # Best-pages still refresh twice a month (1st/15th); we just post once.
+    - cron: '0 15 3-9 * *'
   workflow_dispatch:
     inputs:
       category:
@@ -33,12 +33,7 @@ jobs:
 
           if [ -z "$CATEGORY" ]; then
             DAY=$(date -u +%-d)
-
-            if [ "$DAY" -ge 17 ]; then
-              OFFSET=$((DAY - 17))
-            else
-              OFFSET=$((DAY - 3))
-            fi
+            OFFSET=$((DAY - 3))
 
             case $OFFSET in
               0) CATEGORY="best-travel-cards" ;;


### PR DESCRIPTION
## Summary
- Drop the second monthly posting window (days 17–23) from `post-best-rankings.yml` so each "best" category posts to social once per month instead of twice.
- Best-pages refresh cadence is unchanged — `refresh-best-pages.yml` still runs on the 1st and 15th. Only the social posting changes.
- Cron is now `0 15 3-9 * *` (days 3–9 only); the day-17 branch in the offset logic is removed.

## Test plan
- [ ] Confirm `Post Best Rankings` no longer fires on days 17–23 (next scheduled run is day 3 of next month)
- [ ] Manual `workflow_dispatch` with a `category` input still works
- [ ] Refresh-best-pages still runs twice a month on the 1st/15th

🤖 Generated with [Claude Code](https://claude.com/claude-code)