### PR TITLE
profile: revert BCH report design; portal modal to body for iOS scroll

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -5712,36 +5712,6 @@
   background: color-mix(in oklab, var(--warn) 8%, var(--paper));
   border-color: color-mix(in oklab, var(--warn) 50%, var(--line-2));
 }
-/* "send" action pinned in the modal head — always tappable so users
-   never have to scroll the form to submit. Inserted into .cj-modal-head
-   right before the close button via order rules below. */
-.landing-v2.profile-v2 .cj-bch-report-send {
-  margin-left: auto;
-  font-family: 'Inter Tight', sans-serif;
-  font-size: 11.5px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: lowercase;
-  color: var(--ink);
-  background: var(--accent);
-  border: 0;
-  border-radius: 3px;
-  padding: 5px 12px;
-  cursor: pointer;
-}
-.landing-v2.profile-v2 .cj-bch-report-send:hover:not(:disabled) {
-  background: var(--accent-deep);
-  color: #fff;
-}
-.landing-v2.profile-v2 .cj-bch-report-send:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-/* When the head holds a send button, the close X drops its auto-margin
-   so it sits flush against the send button on the right edge. */
-.landing-v2.profile-v2 .cj-modal-head .cj-bch-report-send + .cj-modal-close {
-  margin-left: 8px;
-}
 
 /* ---------- Long-form content (about / how / terms / privacy) ---------- */
 .landing-v2 .page-body {

--- a/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
+++ b/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { XMarkIcon, CheckIcon } from '@heroicons/react/24/outline';
 import {
   BestCardHereReportPayload,
@@ -17,10 +18,11 @@ interface ReportMerchantModalProps {
 const REASONS: ReadonlyArray<{
   value: BestCardHereReportReason;
   label: string;
+  hint?: string;
 }> = [
-  { value: 'wrong_category', label: 'Wrong category' },
-  { value: 'wrong_card', label: 'Wrong card recommended' },
-  { value: 'merchant_missing', label: "Merchant doesn't exist / closed" },
+  { value: 'wrong_category', label: 'Wrong category for this merchant', hint: 'e.g. listed as dining but it should be grocery' },
+  { value: 'wrong_card', label: 'Wrong card recommended', hint: 'I have a better card in my wallet for this' },
+  { value: 'merchant_missing', label: "This merchant doesn't exist or is closed" },
   { value: 'other', label: 'Something else' },
 ];
 
@@ -33,7 +35,12 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const scrollYRef = useRef(0);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (!show) {
@@ -52,10 +59,10 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
   }, [submitted, onClose]);
 
   // iOS-safe body scroll lock. Plain `body { overflow: hidden }` blocks
-  // page scroll but on iOS Safari it also breaks touch scrolling inside
-  // descendant scroll containers, which is what kept the report card
-  // from scrolling on iPhone 16. Pinning body with `position: fixed`
-  // + restoring scrollY on cleanup is the well-known workaround.
+  // page scroll on iOS Safari but also breaks touch scrolling inside
+  // descendant scroll containers — so the report card itself wouldn't
+  // scroll on iPhone. The position:fixed pattern locks the page without
+  // disabling inner scroll, then restores scrollY on cleanup.
   useEffect(() => {
     if (!show) return;
     scrollYRef.current = window.scrollY;
@@ -66,26 +73,23 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
       left: body.style.left,
       right: body.style.right,
       width: body.style.width,
-      overflow: body.style.overflow,
     };
     body.style.position = 'fixed';
     body.style.top = `-${scrollYRef.current}px`;
     body.style.left = '0';
     body.style.right = '0';
     body.style.width = '100%';
-    body.style.overflow = 'hidden';
     return () => {
       body.style.position = prev.position;
       body.style.top = prev.top;
       body.style.left = prev.left;
       body.style.right = prev.right;
       body.style.width = prev.width;
-      body.style.overflow = prev.overflow;
       window.scrollTo(0, scrollYRef.current);
     };
   }, [show]);
 
-  if (!show) return null;
+  if (!show || !mounted) return null;
 
   const handleSubmit = async () => {
     setSubmitting(true);
@@ -104,7 +108,13 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
     }
   };
 
