### PR TITLE
profile: add Reminders rail block for rotating-category cards

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4542,13 +4542,18 @@
   .landing-v2.profile-v2 .cj-rail-block-news,
   .landing-v2.profile-v2 .cj-rail-cta-news { display: none; }
 
-  /* Upcoming renewals rail block → hidden on mobile except on the More tab.
+  /* Upcoming renewals + Reminders rail blocks → hidden on mobile except on the More tab.
      The More mobile pill stays active for any of these desktop activeTab values. */
-  .landing-v2.profile-v2 .cj-rail-block-renewals { display: none; }
+  .landing-v2.profile-v2 .cj-rail-block-renewals,
+  .landing-v2.profile-v2 .cj-rail-block-reminders { display: none; }
   .landing-v2.profile-v2[data-tab="more"] .cj-rail-block-renewals,
   .landing-v2.profile-v2[data-tab="applications"] .cj-rail-block-renewals,
   .landing-v2.profile-v2[data-tab="referrals"] .cj-rail-block-renewals,
-  .landing-v2.profile-v2[data-tab="settings"] .cj-rail-block-renewals { display: block; }
+  .landing-v2.profile-v2[data-tab="settings"] .cj-rail-block-renewals,
+  .landing-v2.profile-v2[data-tab="more"] .cj-rail-block-reminders,
+  .landing-v2.profile-v2[data-tab="applications"] .cj-rail-block-reminders,
+  .landing-v2.profile-v2[data-tab="referrals"] .cj-rail-block-reminders,
+  .landing-v2.profile-v2[data-tab="settings"] .cj-rail-block-reminders { display: block; }
 
   /* Whole rail → hidden on mobile except on the More tab group.
      Removes empty whitespace under the card list on Cards/Earn/News/Benefits. */

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -12,7 +12,7 @@ import "../landing.css";
 import { getNews, NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
 import ProfileLoader from "./ProfileLoader";
-import { amortizedAnnualValue } from "@/lib/cardDisplayUtils";
+import { amortizedAnnualValue, categoryLabels } from "@/lib/cardDisplayUtils";
 import { TrashIcon, DocumentTextIcon, LinkIcon, ExclamationTriangleIcon, PencilIcon } from "@heroicons/react/24/outline";
 import { calculateApplicationRules, countCardsMissingDates } from "@/lib/applicationRules";
 import {
@@ -265,6 +265,42 @@ export default function ProfileClient() {
   }, [walletCards, cardLookups, walletDisplayNames]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const nextRenewal = upcomingRenewals[0];
+
+  // Reminders — rotating category cards: surface this quarter's bonus categories
+  const reminders = useMemo(() => {
+    type Reminder = {
+      key: string;
+      cardName: string;
+      rate: number;
+      unit: string;
+      period: string;
+      categories: string[];
+    };
+    const list: Reminder[] = [];
+    for (const wc of walletCards) {
+      if (isInactiveCard(wc.card_name)) continue;
+      const card = cardLookups.byName.get(wc.card_name);
+      if (!card?.rewards) continue;
+      for (const r of card.rewards) {
+        if (r.mode !== 'quarterly_rotating') continue;
+        if (!r.current_categories?.length) continue;
+        const cats = r.current_categories.map((c) => {
+          const id = typeof c === 'string' ? c : c.category;
+          const slotNote = typeof c === 'string' ? undefined : c.note;
+          return slotNote ?? categoryLabels[id] ?? id;
+        });
+        list.push({
+          key: `${wc.id}-${r.category}`,
+          cardName: walletDisplayNames.get(wc.id) ?? wc.card_name,
+          rate: r.value,
+          unit: r.unit,
+          period: r.current_period ?? '',
+          categories: cats,
+        });
+      }
+    }
+    return list;
+  }, [walletCards, cardLookups, walletDisplayNames]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     Promise.all([getAllCards(), getNews()])
@@ -718,6 +754,25 @@ export default function ProfileClient() {
               </button>
             )}
           </div>
+
+          {reminders.length > 0 && (
+            <div className="cj-rail-block cj-rail-block-reminders">
+              <div className="cj-rail-label">Reminders</div>
+              <ul className="cj-rail-list">
+                {reminders.map((r) => (
+                  <li key={r.key} className="cj-rail-row">
+                    <div className="cj-rail-row-meta">
+                      {r.period && <span className="cj-rail-row-date">{r.period}</span>}
+                      <span className="cj-rail-row-field">{r.cardName.replace(/ Card$/, '')}</span>
+                    </div>
+                    <div className="cj-rail-row-detail">
+                      {r.rate}{r.unit === 'percent' ? '%' : 'x'} on {r.categories.join(' & ')}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {upcomingRenewals.length > 0 && (
             <div className="cj-rail-block cj-rail-block-renewals">


### PR DESCRIPTION
## Summary
- New **Reminders** section on the right rail of [/profile](apps/web-next/src/app/profile/ProfileClient.tsx), rendered above **Upcoming renewals**.
- For each wallet card with a `quarterly_rotating` reward, surfaces the current `current_period` (e.g. `Q2 2026`), card name, rate, and the active categories from `current_categories` (slot-specific notes win over the default `categoryLabels` lookup).
- Mirrors the existing rail-block visuals (no new CSS) and follows the same mobile-visibility rule as renewals (visible on More/Applications/Referrals/Settings tabs).

## Test plan
- [ ] Sign in with an account that has Discover It, Chase Freedom Flex, or another `quarterly_rotating` card in the wallet — verify the Reminders block appears above renewals with the correct period + categories.
- [ ] Account with no rotating cards: block does not render.
- [ ] Mobile: block hides on Cards/Earn/News/Benefits tabs and shows on More/Applications/Referrals/Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)