### PR TITLE
profile: hide archived cards from add-referral picker

### DIFF
--- a/apps/web-next/src/app/profile/profileSelectors.test.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createCardLookups,
   getEligibleRecordCards,
+  getEligibleReferralCards,
   getRelevantNews,
   getTotalAnnualFees,
   getWalletVisibility,
@@ -40,5 +41,23 @@ describe("profileSelectors", () => {
     ] as never, lookups);
 
     expect(relevantNews.map((item) => item.id)).toEqual(["1"]);
+  });
+
+  it("excludes archived/inactive cards from eligible referral list", () => {
+    const eligibleFromWallet = getEligibleReferralCards(
+      [],
+      walletCards as never,
+      [],
+      lookups
+    );
+    expect(eligibleFromWallet.map((c) => c.card_name)).toEqual(["Chase Sapphire Preferred"]);
+
+    const eligibleFromRecords = getEligibleReferralCards(
+      [{ card_name: "Old Card" }, { card_name: "Chase Sapphire Preferred" }] as never,
+      [],
+      [],
+      lookups
+    );
+    expect(eligibleFromRecords.map((c) => c.card_name)).toEqual(["Chase Sapphire Preferred"]);
   });
 });

--- a/apps/web-next/src/app/profile/profileSelectors.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.ts
@@ -53,8 +53,9 @@ export function getEligibleReferralCards(
 
   for (const w of walletCards) {
     if (excluded.has(w.card_name) || seen.has(w.card_name)) continue;
-    seen.add(w.card_name);
     const card = lookups.byName.get(w.card_name);
+    if (card?.active === false) continue;
+    seen.add(w.card_name);
     result.push({
       card_id: String(w.card_id),
       card_name: w.card_name,
@@ -67,6 +68,7 @@ export function getEligibleReferralCards(
     if (excluded.has(r.card_name) || seen.has(r.card_name)) continue;
     const card = lookups.byName.get(r.card_name);
     if (!card) continue;
+    if (card.active === false) continue;
     const dbId = card.db_card_id ?? Number(card.card_id);
     if (!Number.isFinite(dbId)) continue;
     seen.add(r.card_name);


### PR DESCRIPTION
## Summary
- Filter out cards where `card.active === false` from `getEligibleReferralCards` so archived/inactive cards no longer appear in the "+ add a referral" modal.
- Added unit test coverage for the new exclusion (both wallet- and records-derived candidates).

## Test plan
- [x] `npx vitest run src/app/profile/profileSelectors.test.ts` passes
- [ ] On `/profile` → Referrals → "+ add a referral", archived cards from wallet/records no longer show in the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)