### PR TITLE
profile: lift modals above the fixed mobile profile tab bar

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -5303,10 +5303,13 @@
 }
 
 /* ===== Modal — cj-* styled ===== */
+/* z-index 110 keeps the modal above the mobile profile tab bar (z:100) so
+   the dialog isn't tappable through, and so the bottom of the card isn't
+   covered by the tab bar. */
 .landing-v2.profile-v2 .cj-modal-root {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 110;
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
@@ -5325,7 +5328,10 @@
   min-height: 100%;
   align-items: flex-end;
   justify-content: center;
-  padding: 0;
+  /* Bottom padding lifts the modal card above the fixed mobile profile
+     tab bar so the Send/Save buttons aren't covered. Mirrors the height
+     reserved on .cj-modal-card-bounded above. */
+  padding: 0 0 calc(env(safe-area-inset-bottom, 0px) + 70px);
 }
 @media (min-width: 640px) {
   .landing-v2.profile-v2 .cj-modal-shell {
@@ -5667,7 +5673,9 @@
    min-height:0 + overflow-y:auto. Single-container scroll is dumber
    but reliably works. */
 .landing-v2.profile-v2 .cj-modal-card-bounded {
-  max-height: 100dvh;
+  /* Reserve room for the fixed mobile profile tab bar (~70px + safe area)
+     so the bottom action buttons aren't parked behind it. */
+  max-height: calc(100dvh - env(safe-area-inset-bottom, 0px) - 70px);
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## Summary
You were right — the BCH report modal *was* opening (after [#1142](https://github.com/CreditOdds/creditodds/pull/1142)), but on mobile its bottom action row was hidden behind the fixed profile tab bar so the Send button was unreachable.

Two stacked issues in [landing.css](apps/web-next/src/app/landing.css):

1. \`.cj-modal-root\` was \`z-index: 50\`, but \`.cj-mob-tabbar\` (the fixed bottom tab bar) is \`z-index: 100\` — so the tab bar painted over the dialog and intercepted taps. Bumped to 110.
2. \`.cj-modal-card-bounded\` had \`max-height: 100dvh\` on mobile and \`.cj-modal-shell\` had no bottom padding + \`align-items: flex-end\` — meaning the card filled the viewport and its bottom action row sat *behind* the tab bar. Reserved ~70px + \`safe-area-inset-bottom\` on both the shell's \`padding-bottom\` and the card's \`max-height\` so the buttons clear the tab bar.

Same fix benefits \`EditWalletCardModal\`, which uses the same shell + bounded classes.

## Test plan
- [ ] iPhone /profile → BCH → "report this match": dialog opens, the Send/Cancel row is visible above the tab bar
- [ ] iPhone /profile → cards-tab → Edit on a wallet card: Save button is visible above the tab bar
- [ ] Tab bar can no longer be tapped through the backdrop (z-index)
- [ ] Desktop layout unchanged (640px+ media query keeps the prior \`calc(100dvh - 64px)\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)