### PR TITLE
profile: raise new-user wallet modal above sticky navbar/tabs

### DIFF
--- a/apps/web-next/src/components/ui/DataPointPrompt.tsx
+++ b/apps/web-next/src/components/ui/DataPointPrompt.tsx
@@ -314,10 +314,10 @@ export default function DataPointPrompt() {
       )}
 
       {/* New user modal */}
-      <Dialog open={showModal} onClose={dismissModal} className="relative z-10">
+      <Dialog open={showModal} onClose={dismissModal} className="relative z-50">
         <DialogBackdrop className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
 
-        <div className="fixed inset-0 z-10 overflow-y-auto">
+        <div className="fixed inset-0 z-50 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-4">
             <DialogPanel className="relative transform overflow-hidden rounded-2xl bg-white px-6 pb-6 pt-8 text-center shadow-xl transition-all sm:max-w-sm w-full">
 


### PR DESCRIPTION
## Summary
- The "Add your first card!" Dialog rendered at `z-10`, but the sticky `Navbar` (`z-40`) and sticky profile tabs row (`.cj-main-tabs`, `z-20`) sat above it — so both bands punched through the gray backdrop instead of being dimmed (visible glitch on first login for new accounts).
- Bumped the `<Dialog>` and its inner scroll wrapper to `z-50`, matching the convention already used by `SubmitRecordModal` and `SubmitRecordCardPicker`.

## Test plan
- [ ] Log in with a fresh account (or `localStorage.removeItem('clippy_prompt_dismissed')` + reload `/profile`)
- [ ] Confirm the navbar and "01 Cards / 02 Earn / …" tab row are dimmed under the backdrop, not poking through
- [ ] Confirm "Let's go!" still advances to the card picker and "Maybe later" still dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)