### PR TITLE
profile: abbreviate renewal year and add issuer logos to rule charts

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -5222,6 +5222,16 @@
   letter-spacing: -0.01em;
   color: var(--ink);
   line-height: 1.1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.landing-v2.profile-v2 .cj-rule-logo {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  object-fit: cover;
+  flex-shrink: 0;
 }
 .landing-v2.profile-v2 .cj-rule-period {
   font-size: 10.5px;

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -440,7 +440,7 @@ export default function ProfileClient() {
               <div className="cj-readoff-cell cj-readoff-bonus">
                 <div className="cj-readoff-k">Next renewal</div>
                 <div className="cj-readoff-v">
-                  {nextRenewal ? nextRenewal.renewal.split(' ')[0] + ' ' + nextRenewal.renewal.split(' ')[1].slice(2) : '—'}
+                  {nextRenewal ? `${nextRenewal.renewal.split(' ')[0]} '${nextRenewal.renewal.split(' ')[1].slice(2)}` : '—'}
                 </div>
                 <div className="cj-readoff-foot">
                   {nextRenewal ? `${nextRenewal.name.replace(/ Card$/, '')} · $${nextRenewal.fee}` : 'no fee renewals'}
@@ -726,7 +726,7 @@ export default function ProfileClient() {
                 {upcomingRenewals.map((r) => (
                   <li key={r.name} className="cj-rail-row">
                     <div className="cj-rail-row-meta">
-                      <span className="cj-rail-row-date">{r.renewal.split(' ')[0]} {r.renewal.split(' ')[1].slice(2)}</span>
+                      <span className="cj-rail-row-date">{r.renewal.split(' ')[0]} '{r.renewal.split(' ')[1].slice(2)}</span>
                       <span className="cj-rail-row-field">{r.name.replace(/ Card$/, '')}</span>
                     </div>
                     <div className="cj-rail-row-detail">

--- a/apps/web-next/src/components/charts/RuleProgressChart.tsx
+++ b/apps/web-next/src/components/charts/RuleProgressChart.tsx
@@ -1,13 +1,21 @@
 'use client';
 
+import Image from 'next/image';
 import { RuleResult } from '@/lib/applicationRules';
 
 interface RuleProgressChartProps {
   rule: RuleResult;
 }
 
+const RULE_LOGO: Record<string, string> = {
+  'Chase 5/24': '/logos/chase.jpg',
+  'Amex 2/90': '/logos/amex.jpg',
+  'Capital One 1/6': '/logos/capital-one.jpg',
+};
+
 export default function RuleProgressChart({ rule }: RuleProgressChartProps) {
   const { ruleName, current, limit, periodDescription } = rule;
+  const logo = RULE_LOGO[ruleName];
 
   const status: 'ok' | 'at' | 'over' =
     current > limit ? 'over' : current === limit ? 'at' : 'ok';
@@ -21,7 +29,19 @@ export default function RuleProgressChart({ rule }: RuleProgressChartProps) {
   return (
     <div className="cj-rule">
       <div className="cj-rule-head">
-        <div className="cj-rule-name">{ruleName}</div>
+        <div className="cj-rule-name">
+          {logo && (
+            <Image
+              src={logo}
+              alt=""
+              width={18}
+              height={18}
+              className="cj-rule-logo"
+              aria-hidden="true"
+            />
+          )}
+          <span>{ruleName}</span>
+        </div>
         <div className="cj-rule-period">{periodDescription}</div>
       </div>
 


### PR DESCRIPTION
## Summary
- Abbreviate the renewal year in places that already used a 2-digit year so it doesn't read like a date — \`Oct 26\` → \`Oct '26\` in the readoff card and the upcoming-renewals rail. Wallet table/drawer keep the full year.
- Add small issuer logos next to **Chase 5/24**, **Amex 2/90**, and **Capital One 1/6** on the rule progress charts, reusing the existing \`/logos/{chase,amex,capital-one}.jpg\` files from the /tools page.

## Test plan
- [ ] Profile readoff: "Next renewal" shows \`Oct '26\`
- [ ] Profile rail: "Upcoming renewals" rows show \`Oct '26\`
- [ ] Profile wallet table: Renewal column still shows \`Oct 2026\`
- [ ] Application rules section: each of the three rule cards shows a small issuer logo to the left of the rule name

🤖 Generated with [Claude Code](https://claude.com/claude-code)