### PR TITLE
static pages: redesign about/how/terms/privacy in editorial v2 style

### DIFF
--- a/apps/web-next/src/app/about/page.tsx
+++ b/apps/web-next/src/app/about/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from "next";
 import Image from "next/image";
+import Link from "next/link";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import "../landing.css";
+import "../static-pages.css";
 
 export const metadata: Metadata = {
   title: "About",
@@ -19,91 +21,166 @@ export const metadata: Metadata = {
 
 export default function AboutPage() {
   return (
-    <div className="landing-v2">
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          Can I get <em>this card?</em>
-        </h1>
-        <p className="page-sub">
-          The question that started CreditOdds — and why the data behind it matters more
-          than another sponsored listicle.
-        </p>
-      </section>
-
-      <div className="wrap">
-        <article className="page-body">
-          <figure>
-            <Image
-              src="/assets/Graphic-01.svg"
-              alt="CreditOdds — computer and credit card"
-              width={1184}
-              height={1376}
-            />
-          </figure>
-          <p>
-            My girlfriend asked me that while scrolling through her bank&apos;s credit
-            card selection one evening. We&apos;d just finished going over an introduction
-            to credit card rewards and she was eager to get her free flight to the
-            Maldives.
-          </p>
-          <p>
-            She gave me her credit score, which was decent, and I told her to apply. A
-            few minutes later her application was complete and she hit submit.
-            REJECTED. Gentlemen, guess who she was upset with? (Hint: It wasn&apos;t her
-            bank.)
-          </p>
-          <p>
-            I&apos;ve been working in consumer banking for a little over 2 years and
-            people always ask me to &ldquo;look into their situation.&rdquo; To be
-            honest, I don&apos;t even know where I would start if I needed to find the
-            person in charge of applications here. I work on the technology side and I
-            do know that the approval process is almost completely automated. The
-            bank&apos;s system takes everything you provide, pulls your credit history,
-            and makes a decision based on select criteria. Unfortunately for everyone,
-            these approval metrics aren&apos;t on the application page.
-          </p>
-
-          <blockquote>
-            <p>
-              If a bank decides that nobody with a FICO credit score under 550 should be
-              approved for their card, they&apos;ll still let those people apply.
-            </p>
-          </blockquote>
-
-          <p>
-            While similar to college admissions, there are special cases — but the
-            theory behind CreditOdds is that aggregate data will outline the bank&apos;s
-            approval criteria for each card.
-          </p>
-
-          <h3>Why it matters to my girlfriend and you</h3>
-          <p>
-            My girlfriend was obviously upset that she didn&apos;t get the card, but she
-            also knew from our earlier discussion that she had just received a
-            &ldquo;hard pull&rdquo; on her credit. In short, when banks collect your
-            credit history from a credit bureau that inquiry lowers your credit score.
-            That&apos;s because these hard inquiries remain on your credit report for a
-            few years and too many will make you appear as a high risk to lenders. It
-            also means that immediately following a rejection isn&apos;t the best time
-            to apply for another card.
-          </p>
-
-          <h3>Final note</h3>
-          <p>
-            I&apos;m only scratching the surface in the world of credit cards. If
-            you&apos;re interested in learning more please visit the{' '}
-            <a href="/how">How It Works</a> page.
-          </p>
-          <p>
-            Finally, this site only works with your help. I started this project by
-            reading thousands of credit card forums to collect data points. If
-            you&apos;ve found value in what you&apos;ve seen here please consider
-            posting your results in the future.
-          </p>
-
-          <p className="signature">Max · Founder</p>
-        </article>
+    <div className="landing-v2 static-v2">
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <span className="cj-crumb cj-crumb-current">about</span>
+        </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
+          <span><span className="cj-status-dot" />est. 2021 · independent · founder-built</span>
+        </div>
       </div>
+
+      <div className="cj-layout">
+        <main className="cj-main-static">
+          <header className="cj-page-head">
+            <div className="cj-page-eyebrow">about · the origin story</div>
+            <h1 className="cj-page-h1">
+              Can I get <em className="cj-section-accent">this card?</em>
+            </h1>
+            <p className="cj-page-lede">
+              The question that started CreditOdds — and why the data behind it matters more
+              than another sponsored listicle.
+            </p>
+            <div className="cj-page-meta">
+              <span><b>Founded</b> · 2021</span>
+              <span><b>Built by</b> · Max, founder</span>
+              <span><b>Powered by</b> · real applicant data, not bank marketing</span>
+            </div>
+          </header>
+
+          <section className="cj-static-section">
+            <div className="cj-section-num">01 · the question</div>
+            <h2>It started with a rejection.</h2>
+            <div className="cj-prose">
+              <p>
+                My girlfriend asked me that while scrolling through her bank&apos;s credit
+                card selection one evening. We&apos;d just finished going over an introduction
+                to credit card rewards and she was eager to get her free flight to the
+                Maldives.
+              </p>
+              <p>
+                She gave me her credit score, which was decent, and I told her to apply. A
+                few minutes later her application was complete and she hit submit.
+                REJECTED. Gentlemen, guess who she was upset with? (Hint: It wasn&apos;t her
+                bank.)
+              </p>
+            </div>
+            <div className="cj-figure">
+              <Image
+                src="/assets/Graphic-01.svg"
+                alt="CreditOdds — computer and credit card"
+                width={1184}
+                height={1376}
+              />
+            </div>
+          </section>
+
+          <section className="cj-static-section">
+            <div className="cj-section-num">02 · what banks won&apos;t tell you</div>
+            <h2>The approval criteria aren&apos;t on the application page.</h2>
+            <div className="cj-prose">
+              <p>
+                I&apos;ve been working in consumer banking for a little over 2 years and
+                people always ask me to &ldquo;look into their situation.&rdquo; To be
+                honest, I don&apos;t even know where I would start if I needed to find the
+                person in charge of applications here. I work on the technology side and I
+                do know that the approval process is almost completely automated. The
+                bank&apos;s system takes everything you provide, pulls your credit history,
+                and makes a decision based on select criteria. Unfortunately for everyone,
+                these approval metrics aren&apos;t on the application page.
+              </p>
+              <blockquote>
+                <p>
+                  If a bank decides that nobody with a FICO credit score under 550 should be
+                  approved for their card, they&apos;ll still let those people apply.
+                </p>
+              </blockquote>
+              <p>
+                While similar to college admissions, there are special cases — but the
+                theory behind CreditOdds is that aggregate data will outline the bank&apos;s
+                approval criteria for each card.
+              </p>
+            </div>
+          </section>
+
+          <section className="cj-static-section">
+            <div className="cj-section-num">03 · why it matters</div>
+            <h2>Why it matters to my girlfriend and you.</h2>
+            <div className="cj-prose">
+              <p>
+                My girlfriend was obviously upset that she didn&apos;t get the card, but she
+                also knew from our earlier discussion that she had just received a
+                &ldquo;hard pull&rdquo; on her credit. In short, when banks collect your
+                credit history from a credit bureau that inquiry lowers your credit score.
+                That&apos;s because these hard inquiries remain on your credit report for a
+                few years and too many will make you appear as a high risk to lenders. It
+                also means that immediately following a rejection isn&apos;t the best time
+                to apply for another card.
+              </p>
+            </div>
+            <div className="cj-callout">
+              <b>The lesson:</b> a denial costs more than a missed sign-up bonus. It costs you a hard inquiry, a small score hit, and the next two or three months you might&apos;ve used to apply for something you actually qualify for.
+            </div>
+          </section>
+
+          <section className="cj-static-section">
+            <div className="cj-section-num">04 · how the site works</div>
+            <h2>One question, one community, one dataset.</h2>
+            <div className="cj-prose">
+              <p>
+                Every approval-odds estimate on CreditOdds is built from records submitted
+                by people who actually applied — credit score, income, outcome — not from
+                bank marketing copy or estimated soft-pull APIs. The more people share
+                their results, the sharper the picture gets for everyone reading next.
+              </p>
+            </div>
+            <dl className="cj-deflist">
+              <dt>Founder</dt>
+              <dd>Max — built CreditOdds to answer the question I get asked at every family dinner. Background in consumer-banking technology.</dd>
+              <dt>Independent</dt>
+              <dd>Not owned by an issuer. Not part of an affiliate network. Rankings are not influenced by who pays a commission.</dd>
+              <dt>Community-powered</dt>
+              <dd>The dataset starts with applicants who took two minutes to share their result. Without you, the rest of the site doesn&apos;t work.</dd>
+            </dl>
+          </section>
+
+          <section className="cj-static-section">
+            <div className="cj-section-num">05 · final note</div>
+            <h2>This site only works with your help.</h2>
+            <div className="cj-prose">
+              <p>
+                I&apos;m only scratching the surface in the world of credit cards. If
+                you&apos;re interested in learning more please visit the{' '}
+                <Link href="/how">How It Works</Link> page.
+              </p>
+              <p>
+                Finally, this site only works with your help. I started this project by
+                reading thousands of credit card forums to collect data points. If
+                you&apos;ve found value in what you&apos;ve seen here please consider
+                posting your results in the future.
+              </p>
+              <span className="cj-signature">Max · Founder</span>
+            </div>
+          </section>
+
+          <div className="cj-cta-block">
+            <div>
+              <div className="cj-cta-eyebrow">help build the dataset</div>
+              <h3 className="cj-cta-h">Share your result. Help the next applicant.</h3>
+              <p className="cj-cta-sub">
+                Two minutes, no card connection required. Your data point makes the next person&apos;s odds estimate sharper.
+              </p>
+            </div>
+            <div className="cj-cta-actions">
+              <Link href="/check-odds" className="cj-cta-btn">+ submit a result</Link>
+              <Link href="/how" className="cj-cta-btn-outline">read the methodology</Link>
+            </div>
+          </div>
+        </main>
+      </div>
+
       <V2Footer />
     </div>
   );

--- a/apps/web-next/src/app/how/page.tsx
+++ b/apps/web-next/src/app/how/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import { FAQSchema } from "@/components/seo/JsonLd";
 import "../landing.css";
+import "../static-pages.css";
 
 export const metadata: Metadata = {
   title: "How It Works",
@@ -114,220 +115,204 @@ const FAQS: FAQ[] = [
 
 export default function HowPage() {
   return (
-    <div className="landing-v2">
+    <div className="landing-v2 static-v2">
       <FAQSchema questions={FAQS.map((f) => ({ question: f.question, answer: f.answer }))} />
 
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          Our approach to <em>credit card odds.</em>
-        </h1>
-        <p className="page-sub">
-          CreditOdds is a work in progress. The goal is to highlight the metrics
-          required to get approved for any given card — sourced from real applications,
-          not bank marketing copy.
-        </p>
-      </section>
-
-      <div className="wrap">
-        <article className="page-body">
-          <p>
-            Initially, I sourced this data from Reddit (shout out{' '}
-            <a
-              href="https://reddit.com/r/CreditCards"
-              target="_blank"
-              rel="noreferrer"
-            >
-              /r/CreditCards
-            </a>
-            ) and other credit card forums. This approach isn&apos;t scalable and I am
-            hoping that this site provides a medium for collecting this information at
-            scale. While I have a backlog of features I&apos;d like to achieve, this
-            early version of CreditOdds <strong>will rely heavily on the good will of
-            you</strong> to report your results to help others.
-          </p>
-
-          <h3>The data points we collect</h3>
-          <p>
-            When a user signs up they have the ability to report a result on any card.
-            We ask for a few pieces of important information when submitting a result:
-          </p>
-          <ul>
-            <li>Credit score</li>
-            <li>Income</li>
-            <li>Application date</li>
-            <li>Age of oldest account (length of credit)</li>
-            <li>Existing account with bank</li>
-            <li>Approved?</li>
-          </ul>
-          <p>If approved:</p>
-          <ul>
-            <li>Starting credit limit</li>
-          </ul>
-          <p>If rejected:</p>
-          <ul>
-            <li>Reason provided</li>
-          </ul>
-          <p>
-            There are many other questions I&apos;d like to ask, but this is the
-            baseline that I feel people will answer. I selected these fields because
-            it&apos;s what you&apos;ll likely see on most card applications. Your credit
-            score also gives a good high-level analysis of what the bank sees when they
-            pull your credit.
-          </p>
-
-          <figure>
-            <Image
-              src="/assets/Graphic-03.svg"
-              alt="How the data flows"
-              width={660}
-              height={438}
-            />
-          </figure>
-
-          <p>
-            This is by no means an exact science. As mentioned before, there are
-            special exceptions that aren&apos;t currently accounted for in the reporting
-            template. If you have questions, comments, or concerns, start a discussion
-            on{' '}
-            <a href="https://twitter.com/MaxwellMelcher" target="_blank" rel="noreferrer">
-              Twitter / X
-            </a>
-            .
-          </p>
-        </article>
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <span className="cj-crumb cj-crumb-current">how it works</span>
+        </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
+          <span><span className="cj-status-dot" />methodology · public</span>
+        </div>
       </div>
 
-      <section className="wrap" style={{ paddingTop: 8, paddingBottom: 64 }}>
-        <div
-          style={{
-            maxWidth: 760,
-            margin: '0 auto',
-          }}
-        >
-          <div style={{ marginBottom: 32 }}>
-            <div
-              style={{
-                fontSize: 12,
-                fontWeight: 600,
-                letterSpacing: 1.5,
-                textTransform: 'uppercase',
-                color: 'var(--accent)',
-                marginBottom: 10,
-              }}
-            >
-              Common Questions
-            </div>
-            <h2
-              style={{
-                fontFamily: "'Inter Tight', sans-serif",
-                fontSize: 'clamp(28px, 4vw, 38px)',
-                fontWeight: 700,
-                letterSpacing: -0.5,
-                margin: '0 0 12px',
-                color: 'var(--ink)',
-              }}
-            >
-              Credit card FAQ.
-            </h2>
-            <p
-              style={{
-                fontSize: 16,
-                lineHeight: 1.55,
-                color: 'var(--muted)',
-                margin: 0,
-              }}
-            >
-              Quick answers pulled from our long-form{' '}
-              <Link href="/articles" style={{ color: 'var(--accent)', borderBottom: '1px solid currentColor', textDecoration: 'none' }}>
-                articles
-              </Link>
-              . Tap a question for the short version, then follow the link for the
-              full breakdown.
+      <div className="cj-layout">
+        <main className="cj-main-static">
+          <header className="cj-page-head">
+            <div className="cj-page-eyebrow">how it works · methodology</div>
+            <h1 className="cj-page-h1">
+              Our approach to <em className="cj-section-accent">credit card odds.</em>
+            </h1>
+            <p className="cj-page-lede">
+              CreditOdds is a work in progress. The goal is to highlight the metrics
+              required to get approved for any given card — sourced from real applications,
+              not bank marketing copy.
             </p>
-          </div>
+            <div className="cj-page-meta">
+              <span><b>Approach</b> · community-submitted data</span>
+              <span><b>Source</b> · real applicants, not soft-pull APIs</span>
+              <span><b>Status</b> · always growing</span>
+            </div>
+          </header>
 
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {FAQS.map((faq) => (
-              <details
-                key={faq.question}
-                style={{
-                  background: 'var(--bg-2, #fff)',
-                  border: '1px solid var(--line-2, #e5e7eb)',
-                  borderRadius: 12,
-                  padding: '16px 20px',
-                  fontFamily: "'Inter', sans-serif",
-                }}
-              >
-                <summary
-                  style={{
-                    cursor: 'pointer',
-                    fontSize: 16,
-                    fontWeight: 600,
-                    color: 'var(--ink)',
-                    listStyle: 'none',
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'flex-start',
-                    gap: 16,
-                    lineHeight: 1.4,
-                  }}
-                >
-                  <span>{faq.question}</span>
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      flexShrink: 0,
-                      color: 'var(--muted)',
-                      fontSize: 20,
-                      lineHeight: 1,
-                      marginTop: 2,
-                    }}
-                  >
-                    +
-                  </span>
-                </summary>
-                <div
-                  style={{
-                    marginTop: 12,
-                    fontSize: 15,
-                    lineHeight: 1.6,
-                    color: 'var(--ink-2, #374151)',
-                  }}
-                >
-                  <p style={{ margin: '0 0 10px' }}>{faq.answer}</p>
-                  <Link
-                    href={`/articles/${faq.source.slug}`}
-                    style={{
-                      fontSize: 13,
-                      fontWeight: 600,
-                      color: 'var(--accent)',
-                      textDecoration: 'none',
-                      borderBottom: '1px solid currentColor',
-                    }}
-                  >
-                    Read: {faq.source.title} →
-                  </Link>
-                </div>
-              </details>
-            ))}
-          </div>
+          <section className="cj-static-section">
+            <div className="cj-section-num">01 · the loop</div>
+            <h2>Three steps. That&apos;s the whole product.</h2>
+            <div className="cj-steps">
+              <div className="cj-step">
+                <div className="cj-step-num">1</div>
+                <div className="cj-step-h">You apply.</div>
+                <p className="cj-step-p">Approved or denied — either outcome is a useful data point for the next applicant.</p>
+              </div>
+              <div className="cj-step">
+                <div className="cj-step-num">2</div>
+                <div className="cj-step-h">You share the result.</div>
+                <p className="cj-step-p">Score, income, outcome. Two minutes. Anonymous in aggregate.</p>
+              </div>
+              <div className="cj-step">
+                <div className="cj-step-num">3</div>
+                <div className="cj-step-h">We do the math.</div>
+                <p className="cj-step-p">Aggregated across thousands of submissions to surface real approval patterns per card.</p>
+              </div>
+            </div>
+          </section>
 
-          <p
-            style={{
-              marginTop: 28,
-              fontSize: 14,
-              color: 'var(--muted)',
-              textAlign: 'center',
-            }}
-          >
-            Have a question that should be here?{' '}
-            <Link href="/contact" style={{ color: 'var(--accent)', textDecoration: 'none', borderBottom: '1px solid currentColor' }}>
-              Send it our way
-            </Link>
-            .
-          </p>
-        </div>
-      </section>
+          <section className="cj-static-section">
+            <div className="cj-section-num">02 · the source</div>
+            <h2>Where the data comes from.</h2>
+            <div className="cj-prose">
+              <p>
+                Initially, I sourced this data from Reddit (shout out{' '}
+                <a
+                  href="https://reddit.com/r/CreditCards"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  /r/CreditCards
+                </a>
+                ) and other credit card forums. This approach isn&apos;t scalable and I am
+                hoping that this site provides a medium for collecting this information at
+                scale. While I have a backlog of features I&apos;d like to achieve, this
+                early version of CreditOdds <strong>will rely heavily on the good will of
+                you</strong> to report your results to help others.
+              </p>
+            </div>
+            <div className="cj-callout">
+              <b>What this is not:</b> a soft-pull credit check. It&apos;s a population estimate based on what other applicants with similar profiles experienced. Your actual outcome depends on signals we don&apos;t see — relationship history, recent inquiries, internal issuer flags.
+            </div>
+          </section>
+
+          <section className="cj-static-section">
+            <div className="cj-section-num">03 · the data points</div>
+            <h2>What we ask for when you submit a result.</h2>
+            <div className="cj-prose">
+              <p>
+                When a user signs up they have the ability to report a result on any card.
+                We ask for a few pieces of important information when submitting a result:
+              </p>
+            </div>
+            <dl className="cj-deflist">
+              <dt>Required</dt>
+              <dd>Credit score, income, application date, age of oldest account (length of credit), existing account with bank, approved or denied.</dd>
+              <dt>If approved</dt>
+              <dd>Starting credit limit.</dd>
+              <dt>If rejected</dt>
+              <dd>The reason the bank provided.</dd>
+            </dl>
+            <div className="cj-prose">
+              <p>
+                There are many other questions I&apos;d like to ask, but this is the
+                baseline that I feel people will answer. I selected these fields because
+                it&apos;s what you&apos;ll likely see on most card applications. Your credit
+                score also gives a good high-level analysis of what the bank sees when they
+                pull your credit.
+              </p>
+            </div>
+            <div className="cj-figure">
+              <Image
+                src="/assets/Graphic-03.svg"
+                alt="How the data flows"
+                width={660}
+                height={438}
+              />
+            </div>
+            <div className="cj-prose">
+              <p>
+                This is by no means an exact science. As mentioned before, there are
+                special exceptions that aren&apos;t currently accounted for in the reporting
+                template. If you have questions, comments, or concerns, start a discussion
+                on{' '}
+                <a href="https://twitter.com/MaxwellMelcher" target="_blank" rel="noreferrer">
+                  Twitter / X
+                </a>
+                .
+              </p>
+            </div>
+          </section>
+
+          <section className="cj-static-section">
+            <div className="cj-section-num">04 · what we don&apos;t do</div>
+            <h2>And the lines we don&apos;t cross.</h2>
+            <ul className="cj-dontlist">
+              <li>
+                <span className="cj-x">×</span>
+                <span>We don&apos;t pull your credit. No soft inquiries, no hard inquiries, no bureau access of any kind.</span>
+              </li>
+              <li>
+                <span className="cj-x">×</span>
+                <span>We don&apos;t connect to your bank. Anything we know about your wallet is what you tell us.</span>
+              </li>
+              <li>
+                <span className="cj-x">×</span>
+                <span>We don&apos;t change rankings for affiliate payout. Affiliate links exist; the order of cards on a page is not influenced by them.</span>
+              </li>
+              <li>
+                <span className="cj-x">×</span>
+                <span>We don&apos;t sell individual records, individual user data, or anything tied to your account. See <Link href="/privacy">/privacy</Link> for the long version.</span>
+              </li>
+            </ul>
+          </section>
+
+          <section className="cj-static-section">
+            <div className="cj-section-num">05 · faq</div>
+            <h2>Common questions.</h2>
+            <div className="cj-prose">
+              <p>
+                Quick answers pulled from our long-form{' '}
+                <Link href="/articles">articles</Link>. Tap a question for the short version, then follow the link for the full breakdown.
+              </p>
+            </div>
+            <div className="cj-faq">
+              {FAQS.map((faq) => (
+                <details key={faq.question}>
+                  <summary>
+                    <span>{faq.question}</span>
+                    <span className="cj-faq-marker" aria-hidden="true">+</span>
+                  </summary>
+                  <div className="cj-faq-body">
+                    <p>{faq.answer}</p>
+                    <Link href={`/articles/${faq.source.slug}`}>
+                      Read: {faq.source.title} →
+                    </Link>
+                  </div>
+                </details>
+              ))}
+            </div>
+            <div className="cj-prose" style={{ marginTop: 18 }}>
+              <p>
+                Have a question that should be here?{' '}
+                <Link href="/contact">Send it our way</Link>.
+              </p>
+            </div>
+          </section>
+
+          <div className="cj-cta-block">
+            <div>
+              <div className="cj-cta-eyebrow">help build the dataset</div>
+              <h3 className="cj-cta-h">Submit your result. Sharpen the next person&apos;s odds.</h3>
+              <p className="cj-cta-sub">
+                Two minutes. No card connection, no credit pull. The dataset only works because people share.
+              </p>
+            </div>
+            <div className="cj-cta-actions">
+              <Link href="/check-odds" className="cj-cta-btn">+ submit a result</Link>
+              <Link href="/about" className="cj-cta-btn-outline">about creditodds</Link>
+            </div>
+          </div>
+        </main>
+      </div>
 
       <V2Footer />
     </div>

--- a/apps/web-next/src/app/privacy/page.tsx
+++ b/apps/web-next/src/app/privacy/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from "next";
+import Link from "next/link";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import "../landing.css";
+import "../static-pages.css";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
@@ -16,87 +18,196 @@ export const metadata: Metadata = {
   },
 };
 
-const POLICY: { title: string; body: string }[] = [
-  {
-    title: 'Summary',
-    body:
-      "We respect the EU's General Data Protection Regulations (GDPR) and this policy explains how we collect and treat any information you give us. You won't find any complicated legal terms or long passages of unreadable text. We've no desire to trick you into agreeing to something you might later regret.",
-  },
-  {
-    title: 'Why we value your privacy',
-    body:
-      "We value your privacy as much as we do our own, so we're committed to keeping your personal and business information safe. We're uncomfortable with the information companies, governments, and other organisations keep on file, so we ask for only the bare minimum from our customers. We'll never use your personal information for any reason other than why you gave it, and we'll never give anyone access to it unless we're forced to by law.",
-  },
-  {
-    title: 'How we collect information',
-    body:
-      "We use Google Analytics to understand how visitors use our website. This helps us improve the site and user experience. Google Analytics collects anonymized data about page views and does not personally identify you. We don't use native social media 'like' or 'sharing' buttons which build profiles of your internet activity.",
-  },
-  {
-    title: 'What information we hold',
-    body:
-      "When you contact us by email or through our website, we collect your name, email address, if you've given us that, and your IP address if you conduct a search (this allows us to block a denial of service attack).",
-  },
-  {
-    title: 'Where we store your information',
-    body:
-      'When you contact us by email or through our website, we store your information on our secure cloud database.',
-  },
-  {
-    title: "Who's responsible for your information",
-    body:
-      'Our IT Department is responsible for the security of your information. You can contact them by using the contact feature if you have any concerns about the information we store.',
-  },
-  {
-    title: 'Who has access to information about you',
-    body:
-      "When we store information in our own systems, only the people who need it have access. Our management team has access to everything you've provided.",
-  },
-  {
-    title: 'The steps we take to keep your information private',
-    body:
-      'Where we store your information in third-party services, we restrict access only to people who need it.',
-  },
-  {
-    title: 'How to complain',
-    body:
-      "We take complaints very seriously. If you've any reason to complain about the ways we handle your privacy, please contact us through the contact feature.",
-  },
-  {
-    title: 'Changes to the policy',
-    body:
-      'If we change the contents of this policy, those changes will become effective the moment we publish them on our website.',
-  },
-];
-
 export default function PrivacyPage() {
   return (
-    <div className="landing-v2">
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          Use of private <em>information policy.</em>
-        </h1>
-        <p className="page-sub">
-          No complicated legal terms. No walls of unreadable text. Just what we collect,
-          why, and how to reach us if something doesn&apos;t sit right.
-        </p>
-      </section>
-
-      <div className="wrap">
-        <article className="page-body wide">
-          {POLICY.map((p) => (
-            <div key={p.title}>
-              <h3>{p.title}</h3>
-              <p>{p.body}</p>
-            </div>
-          ))}
-
-          <span className="stamp">
-            <span className="dot" />
-            Updated 1/27/26
-          </span>
-        </article>
+    <div className="landing-v2 static-v2">
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <span className="cj-crumb cj-crumb-current">privacy</span>
+        </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
+          <span><span className="cj-status-dot" />updated jan 27, 2026</span>
+        </div>
       </div>
+
+      <div className="cj-layout">
+        <main className="cj-main-static">
+          <header className="cj-page-head">
+            <div className="cj-page-eyebrow">legal · privacy policy</div>
+            <h1 className="cj-page-h1">
+              Use of private <em className="cj-section-accent">information policy.</em>
+            </h1>
+            <p className="cj-page-lede">
+              No complicated legal terms. No walls of unreadable text. Just what we collect,
+              why, and how to reach us if something doesn&apos;t sit right.
+            </p>
+            <div className="cj-page-meta">
+              <span><b>Last updated</b> · January 27, 2026</span>
+              <span><b>Standard</b> · GDPR-aligned</span>
+              <span><b>Trackers</b> · none beyond Google Analytics</span>
+            </div>
+          </header>
+
+          <div className="cj-callout" style={{ marginTop: 18 }}>
+            <b>The whole policy in one paragraph:</b> we collect what you tell us (your
+            email, the data point you submit when you share an application result) and
+            standard analytics. We use it to run the site and improve the dataset. We don&apos;t
+            sell your information, we don&apos;t share it with anyone except where the law
+            forces us to, and you can ask us to delete it any time.
+          </div>
+
+          <nav className="cj-toc-chips" aria-label="Sections">
+            <a href="#summary"><span>01</span>summary</a>
+            <a href="#why"><span>02</span>why we value privacy</a>
+            <a href="#collect"><span>03</span>how we collect</a>
+            <a href="#what"><span>04</span>what we hold</a>
+            <a href="#where"><span>05</span>where we store it</a>
+            <a href="#responsible"><span>06</span>who&apos;s responsible</a>
+            <a href="#access"><span>07</span>who has access</a>
+            <a href="#protect"><span>08</span>how we protect it</a>
+            <a href="#complain"><span>09</span>how to complain</a>
+            <a href="#changes"><span>10</span>changes</a>
+          </nav>
+
+          <section id="summary" className="cj-static-section">
+            <div className="cj-section-num">01 · summary</div>
+            <h2>Summary.</h2>
+            <div className="cj-callout"><b>In short:</b> GDPR-aligned, plain English, no tricks.</div>
+            <div className="cj-prose">
+              <p>
+                We respect the EU&apos;s General Data Protection Regulations (GDPR) and
+                this policy explains how we collect and treat any information you give us.
+                You won&apos;t find any complicated legal terms or long passages of
+                unreadable text. We&apos;ve no desire to trick you into agreeing to
+                something you might later regret.
+              </p>
+            </div>
+          </section>
+
+          <section id="why" className="cj-static-section">
+            <div className="cj-section-num">02 · why we value your privacy</div>
+            <h2>Why we value your privacy.</h2>
+            <div className="cj-prose">
+              <p>
+                We value your privacy as much as we do our own, so we&apos;re committed to
+                keeping your personal and business information safe. We&apos;re uncomfortable
+                with the information companies, governments, and other organisations keep on
+                file, so we ask for only the bare minimum from our customers. We&apos;ll
+                never use your personal information for any reason other than why you gave
+                it, and we&apos;ll never give anyone access to it unless we&apos;re forced
+                to by law.
+              </p>
+            </div>
+          </section>
+
+          <section id="collect" className="cj-static-section">
+            <div className="cj-section-num">03 · how we collect information</div>
+            <h2>How we collect information.</h2>
+            <div className="cj-callout"><b>In short:</b> Google Analytics for anonymous traffic patterns. No social-media trackers.</div>
+            <div className="cj-prose">
+              <p>
+                We use Google Analytics to understand how visitors use our website. This
+                helps us improve the site and user experience. Google Analytics collects
+                anonymized data about page views and does not personally identify you. We
+                don&apos;t use native social media &apos;like&apos; or &apos;sharing&apos;
+                buttons which build profiles of your internet activity.
+              </p>
+            </div>
+          </section>
+
+          <section id="what" className="cj-static-section">
+            <div className="cj-section-num">04 · what information we hold</div>
+            <h2>What information we hold.</h2>
+            <div className="cj-prose">
+              <p>
+                When you contact us by email or through our website, we collect your name,
+                email address, if you&apos;ve given us that, and your IP address if you
+                conduct a search (this allows us to block a denial of service attack).
+              </p>
+            </div>
+            <dl className="cj-deflist">
+              <dt>You give us</dt>
+              <dd>Email and name when you create an account. The data points you submit when you report an application result — credit score, income, outcome.</dd>
+              <dt>We collect automatically</dt>
+              <dd>IP address (for abuse prevention), basic browser/device class, and anonymized analytics.</dd>
+              <dt>What we do not collect</dt>
+              <dd>We do not pull your credit. We do not connect to your bank. We do not run third-party advertising trackers.</dd>
+            </dl>
+          </section>
+
+          <section id="where" className="cj-static-section">
+            <div className="cj-section-num">05 · where we store your information</div>
+            <h2>Where we store your information.</h2>
+            <div className="cj-prose">
+              <p>
+                When you contact us by email or through our website, we store your
+                information on our secure cloud database.
+              </p>
+            </div>
+          </section>
+
+          <section id="responsible" className="cj-static-section">
+            <div className="cj-section-num">06 · who&apos;s responsible</div>
+            <h2>Who&apos;s responsible for your information.</h2>
+            <div className="cj-prose">
+              <p>
+                Our IT Department is responsible for the security of your information. You
+                can contact them by using the <Link href="/contact">contact</Link> feature
+                if you have any concerns about the information we store.
+              </p>
+            </div>
+          </section>
+
+          <section id="access" className="cj-static-section">
+            <div className="cj-section-num">07 · who has access</div>
+            <h2>Who has access to information about you.</h2>
+            <div className="cj-callout"><b>In short:</b> only the people who actually need it to run the site.</div>
+            <div className="cj-prose">
+              <p>
+                When we store information in our own systems, only the people who need it
+                have access. Our management team has access to everything you&apos;ve
+                provided.
+              </p>
+            </div>
+          </section>
+
+          <section id="protect" className="cj-static-section">
+            <div className="cj-section-num">08 · how we protect it</div>
+            <h2>The steps we take to keep your information private.</h2>
+            <div className="cj-prose">
+              <p>
+                Where we store your information in third-party services, we restrict access
+                only to people who need it.
+              </p>
+            </div>
+          </section>
+
+          <section id="complain" className="cj-static-section">
+            <div className="cj-section-num">09 · how to complain</div>
+            <h2>How to complain.</h2>
+            <div className="cj-prose">
+              <p>
+                We take complaints very seriously. If you&apos;ve any reason to complain
+                about the ways we handle your privacy, please contact us through the{' '}
+                <Link href="/contact">contact</Link> feature.
+              </p>
+            </div>
+          </section>
+
+          <section id="changes" className="cj-static-section">
+            <div className="cj-section-num">10 · changes to the policy</div>
+            <h2>Changes to the policy.</h2>
+            <div className="cj-prose">
+              <p>
+                If we change the contents of this policy, those changes will become
+                effective the moment we publish them on our website.
+              </p>
+            </div>
+          </section>
+        </main>
+      </div>
+
       <V2Footer />
     </div>
   );

--- a/apps/web-next/src/app/static-pages.css
+++ b/apps/web-next/src/app/static-pages.css
@@ -1,0 +1,556 @@
+/* Static content pages — editorial layout for /about, /how, /terms, /privacy.
+   Scoped under .landing-v2.static-v2 to avoid leaking onto other v2 pages. */
+
+.landing-v2.static-v2 {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+/* Terminal / breadcrumb bar */
+.static-v2 .cj-terminal {
+  background: var(--ink);
+  color: #fff;
+  padding: 10px 24px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-family: 'Inter', sans-serif;
+  font-size: 11.5px;
+  flex-wrap: wrap;
+}
+.static-v2 .cj-terminal a { color: inherit; text-decoration: none; }
+.static-v2 .cj-spacer { flex: 1; }
+.static-v2 .cj-term-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.static-v2 .cj-crumbs {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.static-v2 .cj-crumb { color: var(--muted-2); }
+.static-v2 a.cj-crumb:hover { color: #fff; }
+.static-v2 .cj-crumb-current { color: #fff; }
+.static-v2 .cj-sep { color: var(--muted-2); opacity: 0.5; }
+.static-v2 .cj-status-dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: #64d88a;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+/* Layout */
+.static-v2 .cj-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+.static-v2 .cj-main-static {
+  max-width: 880px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 36px 40px 80px;
+  min-width: 0;
+}
+
+/* Page header */
+.static-v2 .cj-page-head {
+  padding: 8px 0 28px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 4px;
+}
+.static-v2 .cj-page-eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 14px;
+}
+.static-v2 .cj-page-h1 {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  font-size: 64px;
+  letter-spacing: -0.03em;
+  line-height: 0.98;
+  margin: 0 0 18px;
+  color: var(--ink);
+}
+.static-v2 .cj-section-accent {
+  color: var(--accent);
+  font-style: italic;
+  font-weight: 400;
+}
+.static-v2 .cj-page-lede {
+  font-size: 18px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  max-width: 60ch;
+  margin: 0;
+}
+.static-v2 .cj-page-meta {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  margin-top: 22px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.static-v2 .cj-page-meta b { color: var(--ink); font-weight: 500; }
+.static-v2 .cj-page-meta a { color: var(--accent); text-decoration: none; }
+.static-v2 .cj-page-meta a:hover { text-decoration: underline; }
+
+/* Numbered section blocks */
+.static-v2 .cj-static-section {
+  padding: 26px 0;
+  border-bottom: 1px solid var(--line);
+}
+.static-v2 .cj-static-section:last-child { border-bottom: 0; }
+.static-v2 .cj-section-num {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+}
+.static-v2 .cj-static-section h2 {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  font-size: 28px;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0 0 14px;
+  color: var(--ink);
+}
+.static-v2 .cj-static-section h3 {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  font-size: 17px;
+  letter-spacing: -0.005em;
+  margin: 18px 0 8px;
+  color: var(--ink);
+}
+
+/* Prose */
+.static-v2 .cj-prose p,
+.static-v2 .cj-prose ul,
+.static-v2 .cj-prose ol {
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: var(--ink-2);
+  margin: 0 0 14px;
+  max-width: 64ch;
+}
+.static-v2 .cj-prose ul,
+.static-v2 .cj-prose ol { padding-left: 20px; }
+.static-v2 .cj-prose p:last-child,
+.static-v2 .cj-prose ul:last-child,
+.static-v2 .cj-prose ol:last-child { margin-bottom: 0; }
+.static-v2 .cj-prose strong,
+.static-v2 .cj-prose b { color: var(--ink); font-weight: 600; }
+.static-v2 .cj-prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+.static-v2 .cj-prose li { margin-bottom: 6px; }
+.static-v2 .cj-prose li::marker { color: var(--muted-2); }
+.static-v2 .cj-prose blockquote {
+  margin: 18px 0;
+  padding: 14px 20px;
+  border-left: 3px solid var(--accent);
+  background: var(--accent-2);
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 17px;
+  line-height: 1.45;
+  color: var(--ink);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+.static-v2 .cj-prose blockquote p { font-size: inherit; color: inherit; margin: 0; }
+
+/* Definition rows */
+.static-v2 .cj-deflist {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 14px 28px;
+  margin: 6px 0 18px;
+  padding: 4px 0 0;
+}
+.static-v2 .cj-deflist dt {
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--muted);
+  padding-top: 2px;
+}
+.static-v2 .cj-deflist dd {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+.static-v2 .cj-deflist dd b { color: var(--ink); font-weight: 600; }
+.static-v2 .cj-deflist dd a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Callout */
+.static-v2 .cj-callout {
+  margin: 8px 0 16px;
+  padding: 14px 18px;
+  background: var(--accent-2);
+  border-left: 3px solid var(--accent);
+  font-size: 13.5px;
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+.static-v2 .cj-callout b { color: var(--accent); font-weight: 600; }
+.static-v2 .cj-callout a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.static-v2 .cj-callout-warn {
+  background: var(--warn-2);
+  border-left-color: var(--warn);
+}
+.static-v2 .cj-callout-warn b { color: var(--warn); }
+
+/* ToC chips */
+.static-v2 .cj-toc-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 18px 0 24px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 8px;
+}
+.static-v2 .cj-toc-chips a {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--ink-2);
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  padding: 5px 12px;
+  text-decoration: none;
+  letter-spacing: 0.01em;
+}
+.static-v2 .cj-toc-chips a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.static-v2 .cj-toc-chips a span {
+  font-size: 10px;
+  color: var(--muted);
+  font-weight: 500;
+}
+.static-v2 .cj-toc-chips a:hover span { color: var(--accent); }
+
+/* Stat strip */
+.static-v2 .cj-stat-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  margin: 4px 0 8px;
+}
+.static-v2 .cj-readoff-cell {
+  background: var(--paper);
+  padding: 12px 14px;
+  min-width: 0;
+  overflow: hidden;
+}
+.static-v2 .cj-readoff-k {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--muted);
+}
+.static-v2 .cj-readoff-v {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  margin-top: 4px;
+  line-height: 1;
+}
+.static-v2 .cj-readoff-foot {
+  font-size: 11.5px;
+  color: var(--muted);
+  margin-top: 5px;
+}
+.static-v2 .cj-readoff-v.cj-accent { color: var(--accent); }
+.static-v2 .cj-readoff-bonus { background: #fef9e8; }
+.static-v2 .cj-readoff-bonus .cj-readoff-k { color: #92722a; }
+
+/* Steps */
+.static-v2 .cj-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  margin: 6px 0 10px;
+}
+.static-v2 .cj-step {
+  background: var(--paper);
+  padding: 18px 18px 20px;
+}
+.static-v2 .cj-step-num {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 30px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  line-height: 1;
+}
+.static-v2 .cj-step-h {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  margin: 8px 0 6px;
+  color: var(--ink);
+}
+.static-v2 .cj-step-p {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  margin: 0;
+}
+
+/* Glossary table */
+.static-v2 .cj-glossary {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  border: 1px solid var(--line-2);
+  margin-top: 6px;
+}
+.static-v2 .cj-glossary th {
+  text-align: left;
+  padding: 9px 14px;
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  font-weight: 600;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+}
+.static-v2 .cj-glossary td {
+  padding: 11px 14px;
+  vertical-align: top;
+  border-top: 1px solid var(--line);
+}
+.static-v2 .cj-glossary td:first-child {
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+  width: 180px;
+}
+.static-v2 .cj-glossary td:last-child {
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+
+/* "Don't do" list — used on /how */
+.static-v2 .cj-dontlist {
+  padding-left: 0;
+  list-style: none;
+  margin: 0;
+}
+.static-v2 .cj-dontlist li {
+  padding: 10px 0;
+  border-top: 1px dashed var(--line);
+  display: flex;
+  gap: 12px;
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+.static-v2 .cj-dontlist li:last-child { border-bottom: 1px dashed var(--line); }
+.static-v2 .cj-dontlist .cj-x {
+  min-width: 22px;
+  color: var(--warn);
+  font-weight: 600;
+}
+
+/* CTA block */
+.static-v2 .cj-cta-block {
+  margin-top: 40px;
+  padding: 32px 36px;
+  background: var(--ink);
+  color: #fff;
+  border-radius: 4px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: center;
+}
+.static-v2 .cj-cta-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-2);
+  margin-bottom: 8px;
+}
+.static-v2 .cj-cta-h {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 30px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0 0 6px;
+  color: #fff;
+}
+.static-v2 .cj-cta-sub {
+  font-size: 13px;
+  color: var(--muted-2);
+  margin: 0;
+  max-width: 50ch;
+  line-height: 1.5;
+}
+.static-v2 .cj-cta-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 200px;
+}
+.static-v2 .cj-cta-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 18px;
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  border-radius: 3px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+.static-v2 .cj-cta-btn:hover { background: var(--accent-deep); }
+.static-v2 .cj-cta-btn-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 18px;
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.25);
+  border-radius: 3px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+}
+.static-v2 .cj-cta-btn-outline:hover { border-color: #fff; }
+
+/* Signature line — used on /about */
+.static-v2 .cj-signature {
+  display: block;
+  margin-top: 18px;
+  font-size: 12.5px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+/* Inline figure (about page graphic) */
+.static-v2 .cj-figure {
+  margin: 18px 0;
+  padding: 18px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  display: flex;
+  justify-content: center;
+}
+.static-v2 .cj-figure img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* FAQ list (How page) */
+.static-v2 .cj-faq {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.static-v2 .cj-faq details {
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  padding: 14px 18px;
+}
+.static-v2 .cj-faq details[open] { border-color: var(--accent); }
+.static-v2 .cj-faq summary {
+  cursor: pointer;
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--ink);
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  line-height: 1.4;
+}
+.static-v2 .cj-faq summary::-webkit-details-marker { display: none; }
+.static-v2 .cj-faq summary .cj-faq-marker {
+  flex-shrink: 0;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+  margin-top: 1px;
+}
+.static-v2 .cj-faq details[open] summary .cj-faq-marker { color: var(--accent); }
+.static-v2 .cj-faq-body {
+  margin-top: 10px;
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--ink-2);
+}
+.static-v2 .cj-faq-body p { margin: 0 0 8px; }
+.static-v2 .cj-faq-body a {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+}
+
+/* Mobile */
+@media (max-width: 720px) {
+  .static-v2 .cj-main-static { padding: 22px 18px 40px; }
+  .static-v2 .cj-page-h1 { font-size: 40px; }
+  .static-v2 .cj-page-lede { font-size: 15px; }
+  .static-v2 .cj-deflist { grid-template-columns: 1fr; gap: 4px; }
+  .static-v2 .cj-deflist dt { padding-top: 12px; }
+  .static-v2 .cj-steps { grid-template-columns: 1fr; }
+  .static-v2 .cj-stat-strip { grid-template-columns: repeat(2, 1fr); }
+  .static-v2 .cj-cta-block { grid-template-columns: 1fr; padding: 24px; }
+  .static-v2 .cj-glossary td:first-child { width: auto; white-space: normal; }
+  .static-v2 .cj-terminal { padding: 10px 16px; }
+}

--- a/apps/web-next/src/app/terms/page.tsx
+++ b/apps/web-next/src/app/terms/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import "../landing.css";
+import "../static-pages.css";
 
 export const metadata: Metadata = {
   title: "Terms of Use",
@@ -18,513 +19,528 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
-    <div className="landing-v2">
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          Terms of <em>use.</em>
-        </h1>
-        <p className="page-sub">
-          The rules that govern how you use CreditOdds. The short version: be decent,
-          don&apos;t resell the data, and we&apos;re not legal advice.
-        </p>
-      </section>
-      <div className="wrap">
-        <article className="page-body wide">
-          <ol>
-            <li>
-              <b>TERMS OF USE (TOU) -</b> Welcome to CreditOdds. We provide
-              an Internet service (&quot;Service&quot;). Your use of the Service is
-              subject to these Terms of Use (&quot;TOU&quot;).
-              <ol className="list-[lower-alpha] list-outside pl-9">
-                <li>
-                  We may modify these TOU at any time without notice to you by
-                  posting revised TOU on the site. You can review the most
-                  current version of the TOU at any time at
-                  www.CreditOdds.com/terms.
-                </li>
-                <li>
-                  Your use of the Service constitutes your binding acceptance of
-                  the TOU, including any modifications that we make. This
-                  Agreement will constitute a binding and enforceable agreement
-                  between you (individually and in your individual capacity as
-                  an employee, officer, agent, partner, etc. of each
-                  organization you represent in connection with any use of the
-                  Service) and CreditOdds. By using the Service, you
-                  acknowledge and agree that you have fully read and agree to be
-                  bound by the provisions of this Agreement. If you do not agree
-                  to be bound by this Agreement in its entirety, then you must
-                  immediately stop using the CreditOdds Website.
-                </li>
-                <li>
-                  Where you use the Service in the course of your employment or
-                  business, you enter into this Agreement both on your own
-                  behalf and in your individual capacity as an employee,
-                  officer, agent, partner, etc. of such organization which you
-                  represent, and references in this Agreement to &quot;you&quot; shall
-                  mean both you as the individual user of the Service and you in
-                  your capacity as a representative of your organization.
-                </li>
-              </ol>
-            </li>
-            <li>
-              <b>DESCRIPTION OF SERVICE</b>
-              <ol className="list-[lower-alpha] list-outside pl-9">
-                <li>
-                  The Service currently provides users with access to a
-                  collection of content, including legal information,
-                  educational information, Internet search services, marketing
-                  information, marketing services, hosted Websites and business
-                  information through its network of properties.
-                </li>
-                <li>
-                  You also understand and agree that the Service may include
-                  advertisements and that these advertisements are necessary for
-                  CreditOdds to provide the Service. Free Website&apos;s on
-                  CreditOdds&apos;s CreditOdds.com service may have search
-                  functionality provided by a third party service. A search box
-                  providing this search functionality may be placed anywhere on
-                  a Web page, including the top of the Web page. Any search that
-                  takes place on the CreditOdds.com Web site may lead to a
-                  search results page on the third party site which may include
-                  advertisements. This advertising revenue will be split between
-                  the third party search provider and CreditOdds.
-                  CreditOdds will also include links on the free
-                  CreditOdds.com Websites to CreditOdds and other online
-                  Websites. These links may be in the header, footer, Web
-                  Resources Page or Web Blog page. In addition CreditOdds
-                  reserves the right to place paid advertisements on the
-                  CreditOdds.com under the footer of the Website&apos;s pages.
-                </li>
-                <li>
-                  You also understand and agree that the Service may include
-                  certain communications from CreditOdds, such as service
-                  announcements, administrative messages and the CreditOdds
-                  Newsletter, and that these communications are considered part
-                  of CreditOdds membership.
-                </li>
-                <li>
-                  Unless explicitly stated otherwise, any new features that
-                  augment or enhance the current Service, including the release
-                  of new CreditOdds properties, shall be subject to the TOU.
-                </li>
-                <li>
-                  You understand and agree that the Service is provided &quot;AS-IS&quot;
-                  and that CreditOdds assumes no responsibility for the
-                  timeliness, deletion, mis-delivery or failure to store any
-                  user communications or personalization settings. You are
-                  responsible for obtaining access to the Service and that
-                  access may involve third party fees (such as Internet service
-                  provider or airtime charges). You are responsible for those
-                  fees, including those fees associated with the display or
-                  delivery of advertisements. In addition, you must provide and
-                  are responsible for all equipment necessary to access the
-                  Service.
-                </li>
-                <li>
-                  <p>
-                    We have the right, but not the obligation, to take any of
-                    the following actions in our sole discretion at any time and
-                    for any reason without giving you any prior notice:
-                  </p>
-                  <ol className="list-[lower-roman] list-outside pl-9">
-                    <li>
-                      Restrict, suspend or terminate your access to all or any
-                      part of the Service;
-                    </li>
-                    <li>
-                      Change, suspend or discontinue all or any part of the
-                      Service;
-                    </li>
-                    <li>
-                      Refuse, move or remove any material that you submit to the
-                      Service for any reason;
-                    </li>
-                    <li>
-                      Refuse, move, or remove any content that is available on
-                      the Service;
-                    </li>
-                    <li>
-                      Deactivate or delete your accounts and all related
-                      information and files in your account;
-                    </li>
-                    <li>
-                      Establish general practices and limits concerning use of
-                      the Service;
-                    </li>
-                    <li>
-                      You agree that we will not be liable to you or any third
-                      party for taking any of these actions.
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li>
-              <b>SPECIAL ADMONITIONS FOR INTERNATIONAL USE</b> - Recognizing the
-              global nature of the Internet, you agree to comply with all local
-              rules regarding online conduct and acceptable Content.
-              Specifically, you agree to comply with all applicable laws
-              regarding the transmission of technical data exported from the
-              United States or the country in which you reside.
-            </li>
-            <li>
-              <b>NO LEGAL ADVICE -</b> The Service and all Content are provided
-              for general informational purposes only, and may not reflect
-              current legal developments, verdicts or settlements. Any
-              information contained in the Content or this Service should not be
-              construed as legal advice and is not intended to be a substitute
-              for legal counsel on any subject matter. No recipient of Content
-              from the Service should act or refrain from acting on the basis of
-              any Content included in, or accessible through, the Service
-              without seeking the appropriate legal or other professional advice
-              on the particular facts and circumstances at issue from a lawyer
-              licensed in the recipient&apos;s state, country or other appropriate
-              licensing jurisdiction.
-            </li>
-            <li>
-              <b>INDEMNITY -</b> You agree to indemnify and hold CreditOdds,
-              and its subsidiaries, affiliates, employees, information
-              providers, partners, licensors, agents, co-branders, officers,
-              directors, owners and employees, harmless from any claim or
-              demand, including reasonable attorneys&apos; fees, made by any third
-              party due to or arising out of Content you submit, post, transmit
-              or make available through the Service, your use of the Service,
-              your connection to the Service, your violation of the TOU, or your
-              violation of any rights of another.
-            </li>
-            <li>
-              <b>NO RESALE OF SERVICE -</b> You agree not to reproduce,
-              duplicate, copy, sell, trade, resell or exploit for any commercial
-              purposes, any portion of the Service (including your
-              CreditOdds Account Identification), use of the Service, or
-              access to the Service.
-            </li>
-            <li>
-              <b>GENERAL PRACTICES REGARDING USE AND STORAGE -</b> You
-              acknowledge that CreditOdds may establish general practices
-              and limits concerning use of the Service, including without
-              limitation the maximum number of days that message board postings
-              or other uploaded Content will be retained by the Service, the
-              maximum disk space that will be allotted on CreditOdds&apos;s
-              servers on your behalf, and the maximum number of times (and the
-              maximum duration for which) you may access the Service in a given
-              period of time. You agree that CreditOdds has no
-              responsibility or liability for the deletion or failure to store
-              any communications or other Content maintained or transmitted by
-              the Service. You acknowledge that CreditOdds reserves the
-              right to log off accounts that are inactive for an extended period
-              of time. You further acknowledge that CreditOdds reserves the
-              right to modify these general practices and limits from time to
-              time.
-            </li>
-            <li>
-              <b>MODIFICATIONS TO SERVICE -</b> CreditOdds reserves the
-              right at any time and from time to time to modify or discontinue,
-              temporarily or permanently, the Service (or any part thereof) with
-              or without notice. You agree that CreditOdds shall not be
-              liable to you or to any third party for any modification,
-              suspension or discontinuance of the Service.
-            </li>
-            <li>
-              <b>TERMINATION -</b> You agree that CreditOdds may, under
-              certain circumstances and without prior notice, immediately
-              terminate your CreditOdds account and access to the Service.
-              Cause for such termination shall include, but not be limited to,
-              (a) breaches or violations of the TOU or other incorporated
-              agreements or guidelines, (b) requests by law enforcement or other
-              government agencies, (c) a request by you (self-initiated account
-              deletions), (d) discontinuance or material modification to the
-              Service (or any part thereof), (e) unexpected technical or
-              security issues or problems, and (f) extended periods of
-              inactivity. Termination of your CreditOdds account includes
-              (a) removal of access to all offerings within the Service,
-              including but not limited to CreditOdds Message Boards and
-              Websites, (b) deletion of your password and all related account
-              information, files and content associated with or inside your
-              account (or any part thereof), and (c) barring further use of the
-              Service. Further, you agree that all terminations for cause shall
-              be made in CreditOdds&apos;s sole discretion and that
-              CreditOdds shall not be liable to you or any third-party for
-              any termination of your account, any associated email address, or
-              access to the Service.
-            </li>
-            <li>
-              <b>LINKS -</b> The Service may provide, or third parties may
-              provide, links to other World Wide Websites or resources. Your use
-              of each of those sites is subject to the conditions, if any, that
-              each of those sites has posted. Because CreditOdds has no
-              control over such sites and resources, you acknowledge and agree
-              that CreditOdds is not responsible for the availability of
-              such external sites or resources, and does not endorse and is not
-              responsible or liable for any Content, advertising, products, or
-              other materials on or available from such sites or resources. You
-              further acknowledge and agree that CreditOdds shall not be
-              responsible or liable, directly or indirectly, for any damage or
-              loss caused or alleged to be caused by or in connection with use
-              of or reliance on any such Content, goods or services available on
-              or through any such site or resource.
-            </li>
-            <li>
-              <b>CreditOdds&apos;s PROPRIETARY RIGHTS -</b> You acknowledge and
-              agree that the Service and any necessary software used in
-              connection with the Service (&quot;Software&quot;) contain proprietary and
-              confidential information that is protected by applicable
-              intellectual property and other laws. You further acknowledge and
-              agree that Content contained in sponsor advertisements or
-              information presented to you through the Service or advertisers is
-              protected by copyrights, trademarks, service marks, patents or
-              other proprietary rights and laws. Except as expressly authorized
-              by CreditOdds or advertisers, you agree not to modify, rent,
-              lease, loan, sell, distribute or create derivative works based on
-              the Service or the Software, in whole or in part.
-              <ol className="list-[lower-alpha] list-outside pl-9">
-                <li>
-                  CreditOdds grants you a personal, non-transferable and
-                  non-exclusive right and license to use the object code of its
-                  Software on a single computer; provided that you do not (and
-                  do not allow any third party to) copy, modify, create a
-                  derivative work of, reverse engineer, reverse assemble or
-                  otherwise attempt to discover any source code, sell, assign,
-                  sublicense, grant a security interest in or otherwise transfer
-                  any right in the Software. You agree not to modify the
-                  Software in any manner or form, or to use modified versions of
-                  the Software, including (without limitation) for the purpose
-                  of obtaining unauthorized access to the Service. You agree not
-                  to access the Service by any means other than through the
-                  interface that is provided by CreditOdds for use in
-                  accessing the Service.
-                </li>
-                <li>
-                  CreditOdds claims no copyright in any works of the US
-                  Federal Government or US State Governments, including court
-                  documents, codes, and regulations.
-                </li>
-              </ol>
-            </li>
-            <li>
-              <b>DISCLAIMER OF WARRANTIES -</b> YOU EXPRESSLY UNDERSTAND AND
-              AGREE THAT:
-              <ol className="list-[lower-alpha] list-outside pl-9">
-                <li>
-                  YOUR USE OF THE SERVICE IS AT YOUR SOLE RISK. THE SERVICE IS
-                  PROVIDED ON AN &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; BASIS.
-                  CreditOdds EXPRESSLY DISCLAIMS ALL WARRANTIES OF ANY KIND,
-                  WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE
-                  IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-                  PARTICULAR PURPOSE, WARRANTIES OF TITLE AND NON-INFRINGEMENT.
-                </li>
-                <li>
-                  CreditOdds MAKES NO WARRANTY THAT (i) THE SERVICE WILL
-                  MEET YOUR REQUIREMENTS, (ii) THE SERVICE WILL BE
-                  UNINTERRUPTED, TIMELY, SECURE, OR ERROR-FREE, (iii) THE
-                  RESULTS THAT MAY BE OBTAINED FROM THE USE OF THE SERVICE WILL
-                  BE ACCURATE OR RELIABLE, (iv) THE QUALITY OF ANY PRODUCTS,
-                  SERVICES, INFORMATION, OR OTHER MATERIAL PURCHASED OR OBTAINED
-                  BY YOU THROUGH THE SERVICE WILL MEET YOUR EXPECTATIONS, AND
-                  (V) ANY ERRORS IN THE SOFTWARE WILL BE CORRECTED.
-                </li>
-                <li>
-                  ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE
-                  OF THE SERVICE IS DONE AT YOUR OWN DISCRETION AND RISK AND
-                  THAT YOU WILL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR
-                  COMPUTER SYSTEM OR LOSS OF DATA THAT RESULTS FROM THE DOWNLOAD
-                  OF ANY SUCH MATERIAL.
-                </li>
-                <li>
-                  NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY
-                  YOU FROM CreditOdds OR THROUGH OR FROM THE SERVICE SHALL
-                  CREATE ANY WARRANTY NOT EXPRESSLY STATED IN THE TOU.
-                </li>
-              </ol>
-            </li>
-            <li>
-              <b>LIMITATION OF LIABILITY -</b> YOU EXPRESSLY UNDERSTAND AND
-              AGREE THAT CreditOdds SHALL NOT BE LIABLE TO YOU FOR ANY
-              DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY
-              DAMAGES, INCLUDING BUT NOT LIMITED TO, DAMAGES FOR LOSS OF
-              PROFITS, GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES (EVEN IF
-              CreditOdds HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
-              DAMAGES), RESULTING FROM: (i) THE USE OR THE INABILITY TO USE THE
-              SERVICE; (ii) THE COST OF PROCUREMENT OF SUBSTITUTE GOODS AND
-              SERVICES RESULTING FROM ANY GOODS, DATA, INFORMATION OR SERVICES
-              PURCHASED OR OBTAINED OR MESSAGES RECEIVED OR TRANSACTIONS ENTERED
-              INTO THROUGH OR FROM THE SERVICE; (iii) UNAUTHORIZED ACCESS TO OR
-              ALTERATION OF YOUR TRANSMISSIONS OR DATA; (iv) STATEMENTS OR
-              CONDUCT OF ANY THIRD PARTY ON THE SERVICE; OR (v) ANY OTHER MATTER
-              RELATING TO THE SERVICE.
-            </li>
-            <li>
-              <b>EXCLUSIONS AND LIMITATIONS -</b> SOME JURISDICTIONS DO NOT
-              ALLOW THE EXCLUSION OF CERTAIN WARRANTIES OR THE LIMITATION OR
-              EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES.
-              ACCORDINGLY, SOME OF THE ABOVE LIMITATIONS OF SECTIONS 12 AND 13
-              MAY NOT APPLY TO YOU. IN SUCH STATES, OUR LIABILITY AND THAT OF
-              OUR THIRD PARTY CONTENT PROVIDERS AND THEIR RESPECTIVE AGENTS
-              SHALL BE LIMITED TO THE GREATEST EXTENT PERMITTED BY LAW.
-            </li>
-            <li>
-              <b>
-                SPECIAL ADMONITION FOR SERVICES RELATING TO LEGAL INFORMATION -
-              </b>{" "}
-              If you intend to create or join any service, receive or request
-              any news, messages, alerts or other information from the Service
-              concerning legal information or services, please read the above
-              Sections 12 and 13 again. They go doubly for you. The Service is
-              provided for informational purposes only, and no Content included
-              in the Service should be relied on as a substitution for the legal
-              advice from a licensed lawyer. CreditOdds, its licensors and
-              partners shall not be responsible or liable for the accuracy,
-              usefulness or availability of any information transmitted or made
-              available via the Service, and shall not be responsible or liable
-              for any trading or investment decisions made based on such
-              information.
-            </li>
-            <li>
-              <b>NO THIRD PARTY BENEFICIARIES -</b> You agree that, except as
-              otherwise expressly provided in this TOU, there shall be no third
-              party beneficiaries to this Agreement.
-            </li>
-            <li>
-              <b>NOTICE -</b> CreditOdds may provide you with notices,
-              including those regarding changes to the TOU, by either email,
-              regular mail, or postings on the Service.
-            </li>
-            <li>
-              <b>TRADEMARK INFORMATION -</b> CreditOdds and the
-              CreditOdds logo are trademarks of CreditOdds Inc. (the
-              &quot;CreditOdds Marks&quot;). Without CreditOdds&apos;s prior
-              permission, you agree not to display or use in any manner, the
-              CreditOdds Marks.
-            </li>
-            <li>
-              <b>
-                NOTICE AND PROCEDURE FOR MAKING CLAIMS OF COPYRIGHT OR
-                INTELLECTUAL PROPERTY INFRINGEMENT -
-              </b>{" "}
-              CreditOdds respects the intellectual property of others, and
-              we ask our users to do the same. CreditOdds may, in
-              appropriate circumstances and at its discretion, disable and/or
-              terminate the accounts of users who may be repeat infringers. If
-              you believe that your work has been copied in a way that
-              constitutes copyright infringement, or your intellectual property
-              rights have been otherwise violated, please provide
-              CreditOdds&apos;s Copyright Agent the following information:
-              <ol className="list-[lower-alpha] list-outside pl-9">
-                <li>
-                  An electronic or physical signature of the person authorized
-                  to act on behalf of the owner of the copyright or other
-                  intellectual property interest;
-                </li>
-                <li>
-                  A description of the copyrighted work or other intellectual
-                  property that you claim has been infringed;
-                </li>
-                <li>
-                  A description of where the material that you claim is
-                  infringing is located on the site;
-                </li>
-                <li>Your address, telephone number, and email address;</li>
-                <li>
-                  A statement by you that you have a good faith belief that the
-                  disputed use is not authorized by the copyright owner, its
-                  agent, or the law;
-                </li>
-                <li>
-                  A statement by you, made under penalty of perjury, that the
-                  above information in your Notice is accurate and that you are
-                  the copyright or intellectual property owner or authorized to
-                  act on the copyright or intellectual property owner&apos;s behalf.
-                </li>
-              </ol>
-            </li>
-            <li>
-              <b>AGENT FOR NOTICE -</b> CreditOdds&apos;s Agent for Notice of
-              claims of copyright or other intellectual property infringement
-              can be reached as follows:
-              <p>By mail:</p>
-              <address className="pl-6">
-                <p>CreditOdds</p>
-                <p>3262 Westheimer Road, No. 222</p>
-                <p>Houston, Texas 77098</p>
-              </address>
-            </li>
-            <li>
-              <b>GENERAL INFORMATION - </b>
-              <u>Entire Agreement</u> - The TOU constitutes the entire agreement
-              between you and CreditOdds and govern your use of the Service,
-              superseding any prior agreements between you and CreditOdds.
-              You also may be subject to additional terms and conditions that
-              may apply when you use or purchase certain other CreditOdds
-              services, affiliate services, third-party content or third-party
-              software.
-              <ol className="list-[lower-alpha] list-outside pl-9">
-                <li>
-                  Choice of Law and Forum - The TOU and the relationship between
-                  you and CreditOdds shall be governed by the laws of the
-                  State of Texas without regard to its conflict of law
-                  provisions. You and CreditOdds agree to submit to the
-                  personal and exclusive jurisdiction of the courts located in
-                  Harris County, Texas.
-                </li>
-                <li>
-                  Arbitration - CreditOdds may elect to resolve any
-                  controversy or claim arising out of or relating to these TOU
-                  or our sites by binding arbitration in accordance with the
-                  commercial arbitration rules of the American Arbitration
-                  Association. Any such controversy or claim shall be arbitrated
-                  on an individual basis, and shall not be consolidated in any
-                  arbitration with any claim or controversy of any other party.
-                  The arbitration shall be conducted in the county of Harris,
-                  Texas, and judgment on the arbitration award may be entered in
-                  any court having jurisdiction thereof. Either you or we may
-                  seek any interim or preliminary relief from a court of
-                  competent jurisdiction in the county of Harris, Texas,
-                  necessary to protect the rights or property of you or
-                  CreditOdds (or its agents, suppliers, and subcontractors)
-                  pending the completion of arbitration.
-                </li>
-                <li>
-                  Waiver and Severability of Terms - The failure of
-                  CreditOdds to exercise or enforce any right or provision
-                  of the TOU shall not constitute a waiver of such right or
-                  provision. If any provision of the TOU is found by a court of
-                  competent jurisdiction to be invalid, the parties nevertheless
-                  agree that the court should endeavor to give effect to the
-                  parties&apos; intentions as reflected in the provision, and the
-                  other provisions of the TOU remain in full force and effect.
-                </li>
-                <li>
-                  No Right of Survivorship and Non-Transferability - You agree
-                  that your CreditOdds account is non-transferable and any
-                  rights to your CreditOdds I.D. or contents within your
-                  account terminate upon your death. Upon receipt of a copy of a
-                  death certificate, your account may be terminated and all
-                  contents therein permanently deleted.
-                </li>
-                <li>
-                  Statute of Limitations - You agree that regardless of any
-                  statute or law to the contrary, any claim or cause of action
-                  arising out of or related to use of the Service or the TOU
-                  must be filed within one (1) year after such claim or cause of
-                  action arose or be forever barred.
-                </li>
-              </ol>
-            </li>
-            <li>
-              <b>TITLES -</b> The section titles in the TOU are for convenience
-              only and have no legal or contractual effect.
-            </li>
-            <li>
-              <b>VIOLATIONS -</b> Please report any violations of the TOU to our
-              Terms of Service Group.
-            </li>
-          </ol>
-          <span className="stamp">
-            <span className="dot" />
-            Updated 4/8/21
-          </span>
-        </article>
+    <div className="landing-v2 static-v2">
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <span className="cj-crumb cj-crumb-current">terms</span>
+        </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
+          <span><span className="cj-status-dot" />updated may 9, 2026</span>
+        </div>
       </div>
+
+      <div className="cj-layout">
+        <main className="cj-main-static">
+          <header className="cj-page-head">
+            <div className="cj-page-eyebrow">legal · terms of use</div>
+            <h1 className="cj-page-h1">
+              Terms of <em className="cj-section-accent">use.</em>
+            </h1>
+            <p className="cj-page-lede">
+              The rules that govern how you use CreditOdds. Be decent, don&apos;t resell
+              the data, and we&apos;re not legal advice. The summaries above each section
+              are not the contract; the section text is.
+            </p>
+            <div className="cj-page-meta">
+              <span><b>Last updated</b> · May 9, 2026</span>
+              <span><b>Governing law</b> · State of Texas</span>
+              <span><b>Forum</b> · Harris County, TX</span>
+            </div>
+          </header>
+
+          <nav className="cj-toc-chips" aria-label="Sections">
+            <a href="#acceptance"><span>01</span>acceptance</a>
+            <a href="#service"><span>02</span>the service</a>
+            <a href="#international"><span>03</span>international use</a>
+            <a href="#no-legal-advice"><span>04</span>no legal advice</a>
+            <a href="#indemnity"><span>05</span>indemnity</a>
+            <a href="#no-resale"><span>06</span>no resale</a>
+            <a href="#use-and-storage"><span>07</span>use &amp; storage</a>
+            <a href="#termination"><span>08</span>termination</a>
+            <a href="#links"><span>09</span>links</a>
+            <a href="#ip"><span>10</span>proprietary rights</a>
+            <a href="#disclaimers"><span>11</span>disclaimers</a>
+            <a href="#liability"><span>12</span>liability</a>
+            <a href="#dmca"><span>13</span>copyright (dmca)</a>
+            <a href="#general"><span>14</span>general</a>
+          </nav>
+
+          <section id="acceptance" className="cj-static-section">
+            <div className="cj-section-num">01 · acceptance</div>
+            <h2>Acceptance of these terms.</h2>
+            <div className="cj-callout"><b>In short:</b> using the site means you&apos;ve read this and agreed.</div>
+            <div className="cj-prose">
+              <p>
+                Welcome to CreditOdds. We provide an Internet service (&quot;Service&quot;).
+                Your use of the Service is subject to these Terms of Use (&quot;TOU&quot;).
+              </p>
+              <p>
+                We may modify these TOU at any time without notice to you by posting revised
+                TOU on the site. You can review the most current version of the TOU at any
+                time at www.CreditOdds.com/terms.
+              </p>
+              <p>
+                Your use of the Service constitutes your binding acceptance of the TOU,
+                including any modifications that we make. This Agreement will constitute a
+                binding and enforceable agreement between you (individually and in your
+                individual capacity as an employee, officer, agent, partner, etc. of each
+                organization you represent in connection with any use of the Service) and
+                CreditOdds. By using the Service, you acknowledge and agree that you have
+                fully read and agree to be bound by the provisions of this Agreement. If you
+                do not agree to be bound by this Agreement in its entirety, then you must
+                immediately stop using the CreditOdds Website.
+              </p>
+              <p>
+                Where you use the Service in the course of your employment or business, you
+                enter into this Agreement both on your own behalf and in your individual
+                capacity as an employee, officer, agent, partner, etc. of such organization
+                which you represent, and references in this Agreement to &quot;you&quot;
+                shall mean both you as the individual user of the Service and you in your
+                capacity as a representative of your organization.
+              </p>
+            </div>
+          </section>
+
+          <section id="service" className="cj-static-section">
+            <div className="cj-section-num">02 · description of service</div>
+            <h2>What the Service is.</h2>
+            <div className="cj-callout"><b>In short:</b> content, search, and tools — provided as-is, sometimes with ads.</div>
+            <div className="cj-prose">
+              <p>
+                The Service currently provides users with access to a collection of content,
+                including legal information, educational information, Internet search
+                services, marketing information, marketing services, hosted Websites and
+                business information through its network of properties.
+              </p>
+              <p>
+                You also understand and agree that the Service may include advertisements
+                and that these advertisements are necessary for CreditOdds to provide the
+                Service. Free Website&apos;s on CreditOdds&apos;s CreditOdds.com service may
+                have search functionality provided by a third party service. A search box
+                providing this search functionality may be placed anywhere on a Web page,
+                including the top of the Web page. Any search that takes place on the
+                CreditOdds.com Web site may lead to a search results page on the third
+                party site which may include advertisements. This advertising revenue will
+                be split between the third party search provider and CreditOdds.
+                CreditOdds will also include links on the free CreditOdds.com Websites to
+                CreditOdds and other online Websites. These links may be in the header,
+                footer, Web Resources Page or Web Blog page. In addition CreditOdds reserves
+                the right to place paid advertisements on the CreditOdds.com under the
+                footer of the Website&apos;s pages.
+              </p>
+              <p>
+                You also understand and agree that the Service may include certain
+                communications from CreditOdds, such as service announcements,
+                administrative messages and the CreditOdds Newsletter, and that these
+                communications are considered part of CreditOdds membership.
+              </p>
+              <p>
+                Unless explicitly stated otherwise, any new features that augment or enhance
+                the current Service, including the release of new CreditOdds properties,
+                shall be subject to the TOU.
+              </p>
+              <p>
+                You understand and agree that the Service is provided &quot;AS-IS&quot; and
+                that CreditOdds assumes no responsibility for the timeliness, deletion,
+                mis-delivery or failure to store any user communications or personalization
+                settings. You are responsible for obtaining access to the Service and that
+                access may involve third party fees (such as Internet service provider or
+                airtime charges). You are responsible for those fees, including those fees
+                associated with the display or delivery of advertisements. In addition, you
+                must provide and are responsible for all equipment necessary to access the
+                Service.
+              </p>
+              <p>
+                We have the right, but not the obligation, to take any of the following
+                actions in our sole discretion at any time and for any reason without giving
+                you any prior notice:
+              </p>
+              <ul>
+                <li>Restrict, suspend or terminate your access to all or any part of the Service;</li>
+                <li>Change, suspend or discontinue all or any part of the Service;</li>
+                <li>Refuse, move or remove any material that you submit to the Service for any reason;</li>
+                <li>Refuse, move, or remove any content that is available on the Service;</li>
+                <li>Deactivate or delete your accounts and all related information and files in your account;</li>
+                <li>Establish general practices and limits concerning use of the Service.</li>
+              </ul>
+              <p>
+                You agree that we will not be liable to you or any third party for taking
+                any of these actions.
+              </p>
+            </div>
+          </section>
+
+          <section id="international" className="cj-static-section">
+            <div className="cj-section-num">03 · international use</div>
+            <h2>Special admonitions for international use.</h2>
+            <div className="cj-callout"><b>In short:</b> if you&apos;re outside the US, follow your local rules too.</div>
+            <div className="cj-prose">
+              <p>
+                Recognizing the global nature of the Internet, you agree to comply with all
+                local rules regarding online conduct and acceptable Content. Specifically,
+                you agree to comply with all applicable laws regarding the transmission of
+                technical data exported from the United States or the country in which you
+                reside.
+              </p>
+            </div>
+          </section>
+
+          <section id="no-legal-advice" className="cj-static-section">
+            <div className="cj-section-num">04 · no legal advice</div>
+            <h2>This is not legal advice.</h2>
+            <div className="cj-callout cj-callout-warn"><b>Important:</b> we&apos;re not lawyers and CreditOdds is not legal counsel.</div>
+            <div className="cj-prose">
+              <p>
+                The Service and all Content are provided for general informational purposes
+                only, and may not reflect current legal developments, verdicts or
+                settlements. Any information contained in the Content or this Service should
+                not be construed as legal advice and is not intended to be a substitute for
+                legal counsel on any subject matter. No recipient of Content from the
+                Service should act or refrain from acting on the basis of any Content
+                included in, or accessible through, the Service without seeking the
+                appropriate legal or other professional advice on the particular facts and
+                circumstances at issue from a lawyer licensed in the recipient&apos;s state,
+                country or other appropriate licensing jurisdiction.
+              </p>
+            </div>
+          </section>
+
+          <section id="indemnity" className="cj-static-section">
+            <div className="cj-section-num">05 · indemnity</div>
+            <h2>Indemnification.</h2>
+            <div className="cj-prose">
+              <p>
+                You agree to indemnify and hold CreditOdds, and its subsidiaries,
+                affiliates, employees, information providers, partners, licensors, agents,
+                co-branders, officers, directors, owners and employees, harmless from any
+                claim or demand, including reasonable attorneys&apos; fees, made by any
+                third party due to or arising out of Content you submit, post, transmit or
+                make available through the Service, your use of the Service, your connection
+                to the Service, your violation of the TOU, or your violation of any rights
+                of another.
+              </p>
+            </div>
+          </section>
+
+          <section id="no-resale" className="cj-static-section">
+            <div className="cj-section-num">06 · no resale</div>
+            <h2>No resale of the Service.</h2>
+            <div className="cj-callout"><b>In short:</b> personal use is fine. Reselling, scraping, or repackaging us is not.</div>
+            <div className="cj-prose">
+              <p>
+                You agree not to reproduce, duplicate, copy, sell, trade, resell or exploit
+                for any commercial purposes, any portion of the Service (including your
+                CreditOdds Account Identification), use of the Service, or access to the
+                Service.
+              </p>
+            </div>
+          </section>
+
+          <section id="use-and-storage" className="cj-static-section">
+            <div className="cj-section-num">07 · use &amp; storage</div>
+            <h2>Practices regarding use, storage, and changes.</h2>
+            <div className="cj-prose">
+              <p>
+                You acknowledge that CreditOdds may establish general practices and limits
+                concerning use of the Service, including without limitation the maximum
+                number of days that message board postings or other uploaded Content will be
+                retained by the Service, the maximum disk space that will be allotted on
+                CreditOdds&apos;s servers on your behalf, and the maximum number of times
+                (and the maximum duration for which) you may access the Service in a given
+                period of time. You agree that CreditOdds has no responsibility or
+                liability for the deletion or failure to store any communications or other
+                Content maintained or transmitted by the Service. You acknowledge that
+                CreditOdds reserves the right to log off accounts that are inactive for an
+                extended period of time. You further acknowledge that CreditOdds reserves
+                the right to modify these general practices and limits from time to time.
+              </p>
+              <p>
+                CreditOdds reserves the right at any time and from time to time to modify
+                or discontinue, temporarily or permanently, the Service (or any part
+                thereof) with or without notice. You agree that CreditOdds shall not be
+                liable to you or to any third party for any modification, suspension or
+                discontinuance of the Service.
+              </p>
+            </div>
+          </section>
+
+          <section id="termination" className="cj-static-section">
+            <div className="cj-section-num">08 · termination</div>
+            <h2>Termination.</h2>
+            <div className="cj-prose">
+              <p>
+                You agree that CreditOdds may, under certain circumstances and without
+                prior notice, immediately terminate your CreditOdds account and access to
+                the Service. Cause for such termination shall include, but not be limited
+                to, (a) breaches or violations of the TOU or other incorporated agreements
+                or guidelines, (b) requests by law enforcement or other government agencies,
+                (c) a request by you (self-initiated account deletions), (d) discontinuance
+                or material modification to the Service (or any part thereof), (e)
+                unexpected technical or security issues or problems, and (f) extended
+                periods of inactivity.
+              </p>
+              <p>
+                Termination of your CreditOdds account includes (a) removal of access to
+                all offerings within the Service, including but not limited to CreditOdds
+                Message Boards and Websites, (b) deletion of your password and all related
+                account information, files and content associated with or inside your
+                account (or any part thereof), and (c) barring further use of the Service.
+                Further, you agree that all terminations for cause shall be made in
+                CreditOdds&apos;s sole discretion and that CreditOdds shall not be liable
+                to you or any third-party for any termination of your account, any
+                associated email address, or access to the Service.
+              </p>
+            </div>
+          </section>
+
+          <section id="links" className="cj-static-section">
+            <div className="cj-section-num">09 · links</div>
+            <h2>Links to other sites.</h2>
+            <div className="cj-prose">
+              <p>
+                The Service may provide, or third parties may provide, links to other World
+                Wide Websites or resources. Your use of each of those sites is subject to
+                the conditions, if any, that each of those sites has posted. Because
+                CreditOdds has no control over such sites and resources, you acknowledge and
+                agree that CreditOdds is not responsible for the availability of such
+                external sites or resources, and does not endorse and is not responsible or
+                liable for any Content, advertising, products, or other materials on or
+                available from such sites or resources. You further acknowledge and agree
+                that CreditOdds shall not be responsible or liable, directly or indirectly,
+                for any damage or loss caused or alleged to be caused by or in connection
+                with use of or reliance on any such Content, goods or services available on
+                or through any such site or resource.
+              </p>
+            </div>
+          </section>
+
+          <section id="ip" className="cj-static-section">
+            <div className="cj-section-num">10 · proprietary rights &amp; trademarks</div>
+            <h2>Our content, software, and marks.</h2>
+            <div className="cj-callout"><b>In short:</b> the site and software are ours; the CreditOdds name and logo are trademarks.</div>
+            <div className="cj-prose">
+              <p>
+                You acknowledge and agree that the Service and any necessary software used
+                in connection with the Service (&quot;Software&quot;) contain proprietary
+                and confidential information that is protected by applicable intellectual
+                property and other laws. You further acknowledge and agree that Content
+                contained in sponsor advertisements or information presented to you through
+                the Service or advertisers is protected by copyrights, trademarks, service
+                marks, patents or other proprietary rights and laws. Except as expressly
+                authorized by CreditOdds or advertisers, you agree not to modify, rent,
+                lease, loan, sell, distribute or create derivative works based on the
+                Service or the Software, in whole or in part.
+              </p>
+              <p>
+                CreditOdds grants you a personal, non-transferable and non-exclusive right
+                and license to use the object code of its Software on a single computer;
+                provided that you do not (and do not allow any third party to) copy, modify,
+                create a derivative work of, reverse engineer, reverse assemble or otherwise
+                attempt to discover any source code, sell, assign, sublicense, grant a
+                security interest in or otherwise transfer any right in the Software. You
+                agree not to modify the Software in any manner or form, or to use modified
+                versions of the Software, including (without limitation) for the purpose of
+                obtaining unauthorized access to the Service. You agree not to access the
+                Service by any means other than through the interface that is provided by
+                CreditOdds for use in accessing the Service.
+              </p>
+              <p>
+                CreditOdds claims no copyright in any works of the US Federal Government or
+                US State Governments, including court documents, codes, and regulations.
+              </p>
+              <p>
+                CreditOdds and the CreditOdds logo are trademarks of CreditOdds Inc. (the
+                &quot;CreditOdds Marks&quot;). Without CreditOdds&apos;s prior permission,
+                you agree not to display or use in any manner the CreditOdds Marks.
+              </p>
+            </div>
+          </section>
+
+          <section id="disclaimers" className="cj-static-section">
+            <div className="cj-section-num">11 · disclaimers</div>
+            <h2>Disclaimer of warranties.</h2>
+            <div className="cj-callout cj-callout-warn"><b>Important:</b> the Service is provided &quot;AS IS&quot; and &quot;AS AVAILABLE.&quot; No warranties.</div>
+            <div className="cj-prose">
+              <p>
+                YOU EXPRESSLY UNDERSTAND AND AGREE THAT YOUR USE OF THE SERVICE IS AT YOUR
+                SOLE RISK. THE SERVICE IS PROVIDED ON AN &quot;AS IS&quot; AND &quot;AS
+                AVAILABLE&quot; BASIS. CREDITODDS EXPRESSLY DISCLAIMS ALL WARRANTIES OF ANY
+                KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED
+                WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, WARRANTIES
+                OF TITLE AND NON-INFRINGEMENT.
+              </p>
+              <p>
+                CREDITODDS MAKES NO WARRANTY THAT (i) THE SERVICE WILL MEET YOUR
+                REQUIREMENTS, (ii) THE SERVICE WILL BE UNINTERRUPTED, TIMELY, SECURE, OR
+                ERROR-FREE, (iii) THE RESULTS THAT MAY BE OBTAINED FROM THE USE OF THE
+                SERVICE WILL BE ACCURATE OR RELIABLE, (iv) THE QUALITY OF ANY PRODUCTS,
+                SERVICES, INFORMATION, OR OTHER MATERIAL PURCHASED OR OBTAINED BY YOU
+                THROUGH THE SERVICE WILL MEET YOUR EXPECTATIONS, AND (V) ANY ERRORS IN THE
+                SOFTWARE WILL BE CORRECTED.
+              </p>
+              <p>
+                ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SERVICE
+                IS DONE AT YOUR OWN DISCRETION AND RISK AND THAT YOU WILL BE SOLELY
+                RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR LOSS OF DATA THAT
+                RESULTS FROM THE DOWNLOAD OF ANY SUCH MATERIAL.
+              </p>
+              <p>
+                NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY YOU FROM
+                CREDITODDS OR THROUGH OR FROM THE SERVICE SHALL CREATE ANY WARRANTY NOT
+                EXPRESSLY STATED IN THE TOU.
+              </p>
+            </div>
+          </section>
+
+          <section id="liability" className="cj-static-section">
+            <div className="cj-section-num">12 · liability</div>
+            <h2>Limitation of liability.</h2>
+            <div className="cj-prose">
+              <p>
+                YOU EXPRESSLY UNDERSTAND AND AGREE THAT CREDITODDS SHALL NOT BE LIABLE TO
+                YOU FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR
+                EXEMPLARY DAMAGES, INCLUDING BUT NOT LIMITED TO, DAMAGES FOR LOSS OF
+                PROFITS, GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES (EVEN IF CREDITODDS
+                HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES), RESULTING FROM: (i)
+                THE USE OR THE INABILITY TO USE THE SERVICE; (ii) THE COST OF PROCUREMENT
+                OF SUBSTITUTE GOODS AND SERVICES RESULTING FROM ANY GOODS, DATA, INFORMATION
+                OR SERVICES PURCHASED OR OBTAINED OR MESSAGES RECEIVED OR TRANSACTIONS
+                ENTERED INTO THROUGH OR FROM THE SERVICE; (iii) UNAUTHORIZED ACCESS TO OR
+                ALTERATION OF YOUR TRANSMISSIONS OR DATA; (iv) STATEMENTS OR CONDUCT OF ANY
+                THIRD PARTY ON THE SERVICE; OR (v) ANY OTHER MATTER RELATING TO THE SERVICE.
+              </p>
+              <p>
+                SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF CERTAIN WARRANTIES OR THE
+                LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL
+                DAMAGES. ACCORDINGLY, SOME OF THE ABOVE LIMITATIONS MAY NOT APPLY TO YOU. IN
+                SUCH STATES, OUR LIABILITY AND THAT OF OUR THIRD PARTY CONTENT PROVIDERS AND
+                THEIR RESPECTIVE AGENTS SHALL BE LIMITED TO THE GREATEST EXTENT PERMITTED
+                BY LAW.
+              </p>
+              <p>
+                <b>Special admonition for legal information.</b> If you intend to create or
+                join any service, receive or request any news, messages, alerts or other
+                information from the Service concerning legal information or services,
+                please read the disclaimers and liability sections again — they go doubly
+                for you. The Service is provided for informational purposes only, and no
+                Content included in the Service should be relied on as a substitution for
+                the legal advice from a licensed lawyer. CreditOdds, its licensors and
+                partners shall not be responsible or liable for the accuracy, usefulness or
+                availability of any information transmitted or made available via the
+                Service, and shall not be responsible or liable for any trading or
+                investment decisions made based on such information.
+              </p>
+              <p>
+                <b>No third party beneficiaries.</b> You agree that, except as otherwise
+                expressly provided in this TOU, there shall be no third party beneficiaries
+                to this Agreement.
+              </p>
+              <p>
+                <b>Notice.</b> CreditOdds may provide you with notices, including those
+                regarding changes to the TOU, by either email, regular mail, or postings on
+                the Service.
+              </p>
+            </div>
+          </section>
+
+          <section id="dmca" className="cj-static-section">
+            <div className="cj-section-num">13 · copyright (DMCA)</div>
+            <h2>Notice and procedure for IP claims.</h2>
+            <div className="cj-callout"><b>In short:</b> we respect IP. If your work was infringed, here&apos;s how to tell us.</div>
+            <div className="cj-prose">
+              <p>
+                CreditOdds respects the intellectual property of others, and we ask our
+                users to do the same. CreditOdds may, in appropriate circumstances and at
+                its discretion, disable and/or terminate the accounts of users who may be
+                repeat infringers. If you believe that your work has been copied in a way
+                that constitutes copyright infringement, or your intellectual property
+                rights have been otherwise violated, please provide CreditOdds&apos;s
+                Copyright Agent the following information:
+              </p>
+              <ul>
+                <li>An electronic or physical signature of the person authorized to act on behalf of the owner of the copyright or other intellectual property interest;</li>
+                <li>A description of the copyrighted work or other intellectual property that you claim has been infringed;</li>
+                <li>A description of where the material that you claim is infringing is located on the site;</li>
+                <li>Your address, telephone number, and email address;</li>
+                <li>A statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law;</li>
+                <li>A statement by you, made under penalty of perjury, that the above information in your Notice is accurate and that you are the copyright or intellectual property owner or authorized to act on the copyright or intellectual property owner&apos;s behalf.</li>
+              </ul>
+            </div>
+            <dl className="cj-deflist">
+              <dt>Agent for notice</dt>
+              <dd>
+                CreditOdds<br />
+                3262 Westheimer Road, No. 222<br />
+                Houston, Texas 77098
+              </dd>
+            </dl>
+          </section>
+
+          <section id="general" className="cj-static-section">
+            <div className="cj-section-num">14 · general</div>
+            <h2>General information.</h2>
+            <div className="cj-prose">
+              <p>
+                <b>Entire Agreement.</b> The TOU constitutes the entire agreement between
+                you and CreditOdds and govern your use of the Service, superseding any
+                prior agreements between you and CreditOdds. You also may be subject to
+                additional terms and conditions that may apply when you use or purchase
+                certain other CreditOdds services, affiliate services, third-party content
+                or third-party software.
+              </p>
+            </div>
+            <dl className="cj-deflist">
+              <dt>Choice of law &amp; forum</dt>
+              <dd>
+                Governed by the laws of the State of Texas without regard to its
+                conflict-of-law provisions. You and CreditOdds agree to submit to the
+                personal and exclusive jurisdiction of the courts located in Harris County,
+                Texas.
+              </dd>
+              <dt>Arbitration</dt>
+              <dd>
+                CreditOdds may elect to resolve any controversy or claim arising out of or
+                relating to these TOU or our sites by binding arbitration in accordance with
+                the commercial arbitration rules of the American Arbitration Association.
+                Any such controversy or claim shall be arbitrated on an individual basis,
+                and shall not be consolidated in any arbitration with any claim or
+                controversy of any other party. The arbitration shall be conducted in the
+                county of Harris, Texas, and judgment on the arbitration award may be
+                entered in any court having jurisdiction thereof.
+              </dd>
+              <dt>Waiver &amp; severability</dt>
+              <dd>
+                The failure of CreditOdds to exercise or enforce any right or provision of
+                the TOU shall not constitute a waiver of such right or provision. If any
+                provision of the TOU is found by a court of competent jurisdiction to be
+                invalid, the parties nevertheless agree that the court should endeavor to
+                give effect to the parties&apos; intentions as reflected in the provision,
+                and the other provisions of the TOU remain in full force and effect.
+              </dd>
+              <dt>Non-transferability</dt>
+              <dd>
+                Your CreditOdds account is non-transferable and any rights to your
+                CreditOdds I.D. or contents within your account terminate upon your death.
+                Upon receipt of a copy of a death certificate, your account may be
+                terminated and all contents therein permanently deleted.
+              </dd>
+              <dt>Statute of limitations</dt>
+              <dd>
+                Regardless of any statute or law to the contrary, any claim or cause of
+                action arising out of or related to use of the Service or the TOU must be
+                filed within one (1) year after such claim or cause of action arose or be
+                forever barred.
+              </dd>
+              <dt>Titles</dt>
+              <dd>The section titles in the TOU are for convenience only and have no legal or contractual effect.</dd>
+              <dt>Violations</dt>
+              <dd>Please report any violations of the TOU to our Terms of Service Group via the contact page.</dd>
+            </dl>
+          </section>
+        </main>
+      </div>
+
       <V2Footer />
     </div>
   );

--- a/apps/web-next/src/components/landing-v2/Chrome.tsx
+++ b/apps/web-next/src/components/landing-v2/Chrome.tsx
@@ -116,7 +116,7 @@ export function V2Footer() {
         </div>
         <div className="foot-bottom">
           <span>© {new Date().getFullYear()} CreditOdds. Built by the community.</span>
-          <span>v2.6 · Last updated Apr 2026</span>
+          <span>v2.6 · Last updated May 2026</span>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Redesigns `/about`, `/how`, `/terms`, `/privacy` using the Claude Design editorial layout (terminal breadcrumb, italic-accent h1, numbered sections, ToC chips, deflists, 'In short' callouts, dark CTA block).
- Preserves original content: Max's about story (the original origin narrative), how-it-works data points + 14 FAQ accordions, the existing Texas-jurisdiction Terms with all clauses + Houston DMCA agent, the GDPR-aligned Privacy policy.
- Adds `apps/web-next/src/app/static-pages.css` — all `.cj-*` classes scoped under `.landing-v2.static-v2` so they don't leak onto other v2 pages.
- Bumps Terms "Last updated" to May 9, 2026 and the V2Footer stamp to "Last updated May 2026."
- Site navbar and footer chrome are untouched.

## Test plan
- [ ] `/about` renders with the dark terminal bar, eyebrow + italic-accent headline, and Max's full origin story preserved
- [ ] `/how` renders the 3-step strip, data-points deflist, "lines we don't cross" list, and 14 FAQ accordions expand correctly
- [ ] `/terms` shows 14 ToC chips, "In short" callouts, Texas/Harris County jurisdiction, and Houston DMCA agent address
- [ ] `/privacy` shows the "whole policy in one paragraph" callout and original GDPR/Google Analytics content
- [ ] Breadcrumb on each page shows only the current page label (no "home")
- [ ] V2Footer reads "Last updated May 2026" on every page
- [ ] Mobile: terminal bar, h1 (40px), deflist (single column), steps (single column), CTA stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)