-  return (
+  // Render the modal at <body> via a portal. Without this, the modal's
+  // position:fixed root is constrained by any ancestor that creates a
+  // containing block (transform / filter / will-change / contain). The
+  // profile page's sticky/transformed wrappers were doing exactly that
+  // on iPhone, breaking touch scroll inside the card. Body-level portal
+  // sidesteps the entire ancestor chain.
+  return createPortal(
     <div className="cj-modal-root" role="dialog" aria-modal="true">
       <div className="cj-modal-backdrop" onClick={submitting ? undefined : onClose} />
       <div className="cj-modal-shell">
@@ -112,16 +122,6 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
           <div className="cj-modal-head">
             <span className="cj-status-dot" />
             <span className="cj-modal-title">report this match</span>
-            {!submitted && (
-              <button
-                type="button"
-                className="cj-bch-report-send"
-                onClick={handleSubmit}
-                disabled={submitting}
-              >
-                {submitting ? 'sending…' : 'send'}
-              </button>
-            )}
             <button
               type="button"
               className="cj-modal-close"
@@ -161,65 +161,105 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
                 Thanks — we&apos;ll take a look.
               </div>
               <div style={{ fontSize: 12.5, color: 'var(--muted)', marginTop: 6, lineHeight: 1.5 }}>
-                Reports help us tune the merchant picker.
+                Reports help us tune the merchant picker. We review them weekly.
               </div>
             </div>
           ) : (
-            <div className="cj-modal-body">
-              {error && <div className="cj-modal-error">{error}</div>}
+            <>
+              <div className="cj-modal-body">
+                {error && <div className="cj-modal-error">{error}</div>}
 
-              <div className="cj-modal-section">
-                <div className="cj-bch-report-target">
-                  <b>{payload.merchant_name}</b>
-                  {payload.merchant_category ? <> · {payload.merchant_category}</> : null}
-                  {payload.recommended_card_name && (
-                    <> · we said <b>{payload.recommended_card_name}</b>{payload.rate_label ? <> ({payload.rate_label})</> : null}</>
-                  )}
+                <div className="cj-modal-section">
+                  <div className="cj-bch-report-target">
+                    <b>{payload.merchant_name}</b>
+                    {payload.merchant_category ? <> · {payload.merchant_category}</> : null}
+                    {payload.merchant_distance ? <> · {payload.merchant_distance}</> : null}
+                    {payload.recommended_card_name && (
+                      <div style={{ marginTop: 4 }}>
+                        We recommended <b>{payload.recommended_card_name}</b>
+                        {payload.rate_label ? <> at {payload.rate_label}</> : null}
+                        {payload.rate_context ? <> {payload.rate_context}</> : null}.
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="cj-modal-section">
+                  <span className="cj-modal-label">What&apos;s wrong?</span>
+                  <div className="cj-bch-report-reasons" role="radiogroup" aria-label="Report reason">
+                    {REASONS.map((r) => {
+                      const isOn = reason === r.value;
+                      return (
+                        <label key={r.value} className={'cj-bch-report-reason' + (isOn ? ' is-on' : '')}>
+                          <input
+                            type="radio"
+                            name="bch-report-reason"
+                            value={r.value}
+                            checked={isOn}
+                            onChange={() => setReason(r.value)}
+                          />
+                          <span className="cj-bch-report-reason-copy">
+                            {r.label}
+                            {r.hint && <small>{r.hint}</small>}
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="cj-modal-section">
+                  <label className="cj-modal-label" htmlFor="bch-report-notes">
+                    Add detail{' '}
+                    <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>
+                      (optional)
+                    </span>
+                  </label>
+                  <textarea
+                    id="bch-report-notes"
+                    className="cj-bch-report-notes"
+                    placeholder="What's the right category, card, or behavior?"
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value.slice(0, NOTES_MAX))}
+                    rows={3}
+                    maxLength={NOTES_MAX}
+                  />
+                  <div style={{ fontSize: 10, color: 'var(--muted-2)', textAlign: 'right', marginTop: 4 }}>
+                    {notes.length} / {NOTES_MAX}
+                  </div>
+                </div>
+
+                <div style={{ fontSize: 10.5, color: 'var(--muted)', lineHeight: 1.5 }}>
+                  We log your wallet size and the merchant shown. We don&apos;t store your coordinates.
                 </div>
               </div>
 
-              <div className="cj-modal-section">
-                <span className="cj-modal-label">What&apos;s wrong?</span>
-                <div className="cj-bch-report-reasons" role="radiogroup" aria-label="Report reason">
-                  {REASONS.map((r) => {
-                    const isOn = reason === r.value;
-                    return (
-                      <label key={r.value} className={'cj-bch-report-reason' + (isOn ? ' is-on' : '')}>
-                        <input
-                          type="radio"
-                          name="bch-report-reason"
-                          value={r.value}
-                          checked={isOn}
-                          onChange={() => setReason(r.value)}
-                        />
-                        <span className="cj-bch-report-reason-copy">{r.label}</span>
-                      </label>
-                    );
-                  })}
+              <div className="cj-modal-footer">
+                <span style={{ fontSize: 11, color: 'var(--muted)' }}>{/* spacer */}</span>
+                <div className="cj-modal-actions">
+                  <button
+                    type="button"
+                    className="cj-modal-btn"
+                    onClick={onClose}
+                    disabled={submitting}
+                  >
+                    cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="cj-modal-btn cj-modal-btn-primary"
+                    onClick={handleSubmit}
+                    disabled={submitting}
+                  >
+                    {submitting ? 'sending…' : 'send report'}
+                  </button>
                 </div>
               </div>
-
-              <div className="cj-modal-section">
-                <label className="cj-modal-label" htmlFor="bch-report-notes">
-                  Add detail{' '}
-                  <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>
-                    (optional)
-                  </span>
-                </label>
-                <textarea
-                  id="bch-report-notes"
-                  className="cj-bch-report-notes"
-                  placeholder="What's the right category or card?"
-                  value={notes}
-                  onChange={(e) => setNotes(e.target.value.slice(0, NOTES_MAX))}
-                  rows={2}
-                  maxLength={NOTES_MAX}
-                />
-              </div>
-            </div>
+            </>
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary
- Revert the BCH report modal back to the original design (cancel + send report in a footer at the bottom; full target box; reason hints; privacy line; rows=3 textarea + char count) — the "Send in head + trim form" pivot felt worse.
- Try a fundamentally different angle on the iPhone scroll bug: **render the modal via createPortal to \`document.body\`**.

## Why portal might fix it
Each previous attempt left the modal inside the profile page tree. Any ancestor with \`transform\` / \`filter\` / \`will-change\` / \`contain\` creates a containing block that breaks \`position: fixed\` and — on iOS Safari specifically — blocks touch scroll inside descendant scroll containers. A body-level portal renders the modal as a direct child of \`<body>\`, sidestepping the entire ancestor chain so the bounded card's \`overflow-y: auto\` becomes the genuine touch target.

This is a known iOS Safari class of bug; we hadn't tried this fix yet.

## Also kept
- iOS-safe \`position: fixed\` body lock (plain \`overflow: hidden\` on body blocks descendant inner-scroll on iOS Safari)
- \`.cj-modal-card-bounded\` single-container scroll
- \`-webkit-overflow-scrolling: touch\` + \`overscroll-behavior: contain\`

## Test plan
- [ ] On iPhone 16 (Safari + Chrome): open the BCH report modal → can scroll down to reach the **Send report** button
- [ ] Page behind doesn't scroll while modal is open; on close, page is at the same scroll position you opened it from
- [ ] Submitting still flips to the Thanks state and auto-closes
- [ ] Modal still looks reasonable on desktop

If this still doesn't scroll on iPhone, options for the next round:
1. Use a third-party scroll-lock library (\`body-scroll-lock-upgrade\`)
2. Switch to the native \`<dialog>\` element
3. Set explicit pixel \`height\` on the body section instead of flex/max-height

🤖 Generated with [Claude Code](https://claude.com/claude-code)