### PR TITLE
profile: remove card count from desktop Wallet rail box

### DIFF
--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -627,9 +627,6 @@ export default function ProfileClient() {
         <aside className="cj-rail">
           <div className="cj-apply">
             <div className="cj-apply-k">Wallet</div>
-            <div className="cj-apply-v">
-              {walletCards.length} card{walletCards.length === 1 ? '' : 's'}
-            </div>
             <button type="button" className="cj-apply-btn" onClick={() => setShowWalletModal(true)}>
               + add a card
             </button>


### PR DESCRIPTION
## Summary
- Removes the `{n} card(s)` line from the purple Wallet box in the desktop profile rail, leaving the "Wallet" heading and the add-card / submit-record buttons.

## Test plan
- [ ] Visit `/profile` on desktop and confirm the Wallet rail box no longer shows the card count.