### PR TITLE
about: change section 01 heading to "Can I get this credit card?"

### DIFF
--- a/apps/web-next/src/app/about/page.tsx
+++ b/apps/web-next/src/app/about/page.tsx
@@ -52,7 +52,7 @@ export default function AboutPage() {
 
           <section className="cj-static-section">
             <div className="cj-section-num">01 · the question</div>
-            <h2>It started with a rejection.</h2>
+            <h2>Can I get this credit card?</h2>
             <div className="cj-prose">
               <p>
                 My girlfriend asked me that while scrolling through her bank&apos;s credit


### PR DESCRIPTION
## Summary
- Replace "It started with a rejection." with "Can I get this credit card?" as the section 01 heading on the /about page

## Test plan
- [ ] Visit /about and confirm the section 01 heading reads "Can I get this credit card?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)