### PR TITLE
profile: scroll the whole BCH report card; drop dead Apple Wallet button

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -5607,31 +5607,24 @@
 }
 .landing-v2.profile-v2 .cj-modal-back:hover { color: var(--accent-deep); }
 
-/* Bottom-sheet bounded card — pins to viewport on mobile so the body
-   can scroll internally while the head + footer stay reachable. Used
-   by ReportMerchantModal where the form runs longer than one screen. */
+/* Bottom-sheet bounded card — caps height to the viewport and makes
+   the entire card scroll as one. Used by ReportMerchantModal where the
+   form runs longer than one screen on small phones.
+
+   We tried flex-column with sticky head/footer first (Apr 2026); on
+   iOS Safari the body refused to scroll inside the card despite
+   min-height:0 + overflow-y:auto. Single-container scroll is dumber
+   but reliably works. */
 .landing-v2.profile-v2 .cj-modal-card-bounded {
-  display: flex;
-  flex-direction: column;
   max-height: 100dvh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 @media (min-width: 640px) {
   .landing-v2.profile-v2 .cj-modal-card-bounded {
     max-height: calc(100dvh - 64px);
   }
-}
-.landing-v2.profile-v2 .cj-modal-card-bounded .cj-modal-head {
-  flex-shrink: 0;
-}
-.landing-v2.profile-v2 .cj-modal-card-bounded .cj-modal-body {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-}
-.landing-v2.profile-v2 .cj-modal-card-bounded .cj-modal-footer {
-  flex-shrink: 0;
 }
 
 /* ---------- Best Card Here · report-merchant modal ---------- */

--- a/apps/web-next/src/components/wallet/BestCardHere.tsx
+++ b/apps/web-next/src/components/wallet/BestCardHere.tsx
@@ -413,7 +413,6 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
                         {next && <PickDetail label="Runner-up" pick={next} />}
                       </div>
                       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                        <button type="button" className="cj-wd-cta">add to apple wallet</button>
                         {best.card.slug && (
                           <a href={`/card/${best.card.slug}`} style={{
                             fontSize: 11.5, color: 'var(--ink-2)', textDecoration: 'none',


### PR DESCRIPTION
## Summary
- **Modal scroll fix (round 2):** the previous flex-column-with-sticky-head/footer pattern still didn't catch touches on iPhone 16 Safari/Chrome — the body refused to scroll inside the bounded card. Switching to a dumber-but-reliable single-container scroll: the whole \`.cj-modal-card-bounded\` is the scroll target. Head and footer scroll along with the content, but the user can reach the **Send report** button. \`overscroll-behavior: contain\` + \`-webkit-overflow-scrolling: touch\` keep the gesture from chaining out.
- **Remove "add to apple wallet" button** from each merchant row in Best Card Here. There is no browser API to open Apple Wallet or Google Wallet with a specific card preselected — \`.pkpass\` adds a pass to the wallet but doesn't switch the default card to tap at the register, which is what the user actually wants here. The button never did anything (no onClick handler), so it goes.

## Test plan
- [ ] On iPhone 16 (Safari + Chrome): open the BCH report modal → swipe inside it → can reach **Send report** button at the bottom
- [ ] Page behind still doesn't scroll while the modal is open
- [ ] Submitting still flips to the Thanks state and auto-closes
- [ ] Each merchant row's expanded view shows "see [Card] rules →" and "report this match" only — no Apple Wallet button

🤖 Generated with [Claude Code](https://claude.com/claude-code)