### PR TITLE
profile: fix Amplify SEO check — give rule-chart logos alt text

### DIFF
--- a/apps/web-next/src/components/charts/RuleProgressChart.tsx
+++ b/apps/web-next/src/components/charts/RuleProgressChart.tsx
@@ -7,10 +7,10 @@ interface RuleProgressChartProps {
   rule: RuleResult;
 }
 
-const RULE_LOGO: Record<string, string> = {
-  'Chase 5/24': '/logos/chase.jpg',
-  'Amex 2/90': '/logos/amex.jpg',
-  'Capital One 1/6': '/logos/capital-one.jpg',
+const RULE_LOGO: Record<string, { src: string; issuer: string }> = {
+  'Chase 5/24': { src: '/logos/chase.jpg', issuer: 'Chase' },
+  'Amex 2/90': { src: '/logos/amex.jpg', issuer: 'American Express' },
+  'Capital One 1/6': { src: '/logos/capital-one.jpg', issuer: 'Capital One' },
 };
 
 export default function RuleProgressChart({ rule }: RuleProgressChartProps) {
@@ -32,12 +32,11 @@ export default function RuleProgressChart({ rule }: RuleProgressChartProps) {
         <div className="cj-rule-name">
           {logo && (
             <Image
-              src={logo}
-              alt=""
+              src={logo.src}
+              alt={`${logo.issuer} logo`}
               width={18}
               height={18}
               className="cj-rule-logo"
-              aria-hidden="true"
             />
           )}
           <span>{ruleName}</span>


### PR DESCRIPTION
## Summary
- The previous PR (#1140) used \`alt=""\` on the new issuer logos in [RuleProgressChart](apps/web-next/src/components/charts/RuleProgressChart.tsx). \`scripts/check-seo.mjs\` rejects empty alt because Bing flags it as missing — this broke the Amplify build.
- Use the issuer name (e.g. \`Chase logo\`) and drop \`aria-hidden\`. Mapped each rule to \`{ src, issuer }\` so the alt is centralized.

## Test plan
- [x] \`node apps/web-next/scripts/check-seo.mjs\` → \`SEO check passed\`
- [ ] Amplify build succeeds for main

🤖 Generated with [Claude Code](https://claude.com/claude-code)