### PR TITLE
profile: per-merchant report modal for Best Card Here

### DIFF
--- a/apps/api/migrations/028_create_best_card_here_reports.sql
+++ b/apps/api/migrations/028_create_best_card_here_reports.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS best_card_here_reports (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  user_id VARCHAR(128) NULL,
+  ip_hash CHAR(64) NULL,
+  reason ENUM('wrong_category','wrong_card','merchant_missing','other') NOT NULL,
+  notes VARCHAR(1000) NULL,
+  merchant_place_id VARCHAR(128) NULL,
+  merchant_name VARCHAR(255) NOT NULL,
+  merchant_address VARCHAR(500) NULL,
+  merchant_category VARCHAR(80) NULL,
+  merchant_distance VARCHAR(20) NULL,
+  recommended_card_id INT NULL,
+  recommended_card_name VARCHAR(255) NULL,
+  rate_label VARCHAR(40) NULL,
+  rate_context VARCHAR(160) NULL,
+  wallet_size INT NULL,
+  user_agent VARCHAR(500) NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_created_at (created_at),
+  INDEX idx_user_id (user_id),
+  INDEX idx_recommended_card_id (recommended_card_id),
+  INDEX idx_reason (reason)
+);

--- a/apps/api/src/handlers/best-card-here-report.js
+++ b/apps/api/src/handlers/best-card-here-report.js
@@ -1,0 +1,190 @@
+// User-submitted report against a Best Card Here merchant recommendation.
+// Replaces the old GitHub-issue feedback link so people without a GitHub
+// account can flag a wrong category / wrong card / missing merchant in
+// two taps. One row per submission; admins read directly from the DB.
+const mysql = require("../db");
+const { hashIp, getOptionalUserId } = require("../click-identity");
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+const VALID_REASONS = new Set([
+  "wrong_category",
+  "wrong_card",
+  "merchant_missing",
+  "other",
+]);
+
+const NOTES_MAX = 1000;
+
+// Self-heal: if migration 028 hasn't been applied yet, the table won't
+// exist and the first POST would 500. Mirror the DDL from
+// migrations/028_create_best_card_here_reports.sql.
+const ENSURE_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS best_card_here_reports (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id VARCHAR(128) NULL,
+    ip_hash CHAR(64) NULL,
+    reason ENUM('wrong_category','wrong_card','merchant_missing','other') NOT NULL,
+    notes VARCHAR(1000) NULL,
+    merchant_place_id VARCHAR(128) NULL,
+    merchant_name VARCHAR(255) NOT NULL,
+    merchant_address VARCHAR(500) NULL,
+    merchant_category VARCHAR(80) NULL,
+    merchant_distance VARCHAR(20) NULL,
+    recommended_card_id INT NULL,
+    recommended_card_name VARCHAR(255) NULL,
+    rate_label VARCHAR(40) NULL,
+    rate_context VARCHAR(160) NULL,
+    wallet_size INT NULL,
+    user_agent VARCHAR(500) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_created_at (created_at),
+    INDEX idx_user_id (user_id),
+    INDEX idx_recommended_card_id (recommended_card_id),
+    INDEX idx_reason (reason)
+  )
+`;
+
+let tableEnsured = false;
+async function ensureTable() {
+  if (tableEnsured) return;
+  await mysql.query(ENSURE_TABLE_SQL);
+  tableEnsured = true;
+}
+
+function trimOrNull(value, max) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.length > max ? trimmed.substring(0, max) : trimmed;
+}
+
+function asPositiveInt(value) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) return null;
+  return n;
+}
+
+function asNonNegativeInt(value) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
+exports.BestCardHereReportHandler = async (event) => {
+  console.info("received:", event);
+
+  let response = {};
+
+  switch (event.httpMethod) {
+    case "OPTIONS":
+      response = {
+        statusCode: 200,
+        headers: responseHeaders,
+        body: JSON.stringify({ statusText: "OK" }),
+      };
+      break;
+
+    case "POST":
+      try {
+        const body = JSON.parse(event.body || "{}");
+        const reason = body.reason;
+        const merchantName = trimOrNull(body.merchant_name, 255);
+
+        if (!VALID_REASONS.has(reason)) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({
+              error: "reason must be one of wrong_category, wrong_card, merchant_missing, other",
+            }),
+          };
+          break;
+        }
+
+        if (!merchantName) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "merchant_name is required" }),
+          };
+          break;
+        }
+
+        const userAgent = event.headers?.["User-Agent"] || event.headers?.["user-agent"] || "";
+        if (/bot|crawler|spider|scraper/i.test(userAgent)) {
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({ success: true }),
+          };
+          break;
+        }
+
+        const ip = event.requestContext?.identity?.sourceIp || null;
+        const ipHash = hashIp(ip);
+        const userId = await getOptionalUserId(event);
+
+        await ensureTable();
+        await mysql.query(
+          `INSERT INTO best_card_here_reports
+             (user_id, ip_hash, reason, notes,
+              merchant_place_id, merchant_name, merchant_address,
+              merchant_category, merchant_distance,
+              recommended_card_id, recommended_card_name,
+              rate_label, rate_context,
+              wallet_size, user_agent)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            userId,
+            ipHash,
+            reason,
+            trimOrNull(body.notes, NOTES_MAX),
+            trimOrNull(body.merchant_place_id, 128),
+            merchantName,
+            trimOrNull(body.merchant_address, 500),
+            trimOrNull(body.merchant_category, 80),
+            trimOrNull(body.merchant_distance, 20),
+            asPositiveInt(body.recommended_card_id),
+            trimOrNull(body.recommended_card_name, 255),
+            trimOrNull(body.rate_label, 40),
+            trimOrNull(body.rate_context, 160),
+            asNonNegativeInt(body.wallet_size),
+            userAgent ? userAgent.substring(0, 500) : null,
+          ]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ success: true }),
+        };
+      } catch (error) {
+        console.error("Error saving best-card-here report:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to save report" }),
+        };
+      }
+      break;
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: `BestCardHereReport only accepts POST and OPTIONS, you tried: ${event.httpMethod}`,
+      };
+      break;
+  }
+
+  console.info(`response from: ${event.path} statusCode: ${response.statusCode}`);
+  return response;
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -499,6 +499,42 @@ Resources:
             RestApiId:
               Ref: CreditCardOddsAPI
 
