### PR TITLE
profile: per-card category selections (Cash+, Custom Cash, etc.)

### DIFF
--- a/apps/api/migrations/029_create_user_card_selections.sql
+++ b/apps/api/migrations/029_create_user_card_selections.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS user_card_selections (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  user_card_id INT NOT NULL,
+  reward_category VARCHAR(80) NOT NULL,
+  reward_rate DECIMAL(5,2) NOT NULL,
+  selected_category VARCHAR(80) NOT NULL,
+  valid_from TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  valid_to TIMESTAMP NULL,
+  source ENUM('user_pick','auto_renew','rotation') NOT NULL DEFAULT 'user_pick',
+  auto_renew BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_user_card_active (user_card_id, valid_to),
+  FOREIGN KEY (user_card_id) REFERENCES user_cards(id) ON DELETE CASCADE
+);

--- a/apps/api/src/handlers/user-card-selections.js
+++ b/apps/api/src/handlers/user-card-selections.js
@@ -1,0 +1,160 @@
+// User Card Selections API — manage per-wallet-card category picks for cards
+// like U.S. Bank Cash+ (user_choice quarterly) and Citi Custom Cash
+// (auto_top_spend monthly). Each wallet card can have multiple active
+// selections (Cash+ has two 5% picks). History is preserved by setting
+// valid_to instead of deleting; the BCH ranker reads only rows where
+// valid_to IS NULL.
+//
+// Routes:
+//   GET    /wallet/{id}/selections   — list active selections + auto_renew
+//   PUT    /wallet/{id}/selections   — replace all active selections
+//   DELETE /wallet/{id}/selections   — clear (expire all active rows)
+const mysql = require("../db");
+
+const responseHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Methods": "GET,PUT,DELETE,OPTIONS",
+};
+
+function bad(status, message) {
+  return {
+    statusCode: status,
+    headers: responseHeaders,
+    body: JSON.stringify({ error: message }),
+  };
+}
+
+function ok(body, status = 200) {
+  return {
+    statusCode: status,
+    headers: responseHeaders,
+    body: JSON.stringify(body),
+  };
+}
+
+exports.UserCardSelectionsHandler = async (event) => {
+  console.info("received:", event);
+
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 200, headers: responseHeaders, body: "" };
+  }
+
+  const userId = event.requestContext?.authorizer?.principalId;
+  if (!userId) return bad(401, "Unauthorized");
+
+  const walletRowId = event.pathParameters?.id ? Number(event.pathParameters.id) : null;
+  if (!walletRowId || !Number.isFinite(walletRowId)) {
+    return bad(400, "wallet row id is required in path");
+  }
+
+  try {
+    const owns = await mysql.query(
+      "SELECT id FROM user_cards WHERE id = ? AND user_id = ?",
+      [walletRowId, userId]
+    );
+    if (owns.length === 0) {
+      await mysql.end();
+      return bad(404, "Wallet card not found");
+    }
+
+    switch (event.httpMethod) {
+      case "GET": {
+        const rows = await mysql.query(
+          `SELECT id, reward_category, reward_rate, selected_category,
+                  valid_from, valid_to, source, auto_renew, created_at
+           FROM user_card_selections
+           WHERE user_card_id = ? AND valid_to IS NULL
+           ORDER BY reward_category, reward_rate DESC, id ASC`,
+          [walletRowId]
+        );
+        await mysql.end();
+        return ok({
+          selections: rows.map((r) => ({
+            reward_category: r.reward_category,
+            reward_rate: Number(r.reward_rate),
+            selected_category: r.selected_category,
+            valid_from: r.valid_from,
+            source: r.source,
+            auto_renew: Boolean(r.auto_renew),
+          })),
+        });
+      }
+
+      case "PUT": {
+        const body = JSON.parse(event.body || "{}");
+        const selections = Array.isArray(body.selections) ? body.selections : null;
+        const autoRenew = Boolean(body.auto_renew);
+
+        if (!selections) {
+          await mysql.end();
+          return bad(400, "selections array is required");
+        }
+
+        for (const s of selections) {
+          if (
+            !s ||
+            typeof s.reward_category !== "string" ||
+            typeof s.selected_category !== "string" ||
+            typeof s.reward_rate !== "number" ||
+            !s.reward_category.match(/^[a-z0-9_]+$/i) ||
+            !s.selected_category.match(/^[a-z0-9_]+$/i)
+          ) {
+            await mysql.end();
+            return bad(400, "each selection needs reward_category (slug), reward_rate (number), selected_category (slug)");
+          }
+        }
+
+        // Expire all active selections for this wallet card, then insert the new set.
+        // Two statements; if the insert fails the expiry persists, leaving the card
+        // unconfigured — same state as DELETE — which is acceptable and recoverable.
+        await mysql.query(
+          `UPDATE user_card_selections
+           SET valid_to = CURRENT_TIMESTAMP
+           WHERE user_card_id = ? AND valid_to IS NULL`,
+          [walletRowId]
+        );
+
+        if (selections.length > 0) {
+          const values = selections.map(() => "(?, ?, ?, ?, 'user_pick', ?)").join(", ");
+          const params = [];
+          for (const s of selections) {
+            params.push(walletRowId, s.reward_category, s.reward_rate, s.selected_category, autoRenew ? 1 : 0);
+          }
+          await mysql.query(
+            `INSERT INTO user_card_selections
+              (user_card_id, reward_category, reward_rate, selected_category, source, auto_renew)
+             VALUES ${values}`,
+            params
+          );
+        }
+
+        await mysql.end();
+        return ok({ message: "Selections updated", count: selections.length, auto_renew: autoRenew });
+      }
+
+      case "DELETE": {
+        await mysql.query(
+          `UPDATE user_card_selections
+           SET valid_to = CURRENT_TIMESTAMP
+           WHERE user_card_id = ? AND valid_to IS NULL`,
+          [walletRowId]
+        );
+        await mysql.end();
+        return ok({ message: "Selections cleared" });
+      }
+
+      default:
+        await mysql.end();
+        return bad(405, `Method ${event.httpMethod} not allowed`);
+    }
+  } catch (error) {
+    console.error("Error:", error);
+    try { await mysql.end(); } catch (_) { /* ignore */ }
+    return {
+      statusCode: 500,
+      headers: responseHeaders,
+      body: JSON.stringify({ error: "Internal server error", details: error.message }),
+    };
+  }
+};

