### PR TITLE
bch: multi-category place mapping for issuer-specific picks

### DIFF
--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -37,6 +37,19 @@ export const categoryLabels: Record<string, string> = {
   amazon: "Amazon.com",
   rei: "REI",
   everything_else: "Everything Else",
+  // U.S. Bank Cash+ 5% bucket categories — labels match cashplus.usbank.com/merchants.
+  fast_food: "Fast Food",
+  electronics_stores: "Electronics Stores",
+  tv_internet_streaming: "TV, Internet & Streaming Services",
+  home_utilities: "Home Utilities",
+  cell_phone_providers: "Cell Phone Providers",
+  furniture_stores: "Furniture Stores",
+  department_stores: "Department Stores",
+  ground_transportation: "Ground Transportation",
+  gyms_fitness: "Gyms/Fitness Centers",
+  select_clothing: "Select Clothing Stores",
+  sporting_goods: "Sporting Goods Stores",
+  movie_theaters: "Movie Theaters",
 };
 
 export function isPortalCategory(category: string): boolean {

--- a/apps/web-next/src/lib/placeTypeMapping.ts
+++ b/apps/web-next/src/lib/placeTypeMapping.ts
@@ -4,6 +4,18 @@
 // `everything_else`, which is also the catch-all that every wallet card
 // usually rewards at 1x.
 //
+// Each match returns *two* layers of categories:
+//   1. `primary`  — the generic taxonomy slug (dining, gas, transit…) used
+//      for labelling the merchant row and for the early-return on
+//      everything_else.
+//   2. `categories` — the primary plus any *issuer-specific subtype* slugs
+//      that apply (fast_food, movie_theaters, ground_transportation…) so a
+//      Cash+ user's "Movie Theaters" pick actually matches an AMC place.
+//
+// This means `categories` is always a superset of `[primary]`. The ranker
+// already iterates an array of categories per store, so multi-matching is
+// transparent — a merchant just carries every applicable bucket.
+//
 // Reference for Google place types:
 // https://developers.google.com/maps/documentation/places/web-service/place-types
 
@@ -73,12 +85,54 @@ const PRIMARY_TYPE_TO_CATEGORY: Record<string, string> = {
   // home improvement
   home_goods_store: 'home_improvement',
   hardware_store: 'home_improvement',
+  // electronics / sporting goods / furniture / fitness — these don't have a
+  // generic taxonomy bucket today, so they fall through to everything_else
+  // *unless* the issuer-subtype map below catches them first via the
+  // alternate path in mapPlaceToCategory.
+};
+
+// Issuer-specific subtypes layered on top of the generic primary category.
+// When a Google Places type is more specific than the generic taxonomy
+// (e.g. `movie_theater` is more precise than `entertainment`), we add the
+// issuer's specific bucket to the merchant's categories so picks like
+// Cash+ "Movie Theaters" actually match.
+//
+// These slugs live in data/categories.yaml and the categoryLabels map.
+const PRIMARY_TYPE_SUBTYPES: Record<string, string[]> = {
+  // U.S. Bank Cash+ 5% buckets
+  fast_food_restaurant: ['fast_food'],
+  meal_takeaway: ['fast_food'],
+  movie_theater: ['movie_theaters'],
+  electronics_store: ['electronics_stores'],
+  furniture_store: ['furniture_stores'],
+  gym: ['gyms_fitness'],
+  fitness_center: ['gyms_fitness'],
+  sporting_goods_store: ['sporting_goods'],
+  taxi_stand: ['ground_transportation'],
+  bus_station: ['ground_transportation'],
+  subway_station: ['ground_transportation'],
+  train_station: ['ground_transportation'],
+  light_rail_station: ['ground_transportation'],
+  transit_station: ['ground_transportation'],
+  // `clothing_store` deliberately omitted — Cash+ "Select Clothing Stores"
+  // is a curated list of partner retailers, not all clothing stores. Until
+  // a merchant_gate-style fixed list is added, surfacing Cash+ at any
+  // clothing place would be a false positive.
 };
 
 export interface PlaceCategoryMatch {
-  category: string;
-  matchedBy: 'brand' | 'primaryType' | 'type' | 'fallback';
+  /** Generic taxonomy slug (dining, gas, etc) — used for labels + everything_else fallback. */
+  primary: string;
+  /** All applicable categories: primary + any issuer-specific subtypes. */
+  categories: string[];
+  matchedBy: 'brand' | 'primaryType' | 'type' | 'subtype' | 'fallback';
   matchedValue?: string;
+}
+
+function withSubtypes(primary: string, sourceType: string | undefined): string[] {
+  if (!sourceType) return [primary];
+  const subtypes = PRIMARY_TYPE_SUBTYPES[sourceType];
+  return subtypes ? [primary, ...subtypes] : [primary];
 }
 
 export function mapPlaceToCategory(place: {
@@ -89,12 +143,19 @@ export function mapPlaceToCategory(place: {
   const lowerName = (place.name || '').toLowerCase();
   for (const { match, category } of BRAND_TO_CATEGORY) {
     if (lowerName.includes(match)) {
-      return { category, matchedBy: 'brand', matchedValue: match };
+      return {
+        primary: category,
+        categories: [category],
+        matchedBy: 'brand',
+        matchedValue: match,
+      };
     }
   }
   if (place.primaryType && PRIMARY_TYPE_TO_CATEGORY[place.primaryType]) {
+    const primary = PRIMARY_TYPE_TO_CATEGORY[place.primaryType];
     return {
-      category: PRIMARY_TYPE_TO_CATEGORY[place.primaryType],
+      primary,
+      categories: withSubtypes(primary, place.primaryType),
       matchedBy: 'primaryType',
       matchedValue: place.primaryType,
     };
@@ -102,13 +163,31 @@ export function mapPlaceToCategory(place: {
   if (place.types) {
     for (const t of place.types) {
       if (PRIMARY_TYPE_TO_CATEGORY[t]) {
+        const primary = PRIMARY_TYPE_TO_CATEGORY[t];
         return {
-          category: PRIMARY_TYPE_TO_CATEGORY[t],
+          primary,
+          categories: withSubtypes(primary, t),
           matchedBy: 'type',
           matchedValue: t,
         };
       }
     }
+    // No generic match, but the place might still be one of the issuer-only
+    // subtypes (e.g. a clothing_store with no primary mapping but maybe an
+    // upstream subtype we want to surface). Right now PRIMARY_TYPE_SUBTYPES
+    // entries always also have a generic primary mapping above, so this
+    // branch is currently dormant — kept for future "issuer-only" subtypes.
+    for (const t of place.types) {
+      const subs = PRIMARY_TYPE_SUBTYPES[t];
+      if (subs && subs.length > 0) {
+        return {
+          primary: subs[0],
+          categories: subs,
+          matchedBy: 'subtype',
+          matchedValue: t,
+        };
+      }
+    }
   }
-  return { category: 'everything_else', matchedBy: 'fallback' };
+  return { primary: 'everything_else', categories: ['everything_else'], matchedBy: 'fallback' };
 }

--- a/apps/web-next/src/lib/walletPicksForPlace.ts
+++ b/apps/web-next/src/lib/walletPicksForPlace.ts
@@ -63,14 +63,14 @@ function rankedToPick(r: RankedPick): PlacePick {
   };
 }
 
-function buildSyntheticCategoryStore(category: string): Store {
+function buildSyntheticCategoryStore(categories: string[]): Store {
   return {
     // Empty slug means rankCards' merchant_gate check (`!storeSlug`) will
     // reject every gated reward — exactly what we want when the merchant
     // isn't a recognized brand.
     slug: '',
     name: 'category',
-    categories: [category],
+    categories,
     intro: '',
   };
 }
@@ -116,8 +116,13 @@ export function pickWalletCardsForPlace(
     primaryType: place.primaryType ?? undefined,
     types: place.types,
   });
-  if (categoryMatch.category === 'everything_else') return null;
-  const categoryId = categoryMatch.category;
+  if (categoryMatch.primary === 'everything_else') return null;
+  // The merchant's primary slug labels the row; the full category list
+  // (primary + issuer-specific subtypes like `movie_theaters`) is what we
+  // match against card rewards and user selections so a Cash+ "Movie
+  // Theaters" pick actually fires at an AMC.
+  const categoryId = categoryMatch.primary;
+  const merchantCategories = categoryMatch.categories;
 
   // Map wallet rows to their card slugs (skipping any that don't resolve).
   // Keep the wallet row alongside so we can build prompts and selection maps.
@@ -142,7 +147,14 @@ export function pickWalletCardsForPlace(
 
   for (const { wallet, card } of resolved) {
     const blocks = selectableBlocks(card);
-    const blocksTouchingMerchant = blocks.filter((b) => b.eligible.includes(categoryId));
+    // A block touches this merchant when its eligible_categories overlap
+    // ANY of the merchant's categories — primary OR issuer-specific subtype.
+    // E.g. an AMC with categories=['entertainment','movie_theaters'] is
+    // touched by Cash+ 5% (which lists 'movie_theaters') even though the
+    // generic 'entertainment' isn't on Cash+'s 5% list.
+    const blocksTouchingMerchant = blocks.filter((b) =>
+      b.eligible.some((c) => merchantCategories.includes(c)),
+    );
 
     // Of the blocks that overlap with this merchant's category, which are
     // unconfigured? Match selection rows by (reward_category, reward_rate).
@@ -173,7 +185,7 @@ export function pickWalletCardsForPlace(
   if (rankableSlugs.length === 0 && unconfiguredCards.length === 0) return null;
 
   const brandMatch = matchPlaceToStoreBrand(place.name, categoryId, brandIndex);
-  const store = brandMatch ? buildBrandStore(brandMatch.store) : buildSyntheticCategoryStore(categoryId);
+  const store = brandMatch ? buildBrandStore(brandMatch.store) : buildSyntheticCategoryStore(merchantCategories);
 
   const ranked = rankableSlugs.length > 0
     ? rankCards(store, allCards, {

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-08T22:20:30.574Z",
+  "generated_at": "2026-05-09T21:28:56.334Z",
   "count": 162,
   "categories": [
     {
@@ -145,6 +145,50 @@
     {
       "id": "department_stores",
       "label": "Department Stores"
+    },
+    {
+      "id": "fast_food",
+      "label": "Fast Food"
+    },
+    {
+      "id": "electronics_stores",
+      "label": "Electronics Stores"
+    },
+    {
+      "id": "tv_internet_streaming",
+      "label": "TV, Internet & Streaming Services"
+    },
+    {
+      "id": "home_utilities",
+      "label": "Home Utilities"
+    },
+    {
+      "id": "cell_phone_providers",
+      "label": "Cell Phone Providers"
+    },
+    {
+      "id": "furniture_stores",
+      "label": "Furniture Stores"
+    },
+    {
+      "id": "ground_transportation",
+      "label": "Ground Transportation"
+    },
+    {
+      "id": "gyms_fitness",
+      "label": "Gyms/Fitness Centers"
+    },
+    {
+      "id": "select_clothing",
+      "label": "Select Clothing Stores"
+    },
+    {
+      "id": "sporting_goods",
+      "label": "Sporting Goods Stores"
+    },
+    {
+      "id": "movie_theaters",
+      "label": "Movie Theaters"
     }
   ],
   "cards": [
@@ -3427,10 +3471,10 @@
         }
       ],
       "signup_bonus": {
-        "value": 75000,
+        "value": 65000,
         "type": "miles",
-        "spend_requirement": 5000,
-        "timeframe_months": 5
+        "spend_requirement": 4000,
+        "timeframe_months": 4
       },
       "apr": {
         "regular": {
@@ -3681,10 +3725,10 @@
         }
       ],
       "signup_bonus": {
-        "value": 60000,
+        "value": 90000,
         "type": "miles",
-        "spend_requirement": 4000,
-        "timeframe_months": 3
+        "spend_requirement": 5000,
+        "timeframe_months": 4
       },
       "apr": {
         "regular": {
@@ -8354,14 +8398,18 @@
           "unit": "percent",
           "choices": 2,
           "eligible_categories": [
-            "gas",
-            "groceries",
-            "online_shopping",
-            "streaming",
-            "transit",
-            "home_improvement",
-            "entertainment",
-            "department_stores"
+            "fast_food",
+            "electronics_stores",
+            "tv_internet_streaming",
+            "home_utilities",
+            "cell_phone_providers",
+            "furniture_stores",
+            "department_stores",
+            "ground_transportation",
+            "gyms_fitness",
+            "select_clothing",
+            "sporting_goods",
+            "movie_theaters"
           ],
           "spend_cap": 2000,
           "cap_period": "quarterly",

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-09T21:28:56.334Z",
+  "generated_at": "2026-05-09T21:33:01.508Z",
   "count": 162,
   "categories": [
     {
@@ -8418,11 +8418,17 @@
           "note": "Choose 2 categories each quarter, up to $2,000 combined"
         },
         {
-          "category": "dining",
+          "category": "selected_categories",
           "value": 2,
           "unit": "percent",
-          "note": "Choose 1 everyday category: gas, grocery, or restaurants",
-          "mode": "user_choice"
+          "choices": 1,
+          "eligible_categories": [
+            "groceries",
+            "gas",
+            "dining"
+          ],
+          "mode": "user_choice",
+          "note": "Choose 1 everyday category: Grocery stores and grocery delivery, Gas stations and EV charging stations, or Restaurants"
         },
         {
           "category": "everything_else",

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -13,7 +13,7 @@ rewards:
     value: 5
     unit: percent
     choices: 2
-    eligible_categories: [gas, groceries, online_shopping, streaming, transit, home_improvement, entertainment, department_stores]
+    eligible_categories: [fast_food, electronics_stores, tv_internet_streaming, home_utilities, cell_phone_providers, furniture_stores, department_stores, ground_transportation, gyms_fitness, select_clothing, sporting_goods, movie_theaters]
     spend_cap: 2000
     cap_period: quarterly
     rate_after_cap: 1

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -19,11 +19,13 @@ rewards:
     rate_after_cap: 1
     mode: user_choice
     note: "Choose 2 categories each quarter, up to $2,000 combined"
-  - category: dining
+  - category: selected_categories
     value: 2
     unit: percent
-    note: "Choose 1 everyday category: gas, grocery, or restaurants"
+    choices: 1
+    eligible_categories: [groceries, gas, dining]
     mode: user_choice
+    note: "Choose 1 everyday category: Grocery stores and grocery delivery, Gas stations and EV charging stations, or Restaurants"
   - category: everything_else
     value: 1
     unit: percent

--- a/data/categories.yaml
+++ b/data/categories.yaml
@@ -71,3 +71,28 @@ categories:
     label: Everything Else
   - id: department_stores
     label: Department Stores
+  # U.S. Bank Cash+ 5% bucket categories — issuer-specific labels lifted
+  # verbatim from cashplus.usbank.com/merchants so the picker reads the
+  # way Cash+ presents them.
+  - id: fast_food
+    label: Fast Food
+  - id: electronics_stores
+    label: Electronics Stores
+  - id: tv_internet_streaming
+    label: TV, Internet & Streaming Services
+  - id: home_utilities
+    label: Home Utilities
+  - id: cell_phone_providers
+    label: Cell Phone Providers
+  - id: furniture_stores
+    label: Furniture Stores
+  - id: ground_transportation
+    label: Ground Transportation
+  - id: gyms_fitness
+    label: Gyms/Fitness Centers
+  - id: select_clothing
+    label: Select Clothing Stores
+  - id: sporting_goods
+    label: Sporting Goods Stores
+  - id: movie_theaters
+    label: Movie Theaters


### PR DESCRIPTION
## Summary
Stacked on #1134 (Cash+ slug additions). `mapPlaceToCategory` now returns a list of categories per place — the generic taxonomy slug plus any issuer-specific subtypes — so a Cash+ user's "Movie Theaters" pick actually fires at an AMC place result instead of getting eaten by `entertainment`.

The ranker already iterates `store.categories` as an array, so multi-matching is transparent: a merchant just carries every applicable bucket and reward blocks match against any of them.

## Subtype coverage
Cash+ 5% buckets that have a Google Places type analog:

| Cash+ category | Triggers |
|---|---|
| `fast_food` | `fast_food_restaurant`, `meal_takeaway` |
| `movie_theaters` | `movie_theater` |
| `electronics_stores` | `electronics_store` |
| `furniture_stores` | `furniture_store` |
| `gyms_fitness` | `gym`, `fitness_center` |
| `sporting_goods` | `sporting_goods_store` |
| `ground_transportation` | `taxi_stand`, `bus_station`, `subway_station`, `train_station`, `light_rail_station`, `transit_station` |

The other four Cash+ buckets (TV/Internet/Streaming, Home Utilities, Cell Phone Providers, Department Stores) are bill-pay or already mapped — no Places hook needed. **Select Clothing Stores deliberately omitted** — Cash+ has a curated partner list, not all clothing stores; surfacing Cash+ at any `clothing_store` would be a false positive. That's a follow-up using a `merchant_gate`-style fixed retailer list.

## Side effect to call out
Place types like `electronics_store` and `gym` previously had no generic taxonomy mapping → fell through to `everything_else` → filtered out of BCH entirely. They now surface with the Cash+ subtype as primary. For Cash+ users with the matching pick, this is the correct rate boost. For everyone else, the merchant just shows up with their best flat-rate card via the existing fallback fill — net positive.

## Verified
- TypeScript passes
- Dev server compiles cleanly; `/profile` and `/login` route OK
- Standalone mapper test (8 cases): AMC → `[entertainment, movie_theaters]`, McDonald's → `[dining, fast_food]`, subway station → `[transit, ground_transportation]`, plain café → `[dining]`, Whole Foods → `[amazon]`, unknown → `[everything_else]`, Best Buy → `[electronics_stores]` (issuer-only), gym → `[gyms_fitness]` (issuer-only).

## Test plan
- [ ] After this and #1134 land, sign in with a wallet that includes Cash+
- [ ] Pick `Movie Theaters` and `Fast Food` as Cash+ 5% picks
- [ ] Run BCH near an AMC and a McDonald's; both should rank Cash+ as `5% on Movie Theaters/Fast Food (your selected category)` — `user_selected` mode, no "if you select it" badge
- [ ] Run BCH at a place that doesn't overlap (e.g. dry cleaner); confirm Cash+ doesn't surface and prompt is not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)