### PR TITLE
profile: keep BCH report-modal scroll inside the modal

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -5607,6 +5607,33 @@
 }
 .landing-v2.profile-v2 .cj-modal-back:hover { color: var(--accent-deep); }
 
+/* Bottom-sheet bounded card — pins to viewport on mobile so the body
+   can scroll internally while the head + footer stay reachable. Used
+   by ReportMerchantModal where the form runs longer than one screen. */
+.landing-v2.profile-v2 .cj-modal-card-bounded {
+  display: flex;
+  flex-direction: column;
+  max-height: 100dvh;
+}
+@media (min-width: 640px) {
+  .landing-v2.profile-v2 .cj-modal-card-bounded {
+    max-height: calc(100dvh - 64px);
+  }
+}
+.landing-v2.profile-v2 .cj-modal-card-bounded .cj-modal-head {
+  flex-shrink: 0;
+}
+.landing-v2.profile-v2 .cj-modal-card-bounded .cj-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+.landing-v2.profile-v2 .cj-modal-card-bounded .cj-modal-footer {
+  flex-shrink: 0;
+}
+
 /* ---------- Best Card Here · report-merchant modal ---------- */
 .landing-v2.profile-v2 .cj-bch-report-target {
   padding: 10px 12px;

--- a/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
+++ b/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
@@ -51,6 +51,19 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
     return () => clearTimeout(t);
   }, [submitted, onClose]);
 
+  // Lock body scroll while the modal is open. Without this, touch scroll
+  // inside a bottom-sheet whose content is shorter than the viewport
+  // bleeds through to the page behind on iOS Safari, leaving the user
+  // unable to reach the submit button when content does overflow.
+  useEffect(() => {
+    if (!show) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [show]);
+
   if (!show) return null;
 
   const handleSubmit = async () => {
@@ -74,7 +87,7 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
     <div className="cj-modal-root" role="dialog" aria-modal="true">
       <div className="cj-modal-backdrop" onClick={submitting ? undefined : onClose} />
       <div className="cj-modal-shell">
-        <div className="cj-modal-card" style={{ maxWidth: 480 }}>
+        <div className="cj-modal-card cj-modal-card-bounded" style={{ maxWidth: 480 }}>
           <div className="cj-modal-head">
             <span className="cj-status-dot" />
             <span className="cj-modal-title">report this match</span>


### PR DESCRIPTION
## Summary
- Body scroll is now locked while the Best Card Here report modal is open, so iOS Safari can't bleed touch-scroll through to the Earn tab behind it.
- New \`cj-modal-card-bounded\` modifier turns the card into a flex column capped at \`100dvh\`. The head + footer are flex-shrink: 0 (so the **Send report** button stays reachable) and only the body scrolls, with \`overscroll-behavior: contain\` to stop chaining at its edges.

## Why
The form runs longer than the viewport on small phones (target box + 4 reasons + textarea + privacy line + footer). With the previous layout the card had \`overflow: hidden\` and the page behind kept its scroll, so the user couldn't reach the submit button.

## Test plan
- [ ] On mobile (signed in, Rewards tab → Best card here → expand a merchant → **report this match**): the page behind no longer scrolls when you swipe inside the modal
- [ ] Long-form report (with reasons + filled-in notes) is fully scrollable and **Send report** remains tappable at the bottom
- [ ] Desktop modal still centers and is reachable; close button + cancel still work
- [ ] AddToWalletModal / EditWalletCardModal unchanged (they don't use the new modifier class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)