### PR TITLE
profile: fix invisible BCH report modal — wrap portal in landing-v2 profile-v2

### DIFF
--- a/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
+++ b/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
@@ -99,10 +99,11 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
   // on iPhone, breaking touch scroll inside the card. Body-level portal
   // sidesteps the entire ancestor chain.
   return createPortal(
-    <div className="cj-modal-root" role="dialog" aria-modal="true">
-      <div className="cj-modal-backdrop" onClick={submitting ? undefined : onClose} />
-      <div className="cj-modal-shell">
-        <div className="cj-modal-card cj-modal-card-bounded" style={{ maxWidth: 480 }}>
+    <div className="landing-v2 profile-v2">
+      <div className="cj-modal-root" role="dialog" aria-modal="true">
+        <div className="cj-modal-backdrop" onClick={submitting ? undefined : onClose} />
+        <div className="cj-modal-shell">
+          <div className="cj-modal-card cj-modal-card-bounded" style={{ maxWidth: 480 }}>
           <div className="cj-modal-head">
             <span className="cj-status-dot" />
             <span className="cj-modal-title">report this match</span>
@@ -241,6 +242,7 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
               </div>
             </>
           )}
+          </div>
         </div>
       </div>
     </div>,


### PR DESCRIPTION
## Summary
The "report this match" button on Best Card Here looked broken: the click registered, but no modal appeared.

**Root cause**: [ReportMerchantModal](apps/web-next/src/components/wallet/ReportMerchantModal.tsx) portals to \`document.body\`, but every \`.cj-modal-*\` CSS rule is scoped under \`.landing-v2.profile-v2\` in [landing.css](apps/web-next/src/app/landing.css). Once portaled, no styles applied — the dialog rendered as unpositioned plain divs at the bottom of the body, no backdrop, no z-index, no \`position: fixed\`. Effectively invisible.

[#1139](https://github.com/CreditOdds/creditodds/pull/1139) added the \`<div className="landing-v2 profile-v2">\` wrapper to \`EditWalletCardModal\` for the same reason; \`ReportMerchantModal\` was missed. This PR adds the same wrapper.

Modal has been broken since [#1133](https://github.com/CreditOdds/creditodds/pull/1133) (when the portal was first introduced).

## Test plan
- [ ] On /profile → Best Card Here, click "report this match" on any merchant — the dialog appears with backdrop and proper styling
- [ ] Submit a report — confirmation thank-you renders
- [ ] iPhone: page behind doesn't scroll while the dialog is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)