+  BestCardHereReportFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/best-card-here-report.BestCardHereReportHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Accept user reports about Best Card Here merchant matches
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+          IP_HASH_PEPPER: !Ref IpHashPepper
+          FIREBASE_PROJECT_ID: creditodds
+      Events:
+        SubmitReport:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /best-card-here-report
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        BestCardHereReportOptions:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /best-card-here-report
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+
   CardApplyClickFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -5607,6 +5607,92 @@
 }
 .landing-v2.profile-v2 .cj-modal-back:hover { color: var(--accent-deep); }
 
+/* ---------- Best Card Here · report-merchant modal ---------- */
+.landing-v2.profile-v2 .cj-bch-report-target {
+  padding: 10px 12px;
+  border: 1px dashed var(--line-2);
+  border-radius: 4px;
+  background: var(--paper-2);
+  font-size: 12px;
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+.landing-v2.profile-v2 .cj-bch-report-target b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.landing-v2.profile-v2 .cj-bch-report-reasons {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.landing-v2.profile-v2 .cj-bch-report-reason {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  cursor: pointer;
+  background: var(--paper);
+  font-size: 13px;
+  color: var(--ink);
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.landing-v2.profile-v2 .cj-bch-report-reason:hover {
+  border-color: color-mix(in oklab, var(--accent) 30%, var(--line-2));
+}
+.landing-v2.profile-v2 .cj-bch-report-reason.is-on {
+  border-color: var(--accent);
+  background: var(--accent-2);
+}
+.landing-v2.profile-v2 .cj-bch-report-reason input {
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+.landing-v2.profile-v2 .cj-bch-report-reason-copy {
+  line-height: 1.4;
+}
+.landing-v2.profile-v2 .cj-bch-report-reason-copy small {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  margin-top: 2px;
+}
+.landing-v2.profile-v2 .cj-bch-report-notes {
+  width: 100%;
+  padding: 10px;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  resize: vertical;
+  min-height: 72px;
+}
+.landing-v2.profile-v2 .cj-bch-report-notes:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-2);
+}
+.landing-v2.profile-v2 .cj-bch-report-trigger {
+  font-size: 11.5px;
+  color: var(--warn);
+  background: color-mix(in oklab, var(--warn) 4%, var(--paper));
+  border: 1px solid color-mix(in oklab, var(--warn) 30%, var(--line-2));
+  border-radius: 3px;
+  padding: 5px 9px;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  font-family: inherit;
+}
+.landing-v2.profile-v2 .cj-bch-report-trigger:hover {
+  background: color-mix(in oklab, var(--warn) 8%, var(--paper));
+  border-color: color-mix(in oklab, var(--warn) 50%, var(--line-2));
+}
+
 /* ---------- Long-form content (about / how / terms / privacy) ---------- */
 .landing-v2 .page-body {
   max-width: 720px;

--- a/apps/web-next/src/components/wallet/BestCardHere.tsx
+++ b/apps/web-next/src/components/wallet/BestCardHere.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useMemo, useState } from 'react';
 import CardImage from '@/components/ui/CardImage';
 import {
+  BestCardHereReportPayload,
   Card,
   NearbyPlace,
   StoreBrandIndexEntry,
@@ -12,6 +13,7 @@ import {
 } from '@/lib/api';
 import { useAuth } from '@/auth/AuthProvider';
 import { PlacePick, pickWalletCardsForPlace } from '@/lib/walletPicksForPlace';
+import ReportMerchantModal from '@/components/wallet/ReportMerchantModal';
 
 // Resolved merchant ready for rendering. `label` is brand name when the
 // place was matched to a Store entry (e.g. "marriott") so the user can
@@ -170,6 +172,8 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [merchants, setMerchants] = useState<Merchant[]>([]);
   const [openIdx, setOpenIdx] = useState<number | null>(null);
+  const [reportPayload, setReportPayload] =
+    useState<Omit<BestCardHereReportPayload, 'reason' | 'notes'> | null>(null);
 
   const cardsCount = walletCards.length;
 
@@ -254,28 +258,22 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
   // referential stability for the row keys.
   const merchantRows = useMemo(() => merchants, [merchants]);
 
-  const feedbackUrl = `https://github.com/CreditOdds/creditodds/issues/new?${new URLSearchParams({
-    title: 'Feedback: Best Card Here (Beta)',
-    labels: 'feedback,best-card-here',
-    body: [
-      '**Feature:** Best Card Here (Beta)',
-      `**Page:** https://creditodds.com/profile (Rewards tab)`,
-      `**Wallet size:** ${cardsCount} card${cardsCount === 1 ? '' : 's'}`,
-      ...(location ? [`**Last lookup:** ${merchants.length} merchant${merchants.length === 1 ? '' : 's'} returned`] : []),
-      '',
-      '### Feedback type',
-      '<!-- delete the ones that don\'t apply -->',
-      '- Bug',
-      '- Suggestion',
-      '- Praise',
-      '',
-      '### What happened or what would you like to see?',
-      '',
-      '',
-      '### Steps to reproduce (if a bug)',
-      '',
-    ].join('\n'),
-  }).toString()}`;
+  const buildReportPayload = (
+    merchant: Merchant,
+    pick: PlacePick,
+  ): Omit<BestCardHereReportPayload, 'reason' | 'notes'> => ({
+    merchant_place_id: merchant.id,
+    merchant_name: merchant.name,
+    merchant_address: merchant.addr || undefined,
+    merchant_category: merchant.label,
+    merchant_distance: merchant.dist,
+    recommended_card_id:
+      typeof pick.card.db_card_id === 'number' ? pick.card.db_card_id : undefined,
+    recommended_card_name: pick.card.card_name,
+    rate_label: pick.rateLabel,
+    rate_context: pick.context,
+    wallet_size: cardsCount,
+  });
 
   return (
     <div className="cj-bch-shell" style={{ paddingBottom: 8 }}>
@@ -293,15 +291,7 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
           Best card <em className="cj-section-accent">here.</em>
         </h2>
         <span className="cj-section-num" style={{ marginLeft: 'auto' }}>
-          pilot ·{' '}
-          <a
-            href={feedbackUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'var(--accent)', textDecoration: 'none' }}
-          >
-            send feedback →
-          </a>
+          pilot
         </span>
       </div>
       <p style={{
@@ -431,9 +421,16 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
                             borderRadius: 3, padding: '5px 9px', letterSpacing: '0.02em',
                           }}>see {best.card.card_name} rules →</a>
                         )}
-                        <a href="#" style={{
-                          fontSize: 11.5, color: 'var(--muted)', textDecoration: 'none', padding: '5px 4px',
-                        }}>not the right category? report</a>
+                        <button
+                          type="button"
+                          className="cj-bch-report-trigger"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setReportPayload(buildReportPayload(m, best));
+                          }}
+                        >
+                          report this match
+                        </button>
                       </div>
                     </div>
                   )}
@@ -445,11 +442,17 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
           <div className="cj-verdict" style={{ marginTop: 18 }}>
             <b>Pilot note.</b> Best-card matching is computed against the {cardsCount} card{cardsCount === 1 ? '' : 's'}
             {' '}currently in your wallet and each card&apos;s published earn rules. Quarterly rotating categories
-            (Freedom Flex, Discover) are not yet considered.{' '}
-            <a href="#" style={{ color: 'var(--accent)' }}>Tell us what&apos;s missing →</a>
+            (Freedom Flex, Discover) are not yet considered. Tap <em>report this match</em> on any merchant
+            if a category, card, or earn rate looks off.
           </div>
         </>
       )}
+
+      <ReportMerchantModal
+        show={reportPayload !== null}
+        onClose={() => setReportPayload(null)}
+        payload={reportPayload ?? { merchant_name: '' }}
+      />
     </div>
   );
 }

--- a/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
+++ b/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { XMarkIcon, CheckIcon } from '@heroicons/react/24/outline';
+import {
+  BestCardHereReportPayload,
+  BestCardHereReportReason,
+  submitBestCardHereReport,
+} from '@/lib/api';
+
+interface ReportMerchantModalProps {
+  show: boolean;
+  onClose: () => void;
+  payload: Omit<BestCardHereReportPayload, 'reason' | 'notes'>;
+}
+
+const REASONS: ReadonlyArray<{
+  value: BestCardHereReportReason;
+  label: string;
+  hint?: string;
+}> = [
+  { value: 'wrong_category', label: 'Wrong category for this merchant', hint: 'e.g. listed as dining but it should be grocery' },
+  { value: 'wrong_card', label: 'Wrong card recommended', hint: 'I have a better card in my wallet for this' },
+  { value: 'merchant_missing', label: "This merchant doesn't exist or is closed" },
+  { value: 'other', label: 'Something else' },
+];
+
+const NOTES_MAX = 1000;
+const THANKS_AUTOCLOSE_MS = 2000;
+
+export default function ReportMerchantModal({ show, onClose, payload }: ReportMerchantModalProps) {
+  const [reason, setReason] = useState<BestCardHereReportReason>('wrong_category');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!show) {
+      setReason('wrong_category');
+      setNotes('');
+      setSubmitting(false);
+      setError(null);
+      setSubmitted(false);
+    }
+  }, [show]);
+
+  useEffect(() => {
+    if (!submitted) return;
+    const t = setTimeout(onClose, THANKS_AUTOCLOSE_MS);
+    return () => clearTimeout(t);
+  }, [submitted, onClose]);
+
+  if (!show) return null;
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submitBestCardHereReport({
+        ...payload,
+        reason,
+        notes: notes.trim() || undefined,
+      });
+      setSubmitted(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to submit report');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="cj-modal-root" role="dialog" aria-modal="true">
+      <div className="cj-modal-backdrop" onClick={submitting ? undefined : onClose} />
+      <div className="cj-modal-shell">
+        <div className="cj-modal-card" style={{ maxWidth: 480 }}>
+          <div className="cj-modal-head">
+            <span className="cj-status-dot" />
+            <span className="cj-modal-title">report this match</span>
+            <button
+              type="button"
+              className="cj-modal-close"
+              onClick={onClose}
+              aria-label="Close"
+              disabled={submitting}
+            >
+              <XMarkIcon style={{ width: 16, height: 16 }} />
+            </button>
+          </div>
+
+          {submitted ? (
+            <div className="cj-modal-body" style={{ alignItems: 'center', textAlign: 'center', padding: '32px 24px 28px' }}>
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 52,
+                  height: 52,
+                  borderRadius: 999,
+                  background: 'var(--accent-2)',
+                  color: 'var(--accent)',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  marginBottom: 12,
+                }}
+              >
+                <CheckIcon style={{ width: 28, height: 28, strokeWidth: 2.5 }} />
+              </span>
+              <div style={{
+                fontFamily: "'Inter Tight', sans-serif",
+                fontSize: 18,
+                fontWeight: 600,
+                letterSpacing: '-0.01em',
+                color: 'var(--ink)',
+              }}>
+                Thanks — we&apos;ll take a look.
+              </div>
+              <div style={{ fontSize: 12.5, color: 'var(--muted)', marginTop: 6, lineHeight: 1.5 }}>
+                Reports help us tune the merchant picker. We review them weekly.
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="cj-modal-body">
+                {error && <div className="cj-modal-error">{error}</div>}
+
+                <div className="cj-modal-section">
+                  <div className="cj-bch-report-target">
+                    <b>{payload.merchant_name}</b>
+                    {payload.merchant_category ? <> · {payload.merchant_category}</> : null}
+                    {payload.merchant_distance ? <> · {payload.merchant_distance}</> : null}
+                    {payload.recommended_card_name && (
+                      <div style={{ marginTop: 4 }}>
+                        We recommended <b>{payload.recommended_card_name}</b>
+                        {payload.rate_label ? <> at {payload.rate_label}</> : null}
+                        {payload.rate_context ? <> {payload.rate_context}</> : null}.
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="cj-modal-section">
+                  <span className="cj-modal-label">What&apos;s wrong?</span>
+                  <div className="cj-bch-report-reasons" role="radiogroup" aria-label="Report reason">
+                    {REASONS.map((r) => {
+                      const isOn = reason === r.value;
+                      return (
+                        <label key={r.value} className={'cj-bch-report-reason' + (isOn ? ' is-on' : '')}>
+                          <input
+                            type="radio"
+                            name="bch-report-reason"
+                            value={r.value}
+                            checked={isOn}
+                            onChange={() => setReason(r.value)}
+                          />
+                          <span className="cj-bch-report-reason-copy">
+                            {r.label}
+                            {r.hint && <small>{r.hint}</small>}
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="cj-modal-section">
+                  <label className="cj-modal-label" htmlFor="bch-report-notes">
+                    Add detail{' '}
+                    <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>
+                      (optional)
+                    </span>
+                  </label>
+                  <textarea
+                    id="bch-report-notes"
+                    className="cj-bch-report-notes"
+                    placeholder="What's the right category, card, or behavior?"
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value.slice(0, NOTES_MAX))}
+                    rows={3}
+                    maxLength={NOTES_MAX}
+                  />
+                  <div style={{ fontSize: 10, color: 'var(--muted-2)', textAlign: 'right', marginTop: 4 }}>
+                    {notes.length} / {NOTES_MAX}
+                  </div>
+                </div>
+
+                <div style={{ fontSize: 10.5, color: 'var(--muted)', lineHeight: 1.5 }}>
+                  We log your wallet size and the merchant shown. We don&apos;t store your coordinates.
+                </div>
+              </div>
+
+              <div className="cj-modal-footer">
+                <span style={{ fontSize: 11, color: 'var(--muted)' }}>{/* spacer */}</span>
+                <div className="cj-modal-actions">
+                  <button
+                    type="button"
+                    className="cj-modal-btn"
+                    onClick={onClose}
+                    disabled={submitting}
+                  >
+                    cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="cj-modal-btn cj-modal-btn-primary"
+                    onClick={handleSubmit}
+                    disabled={submitting}
+                  >
+                    {submitting ? 'sending…' : 'send report'}
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -541,6 +541,50 @@ export async function getComparePartners(slug: string, limit = 5): Promise<Compa
   }
 }
 
+export type BestCardHereReportReason =
+  | 'wrong_category'
+  | 'wrong_card'
+  | 'merchant_missing'
+  | 'other';
+
+export interface BestCardHereReportPayload {
+  reason: BestCardHereReportReason;
+  notes?: string;
+  merchant_place_id?: string;
+  merchant_name: string;
+  merchant_address?: string;
+  merchant_category?: string;
+  merchant_distance?: string;
+  recommended_card_id?: number;
+  recommended_card_name?: string;
+  rate_label?: string;
+  rate_context?: string;
+  wallet_size?: number;
+}
+
+export async function submitBestCardHereReport(
+  payload: BestCardHereReportPayload,
+): Promise<void> {
+  const token = await getAnonymousAuthToken();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API_BASE}/best-card-here-report`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    let message = 'Failed to submit report';
+    try {
+      const data = await res.json();
+      if (data && typeof data.error === 'string') message = data.error;
+    } catch {
+      // ignore JSON parse failures, use default message
+    }
+    throw new Error(message);
+  }
+}
+
 export type CardApplyClickSource = 'direct' | 'referral';
 
 export async function trackCardApplyClick(


### PR DESCRIPTION
## Summary
- Replaces the Best Card Here GitHub-issue feedback link with an in-product report modal attached to each nearby-merchant row, so users without a GitHub account can flag bad picks in two taps.
- New backend endpoint `POST /best-card-here-report` writes to a new `best_card_here_reports` MySQL table (migration 028), mirroring the `card-apply-click` pattern: anonymous-tolerant Firebase uid, sha256-peppered ip hash, bot-UA filter, self-healing `CREATE TABLE IF NOT EXISTS`.
- Modal reuses the existing `cj-modal-*` profile-v2 shell with scoped styles for the reason picker / notes textarea / report trigger button. Coordinates are not stored — preserves the existing "we won't follow you home" promise; only wallet size + the merchant + the recommended card are logged.

## Files
- `apps/api/migrations/028_create_best_card_here_reports.sql` — new table (single statement, per migration rules)
- `apps/api/src/handlers/best-card-here-report.js` — new POST/OPTIONS handler
- `apps/api/template.yml` — `BestCardHereReportFunction` with `IpHashPepper` + Firebase env vars
- `apps/web-next/src/lib/api.ts` — `submitBestCardHereReport()` + types
- `apps/web-next/src/components/wallet/ReportMerchantModal.tsx` — new modal (form state + thanks state w/ 2s autoclose)
- `apps/web-next/src/components/wallet/BestCardHere.tsx` — wired per-row trigger + dropped GitHub URL builder
- `apps/web-next/src/app/landing.css` — scoped `.cj-bch-report-*` styles

## Deploy ordering (manual, since there is no backend CI/CD)
1. `cd apps/api && sam build && sam deploy` — ships the handler + endpoint.
2. Run migration 028 via the `RunMigrationHandler` flow (the handler also self-heals the table at first POST in case migration is delayed).
3. Merge — Amplify auto-deploys the frontend, which now points at the live endpoint.

## Test plan
- [ ] `sam build && sam deploy` succeeds; `BestCardHereReportFunction` shows in CloudFormation
- [ ] Run migration 028; `DESCRIBE best_card_here_reports` shows the expected schema
- [ ] On a real device + signed-in account: open `/profile` → Rewards tab → Best card here → enable location → expand a merchant row → tap **report this match**
- [ ] Modal opens pre-filled with merchant + recommended card; reason radios swap state; notes textarea respects 1000-char cap
- [ ] **Send report** → switches to "Thanks — we'll take a look." and auto-closes after ~2s
- [ ] `SELECT * FROM best_card_here_reports ORDER BY id DESC LIMIT 1;` shows the row with `user_id`, `ip_hash`, `reason`, merchant + card context populated
- [ ] Anonymous (signed-out) report still records (`user_id` null, `ip_hash` set)
- [ ] Bot user-agent gets a 200 with no row written
- [ ] Backdrop click + cancel button both close without submitting; `Esc` does not, and submit is debounced via the disabled state

🤖 Generated with [Claude Code](https://claude.com/claude-code)