--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -82,25 +82,31 @@ exports.UserWalletHandler = async (event) => {
 
         // Active category selections for these wallet rows (Cash+, Custom Cash, etc).
         // Joined into the wallet response so the BCH ranker has everything it needs
-        // in one round-trip.
+        // in one round-trip. Wrapped in try/catch so a missing table (e.g. between
+        // a backend deploy and migration 029 running) doesn't break GET /wallet —
+        // we just degrade to empty selections.
         const walletRowIds = walletCards.map((w) => w.id);
         const selectionsByWalletId = new Map();
         if (walletRowIds.length > 0) {
-          const selectionRows = await mysql.query(
-            `SELECT user_card_id, reward_category, reward_rate, selected_category, auto_renew
-             FROM user_card_selections
-             WHERE user_card_id IN (?) AND valid_to IS NULL`,
-            [walletRowIds]
-          );
-          for (const r of selectionRows) {
-            const list = selectionsByWalletId.get(r.user_card_id) || [];
-            list.push({
-              reward_category: r.reward_category,
-              reward_rate: Number(r.reward_rate),
-              selected_category: r.selected_category,
-              auto_renew: Boolean(r.auto_renew),
-            });
-            selectionsByWalletId.set(r.user_card_id, list);
+          try {
+            const selectionRows = await mysql.query(
+              `SELECT user_card_id, reward_category, reward_rate, selected_category, auto_renew
+               FROM user_card_selections
+               WHERE user_card_id IN (?) AND valid_to IS NULL`,
+              [walletRowIds]
+            );
+            for (const r of selectionRows) {
+              const list = selectionsByWalletId.get(r.user_card_id) || [];
+              list.push({
+                reward_category: r.reward_category,
+                reward_rate: Number(r.reward_rate),
+                selected_category: r.selected_category,
+                auto_renew: Boolean(r.auto_renew),
+              });
+              selectionsByWalletId.set(r.user_card_id, list);
+            }
+          } catch (selErr) {
+            console.error("user_card_selections lookup failed (continuing with empty selections):", selErr.message);
           }
         }
         const enriched = walletCards.map((w) => ({

--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -79,12 +79,40 @@ exports.UserWalletHandler = async (event) => {
           WHERE uc.user_id = ?
           ORDER BY uc.created_at ASC, uc.id ASC
         `, [userId]);
+
+        // Active category selections for these wallet rows (Cash+, Custom Cash, etc).
+        // Joined into the wallet response so the BCH ranker has everything it needs
+        // in one round-trip.
+        const walletRowIds = walletCards.map((w) => w.id);
+        const selectionsByWalletId = new Map();
+        if (walletRowIds.length > 0) {
+          const selectionRows = await mysql.query(
+            `SELECT user_card_id, reward_category, reward_rate, selected_category, auto_renew
+             FROM user_card_selections
+             WHERE user_card_id IN (?) AND valid_to IS NULL`,
+            [walletRowIds]
+          );
+          for (const r of selectionRows) {
+            const list = selectionsByWalletId.get(r.user_card_id) || [];
+            list.push({
+              reward_category: r.reward_category,
+              reward_rate: Number(r.reward_rate),
+              selected_category: r.selected_category,
+              auto_renew: Boolean(r.auto_renew),
+            });
+            selectionsByWalletId.set(r.user_card_id, list);
+          }
+        }
+        const enriched = walletCards.map((w) => ({
+          ...w,
+          selections: selectionsByWalletId.get(w.id) || [],
+        }));
         await mysql.end();
 
         response = {
           statusCode: 200,
           headers: responseHeaders,
-          body: JSON.stringify(walletCards),
+          body: JSON.stringify(enriched),
         };
         break;
       }

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -377,6 +377,52 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  UserCardSelectionsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/user-card-selections.UserCardSelectionsHandler
+      Runtime: nodejs22.x
+      MemorySize: 512
+      Timeout: 30
+      Description: Manage per-wallet-card category selections (Cash+, Custom Cash, etc)
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetSelections:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}/selections
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        PutSelections:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}/selections
+            Method: PUT
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        DeleteSelections:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}/selections
+            Method: DELETE
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        SelectionsOptions:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}/selections
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
   ReferralStatsFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -30,6 +30,7 @@ import {
 const ReferralModal = dynamic(() => import("@/components/forms/ReferralModal"), { ssr: false, loading: () => null });
 const AddToWalletModal = dynamic(() => import("@/components/wallet/AddToWalletModal"), { ssr: false, loading: () => null });
 const EditWalletCardModal = dynamic(() => import("@/components/wallet/EditWalletCardModal"), { ssr: false, loading: () => null });
+const SelectCategoriesModal = dynamic(() => import("@/components/wallet/SelectCategoriesModal"), { ssr: false, loading: () => null });
 const BestCardByCategory = dynamic(() => import("@/components/wallet/BestCardByCategory"), { ssr: false, loading: () => null });
 const BestCardHere = dynamic(() => import("@/components/wallet/BestCardHere"), { ssr: false, loading: () => null });
 const WalletBenefits = dynamic(() => import("@/components/wallet/WalletBenefits"), { ssr: false, loading: () => null });
@@ -115,7 +116,20 @@ export default function ProfileClient() {
   const [submitRecordCard, setSubmitRecordCard] = useState<WalletCard | null>(null);
   const [showRecordCardPicker, setShowRecordCardPicker] = useState(false);
   const [editingRecord, setEditingRecord] = useState<RecordItem | null>(null);
+  const [pickingCategoriesFor, setPickingCategoriesFor] = useState<WalletCard | null>(null);
   const cardLookups = useMemo(() => createCardLookups(allCards), [allCards]);
+
+  // Cards whose YAML defines a `user_choice` or `auto_top_spend` reward block —
+  // these are the cards that can show a "pick categories" affordance.
+  const cardsWithSelectableRewards = useMemo(() => {
+    const set = new Set<string>();
+    for (const c of allCards) {
+      if ((c.rewards || []).some((r) => r.mode === 'user_choice' || r.mode === 'auto_top_spend' || r.category === 'top_category')) {
+        set.add(c.card_name);
+      }
+    }
+    return set;
+  }, [allCards]);
 
   const eligibleReferralCards = useMemo(
     () => getEligibleReferralCards(records, walletCards, referrals.filter((r) => !r.archived_at), cardLookups),
@@ -474,9 +488,11 @@ export default function ProfileClient() {
                 cardLookups={cardLookups}
                 cardsWithRecords={cardsWithRecords}
                 cardsWithActiveReferrals={cardsWithActiveReferrals}
+                cardsWithSelectableRewards={cardsWithSelectableRewards}
                 totalAnnualFees={totalAnnualFees}
                 onAdd={() => setShowWalletModal(true)}
                 onEdit={(c) => setEditingCard(c)}
+                onPickCategories={(c) => setPickingCategoriesFor(c)}
                 onSubmitRecord={(c) => setSubmitRecordCard(c)}
                 onAddReferral={() => setShowReferralModal(true)}
               />
@@ -488,7 +504,19 @@ export default function ProfileClient() {
                   {/* Best Card Here is mobile-only — relies on geolocation
                       and the merchant-card layout doesn't fit a desktop column.
                       Desktop sees a banner pointing them to mobile. */}
-                  <BestCardHere walletCards={walletCards} allCards={allCards} />
+                  <BestCardHere
+                    walletCards={walletCards}
+                    allCards={allCards}
+                    onWalletRefresh={async () => {
+                      const token = await getToken();
+                      if (!token) return;
+                      try {
+                        setWalletCards((await getWallet(token)) || []);
+                      } catch (e) {
+                        console.error('Wallet refresh error:', e);
+                      }
+                    }}
+                  />
                   <div className="cj-bch-desktop-banner" aria-hidden="false">
                     <span className="cj-bch-desktop-banner-icon" aria-hidden="true">
                       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -723,6 +751,13 @@ export default function ProfileClient() {
         onClose={() => setEditingCard(null)}
         onSuccess={loadData}
       />
+      <SelectCategoriesModal
+        show={!!pickingCategoriesFor}
+        walletCard={pickingCategoriesFor}
+        card={pickingCategoriesFor ? cardLookups.byName.get(pickingCategoriesFor.card_name) ?? null : null}
+        onClose={() => setPickingCategoriesFor(null)}
+        onSuccess={loadData}
+      />
       <SubmitRecordCardPicker
         show={showRecordCardPicker}
         onClose={() => setShowRecordCardPicker(false)}
@@ -791,9 +826,11 @@ interface CardsTabProps {
   cardLookups: ReturnType<typeof createCardLookups>;
   cardsWithRecords: Set<string>;
   cardsWithActiveReferrals: Set<string>;
+  cardsWithSelectableRewards: Set<string>;
   totalAnnualFees: number;
   onAdd: () => void;
   onEdit: (c: WalletCard) => void;
+  onPickCategories: (c: WalletCard) => void;
   onSubmitRecord: (c: WalletCard) => void;
   onAddReferral: () => void;
 }
@@ -801,8 +838,8 @@ interface CardsTabProps {
 function CardsTab(props: CardsTabProps) {
   const {
     walletLoaded, walletCards, visibleWalletCards, walletDisplayNames, inactiveCount, showArchived, setShowArchived,
-    openWalletId, setOpenWalletId, cardLookups, cardsWithRecords, cardsWithActiveReferrals,
-    totalAnnualFees, onAdd, onEdit, onSubmitRecord, onAddReferral,
+    openWalletId, setOpenWalletId, cardLookups, cardsWithRecords, cardsWithActiveReferrals, cardsWithSelectableRewards,
+    totalAnnualFees, onAdd, onEdit, onPickCategories, onSubmitRecord, onAddReferral,
   } = props;
 
   if (!walletLoaded) return <LoadingPanel />;
@@ -916,6 +953,15 @@ function CardsTab(props: CardsTabProps) {
                   <div className="cj-wd-actions">
                     {slug && <Link href={`/card/${slug}`}>view card page →</Link>}
                     <button type="button" onClick={() => onEdit(c)}>edit</button>
+                    {cardsWithSelectableRewards.has(c.card_name) && (
+                      <button
+                        type="button"
+                        className={(c.selections && c.selections.length > 0) ? '' : 'cj-wd-cta'}
+                        onClick={() => onPickCategories(c)}
+                      >
+                        {c.selections && c.selections.length > 0 ? 'edit picks' : '+ pick categories'}
+                      </button>
+                    )}
                     {!hasRecord && (
                       <button type="button" className="cj-wd-cta" onClick={() => onSubmitRecord(c)}>
                         + submit a record

--- a/apps/web-next/src/components/wallet/BestCardHere.tsx
+++ b/apps/web-next/src/components/wallet/BestCardHere.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import CardImage from '@/components/ui/CardImage';
 import {
   BestCardHereReportPayload,
@@ -12,8 +12,13 @@ import {
   getStoresBrandIndex,
 } from '@/lib/api';
 import { useAuth } from '@/auth/AuthProvider';
-import { PlacePick, pickWalletCardsForPlace } from '@/lib/walletPicksForPlace';
+import {
+  PlacePick,
+  UnconfiguredCardPrompt,
+  pickWalletCardsForPlace,
+} from '@/lib/walletPicksForPlace';
 import ReportMerchantModal from '@/components/wallet/ReportMerchantModal';
+import SelectCategoriesModal from '@/components/wallet/SelectCategoriesModal';
 
 // Resolved merchant ready for rendering. `label` is brand name when the
 // place was matched to a Store entry (e.g. "marriott") so the user can
@@ -26,6 +31,7 @@ interface Merchant {
   dist: string;
   addr: string;
   picks: { best: PlacePick; next?: PlacePick };
+  unconfiguredCards: UnconfiguredCardPrompt[];
 }
 
 function metersToMiles(m: number): string {
@@ -69,6 +75,7 @@ function placesToMerchants(
         picks: result.next
           ? { best: result.best, next: result.next }
           : { best: result.best },
+        unconfiguredCards: result.unconfiguredCards,
       };
     })
     .filter((m): m is Merchant => m !== null)
@@ -163,9 +170,16 @@ function PickDetail({ label, pick }: { label: string; pick: PlacePick }) {
 interface BestCardHereProps {
   walletCards: WalletCard[];
   allCards: Card[];
+  /**
+   * Called after the user saves category picks for a held card so the
+   * parent (ProfileClient) can re-fetch /wallet and pass fresh
+   * `walletCards` back in. Without this the BCH list keeps stale
+   * "unconfigured" prompts even after saving.
+   */
+  onWalletRefresh?: () => Promise<void> | void;
 }
 
-export default function BestCardHere({ walletCards, allCards }: BestCardHereProps) {
+export default function BestCardHere({ walletCards, allCards, onWalletRefresh }: BestCardHereProps) {
   const { getToken } = useAuth();
   const [location, setLocation] = useState<Location | null>(null);
   const [loading, setLoading] = useState(false);
@@ -174,8 +188,36 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
   const [openIdx, setOpenIdx] = useState<number | null>(null);
   const [reportPayload, setReportPayload] =
     useState<Omit<BestCardHereReportPayload, 'reason' | 'notes'> | null>(null);
+  const [selectionsTarget, setSelectionsTarget] =
+    useState<{ walletCard: WalletCard; card: Card } | null>(null);
+
+  // Cache of the last successful fetch — places + coords + brandIndex —
+  // so we can recompute merchants in-place when the user updates picks
+  // without re-prompting for location or hitting Places again.
+  const [placesCache, setPlacesCache] = useState<{
+    places: NearbyPlace[];
+    brandIndex: StoreBrandIndexEntry[];
+    lat: number;
+    lng: number;
+  } | null>(null);
 
   const cardsCount = walletCards.length;
+
+  // Recompute merchants whenever wallet changes, using the cached places.
+  // Triggers after the user saves selections (parent re-fetches wallet,
+  // walletCards prop updates, this effect fires).
+  useEffect(() => {
+    if (!placesCache) return;
+    const resolved = placesToMerchants(
+      placesCache.places,
+      walletCards,
+      allCards,
+      placesCache.brandIndex,
+      placesCache.lat,
+      placesCache.lng,
+    );
+    setMerchants(resolved);
+  }, [walletCards, allCards, placesCache]);
 
   const enable = async () => {
     setErrorMessage(null);
@@ -232,6 +274,12 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
         coords.longitude,
       );
       setMerchants(resolved);
+      setPlacesCache({
+        places: placesResult.places,
+        brandIndex,
+        lat: coords.latitude,
+        lng: coords.longitude,
+      });
       setLocation({
         label: 'Your location',
         coords: `${coords.latitude.toFixed(4)}° ${coords.latitude >= 0 ? 'N' : 'S'}, ${Math.abs(coords.longitude).toFixed(4)}° ${coords.longitude >= 0 ? 'E' : 'W'}`,
@@ -249,6 +297,35 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
     setMerchants([]);
     setOpenIdx(null);
     setErrorMessage(null);
+    setPlacesCache(null);
+  };
+
+  // Aggregate every "needs picks" card across the visible merchant rows so
+  // we can show one banner at the top (instead of repeating the prompt
+  // per merchant). Dedup by wallet row id; keep the highest potential rate.
+  const unconfiguredAggregate = useMemo(() => {
+    const byRowId = new Map<number, UnconfiguredCardPrompt>();
+    for (const m of merchants) {
+      for (const u of m.unconfiguredCards) {
+        const existing = byRowId.get(u.walletRowId);
+        if (!existing || u.potentialRate > existing.potentialRate) {
+          byRowId.set(u.walletRowId, u);
+        }
+      }
+    }
+    return Array.from(byRowId.values());
+  }, [merchants]);
+
+  const openSelectionsFor = (walletRowId: number) => {
+    const wc = walletCards.find((w) => w.id === walletRowId);
+    if (!wc) return;
+    const card = allCards.find((c) => c.card_name === wc.card_name);
+    if (!card) return;
+    setSelectionsTarget({ walletCard: wc, card });
+  };
+
+  const handleSelectionsSaved = async () => {
+    if (onWalletRefresh) await onWalletRefresh();
   };
 
   const showList = location && !loading;
@@ -343,6 +420,36 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
       {showList && cardsCount > 0 && merchantRows.length === 0 && (
         <div className="cj-verdict" style={{ marginTop: 16 }}>
           No nearby merchants matched a reward category for the cards in your wallet. Try a different spot, or add a card with broader earn categories.
+        </div>
+      )}
+
+      {showList && unconfiguredAggregate.length > 0 && (
+        <div
+          className="cj-verdict"
+          style={{
+            marginTop: 16,
+            background: '#f7f3ff',
+            borderLeftColor: 'var(--accent)',
+          }}
+        >
+          <b>Pick categories to unlock matches.</b>{' '}
+          {unconfiguredAggregate.length === 1
+            ? 'One card in your wallet has bonus categories you choose.'
+            : `${unconfiguredAggregate.length} cards in your wallet have bonus categories you choose.`}
+          {' '}Tell us which ones so they can rank here.
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 8 }}>
+            {unconfiguredAggregate.map((u) => (
+              <button
+                key={u.walletRowId}
+                type="button"
+                onClick={() => openSelectionsFor(u.walletRowId)}
+                className="cj-bch-cta-btn"
+                style={{ padding: '5px 10px', fontSize: 11 }}
+              >
+                pick categories on {u.cardName} →
+              </button>
+            ))}
+          </div>
         </div>
       )}
 
@@ -451,6 +558,14 @@ export default function BestCardHere({ walletCards, allCards }: BestCardHereProp
         show={reportPayload !== null}
         onClose={() => setReportPayload(null)}
         payload={reportPayload ?? { merchant_name: '' }}
+      />
+
+      <SelectCategoriesModal
+        show={selectionsTarget !== null}
+        walletCard={selectionsTarget?.walletCard ?? null}
+        card={selectionsTarget?.card ?? null}
+        onClose={() => setSelectionsTarget(null)}
+        onSuccess={handleSelectionsSaved}
       />
     </div>
   );

--- a/apps/web-next/src/components/wallet/SelectCategoriesModal.tsx
+++ b/apps/web-next/src/components/wallet/SelectCategoriesModal.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import CardImage from '@/components/ui/CardImage';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import {
+  Card,
+  Reward,
+  WalletCard,
+  WalletCardSelection,
+  updateWalletCardSelections,
+} from '@/lib/api';
+import { categoryLabels } from '@/lib/cardDisplayUtils';
+import { useAuth } from '@/auth/AuthProvider';
+
+// Reward blocks the user must configure to unlock category bonuses.
+// Includes both `mode: user_choice` (Cash+, Shopper) and `auto_top_spend`
+// (Custom Cash, Venmo, Amex Business Gold) — from a UX perspective both
+// require the user to tell us which category they normally pick / typically
+// spend on.
+function selectableRewards(card: Card): Reward[] {
+  if (!card.rewards) return [];
+  return card.rewards.filter(
+    (r) =>
+      r.mode === 'user_choice' ||
+      r.mode === 'auto_top_spend' ||
+      r.category === 'top_category',
+  );
+}
+
+function labelFor(slug: string): string {
+  return categoryLabels[slug] ?? slug.replace(/_/g, ' ');
+}
+
+function cadenceLabel(reward: Reward): string {
+  switch (reward.cap_period) {
+    case 'monthly':
+      return 'each month';
+    case 'quarterly':
+      return 'each quarter';
+    case 'billing_cycle':
+      return 'each billing cycle';
+    case 'annual':
+      return 'each year';
+    default:
+      return '';
+  }
+}
+
+interface SelectCategoriesModalProps {
+  show: boolean;
+  walletCard: WalletCard | null;
+  card: Card | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+interface BlockState {
+  reward_category: string;
+  reward_rate: number;
+  picks: number;
+  eligible: string[];
+  selected: string[];
+  reward: Reward;
+}
+
+export default function SelectCategoriesModal({
+  show,
+  walletCard,
+  card,
+  onClose,
+  onSuccess,
+}: SelectCategoriesModalProps) {
+  const { getToken } = useAuth();
+  const [blocks, setBlocks] = useState<BlockState[]>([]);
+  const [autoRenew, setAutoRenew] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const rewards = useMemo(() => (card ? selectableRewards(card) : []), [card]);
+
+  useEffect(() => {
+    if (!walletCard || !card) {
+      setBlocks([]);
+      setAutoRenew(false);
+      setError(null);
+      return;
+    }
+    const existing = walletCard.selections || [];
+    const initial: BlockState[] = rewards.map((r) => {
+      const eligible = r.eligible_categories || [];
+      // Prefill from saved selections matching this block.
+      const prefill = existing
+        .filter((s) => s.reward_category === r.category && s.reward_rate === r.value)
+        .map((s) => s.selected_category)
+        .filter((c) => eligible.includes(c));
+      return {
+        reward_category: r.category,
+        reward_rate: r.value,
+        picks: r.choices ?? 1,
+        eligible,
+        selected: prefill,
+        reward: r,
+      };
+    });
+    setBlocks(initial);
+    setAutoRenew(existing.some((s) => s.auto_renew));
+    setError(null);
+  }, [walletCard, card, rewards]);
+
+  if (!show || !walletCard || !card) return null;
+
+  const togglePick = (blockIdx: number, category: string) => {
+    setBlocks((prev) =>
+      prev.map((b, i) => {
+        if (i !== blockIdx) return b;
+        const has = b.selected.includes(category);
+        if (has) return { ...b, selected: b.selected.filter((c) => c !== category) };
+        if (b.selected.length >= b.picks) {
+          // Bump the oldest pick out so the click feels responsive — the user
+          // is replacing one of their picks rather than hitting a hard cap.
+          return { ...b, selected: [...b.selected.slice(1), category] };
+        }
+        return { ...b, selected: [...b.selected, category] };
+      }),
+    );
+  };
+
+  const incomplete = blocks.some((b) => b.selected.length !== b.picks);
+
+  const handleSave = async () => {
+    if (!walletCard) return;
+    if (incomplete) {
+      setError('Pick the required number of categories for every block before saving.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error('You need to be signed in.');
+      const selections: WalletCardSelection[] = [];
+      for (const b of blocks) {
+        for (const cat of b.selected) {
+          selections.push({
+            reward_category: b.reward_category,
+            reward_rate: b.reward_rate,
+            selected_category: cat,
+            auto_renew: autoRenew,
+          });
+        }
+      }
+      await updateWalletCardSelections(
+        walletCard.id,
+        {
+          selections: selections.map((s) => ({
+            reward_category: s.reward_category,
+            reward_rate: s.reward_rate,
+            selected_category: s.selected_category,
+          })),
+          auto_renew: autoRenew,
+        },
+        token,
+      );
+      onSuccess();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save selections.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="cj-modal-root" role="dialog" aria-modal="true">
+      <div className="cj-modal-backdrop" onClick={saving ? undefined : onClose} />
+      <div className="cj-modal-shell">
+        <div className="cj-modal-card">
+          <div className="cj-modal-head">
+            <span className="cj-status-dot" />
+            <span className="cj-modal-title">pick categories</span>
+            <button
+              type="button"
+              className="cj-modal-close"
+              onClick={onClose}
+              aria-label="Close"
+              disabled={saving}
+            >
+              <XMarkIcon style={{ width: 16, height: 16 }} />
+            </button>
+          </div>
+
+          <div className="cj-modal-body">
+            {error && <div className="cj-modal-error">{error}</div>}
+
+            <div className="cj-modal-section">
+              <div className="cj-modal-card-row">
+                <span className="cj-modal-thumb">
+                  <CardImage
+                    cardImageLink={card.card_image_link}
+                    alt={card.card_name}
+                    fill
+                    className="object-contain"
+                    sizes="56px"
+                  />
+                </span>
+                <div style={{ minWidth: 0 }}>
+                  <div className="cj-modal-card-name">{card.card_name}</div>
+                  <div className="cj-modal-card-meta">{card.bank}</div>
+                </div>
+              </div>
+            </div>
+
+            {blocks.length === 0 ? (
+              <div className="cj-modal-section" style={{ color: 'var(--muted)', fontSize: 13 }}>
+                This card has no selectable bonus categories.
+              </div>
+            ) : (
+              blocks.map((b, idx) => {
+                const cad = cadenceLabel(b.reward);
+                const heading = `${b.reward_rate}% — pick ${b.picks}${cad ? ` ${cad}` : ''}`;
+                return (
+                  <div className="cj-modal-section" key={`${b.reward_category}-${b.reward_rate}`}>
+                    <label className="cj-modal-label">{heading}</label>
+                    {b.eligible.length === 0 ? (
+                      <div style={{ color: 'var(--muted)', fontSize: 12 }}>
+                        Eligible categories aren&apos;t enumerated for this card yet.
+                      </div>
+                    ) : (
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 }}>
+                        {b.eligible.map((cat) => {
+                          const active = b.selected.includes(cat);
+                          return (
+                            <button
+                              type="button"
+                              key={cat}
+                              onClick={() => togglePick(idx, cat)}
+                              className="cj-chip"
+                              style={{
+                                padding: '6px 10px',
+                                fontSize: 12,
+                                borderRadius: 999,
+                                border: `1px solid ${active ? 'var(--accent)' : 'var(--line-2)'}`,
+                                background: active ? 'var(--accent)' : 'var(--paper)',
+                                color: active ? '#fff' : 'var(--ink)',
+                                cursor: 'pointer',
+                                letterSpacing: '0.01em',
+                              }}
+                            >
+                              {labelFor(cat)}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                    <div style={{ marginTop: 6, fontSize: 11, color: 'var(--muted)' }}>
+                      {b.selected.length} of {b.picks} picked
+                    </div>
+                  </div>
+                );
+              })
+            )}
+
+            {blocks.length > 0 && (
+              <div className="cj-modal-section">
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    cursor: 'pointer',
+                    fontSize: 13,
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={autoRenew}
+                    onChange={(e) => setAutoRenew(e.target.checked)}
+                  />
+                  <span>
+                    Always pick these — don&apos;t ask me again each cycle.
+                  </span>
+                </label>
+                <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 4, marginLeft: 24 }}>
+                  We&apos;ll keep these picks active going forward unless the issuer changes
+                  the eligible list.
+                </div>
+              </div>
+            )}
+
+            <div
+              style={{
+                display: 'flex',
+                gap: 8,
+                justifyContent: 'flex-end',
+                paddingTop: 12,
+                borderTop: '1px solid var(--line-2)',
+              }}
+            >
+              <button
+                type="button"
+                className="cj-inline-cta"
+                onClick={onClose}
+                disabled={saving}
+                style={{ padding: '7px 12px' }}
+              >
+                cancel
+              </button>
+              <button
+                type="button"
+                className="cj-bch-cta-btn"
+                onClick={handleSave}
+                disabled={saving || blocks.length === 0 || incomplete}
+                style={{ padding: '7px 14px', fontSize: 12 }}
+              >
+                {saving ? 'saving…' : 'save picks'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -317,6 +317,17 @@ export async function archiveReferral(referralId: number, token: string) {
 }
 
 // Wallet types and API functions
+// One user pick for a selectable reward block on a held card. Cash+ (5%
+// quarterly) stores two rows per wallet card; Custom Cash stores one.
+// Identified by (reward_category, reward_rate) so we can match it back
+// to the YAML reward block without leaking array indexes.
+export interface WalletCardSelection {
+  reward_category: string;
+  reward_rate: number;
+  selected_category: string;
+  auto_renew: boolean;
+}
+
 export interface WalletCard {
   id: number;
   card_id: number;
@@ -327,6 +338,7 @@ export interface WalletCard {
   acquired_year?: number;
   created_at: string;
   user_rating?: number | null;
+  selections?: WalletCardSelection[];
 }
 
 export async function getWallet(token: string): Promise<WalletCard[]> {
@@ -402,6 +414,52 @@ export async function removeFromWallet(walletRowId: number, token: string): Prom
   if (!res.ok) {
     const errorText = await res.text().catch(() => 'Unknown error');
     throw new Error(`Failed to remove card from wallet: ${errorText}`);
+  }
+  return res.json();
+}
+
+// User category selections per wallet card (Cash+, Custom Cash, etc).
+// PUT replaces the active set wholesale — partial updates aren't supported.
+export interface UpdateSelectionsBody {
+  selections: Array<{
+    reward_category: string;
+    reward_rate: number;
+    selected_category: string;
+  }>;
+  auto_renew: boolean;
+}
+
+export async function updateWalletCardSelections(
+  walletRowId: number,
+  body: UpdateSelectionsBody,
+  token: string,
+): Promise<{ message: string; count: number; auto_renew: boolean }> {
+  const res = await fetch(`${API_BASE}/wallet/${walletRowId}/selections`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to update selections: ${errorText}`);
+  }
+  return res.json();
+}
+
+export async function clearWalletCardSelections(
+  walletRowId: number,
+  token: string,
+): Promise<{ message: string }> {
+  const res = await fetch(`${API_BASE}/wallet/${walletRowId}/selections`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to clear selections: ${errorText}`);
   }
   return res.json();
 }

--- a/apps/web-next/src/lib/storeRanking.ts
+++ b/apps/web-next/src/lib/storeRanking.ts
@@ -1,4 +1,4 @@
-import type { Card, Reward } from '@/lib/api';
+import type { Card, Reward, WalletCardSelection } from '@/lib/api';
 import type { Store } from '@/lib/stores';
 import { getValuation } from '@/lib/valuations';
 
@@ -7,7 +7,10 @@ export type MatchMode =
   | 'rotating_current'
   | 'rotating_eligible'
   | 'user_choice'
+  | 'user_selected'
   | 'top_spend';
+
+export type UserSelectionsByCard = Map<string, WalletCardSelection[]>;
 
 export type Channel = 'both' | 'online' | 'in_store';
 
@@ -44,6 +47,14 @@ export interface RankCardsOptions {
    * defaults the rate floors to 0 so every wallet card surfaces.
    */
   walletCardSlugs?: string[];
+  /**
+   * Per-card user selections (Cash+ picks, Custom Cash top category, etc).
+   * Keyed by card slug. When set for a card, `user_choice`/`auto_top_spend`
+   * reward blocks match ONLY the user's saved categories — speculative
+   * "if you select it" matches are suppressed and confirmed picks rank as
+   * direct matches via the new `user_selected` mode.
+   */
+  userSelections?: UserSelectionsByCard;
 }
 
 const CATEGORY_CHANNEL: Record<string, Channel> = {
@@ -133,10 +144,12 @@ export function findCategoryMatch(
   categories: string[],
   storeSlug: string | null,
   includeMerchantSpecific = false,
+  userSelections?: WalletCardSelection[],
 ): CardMatch | null {
   if (!card.rewards) return null;
   const modeRank: Record<MatchMode, number> = {
     direct: 5,
+    user_selected: 5,
     rotating_current: 4,
     user_choice: 3,
     top_spend: 2,
@@ -197,21 +210,32 @@ export function findCategoryMatch(
       continue;
     }
 
-    if (inferred === 'auto_top_spend') {
+    if (inferred === 'auto_top_spend' || inferred === 'user_choice') {
       const eligible = r.eligible_categories || [];
-      const matched = categories.find((c) => eligible.includes(c));
-      if (matched) {
-        const candidate: CardMatch = { reward: r, matchedCategory: matched, mode: 'top_spend' };
-        if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
-      }
-      continue;
-    }
 
-    if (inferred === 'user_choice') {
-      const eligible = r.eligible_categories || [];
+      // Block-level selections for this reward, if the caller passed any.
+      const blockSelections = userSelections?.filter(
+        (s) => s.reward_category === r.category && s.reward_rate === r.value,
+      );
+
+      if (blockSelections && blockSelections.length > 0) {
+        // User has configured this reward block. Match ONLY their saved picks —
+        // speculative "if you select it" badges are suppressed.
+        const userPicks = new Set(blockSelections.map((s) => s.selected_category));
+        const matched = categories.find((c) => userPicks.has(c) && eligible.includes(c));
+        if (matched) {
+          const candidate: CardMatch = { reward: r, matchedCategory: matched, mode: 'user_selected' };
+          if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
+        }
+        continue;
+      }
+
+      // No selections (legacy path / non-wallet pages): show speculative match so
+      // /store pages still surface the card with a "if you select it" badge.
       const matched = categories.find((c) => eligible.includes(c));
       if (matched) {
-        const candidate: CardMatch = { reward: r, matchedCategory: matched, mode: 'user_choice' };
+        const mode: MatchMode = inferred === 'auto_top_spend' ? 'top_spend' : 'user_choice';
+        const candidate: CardMatch = { reward: r, matchedCategory: matched, mode };
         if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
       }
     }
@@ -243,6 +267,11 @@ function reasonAndBadgeForMatch(match: CardMatch): { reason: string; badge: stri
       return {
         reason: `${rateStr} on ${catLabel} if you select it as a bonus category${cap}`,
         badge: 'if you select it',
+      };
+    case 'user_selected':
+      return {
+        reason: `${rateStr} on ${catLabel} (your selected category)${cap}`,
+        badge: 'selected',
       };
     case 'top_spend':
       return {
@@ -279,7 +308,13 @@ export function rankCards(
   for (const slug of store.co_brand_cards || []) {
     const card = cardsBySlug.get(slug);
     if (!card || used.has(slug)) continue;
-    const match = findCategoryMatch(card, store.categories, store.slug, true);
+    const match = findCategoryMatch(
+      card,
+      store.categories,
+      store.slug,
+      true,
+      options.userSelections?.get(card.slug),
+    );
     const r = match?.reward || flatRateReward(card);
     const rate = r?.value ?? 0;
     const unit = (r?.unit as 'percent' | 'points_per_dollar') ?? 'percent';
@@ -326,7 +361,13 @@ export function rankCards(
   for (const card of active) {
     if (used.has(card.slug)) continue;
     if (candidates.some((c) => c.card.slug === card.slug)) continue;
-    const m = findCategoryMatch(card, store.categories, store.slug);
+    const m = findCategoryMatch(
+      card,
+      store.categories,
+      store.slug,
+      false,
+      options.userSelections?.get(card.slug),
+    );
     if (!m) continue;
     const eff = effectiveCashbackRate(
       m.reward.value,

--- a/apps/web-next/src/lib/walletPicksForPlace.ts
+++ b/apps/web-next/src/lib/walletPicksForPlace.ts
@@ -13,17 +13,28 @@
 // This replaces the older walletPicksForCategory.ts which ignored
 // `merchant_gate` and recommended Boundless 6x at any hotel.
 
-import { Card, NearbyPlace, StoreBrandIndexEntry, WalletCard } from '@/lib/api';
+import { Card, NearbyPlace, StoreBrandIndexEntry, WalletCard, WalletCardSelection } from '@/lib/api';
 import type { Store } from '@/lib/stores';
 import { categoryLabels } from '@/lib/cardDisplayUtils';
 import { mapPlaceToCategory } from '@/lib/placeTypeMapping';
 import { matchPlaceToStoreBrand } from '@/lib/storeFromPlace';
-import { formatRate, rankCards, RankedPick } from '@/lib/storeRanking';
+import { formatRate, rankCards, RankedPick, UserSelectionsByCard } from '@/lib/storeRanking';
 
 export interface PlacePick {
   card: Card;
   rateLabel: string;
   context: string;
+}
+
+export interface UnconfiguredCardPrompt {
+  /** Wallet row id — used as the target for the SelectionsModal. */
+  walletRowId: number;
+  cardSlug: string;
+  cardName: string;
+  cardImageLink?: string;
+  /** Best rate the card *could* earn here if the user picks the matching category. */
+  potentialRate: number;
+  potentialUnit: 'percent' | 'points_per_dollar';
 }
 
 export interface PlaceMatchResult {
@@ -35,6 +46,13 @@ export interface PlaceMatchResult {
   brandSlug: string | null;
   /** Resolved reward category id (e.g. "hotels", "dining"). */
   categoryId: string;
+  /**
+   * Held cards that *could* match this merchant via a `user_choice` /
+   * `auto_top_spend` reward but the user hasn't told us which categories
+   * they picked. Surfaced as inline prompts so the user can configure
+   * them and unlock the rate.
+   */
+  unconfiguredCards: UnconfiguredCardPrompt[];
 }
 
 function rankedToPick(r: RankedPick): PlacePick {
@@ -67,8 +85,28 @@ function buildBrandStore(brand: StoreBrandIndexEntry): Store {
   };
 }
 
+/**
+ * Reward blocks a user must configure to unlock category bonuses on a card.
+ * Returns one entry per `user_choice` / `auto_top_spend` reward block.
+ */
+function selectableBlocks(card: Card): Array<{ category: string; rate: number; unit: 'percent' | 'points_per_dollar'; eligible: string[] }> {
+  if (!card.rewards) return [];
+  return card.rewards
+    .filter((r) => r.mode === 'user_choice' || r.mode === 'auto_top_spend' || r.category === 'top_category')
+    .map((r) => ({
+      category: r.category,
+      rate: r.value,
+      unit: (r.unit as 'percent' | 'points_per_dollar') ?? 'percent',
+      eligible: r.eligible_categories || [],
+    }));
+}
+
+interface WalletCardWithSelections extends WalletCard {
+  selections?: WalletCardSelection[];
+}
+
 export function pickWalletCardsForPlace(
-  walletCards: WalletCard[],
+  walletCards: WalletCardWithSelections[],
   allCards: Card[],
   place: NearbyPlace,
   brandIndex: StoreBrandIndexEntry[],
@@ -81,26 +119,99 @@ export function pickWalletCardsForPlace(
   if (categoryMatch.category === 'everything_else') return null;
   const categoryId = categoryMatch.category;
 
-  const walletCardSlugs = walletCards
-    .map((wc) => allCards.find((c) => c.card_name === wc.card_name)?.slug)
-    .filter((s): s is string => !!s);
-  if (walletCardSlugs.length === 0) return null;
+  // Map wallet rows to their card slugs (skipping any that don't resolve).
+  // Keep the wallet row alongside so we can build prompts and selection maps.
+  type Resolved = { wallet: WalletCardWithSelections; card: Card };
+  const resolved: Resolved[] = walletCards
+    .map((wc): Resolved | null => {
+      const card = allCards.find((c) => c.card_name === wc.card_name);
+      return card ? { wallet: wc, card } : null;
+    })
+    .filter((r): r is Resolved => r !== null);
+
+  if (resolved.length === 0) return null;
+
+  // Split resolved cards into: configured-or-irrelevant (rankable) vs
+  // unconfigured-with-overlap (prompt). A card "needs a prompt" only when
+  // at least one of its selectable reward blocks (a) covers this merchant
+  // category and (b) has no saved selection.
+  const rankableSlugs: string[] = [];
+  const userSelections: UserSelectionsByCard = new Map();
+  const unconfiguredCards: UnconfiguredCardPrompt[] = [];
+  const unconfiguredSlugs = new Set<string>();
+
+  for (const { wallet, card } of resolved) {
+    const blocks = selectableBlocks(card);
+    const blocksTouchingMerchant = blocks.filter((b) => b.eligible.includes(categoryId));
+
+    // Of the blocks that overlap with this merchant's category, which are
+    // unconfigured? Match selection rows by (reward_category, reward_rate).
+    const sels = wallet.selections || [];
+    const unconfiguredOverlap = blocksTouchingMerchant.filter((b) => {
+      return !sels.some((s) => s.reward_category === b.category && s.reward_rate === b.rate);
+    });
+
+    if (unconfiguredOverlap.length > 0) {
+      // Headline rate = highest-value unconfigured overlap.
+      const headline = unconfiguredOverlap.reduce((a, b) => (b.rate > a.rate ? b : a));
+      unconfiguredCards.push({
+        walletRowId: wallet.id,
+        cardSlug: card.slug,
+        cardName: card.card_name,
+        cardImageLink: card.card_image_link,
+        potentialRate: headline.rate,
+        potentialUnit: headline.unit,
+      });
+      unconfiguredSlugs.add(card.slug);
+      continue;
+    }
+
+    rankableSlugs.push(card.slug);
+    if (sels.length > 0) userSelections.set(card.slug, sels);
+  }
+
+  if (rankableSlugs.length === 0 && unconfiguredCards.length === 0) return null;
 
   const brandMatch = matchPlaceToStoreBrand(place.name, categoryId, brandIndex);
+  const store = brandMatch ? buildBrandStore(brandMatch.store) : buildSyntheticCategoryStore(categoryId);
 
-  const store = brandMatch
-    ? buildBrandStore(brandMatch.store)
-    : buildSyntheticCategoryStore(categoryId);
-
-  const ranked = rankCards(store, allCards, {
-    walletCardSlugs,
-    maxPicks: 2,
-  });
-  if (ranked.length === 0) return null;
+  const ranked = rankableSlugs.length > 0
+    ? rankCards(store, allCards, {
+        walletCardSlugs: rankableSlugs,
+        userSelections,
+        maxPicks: 2,
+      })
+    : [];
 
   const label = brandMatch
     ? brandMatch.store.name.toLowerCase()
     : (categoryLabels[categoryId]?.toLowerCase() ?? categoryId);
+
+  // No rankable picks AND no prompts → caller drops the merchant entirely.
+  if (ranked.length === 0 && unconfiguredCards.length === 0) return null;
+
+  // No rankable picks but prompts exist → still surface the merchant so the
+  // user can configure their cards and unlock matches.
+  if (ranked.length === 0) {
+    const top = unconfiguredCards.reduce((a, b) => (b.potentialRate > a.potentialRate ? b : a));
+    return {
+      best: {
+        // Synthetic placeholder pick — the UI replaces this row with a prompt
+        // when `best.context` starts with the prompt sentinel.
+        card: {
+          card_name: top.cardName,
+          slug: top.cardSlug,
+          card_image_link: top.cardImageLink,
+        } as Card,
+        rateLabel: formatRate(top.potentialRate, top.potentialUnit),
+        context: `pick categories on ${top.cardName} to unlock`,
+      },
+      label,
+      brandSlug: brandMatch?.store.slug ?? null,
+      categoryId,
+      unconfiguredCards,
+    };
+  }
 
   return {
     best: rankedToPick(ranked[0]),
@@ -108,5 +219,6 @@ export function pickWalletCardsForPlace(
     label,
     brandSlug: brandMatch?.store.slug ?? null,
     categoryId,
+    unconfiguredCards,
   };
 }


### PR DESCRIPTION
## Summary
- New `user_card_selections` table + `/wallet/{id}/selections` endpoint to capture which categories a user picked on cards like U.S. Bank Cash+ (quarterly user_choice), Citi Custom Cash / Venmo / Amex Business Gold (auto_top_spend). History-preserving via `valid_from`/`valid_to` plus an `auto_renew` flag so picks can carry forward without re-prompting.
- BCH ranker gains a `user_selected` match mode that ranks equal to a direct match and suppresses the speculative "if you select it" badge once a block is configured. Cards whose unconfigured blocks overlap a nearby merchant category are held out of the rank and surfaced as a "pick categories on Cash+ →" CTA at the top of the merchant list — feature stays alive for everything else.
- `SelectCategoriesModal` reachable from both the BCH banner and the wallet card detail row; chip picker enforces `picks_required` per block and offers an "Always pick these" toggle.

## Files
- DB: `apps/api/migrations/029_create_user_card_selections.sql`
- Backend: `apps/api/src/handlers/user-card-selections.js`, enriched `user-wallet.js` GET, SAM template wiring
- Frontend lib: `storeRanking.ts` (new `user_selected` mode + selections plumbing), rewritten `walletPicksForPlace.ts`, `api.ts` types + clients
- Frontend UI: new `SelectCategoriesModal.tsx`, BCH banner + recompute on save, wallet detail panel button

## Deferred
- **Cadence rollover Lambda** — schema supports it (`auto_renew`, `valid_to`, `source='auto_renew'`) but the cron is blocked on the EventBridge `events:*` IAM gap noted in CLAUDE.md. v1 relies on user-driven re-picks; soft-confirm UX comes in v2.
- **Telemetry** on prompt impressions/conversions.

## Test plan
- [ ] Run migration `029_create_user_card_selections.sql` via `RunMigrationHandler`
- [ ] `cd apps/api && sam build && sam deploy` — verify new `UserCardSelectionsFunction` deploys and `/wallet/{id}/selections` is reachable
- [ ] Sign in, go to Profile → Cards. Add U.S. Bank Cash+ (or Custom Cash). Confirm a `+ pick categories` button appears in the detail panel.
- [ ] Open the modal, pick the required categories, save. Confirm picks persist after a refresh.
- [ ] Toggle to Rewards tab, run BCH at a location that hits an eligible category. Confirm the configured card now ranks as `user_selected` (no "if you select it" badge) and the rate matches.
- [ ] Reverse: clear selections, confirm Cash+ disappears from BCH and the banner CTA appears for nearby merchants in its category.
- [ ] Verify `auto_renew=true` round-trips and is reflected on the modal next open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)