### PR TITLE
profile (BCH): trim mobile intro copy so the CTA lifts above the fold

### DIFF
--- a/apps/web-next/src/components/wallet/BestCardHere.tsx
+++ b/apps/web-next/src/components/wallet/BestCardHere.tsx
@@ -170,7 +170,6 @@ function LocationBlock({ location, onEnable, onClear }: LocationBlockProps) {
   if (!location) {
     return (
       <div className="cj-bch-cta-wrap">
-        <p className="cj-bch-cta-prompt">Tap to find the best card to swipe at the businesses around you.</p>
         <button type="button" className="cj-bch-cta-btn" onClick={onEnable}>
           Find Best Near Me
         </button>
@@ -433,9 +432,8 @@ export default function BestCardHere({ walletCards, allCards, onWalletRefresh }:
         lineHeight: 1.6,
         maxWidth: '64ch',
       }}>
-        We&apos;re piloting a wallet-aware merchant lookup. Share your location and we&apos;ll show
-        the 5–12 closest businesses with the single best card from your wallet to swipe at each one.
-        We won&apos;t store coordinates and we won&apos;t follow you home.
+        Share your location to see nearby businesses with the best card from your wallet
+        to swipe at each. We don&apos;t store coordinates.
       </p>
 
       <LocationBlock


### PR DESCRIPTION
## Summary
- Drop the redundant \"Tap to find the best card to swipe at the businesses around you\" prompt above the button — the button label (\"Find Best Near Me\") already says it.
- Tighten the pilot blurb from three sentences to one, keeping the privacy reassurance (\"We don't store coordinates\").

Result: on mobile `/profile` → Earn tab, the **Find Best Near Me** CTA reaches above the fold instead of sitting under ~5 lines of intro copy.

## Test plan
- [ ] Sign in, open `/profile` → Earn tab on mobile (375px wide), confirm the button is reachable without scrolling.
- [ ] Tap the button and confirm the location flow + merchant list still render correctly.
- [ ] Check desktop layout still looks balanced with the shorter intro paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)