### PR TITLE
articles: queue 20 scheduled articles + add daily publish cron

### DIFF
--- a/.github/workflows/publish-scheduled-articles.yml
+++ b/.github/workflows/publish-scheduled-articles.yml
@@ -1,0 +1,50 @@
+name: Publish Scheduled Articles
+
+# Daily cron that promotes any article in data/articles/drafts/ whose `date`
+# field has arrived into data/articles/. The resulting commit triggers the
+# normal build-articles.yml pipeline (S3 upload, image sync, social post,
+# IndexNow), so a scheduled article publishes itself end-to-end with no
+# manual action.
+
+on:
+  schedule:
+    # 14:00 UTC daily = 10:00 ET (DST) / 09:00 ET (standard).
+    - cron: '0 14 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Move scheduled articles into data/articles/
+        run: node scripts/publish-scheduled-articles.js
+
+      - name: Commit and push if anything moved
+        run: |
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No articles ready to publish today."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A data/articles/
+          git commit -m "articles: publish scheduled articles for $(date -u +%Y-%m-%d)"
+          git push

--- a/data/articles/drafts/README.md
+++ b/data/articles/drafts/README.md
@@ -1,0 +1,17 @@
+# Article Drafts (Scheduled Publishing)
+
+Articles in this folder are **not yet published**. They sit here until their `date` field has been reached, at which point a daily GitHub Actions cron (`.github/workflows/publish-scheduled-articles.yml`) moves them into `data/articles/`, which fires the normal build pipeline (`build-articles.yml`) — building `articles.json`, syncing hero images, posting to social, and submitting to IndexNow.
+
+## How it works
+
+- The article build script (`scripts/build-articles.js`) only reads `*.yaml` / `*.yml` directly inside `data/articles/`. Subdirectories — including this one — are ignored, so drafts never leak into `articles.json`.
+- `scripts/publish-scheduled-articles.js` runs daily at 14:00 UTC. For each YAML in `drafts/` whose `date` is on or before today (UTC), it copies the file into `data/articles/` and deletes the draft. It commits and pushes if anything moved.
+- The new file landing in `data/articles/` triggers the existing `build-articles.yml` workflow, which treats it as a brand-new article (added file, not a rename) — so social posts and IndexNow submissions still fire correctly.
+
+## Adding a scheduled article
+
+1. Drop the YAML in this folder.
+2. Set `date:` to the day you want it to publish (UTC).
+3. Commit and push. It'll publish itself when the day arrives.
+
+To manually publish ahead of schedule, run the workflow with `workflow_dispatch` or just `git mv drafts/foo.yaml ../foo.yaml`.

--- a/data/articles/drafts/amex-once-per-lifetime-rule.yaml
+++ b/data/articles/drafts/amex-once-per-lifetime-rule.yaml
@@ -1,0 +1,198 @@
+id: "amex-once-per-lifetime-rule"
+slug: "amex-once-per-lifetime-rule"
+title: "The Amex Once-Per-Lifetime Rule: Which Cards, Which Loopholes, and How to Check Eligibility"
+date: "2026-05-25"
+author: "CreditOdds"
+summary: "How American Express's lifetime welcome bonus rule actually works in 2026, which card families share eligibility, and the soft-pull tool that tells you if you'll get the bonus before you apply."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - american-express-gold-card
+  - blue-cash-preferred-card
+  - blue-cash-everyday-card
+  - amex-everyday-credit-card
+  - american-express-green-card
+seo_title: "Amex Once-Per-Lifetime Rule Explained (2026) | CreditOdds"
+seo_description: "Which Amex cards trigger once-per-lifetime welcome bonus restrictions, how the family-of-cards rule works, and the pre-qualification tool that tells you eligibility before applying."
+social_title: "Amex's Once-Per-Lifetime Rule, Explained"
+content: |
+  American Express has the most aggressive welcome bonus restriction in the credit card industry: **once per lifetime**. If you've ever received a welcome bonus on a specific Amex card — even years ago — you generally cannot receive it again. Ever.
+
+  This rule traps thousands of applicants every year. They apply for the Gold Card, expecting a 60K Membership Rewards bonus, only to discover after spending the qualifying $6,000 that they're not eligible because they had the same card eight years ago and forgot. Amex's customer service will not retroactively grant the bonus, and the eligibility decision is final.
+
+  Here's exactly how the rule works, which card families share eligibility, the loopholes that still exist, and the tool that lets you check before you apply.
+
+  ## What "Once Per Lifetime" Actually Means at Amex
+
+  When you apply for an Amex card, the application's terms include a clause along the lines of:
+
+  > "Welcome bonus offer not available to applicants who have or have had this Card or previous versions of this Card."
+
+  In plain language: if you've ever **had** that specific card — whether you got a welcome bonus or not, whether you closed it or not, whether it was 2 years ago or 15 — you're not eligible for the bonus.
+
+  Three nuances:
+
+  1. **"Or previous versions"** is the most aggressive part. If Amex has rebranded or refreshed the card over the years, the lineage usually counts as one. Old Premier Rewards Gold = Gold Card lineage. Original Platinum = current Platinum lineage. Even pre-2009 versions often count.
+  2. **Just having the card counts.** Some people remember not getting a bonus and assume they're still eligible. They're usually not. Eligibility is tied to having the card open at any point, not whether you completed the welcome bonus requirements.
+  3. **Closing the card doesn't reset the clock.** It's a lifetime restriction. Closing the account today and applying again tomorrow won't help.
+
+  ## The Family-of-Cards Issue
+
+  The bigger trap: Amex groups some cards into **families**, and having one card in a family can sometimes block the bonus on the others. The rules here are inconsistent and have shifted over time, but the most reliable groupings as of mid-2026:
+
+  ### The Platinum family
+  - **Personal Platinum** (Amex Platinum)
+  - **Business Platinum**
+
+  These are **separate** lineages. Having one doesn't block the other's welcome bonus. You can collect the Personal Platinum bonus and the Business Platinum bonus as distinct events.
+
+  ### The Gold family
+  - **Personal Gold Card**
+  - **Business Gold Card**
+
+  Same deal — separate. Gold Card and Business Gold Card are independently eligible.
+
+  ### The Blue Cash family
+  - **Blue Cash Everyday**
+  - **Blue Cash Preferred**
+
+  These two are **less clear**. Some applicants report having both bonuses successfully; others report being declined the second bonus. The safest assumption: they're treated as related products and you may only get one bonus per family. If you're considering both, do Blue Cash Preferred first (the bonus is larger).
+
+  ### The Delta cobranded cards
+  - Delta SkyMiles Gold, Platinum, Reserve
+
+  These are tiered. You can typically have one bonus per tier — Gold + Platinum + Reserve simultaneously is possible, but two Delta Gold bonuses is not. The Business versions of each are separate from the personal versions.
+
+  ### The Hilton cobranded cards
+  - Hilton Honors, Hilton Honors Surpass, Hilton Honors Aspire
+
+  Similar tiering. Each tier counts once-per-lifetime, but each tier (Honors, Surpass, Aspire) is separate from the others.
+
+  ### The Marriott Bonvoy cobrand
+  - Marriott Bonvoy Brilliant
+  - Marriott Bonvoy Bevy
+  - Plus the Chase-issued Marriott cards (Boundless, Bountiful)
+
+  Marriott has the most byzantine cross-issuer rules. The general principle: you can hold one Amex Marriott card and one Chase Marriott card simultaneously, but bonus eligibility is gated by both 24-month and lifetime rules across the brand. We won't try to map every combination here — Marriott's rules are their own deep rabbit hole.
+
+  ## How Amex Decides Bonus Eligibility
+
+  When you apply, Amex's system checks your full account history with them — closed accounts, current accounts, even very old accounts. The check is automated. If you've had the card or product family before in a way that triggers the rule, the system silently flags your application as **bonus ineligible**.
+
+  Critically: **you can still be approved for the card with no welcome bonus**. The application is independent from the bonus eligibility decision. Most applicants who fall into this trap discover the issue only after spending the welcome bonus minimum and seeing no bonus post.
+
+  Some people in the data-points community report receiving an explicit "welcome bonus offer not available" message during application. Others see nothing. Don't rely on the absence of a warning as evidence you're eligible.
+
+  ## The Tool That Actually Tells You Before You Apply
+
+  This is the most important paragraph in this article: **Amex has a pre-qualification tool that explicitly indicates welcome bonus eligibility**.
+
+  Visit [americanexpress.com/en-us/credit-cards/check-for-offers/](https://www.americanexpress.com/en-us/credit-cards/check-for-offers/) and run the soft-pull pre-qualification check. The results page lists cards along with their welcome bonus terms.
+
+  Two readings of this output:
+
+  - **A specific welcome bonus is shown next to a card** → you're eligible and that's the bonus you'll get
+  - **The card appears with no welcome bonus shown, or shows "no offer at this time"** → you're not eligible for the welcome bonus on that card
+
+  The tool is soft-pull (no score impact), no commitment, and reflects Amex's actual eligibility decision for your account. It's the only authoritative way to check before you trigger the hard pull. Use it before every Amex application without exception.
+
+  Caveats:
+
+  - Sometimes the tool shows targeted offers (higher than the public bonus). These are tied to your specific eligibility and worth applying for via the displayed link.
+  - The tool occasionally underrepresents eligibility — some applicants pre-qualify with no offer shown but still receive the public bonus when they apply. Rare, but it happens.
+  - It can't predict whether your application will be approved at hard-pull stage. It only confirms welcome bonus eligibility.
+
+  ## Loopholes and Edge Cases
+
+  ### Loophole 1: Personal vs Business
+  As above — personal and business versions of the same product (Gold/Platinum) are independent. If you've already gotten the Personal Gold bonus, you can still target the Business Gold bonus, and vice versa.
+
+  ### Loophole 2: Refreshed product line
+  When Amex significantly refreshes a card (new branding, new core benefits), some applicants successfully argue they had the "old" version and the "new" version is a different product. Success here is inconsistent. The Premier Rewards Gold → Gold Card transition was generally treated as the same lineage; the Optima → Blue transition (long ago) was treated as different. Don't bet on this loophole — Amex usually treats refreshes as the same lineage.
+
+  ### Loophole 3: NLL (No Lifetime Language) offers
+  Periodically, Amex runs targeted offers that explicitly do NOT contain the lifetime restriction language. These are rare and short-lived but legitimate. The offer terms will be visible on the application page — read the bonus terms before clicking apply. If the once-per-lifetime clause is missing from your specific offer, you can collect the bonus even if you previously had the card.
+
+  Where to find these:
+
+  - Mailers and email targeted offers (read the fine print carefully)
+  - Limited-time public promotions (less common but they happen 1–2 times per year on specific cards)
+  - Some referral links carry NLL terms (rare; only when explicitly stated)
+
+  ### Loophole 4: The Schwab Platinum
+  The Charles Schwab-branded Amex Platinum is technically a separate product from the regular Personal Platinum. You can sometimes hold both bonuses despite the lineage. Only available to Schwab brokerage customers.
+
+  ### Loophole 5: Annual reset on co-branded cards (sometimes)
+  Some Amex co-brands (specifically older Hilton and Delta variations) historically had 24-month reset windows rather than once-per-lifetime. Always check the actual offer terms — a small minority of cards in 2026 still use a 24-month rule rather than a lifetime one. The exact terms are in the application's bonus disclosure.
+
+  ## What to Do If You're Already Trapped
+
+  If you applied, were approved, and discovered you weren't bonus-eligible after the fact, you have very limited recourse.
+
+  Things that occasionally work:
+
+  - **Calling and asking politely**, especially if you've held many Amex cards over the years and the offer terms were ambiguous. Success rate: under 10%, but free to try.
+  - **Pointing to a specific NLL offer you reasonably believed applied to you.** If you can show you applied through an NLL link or mailer, Amex sometimes honors the bonus.
+
+  Things that don't work:
+
+  - "I forgot I had the card." Amex doesn't grant bonus exceptions for memory.
+  - "The CSR at signup didn't mention the rule." The rule is in the application terms; verbal omissions don't override.
+  - Closing the card and reapplying. Lifetime is lifetime.
+
+  Practical move if you're stuck without a bonus: keep the card if it earns its annual fee for you. Otherwise, downgrade or close. Don't double down by trying to "earn the bonus through purchases" — there is no bonus to earn.
+
+  ## Strategic Application Order for Amex Cards
+
+  If you're new to Amex (or new enough that you have many bonuses still ahead of you), the order matters. A reasonable sequence over 24+ months:
+
+  1. **Amex Gold** — best welcome bonus value among entry-tier cards, opens MR account
+  2. **Amex Platinum** — premium bonus, often targeted at 100K+ MR
+  3. **Business Gold** — separate bonus from Personal Gold, business income required (which is easy — see our [biz-cards article](/articles/business-cards-not-on-personal-credit))
+  4. **Business Platinum** — separate from Personal Platinum
+  5. **Blue Cash Preferred** — useful daily-spend card, bonus around $250
+  6. **Delta or Hilton co-brand** if travel patterns justify
+
+  Space these 90+ days apart to avoid Amex's velocity throttling, and run pre-qualification before each one.
+
+  ## FAQ
+
+  ### What counts as "having the card before"?
+  Any time the card was open in your name, even briefly. Authorized user status doesn't count — being an authorized user on someone else's card doesn't burn your lifetime eligibility for the same card.
+
+  ### Does the Amex once-per-lifetime rule apply to Amex business cards?
+  Yes — each business card has its own once-per-lifetime restriction. They're separate lineages from personal cards but identical rule structure.
+
+  ### Does it apply to charge cards (Gold, Platinum, Green) and credit cards (Blue Cash, EveryDay)?
+  Yes, both card categories follow the rule equally.
+
+  ### Can I check eligibility with customer service?
+  Sometimes. If you call and ask, "Am I eligible for the welcome bonus on the [card]?", the rep can sometimes check and confirm in their system. The pre-qualification tool is more reliable, but a phone call is a reasonable backup.
+
+  ### Does upgrading from one Amex card to another use up my once-per-lifetime?
+  Yes — if you upgrade from a Green to Gold, you've now "had" the Gold and your once-per-lifetime is consumed. Same for upgrading from Gold to Platinum.
+
+  ### What if I hit the SUB years ago, closed the card, and applied for a different Amex card?
+  No issue. The once-per-lifetime is per card, not across all Amex cards. You can have collected bonuses on Gold, Blue Cash, Platinum, and Delta Gold over the years and still be eligible for any new Amex card you haven't held.
+
+  ### Is the rule really lifetime, or is it 7 years?
+  Some Amex cards historically used a 7-year window. The current standard is **lifetime** for most products as of 2026. Always check your specific application's bonus terms — the exact window is disclosed there.
+
+  ### Can I get the bonus through a referral link if I'm not normally eligible?
+  No. Referral bonuses for the referee are subject to the same once-per-lifetime rule. The referrer gets their referral reward regardless, but the new applicant has to be eligible for the welcome bonus.
+
+  ### Will I be denied the application if I'm not bonus-eligible?
+  Usually not. The application can still be approved; you just won't get the welcome bonus. This is the trap — most people who get hit by the rule are approved for the card and only realize too late.
+
+  ### Does Amex publish a list of which cards I'm eligible for?
+  Not directly. The pre-qualification tool is the closest — it shows you cards with their bonus offers, and the absence of a bonus on a card you'd expect to see one for indicates ineligibility.
+
+  ## The Bottom Line
+
+  The Amex once-per-lifetime rule is the single most expensive trap in credit card applications. Two rules cover all of it:
+
+  1. **Run the Amex pre-qualification tool before every Amex application.** It's a soft pull, free, and tells you whether you're eligible for the welcome bonus on each card you'd consider.
+  2. **Treat each card as a one-shot opportunity.** If you've held it before, the lifetime rule almost always applies. Plan your Amex applications carefully because you don't get a second chance.
+
+  Personal and business versions are independent. Card refreshes usually count as the same lineage. NLL offers are real but rare. The pre-qualification tool tells the truth. Use it.

--- a/data/articles/drafts/annual-fee-math.yaml
+++ b/data/articles/drafts/annual-fee-math.yaml
@@ -1,0 +1,257 @@
+id: "annual-fee-math"
+slug: "annual-fee-math"
+title: "Annual Fee Math: When Premium Credit Cards Actually Pay Off"
+date: "2026-07-09"
+author: "CreditOdds"
+summary: "How to calculate whether a $95, $250, or $695 annual fee card is worth it for you, the credits that actually count, and the cards that look better on paper than in real life."
+tags:
+  - guide
+  - strategy
+  - analysis
+related_cards:
+  - chase-sapphire-preferred
+  - chase-sapphire-reserve
+  - american-express-gold-card
+  - capital-one-venture-x
+  - american-express-business-gold-card
+seo_title: "Annual Fee Math: Premium Card Break-Even (2026) | CreditOdds"
+seo_description: "How to honestly calculate whether a credit card's annual fee pays off — which credits really count, the rewards math, and the cards most likely to underperform their pitch."
+social_title: "Is That Annual Fee Worth It?"
+content: |
+  Premium credit cards pitch themselves with a long list of benefits, credits, and rewards multipliers, all designed to make a $250 or $695 annual fee feel like an obvious win. The math, however, is rarely as simple as the marketing copy.
+
+  Some annual fees pay for themselves three times over for the right person. Some are a slow leak for someone whose spending pattern doesn't match the card. The difference is usually 10 minutes of honest math — and most people skip it.
+
+  Here's the framework for figuring out whether any specific premium card is actually worth its annual fee for you, and the cards that most often look better on paper than in real life.
+
+  ## The Honest Annual Fee Calculation
+
+  For any premium card, run this five-line math:
+
+  1. **Annual fee** (subtract)
+  2. **+ Cash credits you will actually use** (added)
+  3. **+ Rewards earned at premium multipliers** (added, valued conservatively)
+  4. **+ Quantifiable benefits with cash equivalents** (added)
+  5. **= Net value**
+
+  If net value > $0, the card is worth keeping. If net value < $0, downgrade or close.
+
+  Two principles make or break this math:
+
+  ### Principle 1: Only count credits you'll actually use
+  Card marketing pages list every possible credit. Your math should only count the ones you'd realistically claim each year. A $300 travel credit is worth $300 only if you genuinely travel. A $200 Uber credit is worth $200 only if you use Uber regularly. A $200 Equinox credit is worth $200 only if you have an Equinox membership — otherwise it's worth zero.
+
+  Never count credits at face value just because they're listed. The card's effective annual fee is the listed AF minus the credits you actually use, which often means the AF feels much higher than the marketing implies.
+
+  ### Principle 2: Value rewards conservatively
+  Premium cards earn at multipliers (3x dining, 5x travel, etc.). Your incremental rewards value is the multiplier above what you'd earn on a no-fee card.
+
+  - A 2% no-fee card earns $200 on $10K of spend
+  - A 4x dining card earns 4 points per dollar — at, say, 1.5 cents/point conservative redemption value, that's $600 on $10K
+  - **The premium card's incremental value is $400, not $600** — you'd earn $200 anyway on the no-fee card
+
+  Always do incremental math, not gross math. Otherwise every premium card looks free.
+
+  ## Worked Examples
+
+  ### Chase Sapphire Reserve: $550 AF
+
+  **Credits to factor**:
+  - $300 annual travel credit (auto-applied to first $300 of travel charges) — easy to use, worth $300 if you travel at all
+  - Priority Pass lounge access — worth $50–$200 depending on how often you actually visit lounges
+  - $5/month DoorDash credit + $25/month DashPass — worth $20/year if you use DashPass, more if you'd buy it standalone
+  - Lyft Pink — worth $0–$200 depending on Lyft usage
+  - Global Entry / TSA PreCheck reimbursement — $100 every 4 years, so $25/year amortized
+
+  **Rewards math** (assuming $40K/year spend):
+  - Sapphire Reserve earns 3x on dining, 5x on travel via Chase, 3x on travel direct
+  - Vs. baseline 2% on a no-fee card: incremental value depends heavily on spend mix
+  - Typical incremental value for a moderate traveler: $200–$500/year
+
+  **Net value calculation for a moderate traveler**:
+  - $550 AF
+  - + $300 travel credit
+  - + $100 Priority Pass
+  - + $20 DoorDash
+  - + $25 Global Entry
+  - + $300 incremental rewards
+  - = **$195 net positive**
+
+  CSR pencils for moderate travelers. For someone who travels rarely or doesn't use lounges, the math is much closer to break-even or negative.
+
+  ### Amex Platinum: $695 AF
+
+  **Credits to factor**:
+  - $200 hotel credit (FHR/THC bookings) — worth $200 if you book luxury hotels through Amex Travel
+  - $200 airline incidental credit — worth $0–$200 depending on whether you can use it for actual airline charges
+  - $200 Uber credit (split monthly) — worth $0–$200 depending on Uber usage
+  - $300 Equinox credit — worth $0–$300 depending on Equinox membership
+  - $240 digital entertainment credit — worth $0–$240 depending on whether you subscribe to listed services
+  - $189 CLEAR Plus credit — worth $0–$189 depending on whether you'd buy CLEAR
+  - $155 Walmart+ credit — worth $0–$155 depending on Walmart+ membership
+  - Centurion Lounge access — worth $50–$300 depending on usage
+  - Global Entry/TSA PreCheck reimbursement — $25/year amortized
+
+  **The Amex Platinum trap**: the listed credits total over $1,500 — but only if you use every single one. Most cardholders use 30–60% of the credits, putting their actual credit value at $400–$900.
+
+  **Rewards math** (assuming $30K/year spend):
+  - 5x on flights booked direct or via Amex Travel
+  - 5x on prepaid hotels via Amex Travel
+  - 1x on most other spend
+  - Incremental value over a 2% no-fee card: typically $0–$300, depending on travel spend
+
+  **Net value calculation for a moderate Amex Platinum holder using ~50% of credits**:
+  - $695 AF
+  - + $400 effective credit value (mid-case)
+  - + $200 lounge access value
+  - + $200 incremental rewards
+  - + $25 Global Entry
+  - = **$130 net positive**
+
+  Amex Platinum penciles only for users who actively use the credits. The card is famous for under-delivery for users who treat the credits as theoretical rather than scheduled events.
+
+  ### Amex Gold: $325 AF
+
+  **Credits to factor**:
+  - $120 Uber credit ($10/month) — worth $0–$120 depending on Uber usage
+  - $120 dining credit (specific restaurants, $10/month) — worth $0–$120 depending on whether you'd eat at those places
+  - $84 Dunkin' credit ($7/month) — worth $0–$84 depending on Dunkin usage
+  - $100 hotel credit (with Resy) — worth $100 if you book hotels through the Amex Travel platform
+
+  **Rewards math** (assuming $15K/year of dining + grocery):
+  - 4x on dining and US supermarkets (capped at $25K/year on each)
+  - At 2 cents/point conservative MR value: 4x on $15K = $1,200/year
+  - Vs. 2% no-fee card on same $15K = $300/year
+  - Incremental value: $900/year
+
+  **Net value calculation for a heavy diner**:
+  - $325 AF
+  - + $200 effective credit value (mid-case)
+  - + $900 incremental rewards
+  - = **$775 net positive**
+
+  Amex Gold is one of the highest-leverage premium cards for anyone with substantial dining and grocery spend. The math is significantly stronger than its higher-fee siblings.
+
+  ### Capital One Venture X: $395 AF
+
+  **Credits to factor**:
+  - $300 travel credit (Capital One Travel portal) — worth $300 if you book any travel through Capital One's portal
+  - 10K anniversary miles — worth ~$100 cash value (1 cent/mile)
+  - Priority Pass — worth $50–$200 depending on usage
+  - Capital One Lounge access — worth $50–$200 depending on usage
+  - Global Entry/TSA PreCheck reimbursement — $25/year amortized
+
+  **Rewards math** (assuming $30K/year spend):
+  - 2x on all spend (uncapped)
+  - 5x on flights via Capital One Travel; 10x on hotels via Capital One Travel
+  - Incremental value over 2% no-fee card: $0 baseline (Venture X is also 2% baseline), plus 3% on travel via portal
+
+  **Net value calculation for moderate traveler**:
+  - $395 AF
+  - + $300 travel credit
+  - + $100 anniversary miles
+  - + $100 Priority Pass + lounge
+  - + $25 Global Entry
+  - + $100 incremental travel rewards
+  - = **$230 net positive**
+
+  Venture X is one of the lowest-effort premium cards to make pencil. The $300 credit + 10K miles cover the AF for almost anyone who travels at all.
+
+  ## Cards That Most Often Underperform Their Pitch
+
+  ### Hilton Honors Aspire ($550 AF)
+  Free weekend night at Hilton, Diamond status, multiple lounge accesses — sounds great. But the marginal value depends entirely on whether you actually stay at Hilton properties multiple times per year. For someone who stays at Hilton 1–2 times annually, the card is significantly underwater on AF.
+
+  ### Marriott Bonvoy Brilliant ($650 AF)
+  Free anniversary night, $300 dining credit, Platinum Elite status. Strong for heavy Marriott customers; weak for anyone who stays elsewhere.
+
+  ### Citi Prestige (legacy, no longer sold but held by some)
+  Originally a strong card, watered down over years of benefit cuts. Most current holders are better off downgrading.
+
+  ### Specialty co-brand cards with narrow benefits
+  British Airways Visa, Iberia Visa, IHG Premier — strong only for cardholders deeply embedded in those specific loyalty programs. For occasional users, the AF rarely pencils.
+
+  ## The "Effective AF" Concept
+
+  A useful shortcut: calculate the **effective annual fee** by subtracting only the credits you'll realistically use, then compare that to the rewards multipliers.
+
+  - **Sapphire Reserve effective AF**: $550 − $300 (travel credit, easy to use) = $250
+  - **Amex Platinum effective AF**: $695 − $400 (mid-case credits used) = $295
+  - **Amex Gold effective AF**: $325 − $200 (mid-case credits used) = $125
+  - **Venture X effective AF**: $395 − $300 (travel credit) − $100 (anniversary miles) = $0 (or negative)
+
+  Once you've reduced to effective AF, the comparison to rewards earned becomes clearer. A $0 effective AF card just needs to earn rewards to be worth it. A $300 effective AF card needs to earn at least $300 of incremental rewards to break even.
+
+  ## Multi-Card Stacking and Effective AF
+
+  When you hold multiple premium cards, the math gets more nuanced:
+
+  - You can only use credits on each card if they're distinct (you can't double-claim the same Uber ride against two cards)
+  - Some credits overlap (Sapphire Reserve and Amex Platinum both cover Global Entry; you can only get reimbursed once every 4 years)
+  - Premium cards' incremental rewards depend on spend allocation: if you put 5x dining on Amex Gold, you can't also put it on Sapphire Reserve
+
+  Run the math individually for each card, but reduce overlapping credits and split your spend allocation conservatively across the cards before calling each one "worth it."
+
+  ## When to Downgrade Instead
+
+  If a card's AF doesn't pencil out, downgrade is almost always better than closing. Common downgrade paths:
+
+  - **Sapphire Reserve → Sapphire Preferred ($95 AF) → Freedom Unlimited (no AF)**
+  - **Amex Platinum → Amex Green ($150) → Amex EveryDay (no AF)**
+  - **Amex Gold → Amex EveryDay (no AF)**
+  - **Venture X → Venture ($95) → VentureOne (no AF)**
+
+  Downgrading preserves the credit limit and account age while eliminating the AF. The no-fee version may earn less rewards, but it's still useful as a tradeline. See our [closing cards article](/articles/closing-credit-cards-safely) for the full sequence.
+
+  ## Annual Audit: The 30-Minute Routine
+
+  Every December, run this audit:
+
+  1. List every credit card you hold with an annual fee
+  2. For each card, calculate net value: AF − used credits − incremental rewards
+  3. Cards with positive net value: keep
+  4. Cards with negative net value: decide between
+     - Asking for [retention offer](/articles/retention-offers-and-scripts) within the 30-day post-AF window
+     - Downgrading to no-fee version
+     - Closing if neither retention nor downgrade is meaningful
+
+  This 30 minutes of math, repeated annually, often saves $500–$2,000 per year for credit-card-heavy households.
+
+  ## FAQ
+
+  ### How do I value points conservatively?
+  Different programs have different baseline redemption values. Conservative defaults: Chase UR at 1.25–1.5 cents/point, Amex MR at 1–1.5 cents/point, Capital One miles at 1 cent each, Citi TY at 1 cent each. Higher values are achievable through transfer partners, but those require active research and effort.
+
+  ### Should I count statement credits I'd use anyway?
+  Yes — but only at face value. A $200 hotel credit you'd use on a $200 hotel charge is worth $200. A $200 hotel credit forcing you to book luxury hotels you wouldn't otherwise book is worth less than $200 (closer to the cost above what you'd otherwise spend).
+
+  ### What if I value the prestige or status?
+  Subjective value is real but should be honest. If lounge access genuinely improves your travel quality of life, count it. If you'd never set foot in a lounge, count it as $0. Don't hand-wave with "it's nice to have."
+
+  ### How do business card annual fees compare?
+  Same math, but with one extra benefit: business card AFs are tax-deductible as business expenses (Schedule C). Effective AF is the listed AF × (1 − marginal tax rate) for business owners.
+
+  ### What's the highest-AF card actually worth keeping?
+  Depends on usage. Amex Platinum and Hilton Honors Aspire each have AFs above $550 that pencil for the right user (heavy travel + premium hotel stays). Most other ultra-premium cards (Diamond Honors hotel cards, ultra-premium Amex variants) are narrower in their fit.
+
+  ### Should I optimize for AF cards or no-AF cards?
+  Mix. A typical optimized portfolio: 2–4 no-AF cards for utility (catch-all 2%, category bonuses, balance transfers) + 1–3 AF cards for premium rewards multipliers and welcome bonuses.
+
+  ### How does the AF interact with welcome bonuses?
+  Welcome bonuses dwarf AFs in year 1. A $695 Amex Platinum with a 100K MR bonus delivers roughly $1,500 in value vs. its $695 AF, netting +$800 in year one. Year 2 is when the AF math really matters — the welcome bonus is gone and the card has to earn its keep through credits and rewards.
+
+  ### Can I claim credits I haven't used yet at year-end?
+  Some credits are calendar-year (e.g., $200/year hotel credit refreshes January 1). Use them before year-end or they're forfeited. Other credits are anniversary-year (refresh on your card's open-date anniversary). Track which is which.
+
+  ### What if my card has fewer credits than its peers?
+  Then it competes more on rewards multipliers and welcome bonuses. Cards like Citi Strata Premier ($95 AF, fewer credits) need to earn their keep through earning rate (3x dining, 3x grocery, 3x gas, 3x air travel) rather than statement credits.
+
+  ## The Bottom Line
+
+  Annual fees aren't inherently bad — they're an exchange. You pay $250 or $550 or $695, and the card delivers credits, rewards multipliers, and benefits. The math works only if you actually use them. Three rules:
+
+  1. **Calculate honestly.** Only count credits you'll realistically use, not the full marketing tally.
+  2. **Audit annually.** Every December, recompute net value. Cards that no longer pencil should be downgraded or closed.
+  3. **Value your time.** A card that requires constant effort to maximize credits has a hidden cost. Cards like Venture X (single $300 travel credit, easy to use) are lower-effort than Amex Platinum (10+ specific credits to track and use).
+
+  Done well, premium cards can deliver $500–$2,000 of net value per year. Done lazily, they leak hundreds annually with little benefit. The difference is the 30 minutes of honest math — and the willingness to downgrade when the math doesn't work.

--- a/data/articles/drafts/authorized-user-strategy.yaml
+++ b/data/articles/drafts/authorized-user-strategy.yaml
@@ -1,0 +1,218 @@
+id: "authorized-user-strategy"
+slug: "authorized-user-strategy"
+title: "Authorized User Strategy: When It Boosts Your Score, When It Doesn't, and What Most Guides Get Wrong"
+date: "2026-06-15"
+author: "CreditOdds"
+summary: "How authorized user status actually affects your credit, which issuers report it, the limits at each major bank, and the scenarios where adding (or being added) makes sense."
+tags:
+  - guide
+  - strategy
+  - beginner
+related_cards:
+  - chase-freedom-unlimited
+  - american-express-gold-card
+  - capital-one-quicksilver
+  - citi-double-cash
+  - discover-it-cash-back
+seo_title: "Authorized User Strategy: Real Score Impact Explained (2026) | CreditOdds"
+seo_description: "How authorized user status affects credit scores, which issuers report AU activity, AU limits per card, and when adding someone (or being added) actually helps."
+social_title: "Authorized User: When It Helps, When It Doesn't"
+content: |
+  Adding someone as an authorized user (AU) on your credit card is one of the few credit moves that can genuinely help another person's score without costing you anything — when done right. It's also one of the most overhyped strategies, with marketers selling "tradeline rentals" that often don't deliver and credit-repair forums repeating advice that's been outdated for a decade.
+
+  Here's how AU status actually works in 2026, which issuers report, what the score impact really is, and the scenarios where it makes sense.
+
+  ## What an Authorized User Actually Is
+
+  An authorized user is someone added to a credit card account as a secondary user. They get:
+
+  - A card in their name (usually) with the same account number as the primary's card
+  - The ability to make charges on the account
+  - **No legal obligation to pay** the balance — that stays with the primary cardholder
+
+  The AU has no application process at most issuers — the primary just adds them by phone or online. There's typically no credit check on the AU (a few issuers do soft pulls; almost none do hard pulls).
+
+  Three things AU status does NOT do:
+
+  - It does not make the AU jointly liable for the debt
+  - It does not give the AU access to change account settings, dispute charges as primary, or close the account
+  - It does not always show up on the AU's credit report
+
+  That last point is where the strategy lives or dies.
+
+  ## Whether AU Activity Reports to Your Credit
+
+  Some issuers report authorized user activity to the bureaus on the AU's credit report. Some don't. Some only report to certain bureaus. Some only report under certain conditions. As of mid-2026:
+
+  ### Issuers that reliably report AU activity to all three bureaus
+  - **Chase** (most cards)
+  - **American Express**
+  - **Citi**
+  - **Bank of America**
+  - **U.S. Bank**
+  - **Wells Fargo**
+
+  ### Issuers that report AU activity but with caveats
+  - **Capital One** — reports AU activity, but historical reporting on AU age has been inconsistent
+  - **Discover** — reports, but only if the AU is over 18 (some accounts) and the activity meets certain thresholds
+
+  ### Issuers that often don't report AU activity
+  - **Synchrony** (Amazon, Care Credit, etc.)
+  - **Comenity** (department store cards)
+  - **Most store/co-brand cards** issued by smaller banks
+
+  Practical implication: if you want AU status to actually affect your credit, the primary cardholder needs to have the card with one of the reliably-reporting issuers. A no-name store card AU does very little for your score.
+
+  ## What Gets Inherited When You're Added as AU
+
+  When the AU's credit gets the new tradeline, it inherits:
+
+  - **The primary's credit limit** on that card
+  - **The primary's payment history** on that card (sometimes from the start of the account, sometimes only from when you were added — issuer-dependent)
+  - **The primary's account age** (in some cases, going back to the original account opening; in others, only from your add date)
+  - **The primary's current balance and utilization**
+
+  This is what makes AU status powerful. A 25-year-old with no credit history added to a parent's 20-year-old Amex with a $30K limit and a $0 balance suddenly has, on their report:
+
+  - 20 years of payment history
+  - $30K of available credit
+  - 0% utilization
+  - Solid account age
+
+  Their score can jump 50–100+ points overnight. This is the legitimate, well-documented use of AU strategy.
+
+  ## When AU Status Actually Helps
+
+  ### Scenario 1: Building credit from zero
+  Anyone with no credit history (young adults, recent immigrants, people emerging from unbanked situations) can benefit massively from AU status on a long-aged, low-utilization card. Even one AU tradeline often unlocks approval for a regular starter card on the AU's own application.
+
+  ### Scenario 2: Recovering from past damage
+  AU on a clean account can dilute the impact of older negative items by adding positive history to your file. The score boost varies by file specifics but can be 20–60 points.
+
+  ### Scenario 3: Pushing average account age higher
+  If your file is thin or your existing accounts are all recent, an AU tradeline that goes back many years can lift your average account age significantly — especially helpful if you're approaching a major credit event like a mortgage application.
+
+  ### Scenario 4: Boosting available credit (lowering utilization)
+  Adding an AU tradeline with a $30K limit instantly lowers your aggregate utilization. Useful as a tactical move before a credit application, mortgage shopping, or auto loan.
+
+  ### Scenario 5: Family members building credit together
+  A common, healthy pattern: parents add their teenagers as AUs at age 16–17 so they have ~5 years of credit history by the time they're applying for their first apartment, car loan, or credit card themselves.
+
+  ## When AU Status Doesn't Help (Or Hurts)
+
+  ### Scenario 1: The primary's account is in trouble
+  Late payments, high utilization, charge-offs — these get inherited by the AU just like positive history does. Being on a high-utilization card can drag the AU's score down by 20–40 points.
+
+  ### Scenario 2: The AU was added very recently
+  If you're added as AU and apply for a mortgage two weeks later, lenders may discount the AU tradeline as not establishing real credit history. Add early, hold long.
+
+  ### Scenario 3: The issuer doesn't report AU activity
+  Adding a 20-year-old to your Synchrony Amazon card and expecting it to boost their credit will fail. The tradeline simply doesn't appear on their report.
+
+  ### Scenario 4: The AU is treated as a bonus-chasing signal
+  This is rare but real. If someone is added as AU on multiple cards across multiple issuers in quick succession, some issuers' risk models flag the pattern. This can affect the AU's own future applications at those issuers.
+
+  ### Scenario 5: The relationship sours
+  AU is fundamentally trust-based. The primary can remove the AU at any time, removing the tradeline. The AU can run up charges that the primary is responsible for. Both sides need to actually trust each other.
+
+  ## AU Limits at Each Major Issuer
+
+  Different issuers cap how many AUs you can add per account:
+
+  - **Chase**: 5 AUs per card (some cards: unlimited)
+  - **American Express**: typically 5–7 AUs per card; Platinum and similar premium cards may include "free" AU slots before charging
+  - **Capital One**: usually no hard limit, but practical limit around 5–8
+  - **Citi**: typically 5–6
+  - **Bank of America**: typically 5
+  - **Discover**: 5
+  - **Wells Fargo**: 5
+
+  Some issuers charge per AU on premium cards. Amex Platinum, for example, charges $195 per AU after the first few. Always check the AU pricing for premium cards.
+
+  ## The "Tradeline Rental" Industry
+
+  Search for "buy AU tradelines" and you'll find services that, for a fee ($200–$1,500), add you as an AU on a stranger's high-limit, long-aged card for 60–90 days. The pitch is a quick credit score boost.
+
+  Two reasons to be skeptical:
+
+  ### Issuers have caught on
+  Major issuers (especially Amex and Chase) now flag patterns that look like tradeline rental — same primary adding many unrelated AUs in quick succession, AUs with no apparent relationship to the primary. When flagged, the AU tradeline may not be reported, or the issuer may shut down the entire account.
+
+  FICO and VantageScore models also have logic that discounts AU tradelines that look "rented" — short tenure, no shared address, no other indicators of a real relationship.
+
+  ### Even when it works, it's temporary
+  Tradeline rentals are 60–90 day arrangements. The score boost lasts only while you're an AU. Once you're removed, the tradeline drops off and your score reverts. If you're using AU to qualify for a mortgage, the lender will pull credit again at closing — if the AU has been removed, your score may drop and the loan terms can change.
+
+  Real AU benefits come from real, long-term relationships, not paid arrangements.
+
+  ## Best Practices for Using AU Strategy
+
+  ### If you're being added as AU
+  1. Confirm the primary's card is with a reliably-reporting issuer (Chase, Amex, Citi, BofA, US Bank, Wells Fargo).
+  2. Confirm the card has clean payment history and low utilization.
+  3. Get a sense of how long the card has been open. Older = better for your average age.
+  4. Don't request a physical card unless you actually need to spend on it. The AU effect on credit is the same with or without a physical card — only the bureau reporting matters.
+  5. Set a calendar reminder to check your credit report 30–60 days after being added to verify the tradeline appears.
+
+  ### If you're adding someone as AU
+  1. Pick a card with a high limit, low utilization, and clean history (no late payments).
+  2. Add early in your relationship — the longer the AU is on the account, the more credit "age" they accumulate.
+  3. Decide whether to give them a physical card. If they're a child, partner, or someone who needs to make actual purchases, yes. If it's a credit-only add (relative who needs the boost but won't spend), don't request a card and you'll never have to worry about charges.
+  4. Set up alerts on the account so you see any AU charges in real time.
+  5. Discuss expectations explicitly. Even with family, "you can use this card if you tell me first" needs to be said out loud.
+
+  ### Removing an AU
+  Removal is one phone call. The AU's tradeline disappears from their credit report at the next monthly reporting cycle (usually within 30–60 days). For mid-divorce or mid-falling-out situations, removal is fast and clean.
+
+  ## AU Strategy and Credit Card Approvals
+
+  AU tradelines count toward issuer velocity rules differently across banks:
+
+  - **Chase 5/24**: AU accounts **do count** toward the 5/24 calculation. This is a frequent surprise — even though you didn't open the card, it shows on your credit report and counts as one of your 5.
+  - **Amex velocity rules**: AU accounts generally don't count
+  - **Bank of America 2/3/4**: AU accounts don't count
+  - **Citi family rules**: AU accounts don't count for bonus eligibility
+
+  The Chase 5/24 wrinkle is significant. If your parent recently added you to their Sapphire Reserve, that adds an account to your 5/24 count. You may be at 4 self-opened cards plus 1 AU and effectively over 5/24 from Chase's perspective. Workaround: ask the primary to remove you, wait a couple months for the tradeline to drop off, then apply for the Chase card you wanted.
+
+  ## FAQ
+
+  ### Will adding my child as an AU help their credit?
+  Yes, on most major issuers. Most AU tradelines are reported to the bureaus, and the activity boosts the AU's credit history. Best for ages 13+, when the credit-building lead time pays off by the time they're 18.
+
+  ### Does the AU need to be a family member?
+  No. Most issuers don't require any specific relationship. You can add a friend, partner, business associate, etc.
+
+  ### What credit score does an AU need to be added?
+  None. AUs aren't underwritten — there's no credit pull required at most issuers (some do soft pulls). Anyone, including a child or someone with no credit history, can be added.
+
+  ### Can I be added as an AU on multiple cards?
+  Yes, and that compounds the credit benefit if the cards are all clean and old. Caution: if you're being added across many unrelated cards in quick succession, scoring models may downweight them.
+
+  ### How long does it take for an AU tradeline to appear on my credit report?
+  Usually 30–60 days from the add date. Some issuers report faster, some slower. If 60 days have passed and the tradeline hasn't appeared, contact the primary's issuer to confirm AU reporting was activated.
+
+  ### Does AU status help me qualify for a mortgage?
+  Yes, indirectly. AU tradelines lift your score and lower your utilization, both of which improve mortgage application terms. Some mortgage lenders manually discount AU tradelines during underwriting, especially if the tradeline is recent. To minimize discounting, be added at least 12+ months before the mortgage application.
+
+  ### Can my AU tradeline hurt my score?
+  Yes, if the primary's account has problems. Late payments, high utilization, or charge-offs on the primary's account can drag down the AU's score. Choose carefully whose AU you become.
+
+  ### Will being added as AU trigger a hard inquiry?
+  Almost never. Most issuers do no credit check on AUs. A few do soft pulls (which don't affect score). Hard pulls for AU adds are rare and unusual.
+
+  ### Can my AU make charges that I have to pay?
+  Yes. The primary cardholder is legally responsible for all charges on the account, regardless of who made them. Choose AUs you trust completely, and consider not requesting a physical card if you only want the credit benefit without the spend access.
+
+  ### Does AU status work the same on FICO and VantageScore?
+  Yes for current AU status. Both models include AU tradelines. FICO 9 and VantageScore 4.0 (the newer models) discount AU tradelines that look "rented" but reward real long-term AU relationships normally.
+
+  ## The Bottom Line
+
+  Authorized user status is one of the highest-leverage credit moves you can make for someone you trust — or that someone you trust can make for you. Three rules:
+
+  1. **Pick the right issuer.** AU tradelines only help if they actually report. Chase, Amex, Citi, BofA, US Bank, and Wells Fargo are the safe choices.
+  2. **Pick the right card.** High limit, low utilization, long history, clean payment record. Adding to a high-utilization or recently-late account can hurt rather than help.
+  3. **Use real relationships, not rentals.** Real AU benefits come from family or close-trust additions held for years. Tradeline rental services are increasingly detected and discounted.
+
+  Done well, AU is the closest thing in credit to a free score boost. Done carelessly, it inherits whatever's wrong with the primary's account. Pick carefully.

--- a/data/articles/drafts/bank-of-america-2-3-4-rule.yaml
+++ b/data/articles/drafts/bank-of-america-2-3-4-rule.yaml
@@ -1,0 +1,176 @@
+id: "bank-of-america-2-3-4-rule"
+slug: "bank-of-america-2-3-4-rule"
+title: "The Bank of America 2/3/4 Rule Explained: How BofA Limits Card Approvals"
+date: "2026-06-01"
+author: "CreditOdds"
+summary: "How Bank of America's 2/3/4 velocity rule actually works, the rolling windows it enforces, the Preferred Rewards override, and how to plan around it."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - bank-of-america-customized-cash-rewards
+  - bank-of-america-unlimited-cash-rewards
+  - bank-of-america-travel-rewards
+  - bank-of-america-premium-rewards
+  - bank-of-america-premium-rewards-elite
+seo_title: "Bank of America 2/3/4 Rule Explained (2026) | CreditOdds"
+seo_description: "How BofA's 2/3/4 velocity rule limits new credit cards (2 in 30 days, 3 in 12 months, 4 in 24 months), the Preferred Rewards override, and timing strategy."
+social_title: "Bank of America's 2/3/4 Rule, Explained"
+content: |
+  Bank of America runs the second-most-restrictive velocity rule in major-issuer card underwriting (after Chase 5/24). It's called the **2/3/4 rule**, and it caps how many BofA cards you can be approved for over three rolling time windows. Cross any of the three lines and your application auto-declines, regardless of your credit score, income, or banking relationship.
+
+  The rule is real, well-documented, and usually inflexible — but with one important exception that most applicants don't know about. Here's how 2/3/4 actually works in 2026, and how to plan around it.
+
+  ## What 2/3/4 Means
+
+  Three rolling windows, each independently enforced:
+
+  - **2 in 30 days**: Maximum 2 BofA personal credit card approvals in any rolling 30-day window
+  - **3 in 12 months**: Maximum 3 BofA personal credit card approvals in any rolling 12-month window
+  - **4 in 24 months**: Maximum 4 BofA personal credit card approvals in any rolling 24-month window
+
+  The rule applies to **approvals**, not applications. A declined application doesn't burn a slot. But each approved card counts against all three windows simultaneously, so a fourth approved card in 24 months auto-declines even if you're well within the 12- and 30-day caps.
+
+  Some additional structure that's important to understand:
+
+  ### Counted: BofA personal credit cards
+  Any consumer-branded BofA Visa or Mastercard counts. The Customized Cash Rewards, Unlimited Cash Rewards, Travel Rewards, Premium Rewards, and Premium Rewards Elite all count.
+
+  ### Not counted: Business cards
+  BofA business credit cards are exempt from 2/3/4. You can hold business cards in addition to your four-personal-card maximum.
+
+  ### Not counted: Cards from other issuers
+  2/3/4 is BofA-specific. New cards from Chase, Amex, Citi, etc. don't count toward your BofA velocity windows.
+
+  ### Authorized user accounts
+  AU status on someone else's BofA card generally doesn't count toward your 2/3/4. The rule applies to cards opened in your name.
+
+  ## How the Rule Is Enforced
+
+  The 2/3/4 check happens automatically as part of BofA's underwriting at application time. The bank pulls your credit and checks how many BofA personal cards have been opened in your name within each window. If you've hit the cap on any window, the application is declined with a denial reason like "too many recent BofA accounts" or "exceeded velocity limits."
+
+  Reconsideration won't fix a 2/3/4 violation. The rule is hard-coded. Calling and explaining your situation typically won't override it.
+
+  ## The Preferred Rewards Loophole
+
+  Here's the part most applicants miss: **Preferred Rewards customers may get exceptions to the 2/3/4 rule** under certain circumstances.
+
+  Bank of America's Preferred Rewards program tiers customers by total assets held with BofA and Merrill (the bank's brokerage):
+
+  - **Gold**: $20K+ in combined balances
+  - **Platinum**: $50K+
+  - **Platinum Honors**: $100K+
+  - **Diamond**: $1M+
+  - **Diamond Honors**: $10M+
+
+  At higher tiers (Platinum Honors and above), the 2/3/4 rule is reportedly enforced more leniently — some applicants successfully open a 4th card within 12 months or a 5th card within 24 months when they're at Platinum Honors or above. The exception isn't published; it's an underwriter-level discretionary call. Don't bet on it as a guarantee, but if you're in the higher Preferred Rewards tiers, it's worth applying and seeing what happens.
+
+  Lower Preferred Rewards tiers (Gold, Platinum) don't reliably get exceptions to 2/3/4 — but they do get other valuable benefits (25–75% bonus on rewards earnings) that make BofA's card lineup more competitive against other issuers.
+
+  ## Strategic Application Order
+
+  Given the three caps, the optimal way to build out a BofA card portfolio is to plan 24 months ahead. A reasonable lineup:
+
+  ### Year 1, Month 1: Customized Cash Rewards #1
+  - 3% category card (Gas, Online Shopping, etc.)
+  - Pick the category that fits your spend pattern
+
+  ### Year 1, Month 6: Customized Cash Rewards #2
+  - Same card, different category
+  - You can hold multiple Customized Cash cards with different categories — this is the most efficient way to maximize 3% earning across multiple spend types
+
+  ### Year 1, Month 12: Travel Rewards or Unlimited Cash Rewards
+  - Adds a flat-rate earner to your BofA stack
+  - Travel Rewards has 1.5x on all spend; Unlimited Cash Rewards has 1.5% flat cash
+
+  ### Year 2, Month 13+: Premium Rewards or Premium Rewards Elite
+  - The premium tier — Premium Rewards has $95 annual fee; Elite has $550
+  - Worth it primarily if you're at Platinum Honors Preferred Rewards tier (where the rewards bonus stacks)
+
+  ### Year 2, Month 18: Customized Cash Rewards #3 (optional)
+  - If you have a third 3% category that matches major spend, a third Customized Cash card adds another 3% lane
+
+  This sequence respects all three windows: 2 in 30 days never triggered, 3 in 12 months at most, 4 in 24 months at most.
+
+  ## Counting Cards Correctly
+
+  Two common mistakes when applicants self-count:
+
+  ### Mistake 1: Counting from application date instead of approval date
+  The 2/3/4 windows are anchored to **approval date**, not application date. If you applied for a card on March 1 and were approved on March 15, the relevant date is March 15 for the windows.
+
+  ### Mistake 2: Forgetting old closed cards
+  A BofA card you opened and closed within the last 24 months still counts. Closing the card doesn't remove it from the window — only time does.
+
+  Practical tip: pull your credit reports from all three bureaus (annualcreditreport.com is free) and look at the BofA account list. Each card has an "Opened" date. Count the BofA cards opened in the last 24 months, then 12 months, then 30 days. That's your current 2/3/4 count.
+
+  ## What Triggers a 2/3/4 Reset
+
+  The windows are rolling, so they don't "reset" all at once — they decay continuously as the oldest approval ages out.
+
+  - The day after your second card's 30-day window ends, you regain a 30-day slot.
+  - The day after your third card's 12-month window ends (12 months and one day from approval), you regain a 12-month slot.
+  - The day after your fourth card's 24-month window ends, you regain a 24-month slot.
+
+  If you're tight on a window, calculate the exact day the oldest card ages out, and time your next application for the day after.
+
+  ## How 2/3/4 Compares to Other Velocity Rules
+
+  | Rule | Scope | Cap |
+  |---|---|---|
+  | **Chase 5/24** | All issuers, personal cards | 5 new accounts in 24 months |
+  | **BofA 2/3/4** | BofA personal cards only | 2/30d, 3/12m, 4/24m |
+  | **Amex 1-in-5 (rumored)** | Amex personal cards | ~1 every 90 days, soft enforcement |
+  | **Citi 1/8/65/95** | Citi family-of-cards | Various bonus eligibility windows |
+  | **Capital One 1/6** | Capital One cards | 1 new card per 6 months |
+
+  BofA 2/3/4 is **scope-limited** — it only counts BofA cards. This is friendlier than Chase 5/24, which counts cards from every issuer. The tradeoff: BofA's caps are smaller. Three approvals in 12 months is tight if you wanted to load up on Customized Cash variants for category stacking.
+
+  ## When 2/3/4 Doesn't Matter as Much
+
+  Two situations where 2/3/4 fades into the background:
+
+  ### You're not interested in volume
+  If you only want one or two BofA cards over your lifetime, 2/3/4 is a non-issue. The rule only constrains rapid stacking.
+
+  ### You're optimizing for Preferred Rewards stacking
+  The real value of BofA cards comes from the rewards bonuses at Platinum Honors+ Preferred Rewards. Once your assets are at BofA, the 2/3/4 rule still applies, but the underlying card economics get strong enough that you don't need 4+ cards to capture most of the value. Two well-chosen Customized Cash cards plus a Premium Rewards Elite covers most spend categories at high effective rates.
+
+  ## FAQ
+
+  ### Does 2/3/4 apply to BofA business cards?
+  No. Business cards are exempt from the rule. You can hold business cards on top of your four-personal-card cap.
+
+  ### Does an authorized user account count toward 2/3/4?
+  No, generally. AU status doesn't open a tradeline in your name in the way primary cardholder approval does, and the 2/3/4 rule is anchored to primary approvals.
+
+  ### What if I'm Platinum Honors Preferred Rewards — can I exceed 2/3/4?
+  Sometimes, on a discretionary underwriter basis. There's no published exception, but data points consistently show some Platinum Honors+ customers approved for a 4th card in 12 months or 5th in 24 months when their relationship strength was strong. Don't count on it as automatic.
+
+  ### Does a denied BofA application count toward 2/3/4?
+  No. Only approved applications count. A denial doesn't consume a slot.
+
+  ### What happens if I close a BofA card?
+  The closed card still counts toward 2/3/4 windows for the full 24 months from the original approval date. Closing does not remove the card from the count.
+
+  ### Can I downgrade a BofA card to avoid 2/3/4 issues?
+  Downgrading (product change) doesn't free a slot — it converts an existing card to a different product without opening a new account. So if you want a Customized Cash with a new category but you're at the 12-month cap, downgrading your existing Premium Rewards to a Customized Cash works without burning a slot.
+
+  ### Does BofA's 2/3/4 rule count cards from Merrill or US Trust?
+  Merrill credit cards are issued through BofA — they count. US Trust co-branded cards may also count, depending on issuance. Check your credit report for the actual issuer.
+
+  ### Is 2/3/4 enforced strictly even for high-income, high-credit-score applicants?
+  Yes for the 30-day and 12-month windows. The 24-month window has slightly more flexibility for top-tier Preferred Rewards customers, as noted above.
+
+  ### What if BofA pre-approves me for a card that would violate 2/3/4?
+  Rare but possible — pre-approval is run on different infrastructure than the actual application underwriting. If you accept and apply, the application can still be denied for 2/3/4 even though pre-approval said yes. Always check your own count before applying.
+
+  ## The Bottom Line
+
+  Bank of America's 2/3/4 rule is narrower than Chase's 5/24 (it only counts BofA cards) but tighter within its scope. Three rules cover almost all of it:
+
+  1. **Plan 24 months ahead.** If you want a full BofA card lineup (multiple Customized Cash variants + a flat-rate + a premium card), space them at least 4–6 months apart.
+  2. **The Preferred Rewards override is real but discretionary.** If you're at Platinum Honors or above, you may get exceptions — but don't bet on them.
+  3. **Business cards and downgrades are your flex.** Both work around the rule legitimately when you need extra category coverage.
+
+  Get those three right and you can build a BofA card portfolio that captures every available rewards bonus without ever running into a velocity decline.

--- a/data/articles/drafts/best-first-credit-card-no-history.yaml
+++ b/data/articles/drafts/best-first-credit-card-no-history.yaml
@@ -1,0 +1,222 @@
+id: "best-first-credit-card-no-history"
+slug: "best-first-credit-card-no-history"
+title: "Best First Credit Card with No Credit History: 2026 Picks for Students, Young Adults, and Recent Immigrants"
+date: "2026-06-25"
+author: "CreditOdds"
+summary: "The best starter cards for someone with no credit history, what each one actually approves on, and the order to apply that maximizes your odds without burning unnecessary inquiries."
+tags:
+  - guide
+  - beginner
+related_cards:
+  - discover-it-cash-back
+  - discover-it-secured-credit-card
+  - capital-one-savor-student
+  - chase-freedom-student
+  - capital-one-platinum-secured
+  - capital-one-quicksilverone
+seo_title: "Best First Credit Card with No Credit History (2026) | CreditOdds"
+seo_description: "Top starter credit cards for applicants with no credit, what each approves on, secured vs unsecured options, and the application order to maximize approval odds."
+social_title: "Best First Credit Card With No History"
+content: |
+  Getting your first credit card with no credit history feels like a chicken-and-egg problem: you need credit to get approved, but you need to be approved to start building credit. The good news is the industry has solved this — there are several legitimate starter products designed specifically for people with no credit, and most of them are no-annual-fee cards that you can keep for life.
+
+  Here are the best first credit cards in 2026, what each one is actually best for, and the order to apply if your goal is to maximize approval odds without burning hard inquiries on cards you can't qualify for.
+
+  ## Three Categories of First Cards
+
+  Before getting into specific picks, it's worth understanding the three product categories that target no-credit applicants:
+
+  ### 1. Student cards (no credit history needed, must be enrolled in school)
+  Designed for college students. Underwriting is lighter — you don't need a credit history, and income requirements are minimal. Most are no annual fee. Examples: Discover It Student, Chase Freedom Student, Capital One Savor Student, Bilt Blue.
+
+  ### 2. Unsecured starter cards (no credit history accepted, no school enrollment required)
+  Designed for thin-file applicants regardless of school status. Slightly tougher underwriting than student cards but still very accessible. Examples: Capital One QuicksilverOne, Petal 2, Mission Lane.
+
+  ### 3. Secured cards (deposit-backed, guaranteed approval if deposit posts)
+  Backed by a refundable security deposit. Designed for applicants who can't get approved for unsecured cards — either because of no credit, damaged credit, or both. Examples: Discover It Secured, Capital One Platinum Secured, Capital One Quicksilver Secured.
+
+  We have a separate piece on [secured cards](/articles/secured-credit-cards-explained) covering that category in depth. The picks below focus on student and unsecured starter cards, since most no-credit applicants are eligible for at least one of them.
+
+  ## The Best First Card Picks
+
+  ### Best for college students: Discover It Student Cash Back
+  - **Annual fee**: $0
+  - **Rewards**: 5% on rotating quarterly categories (up to $1,500/quarter activated), 1% on everything else
+  - **Welcome bonus**: Cashback Match — Discover doubles your first year's cashback at the end of the year
+  - **Why it's a great first card**: Low approval bar (most students with verifiable income get approved), strong rewards, the Cashback Match welcome bonus is genuinely the best in the student category, and Discover's customer service is consistently rated highest in the industry. It also has free FICO score access in the app, useful for someone tracking their first year of credit-building.
+
+  Approves on: enrolled student status, $0–$15K reported income, no prior credit history.
+
+  ### Best for college students who want flat-rate simplicity: Chase Freedom Student
+  - **Annual fee**: $0
+  - **Rewards**: 1% on everything (basic), $20 Good Standing Rewards each year for staying current
+  - **Welcome bonus**: $50 statement credit after first purchase
+  - **Why it's a great first card**: Chase is a major issuer with a wide product family. Starting here puts you on the path to the [full Chase Ultimate Rewards ecosystem](https://creditodds.com/articles) — Sapphire Preferred, Sapphire Reserve, Freedom Unlimited — once your credit profile is established. Plus, having Chase as your first card gets your foot in the door for [staying 5/24-compliant](/articles/chase-5-24-rule-explained) early.
+
+  Approves on: enrolled student status, $0–$15K reported income.
+
+  ### Best for college students with travel/dining spend: Capital One Savor Student
+  - **Annual fee**: $0
+  - **Rewards**: 3% on dining, entertainment, popular streaming services, and grocery stores; 1% everywhere else
+  - **Welcome bonus**: $50 statement credit after $100 spent in 3 months
+  - **Why it's a great first card**: 3% on dining and entertainment is competitive even against non-student cards, and the SavorOne is one of the few starter cards that actually pays meaningful rewards on the spend categories that students hit. Capital One is also known for fast credit limit increases and graduation paths to better cards.
+
+  Approves on: enrolled student status, $0–$15K reported income.
+
+  ### Best for non-students with no credit: Capital One QuicksilverOne
+  - **Annual fee**: $39
+  - **Rewards**: 1.5% on everything
+  - **Welcome bonus**: None
+  - **Why it's a great first card**: One of the few unsecured cards that approves on no credit history. The $39 annual fee is the cost of entry — but you typically graduate to the no-fee Capital One Quicksilver after 6–12 months of clean use. Treat the $39 as a one-time investment in building credit.
+
+  Approves on: $20K+ income, fair-or-no credit. The most reliable unsecured option for non-students.
+
+  ### Best for paying off debt while building credit: Petal 2 Visa
+  - **Annual fee**: $0
+  - **Rewards**: 1–1.5% on all purchases (1.5% after 12 on-time payments)
+  - **Welcome bonus**: Up to 10% cashback at select merchants in the app
+  - **Why it's a great first card**: Petal underwrites based on your bank account history (cash flow) rather than primarily relying on credit history. If you have a checking account with regular deposits and decent balance management, Petal can approve you when traditional issuers won't.
+
+  Approves on: bank account history showing income and balance management, no minimum credit history required.
+
+  ### Best secured card backstop: Discover It Secured
+  - **Annual fee**: $0
+  - **Rewards**: 2% on gas/restaurants up to $1,000/quarter, 1% on everything else
+  - **Cashback Match**: Discover doubles all cashback earned in the first year
+  - **Deposit**: $200 minimum (refundable, becomes your credit limit)
+  - **Why it's a great first card**: If you can't get approved for any unsecured product (including QuicksilverOne and Petal 2), Discover It Secured is the gold-standard secured card. Discover automatically reviews your account for graduation to an unsecured card after 7 months — you get your deposit back and the card converts. It's the fastest legitimate path from no credit to a real unsecured card.
+
+  Approves on: $200+ refundable deposit, $0+ income.
+
+  ## The Recommended Application Order
+
+  If you have no credit history, here's the order that maximizes your odds while minimizing inquiry damage:
+
+  ### If you're a current college student:
+  1. **Discover It Student Cash Back** (apply first — best rewards, easiest approval for students)
+  2. If approved, hold for 6+ months before considering second card
+  3. **Chase Freedom Student** as second card after 6 months (starts the Chase relationship before 5/24 matters)
+
+  ### If you're not a student, with regular income $20K+:
+  1. **Capital One QuicksilverOne** (apply first — most reliable unsecured no-credit approval)
+  2. If declined, try **Petal 2** (different underwriting model, often approves Capital One declines)
+  3. If both decline, fall back to **Discover It Secured** (guaranteed approval with $200 deposit)
+
+  ### If your income is under $20K and you're not a student:
+  1. **Discover It Secured** (most reliable approval at any income level)
+  2. After 6+ months of clean use, apply for **Capital One QuicksilverOne** or **Capital One SavorOne** unsecured
+  3. Discover will graduate your secured card to unsecured automatically around month 7
+
+  ### If you're a recent immigrant with no US credit:
+  1. **Discover It Secured** (Discover accepts applicants with ITIN — Individual Taxpayer Identification Number — instead of SSN, which most immigrants have before getting an SSN)
+  2. **American Express** can sometimes import credit history from your home country (Canada, UK, India, Mexico, Brazil, and others) via the Amex Global Pay program — apply for a basic Amex (Blue Cash Everyday or Green Card) after that
+  3. After 6+ months, transition to unsecured with **Capital One QuicksilverOne** or apply for a regular Discover It Cash Back
+
+  ## What Each Issuer Looks At for No-Credit Applicants
+
+  ### Discover
+  - Verifiable income (any amount)
+  - SSN OR ITIN
+  - No bankruptcy in the last 5 years
+  - Generally the most lenient major issuer for thin files
+
+  ### Capital One
+  - Income (typically $20K+ for unsecured starter; $0+ for secured)
+  - Will pull all three bureaus (triple-pull) — ensure you're prepared for three inquiries
+  - Generally underwrites more conservatively on QuicksilverOne than Discover does on the It Cash Back
+
+  ### Chase
+  - Student status (for student cards) or some existing credit history (for non-student cards)
+  - Chase generally won't approve no-credit non-student applicants for any card — Chase is not a starter-card issuer
+
+  ### Petal
+  - Cash flow analysis from your linked bank account
+  - Income and stable balance over the last 3+ months
+  - Different model from traditional issuers — can approve when others don't
+
+  ### American Express
+  - For applicants with no US credit but verifiable income
+  - Global Pay program imports international credit history
+  - Generally requires $20K+ income for first Amex
+
+  ## What to Do After You're Approved
+
+  Once you have your first card, three rules:
+
+  ### 1. Use it for small recurring charges only
+  Set up one or two monthly subscriptions ($10–$30 total) on autopay. That's it. Don't use the card for groceries, gas, or any large purchases — at least for the first 6 months.
+
+  Why: low utilization (under 10%) is the fastest way to grow your score. A $30 statement balance on a $500 limit is 6% — perfect.
+
+  ### 2. Set autopay for full statement balance
+  Never miss a payment. Even one 30-day late payment in your first year tanks your score by 80–110 points and stays on your report for 7 years.
+
+  ### 3. Don't apply for more cards in the first 6 months
+  Let the card age. Each new card application is a hard inquiry plus a new account, both of which drag your thin file. Wait at least 6 months — ideally 12 — before adding a second card.
+
+  ## The Score Trajectory You Can Expect
+
+  Starting from no credit, with one starter card used responsibly:
+
+  - **Month 1–2**: First credit report appears. No score yet (need 6 months of history for FICO; some scoring models give a score after 3 months).
+  - **Month 3–6**: First score generates. Typically 650–700 if you've used the card responsibly.
+  - **Month 6–12**: Score moves into the 720–740 range.
+  - **Month 12–24**: With consistent on-time payments and low utilization, 740+ is achievable on a single card.
+
+  After 12 months of clean use on your first card, your file is strong enough to qualify for most mainstream cards (Chase Freedom Unlimited, Citi Double Cash, Capital One Savor) at no-credit-needed approval. That's the milestone — once you're past it, your no-credit-history phase is done.
+
+  ## Common Mistakes
+
+  ### Mistake 1: Applying for premium cards too early
+  Some applicants try Sapphire Preferred or Amex Gold as their first card. These will decline almost universally for no-credit applicants. Save the inquiry — start with a starter product.
+
+  ### Mistake 2: Applying for too many cards in quick succession
+  Stacking 3–4 applications in a month creates a velocity signal that flags every issuer. The first decline often spirals into denial across the board.
+
+  ### Mistake 3: Treating QuicksilverOne's annual fee as a deal-breaker
+  $39/year is the cost of building credit fast for a non-student. After 6–12 months, the card upgrades to no-fee Quicksilver and the $39 was a one-time investment. Don't avoid it because of the fee.
+
+  ### Mistake 4: Getting a sub-prime card with predatory fees
+  Cards like Total Visa, Indigo Mastercard, First Premier — these charge $75–$175 annual fees, low credit limits, and offer no rewards. Avoid them. The starter cards above are cheaper and faster to graduate from.
+
+  ### Mistake 5: Not using the card at all
+  A card with $0 charges every month doesn't build credit. The bureaus need to see active use. One small charge per month is enough.
+
+  ## FAQ
+
+  ### What's the minimum income for a first credit card?
+  Most starter cards approve at $0–$15K. Discover It Secured approves at $0+. Capital One QuicksilverOne typically wants $20K+. Petal 2 cares more about bank account history than absolute income.
+
+  ### How long does it take to build credit from zero?
+  About 3–6 months to generate a first FICO score, and 12–18 months of clean use to reach the 720+ range eligible for most mainstream cards. See our [credit-building timeline article](/articles/how-long-to-build-credit) for full month-by-month expectations.
+
+  ### Can I be approved for a credit card at age 18?
+  Yes, but the CARD Act requires applicants under 21 to demonstrate independent ability to repay (or a co-signer, which most issuers don't accept). For most 18–20-year-olds, the path is a student card with student-specific income disclosure, or a secured card.
+
+  ### Will being added as an authorized user count as my "first card"?
+  It can. AU status on a long-aged, clean account creates credit history for you faster than your first own card would. See our [authorized user strategy piece](/articles/authorized-user-strategy) for details.
+
+  ### Can I get a credit card with no Social Security Number?
+  Some issuers (Discover, Amex, BBVA, Marcus) accept ITINs from non-SSN applicants. Most others don't. Recent immigrants without SSNs can typically get a Discover It Secured.
+
+  ### What credit limit will I get on my first card?
+  Typically $300–$1,000 on student and starter cards; $200 (or your deposit amount) on secured cards. Limits grow with use — most issuers offer credit limit increases after 6 months of clean use.
+
+  ### Should I apply for two cards on the same day to maximize approvals?
+  No. Stacking applications creates a velocity signal that triggers declines across all the simultaneous applications. Apply for one card, wait for the decision, hold it for 6+ months, then apply for the second.
+
+  ### Is there a way to be 100% sure I'll be approved?
+  Only with a secured card, where the deposit functionally guarantees approval. Pre-qualification tools (Capital One, Discover) can predict unsecured approvals with high accuracy — but no unsecured card is a guarantee for a no-credit applicant.
+
+  ### Will a denial on my first application hurt me?
+  A single hard inquiry from a denial costs ~5 points and recovers in 6 months. Worth the test. Avoid stacking multiple denials, since the cumulative inquiry damage adds up.
+
+  ## The Bottom Line
+
+  No credit history is a temporary problem with a clear solution. Three rules:
+
+  1. **Pick the right starter category for your situation.** Students go for Discover It Student. Non-student earners try QuicksilverOne or Petal 2. Anyone who can't qualify unsecured uses Discover It Secured.
+  2. **Hold the card 12+ months and use it lightly.** A small recurring charge on autopay, paid in full every month. That's all your file needs.
+  3. **Don't chase too fast.** Wait 6+ months before your second application. The path from no credit to qualifying for any mainstream card is roughly 12–18 months of clean use on one starter card.
+
+  Done right, your "no credit" status is a 12-month phase, not a permanent ceiling. Pick the right first card and the rest of the credit world opens up on its own schedule.

--- a/data/articles/drafts/business-cards-not-on-personal-credit.yaml
+++ b/data/articles/drafts/business-cards-not-on-personal-credit.yaml
@@ -1,0 +1,252 @@
+id: "business-cards-not-on-personal-credit"
+slug: "business-cards-not-on-personal-credit"
+title: "Business Credit Cards That Don't Report to Personal Credit: The 5/24 Workaround Everyone Wants"
+date: "2026-06-18"
+author: "CreditOdds"
+summary: "Which business cards stay off your personal credit report, why this is the most effective 5/24 bypass, and how to legitimately qualify as a 'business' for application purposes."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-ink-business-preferred
+  - chase-ink-business-cash
+  - chase-ink-business-unlimited
+  - american-express-business-gold-card
+  - blue-business-cash-card-from-american-express
+  - blue-business-plus-credit-card-from-american-express
+seo_title: "Business Cards That Don't Report to Personal Credit (2026) | CreditOdds"
+seo_description: "Which business credit cards stay off your personal credit report by issuer, how to qualify as a 'business,' and why this is the most effective Chase 5/24 workaround."
+social_title: "Business Cards That Don't Report to Personal Credit"
+content: |
+  Business credit cards are the most underused tool in personal credit optimization. The reason: at most major issuers, **business cards do not appear on your personal credit report**. They don't count toward Chase 5/24, they don't show up in your account list when other lenders pull your credit, and their utilization doesn't drag your personal score.
+
+  This makes them the single most effective workaround for issuer velocity rules. You can be at 4/24 with Chase, open three Chase Ink business cards, and still be at 4/24 — the business cards don't count.
+
+  Here's exactly which business cards stay off personal credit, how to qualify as a "business" without being one in any traditional sense, and how to use the strategy responsibly.
+
+  ## Business Cards: What "Reports to Personal Credit" Actually Means
+
+  Two separate things can happen when you open a business card:
+
+  ### 1. The hard inquiry from the application
+  This goes on your **personal** credit report, almost universally. Business cards still pull your personal credit during application underwriting, so the inquiry shows up the same as a personal-card inquiry would.
+
+  ### 2. The tradeline (the account itself)
+  This is where the variation lives. Some issuers report the business card tradeline to your personal credit — meaning the account, balance, utilization, and payment history all appear on your personal report. Others only report it to commercial credit bureaus (Dun & Bradstreet, Experian Business) where personal credit lenders typically don't look.
+
+  The hard inquiry is unavoidable. The tradeline placement is the strategic difference.
+
+  ## Issuers That Don't Report Business Cards to Personal Credit
+
+  As of mid-2026:
+
+  ### Chase
+  - **Chase Ink Business Preferred**: Does NOT report to personal credit
+  - **Chase Ink Business Cash**: Does NOT report to personal credit
+  - **Chase Ink Business Unlimited**: Does NOT report to personal credit
+  - **Chase Ink Business Premier**: Does NOT report to personal credit
+  - **Chase United Business Cards**: Generally don't report to personal
+  - **Chase Marriott Business**: Does not report
+  - **Chase IHG Business**: Does not report
+
+  Chase is the strongest workaround issuer — none of their major business cards appear on your personal credit report (except for the application's hard inquiry).
+
+  ### American Express
+  - **All Amex business cards** (Business Gold, Business Platinum, Business Green, Business Blue Cash, Business Plus): Do NOT report to personal credit
+  - **Delta SkyMiles Business**, **Hilton Business**, **Marriott Bonvoy Business**: Do NOT report
+  - **Lowe's Business Rewards** (formerly Lowe's Business): Does not report
+
+  Amex has the broadest set of non-reporting business products in the market.
+
+  ### Citi
+  - **Citi cobranded business cards** (American AAdvantage Business): Do NOT report to personal credit
+  - **Citi business standalone cards** are limited; the few that exist generally don't report
+
+  ### U.S. Bank
+  - **U.S. Bank Business Triple Cash Rewards**: Does NOT report
+  - **U.S. Bank Business Altitude Power**: Does NOT report
+
+  ### Wells Fargo
+  - **Wells Fargo business cards** generally do NOT report to personal credit
+
+  ### Bank of America
+  - **BofA Business Advantage** cards: Do NOT report to personal credit
+  - This is one of BofA's nicer features, since their personal-card 2/3/4 rule is so tight
+
+  ### Issuers That DO Report Business Cards to Personal Credit
+  - **Capital One** (almost all business cards): REPORT to personal credit
+  - **TD Bank**: Reports
+  - **Discover Business**: Reports
+
+  Capital One is the major outlier — their business cards (Spark Cash Plus, Spark Miles, Venture Business) appear on your personal credit report, complete with balances and utilization. This is one of the reasons Capital One's underwriting feels so much more constrained: their products eat your 5/24 slot AND your utilization headroom.
+
+  ## Why This Works as a 5/24 Workaround
+
+  Chase's 5/24 rule looks at your personal credit report and counts how many new accounts you've opened in the last 24 months. The rule's logic:
+
+  - Look at the personal credit report
+  - Count account opening dates within 24 months
+  - If 5 or more, decline new Chase personal applications
+
+  Because Chase Ink business cards don't appear on your personal credit report, they're invisible to the 5/24 check. You can:
+
+  - Be at 4/24 personal cards
+  - Open Chase Ink Business Cash → still at 4/24 (business card invisible)
+  - Open Chase Ink Business Preferred → still at 4/24
+  - Open Chase Ink Business Unlimited → still at 4/24
+  - Apply for a new Chase personal card → still under 5/24, still eligible
+
+  This is real, well-documented, and used heavily by anyone optimizing welcome bonuses. Three Chase Ink applications can land $3K+ in welcome bonus value while staying eligible for personal cards.
+
+  Two important caveats:
+
+  ### Caveat 1: 5/24 still applies to the business card application itself
+  Chase requires you to be **under 5/24 on personal credit** when applying for any Chase card, including business cards. The business card you open doesn't add to your 5/24 going forward — but you have to start under 5/24 to open it.
+
+  ### Caveat 2: Hard inquiries still hit personal credit
+  Each business card application generates a hard inquiry on your personal credit report. The tradeline doesn't show, but the inquiry does. Multiple inquiries in a short window will affect your personal score and your other-issuer approval odds.
+
+  ## Qualifying as a "Business"
+
+  This is the part most personal users don't realize: **the bar to qualify as a business for credit card purposes is extraordinarily low**.
+
+  You don't need:
+  - An LLC or corporation
+  - A registered DBA
+  - A business bank account
+  - Employees
+  - A website
+  - Significant revenue
+
+  You DO need:
+  - A legitimate income-generating activity
+  - The intent to continue doing it for profit
+  - The ability to honestly disclose your business income
+
+  Examples of activities that qualify as a "business" for credit card application purposes:
+
+  - **Reselling on eBay, Mercari, Poshmark, or Amazon** — if you've sold $500+ worth of items in a year, you're a business
+  - **Freelance writing, design, programming, photography** — any 1099 income at all
+  - **Driving for Uber, Lyft, DoorDash, or Instacart** — gig economy
+  - **Tutoring, music lessons, fitness coaching, language instruction** — even a few students per month
+  - **Renting a property on Airbnb or VRBO**
+  - **Selling crafts, art, or homemade goods** at any volume
+  - **Running a YouTube channel, podcast, blog** with any monetization
+  - **Walking dogs, pet sitting, babysitting** — gig or word-of-mouth
+  - **Buying and selling collectibles** (cards, sneakers, vintage items)
+
+  When you fill out the business application, you'll need:
+
+  - **Business name**: Most issuers accept your full legal name with " (Sole Prop)" or just your name
+  - **Business type**: Sole Proprietorship is the default
+  - **Tax ID**: Use your Social Security Number — sole proprietors don't need an EIN, though you can get a free one in 5 minutes at irs.gov if you want a separation between business and personal
+  - **Years in business**: Be honest — if you started selling on eBay 6 months ago, that's 0 years
+  - **Annual revenue**: Be conservative and honest — issuers often don't verify, but the application should be answerable under verification
+
+  Lying about having a business is fraud. But the bar for a real business is genuinely low. Most people doing any side income at all qualify legitimately.
+
+  ## Income Reporting for Business Card Applications
+
+  On a business card application, you typically report:
+
+  - **Personal income** (your full personal income — same number you'd put on a personal card)
+  - **Business revenue** (gross sales from the business)
+  - **Business expenses or net income** (varies by issuer)
+
+  The personal income drives most of the underwriting decision. Business revenue is treated as supplemental signal. A side hustle making $2,000/year with $90K personal income still qualifies for most business cards.
+
+  ## What Happens When You Carry a Balance
+
+  Because business card balances don't show on personal credit (at the issuers above), you can carry larger business balances without affecting your personal credit score's utilization calculation.
+
+  This is sometimes used strategically:
+
+  - Run a 0% APR business card balance during a cash-flow gap without dragging personal utilization
+  - Use Chase Ink Business Cash 0% intro APR for ~12 months as a personal financing bridge
+
+  Caution: this strategy **only works on issuers that don't report to personal credit**. Doing the same on a Capital One business card would hit your personal utilization just like a personal card would.
+
+  Also: business card terms aren't always identical to personal cards. Many business cards have slightly higher APRs, different late-fee structures, and fewer consumer protections (the CARD Act of 2009 doesn't fully cover business cards). Read terms before relying on a business card for personal financing.
+
+  ## Application Order: How to Stack Business Cards Strategically
+
+  A common 12-month sequence, starting from 4/24 personal:
+
+  1. **Month 0**: Chase Ink Business Cash. Welcome bonus around $750. 5/24 unaffected.
+  2. **Month 4**: Chase Ink Business Unlimited. Welcome bonus around $750. 5/24 unaffected.
+  3. **Month 8**: Chase Ink Business Preferred. Welcome bonus around $1,200 (100K UR points). 5/24 unaffected.
+  4. **Month 12**: Personal Chase card if desired (Sapphire Preferred, Freedom Flex). Now at 5/24, but eligible because you were 4/24 personal at application time.
+
+  Total welcome bonus value over 12 months: ~$2,700. All while remaining 5/24-compliant for personal Chase cards.
+
+  Constraints:
+
+  - Chase has its own velocity caps on Ink applications — typically one Ink card per 90 days
+  - Each application is a hard inquiry on personal credit, so the 5/24 inquiry damage still applies
+  - Welcome bonus eligibility on Chase Ink cards is restricted (24 months between same-card bonuses, generally)
+
+  ## Other Issuer-Specific Strategies
+
+  ### Amex business stack
+  Personal Amex cards each have once-per-lifetime bonus restrictions. The business versions are **separate** lineages, so you can collect:
+
+  - Personal Gold + Business Gold (both bonuses available)
+  - Personal Platinum + Business Platinum (both bonuses)
+  - Blue Business Cash + Blue Business Plus (no annual fees, both available)
+
+  Amex business cards don't report to personal credit, so utilization on your business card doesn't hit your score.
+
+  ### BofA business cards bypass 2/3/4
+  Bank of America's 2/3/4 rule applies to personal cards. BofA business cards are exempt — you can have multiple BofA business cards on top of your four-personal-card cap.
+
+  ### Stack across issuers
+  A typical 24-month roadmap for someone at 0/24 starting out:
+
+  - 3 Chase Ink cards (~$2,700 in bonuses)
+  - 2 Amex business cards (~$1,500 in bonuses)
+  - 1 BofA business card (~$500 in bonuses)
+  - Total: ~$4,700 in welcome bonuses with **zero impact on personal 5/24**
+
+  This is the kind of math that makes business cards the highest-leverage product in personal credit optimization.
+
+  ## FAQ
+
+  ### Do I need an LLC to apply for business credit cards?
+  No. Sole proprietorships are accepted by every major business card issuer. Use your SSN as the tax ID.
+
+  ### Will the issuer verify my business?
+  Rarely. Issuers occasionally request documentation (Schedule C, business bank statements) for very high-limit business cards or when the applicant claims very large business revenue. For most applications, the disclosure is taken at face value at application time.
+
+  ### Are business card welcome bonuses taxable?
+  Generally yes, when the card is held in the business's name. For sole proprietors, the welcome bonus is treated as business income, taxable on your Schedule C. Personal-card welcome bonuses are usually treated as rebates and not taxable.
+
+  ### Will my business card help build business credit?
+  Sometimes. Business cards reported to commercial credit bureaus (D&B, Experian Business) build a business credit profile that can help you qualify for business loans, lines of credit, or higher-tier business products. The strength of business credit reporting varies by issuer.
+
+  ### Does opening a business card affect my Chase 5/24 status?
+  No, on issuers that don't report business cards to personal credit (Chase, Amex, Citi, BofA, US Bank). The hard inquiry is on personal credit, but the tradeline isn't, so 5/24 doesn't count it.
+
+  ### Can I deduct the annual fee on my business card?
+  Yes, if the card is genuinely used for business expenses. Annual fees on business credit cards are deductible business expenses on Schedule C.
+
+  ### What happens if I close a business card?
+  Same mechanics as a personal card closure, but the tradeline drop only affects business credit (not personal). Close after the welcome bonus posts and the 12-month "bonus chasing" risk window has passed.
+
+  ### Can my business card be linked to my personal card's loyalty program?
+  Yes, often. Chase Ink cards earn into your same Ultimate Rewards account. Amex business cards earn into your same Membership Rewards account. This lets you pool rewards across personal and business cards efficiently.
+
+  ### Is using a personal card for business expenses safer than getting a business card?
+  Tax-wise, no — keeping personal and business expenses separate is cleaner for tax filing. Strategically, using a business card preserves personal credit headroom (no impact on personal utilization, no 5/24 count) so business cards generally win.
+
+  ### What if I'm not actually running a business?
+  Then don't apply for a business card. Lying on a credit application is fraud, and even a small genuine income-generating activity (eBay sales, gig driving) qualifies — so for most people the answer is "you probably do have a business."
+
+  ## The Bottom Line
+
+  Business credit cards that don't report to personal credit are the most underused tool in credit optimization. Three rules:
+
+  1. **Use Chase, Amex, Citi, BofA, US Bank, and Wells Fargo** for non-reporting business cards. Avoid Capital One business cards if your goal is to keep them off your personal credit.
+  2. **Qualify legitimately.** Sole proprietorships are accepted everywhere; even small side-income activities qualify. But don't fabricate.
+  3. **Stack carefully.** Each application is a hard inquiry on personal credit, so velocity still matters even when the tradeline doesn't show.
+
+  Done right, business cards can add several thousand dollars in welcome bonuses per year while keeping your personal credit profile clean for the next big application.

--- a/data/articles/drafts/capital-one-bucket-system.yaml
+++ b/data/articles/drafts/capital-one-bucket-system.yaml
@@ -1,0 +1,201 @@
+id: "capital-one-bucket-system"
+slug: "capital-one-bucket-system"
+title: "Capital One's Auto-Decline Rules and Bucket System: Why You Keep Getting Denied (And How to Get Out)"
+date: "2026-05-28"
+author: "CreditOdds"
+summary: "Capital One's internal applicant-tier system, the auto-decline rules nobody publishes, and the path from a bucket-1 starter card to a Venture X."
+tags:
+  - guide
+  - strategy
+  - analysis
+related_cards:
+  - capital-one-platinum
+  - capital-one-quicksilverone
+  - capital-one-quicksilver
+  - capital-one-savorone
+  - capital-one-venture-rewards
+  - capital-one-venture-x
+seo_title: "Capital One Bucket System & Auto-Decline Rules (2026) | CreditOdds"
+seo_description: "How Capital One's internal applicant tiering works, which auto-decline rules trip up applicants, and the path from subprime starter cards to Venture X eligibility."
+social_title: "Capital One's Bucket System, Decoded"
+content: |
+  Capital One's underwriting is unlike any other major issuer. Instead of pulling one bureau and weighing your file holistically, Capital One pulls **all three bureaus** on most applications and routes you into one of several internal applicant tiers — informally called "buckets" by the credit-card community. Which bucket you land in determines which cards you're eligible for, what credit limits you'll receive, and how long it takes to graduate to better products.
+
+  Capital One has never publicly confirmed the bucket system, but the data points across thousands of applicants are consistent enough that the structure is well-mapped. Here's how it actually works in 2026, and how to navigate it.
+
+  ## The Three Capital One Buckets
+
+  ### Bucket 1: "Subprime / Building"
+  - **Eligible for**: Capital One Platinum, Capital One QuicksilverOne, Capital One Platinum Secured
+  - **Typical credit limits**: $300–$3,000
+  - **Profile**: thin file, sub-650 score, recent negative items (collections, late payments), bankruptcy in the last few years
+  - **Income relevance**: relatively low — bucket 1 cards approve at $0–$25K reported income
+
+  ### Bucket 2: "Mid-Prime"
+  - **Eligible for**: Capital One Quicksilver (no "One"), Capital One SavorOne, Capital One VentureOne
+  - **Typical credit limits**: $3,000–$15,000
+  - **Profile**: 650–730 score, established file, no recent negatives, modest income
+  - **Income relevance**: $25K+ usually opens these
+
+  ### Bucket 3: "Prime"
+  - **Eligible for**: Capital One Savor (Cash), Capital One Venture, Capital One Venture X, all Capital One business cards
+  - **Typical credit limits**: $10,000–$50,000+
+  - **Profile**: 730+ score, thick file, clean history, income $80K+
+  - **Income relevance**: high — Venture X especially has practical income floors around $80K
+
+  Some applicants split between buckets in unusual ways (e.g., bucket 3 score with thin file lands as bucket 2; bucket 2 score with very high income reaches bucket 3 prime products). The boundaries are fuzzy, but the broad structure is real.
+
+  ## How You Land in a Bucket
+
+  Capital One's underwriting algorithm assigns a bucket based on the total picture: credit score, file thickness, income, recent inquiries, debt-to-income, derogatory marks, and history with Capital One specifically.
+
+  The catch: **once you're in a bucket, getting out is hard**. Capital One does not simply re-evaluate your file when you reapply for a higher card — their system tends to keep you in your current bucket and decline higher-tier applications even as your underlying credit improves.
+
+  This is the central frustration: an applicant who was approved for a Platinum card with a 580 score in 2020 may have a 750 score in 2026 and still be unable to get approved for a Venture X. They're "stuck" in bucket 1 from Capital One's perspective even though objectively their profile fits bucket 3.
+
+  ## The Auto-Decline Rules
+
+  Capital One has several velocity rules that auto-decline applications regardless of your underlying credit profile:
+
+  ### Rule 1: Maximum 2 Capital One personal cards
+  You can only have **two open Capital One personal credit cards** at any time. If you already hold two and you apply for a third, the application will auto-decline regardless of how strong your file is.
+
+  This includes both your own primary cards. Authorized user status on someone else's Capital One card doesn't count toward the limit.
+
+  Workaround: close one of your existing Capital One cards before applying for a new one. (Be cautious about closing your oldest card — it can affect average account age. We have a piece on [closing cards safely](/articles/closing-credit-cards-safely).)
+
+  ### Rule 2: One Capital One application every 6 months
+  Capital One enforces a rolling 6-month window — you can only be approved for one new Capital One credit card every 6 months. Apply for two within that window and the second one auto-declines, even if it's a different product.
+
+  Some applicants get tighter throttling (one per 12 months) if their first application was for a product they were already cardholders of, or if their account history shows a pattern Capital One reads as bonus-chasing.
+
+  ### Rule 3: Capital One business cards are separate from personal limits
+  Capital One business cards (Spark Cash Plus, Spark Miles, Venture Business) are not counted against the personal-card limits. You can have two personal Capital One cards and one business card simultaneously. The 6-month application window does count business applications, though.
+
+  ### Rule 4: Any open bankruptcy or charge-off auto-declines for prime products
+  Bucket 3 cards (Venture X especially) auto-decline applicants with active bankruptcy on file or recent (under 5 years) charge-offs, regardless of current credit score.
+
+  ## How to Escape Your Bucket
+
+  This is the question that gets asked most often, and the honest answer is: **it's hard, but there are paths**.
+
+  ### Path 1: Wait and rebuild outside Capital One
+  The most reliable path. Build a stronger credit file over 2–3 years through:
+  - Cards from other issuers (Discover, Chase, Citi, Amex)
+  - Aging your accounts
+  - Driving utilization to 1–9% reported on every card
+  - Letting old negatives age off your report
+
+  Then apply for a Capital One prime product (Venture or Venture X) cold. With a clean, thick, high-income file, the bucket assignment often resets and the prime product is approved.
+
+  ### Path 2: Pre-qualify and treat the result as truth
+  Capital One's [pre-qualification tool](https://www.capitalone.com/credit-cards/pre-qualified/) is the most reliable in the industry. If you pre-qualify for a Venture or Venture X, your bucket has effectively reset. If you only pre-qualify for QuicksilverOne and Platinum, you're still in bucket 1 from Capital One's perspective.
+
+  Don't apply for cards you didn't pre-qualify for. The decline rate is near 100% and you'll waste three hard inquiries (the triple-pull is brutal) on every attempt.
+
+  ### Path 3: Product change instead of new application
+  If you're stuck in bucket 1 with a Platinum card you've outgrown, you can sometimes **product-change** that card to a Quicksilver or QuicksilverOne. This doesn't escape the bucket entirely — Capital One will only product-change to a card the system thinks you'd qualify for — but it can move you up within bucket 1 or to the bottom of bucket 2 without a new hard pull.
+
+  Call: 1-800-227-4825 (Capital One credit card services) and ask "I'd like to product-change my [card name] to a [target card name]."
+
+  Constraints:
+
+  - You typically can't product-change between buckets (Platinum → Venture X won't happen)
+  - You generally have to keep the same network (Visa↔Visa, Mastercard↔Mastercard)
+  - Product changes don't trigger welcome bonuses on the new card
+
+  ### Path 4: Reconsideration for the right reason
+  Capital One's reconsideration line (1-800-625-7866) is more responsive than most. If you're declined for a card you pre-qualified for, calling and walking through the file can occasionally flip the decision — especially if the issue was income misreported or a recent positive change not yet reflected in the bureau data.
+
+  Reconsideration won't, however, jump you between buckets. If you're a bucket 1 applicant who applied for a Venture X, no reconsideration story will work.
+
+  ### Path 5: Wait out a major negative item, then cold-apply
+  Capital One's bucket assignment is heavily influenced by derogatory marks. If your file has, say, a 5-year-old charge-off and a 3-year-old collection, those items aging off (collections fall off after 7 years, charge-offs after 7 years) often unlocks a bucket transition on its own. Don't apply during the aging period — let the file clean up first, then apply cold once or twice a year to test where you land.
+
+  ## The Triple-Bureau Pull Problem
+
+  Capital One pulls **all three bureaus** (Experian, Equifax, TransUnion) on most credit card applications. This is unique among major issuers and has two consequences:
+
+  1. **Three hard inquiries per application.** A single Capital One application costs you three inquiries. Applying for two Capital One cards on the same day costs you six.
+  2. **The strongest bureau doesn't help you.** At other issuers, you can sometimes time an application to hit the bureau where your score is highest. Capital One doesn't let you optimize this — they pull all three regardless.
+
+  Practical implications:
+
+  - **Use Capital One pre-qualification religiously.** A wasted application costs 3x the inquiry damage of a wasted application elsewhere.
+  - **Don't stack Capital One applications.** Six inquiries from a single day looks awful to every other issuer for the next 12 months.
+  - **Time around mortgages or auto loans.** Don't apply for Capital One cards in the 6 months before any major credit event.
+
+  ## Bucket-Specific Strategies
+
+  ### If you're a bucket 1 applicant
+  Your main goal is **not** to keep applying for Capital One cards. Each application is three inquiries and almost certainly a decline above your bucket. Instead:
+
+  1. Use the Platinum or QuicksilverOne you have responsibly. Pay before the statement closes (utilization under 10%). Never miss a payment.
+  2. Build with non-Capital One cards in parallel — Discover, Chase if 5/24 allows, Amex Blue Cash Everyday, Citi Double Cash. These add tradelines and aging without burning Capital One inquiries.
+  3. After 12+ months of clean history, run Capital One pre-qualification. If a bucket-2 card appears (Quicksilver, SavorOne, VentureOne), apply for that.
+  4. If only bucket-1 cards appear, try a product change instead — Platinum → QuicksilverOne or Quicksilver to escape the secured/sub-prime structure without burning inquiries.
+
+  ### If you're a bucket 2 applicant
+  You have more flexibility. The path to bucket 3:
+
+  1. Hold your bucket-2 card open and use it for at least 12–18 months.
+  2. Build score and income concurrently through non-Capital One products.
+  3. Pre-qualify periodically. The first time a Venture (or Venture X) shows up in pre-qualification, that's your signal.
+  4. Time a Venture X application carefully — it's worth not wasting on a low-confidence shot. The annual fee structure rewards calendar-year planning.
+
+  ### If you're already in bucket 3
+  You can hold up to two open Capital One personal cards plus business products. Strategic plays:
+
+  - **Venture X for premium travel** — annual fee easily justified by the $300 travel credit, anniversary 10K miles, and Priority Pass
+  - **Venture or Savor as second card** for category coverage
+  - **Spark Cash Plus or Venture Business** for self-employment / side hustle spend (see our piece on [business cards that don't report to personal](/articles/business-cards-not-on-personal-credit))
+
+  ## What Doesn't Work
+
+  ### Repeatedly applying for the same card
+  Some applicants assume the bucket system will reset if they just keep trying. It won't. Each application generates three inquiries, none of which improve your odds. The bucket re-evaluates based on your file changing, not based on application volume.
+
+  ### "Building" through QuicksilverOne or Platinum velocity
+  Holding multiple bucket-1 cards doesn't accelerate the path to bucket 2 or 3. Capital One looks at your overall file, not how many of their starter products you've held. One Platinum used responsibly is enough; opening a second QuicksilverOne is wasted effort.
+
+  ### Trying to product-change across buckets
+  Platinum → Venture X product changes don't happen. The system blocks them. If you want a Venture X, you'll need to apply fresh after your file qualifies for it.
+
+  ### Asking customer service to "upgrade" your bucket
+  There's no manual override. Even reconsideration analysts can't move you between buckets directly. The path is data-driven only.
+
+  ## FAQ
+
+  ### Is the Capital One bucket system real?
+  Capital One has never officially confirmed it. The structure is community-derived from thousands of consistent data points over a decade-plus. Treat it as an empirical model that predicts reality well, not as official Capital One policy.
+
+  ### How do I know which bucket I'm in?
+  Run Capital One's pre-qualification tool. The cards that appear are the ones in your bucket (or, occasionally, one bucket up if you're on the edge). If only Platinum and QuicksilverOne appear, you're bucket 1. If Quicksilver and VentureOne appear, you're bucket 2. If Venture and Venture X appear, you're bucket 3.
+
+  ### Will paying off my Capital One Platinum and closing it move me up a bucket?
+  Closing a card alone doesn't trigger a bucket reassessment. What might help is **everything else you do over the same period** — building score, growing income, aging accounts. Closing a Platinum that's no longer needed can be fine, but don't expect it to be the lever.
+
+  ### How long does it take to escape bucket 1?
+  Realistically, 18–36 months of clean credit-building behavior, with most of the activity happening on non-Capital One cards. Faster paths exist for applicants whose bucket-1 placement was driven by a single derogatory item that ages off.
+
+  ### Can I apply for a Capital One business card if I have two open personal cards?
+  Yes — business cards are a separate count. You can have two personal cards plus one business card.
+
+  ### Does the 6-month application throttle apply to denials?
+  Yes. A denied Capital One application still consumes the slot. If you applied for QuicksilverOne and were denied in March, applying again for any Capital One card in May will auto-decline.
+
+  ### Is Capital One pre-qualification 100% accurate?
+  Very close. If you pre-qualify, your application approval rate is around 85–90%. If you don't pre-qualify, the application decline rate is around 95–100%. Treat pre-qualification as gospel.
+
+  ### Do Capital One charge cards (none currently) follow the bucket system?
+  Capital One doesn't currently issue charge cards — all their products are credit cards. Some cobranded products (e.g., previously REI's Capital One co-brand, now defunct) followed the same bucket logic.
+
+  ## The Bottom Line
+
+  Capital One's bucket system is the most rigid applicant-tiering structure among major issuers, and the cost of fighting it is high — three hard inquiries per failed application. Three rules:
+
+  1. **Pre-qualify before every Capital One application.** No exceptions. The triple-pull makes wasted applications painful.
+  2. **Build patiently outside Capital One** if you're stuck in a lower bucket. Capital One responds to clean files over 12–24+ months, not to volume of applications.
+  3. **Product-change within buckets, apply across buckets.** Platinum → QuicksilverOne by phone (no inquiry); QuicksilverOne → Venture by application after pre-qualification.
+
+  The reward for patience is real. Once you're in bucket 3, the Venture X is one of the best premium travel cards on the market and Capital One's annual-fee math (low fee, generous credits) is among the friendliest of the premium tier.

--- a/data/articles/drafts/chase-pop-up-jail.yaml
+++ b/data/articles/drafts/chase-pop-up-jail.yaml
@@ -1,0 +1,194 @@
+id: "chase-pop-up-jail"
+slug: "chase-pop-up-jail"
+title: "Chase Pop-Up Jail: What Triggers It and How to Get Out"
+date: "2026-06-04"
+author: "CreditOdds"
+summary: "What 'pop-up jail' actually is at Chase, the patterns that trigger it, the typical sentence length, and what works (and doesn't) to get back into Chase's good graces."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-sapphire-preferred
+  - chase-sapphire-reserve
+  - chase-freedom-flex
+  - chase-freedom-unlimited
+  - chase-ink-business-preferred
+  - chase-ink-business-cash
+seo_title: "Chase Pop-Up Jail Explained (2026) | CreditOdds"
+seo_description: "What triggers Chase pop-up jail (the 'we're unable to offer you this product' message), how long it lasts, and the strategies that actually help you get back to approved Chase applications."
+social_title: "What Is Chase Pop-Up Jail?"
+content: |
+  You're applying for a Chase Sapphire Preferred. You've checked 5/24 — you're at 3 — and your credit score is solid. You hit submit, expecting an instant approval. Instead, the screen displays:
+
+  > "Based on your relationship with us, we are unable to offer you this product at this time."
+
+  No application was submitted for hard-pull review. No formal decline. No reconsideration path. You've just hit **Chase pop-up jail**.
+
+  Pop-up jail is the credit-card community's name for a Chase pre-screening block — a soft signal Chase shows certain applicants before the application is fully processed. It doesn't appear on your credit report (no hard inquiry), doesn't formally count as a denial, and isn't always permanent. But while you're in pop-up jail, **no Chase personal credit card application will go through**, regardless of which card you apply for.
+
+  Here's what triggers it, how long the typical sentence runs, and what actually gets you out.
+
+  ## What Pop-Up Jail Actually Is
+
+  Pop-up jail is Chase's pre-application screen — a soft check that runs against your file before the formal hard pull. If the system identifies certain risk patterns, it short-circuits the application before it submits, displaying the "unable to offer" message.
+
+  Some critical mechanics:
+
+  - **No hard inquiry.** Pop-up jail blocks the hard pull from happening, so there's no inquiry on your report.
+  - **Not a denial.** Because the application never formally submitted, there's no adverse action notice and no decline on record.
+  - **Not card-specific.** If you're in pop-up jail and apply for the Sapphire Preferred, you'll see the same message if you turn around and apply for the Freedom Unlimited five minutes later. The block is profile-level, not product-level.
+  - **It's not always permanent.** Most applicants come out of pop-up jail eventually, though sentences range from a few months to multiple years.
+
+  ## What Triggers Pop-Up Jail
+
+  Chase has never publicly disclosed the triggers, but the data points across thousands of applicants are consistent. The most common triggers, in rough order of how likely each is to put you there:
+
+  ### 1. Bonus chasing patterns
+  This is the most-cited trigger. If your account history with Chase shows a pattern of:
+  - Opening a card primarily to capture the welcome bonus
+  - Hitting the spend requirement quickly
+  - Downgrading or closing the card within 12 months
+  - Repeating the cycle
+
+  …Chase's risk system reads you as unprofitable and starts blocking new applications.
+
+  Specific patterns that flag risk:
+  - Closing a Sapphire Preferred or Sapphire Reserve within ~12 months of opening
+  - Downgrading a premium card before paying its annual fee twice
+  - Opening multiple Chase cards within short windows
+  - Using cards almost exclusively for category-bonus or signup-bonus spend
+
+  ### 2. High new-credit velocity (especially across all issuers)
+  Even though Chase 5/24 is its own separate rule, applicants who are slightly under 5/24 but have a heavy new-credit pattern (3–4 new cards across all issuers in the last 6 months) sometimes get pop-up jailed even when 5/24-eligible.
+
+  ### 3. Existing Chase cards underutilized
+  If you have multiple Chase cards open but barely use them, the system can read this as low-engagement and start blocking new applications. The fix is just using your existing Chase cards more.
+
+  ### 4. Recent account closures (yours)
+  Closing a Chase card recently — especially a long-held card or one with a meaningful credit limit — can trigger pop-up jail on subsequent applications. The pattern looks like "downgrading" relationship strength to Chase's system.
+
+  ### 5. Recent credit issues elsewhere
+  Late payments, charge-offs, or collections from any issuer in the last 12 months. Chase has higher standards here than most issuers — even one 30-day late from a year ago can put you in pop-up jail.
+
+  ### 6. Manufactured spend patterns
+  Heavy use of gift card resellers, prepaid card loading, peer-to-peer payments tied to bonus spend — Chase has gotten very good at flagging manufactured-spend signatures. This can trigger pop-up jail and, in extreme cases, cause Chase to shut down all your accounts.
+
+  ## How Long Pop-Up Jail Lasts
+
+  Sentence lengths reported by the community vary significantly:
+
+  - **Short jail (3–6 months)**: Mild trigger, like high inquiry velocity that's about to age out
+  - **Medium jail (6–18 months)**: Moderate trigger, like a bonus-chasing pattern with one or two recent closures
+  - **Long jail (18+ months)**: Heavy trigger, like multiple recent Chase closures, manufactured spend flags, or shutdown history
+  - **Permanent (rare)**: Account-level shutdowns and the worst manufactured-spend cases
+
+  Most applicants come out of pop-up jail in 12–18 months if they change behavior. The sentence is reduced significantly by demonstrating the patterns Chase wants — actual organic spending on existing Chase cards, banking deposits, no further closures.
+
+  ## How to Tell If You're in Pop-Up Jail
+
+  The best test is the **Pop-Up Jail Application** approach — apply for a Chase card and observe the response.
+
+  Before doing this, check that your file is otherwise eligible (under 5/24, decent score, no fresh negatives). Then apply for the lowest-stakes Chase card you'd realistically want — typically the Freedom Flex, Freedom Unlimited, or a Sapphire Preferred. If you see the "unable to offer" message before any hard-pull processing begins, you're in pop-up jail.
+
+  Important: this test does not generate a hard inquiry, so it's free to run. Apply once or twice every 3–6 months to test if the jail is still active.
+
+  ## What Actually Gets You Out
+
+  ### 1. Time
+  The most reliable factor. Most pop-up jail sentences expire on their own as the trigger ages out of Chase's review window.
+
+  ### 2. Use your existing Chase cards
+  If you have any open Chase cards, **put real spend on them**. Recurring bills, daily purchases, anything organic. Chase's risk model rewards engagement. A Chase Sapphire Preferred you put $500/month on for 6 months reads very differently from one that hasn't been swiped in 8 months.
+
+  ### 3. Build the banking relationship
+  Open a Chase checking account if you don't have one. Use it as your primary checking — direct deposit, regular activity, $5K+ minimum balance ideally. Chase Private Client (CPC) tier (~$150K+ in assets) is reportedly correlated with faster pop-up jail releases.
+
+  ### 4. Don't close anything
+  While you're in pop-up jail, do not close any Chase cards (even old ones with annual fees). Closing makes it worse. If you have an annual-fee card you don't want to keep, **downgrade it** to a no-fee version (Sapphire Preferred → Freedom Unlimited or Freedom Flex; CSR → Sapphire Preferred → no-fee Freedom).
+
+  ### 5. Don't apply for non-Chase cards aggressively
+  New inquiries elsewhere, even if they don't directly affect Chase's models, contribute to overall velocity signals that pop-up jail factors in. Going quiet on credit applications across all issuers for 6–12 months helps.
+
+  ### 6. Pay annual fees on existing premium Chase cards
+  An on-time annual fee payment on Sapphire Preferred or CSR is read as "I'm staying" — exactly the signal Chase wants. Skip the annual fee and either downgrade or close, and you're confirming the "bonus chaser" signal.
+
+  ### 7. Don't try to "earn your way out" through manufactured spend
+  Heavy spending is good. Heavy spending that looks like manufactured spend (round-number swipes, gift card stores, CardCash, payment routing) is bad and can extend the sentence. Real, organic, varied spend works.
+
+  ## What Doesn't Work
+
+  ### Reconsideration calls
+  Because pop-up jail isn't a formal denial, reconsideration analysts can't override it. The pre-application screen blocks the file before it reaches an underwriter. Calling and asking for a manual review almost never works for pop-up jail specifically.
+
+  ### Closing other issuers' cards
+  Pop-up jail is about your relationship with Chase. Closing Citi or Capital One cards doesn't help.
+
+  ### Applying for Chase business cards
+  Chase business cards are evaluated separately, but if your personal profile is in pop-up jail, the business card system often shows the same "unable to offer" message. Worth testing once if you have legitimate business activity, but don't expect it to bypass the block reliably.
+
+  ### Switching to a Chase co-brand (United, Marriott, IHG, Aer Lingus)
+  Most Chase co-brand applications run through the same pre-screen as direct Chase products. Pop-up jail typically blocks them too.
+
+  ### Multiple applications back-to-back
+  Submitting 4 applications in 24 hours hoping one slips through doesn't work. The pre-screen runs on every attempt and will block them all.
+
+  ## What If You're Trapped Forever?
+
+  A small subset of applicants — typically those flagged for severe manufactured spend or those Chase has previously shut down — appear to be in permanent pop-up jail. The signal is multi-year inability to apply successfully despite clean files and good behavior.
+
+  In these cases:
+
+  1. **Confirm shutdown status.** Log into chase.com and check your account list. If you've been formally shut down (FR, financial review, account closure), no application strategy will get you back in.
+  2. **Don't apply repeatedly.** This actually entrenches the block.
+  3. **Consider the relationship as ended.** Many applicants in this position eventually move on to other issuers entirely. Amex, Capital One, Citi, BofA, and Wells Fargo all offer competitive products without Chase's specific risk-management profile.
+
+  Most pop-up jails are not permanent. Confirm before assuming the worst.
+
+  ## How to Avoid Pop-Up Jail Going Forward
+
+  Once you're out (or if you've never been in), the rules to stay out:
+
+  1. **Hold Chase cards for 24+ months minimum.** Closing or downgrading within 12 months of opening is the single biggest trigger.
+  2. **Pay all annual fees at least once.** Skip the AF and downgrade right after the bonus is the most flagged behavior.
+  3. **Use Chase cards organically.** Don't keep a CSR open just for travel-bonus spend. Use it for groceries, gas, regular life — even if the rewards aren't optimal.
+  4. **Build a Chase banking relationship.** Even a basic checking account with regular activity helps.
+  5. **Stay 5/24-compliant.** Even when you can stretch with non-Chase cards, going to 6/24 or higher signals the kind of velocity that triggers pop-up jail later.
+
+  ## FAQ
+
+  ### Does pop-up jail show on my credit report?
+  No. The hard inquiry never happens, so there's no record on your credit report. Other lenders won't see it.
+
+  ### Will pop-up jail expire automatically?
+  Usually yes — most sentences are 6–18 months and expire as the underlying triggers age out. A small subset (severe cases) can be functionally permanent.
+
+  ### Can I check pop-up jail status without applying?
+  Not directly. The cleanest test is to apply for a low-stakes Chase card and observe whether the pre-screen blocks you. Since pop-up jail blocks the hard pull, this test is free.
+
+  ### Does pop-up jail affect my Chase Ultimate Rewards account?
+  No. Existing accounts and points balances are unaffected. Pop-up jail only blocks new applications.
+
+  ### What if I have a Chase business card and I'm in personal pop-up jail?
+  The systems are separate at underwriting time, but pop-up jail can extend across both. Apply for a business card once to test; if blocked, focus on the strategies above.
+
+  ### Does pop-up jail apply to authorized user adds?
+  Sometimes. AU adds can be blocked by some of the same risk patterns, but the rule is less strict than for primary applications. AU adds for family members typically still go through.
+
+  ### How is pop-up jail different from being declined?
+  A decline happens after the hard pull — Chase reviewed your file and said no. Pop-up jail happens before the hard pull — Chase's pre-screen blocked the application from formally submitting. Pop-up jail leaves no record on your credit report; a decline does (the inquiry, plus the decline shows up if anyone asks Chase for verification).
+
+  ### Will Chase tell me why I'm in pop-up jail?
+  No. Customer service reps don't have access to the pre-screen logic and generally can't explain or override it. The triggers are inferred from data points across applicants, not disclosed by Chase.
+
+  ### What if I'm at 5/24 and I see the pop-up message — is it 5/24 or pop-up jail?
+  The 5/24 decline at the actual application stage is a different message and produces a hard inquiry. The pop-up "unable to offer" message before submission, with no hard inquiry, is pop-up jail. If you can't tell, check your credit reports a few days later — if there's no new Chase inquiry, you saw pop-up jail, not a 5/24 decline.
+
+  ## The Bottom Line
+
+  Pop-up jail is Chase's pre-screen telling you that, based on your current relationship with them, they don't want to extend new credit yet. Three things to remember:
+
+  1. **It's not a denial.** No hard pull, no formal decline, no record on your credit report.
+  2. **Time and engagement get you out.** Use existing Chase cards organically, hold cards for 24+ months, build a banking relationship, don't close things.
+  3. **Don't apply repeatedly.** Each attempt is a free test, but stacking them doesn't help — and it can extend the sentence.
+
+  If you want a single thing to optimize for: **make Chase profitable on the cards you already have**. Real spend on real life expenses, paid in full, every month. Chase rewards relationships. Pop-up jail is what happens when their model decides you're not building one.

--- a/data/articles/drafts/closing-credit-cards-safely.yaml
+++ b/data/articles/drafts/closing-credit-cards-safely.yaml
@@ -1,0 +1,210 @@
+id: "closing-credit-cards-safely"
+slug: "closing-credit-cards-safely"
+title: "How to Close a Credit Card Without Tanking Your Score"
+date: "2026-06-11"
+author: "CreditOdds"
+summary: "What actually happens to your score when you close a card, the order of operations to minimize damage, and the cards you should never close."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-freedom-unlimited
+  - citi-double-cash
+  - capital-one-quicksilver
+  - discover-it-cash-back
+  - wells-fargo-active-cash
+seo_title: "How to Close a Credit Card Without Hurting Your Score (2026) | CreditOdds"
+seo_description: "What happens to your credit score when you close a card, the safe sequence to follow, when downgrading is better than closing, and which cards to keep open forever."
+social_title: "How to Close a Credit Card Safely"
+content: |
+  Closing a credit card sounds like a clean, decisive move. In practice, it's one of the few credit decisions that can have multi-year consequences if you do it wrong. Close the wrong card at the wrong time and you can drop your score 30+ points overnight, raise the cost of an upcoming mortgage by tens of thousands of dollars, or trip an issuer's "downgrading relationship" risk flag.
+
+  But sometimes closing is the right move. Here's exactly what happens to your score when you close a card, the right order of operations, and the cards you should almost never close.
+
+  ## What Happens to Your Score When You Close a Card
+
+  Three mechanical effects, in order of how much they typically matter:
+
+  ### 1. Your total available credit drops
+  This is the biggest effect. Your aggregate credit utilization is calculated as (sum of balances) / (sum of credit limits). Closing a card removes its limit from the denominator, instantly raising your utilization percentage on the same balances.
+
+  Example: you have $20K of total credit limits across 4 cards, with $2,000 in total balances. Aggregate utilization: 10%. You close one of those cards with a $7,500 limit. Now you have $12,500 of limits and the same $2,000 balance. Aggregate utilization jumps to **16%**. That alone can cost 10–20 points immediately.
+
+  This is why the conventional wisdom "don't close cards" exists. It's mostly a utilization concern.
+
+  ### 2. Your account average age may drop (eventually)
+  Here's the wrinkle most people don't know: **closed cards continue to age and continue to count toward your average account age for ~10 years**. Closing a card today doesn't immediately remove it from your history.
+
+  After ~10 years, the closed card drops off your credit report entirely. At that point, your average age recalculates without it, and depending on the rest of your file, your score may drop again — but this is a future-decade problem, not a today problem.
+
+  Closing a brand-new card (held under 6 months) has minimal age impact today. Closing a 15-year-old card has minimal age impact today (it'll keep counting for the next decade) but a big impact when it eventually ages off.
+
+  ### 3. Your credit mix may change
+  Minor. If the closed card is one of only a few revolving accounts you hold, you can lose a few points from credit mix. If you have many cards, this is a non-factor.
+
+  ## What Doesn't Happen When You Close a Card
+
+  - **No new hard inquiry.** Closing is initiated by you and doesn't trigger a credit pull.
+  - **No fee.** Closing a card is always free.
+  - **No payment history loss.** Your past on-time payments stay on the closed card and continue to count for the full 10-year reporting window.
+  - **No immediate aging-related drop**, in most cases. The 10-year tail keeps the card "alive" for FICO purposes.
+
+  ## The Order of Operations: Closing a Card Safely
+
+  ### Step 1: Spend down the card to $0
+  Pay off any current balance, including any pending charges. Wait for the next statement to confirm the balance is genuinely zero.
+
+  ### Step 2: Use up any rewards
+  Convert points or cash back rewards. Rewards rules vary by issuer:
+
+  - **Chase Ultimate Rewards**: If you close the only card that earns UR (Sapphire Preferred, Sapphire Reserve, or Ink Preferred), your UR balance is forfeited. Transfer to airline/hotel partners or use for travel through the Chase portal first.
+  - **Amex Membership Rewards**: Usually preserved if you hold any other MR-earning card. Forfeited if you close your last MR card.
+  - **Capital One miles, Citi ThankYou Points, Bilt Points**: Generally similar — preserve at least one earning card or burn the points before closing.
+  - **Cash back**: Usually credited to your statement automatically before closure. Confirm with the issuer.
+
+  ### Step 3: Move credit limit (if possible) to another card from the same issuer
+  This is the underappreciated trick. Most major issuers (Chase, Amex, Capital One, Citi, BofA, Wells Fargo) will let you transfer credit limit from one of their cards to another over the phone. Before closing, call and ask: "Can you move my credit limit from this card I'm about to close to my [other card name from same issuer]?"
+
+  This preserves your total available credit even after the close, eliminating the utilization impact entirely. The receiving card just gets a higher limit.
+
+  ### Step 4: Confirm autopay and recurring charges are moved
+  Pull the last 12 months of statements and identify every recurring charge that hits this card — subscriptions, utilities, insurance, etc. Move them to a different card before closing. Otherwise the next charge will fail and you'll have to scramble.
+
+  ### Step 5: Close by phone
+  Call the customer service number on the back of the card. Tell them you'd like to close the account. They'll often:
+
+  - Try to retain you with a fee waiver, statement credit, or bonus offer
+  - Confirm that your balance is $0 and there's no pending activity
+  - Process the closure and mail you a confirmation letter
+
+  Get the closure confirmation in writing. Some applicants discover months later that the card was never actually closed, leaving an annual fee they didn't expect.
+
+  ### Step 6: Verify on your credit report 30–60 days later
+  The closure should appear on your credit reports as "Closed at consumer's request." Check all three bureaus to confirm it's reported correctly. If not, dispute through the bureau directly.
+
+  ## When You Should Downgrade Instead of Close
+
+  Most premium cards (annual fee cards) have a no-fee downgrade path. Downgrading is almost always better than closing because:
+
+  - **No utilization impact.** The card stays open with the same credit limit.
+  - **No average age impact** (today or in 10 years). The account remains in your file indefinitely.
+  - **No risk-flag impact.** Closing within 12 months of opening can flag you for the issuer's risk system; downgrading does not.
+
+  Common downgrade paths:
+
+  - **Chase Sapphire Reserve → Sapphire Preferred → Freedom Unlimited or Freedom Flex**
+  - **Amex Platinum → Amex Green or Amex EveryDay**
+  - **Amex Gold → Amex EveryDay or Blue Cash Everyday**
+  - **Capital One Venture X → Venture → VentureOne**
+  - **Citi Strata Premier → Custom Cash or Double Cash**
+  - **BofA Premium Rewards → Customized Cash Rewards or Travel Rewards**
+
+  Constraints:
+
+  - The downgrade target usually has to be on the same network (Visa↔Visa, Mastercard↔Mastercard, Amex↔Amex)
+  - You generally can't downgrade across radically different products (no-fee → premium-fee in the same call)
+  - Some issuers require the card to be at least 12 months old before downgrading
+
+  Call the customer service number, ask "I'd like to product-change my [card] to a [target card] without a hard inquiry," and they'll usually do it on the same call.
+
+  ## Cards You Should Almost Never Close
+
+  ### 1. Your oldest credit card
+  This is the single most-protected slot in any portfolio. Your oldest card anchors your average account age and your credit history length. If it has no annual fee, keep it open forever — even if you don't use it.
+
+  Run a small recurring charge ($5/month subscription) on autopay to prevent inactivity-based closure by the issuer.
+
+  ### 2. A no-annual-fee card with a high credit limit
+  High limit + no fee = pure utility. The card costs nothing and contributes meaningfully to your aggregate credit limit. Keep it. Use it occasionally to avoid issuer inactivity closures.
+
+  ### 3. A card you opened in the last 12 months
+  Closing a card within 12 months can flag your file at that issuer (and sometimes more broadly) for "bonus chasing" risk. Wait until the card is 12+ months old before closing, even if you've decided you don't want it.
+
+  ### 4. A card with rewards you haven't used
+  As above — burn or transfer the rewards first. Closing forfeits remaining rewards in many cases.
+
+  ## Cards Where Closing Makes Sense
+
+  ### 1. A premium card whose annual fee no longer pencils out
+  If your $695 Amex Platinum is earning you less than $695 in usable credits and rewards, downgrade or close. Don't keep paying for prestige.
+
+  ### 2. A card that's been the source of identity-theft headaches
+  If a card has been compromised multiple times or has fraud-prone usage patterns, closing and replacing it with a fresh card from the same issuer is reasonable.
+
+  ### 3. A duplicate from the same issuer that doesn't add value
+  If you have three Chase Freedom Flex cards and you only need one for the rotating categories, closing the extras (or product-changing them to other Chase no-fee cards if you want to preserve the limit) is fine.
+
+  ### 4. A card with crippling fees or terms you can't escape
+  Some sub-prime "starter" cards have fees that make them genuinely bad over time (Total Visa, Indigo, etc.). Once you've graduated to better products, closing these is a positive move regardless of score impact.
+
+  ## Special Case: The Annual Fee Trap
+
+  A common scenario: you have a premium card with a $95 annual fee that's about to post. You're not sure if you want to keep it. Here's the timeline:
+
+  - **The annual fee posts on the card's anniversary.**
+  - **Most issuers give a 30-day grace period** during which you can cancel the card and receive a full refund of the annual fee (Chase: full refund within 30 days; Amex: similar; Citi, BofA, Capital One: typically full refund within 30 days but verify).
+  - **After the grace period**, the fee is non-refundable for that year.
+
+  So the right move when you're unsure is:
+
+  1. Wait for the annual fee to post
+  2. Use that as the deadline to decide
+  3. Within 30 days, either close (full refund), downgrade (full or partial refund of the AF, depending on issuer), or keep (you've decided it's worth it)
+
+  Don't close pre-emptively before the annual fee posts — sometimes a retention offer (statement credit, bonus points) appears that swings the math toward keeping the card. We have a separate piece on [retention offers and the scripts to ask for them](/articles/retention-offers-and-scripts).
+
+  ## How Closing Affects Future Applications
+
+  Closing a card is generally **neutral** for your applications going forward — but with a few specific exceptions:
+
+  - **Closing within 12 months of opening** can flag you at that issuer for "bonus chasing." Notably bad with Chase (can contribute to pop-up jail) and Amex.
+  - **Closing a card immediately after collecting the welcome bonus** is the worst form of this — issuers track this pattern and apply velocity throttles.
+  - **Closing reduces your "relationship" with the issuer.** Total credit extended at that bank goes down, which can slightly reduce your odds of approval for new cards from the same issuer over the next 6–12 months.
+  - **Closing a 0% APR card with a remaining promotional balance** locks you into the card-use APR or accelerates the balance — read your terms.
+
+  Outside these specific cases, closing is largely invisible to other lenders. Your score recalculates based on remaining accounts, and other issuers see "you have N open cards" with no flag for the fact that you closed something last week.
+
+  ## What If You Already Closed a Card and Regret It?
+
+  - **Within 30 days**: Most issuers will reopen the account on request. Call customer service. The card number, credit limit, and account age all return.
+  - **30 days to 12 months**: Reopening becomes harder but is sometimes possible — analyst discretion. Worth asking, but don't count on it.
+  - **After 12 months**: Reopening generally isn't possible. You'd have to apply for the card fresh, which is a new application, new inquiry, and (if the welcome bonus has a once-per-lifetime restriction like Amex) likely no new bonus.
+
+  ## FAQ
+
+  ### Will closing a credit card hurt my score?
+  Sometimes, primarily through utilization impact. Sometimes not at all if your other cards have ample credit limit. The age effect is delayed (~10 years) and usually small.
+
+  ### How long does the score impact last?
+  The utilization impact is immediate but reverses as soon as you pay down balances or open another card with similar limits. The age impact (when the closed account drops off your report) is permanent but happens 10 years later.
+
+  ### Should I close a card with a $0 balance?
+  Closing a $0-balance card is technically fine — but the question is whether you should. If the card has no annual fee, keeping it open contributes to your credit limit and account age at zero cost. If it has an annual fee that doesn't pencil out, downgrade rather than close.
+
+  ### Can I close a credit card online?
+  Some issuers allow online closure (Discover, Capital One). Others require a phone call (Chase, Amex). The phone call has the side benefit of giving you a chance to hear retention offers.
+
+  ### What if my card has a balance — can I still close it?
+  Most issuers allow you to close a card with a balance. The account closes to new charges; you continue paying down the existing balance under the same terms (or sometimes accelerated, depending on the agreement). It's almost always cleaner to pay off first, then close.
+
+  ### Does closing a credit card affect my available credit on other cards?
+  No. Each card has its own independent limit. Closing one doesn't affect the limits on others. It just removes that card's limit from your aggregate total.
+
+  ### What's the difference between closing and "putting the card in a drawer"?
+  A "sock drawer" card is open but unused. It still counts toward your available credit, your average age, and may have an annual fee. A closed card is none of those — closure is a permanent action by the issuer.
+
+  ### Can the issuer close my card without telling me?
+  Yes — most card agreements allow the issuer to close inactive accounts. Discover and BofA tend to close after 12–18 months of inactivity. Capital One, Chase, and Amex are more lenient. To prevent issuer-initiated closure, run a small recurring charge on each card every 90 days.
+
+  ### Do I need to keep credit cards from my early adulthood for "credit history"?
+  As long as the cards are no-fee. They anchor your account age and contribute to your file's apparent stability. Yes, keep them.
+
+  ## The Bottom Line
+
+  Closing a credit card is rarely a clean decision and is almost never urgent. Three rules:
+
+  1. **Downgrade instead of closing** when possible. No-fee versions of your premium cards preserve everything except the annual fee.
+  2. **If you must close, do it in order**: spend to zero, burn rewards, move credit limit to another same-issuer card, move autopays, then call to close.
+  3. **Never close your oldest card or a high-limit no-fee card.** The cost is real and the benefit is usually zero.
+
+  When in doubt, downgrade. When you can't downgrade, ask for a retention offer. When you can't get a retention offer that justifies keeping it, then close — and only then.

--- a/data/articles/drafts/credit-card-denied-reconsideration.yaml
+++ b/data/articles/drafts/credit-card-denied-reconsideration.yaml
@@ -1,0 +1,213 @@
+id: "credit-card-denied-reconsideration"
+slug: "credit-card-denied-reconsideration"
+title: "Why You Got Denied: The Real Reasons Banks Decline You and How to Win on the Reconsideration Line"
+date: "2026-05-14"
+author: "CreditOdds"
+summary: "The denial reasons banks actually cite, what each one really means, and the reconsideration phone scripts that flip declines into approvals — by issuer."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-sapphire-preferred
+  - american-express-gold-card
+  - capital-one-venture-rewards
+  - citi-double-cash
+  - bank-of-america-customized-cash-rewards
+seo_title: "Credit Card Denied? Reconsideration Scripts by Issuer (2026) | CreditOdds"
+seo_description: "Why banks really decline credit card applications, what each adverse action notice means, and the exact reconsideration phone scripts to flip denials at Chase, Amex, Capital One, Citi, and Bank of America."
+social_title: "How to Flip a Credit Card Denial Into an Approval"
+content: |
+  Getting denied for a credit card feels personal. It isn't. It's an algorithm reading your file against a set of issuer-specific rules, and most of the time, the same algorithm has already laid out exactly which rule you tripped — in the **adverse action notice** the bank is required by law to send you within 30 days.
+
+  More importantly: a denial is rarely the final word. Major issuers all run **reconsideration lines** — direct phone numbers staffed by analysts who can review your application by hand and override an automated decline. The success rate on a well-prepared reconsideration call is roughly 30–50%. The success rate on a panicked, unprepared call is close to zero.
+
+  Here's how to read your denial, when to call, and what to say.
+
+  ## The Adverse Action Notice: Decoding What the Bank Actually Said
+
+  When a bank declines your application, federal law (the Fair Credit Reporting Act and Equal Credit Opportunity Act) requires them to send you a written explanation within 30 days. It's called the **adverse action notice** and it'll list one or more reasons your application was declined.
+
+  These are the canonical reasons you'll see, what they actually mean, and how reconsiderable each one is:
+
+  ### "Too many recent inquiries on credit bureau report"
+  **What it means:** You've applied for too many cards in too short a window. At most issuers, this triggers when you have 4–6+ inquiries in the last 6–12 months.
+  **Reconsiderable?** Sometimes. If you can explain the inquiries (rate shopping for a mortgage, identity theft) you have a real shot. If they're all credit card applications, you're unlikely to flip this one.
+
+  ### "Too many accounts opened recently" / "Number of new accounts established"
+  **What it means:** Specifically the Chase 5/24 issue, or the Bank of America 2/3/4 rule, or one of the issuer-specific velocity caps. The bank counts new credit accounts you've opened, not just inquiries.
+  **Reconsiderable?** Rarely. These are hard rules. If you're at 5/24 with Chase, no amount of phone charm will get you under it.
+
+  ### "Length of credit history" / "Time since oldest account established"
+  **What it means:** Your file is too thin or too young. Your average account age is below the issuer's threshold.
+  **Reconsiderable?** Sometimes — especially if you can point to specific old accounts (closed but still on report) that show you're not actually new to credit.
+
+  ### "Insufficient income"
+  **What it means:** The income you reported is too low for the credit limit you'd need. This is more common on premium cards (Sapphire Reserve, Venture X, Amex Platinum) where the typical limit starts at $10K–$15K.
+  **Reconsiderable?** Very. This is one of the most reconsideration-friendly denials. If you understated your income or have additional household income you can include (more on this in our [income reporting piece](/articles/credit-card-income-what-to-put)), updating it can flip the decision immediately.
+
+  ### "Existing credit obligations are too high" / "Proportion of balances to credit limits"
+  **What it means:** Your utilization is too high. The bank doesn't want to extend more credit while you're already heavily using what you have.
+  **Reconsiderable?** Strong yes. Pay your balances down, wait for them to report, then call back. We have a piece on [credit utilization](/articles/credit-utilization-explained) covering exactly how to drop reported utilization fast.
+
+  ### "Unable to verify information"
+  **What it means:** Something on your application didn't match what the bank could verify — usually address, phone number, or employer.
+  **Reconsiderable?** Almost always reversible. Call the reconsideration line and verify the missing data point with a human. This is the single easiest denial to flip.
+
+  ### "Too much credit available with this issuer"
+  **What it means:** You already have a lot of credit limit with the same bank across other cards. Issuer-specific exposure cap. Common at Chase ($50K total exposure cap is typical), American Express, and Bank of America.
+  **Reconsiderable?** Often yes — by **moving credit limit** from an existing card to the new one. The reconsideration analyst can shift, say, $5K of your existing Freedom Unlimited limit over to a new Sapphire Preferred to keep total exposure flat.
+
+  ### "Frequent applications" / "Pattern of recent credit applications"
+  **What it means:** Risk system flagged you as a "churner" — someone applying primarily to capture welcome bonuses.
+  **Reconsiderable?** Tough. The ones where reconsideration works are usually where the pattern was a one-off (small business launch, divorce, etc.) you can explain.
+
+  ### "Information from credit reporting agency"
+  **What it means:** Catch-all when the underlying issue is a specific item on your credit report — collections, charge-offs, late payments, bankruptcy.
+  **Reconsiderable?** Depends on the underlying item. Bankruptcies and recent charge-offs: no. A single 30-day late from 3 years ago: very plausibly yes with a clean explanation.
+
+  ## When Reconsideration Works (And When It Doesn't)
+
+  Reconsideration is most likely to succeed when:
+
+  - **The denial reason is fixable in real time** (income update, address verification, credit limit shift)
+  - **You can provide context the algorithm couldn't see** (recently received raise, paid down a big balance that hasn't reported yet, a fraud-related inquiry that wasn't really yours)
+  - **You're a longstanding customer with the bank** in good standing
+  - **You're polite, prepared, and know what you want**
+
+  It's most likely to fail when:
+
+  - **The denial is rule-based** (5/24, 2/3/4, once-per-lifetime, velocity caps)
+  - **The underlying credit history is the problem** (recent bankruptcy, multiple collections, very thin file)
+  - **You argue with the analyst** — the call is a soft credit interview, not a debate
+
+  ## The Universal Reconsideration Phone Script
+
+  This template works at every major issuer. Adjust the specifics per bank.
+
+  > **You:** "Hi, my name is [name], I just got a notice that my application for the [card name] was declined. I'd really like to be a [bank] customer and I think there's some context that might not have been captured in the automated review. Could you take another look at my application?"
+  >
+  > **Analyst:** "Sure, can I get your application reference number / SSN last 4 to pull it up?"
+  >
+  > [pause while they pull the file]
+  >
+  > **Analyst:** "I see you were declined for [reason]. Can you tell me about that?"
+  >
+  > **You:** [your one-sentence honest explanation, plus the specific update or context you want them to consider]
+  >
+  > **Analyst:** "Okay, I can [reread the file / move credit / re-verify income]. Give me a few minutes."
+
+  Three rules:
+
+  1. **Be honest.** They can see your full credit file. Lying about your income, your other inquiries, or your reason for applying gets the application denied permanently and may close your other accounts at the same bank.
+  2. **Be specific about what you want.** Don't ask "can you reconsider?" Ask "would you be willing to move $5,000 of credit limit from my existing Freedom Unlimited to this Sapphire Preferred application?" or "can you update my income to $X — I undercounted because I forgot to include side income."
+  3. **Don't argue.** If the analyst says no, thank them and hang up. You can call back later and get a different analyst — sometimes the second or third one has more flexibility, sometimes a new piece of context lands. But arguing with the first one closes the door.
+
+  ## Issuer-Specific Reconsideration Numbers and Notes
+
+  ### Chase
+  **Reconsideration line:** 1-888-270-2127 (personal cards), 1-800-453-9719 (business cards)
+  **Best for:** Income updates, credit limit reallocation between Chase cards, "second chance" review on borderline files.
+  **What works:** Offering to move credit from existing cards. Explaining a non-recurring spike in inquiries (mortgage, divorce). Noting you're an existing checking/savings/Sapphire customer.
+  **What doesn't:** 5/24 violations. Chase 5/24 is hard-coded — no analyst can override it.
+
+  ### American Express
+  **Reconsideration line:** 1-800-567-1083 (general), or call the number on the back of any existing Amex
+  **Best for:** Income corrections, explaining a recent inquiry pattern, asking for a manual review on a "credit not established" decline.
+  **What works:** Long-time relationship with Amex. Updating income to include all household sources. Explaining one specific item.
+  **What doesn't:** Once-per-lifetime welcome bonus rules. The "no SUB" outcome is final and reconsideration won't help.
+
+  ### Capital One
+  **Reconsideration line:** 1-800-625-7866
+  **Best for:** Income updates and "bucket" review (Capital One has a known internal tier system; some applicants are "subprime bucketed" and need a manual review to escape).
+  **What works:** Specific, narrow asks. Capital One analysts are unusually willing to review and reverse if you present clean facts.
+  **What doesn't:** Vague pleas. "Please reconsider, I really want this card" gets you nowhere.
+
+  ### Citi
+  **Reconsideration line:** 1-800-695-5171 (consumer credit), 1-800-577-1255 (consumer underwriting)
+  **Best for:** Verifying income, addressing soft denials, fixing application data errors.
+  **What works:** Existing Citi banking relationships. Walking through your file calmly. Highlighting that the negative item flagged is old or already resolved.
+  **What doesn't:** Citi's family-of-cards welcome-bonus restrictions. Those are policy.
+
+  ### Bank of America
+  **Reconsideration line:** 1-866-458-8805 (consumer cards), 1-866-695-6598 (business)
+  **Best for:** Updating banking-relationship info (Preferred Rewards tier), explaining inquiries, income corrections.
+  **What works:** Existing BofA checking, savings, or Merrill investment accounts — bring those up immediately.
+  **What doesn't:** Direct violations of the 2/3/4 rule.
+
+  ### Wells Fargo
+  **Reconsideration line:** 1-800-967-9521
+  **Best for:** Application data verification, income updates.
+  **What works:** Wells customers in good standing get more leniency.
+  **What doesn't:** Recent late payments, even on non-Wells accounts.
+
+  ### Discover
+  **Reconsideration line:** 1-800-347-3085
+  **Best for:** Thin-file applicants, students, recent immigrants. Discover is unusually willing to manually review and approve borderline files.
+  **What works:** Demonstrating steady income and explaining a thin credit file with school enrollment, recent move, etc.
+  **What doesn't:** Recent collections or charge-offs.
+
+  ## Timing Your Reconsideration Call
+
+  Three timing rules:
+
+  1. **Don't call the same day you got denied** if your denial reason needs a fix (paying down a balance, updating income on file, etc.). Fix the issue first, then call.
+  2. **Do call the same day** if your denial reason is data-related (address mismatch, employer verification, income misreported on the form). The fastest way to fix data errors is a same-day reconsideration call.
+  3. **Call during business hours, on weekdays, late morning.** You'll get the most experienced analysts. Late nights and weekends get junior staff with less flexibility.
+
+  ## What to Have in Front of You Before You Call
+
+  Make a one-page sheet with:
+
+  - **Your full income** including all sources (W-2, side income, household income if you're 21+, alimony/child support if you choose to disclose)
+  - **Your existing credit limits** with this same bank (so you know what could be moved)
+  - **The denial reason** from the adverse action notice (don't call until you have it — analysts can sometimes see partial reasons in their system, but you want the same information they have)
+  - **Your relationship with the bank** — checking accounts, savings, mortgage, investment accounts (note opening dates if you can)
+  - **One sentence explaining anything unusual** in your recent application history
+
+  Five minutes of prep doubles your reconsideration success rate.
+
+  ## When NOT to Call Reconsideration
+
+  Some situations where the call will hurt more than help:
+
+  - **Denial because of bankruptcy in the last 5 years.** Wait until it's older.
+  - **Multiple recent declines from the same bank.** They've already manually reviewed you. Calling again pushes you toward a "no further applications" flag.
+  - **Active fraud alert on your file** that hasn't been resolved. Resolve the alert first, then reapply (don't reconsider — start fresh).
+  - **You don't have a real fix or context to add.** If all you can say is "please give me another look," skip the call.
+
+  ## FAQ
+
+  ### Will calling reconsideration trigger another hard inquiry?
+  No. Reconsideration uses your existing application's hard inquiry — they're re-reviewing the file, not pulling fresh credit. The exception: if the analyst suggests applying for a different card instead, that new application would trigger a new pull.
+
+  ### How long do I have to call reconsideration after a denial?
+  Most issuers will reconsider within 30 days of the original application, sometimes longer. After 30 days, you generally need to reapply (which means a new hard pull). Call as soon as you have your fix or context ready.
+
+  ### What's the success rate of reconsideration?
+  Roughly 30–50% across major issuers, with variation by denial reason. Income-based denials reconsider successfully 60%+ of the time. Velocity-based denials reconsider successfully under 10% of the time.
+
+  ### Can I be approved for a different card during the reconsideration call?
+  Sometimes — Capital One in particular is known for "downgrading" the application to a card you'd qualify for instead of declining outright. Most other issuers will require you to apply separately for a different card.
+
+  ### Should I mention I'm shopping multiple banks?
+  Don't volunteer it. If asked directly, be honest — but framing it as "I'm trying to find the right card for my situation" is fine. Don't say "I'll close my other cards if you approve me" unless you actually mean it.
+
+  ### Will reconsideration affect my approval odds at other banks?
+  No. Reconsideration is internal to one bank. Other banks don't see whether you reconsidered or not — only that you applied and were either approved or declined.
+
+  ### Can I reconsider an instant-approval that was for a lower limit than I wanted?
+  Yes. Most issuers will increase the initial limit on a brand-new card if you call within a week or two of approval and explain why you need more (income justifies it, etc.). This is technically not a reconsideration — it's a credit limit increase request — but the script and timing are the same.
+
+  ## The Bottom Line
+
+  A denial is the start of the conversation, not the end of it. The adverse action notice tells you exactly what tripped the algorithm; the reconsideration line lets you talk to a human who can override the algorithm if your story holds up.
+
+  Three things to remember:
+
+  1. **Read the adverse action notice carefully.** It tells you what to fix.
+  2. **Fix what you can fix before you call.** Pay down balances, update income, resolve data mismatches.
+  3. **Be specific, polite, and prepared on the call.** Know what you want and how it would work.
+
+  Most denials at the major issuers are reversible. The only ones that aren't are the rule-based ones — Chase 5/24, Amex once-per-lifetime, BoA 2/3/4 — and even those have predictable timelines for becoming reconsiderable again.
+
+  If you want to see your odds of approval before you apply (and avoid the denial in the first place), that's exactly what our [check-odds](/check-odds) tool is built for.

--- a/data/articles/drafts/credit-card-income-what-to-put.yaml
+++ b/data/articles/drafts/credit-card-income-what-to-put.yaml
@@ -1,0 +1,235 @@
+id: "credit-card-income-what-to-put"
+slug: "credit-card-income-what-to-put"
+title: "What Income to Put on a Credit Card Application: The Rules, the Math, and What Actually Counts"
+date: "2026-05-21"
+author: "CreditOdds"
+summary: "What you can legally include as income (more than you think), what gets verified, and how the income number actually affects your approval decision and credit limit."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-sapphire-preferred
+  - american-express-gold-card
+  - capital-one-venture-rewards
+  - citi-double-cash
+  - capital-one-venture-x
+seo_title: "What Income to Put on a Credit Card Application (2026) | CreditOdds"
+seo_description: "What counts as income on a credit card application — household income, side income, investment returns, alimony — what gets verified, and how the income number actually affects approval and credit limit."
+social_title: "Credit Card Income: What to Put"
+content: |
+  The income box on a credit card application is the one most people undercount, and undercounting costs them. Income drives both your approval probability and your initial credit limit. A $50,000 income on a Chase Sapphire Preferred application might get you a $5,000 limit; the same person reporting $90,000 of legitimate household income might get $15,000.
+
+  More importantly: federal law explicitly **allows** applicants 21 and older to include household income, even if it isn't yours. Most people don't realize this and report only their personal W-2 income, leaving real approval power on the table.
+
+  Here's what counts, what gets verified, what doesn't, and what number to actually put in the box.
+
+  ## What "Income" Actually Means on a Credit Card Application
+
+  Issuers ask for income because they need to assess whether you can afford to repay credit. The Credit CARD Act of 2009 specifies that the figure you report must be income or other resources you "can reasonably expect access to" to make payments on the account.
+
+  That last clause matters. The 2013 amendment to the CARD Act (effective for applicants 21+) explicitly extended this to **shared household income** — your spouse's earnings, money in joint accounts, etc. — as long as you have reasonable access to it for paying credit card bills.
+
+  Translation: you don't need to be the earner. You need to have access to the money.
+
+  ## Everything That Counts as Income
+
+  Per the regulations and standard issuer practice in 2026, here's what you can legitimately include:
+
+  ### Personal earned income
+  - Salary or hourly wages (gross, before taxes)
+  - Tips, commissions, bonuses (annualized)
+  - Self-employment income (net, after business expenses, but before personal taxes)
+  - Side income from gigs, freelancing, contract work
+
+  ### Investment income
+  - Interest on savings, CDs, money market funds
+  - Dividends from stocks, ETFs, mutual funds
+  - Capital gains realized in a typical year (if recurring)
+  - Rental income from properties you own
+
+  ### Retirement and benefit income
+  - Social Security
+  - Pension distributions
+  - 401(k) / IRA distributions if you're actively taking them
+  - VA benefits
+  - Disability income
+
+  ### Household income (for applicants 21+)
+  - Your spouse's salary
+  - Your partner's income, if you live together and share finances
+  - Any household member whose income you can reasonably access for bill payment
+
+  ### Other regular access
+  - Alimony or child support (you choose whether to disclose)
+  - Trust distributions, if recurring
+  - Allowance from a parent or family member, if it's regular and substantive
+
+  ### Non-traditional but acceptable
+  - Scholarships and grants (the portion not already used for tuition — i.e., living-stipend amounts)
+  - Stipends from research, fellowships, residencies
+  - Regular gambling winnings if professional and verifiable (rare, but it's been done)
+
+  ## Everything That Does NOT Count
+
+  - **One-time windfalls.** Inheritance, lottery wins, lawsuit settlements unless paid as a recurring annuity.
+  - **Retirement assets you're not drawing from.** Your 401(k) balance is wealth, not income. Don't list it.
+  - **Home equity or unrealized investment gains.** Same logic.
+  - **Loans.** Money you've borrowed isn't income.
+  - **Anticipated future raises.** Use what you actually earn now, not what you expect.
+
+  Trying to inflate the income number with these doesn't just risk denial — it can be flagged as application fraud, which is a federal offense. There's no need; the legitimate categories above already give most people 30–60% more income than they'd report on instinct.
+
+  ## What Gets Verified (And What Doesn't)
+
+  Banks **almost never** verify income at application time for credit card applications. They reserve verification for:
+
+  - **High-limit cards** (Sapphire Reserve, Amex Platinum, Venture X) where the requested limit warrants it
+  - **Credit limit increases** that would push you above a certain threshold
+  - **Random spot-checks** — small percentage of applications selected by the issuer's risk algorithm
+  - **Reconsideration calls** where you cite an income different from your application
+
+  When verification happens, the most common methods are:
+
+  1. **W-2 or 1099 request** — they'll ask you to upload or fax recent tax forms
+  2. **Pay stub request** — recent stubs covering 1–3 months
+  3. **Tax return request** — full prior-year return for self-employed applicants or anyone whose income spans multiple sources
+  4. **Bank statement request** — to verify deposit patterns matching reported income
+
+  This is why **honesty matters even when verification is unlikely**: if you ever apply for a credit limit increase or reconsider a denial, the bank may ask for documentation of the income you originally reported. If your paperwork doesn't match, the issuer can decline, close existing accounts, and (in extreme cases) report fraud.
+
+  Numbers within ~10% of what you can verify are safe. Numbers wildly out of line aren't.
+
+  ## How Income Affects Your Approval Decision
+
+  Three mechanisms:
+
+  ### 1. Debt-to-Income (DTI) calculations
+  Issuers compute your DTI from your reported income and the credit obligations they can see on your credit report. A high DTI (above 35–40% in most issuer models) makes approval harder. Reporting more legitimate income lowers your DTI directly.
+
+  ### 2. Credit limit assignment
+  Most issuers use a "max exposure" model where your total approved limits across all their cards can't exceed some multiple of your reported income — typically 30–50%. If you report $40K income and already have $15K of credit limit at Chase, a new Chase card may only get you a small additional limit. Reporting $80K opens more headroom.
+
+  ### 3. Premium card eligibility thresholds
+  Some premium cards have hard income floors:
+
+  - **Chase Sapphire Reserve**: practical floor around $80K (no published minimum, but rare approvals below)
+  - **Amex Platinum**: practical floor around $50K, though Amex is more flexible than most
+  - **Capital One Venture X**: practical floor around $80K
+  - **Bank of America Premium Rewards Elite**: around $75K plus existing BofA banking relationship
+
+  These aren't published, but they're consistent enough across data points to be predictive. If your real reported income is below the floor, no amount of script tricks on the reconsideration line will fix it.
+
+  ## When to Use Household Income
+
+  If you're 21+, you can include household income — and you usually should. Two scenarios:
+
+  ### You earn less than your spouse/partner
+  Use household income. There's no benefit to under-reporting in this case. The income box is asking what you have access to; if your spouse earns $90K and you earn $30K and you share finances, your household income for credit application purposes is $120K.
+
+  ### You're a stay-at-home spouse, student, or recent retiree
+  Use household income. The 2013 CARD Act amendment was specifically written to allow this — without it, non-earning spouses had no path to a credit card in their own name. You can apply and report your spouse's income (or a portion of it that you have access to) as your household income.
+
+  ### One nuance: separate finances
+  If you and your partner genuinely keep finances separate — separate bank accounts, separate bills, no joint credit accounts — and you wouldn't actually use their money to pay your credit card, you should not include it. The standard is access, not legal entitlement.
+
+  ## When to Annualize
+
+  If your income is irregular (commission-based, freelance, seasonal), the right number is your **typical annual gross** — not your highest year, not your lowest, the realistic average over the last 1–2 years.
+
+  Some specific cases:
+
+  - **New job that pays better**: use your new annualized salary (e.g., $7,500/month × 12 = $90K), even if you've only been earning at that rate for a few months. The bank cares about your current run rate.
+  - **Recently lost income**: be honest about the lower number. Reporting the old higher number when you've lost the income source is fraud.
+  - **Highly seasonal income**: average over a typical year. Don't report a single quarter's earnings × 4.
+  - **Recent grad or first job**: use your annualized starting salary, not whatever fraction you've actually earned this year.
+
+  ## Special Cases
+
+  ### Students
+  If you're under 21 and a student, the CARD Act requires you to demonstrate independent ability to pay — household income generally doesn't apply. Use:
+
+  - Earned income from your job(s)
+  - Scholarships and grants (the living-stipend portion)
+  - Stipends from research, internships, or fellowships
+  - Recurring family support if it's substantive and regular (case-by-case)
+
+  Student cards (Chase Freedom Student, Discover It Student, Capital One Savor Student, Bilt Blue) accept lower income figures and often approve at $0–$15K reported income because they're priced for thin files.
+
+  ### Self-employed and 1099 contractors
+  Use your **net** business income (gross revenue minus business expenses), not gross. This is what shows up on your Schedule C and what would be verified if asked. Banks know self-employed applicants tend to have higher gross-to-net ratios; they want the net.
+
+  ### Retirees
+  Include all sustained income sources: Social Security, pension, RMDs from retirement accounts, dividend/interest income on investments, rental income. The portfolio balance itself isn't income, but the recurring distributions and yields are.
+
+  ### Investment-heavy households
+  If a meaningful chunk of your wealth is in investments and you regularly draw from those investments (dividends, capital gains, interest), include the typical annual realized portion. Don't include unrealized appreciation.
+
+  ### Crypto holders
+  Tricky. Realized crypto gains in a typical year, taxed and reportable on a 1099, count. Unrealized crypto holdings don't. Most issuers don't have great mental models for crypto income, so be conservative.
+
+  ## What Number to Actually Put
+
+  Practical formula:
+
+  > **Personal gross earned income + household share of partner's income + recurring investment income + recurring benefit income**
+
+  Round to the nearest $1,000. Don't artificially round up; if your honest answer is $87,400, write $87,000 or $87,400, not $90,000.
+
+  Example: married 33-year-old with a $65K salary, $5K of side freelance income, $2K of dividend income, and a spouse making $80K. Honest income figure: $65K + $80K + $5K + $2K = **$152K**.
+
+  Most people in this situation would report $65K. They're leaving roughly $87K of legitimate income off the application.
+
+  ## Updating Income on Existing Cards
+
+  Once a card is open, you can usually update your income with the issuer at any time, often through their app or website. Two reasons to do this:
+
+  1. **Income went up.** Updating increases your eligibility for credit limit increases on that card and across the issuer's other cards.
+  2. **You realize you under-reported.** Update to the correct number. The issuer will use the updated figure for future limit reviews.
+
+  For Chase, log into chase.com → card details → "Update Income."
+  For American Express, the income update flow is on the home dashboard, usually under account services.
+  Capital One, Citi, Bank of America, Discover, and Wells Fargo all have similar self-serve flows.
+
+  Updating costs nothing, isn't a hard pull, and almost always improves your standing.
+
+  ## FAQ
+
+  ### Will the bank check my actual tax return when I apply?
+  Almost never at the credit card application stage. They might at credit limit increase time, on premium cards, or during random spot-checks — but most credit card applications are decided without any income verification.
+
+  ### Is including my spouse's income legal if we file taxes separately?
+  Yes. The standard is whether you have reasonable access to the money for bill-paying purposes, not how you file taxes. Filing status is irrelevant.
+
+  ### What if my income changed dramatically this year?
+  Use your current annualized run rate. If you're earning $10K/month now after a raise from $7K/month, your reported income should be $120K, even if your actual year-to-date earnings are lower.
+
+  ### Can I include my parent's income?
+  If you're under 21 and a dependent, parental support that's regular and substantive can count. If you're 21+ and live independently, it generally shouldn't be included — you don't have continuous access to it the way a spouse's income would be.
+
+  ### Does reporting higher income help my credit limit?
+  Yes, almost always. Most issuers cap initial credit limits at some multiple (30–50%) of reported income. Higher income equals headroom for higher limits.
+
+  ### Will my reported income affect my approval if my credit score is borderline?
+  Yes. Two applicants with the same borderline score will be approved or declined differently based on income — higher income lowers DTI and reduces lender risk.
+
+  ### What's the minimum income for most credit cards?
+  Below $15K is hard. Between $15K–$25K, you'll qualify for student and entry-level cards (Discover It Student, Capital One Savor Student, Discover It Cash Back). At $30K+, most mid-tier cards open up. At $75K+, most premium cards become possible.
+
+  ### Should I report income before or after taxes?
+  Before taxes (gross). Standard practice, and what every issuer expects unless they explicitly ask for "take-home" or "net."
+
+  ### What if I just lost my job?
+  Be honest. Use the income you reasonably expect to have access to going forward — unemployment benefits if you're collecting them, household income if your partner earns, savings drawdowns if you've planned around that. Don't report your former salary as if you still earned it.
+
+  ### Can I update my income to fix a denial?
+  Yes — this is one of the strongest reconsideration plays. If you under-reported because you forgot side income, household income, or a recent raise, calling reconsideration with the correct higher figure is one of the highest-success-rate paths to flipping a denial. We have a separate piece on [reconsideration scripts](/articles/credit-card-denied-reconsideration).
+
+  ## The Bottom Line
+
+  The income box matters more than most people realize, and most people put a number that's well below what they're entitled to claim. Three rules:
+
+  1. **Include household income** if you're 21+ and share finances with your partner.
+  2. **Include all recurring sources** — investment income, benefits, side income, support.
+  3. **Be honest within ~10% of what you can verify.** Stretching legitimate categories is fine. Inventing income is fraud.
+
+  If you're not sure what your number should be, write it out: gross personal income + household share + investment income + recurring other. That's your figure. Round to the nearest thousand and put it on the application.

--- a/data/articles/drafts/credit-limit-increases.yaml
+++ b/data/articles/drafts/credit-limit-increases.yaml
@@ -1,0 +1,225 @@
+id: "credit-limit-increases"
+slug: "credit-limit-increases"
+title: "Credit Limit Increases: How to Ask, When It Helps, and Which Issuers Do Soft Pulls"
+date: "2026-07-02"
+author: "CreditOdds"
+summary: "How issuers actually decide credit limit increases, which ones use soft pulls vs hard pulls, the right time to ask, and how to maximize the increase amount."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - capital-one-quicksilver
+  - citi-double-cash
+  - bank-of-america-customized-cash-rewards
+  - chase-freedom-unlimited
+  - american-express-gold-card
+seo_title: "Credit Limit Increases: Soft Pull vs Hard Pull (2026) | CreditOdds"
+seo_description: "How to request a credit limit increase, which major issuers use soft pulls (Capital One, Citi, BofA) vs hard pulls (Chase, Amex, Wells), and the timing that maximizes approvals."
+social_title: "Credit Limit Increases, Decoded"
+content: |
+  Credit limit increases (CLIs) are one of the most underused tools in credit optimization. A higher limit means lower utilization on the same balance, which directly improves your score. It also means more headroom for unexpected spending without spiking your reported balance, and it signals to other issuers that the bank trusts you.
+
+  But asking for a CLI the wrong way — at the wrong time, on the wrong card, through the wrong channel — can cost you a hard inquiry for nothing. Here's exactly how CLIs work in 2026, which issuers do soft pulls vs hard pulls, and the request strategy that maximizes the increase you'll get.
+
+  ## What a Credit Limit Increase Actually Does
+
+  When approved, a CLI raises your card's available credit. The new limit takes effect immediately or within 1–2 billing cycles, and the higher limit reports to the credit bureaus on the next statement.
+
+  Effects:
+
+  - **Lower utilization on the same balance**: a $1,000 balance on a $5,000 limit is 20% utilization; the same $1,000 on a $10,000 limit is 10%. Score boost typical: 5–20 points.
+  - **Higher absolute spending capacity**: useful for emergency expenses, large purchases, or just avoiding accidentally maxing the card during high-spend periods.
+  - **Signal of trust to other lenders**: a higher limit on an existing card slightly improves underwriting at other banks.
+
+  CLIs are **per-card**. Increasing your Chase Freedom Unlimited limit doesn't affect your Citi Double Cash limit; you'd need separate requests at each issuer.
+
+  ## Soft Pull vs Hard Pull by Issuer
+
+  This is the most important distinction. Some issuers use soft pulls for CLI requests (no impact on score, no inquiry on report). Others use hard pulls (5-point hit, visible to other lenders for 2 years).
+
+  As of mid-2026:
+
+  ### Soft pull issuers (no score impact)
+  - **Capital One** — soft pull for all CLI requests on most cards
+  - **Citi** — soft pull
+  - **Bank of America** — soft pull most of the time; occasional hard pulls on large requests
+  - **Discover** — soft pull
+  - **U.S. Bank** — soft pull on most cards
+
+  ### Hard pull issuers
+  - **Chase** — hard pull on all CLI requests
+  - **American Express** — hard pull when you request more than 3x your existing limit; otherwise often soft pull (Amex's "preset spending limit" requests are usually soft, but explicit CLI on a credit card is usually hard)
+  - **Wells Fargo** — hard pull on most cards
+  - **Barclays** — hard pull
+
+  ### Hybrid / depends on the card
+  - **Synchrony, Comenity** (store cards): Vary by partner; usually soft pull but verify before requesting
+
+  The practical implication: at soft-pull issuers, you can request CLIs aggressively and frequently with no downside. At hard-pull issuers, every CLI request is essentially a credit application — make it count.
+
+  ## When to Ask for a CLI
+
+  ### Optimal timing windows:
+
+  ### 1. After 6 months of clean use
+  Most issuers won't approve a CLI on a card you've held for under 6 months. The exceptions: automatic limit increases (no request needed) that some issuers grant proactively at month 4–7 mark.
+
+  ### 2. After a positive credit event
+  Score increases (you reached a new tier), income increases (new job, raise), reduction in other debt — any positive change in your file is a good time to request.
+
+  ### 3. Before a big purchase
+  If you know you'll spend a large amount in the next month (vacation, home repair, medical bill), requesting a CLI 30 days in advance keeps your utilization from spiking to bad levels when the charges hit.
+
+  ### 4. As part of a score-optimization pass
+  If you're 60–90 days from a mortgage application or any major credit event, increasing your limits across all soft-pull cards is one of the highest-leverage moves to lower utilization without paying anything down.
+
+  ### Avoid:
+
+  - **Requesting within 30 days of opening the card** — almost always declined, may flag your file
+  - **Requesting after a missed payment** — declined and may trigger a credit limit decrease instead
+  - **Requesting at a hard-pull issuer when you have other applications pending** — burns inquiries that could hurt your other applications
+
+  ## How to Request a CLI
+
+  ### Step 1: Update your income on file first
+  Most issuers base CLI decisions partly on the income they have on file. If your income has gone up since you applied for the card, update it before requesting the CLI. The update is free and doesn't trigger any pull.
+
+  - **Chase**: chase.com → Account Services → Update Personal Information → Income
+  - **Amex**: americanexpress.com → My Profile → Update Income
+  - **Capital One**: capitalone.com → Profile → Update Information
+  - **Citi**: citi.com → Account Profile → Update Information
+  - **Bank of America**: bankofamerica.com → Help & Support → Update Income
+
+  ### Step 2: Determine the request amount
+  Three ways to think about it:
+
+  - **Aggressive**: 2–3x your current limit. Caps the upside but also caps the approval rate.
+  - **Moderate**: 50% increase from current limit. Strong approval rate, meaningful boost.
+  - **Conservative**: 25–30% increase. Almost always approved if you're in good standing.
+
+  Some issuers will counter-offer if your request is too high. Capital One in particular will often approve a smaller increase than requested rather than declining outright.
+
+  ### Step 3: Submit the request
+  Each issuer has its own process:
+
+  - **Capital One**: capitalone.com → card details → Request Credit Line Increase. Soft pull, instant decision usually.
+  - **Citi**: citi.com → card services → Request Credit Limit Increase. Soft pull, often instant.
+  - **Bank of America**: bankofamerica.com → Account Services → Request Credit Line Increase. Soft pull, often instant.
+  - **Chase**: chase.com → card details → Account Services → Credit Line Increase. **Hard pull**, decision in seconds.
+  - **Amex**: americanexpress.com → Account Services → Credit Limit Increase. Mix of soft and hard depending on amount; ask first.
+  - **Discover**: discover.com → Manage → Credit Limit Increase. Soft pull, instant.
+  - **Wells Fargo**: wellsfargo.com → Account Services → Credit Line Increase. **Hard pull**.
+
+  ### Step 4: If declined, request a reason
+  Issuers are required by law to send an adverse action notice if your CLI is declined. Read the reason — it'll point to what to fix before requesting again. Common reasons:
+
+  - Insufficient income (update income, retry)
+  - High utilization on other cards (pay down balances first)
+  - Recent inquiries (wait 6 months)
+  - Account too new (wait until 12 months)
+  - Recent late payment on this or other accounts (wait until it ages)
+
+  ## How Much of an Increase to Expect
+
+  Patterns from community data points:
+
+  - **Capital One**: Often modest first CLI ($500–$1,500 increase), more generous after multiple successful requests
+  - **Citi**: Variable but often gives 50–100% increase requests
+  - **Bank of America**: Typically generous — full-amount approvals more often than other issuers
+  - **Discover**: Conservative initially, more generous after 12+ months of use
+  - **Chase**: Hard pull required, but approvals are typically substantial when granted (often the full request)
+  - **Amex**: Famous for "no preset spending limit" charge cards (Gold, Platinum, Green) — different mechanism from CLIs. For credit cards (Blue Cash variants), approvals can be very generous
+
+  ## Soft Pull Hacks for Score Optimization
+
+  At the soft-pull issuers (Capital One, Citi, BofA, Discover), you can:
+
+  ### 1. Request CLIs every 6 months on every card
+  Free score optimization. The aggregate of multiple successful CLIs across your soft-pull cards meaningfully lowers your utilization and raises your score over 1–2 years.
+
+  ### 2. Request large increases speculatively
+  Worst case: declined, no consequence. Best case: a 2x or 3x increase in one go.
+
+  ### 3. Time it before major events
+  60 days before a mortgage application, request CLIs across all soft-pull cards. The increased aggregate limit lowers your utilization on the credit pull at mortgage close.
+
+  At hard-pull issuers (Chase, Amex, Wells), the same strategies cost you 5 points and a 24-month inquiry on your file. Be more deliberate.
+
+  ## Automatic Credit Limit Increases
+
+  Some issuers proactively increase limits without you asking. Patterns:
+
+  - **Capital One**: Reviews accounts every 6 months and may auto-increase. If you spend a lot but pay in full, automatic CLIs are common.
+  - **Discover**: Reviews monthly; consistent low utilization with regular spending tends to trigger automatic increases.
+  - **Chase**: Less common automatic CLIs on personal cards.
+  - **Amex**: "Preset spending limit" credit cards may have limits raised automatically without notice.
+
+  Automatic CLIs are always soft pull (no inquiry). If you're getting them automatically, you usually don't need to request manually.
+
+  ## Credit Limit Decreases (CLDs)
+
+  The flip side: issuers can also lower your limit. Triggers:
+
+  - **Inactivity**: long stretches with no spend
+  - **High utilization**: maxed-out cards across multiple issuers
+  - **Late payments**
+  - **Risk-system flags**: unusual spending patterns, fraud signals
+  - **Economic conditions**: during recessions, issuers sometimes broadly trim limits across portfolios
+
+  When a CLD happens, your utilization spikes overnight (same balance, lower denominator). Score can drop 10–30 points. To prevent CLDs, use cards regularly (small monthly charge) and keep utilization low.
+
+  ## CLIs and Other Issuer-Specific Rules
+
+  ### Chase 5/24
+  CLIs do not count toward 5/24 — only new account openings do. You can request CLIs at Chase without affecting your 5/24 status.
+
+  ### Amex velocity rules
+  CLIs do not count against Amex's account velocity. You can request them while still being eligible for new Amex card applications.
+
+  ### BofA 2/3/4
+  CLIs do not count against 2/3/4. The rule is about new card openings, not limit changes.
+
+  ### Capital One bucket rules
+  CLIs do not move you between buckets. The bucket assignment is based on your overall file profile, not your current Capital One limits.
+
+  ## FAQ
+
+  ### Will requesting a credit limit increase hurt my score?
+  At soft-pull issuers, no. At hard-pull issuers, ~5 points temporarily, recovered in 6 months.
+
+  ### How often can I request a credit limit increase?
+  Most issuers allow requests every 6 months. Capital One every 6 months. Citi every 4 months. Discover every 6 months. BofA every 6 months. Requesting more frequently usually triggers an automatic decline without a pull.
+
+  ### What's the maximum credit limit I can get?
+  Depends on income and issuer. $50K+ is achievable on premium cards (Sapphire Reserve, Amex high-tier, Venture X). Most major cards cap at $25K–$50K; some specialty business cards go to $100K+.
+
+  ### Can I be denied for asking for too much?
+  No, you'll just be approved for less. Most issuers will counter with a smaller increase if your request is too aggressive.
+
+  ### Will higher limits encourage me to overspend?
+  Behavioral risk only. Mechanically, a higher limit doesn't change your spending — it just lowers utilization on the spending you'd do anyway.
+
+  ### What's the best way to update my income for CLI purposes?
+  Through the issuer's online portal. The income update is independent of the CLI request and doesn't trigger any pull. Always update income before requesting a CLI if it's grown since you applied.
+
+  ### Can I get a CLI with a 30-day late on my account?
+  Almost certainly no. Wait until the late ages off (7 years) or at minimum until you have 12+ months of clean payments after the late.
+
+  ### Does asking for a CLI affect my approval odds for other cards?
+  At soft-pull issuers, no. At hard-pull issuers, the inquiry adds to your inquiry count, which can affect velocity-rule decisions at other issuers (Chase 5/24 doesn't care about inquiries directly, but BofA's 2/3/4 and several other rules consider inquiries).
+
+  ### Can I get my limit decreased on purpose?
+  Yes, by calling and asking. Reasons people sometimes do this: lowering exposure for self-imposed spending discipline, reducing visibility to other lenders, freeing up issuer "exposure" for a different card from the same issuer.
+
+  ### What if my issuer offers an auto-CLI but I want more?
+  Accept the auto-CLI, then 6 months later request a manual CLI for additional. Stacking works.
+
+  ## The Bottom Line
+
+  Credit limit increases are one of the highest-leverage credit optimization moves available, and at soft-pull issuers they're essentially free. Three rules:
+
+  1. **Use soft-pull issuers aggressively.** Capital One, Citi, BofA, Discover — request every 6 months, no downside.
+  2. **Be deliberate at hard-pull issuers.** Chase, Amex, Wells — only request when you have a clear need or your file has materially improved.
+  3. **Update income first.** Almost every CLI decision depends partly on income on file. Updating costs nothing and improves the offer.
+
+  Done quarterly across your soft-pull portfolio, CLIs alone can lift your score 10–30 points over 12 months — without paying down a dollar of debt or opening a single new card.

--- a/data/articles/drafts/fico-vs-vantagescore.yaml
+++ b/data/articles/drafts/fico-vs-vantagescore.yaml
@@ -1,0 +1,223 @@
+id: "fico-vs-vantagescore"
+slug: "fico-vs-vantagescore"
+title: "FICO vs VantageScore: Which One Lenders Actually Use, and Why Your Free Score Isn't Your Real Score"
+date: "2026-07-13"
+author: "CreditOdds"
+summary: "The two main credit scoring models in 2026, which lenders use which, why 'free score' apps often show you a different number than your lender, and what each model actually weighs differently."
+tags:
+  - guide
+  - beginner
+related_cards:
+  - chase-freedom-unlimited
+  - citi-double-cash
+  - capital-one-quicksilver
+  - discover-it-cash-back
+  - wells-fargo-active-cash
+seo_title: "FICO vs VantageScore: Which Score Lenders Use (2026) | CreditOdds"
+seo_description: "How FICO and VantageScore differ, which lenders use which model, why your Credit Karma score isn't what your lender sees, and what each model weighs."
+social_title: "FICO vs VantageScore"
+content: |
+  Open Credit Karma. Open Experian. Check your Chase app. Three different credit scores. Sometimes 30+ points apart. All correct. All from real scoring models. None of them necessarily matches what a lender will pull when you apply for a credit card or mortgage.
+
+  This is the most confusing part of credit for most consumers, and the credit-scoring industry has done little to clarify it. Here's the actual landscape: which scores exist, which lenders use which, and why your free score is often **higher** than your real score.
+
+  ## The Two Big Players
+
+  ### FICO
+  Developed by Fair Isaac Corporation in 1989. The dominant scoring model for lending decisions. **Used by ~90% of major lenders** for credit cards, mortgages, and auto loans.
+
+  Range: 300–850. Sub-models exist for different products:
+
+  - **FICO 8** — most common general-purpose score
+  - **FICO 9** — newer model, used by some lenders
+  - **FICO Auto Score 8 / 9** — auto-loan-specific, weights auto-loan history more heavily
+  - **FICO Bankcard Score 8 / 9** — credit-card-specific, weights credit-card history more heavily
+  - **FICO 2 / 4 / 5** — older models still used for mortgages by Fannie Mae and Freddie Mac
+
+  Yes, you can have a different FICO score for credit cards vs auto loans vs mortgages, even on the same day, because each model weighs your file slightly differently.
+
+  ### VantageScore
+  Developed in 2006 by the three credit bureaus jointly (Equifax, Experian, TransUnion) as an alternative to FICO. Range: 300–850 (matched to FICO for easier consumer comprehension, though originally 501–990).
+
+  Versions:
+
+  - **VantageScore 3.0** — most common version on free credit apps (Credit Karma, Credit Sesame)
+  - **VantageScore 4.0** — newer, more lenient on alternative data (rent payments, utility bills)
+
+  VantageScore is **growing in lender adoption** but still trails FICO. Most credit card and mortgage decisions in 2026 still use FICO.
+
+  ## Why Your Free Score Differs From Your Real Score
+
+  Most "free credit score" apps (Credit Karma, Credit Sesame, Mint, your bank's free score offer) show you a **VantageScore**, not a FICO. This is because VantageScore licensing is cheaper and the licensing terms allow free distribution to consumers.
+
+  When you actually apply for a credit card, the lender pulls a **FICO score** — typically FICO 8 or FICO Bankcard 8. That number can be:
+
+  - **30+ points higher** than your VantageScore (less common but happens)
+  - **30+ points lower** than your VantageScore (more common, especially with newer accounts or recent inquiries)
+
+  The differences come from:
+
+  1. **Different weighting**. FICO weighs payment history at 35% and amounts owed at 30%. VantageScore weighs payment history less heavily and considers more factors.
+  2. **Different treatment of certain events**. FICO penalizes a single late payment more than VantageScore does. VantageScore penalizes high utilization more than FICO.
+  3. **Different thresholds for "established" credit**. FICO requires 6 months of credit history before generating a score. VantageScore can generate a score after just 1 month.
+  4. **Different models per bureau**. Credit Karma's TransUnion and Equifax VantageScores can differ from each other by 20+ points based on which bureau has more recent updates.
+
+  This is why you see "I have a 740 on Credit Karma but got declined for a Sapphire Preferred" stories. The 740 is a VantageScore. The lender pulled a FICO Bankcard 8, which might have been 690 — below the typical Sapphire Preferred approval threshold.
+
+  ## Which Lenders Use Which
+
+  As of mid-2026:
+
+  ### Credit card issuers (almost all use FICO)
+  - **Chase**: FICO 8 (sometimes FICO 9)
+  - **American Express**: FICO 8 + Amex's internal scoring
+  - **Capital One**: FICO 8 + Capital One's internal scoring
+  - **Citi**: FICO 8
+  - **Bank of America**: FICO 8
+  - **Discover**: FICO 8
+  - **Wells Fargo**: FICO 8
+  - **U.S. Bank**: FICO 8
+  - **Synchrony / Comenity**: FICO 8 or FICO Bankcard 8
+
+  ### Mortgages (older FICO versions)
+  - **Most conventional mortgages (Fannie Mae / Freddie Mac)**: FICO 2 + FICO 4 + FICO 5 (one per bureau, lender uses middle of three)
+  - **FHA loans**: Same FICO 2/4/5 model
+  - **VA loans**: Same FICO 2/4/5 model
+  - **Some non-conforming mortgages**: FICO 8 or FICO 9
+
+  Mortgage scoring is the slowest-changing segment of consumer credit. Until Fannie/Freddie modernize (a multi-year process underway), most home buyers will have their score evaluated using FICO models from the early 2000s.
+
+  ### Auto loans
+  - **Most auto lenders**: FICO Auto Score 8 or 9
+  - **Captive lenders (manufacturer financing)**: FICO Auto + their internal models
+
+  ### Personal loans / fintech lenders
+  - **Most**: FICO 8 or 9
+  - **Some newer fintechs**: VantageScore 3.0 or 4.0 (especially those targeting thinner-file applicants)
+
+  ### Apartment rentals
+  - **Many**: VantageScore (because it's cheaper for landlords to license)
+  - **Some**: FICO
+
+  ### Insurance underwriting
+  - **Most**: Insurance-specific scoring models (LexisNexis, etc.) — different from FICO and VantageScore
+
+  ## What Each Model Weighs
+
+  ### FICO 8 weights
+  - Payment history: 35%
+  - Amounts owed (utilization): 30%
+  - Length of credit history: 15%
+  - Credit mix: 10%
+  - New credit: 10%
+
+  ### VantageScore 3.0 weights (per VantageScore's documentation)
+  - Payment history: ~40%
+  - Age and type of credit: ~21%
+  - Credit utilization: ~20%
+  - Total balances/debt: ~11%
+  - Recent credit behavior: ~5%
+  - Available credit: ~3%
+
+  Practical differences:
+
+  - **VantageScore weighs payment history slightly more** than FICO
+  - **FICO weighs utilization slightly more** than VantageScore
+  - **VantageScore is more lenient on thin files** — generates a score earlier in your credit life
+  - **FICO is more punitive on late payments** — a single 30-day late costs more on FICO than on VantageScore
+  - **VantageScore 4.0 includes alternative data** (rent payments, utility bills) when reported, FICO 8/9 typically does not
+
+  ## Where to Get Your Real FICO Score
+
+  Free options:
+
+  - **Bank apps**: Most major issuers now provide a real FICO 8 score for free in their app or online dashboard. Chase shows VantageScore 3.0 (Credit Journey). Discover shows real FICO 8. Citi shows real FICO 8. Capital One CreditWise shows VantageScore 3.0.
+  - **Annual credit reports**: At [annualcreditreport.com](https://www.annualcreditreport.com), you get free credit reports (not scores) from all three bureaus weekly. Bureau-direct paid options ($20–$30/month) include real FICO scores.
+
+  Paid options:
+
+  - **MyFICO.com**: $20–$40/month, gives you all FICO sub-scores (8, 9, Bankcard, Auto, Mortgage) across all three bureaus. Best paid option for serious credit monitors.
+  - **Experian, Equifax, TransUnion direct**: Various subscription tiers, typically include FICO 8 + VantageScore + monitoring.
+
+  Practical recommendation: rely on your **issuer's free FICO score** (Discover, Citi, Bank of America, Amex, etc. all provide it) for general monitoring. Subscribe to MyFICO temporarily before a major credit event (mortgage application, large purchase) to see all your sub-scores.
+
+  ## Score Tiers and What They Unlock
+
+  Roughly applicable to FICO scoring across major lenders:
+
+  | Tier | Range | Cards typically eligible |
+  |---|---|---|
+  | Exceptional | 800+ | Anything, with maximum credit limits |
+  | Very Good | 740–799 | Most premium cards (Sapphire Reserve, Amex Platinum, Venture X) |
+  | Good | 670–739 | Most mainstream cards (Sapphire Preferred, Amex Gold, Venture, BofA Premium) |
+  | Fair | 580–669 | Starter cards, secured cards, some mid-tier cards |
+  | Poor | <580 | Secured cards primarily |
+
+  These thresholds aren't hard cutoffs at every issuer — Chase Sapphire Reserve approvals at 720 happen, and Amex Gold approvals at 680 happen. But the broad pattern holds.
+
+  ## Score Volatility and Reporting Cycles
+
+  Your FICO score updates each time a creditor reports new data to a bureau. Most issuers report monthly, around the time your statement closes. So your score can move:
+
+  - 5–20 points up or down in a single month based on utilization changes
+  - 10–30 points down from a single new account opening (inquiry + new account)
+  - 50–100+ points down from a single 30-day late payment
+
+  Day-to-day volatility is normal and not concerning. Persistent downward trends should prompt investigation.
+
+  ## How to Optimize for Both Models
+
+  Most behaviors that boost FICO also boost VantageScore. The differences are minor enough that you don't need separate strategies. Universal optimization:
+
+  1. **Pay every bill on time, every time.** Both models weigh payment history heaviest.
+  2. **Keep utilization under 10% reported.** Both models reward low utilization.
+  3. **Hold accounts long-term.** Both models reward account age.
+  4. **Don't open too many new accounts in short windows.** Both models penalize new-credit velocity.
+  5. **Pay down balances before statements close** to control reported numbers. See our [statement balance article](/articles/statement-balance-vs-current-balance).
+
+  The few differences that matter:
+
+  - **VantageScore is more forgiving of thin files** — if you're new to credit, VantageScore may show a higher number than FICO. Use VantageScore as a "directional" gauge but expect FICO to be lower.
+  - **FICO is harder on late payments** — if you have a recent late, your FICO will recover slower than your VantageScore.
+
+  ## FAQ
+
+  ### Why does my Credit Karma score differ from my actual lender's score?
+  Credit Karma shows VantageScore 3.0. Most lenders use FICO 8. The two models can differ by 20–50+ points on the same file.
+
+  ### Which score is the "right" one?
+  The one your lender will pull. For credit cards: FICO 8. For mortgages: FICO 2/4/5. For auto: FICO Auto 8 or 9. There's no single "right" score — it depends on the application context.
+
+  ### Why does my FICO score differ across bureaus?
+  Because each bureau (Experian, Equifax, TransUnion) maintains your file slightly differently. Reporting timing varies, some accounts report to only 1 or 2 bureaus, and disputes can be resolved at one bureau but not another. Multi-bureau differences of 10–30 points are common.
+
+  ### How often does my FICO score update?
+  Whenever a creditor reports new data to the bureaus. Most credit card issuers report monthly, around your statement close. So your FICO score on each bureau updates roughly monthly.
+
+  ### Will checking my own credit hurt my score?
+  No. Pulling your own credit through any consumer-facing service (Credit Karma, Experian, your bank app, annualcreditreport.com) is always a soft pull, no score impact.
+
+  ### Why is my Credit Karma TransUnion score different from my Credit Karma Equifax score?
+  Same reason as above — Credit Karma pulls separately from each bureau, and the underlying bureau files differ in timing and content. Plus, both are VantageScores but each is computed on different bureau data.
+
+  ### What FICO score do mortgage lenders use?
+  Most conventional mortgages use FICO 2/4/5 (one per bureau, lender takes middle of three). Some non-conforming or jumbo mortgages use FICO 8 or 9.
+
+  ### Should I pay for MyFICO?
+  For routine monitoring, no — your bank's free FICO score is enough. Before major credit events (mortgage in next 6 months, large auto loan), subscribing to MyFICO for a few months gives you visibility into all sub-scores and is worth the $80–$160 spend.
+
+  ### Why does my score drop when I pay off a credit card?
+  Sometimes the bureaus see "balance reported" go from $5K to $0 and trigger a small temporary score change because the file looks like it has less active recent credit use. The effect usually reverses within a month as the next reporting cycle arrives.
+
+  ### Does paying off a credit card balance to $0 always help my score?
+  Almost always. The exception is if doing so leaves your overall file showing 0% utilization across all cards — some scoring models slightly penalize 0% as "no recent activity." If you're optimizing precisely, leave 1–5% reported on at least one card.
+
+  ## The Bottom Line
+
+  FICO and VantageScore are different models built for different purposes by different organizations. Three rules:
+
+  1. **Lenders use FICO.** The score that matters for credit card or mortgage approvals is FICO 8 (cards), FICO 2/4/5 (mortgages), or FICO Auto (auto loans).
+  2. **Free apps usually show VantageScore.** Credit Karma, Capital One CreditWise, and many bank-provided "credit health" tools show VantageScore. Use them as directional indicators, not as a precise predictor of lender outcomes.
+  3. **Most issuer apps now show real FICO 8.** Discover, Citi, Bank of America, American Express, and several others provide your actual FICO 8 score for free in-app. Use those for the most accurate read on what a credit card lender will see.
+
+  The day-to-day optimization is the same regardless of model: pay on time, keep utilization low, hold accounts long-term, don't apply too fast. Get those right and both your FICO and your VantageScore will sit comfortably in the "very good" or "exceptional" tier.

--- a/data/articles/drafts/foreign-transaction-fees.yaml
+++ b/data/articles/drafts/foreign-transaction-fees.yaml
@@ -1,0 +1,207 @@
+id: "foreign-transaction-fees"
+slug: "foreign-transaction-fees"
+title: "Foreign Transaction Fees: Which Cards Waive Them, and Why 'No FTF' Cards Can Still Cost You Abroad"
+date: "2026-07-16"
+author: "CreditOdds"
+summary: "What foreign transaction fees actually are, which cards have them and which don't, the dynamic-currency-conversion trap, and the no-FTF picks for international travelers."
+tags:
+  - guide
+  - beginner
+related_cards:
+  - chase-sapphire-preferred
+  - capital-one-venture-rewards
+  - capital-one-venture-x
+  - american-express-gold-card
+  - capital-one-savorone
+  - bank-of-america-travel-rewards
+seo_title: "Foreign Transaction Fees: Which Cards Waive Them (2026) | CreditOdds"
+seo_description: "Which credit cards charge foreign transaction fees, which waive them entirely, the dynamic currency conversion trap, and the best no-FTF cards for international travel."
+social_title: "Foreign Transaction Fees, Decoded"
+content: |
+  A foreign transaction fee (FTF) is a 2–3% surcharge that some credit cards add to any transaction processed outside the United States — including online purchases from foreign merchants, even if you never leave home. For frequent travelers and people who buy regularly from international online retailers, the fee can quietly add hundreds of dollars per year.
+
+  More confusingly: even cards that **don't charge FTFs** can still cost you abroad if you fall into the dynamic-currency-conversion trap or use the wrong card on the wrong network. Here's what's really going on, which cards waive FTFs, and how to actually avoid foreign-transaction costs altogether.
+
+  ## What a Foreign Transaction Fee Actually Is
+
+  When you swipe a US credit card overseas (or buy online from a foreign merchant), the transaction is processed through your card's payment network (Visa, Mastercard, Amex, Discover) and converted from the local currency to USD. The conversion happens at the network's daily exchange rate, which is generally close to the mid-market rate.
+
+  The **foreign transaction fee** is an additional charge layered on top of the conversion by your card issuer. It typically ranges from 1% to 3% (most commonly 3%). It's separate from any currency conversion fee built into the network's exchange rate.
+
+  Two distinct components on most foreign transactions:
+
+  - **Network conversion** (Visa, Mastercard, Amex, Discover): Fair market rate plus a tiny network fee, typically negligible
+  - **Issuer foreign transaction fee**: 1–3% surcharge added by your card issuer, on top of the converted amount
+
+  The first one is unavoidable on any international transaction. The second one is **completely optional** — it depends on which card you use.
+
+  ## Cards That Don't Charge Foreign Transaction Fees
+
+  This list isn't comprehensive but covers most of the popular options:
+
+  ### No FTF, no annual fee
+  - **Capital One QuicksilverOne** ($39 AF — counts as "low fee," still waives FTF)
+  - **Capital One SavorOne** (no AF)
+  - **Capital One VentureOne** (no AF)
+  - **Discover It Cash Back** (no AF — but Discover acceptance abroad is poor; see below)
+  - **Bank of America Travel Rewards** (no AF)
+  - **Wells Fargo Active Cash** (no AF — verify; some Wells cards charge FTF)
+  - **Bilt Mastercard** (no AF)
+
+  ### No FTF, with annual fee
+  - **Chase Sapphire Preferred** ($95 AF)
+  - **Chase Sapphire Reserve** ($550 AF)
+  - **Chase Ink Business Preferred** ($95 AF) and other Chase Ink business cards
+  - **American Express Gold Card** ($325 AF)
+  - **American Express Platinum Card** ($695 AF)
+  - **Capital One Venture Rewards** ($95 AF)
+  - **Capital One Venture X** ($395 AF)
+  - **Citi Strata Premier** ($95 AF)
+  - **Bank of America Premium Rewards** ($95 AF)
+  - **Bank of America Premium Rewards Elite** ($550 AF)
+
+  ### Cards that DO charge FTF (typically 3%)
+  - **Citi Double Cash** (charges 3% FTF — surprises many; Double Cash is otherwise fantastic)
+  - **Wells Fargo Active Cash** in some configurations (verify with your specific card)
+  - **Most store credit cards** (Synchrony, Comenity)
+  - **Most basic Bank of America cash-back cards** (Customized Cash Rewards, Unlimited Cash Rewards, Cash Rewards Secured)
+  - **Most Chase Freedom and basic Chase cards** (Freedom Flex, Freedom Unlimited — yes, even though Sapphire is FTF-free, the Freedom cards are not)
+
+  This last group is the trap: many people assume their primary daily-driver no-fee card (Citi Double Cash, Chase Freedom Unlimited) waives FTF when it doesn't. Always verify before traveling.
+
+  ## The Dynamic Currency Conversion Trap
+
+  When you pay with a US card abroad, the merchant's terminal sometimes asks: "Would you like to pay in USD or [local currency]?"
+
+  **Always choose the local currency.**
+
+  If you pay in USD, the merchant's payment processor (not your card issuer's network) handles the currency conversion at a much worse rate — typically 4–7% above the network rate. This is called **dynamic currency conversion (DCC)** and it's the single most expensive trap in international card use.
+
+  By choosing local currency, the conversion happens through Visa/Mastercard/Amex's network at the actual exchange rate, plus only your card's FTF (if any). On a no-FTF card paying in local currency, you pay essentially zero conversion premium.
+
+  Sample math on a €100 charge:
+
+  - Pay in EUR (no DCC), no-FTF card: ~$108 USD (network rate, no fees)
+  - Pay in USD (DCC), no-FTF card: ~$112 USD (DCC adds ~4%)
+  - Pay in EUR (no DCC), 3% FTF card: ~$111 USD (network rate + 3% FTF)
+  - Pay in USD (DCC), 3% FTF card: ~$115 USD (DCC + FTF — worst case)
+
+  **Always say "local currency" or "EUR" / "GBP" / "JPY" when prompted.** The merchant's display sometimes makes USD the default — actively decline.
+
+  ## Network Acceptance Abroad
+
+  US-issued cards work on five major networks, with very different international acceptance:
+
+  ### Visa
+  Best international acceptance. Works in nearly every country and merchant that accepts cards. Default first choice for international travel.
+
+  ### Mastercard
+  Nearly equivalent to Visa internationally. Some merchants accept one but not the other; the difference is small.
+
+  ### American Express
+  Strong in major US-tourist destinations (Western Europe, Japan, popular vacation spots) but spotty in many other countries (rural areas, much of South America, parts of Asia, Africa). Don't rely on Amex as your only card abroad.
+
+  ### Discover
+  Limited international acceptance. Discover has partnerships with networks in some countries (Diners Club, BC Card in Korea, JCB in Japan, RuPay in India), but coverage is uneven. Don't rely on Discover for primary international use.
+
+  ### UnionPay
+  Common in China; cards backed by other networks (especially Discover/Diners) sometimes work via UnionPay reciprocity.
+
+  Practical recommendation: carry at least one Visa or Mastercard for international trips, plus an Amex as backup if you have one. Don't rely on a Discover-only wallet.
+
+  ## EMV Chip and PIN Compatibility
+
+  Most US credit cards default to **chip-and-signature** authorization. Most foreign automated systems (train ticket machines, gas pumps, parking meters in Europe and Asia) require **chip-and-PIN**. Without a PIN, those automated transactions fail.
+
+  Some US cards support chip-and-PIN by default (including most Capital One, Bank of America, and US Bank cards). Others don't (most Chase, Amex, and Citi cards default to signature).
+
+  Workarounds:
+
+  - Set up a **PIN** on your card before traveling. Even cards that don't natively chip-and-PIN often have an issuer-set "cash advance PIN" that works on automated machines abroad. Call your issuer and ask: "Can you set a PIN on my [card] for use on automated terminals in [country]?"
+  - Carry at least one card known to support chip-and-PIN as a backup
+  - For automated rail/transit systems: use cash or a chip-and-PIN card; signature cards often don't work
+
+  ## How to Choose a No-FTF Card for Travel
+
+  ### If you want a single primary travel card
+  **Chase Sapphire Preferred** ($95 AF): Best balance of rewards, no FTF, broad Visa acceptance, and no-FTF behavior. The most-recommended single travel card.
+
+  Alternative: **Capital One Venture X** ($395 AF) for premium travel — the $300 travel credit and 10K anniversary miles roughly cover the AF, plus comprehensive travel benefits and no FTF.
+
+  ### If you want no annual fee
+  **Capital One SavorOne** or **VentureOne** are the strongest no-AF, no-FTF options. Bilt Mastercard is also strong, especially for renters. Bank of America Travel Rewards is decent if you have a Preferred Rewards relationship.
+
+  ### If you want premium travel benefits
+  **Chase Sapphire Reserve** ($550) or **Amex Platinum** ($695) — both no FTF, both with extensive travel benefits and lounge access. See our [annual fee math article](/articles/annual-fee-math) for whether the AF makes sense for your travel patterns.
+
+  ### If you want flat 2% on all spend abroad
+  **Capital One Venture Rewards** ($95 AF) — flat 2x miles on all spend, no FTF.
+
+  ## The Hidden Costs Beyond FTF
+
+  Even with no FTF, international card use can have a few less-obvious costs:
+
+  ### 1. Cash advances at foreign ATMs
+  Using your credit card to withdraw cash abroad triggers cash-advance APR (typically 25–30%) and a cash-advance fee (typically 5%). Plus the FTF if your card has one. Avoid using credit cards for foreign ATM withdrawals — use a debit card from a US bank that reimburses ATM fees (Charles Schwab, Fidelity Cash Management).
+
+  ### 2. ATM scams (skimmers, fake ATMs)
+  Common in tourist areas, especially Eastern Europe and Southeast Asia. Use ATMs at major banks; avoid standalone ATMs in tourist districts. Same advice for credit cards: avoid sketchy POS terminals in tourist scams.
+
+  ### 3. Currency holds at hotels and rental cars
+  Hotels and rental car companies often place a **hold** for the estimated total plus a buffer. The hold is in foreign currency. When the actual charge posts later, the original hold (in foreign currency) and the final charge (in foreign currency) are converted separately, sometimes producing minor exchange-rate differences.
+
+  ### 4. Tipping confusion
+  Many countries don't tip the way the US does. Adding a tip to a card that auto-prompts can result in a charge much higher than expected, especially if the prompt is in local currency and you're not paying attention.
+
+  ## Pre-Travel Checklist
+
+  Before any international trip:
+
+  1. **Confirm your card has no FTF.** Check the cardmember terms or your account dashboard.
+  2. **Set a travel notification.** Most issuers have removed the requirement, but it doesn't hurt — a few still flag international charges as fraud without a notification.
+  3. **Set a PIN if needed.** Call your issuer and request a PIN for use on automated terminals.
+  4. **Carry 2+ cards from different networks.** Visa or Mastercard primary; Amex secondary if you have one.
+  5. **Bring a small amount of local currency** for cash-only situations, especially in countries with strong cash culture (Japan, Germany, parts of Italy, much of Eastern Europe).
+  6. **Review your card's travel benefits.** Trip cancellation, lost-luggage coverage, primary rental car insurance — confirm what's included so you know what to claim if needed.
+
+  ## FAQ
+
+  ### Are foreign transaction fees deductible on taxes?
+  Only if the spend was for business purposes. Personal travel FTFs are not deductible.
+
+  ### Do foreign transaction fees apply to online purchases from foreign merchants?
+  Yes. Buying from a UK-based online retailer (in GBP) from a US-based card with a 3% FTF will charge the FTF, even though you never left the US. The fee is based on where the transaction is processed, not where the cardholder is.
+
+  ### What about purchases from US-based platforms that charge in foreign currency?
+  Tricky. Some platforms (Amazon, Apple) bill US customers in USD even on foreign merchants — no FTF. Some (Booking.com, Airbnb) sometimes bill in the merchant's local currency — FTF applies if your card has one. Always check the actual currency on the charge before completing.
+
+  ### Will the merchant's POS terminal show the correct exchange rate?
+  No. The "USD equivalent" displayed during dynamic currency conversion at the terminal is at a worse rate than what the network would charge. Always pay in local currency to use the network's better rate.
+
+  ### Are there cards that pay cash back ON foreign transactions?
+  Yes — most rewards cards earn rewards on foreign transactions just like domestic ones (sometimes at the bonus category multiplier). For example, Sapphire Preferred earns 2x on travel direct, including travel charges in foreign currency.
+
+  ### What if I'm traveling to multiple countries on one trip?
+  Same rules apply across all of them. Use no-FTF cards, pay in local currency, choose Visa or Mastercard for broad acceptance, carry a backup card on a different network.
+
+  ### Do debit cards have foreign transaction fees too?
+  Yes, most do (1–3%). Some debit cards waive FTF (Charles Schwab Investor Checking, Fidelity Cash Management, Capital One 360 Checking) and reimburse ATM fees globally. These are ideal for travel cash needs.
+
+  ### Will my US card work in countries that primarily use cash?
+  In countries with strong cash cultures (Japan, Germany), card acceptance can be limited at smaller establishments. Restaurants, hotels, and major retailers in tourist areas usually accept cards. Smaller merchants, transit, and family-run businesses often don't. Carry local cash for those.
+
+  ### What's the worst case for foreign transaction costs?
+  3% FTF + DCC (4–7% at the worst) + bad network = up to 10% above the actual cost. On a $1,000 abroad spend, this can mean $80–$100 in fees that a no-FTF card paying in local currency would have avoided entirely.
+
+  ### Does my no-FTF card protect me from currency fluctuations?
+  No. The conversion happens at the time the transaction posts. If exchange rates move between the swipe and the post (typically 1–3 days later), your USD charge can differ slightly from what the local price would suggest.
+
+  ## The Bottom Line
+
+  Foreign transaction fees are real money quietly leaving your wallet — and they're 100% avoidable with the right card choice. Three rules:
+
+  1. **Use a no-FTF card for every international purchase.** Online or in-person, whether you're abroad or buying from a foreign merchant. Sapphire Preferred, Venture, or any of the no-FTF picks above.
+  2. **Pay in local currency.** Always. Decline dynamic currency conversion when prompted. The "USD equivalent" displayed at the terminal is always worse than the network rate.
+  3. **Carry at least one Visa or Mastercard** as your primary international card. Amex is fine as backup; Discover should not be relied on alone abroad.
+
+  Done right, foreign transaction costs effectively vanish — your card works abroad as if you're at home, and you collect rewards on the spend just like any other purchase. Done wrong, you pay 5–10% on every international charge for years without realizing it.

--- a/data/articles/drafts/hard-inquiries-explained.yaml
+++ b/data/articles/drafts/hard-inquiries-explained.yaml
@@ -1,0 +1,182 @@
+id: "hard-inquiries-explained"
+slug: "hard-inquiries-explained"
+title: "Hard Inquiries Explained: How Much They Hurt, How Long They Last, and the Real Recovery Timeline"
+date: "2026-05-11"
+author: "CreditOdds"
+summary: "What a hard pull actually does to your score, how long it lingers, which lenders use which bureau, and the rules that let multiple inquiries count as one."
+tags:
+  - guide
+  - beginner
+  - strategy
+related_cards:
+  - chase-sapphire-preferred
+  - capital-one-venture-rewards
+  - american-express-gold-card
+  - citi-double-cash
+  - discover-it-cash-back
+seo_title: "Hard Inquiries Explained: Score Impact + Timeline (2026) | CreditOdds"
+seo_description: "How much a hard pull hurts your credit (typically 3–8 points), how long it stays on your report (2 years), and the rate-shopping rules that let multiple inquiries count as one."
+social_title: "Hard Inquiries: How Much They Actually Hurt"
+content: |
+  Every time you apply for a credit card, an auto loan, or a mortgage, the lender pulls your credit. That pull — called a **hard inquiry** or **hard pull** — leaves a mark on your credit report that lasts for two years and dings your score for one.
+
+  Most people overestimate how badly hard inquiries hurt them. A few people underestimate it. Both are working from the same source: vague advice that was already out of date a decade ago. Here's what actually happens to your score, your report, and your approval odds when a lender pulls your credit in 2026.
+
+  ## What a Hard Inquiry Actually Is
+
+  A hard inquiry is a request from a lender to one of the three major credit bureaus (Equifax, Experian, TransUnion) to retrieve your full credit report — including your score, your account list, your payment history, and your existing inquiries. The lender pays the bureau a fee for the report and is required by law to have a "permissible purpose" — almost always, that purpose is your application for new credit.
+
+  Hard inquiries are different from **soft inquiries** in three important ways:
+
+  - **Soft pulls don't affect your score.** Hard pulls do.
+  - **Soft pulls aren't visible to other lenders.** Hard pulls show up on your report for two years and are visible to anyone who pulls your credit.
+  - **Soft pulls don't require your active permission for each pull.** Hard pulls do — when you click "submit application," you're authorizing the hard pull.
+
+  Things that trigger soft pulls (no score impact): checking your own credit, pre-qualification tools, employer background checks, account reviews by lenders you already have a relationship with, and most insurance quotes.
+
+  Things that trigger hard pulls: credit card applications, auto loan applications, mortgage applications, personal loan applications, and (sometimes) credit limit increase requests.
+
+  ## How Much a Hard Inquiry Actually Hurts Your Score
+
+  The honest answer most blogs won't give you: **3 to 8 points per inquiry, for most people, recovered fully within 6 to 12 months.**
+
+  Some specifics:
+
+  - **Thin file (under 5 accounts, under 2 years of history)**: A single inquiry can drop your score by 10–15 points. The bureaus have less data to weigh against the new-credit signal, so each inquiry carries more weight.
+  - **Average file (5–15 accounts, 2–7 years of history)**: 5–8 points per inquiry, typically.
+  - **Thick file (15+ accounts, 7+ years of history)**: 3–5 points per inquiry. Sometimes none — if your file is robust enough, FICO and VantageScore models barely register a single new inquiry.
+
+  These are the **score** impacts. The **approval-decision** impact is separate, and often bigger. Issuers look at the raw inquiry count on your report, not just the score:
+
+  - Most issuers won't blink at 1–2 inquiries in the past 6 months
+  - 3–5 in the past 6 months starts to draw flags from conservative issuers
+  - 6+ in the past 6 months will cause auto-declines at some banks regardless of your score
+
+  This is why, in the credit-card world, the "5/24 rule" and similar issuer-specific rules matter more than the raw point hit. We have a separate piece on [the Chase 5/24 rule](/articles/chase-5-24-rule-explained) — but the underlying principle is: lenders care less about a few points off your score and more about the pattern of how many cards you're seeking how fast.
+
+  ## How Long They Stick Around
+
+  Two timelines, and they're different:
+
+  - **Score impact: ~12 months.** After about a year, FICO and VantageScore models stop counting the inquiry against your score. The point hit goes away on its own.
+  - **Visibility on your report: 2 years.** The inquiry stays listed on your credit report for 24 months from the date of the pull, even though it stops affecting your score after 12. New lenders pulling your credit can see it during this entire window.
+
+  This second window matters because of those issuer-specific rules. Chase doesn't just look at your score — they look at how many new accounts you've opened in the last 24 months. The same is true at Bank of America (with their 2/3/4 rule), Citi (with their family-of-cards bonus rules), and several others. **Inquiries you "stopped paying for" in your score can still cost you approvals.**
+
+  ## Which Bureau a Lender Pulls (And Why You Should Care)
+
+  All three bureaus carry roughly the same data on you, but not exactly the same data. Each lender has a habit of pulling from one or two specific bureaus depending on your state, the product you're applying for, and the lender's internal cost-of-data agreements.
+
+  Rough patterns by major issuer (these change, but as of mid-2026):
+
+  - **Chase**: Most often Experian, sometimes Equifax
+  - **American Express**: Almost always Experian
+  - **Capital One**: Pulls all three bureaus on most applications (yes, really — three hard inquiries from one application)
+  - **Citi**: Equifax in most states, occasionally Experian
+  - **Bank of America**: TransUnion in most states, sometimes Experian
+  - **Discover**: TransUnion most often
+  - **Wells Fargo**: Experian most commonly
+
+  Why this matters: if you know your strongest score is on TransUnion and your application is going to Bank of America, you have a small advantage. If you can find out which bureau a lender pulls in your state (CreditBoards.com keeps a community-maintained data point database for this), you can sometimes time applications around recent inquiries on a specific bureau to keep your strongest one fresh.
+
+  Capital One is the outlier worth flagging: their **triple-pull** behavior is rare and aggressive. If you apply for one Capital One card, expect three hard inquiries on your report. If you apply for two Capital One cards on the same day, that's six inquiries. This is a major reason to be deliberate about Capital One applications.
+
+  ## Rate Shopping: When Multiple Inquiries Count as One
+
+  Here's the rule that saves people thousands of dollars on mortgages and car loans, and that almost no one knows: **multiple inquiries of the same type within a short window count as a single inquiry for scoring purposes.**
+
+  This is called **rate shopping** or **deduplication**, and it applies to:
+
+  - **Auto loans**: All inquiries within a 14- to 45-day window (depending on the FICO model) count as one
+  - **Mortgages**: Same window — 14 to 45 days, all inquiries count as one
+  - **Student loans**: Same treatment
+
+  This is **only for installment loans where shopping around is expected**. Credit card inquiries are NOT deduplicated — every credit card hard pull is its own inquiry that counts separately.
+
+  Practical takeaway: if you're shopping for a mortgage or auto loan, get all your rate quotes within a 2-week window. You'll get one inquiry on your report regardless of how many lenders you talked to. Spread them out over 60 days and each one becomes a separate hit.
+
+  ## The Inquiry-Reduction Strategies That Actually Work
+
+  ### 1. Use soft-pull pre-qualification before applying
+
+  Most major issuers (Capital One, Discover, American Express, Citi, Chase) have prequalification tools that do soft pulls. These tell you whether you'd likely be approved before you trigger a hard inquiry. We have a separate piece on [pre-approval vs pre-qualification](/articles/pre-approval-vs-pre-qualification) covering which tools are reliable and which are mostly marketing.
+
+  Pre-qualification isn't a guarantee of approval — but a decline at the prequal stage is a near-guarantee that you'd be denied if you applied. Treat it as a free filter.
+
+  ### 2. Time applications strategically
+
+  If you know you'll apply for multiple cards in the next 12 months, group them. The point hit from inquiry #2 happens whether it's two days after #1 or two months after — but the score recovery from #1 has already started by month 6, so a cluster early in the year and silence afterward looks better at year-end than a steady drip.
+
+  More importantly: **don't apply within 30 days of any major credit event** (mortgage application, auto loan, refinance). The fresh inquiry will drag your score and possibly your approval terms.
+
+  ### 3. Avoid Capital One when you can't afford three inquiries
+
+  As above — Capital One pulls all three bureaus. If you have only one or two inquiries to spare on a given bureau before you'd hit an internal threshold at another issuer, applying for a Capital One card spends three of them at once.
+
+  ### 4. Don't apply for store cards on impulse
+
+  The cashier offering 15% off your purchase if you open a card right now is asking you to sacrifice 5 points of credit score for a discount. Maybe worth it for a $2,000 furniture purchase. Almost never worth it for $80 of clothes.
+
+  ### 5. Wait 6 months between credit card applications when possible
+
+  Six months is the rough natural recovery window for the inquiry's worst point hit. Spacing applications six months apart keeps your inquiry count low at any given moment, which keeps you below the trigger thresholds at most issuers.
+
+  ## Disputing a Hard Inquiry
+
+  You can dispute a hard inquiry, but only on specific grounds:
+
+  - **It's fraudulent.** You didn't authorize it. Someone else applied for credit using your information.
+  - **The lender pulled the wrong type.** They were supposed to do a soft pull (e.g., for a credit limit increase or pre-qualification check) and instead did a hard pull.
+  - **Duplicate.** The same lender pulled twice for one application.
+
+  You **cannot** dispute a hard inquiry just because you don't want it on your report. "I changed my mind" or "the application was denied" don't qualify — once you authorize a pull, it's there.
+
+  To dispute: file directly with the bureau (Experian, Equifax, TransUnion all have online dispute portals) and provide documentation. Disputes typically resolve in 30 days. If the bureau confirms the inquiry was unauthorized, it's removed and your score recalculates without it.
+
+  ## How Hard Inquiries Affect Approval Odds
+
+  Beyond the score impact, hard inquiries affect your odds of approval through three mechanisms:
+
+  1. **Issuer-specific velocity rules** — Chase 5/24, BoA 2/3/4, Citi's various 6/24 and 24-month rules, etc.
+  2. **Internal scoring models** — many issuers have their own scorecards that weigh recent inquiries more heavily than FICO does, especially for premium cards
+  3. **Manual underwriting flags** — at higher card tiers (Sapphire Reserve, Amex Platinum), human underwriters review applications and may decline based on inquiry patterns even when the score and income would otherwise approve
+
+  This is why our [check-odds tool](/check-odds) factors recent inquiries directly — it's one of the strongest predictors of approval after score and income.
+
+  ## FAQ
+
+  ### How many hard inquiries are too many?
+  For score impact: 5+ in 6 months starts costing you meaningful points beyond the per-inquiry hit, because the cumulative pattern is itself a risk signal. For approval odds: depends on the issuer. Chase auto-declines at 5+ new accounts in 24 months. Most other issuers tolerate up to 5–6 inquiries in 6 months but get nervous past that.
+
+  ### Does checking my own credit count as a hard inquiry?
+  No. Checking your own credit through Credit Karma, Experian, your card's free score feature, or any of the official annualcreditreport.com pulls is always a soft inquiry. Pull your own credit as often as you want with no score impact.
+
+  ### Do hard inquiries hurt your score for the full 2 years they're on your report?
+  No. Score impact fades completely after about 12 months. The remaining year on your report is visibility-only — lenders can still see the inquiry, but it stops moving your score.
+
+  ### Can I be approved for a card despite a recent hard inquiry?
+  Yes, often. A single recent inquiry rarely tanks an application. Issuers care more about the cumulative inquiry count and the pattern. One inquiry from last week is fine. Six inquiries from the last six weeks is a problem.
+
+  ### Do credit limit increase requests cause a hard inquiry?
+  It depends on the issuer. Capital One, Citi, and Bank of America typically use soft pulls for CLI requests. Chase, American Express, and Wells Fargo typically use hard pulls. Always ask before submitting the request — most issuer reps will tell you which type of pull they use.
+
+  ### What about pre-approval offers in the mail or online?
+  Pre-approval offers are based on soft pulls — the issuer pulled a basic version of your credit through their internal pre-screening process. Accepting the offer and submitting the actual application triggers the hard pull. The pre-approval is a strong signal you'll be approved, but it's not a guarantee.
+
+  ### Are hard inquiries the same on FICO and VantageScore?
+  Both penalize hard inquiries, but VantageScore is slightly more lenient on inquiry count and slightly more aggressive on rate-shopping deduplication (treating shopping windows as one inquiry across more loan types). For credit card applications, the impact is similar across both models.
+
+  ### What's the worst possible inquiry behavior for approval odds?
+  Applying for multiple credit cards on the same day or within the same week, especially across different issuers. This pattern — sometimes called "app spree" — used to be a popular hack but now triggers near-instant declines at most major issuers. Their fraud and risk systems flag the pattern in real time and decline pending applications even when individual ones would have been approved.
+
+  ## The Bottom Line
+
+  Hard inquiries are a real cost, but they're a small one — usually 3–8 points, recovered in a year. The bigger cost is the **velocity** signal they send to issuers, which can affect your approval odds for two full years even after the score impact has faded.
+
+  Three rules cover 90% of what you need to do:
+
+  1. **Use soft-pull pre-qualification tools before applying.** Filter declines for free.
+  2. **Group rate-shopping inquiries within 14 days** for mortgages and auto loans — they count as one.
+  3. **Space credit card applications 6 months apart** unless you have a specific reason and the headroom to absorb a cluster.
+
+  Get those right and inquiries become a non-issue. Ignore them and you'll spend a year wondering why your applications keep getting declined despite a "good" score.

--- a/data/articles/drafts/how-many-credit-cards-is-too-many.yaml
+++ b/data/articles/drafts/how-many-credit-cards-is-too-many.yaml
@@ -1,0 +1,214 @@
+id: "how-many-credit-cards-is-too-many"
+slug: "how-many-credit-cards-is-too-many"
+title: "How Many Credit Cards Is Too Many? What Actually Happens to Your Score, Your Approvals, and Your Life"
+date: "2026-06-08"
+author: "CreditOdds"
+summary: "The real score impact of holding many cards, the velocity rules that matter more than total count, and how to know when you've hit your personal limit."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-freedom-unlimited
+  - citi-double-cash
+  - capital-one-savorone
+  - american-express-gold-card
+  - discover-it-cash-back
+seo_title: "How Many Credit Cards Is Too Many? (2026) | CreditOdds"
+seo_description: "What happens to your credit score and approval odds as you accumulate cards, why velocity matters more than total count, and how to know when you've hit your limit."
+social_title: "How Many Credit Cards Is Too Many?"
+content: |
+  The standard advice — "two or three cards is enough for most people" — is wrong in both directions. It's too low for anyone seriously optimizing rewards, and the underlying logic (more cards = lower score) is mostly false.
+
+  The real answer is more nuanced: **your total card count barely affects your credit score.** What affects your score, your approvals, and your sanity are different things — velocity, utilization, account age, and how many cards you can actually keep track of. Here's the breakdown.
+
+  ## What FICO Actually Looks At
+
+  Your FICO score is built from five factors:
+
+  - **Payment history (35%)**: Did you pay on time?
+  - **Amounts owed (30%)**: Your utilization, plus total balances
+  - **Length of credit history (15%)**: Average and oldest account age
+  - **Credit mix (10%)**: Variety of credit types (revolving, installment, mortgage)
+  - **New credit (10%)**: Recent inquiries and recent account openings
+
+  Total card count is **not** a direct factor. The number of open credit cards you have shows up in the score only indirectly:
+
+  - More cards generally means more total credit limit → lower utilization → better score
+  - More cards generally means more accounts in your file → potentially older average age (good) or younger (bad), depending on how recently you opened them
+  - More cards means more potential for missed payments → score risk
+
+  Holding 15 cards with clean history and low utilization will produce a higher score than holding 3 cards with high utilization. The number isn't the issue — the behavior is.
+
+  ## Where the "Too Many Cards Hurts You" Myth Comes From
+
+  The myth has two real grains of truth that get over-extrapolated:
+
+  ### Grain 1: Recent applications hurt your score
+  When you apply for a new card, you take a 3–8 point hit from the inquiry plus another small hit from the new account lowering your average age. Multiple applications close together compound the damage.
+
+  But the damage comes from **applying**, not from **having**. Once a card is approved and aged 12+ months, it's a net positive on your score (more available credit, more history). Applying for 10 cards in 2 months is bad. Holding 10 cards that were opened over a 10-year period is fine.
+
+  ### Grain 2: Issuers care about your velocity
+  Even if FICO doesn't penalize you for total card count, individual issuers do — but specifically for the **velocity** of new accounts, not the total. Chase 5/24 caps you at 5 new accounts in 24 months. BofA 2/3/4 caps you at 4 in 24 months. These rules don't say anything about how many cards you can have lifetime — only how fast you can add them.
+
+  This is the real constraint. You can have 25 open cards and still apply for a Chase Sapphire Preferred tomorrow as long as 4 or fewer of them were opened in the last 24 months.
+
+  ## Score Impact at Different Card Counts
+
+  Rough patterns observed across the credit-card community (your specifics will vary):
+
+  ### 1–2 cards
+  Lowest score range, especially if both are recent. Thin file, average age low, every utilization fluctuation has outsized impact.
+
+  ### 3–5 cards
+  Common "responsible adult" range. Average age of accounts builds. Utilization easier to manage across multiple cards. Most people score well here.
+
+  ### 6–10 cards
+  Optimal for many score-optimizers. Total credit limit is high enough that utilization is a non-issue. Old cards are aging into account-age bonuses. New-card pace can be sustained without breaking velocity rules.
+
+  ### 11–20 cards
+  Very common in the rewards-optimization community. Score continues at high levels if velocity is managed. Practical complexity becomes the real constraint, not the score.
+
+  ### 21+ cards
+  Rare outside the manufactured-spend community. Score not negatively affected by the number itself, but real life management gets challenging. Risk of issuer shutdowns increases when patterns look extreme.
+
+  The pattern: **score plateaus around 6–10 cards**. After that, additional cards don't materially help your score — they help your category coverage, your welcome bonus accumulation, or your travel benefits.
+
+  ## When More Cards Actually Hurt
+
+  Five situations where adding cards is genuinely bad for you:
+
+  ### 1. You can't keep up with payments
+  The single biggest risk. Each card is a separate due date, a separate minimum payment, a separate place a fee can land if you miss something. Autopay eliminates this risk for most people, but only if your bank account can sustain the autopay drafts. **The math: a single 30-day late payment costs more in score than 10 new cards combined.**
+
+  ### 2. Your spending changes
+  Some people open cards specifically to capture rewards on certain categories, then find that spend pattern changes (move, new job, life event) and the card becomes useless. Holding it for years just for the credit line is fine, but if it has an annual fee, it becomes a recurring cost for nothing.
+
+  ### 3. You're approaching a major credit event
+  Mortgage, auto loan, refinance — any event where you'll be evaluated by an underwriter. New cards in the 6 months before bring fresh inquiries, lower average age, and add complexity to your file. Pause card applications 6 months before, ideally 12.
+
+  ### 4. You're getting flagged by issuer risk systems
+  At some point, very heavy card velocity or unusual spend patterns trigger soft bans (Chase pop-up jail) or hard shutdowns (Amex financial review). The threshold varies by issuer and by behavior, but multiple cards across multiple issuers makes you more visible.
+
+  ### 5. You have a partner or shared finances
+  Two people with separate card portfolios optimizing in parallel can hit issuer relationship caps faster than expected. Coordinate household-wide if you're a couple, both maximizing rewards.
+
+  ## When You've Genuinely Hit Your Limit
+
+  Practical signals that you're at your personal max:
+
+  - You can't remember the categories on cards you own
+  - You've accidentally missed a statement or autopay because you weren't tracking it
+  - You hold cards primarily for credits you forget to use
+  - You're keeping a card "just in case" with no current value
+  - The annual fees are above the rewards you're earning
+
+  When any of these are true, you're not optimizing — you're collecting. The right move is to start downgrading or closing the cards that aren't pulling weight.
+
+  ## Total Cards vs Active Cards
+
+  An important distinction: not every card you hold needs to be actively used. The credit-card community calls cards you keep but rarely swipe **"sock drawer"** cards. They're still valuable because they:
+
+  - Add to your total credit limit (lowering utilization)
+  - Continue aging (adding to your average account age)
+  - Are available for emergencies
+  - Cost nothing if they have no annual fee
+
+  The constraint on sock-drawer cards is issuer behavior. Some issuers (Bank of America, Discover, US Bank) close cards for inactivity after 6–18 months. Others (Capital One, Chase, Amex) leave them open indefinitely. To prevent inactivity-based closures, run a small purchase ($5 streaming subscription, occasional gas fill-up) on each card every 90 days. Set a calendar reminder.
+
+  ## The Annual Fee Math at Scale
+
+  When you hold many cards, annual fees compound. A common high-end portfolio:
+
+  - Chase Sapphire Reserve ($550)
+  - Amex Platinum ($695)
+  - Capital One Venture X ($395)
+  - Amex Gold ($325)
+  - Citi Strata Premier or similar ($95)
+
+  That's $2,060 in annual fees. Justifying that requires using the cards' credits and benefits — most premium cards include $300+ of rebatable credits each that, if you actually use them, partially offset the fee. But "if you actually use them" is the critical clause.
+
+  Practical filter: every December, audit each premium card. If its rewards earned + credits used > annual fee × 1.3, keep it. If not, downgrade to a no-fee version (most premium cards have a no-fee downgrade path) or close it.
+
+  ## Card-Count Strategies by Goal
+
+  ### Maximizing rewards on daily spend
+  Sweet spot: 4–6 cards covering all major categories.
+
+  - One catch-all (Citi Double Cash, Wells Fargo Active Cash, Capital One Quicksilver) at 2%
+  - Dining card (Amex Gold, Sapphire Preferred, Capital One Savor)
+  - Grocery card (Blue Cash Preferred, Amex Gold)
+  - Travel category (Chase Freedom Unlimited has 5x travel via UR portal; Sapphire Preferred has 2x direct)
+  - Optional: rotating-category card (Discover It, Chase Freedom Flex) for quarterly 5%
+
+  Six cards covers ~95% of optimization upside. Beyond that, you're managing complexity for diminishing return.
+
+  ### Welcome bonus chasing
+  Sweet spot: as many as your velocity allows.
+
+  Apply quarterly, hold each card 12+ months, downgrade to no-fee versions or close based on retention offers. Two welcome bonuses per year ($1K each) outpaces virtually all category-bonus optimization.
+
+  ### Travel hacking
+  Sweet spot: 8–15 cards across multiple issuers.
+
+  Diversify points (Chase UR, Amex MR, Capital One miles, Citi TY) plus cobranded hotel and airline cards for elite status and free nights. Real diversification requires a high card count because each program's value sits in different cards.
+
+  ### Just want simple
+  Sweet spot: 1–3 cards.
+
+  One catch-all at 2%, optionally one dining/travel card, optionally one balance-transfer / 0% APR card. You'll leave 1–2% on the table compared to optimizers, but you'll never miss a payment or wonder which card to use.
+
+  ## How to Add Cards Safely
+
+  If you've decided you want to grow your portfolio, four rules:
+
+  ### 1. Stay 5/24-compliant
+  Even if you're not chasing Chase cards specifically, staying under 5/24 keeps you eligible for the broadest set of issuers. Open at most 4 new cards in any rolling 24 months.
+
+  ### 2. Pre-qualify before every application
+  Saves the inquiry damage on declined applications. Use issuer pre-qualification tools, especially Capital One (triple-pull), Amex (lifetime bonus check), and Citi.
+
+  ### 3. Time around major credit events
+  No new cards in the 12 months before a mortgage application, 6 months before any auto loan or refinance.
+
+  ### 4. Hold cards 24+ months minimum
+  Closing a card within 12 months — especially Chase or Amex — flags you for "bonus chasing" which can cause downstream pop-up jail or velocity blocks. Hold long, downgrade if needed, close as last resort.
+
+  ## FAQ
+
+  ### Will closing cards reduce my score?
+  Sometimes. Closing reduces total credit limit (raising utilization) and eventually lowers your average account age (closed accounts continue to count for 10 years, then drop off). For specifics, see our piece on [closing cards safely](/articles/closing-credit-cards-safely).
+
+  ### Does my credit score have a "too many cards" cliff?
+  No. Score plateaus around 6–10 cards but doesn't actively decline as you add more. Each new card has a small short-term hit (inquiry + new account) that recovers within 12 months.
+
+  ### How many cards do most people in their 30s have?
+  US average across all adults: ~4 active cards. Among rewards optimizers, 8–15 is common. Among the most aggressive travel hackers, 25+ isn't unusual.
+
+  ### Will issuers reject me for having too many cards?
+  Direct rejections for total card count are rare. Issuers care more about your relationship with them specifically (how many of their cards you hold, your velocity with them, how profitable you are) than total external card count.
+
+  ### How do I keep track of many cards?
+  Spreadsheet: card name, annual fee, opening date, autopay setup, primary use, key benefits and credits to use each year. Update annually. Set quarterly calendar reminders to put a small charge on sock-drawer cards.
+
+  ### Can I have multiple cards from the same issuer?
+  Yes. Most issuers allow 5–10 personal cards per applicant. Capital One caps at 2. Chase, Amex, Citi, and BofA all allow more, with their own velocity rules.
+
+  ### Does having lots of cards hurt my apartment rental application?
+  Generally no. Landlords pull a credit score, not a card count. As long as your score is good and your utilization is low, the number of cards is irrelevant to most rental applications.
+
+  ### Is there a card count where issuers automatically shut down accounts?
+  Not strictly count-based. Shutdowns are pattern-based — manufactured spend, sudden velocity, suspicious behavior. Holding many cards used responsibly does not trigger shutdowns.
+
+  ### How does my credit score react when I open my 10th card?
+  Roughly the same way it reacts when you open your 4th: small temporary dip from the inquiry and the new account, recovery in 6–12 months. Total card count itself doesn't compound the impact.
+
+  ## The Bottom Line
+
+  Total card count barely matters. Velocity, utilization, payment history, and issuer relationships matter a lot. Three rules cover almost all practical decisions:
+
+  1. **Add cards based on what they earn you, not what your "credit advisor" says is acceptable.** Six cards optimized for your spend will earn you more than two generic cards.
+  2. **Watch velocity, not total.** 4 new cards in 12 months is risky. 12 cards opened over 8 years is fine.
+  3. **Audit annually.** Cards that no longer earn their annual fee or carry strategic value should be downgraded or closed. Don't accumulate dead weight.
+
+  When in doubt, the right card count is the one you can manage without missing a payment. For most people that's somewhere between 3 and 10. For some it's higher. Both are fine.

--- a/data/articles/drafts/pre-approval-vs-pre-qualification.yaml
+++ b/data/articles/drafts/pre-approval-vs-pre-qualification.yaml
@@ -1,0 +1,200 @@
+id: "pre-approval-vs-pre-qualification"
+slug: "pre-approval-vs-pre-qualification"
+title: "Pre-Approval vs Pre-Qualification: Which Tools Actually Predict Credit Card Approval"
+date: "2026-05-18"
+author: "CreditOdds"
+summary: "What pre-approval and pre-qualification really mean, which issuer tools are reliable predictors, and how to use them to filter out denials before they hit your credit report."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - capital-one-venture-rewards
+  - american-express-gold-card
+  - citi-double-cash
+  - chase-sapphire-preferred
+  - discover-it-cash-back
+seo_title: "Pre-Approval vs Pre-Qualification for Credit Cards (2026) | CreditOdds"
+seo_description: "The real difference between pre-approval and pre-qualification on credit card applications, which issuer tools actually predict approval, and the soft-pull links by bank."
+social_title: "Pre-Approval vs Pre-Qualification, Decoded"
+content: |
+  "Pre-approved." "Pre-qualified." "You're a perfect match." Every major credit card issuer runs at least one of these tools, all of them sound like a green light, and most consumers have no idea what any of them actually mean. Some are reliable predictors of approval. Some are barely better than throwing darts.
+
+  Here's what each label really means, which issuer tools to trust, and how to use them to filter declines before they ever touch your credit report.
+
+  ## The Three Things "Pre-" Can Mean
+
+  Despite how the words sound, pre-approval and pre-qualification are not interchangeable, and there's a third related concept — **targeted offers** — that often gets lumped in. They mean three different things:
+
+  ### Pre-Qualification
+  A **soft-pull** check the issuer runs against your credit file in response to your request. You enter basic info (name, address, last 4 of SSN) on the issuer's website, they soft-pull your credit, and they tell you which of their cards you'd "likely" be approved for.
+
+  - Soft pull only — no score impact, not visible to other lenders
+  - Initiated by you
+  - Indicates likelihood, not certainty
+  - You still have to apply separately, which triggers the actual hard pull
+
+  ### Pre-Approval
+  An offer extended **to you** based on a soft pull the issuer ran on a list they bought or generated. You didn't ask for it; the issuer found you and decided you'd probably be approved.
+
+  - Soft pull only — no score impact
+  - Initiated by the issuer (you might see these in mail, email, or your existing online banking dashboard)
+  - Stronger signal than pre-qualification — the issuer actively wants you to apply
+  - Still not a guarantee, but the approval rate is much higher than blind applications
+
+  ### Targeted Offers
+  Specific bonuses or terms tied to a pre-approval (e.g., a 100K-point bonus when the public offer is 60K). Targeted offers are pre-approvals with extra strings attached — usually they're personalized to make the card more attractive to that specific applicant.
+
+  - Soft-pull based, like pre-approvals
+  - The bonus or terms are usually NOT available on the public website — you can only get them by accepting the targeted offer
+  - These often expire (90 days is typical)
+
+  **Practical hierarchy of how strongly each one predicts approval:**
+
+  Targeted offer (90%+ approval) → Pre-approval (75–85%) → Pre-qualification (60–75%) → Public application with no soft-pull data (depends entirely on your file)
+
+  ## Which Issuer Tools Are Reliable
+
+  ### Capital One — Strong
+  Capital One's pre-qualification tool ([capitalone.com/credit-cards/pre-qualified](https://www.capitalone.com/credit-cards/pre-qualified/)) is the most reliable in the industry. If you pre-qualify, you're approved on actual application about **85%+ of the time**. If you don't pre-qualify, you're virtually guaranteed to be declined.
+
+  - Soft-pull only
+  - Returns a list of specific cards you'd likely be approved for, often with the specific bonus offer
+  - Tip: Capital One does triple-bureau hard pulls when you actually apply, so use this tool aggressively to make sure the application is worth the inquiries
+  - Tip: a "no offers" result usually means you're temporarily ineligible for new Capital One cards (their internal velocity rules) — don't reapply for at least 6 months
+
+  ### American Express — Strong
+  Amex's pre-qualification tool ([americanexpress.com/en-us/credit-cards/check-for-offers/](https://www.americanexpress.com/en-us/credit-cards/check-for-offers/)) is highly reliable. Approval rate on pre-qualified Amex cards is roughly **80%+**.
+
+  - Soft-pull only
+  - Frequently shows targeted bonus offers (e.g., 100K MR vs. the 60K public offer)
+  - Tip: targeted offers expire — write down the offer code if you see one
+  - Tip: this is the only legitimate way to find out whether you'd avoid the [once-per-lifetime](/articles/amex-once-per-lifetime-rule) issue on a specific card before applying
+
+  ### Citi — Mixed
+  Citi's pre-qualification tool exists but is less reliable than Capital One's or Amex's. Approval rate on pre-qualified Citi cards is **65–75%** — better than blind applying, but the soft-pull screen is less rigorous.
+
+  - Soft-pull only
+  - Doesn't always reflect Citi's full velocity and family-of-cards rules — you can pre-qualify and still get hit by their 24-month bonus restrictions on actual application
+  - Tip: useful as a first filter, but don't treat it as a green light
+
+  ### Bank of America — Decent
+  BofA's pre-qualification works through your existing online banking dashboard if you're already a customer. They'll show you "selected for you" cards.
+
+  - Soft-pull based
+  - Approval rate is high if you're a Preferred Rewards customer (Platinum/Platinum Honors tier especially)
+  - Tip: most reliable when you have an existing BofA banking relationship — random pre-quals via their public site are weaker
+
+  ### Chase — The Outlier
+  Chase has the **least useful** pre-qualification tooling of any major issuer. Their public pre-qualification site exists but rarely returns the cards people actually want (Sapphire, Ink, Freedom). When it does return something, it's typically a no-bonus version of the public offer.
+
+  - The most reliable Chase signal is **pre-approval inside your existing Chase online banking** — if you log in and see a card under "offers for you," that's a soft-pull pre-approval and approval rates are high (~80%)
+  - The Chase 5/24 rule applies to most cards regardless of pre-approval status, so pre-approval doesn't override 5/24 for personal cards
+  - Tip: worth checking your Chase dashboard before any application — but don't rely on the public pre-qualification page
+
+  ### Discover — Strong
+  Discover's pre-approval tool is reliable, with approval rates of **80%+** on pre-approved offers.
+
+  - Soft-pull based
+  - Particularly useful for thin-file applicants (Discover is willing to approve thinner files than most issuers)
+  - Tip: if you don't pre-approve at Discover, your file probably has a recent negative item the bureaus are still showing
+
+  ### Wells Fargo — Mixed
+  Their pre-qualification works, but approval rates are middle of the pack (~70%). Wells doesn't have a strong velocity rule, so a pre-qualified result usually means the actual application will follow through, but the bonus structures sometimes shift between pre-qual and apply.
+
+  ### Smaller and Co-Branded Issuers
+  Most major retail co-brand cards (Apple, Costco, Bilt's affiliated cards, hotel co-brands) inherit their underwriter bank's pre-qualification — Apple/Goldman, Costco/Citi, Bilt/Wells Fargo. Use the underwriter's tool when one exists.
+
+  ## How to Use Pre-Qualification Tools Correctly
+
+  ### Strategy 1: Filter before applying
+  Always run pre-qualification before applying for a card you're unsure about. A "no offers" result on Capital One or Amex is a strong signal you'd be denied — save the inquiry.
+
+  ### Strategy 2: Hunt for targeted offers
+  Targeted bonus offers can be **2–3x the public welcome bonus**. Before applying for any premium card, run pre-qualification at the issuer to see if there's a targeted offer available to you. This is the single highest-leverage 60 seconds in credit card application strategy.
+
+  Where to check:
+
+  - Capital One: their pre-qualification page
+  - Amex: their pre-qualification page (the offer will appear in the results if you have one)
+  - Chase: your Chase online banking "offers for you" tab
+  - Citi: your Citi online banking
+  - Bank of America: your BofA online banking
+  - Discover: their pre-approval page
+
+  ### Strategy 3: Don't pre-qualify the same day you'll apply
+  This is a small one but it matters: some issuer pre-qualification systems briefly tag your file as "shopping" for credit. Pre-qualify, decide, then apply 24+ hours later. This avoids a small percentage of mid-application declines tied to duplicate-pull detection.
+
+  ### Strategy 4: Use it to find your best card before paying for credit monitoring
+  If you're trying to figure out where you stand without paying for a service, soft-pulling all the major issuer pre-qualification tools is essentially free. Within an hour you'll have a clear picture of what you'd qualify for at every major bank.
+
+  ## What Pre-Approval Doesn't Tell You
+
+  Pre-approval is a soft-pull screen against the issuer's basic eligibility model. It doesn't catch:
+
+  - **Velocity rules**. Chase 5/24, BoA 2/3/4, Citi 24-month bonus rules — these are sometimes not enforced at the pre-qualification stage and only kick in at actual application.
+  - **Once-per-lifetime / once-per-X-years bonus rules**. Pre-qualification will gladly tell you you'd be approved even if you've already received the welcome bonus before. The bonus eligibility check happens at application time.
+  - **Manual underwriting flags**. For premium cards (Sapphire Reserve, Venture X, Amex Platinum), a human underwriter sometimes reviews even pre-approved applications and may decline based on the specifics of your file.
+  - **Income mismatches**. The pre-qualification tool doesn't validate income against external data sources. The application does, sometimes.
+
+  This is why pre-approval is **strong** but not **certain** — about 1 in 5 pre-approved applications still get declined for one of these reasons.
+
+  ## Reading the Direct-Mail Pre-Approval Letter
+
+  Here's a quick decoder for the pre-approval mailers that show up in your mailbox:
+
+  - **"You are pre-selected"** = You were on a soft-pull list. Same as pre-qualification.
+  - **"You are pre-approved"** = Stronger language but still soft-pull. ~75–85% approval rate at actual application.
+  - **"You qualify for X"** = Marketing speak, often just an unsolicited offer with no soft-pull behind it. Treat as zero signal.
+  - **"Acceptance certificate"** with your name, a specific reservation number, and a soft-pull disclosure on the back = legitimate pre-approval. Apply via the URL or code in the letter to lock in any targeted offer.
+
+  Always compare the offer against the public website. If the targeted bonus is the same or worse than the public one, just apply through the public site (which sometimes has fewer terms than the targeted version).
+
+  ## What to Do if You Don't Pre-Qualify Anywhere
+
+  If you run all the major pre-qualification tools and get nothing, your credit file likely has one of these issues:
+
+  - **Recent inquiries cluster** — wait 6 months for them to age
+  - **Recent negative item** (collection, charge-off, late payment) — typically clears in 12–24 months from the issue date
+  - **Thin or no file** — work on building credit through a [secured card](/articles/secured-credit-cards-explained), authorized user status, or a credit-builder loan
+  - **Recent bankruptcy** — wait. Most major issuers want 4–7 years post-discharge before pre-approving anything
+
+  Use our [check-odds tool](/check-odds) to see specifically which cards your file is closest to qualifying for, and what would need to change to flip the answer.
+
+  ## FAQ
+
+  ### Does pre-qualification show up on my credit report?
+  No. Pre-qualifications are soft pulls — they're visible only to you when you check your own report, and they don't affect your score.
+
+  ### If I pre-qualify, am I guaranteed to be approved?
+  No. Pre-qualification is a soft-pull screen against basic eligibility. Roughly 15–25% of pre-qualified applications still get declined at hard-pull stage, usually for velocity, bonus eligibility, or manual underwriting reasons.
+
+  ### Can I pre-qualify multiple times in a row?
+  Yes. Soft pulls don't accumulate, and there's no penalty for repeated checks. Some issuers refresh their pre-qualification results every 30 days, so checking monthly when you're tracking eligibility is reasonable.
+
+  ### Why do I see different cards each time I pre-qualify?
+  Issuer pre-qualification models incorporate your latest credit data each time. New inquiries, new accounts, score changes, and the issuer's current marketing priorities all shift which cards you'll see.
+
+  ### What if I pre-qualify but never see a targeted bonus offer?
+  Then your offer is the public offer. Apply through the regular public link — there's nothing extra to capture in your specific case. Targeted offers aren't extended to everyone; if you don't see one, the public bonus is your bonus.
+
+  ### Can I get a targeted offer by applying through a friend's referral?
+  Sometimes. Referral links sometimes carry an enhanced bonus that isn't available on the public site. They're not pre-approvals — they're offers tied to the referrer's relationship with the issuer. Compare any targeted pre-approval bonus to the referral bonus before deciding which to use.
+
+  ### Does pre-qualification affect my approval odds the next time I apply?
+  No. Soft pulls leave no trace visible to other issuers and don't accumulate against you in scoring models.
+
+  ### Why didn't my pre-qualification show me the card I wanted?
+  Either you don't currently meet that card's underwriting criteria, the issuer chose not to surface it for marketing reasons, or — common at Chase — the pre-qualification system simply doesn't include that specific card. Check the issuer's online banking dashboard if you're an existing customer; pre-approvals there are often more comprehensive.
+
+  ### Can targeted offers be combined with referrals?
+  Generally no — you have to pick one. Compare the bonuses and terms; usually the targeted offer wins because it's personalized.
+
+  ## The Bottom Line
+
+  Pre-qualification and pre-approval are free, soft-pull, no-risk tools that filter out denials before they hit your credit report. Treat them as the first step in any credit card decision:
+
+  1. **Run pre-qualification at the issuer first.** Capital One and Amex are the most reliable. Chase's online-banking offers section is the most reliable for Chase. Discover for thin files.
+  2. **Hunt for targeted bonus offers.** They're often 1.5–2x the public bonus and only show up in pre-qualification.
+  3. **Don't treat pre-approval as a guarantee** — about 1 in 5 still gets declined at the hard-pull stage for velocity, bonus eligibility, or manual underwriting.
+
+  And if you want a single tool that aggregates all of this signal — pre-qualification status, velocity rules, your file's strength against specific issuer thresholds — that's exactly what our [check-odds page](/check-odds) is built to do.

--- a/data/articles/drafts/retention-offers-and-scripts.yaml
+++ b/data/articles/drafts/retention-offers-and-scripts.yaml
@@ -1,0 +1,220 @@
+id: "retention-offers-and-scripts"
+slug: "retention-offers-and-scripts"
+title: "Retention Offers: How to Ask for One, What to Expect, and the Scripts That Actually Work"
+date: "2026-06-29"
+author: "CreditOdds"
+summary: "How retention offers really work, the typical offer values by issuer, the phone scripts that get them, and when to take the offer vs. close the card."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-sapphire-preferred
+  - chase-sapphire-reserve
+  - american-express-gold-card
+  - capital-one-venture-rewards
+  - citi-double-cash
+seo_title: "Credit Card Retention Offers: Scripts by Issuer (2026) | CreditOdds"
+seo_description: "How to get retention offers from Chase, Amex, Citi, BofA, and Capital One — typical offer values, phone scripts, timing, and when to accept vs. close."
+social_title: "Credit Card Retention Offers, Decoded"
+content: |
+  Every annual fee credit card has a hidden negotiation built into it: when you call to close the card or hint at it, the issuer's retention department can offer you statement credits, bonus points, or annual fee waivers to keep you. These are called **retention offers**, and they're one of the most overlooked sources of value in credit card optimization.
+
+  Most people pay annual fees for years without ever asking. Of those who do ask, the success rate is high — typically 50–70% across major issuers — and the offers regularly cover the full annual fee or more. Done right, asking for retention adds 30 minutes to your year and saves you $50–$500.
+
+  Here's exactly how retention works, what to expect from each issuer, and the scripts that actually get the offers.
+
+  ## What a Retention Offer Actually Is
+
+  When you call your credit card's customer service number and indicate you're considering closing the card, the call is routed (sometimes immediately, sometimes after a few back-and-forths) to a **retention specialist** — an analyst whose job is to retain customers who would otherwise close. They have authority to offer:
+
+  - **Statement credits** ($50, $100, $200+ depending on card and value to issuer)
+  - **Bonus points or miles** (typically 5K–25K)
+  - **Annual fee waivers** (covering the next year's fee in full)
+  - **Spend-bonus offers** ("spend $X in 3 months for $Y back")
+  - **Combinations** of the above
+
+  The offer is presented after a brief conversation about why you're considering closing. If you accept, the offer posts to your account within 1–2 billing cycles. The card stays open and the next year's annual fee posts as scheduled, but the retention offer offsets it (in part or in full).
+
+  ## When Retention Offers Are Most Available
+
+  Retention offers are tied to the **annual fee anniversary**. Issuers want to retain you specifically when the fee is about to post or has just posted, because that's when the customer is most likely to close.
+
+  Best timing window: **30 days before through 30 days after the annual fee posts**.
+
+  - Earlier (60+ days before): retention may not be flagged yet, offers are often weaker
+  - Later (60+ days after): the issuer has already collected your fee and has less incentive to offer retention
+
+  Most issuers also have a **30-day refund window** after the AF posts — within that window, you can close the card and get the AF refunded in full. This is the strongest leverage point: you can credibly close, the issuer knows it, and the retention offer reflects that.
+
+  ## Typical Retention Offers by Issuer
+
+  ### Chase
+  - **Sapphire Preferred** ($95 AF): Common offers — $95 statement credit, or 10K–15K UR bonus, or "spend $1K in 3 months for $100 back"
+  - **Sapphire Reserve** ($550 AF): Common offers — $200–$300 statement credit, or 25K–30K UR bonus, or full annual fee waiver in some cases
+  - **Freedom Flex / Freedom Unlimited** (no AF): Generally no retention offers — there's no fee to negotiate against
+  - **Ink Business Preferred** ($95 AF): Common offers — $95 credit or 10K–15K UR
+  - **United Quest** ($250 AF): Common offers — $100 credit, 5K–10K UR
+  - **United Club Infinite** ($525 AF): Common offers — $250 credit, 15K–25K UR
+
+  Chase's retention department is reachable by calling the number on the back of your card and saying "I'd like to consider closing my account." You'll be transferred to retention.
+
+  ### American Express
+  - **Gold Card** ($325 AF): Common offers — $100–$200 statement credit, or $250 dining credit, or 15K–25K MR
+  - **Platinum Card** ($695 AF): Common offers — $250–$500 statement credit, or 25K–50K MR, or full AF waiver in rare cases
+  - **Green Card** ($150 AF): Common offers — $50–$100 credit, or 5K–10K MR
+  - **Blue Cash Preferred** ($95 AF): Common offers — $50 credit, or "spend $X for $Y back"
+
+  Amex retention is reachable via chat or by phone. The chat representatives can sometimes provide retention offers without escalation. Phone retention is more reliable for higher offer values.
+
+  ### Citi
+  - **Strata Premier** ($95 AF): Common offers — $50–$100 credit, or 5K–10K TY points
+  - **Premier (legacy) / Prestige (legacy)**: Common offers vary by card, similar magnitudes
+  - **AAdvantage Executive** ($595 AF): Common offers — $200 credit, 25K AA miles
+
+  Citi retention is reached via the standard customer service line. Citi has been more inconsistent than other issuers — some applicants get strong offers, others get nothing, on similar profiles.
+
+  ### Capital One
+  - **Venture X** ($395 AF): Common offers — minimal. Capital One's retention department rarely offers significant retention because the card's existing $300 travel credit and 10K anniversary miles already cover the fee for most users
+  - **Venture** ($95 AF): Common offers — $50 credit, 5K miles
+  - **Savor** ($95 AF): Common offers — $50 credit
+
+  Capital One is generally the **least generous** with retention offers. Expectations should be lower; if no offer is given, downgrading to a no-fee version (VentureOne, SavorOne) is a clean alternative.
+
+  ### Bank of America
+  - **Premium Rewards** ($95 AF): Common offers — $50 credit
+  - **Premium Rewards Elite** ($550 AF): Common offers — $200 credit, sometimes more for Preferred Rewards Platinum Honors customers
+  - **Customized Cash Rewards** (no AF): Generally no retention since there's no fee to negotiate
+
+  ## The Phone Scripts That Work
+
+  ### Universal opening
+  When you call the number on the back of your card, navigate the menu to "speak to a representative" or "account services." When the rep picks up:
+
+  > **You:** "Hi, my name is [name]. I have my account number ready. I'm calling because my annual fee just posted and I'm considering whether to keep this card. I love the [specific feature you actually use], but the annual fee is steep, and I wanted to see if there's anything you can do to help me justify keeping the card open."
+
+  Three things this script does:
+  1. Shows you've thought about it (not impulsive)
+  2. Names a specific feature you value (proves you use the card)
+  3. Specifies "annual fee is the issue" (gives them the lever to pull)
+
+  ### What you'll hear next
+
+  - **Best case**: "Let me check what we can offer." Pause. "I can offer you [retention offer]. Would you like to accept?"
+  - **Mid case**: "I'd like to transfer you to our retention team. One moment." (Transfer happens, then the same exchange.)
+  - **Worst case**: "I don't see any offers available for your account at this time. Would you like to close the card?"
+
+  If you get the worst case, you have two options:
+  1. **Hang up and try again in 1–2 weeks**. Different reps have different visibility into offers; sometimes a second call gets a different outcome.
+  2. **Downgrade instead**. "If there's no retention offer available, I'd like to downgrade this card to [no-fee version]." Most issuers will process the downgrade on the same call, no inquiry, no AF on the new card.
+
+  ### When the offer is borderline
+
+  If the offer barely beats the annual fee — e.g., $100 retention on a $95 AF card — calculate honestly: is the card actually worth $95 of value to you each year? If yes, accept the retention. If no, decline politely and either close or downgrade.
+
+  > **You:** "Thanks for the offer, but $100 doesn't quite tip the math for me on the $95 fee. Is there anything else available, or should I just close the card today?"
+
+  Sometimes a stronger offer appears after this nudge. Sometimes the rep confirms that's the only offer, in which case you make the decision honestly.
+
+  ### The downgrade-as-alternative script
+
+  > **You:** "I appreciate the offer. If there isn't a retention option that makes the math work for me, I'd like to downgrade this card to [no-fee version] without a hard inquiry. Can you process that today?"
+
+  Most issuers can downgrade on the same call. The card converts to the no-fee product, your credit limit and account age stay the same, and the annual fee is refunded if you're within the 30-day window.
+
+  ## What Not to Do
+
+  ### Don't bluff aggressively
+  "If you don't give me a retention offer, I'll close every card I have at this bank!" doesn't work. Retention reps see your full account portfolio. Empty threats just make you look unreasonable.
+
+  ### Don't accept the first offer if it's weak
+  A reflexive "yes" to a $50 retention offer on a $550 fee leaves money on the table. It's reasonable to say "Could you check if there's anything else available?" once. Push past that and you risk annoying the rep.
+
+  ### Don't call right after opening
+  Retention offers in the first year are extremely rare. The card's first annual fee is the issuer's anchor for value extraction. Wait until the second annual fee posts (year 2 anniversary) for meaningful offers.
+
+  ### Don't lie about wanting to close
+  If you decline a retention offer and don't close, that's fine. But saying "I'm definitely closing if you don't offer X" and then keeping the card without the offer makes future retention conversations harder — analysts see notes.
+
+  ### Don't call on weekends or evenings
+  Retention is staffed best during business hours. Late-night and weekend reps often have less authority to offer top-tier retention. Call midday on Tuesday–Thursday.
+
+  ## Stacking Retention Offers
+
+  Most retention offers come with **spend requirements** — "spend $3,000 in 3 months for $300 back," for example. These can be stacked with:
+
+  - Welcome bonus spend on a different new card
+  - Existing organic spend on the retention card
+  - Manufactured spend (within reason — heavy MS triggers shutdowns separately)
+
+  If you have multiple cards from the same issuer, you can sometimes coordinate retention offers across them. Call about Card A, get $200 credit. Call about Card B a few days later, get $100 credit. Both offers post, both cards stay open.
+
+  Caveat: don't stack so aggressively that the issuer flags you as gaming retention. Two retention offers in a year per issuer is the rough sustainable cadence.
+
+  ## When You Don't Get a Retention Offer
+
+  Three options:
+
+  ### Option 1: Pay the AF and reassess in 6 months
+  If the card's value (rewards earned + benefits used) genuinely exceeds the AF, just keep it. Not every card needs a retention offer to be worth keeping.
+
+  ### Option 2: Downgrade
+  Keep the credit limit and account age, lose the premium benefits, eliminate the AF. Best move when the card no longer pencils but you still want the tradeline.
+
+  ### Option 3: Close
+  If downgrade isn't an option (some specialty cards have no no-fee version) or if you have no use for the no-fee version either, close the card. Within the 30-day grace period, the AF refunds. After, it's gone.
+
+  ## Special Cases
+
+  ### Authorized user fees
+  Some premium cards charge per AU. If retention isn't enough to keep the main card, ask about removing AU fees as a partial retention. Sometimes works.
+
+  ### Recently downgraded cards
+  If you downgraded a year ago and now have the no-fee version of a former premium card, you're typically not eligible for retention (no fee to retain against). The retention conversation is anchored to AF cards.
+
+  ### Cards opened with a referral
+  No effect on retention. Whether the card was opened via referral, organic application, or in-branch signup doesn't change retention eligibility.
+
+  ### Business cards
+  Business cards often have parallel retention offers, sometimes more generous than personal cards. Always ask retention about your business cards too — Chase Ink Preferred, Amex Business Gold, etc. all run retention programs.
+
+  ## FAQ
+
+  ### When is the best time to call for retention?
+  About 30 days before through 30 days after your annual fee posts. The 30-day window after posting is the strongest leverage because you can still close for a full AF refund.
+
+  ### Will calling retention hurt my credit?
+  No. There's no inquiry, no account change, no impact. Calling and getting "no offer" is invisible to your credit profile.
+
+  ### Can I get a retention offer on a no-annual-fee card?
+  Generally no. Retention offers are anchored to annual fees. No-fee cards rarely have retention.
+
+  ### How often can I get retention offers?
+  Once per anniversary, per card, in most cases. Some applicants successfully get two retention offers per year on the same card by calling twice ~6 months apart, but it's not guaranteed.
+
+  ### What if I have multiple cards from the same issuer?
+  Each card can have its own retention offer, called independently. Call about Card A, then Card B, etc. Don't combine into one call — analysts handle one card at a time.
+
+  ### Should I close the card if I get a poor retention offer?
+  Decide based on the card's standalone value, not the offer. If $95 AF earns you $200 of organic value (rewards + benefits used), keep it. If it earns you $50 of value, the retention offer needs to bridge the gap or you should downgrade/close.
+
+  ### Will retention offers count against my credit?
+  No. The offer posts as a statement credit or rewards bonus. Your account remains in good standing, no inquiry, no flag.
+
+  ### Can I negotiate retention via chat?
+  Sometimes. American Express's online chat representatives often can offer retention. Chase chat usually transfers to phone. Citi's retention is generally phone-only.
+
+  ### Will retention offers affect future welcome bonuses?
+  No. Retention is separate from welcome bonus eligibility. Receiving retention on Card X doesn't affect your eligibility for the welcome bonus on Card Y.
+
+  ### What's the highest retention offer ever reported?
+  In community data points, the largest retention offers are typically on Amex Platinum and Chase Sapphire Reserve — sometimes $500+ statement credits or full AF waivers. Average retention offers are far smaller (50–100% of the AF on most cards).
+
+  ## The Bottom Line
+
+  Retention offers are free money sitting on the table for anyone willing to make a 10-minute phone call. Three rules:
+
+  1. **Call within 30 days of your annual fee posting.** Earlier is too soon for the issuer to engage; later is past the AF refund window.
+  2. **Use the universal script**: name a feature you value, mention the AF as your concern, ask if there's anything they can do. Don't bluff or threaten.
+  3. **Have a clean alternative ready.** If retention doesn't pencil out, downgrade. If you can't downgrade, close. The leverage is in your willingness to walk away.
+
+  Most cards' retention offers cover 50–100% of the annual fee. Compounded across a portfolio of premium cards, that's $500–$2,000/year for a few hours of phone calls. The math is too good to skip.

--- a/data/articles/drafts/statement-balance-vs-current-balance.yaml
+++ b/data/articles/drafts/statement-balance-vs-current-balance.yaml
@@ -1,0 +1,209 @@
+id: "statement-balance-vs-current-balance"
+slug: "statement-balance-vs-current-balance"
+title: "Statement Balance vs Current Balance: What the Difference Costs You"
+date: "2026-06-22"
+author: "CreditOdds"
+summary: "What statement balance and current balance actually mean, why only one of them affects your credit score, and how to time payments to keep both numbers working for you."
+tags:
+  - guide
+  - beginner
+related_cards:
+  - chase-freedom-unlimited
+  - citi-double-cash
+  - capital-one-quicksilver
+  - wells-fargo-active-cash
+  - discover-it-cash-back
+seo_title: "Statement Balance vs Current Balance Explained (2026) | CreditOdds"
+seo_description: "What statement balance and current balance really are, which one affects your credit score, and how to time payments around your statement closing date for the best score."
+social_title: "Statement Balance vs Current Balance"
+content: |
+  Open your credit card app and you'll see two balance numbers, sometimes labeled differently across issuers:
+
+  - **Statement balance** (also "last statement balance" or "balance at last statement")
+  - **Current balance** (also "outstanding balance" or just "balance")
+
+  Most people pay one or the other based on which is easier to find in the app. The choice has real consequences: which one you pay determines whether you owe interest, and the **timing** of your payment determines what gets reported to the credit bureaus — which is the actual driver of your score.
+
+  Here's exactly what each number means, when each one matters, and the payment routine that makes both work for you.
+
+  ## What Each Number Actually Means
+
+  ### Statement Balance
+  Your statement balance is the total amount you owed on your credit card **as of your statement closing date**. The closing date is a fixed day each month (e.g., the 15th) when the issuer "closes the books" for that billing cycle and generates your statement.
+
+  Your statement balance is:
+
+  - The number printed on the top of your statement PDF
+  - The amount the issuer reports to the three credit bureaus
+  - The amount you must pay in full to avoid interest charges
+  - Frozen — it doesn't change after the statement closes, regardless of new charges or payments you make afterward
+
+  ### Current Balance
+  Your current balance is the live amount you owe **right now**, including:
+
+  - Anything left unpaid from your last statement
+  - Any new purchases since the statement closed
+  - Less any payments you've made
+
+  The current balance updates in real time. It can be higher or lower than the statement balance, depending on whether you've spent more or paid more since the close.
+
+  ## The Critical Distinction
+
+  ### Statement balance drives:
+  - **What you owe interest on** if you don't pay in full by the due date
+  - **What gets reported to the credit bureaus** for utilization calculation
+  - **The minimum payment due** (a fraction of statement balance, varies by issuer)
+
+  ### Current balance drives:
+  - **Nothing on your credit report**
+  - **Nothing about interest charges** (interest is calculated on what was unpaid from the statement, not on current activity)
+
+  This is the big surprise for most credit card users: **the bureaus don't see your current balance**. They see what was on your statement at close. If you spent $5K on groceries and paid it off the day before the statement closed, your reported balance is whatever was on the card AT close (probably very low), not the $5K you spent during the cycle.
+
+  ## The Payment Timing That Matters
+
+  Two timing decisions determine what your credit looks like to the bureaus and what you pay in interest:
+
+  ### Decision 1: Pay before the due date
+  If you pay your full statement balance by the due date, you owe **zero interest** for that cycle. The grace period guarantees this — typically 21–25 days from statement close to due date.
+
+  Miss the due date even by a day, and:
+  - The full statement balance retroactively starts accruing interest from the original purchase dates
+  - You may also be charged a late fee (~$30 for first late, $40 for repeat lates)
+  - A 30-day late payment gets reported to the bureaus and tanks your score by 80–110 points if you have otherwise clean credit
+
+  Lesson: never miss the due date. Set autopay for at least the minimum payment as a backup, even if you also pay manually.
+
+  ### Decision 2: Pay before the statement closes (for utilization optimization)
+  If your goal is to optimize what reports to the bureaus, paying before the statement closes is what lowers your reported utilization.
+
+  Two-payment cadence:
+
+  - **Day -3 to -5 from statement close**: pay your balance down to under 10% of your credit limit
+  - **Day -1 to +20 from statement close** (anywhere within the grace period): pay any remaining balance to $0
+
+  This "double payment" approach means:
+  - The statement closes with a low balance reported (good utilization)
+  - You owe zero interest because you paid the full statement amount before the due date
+  - The first payment is the optimization move; the second is the standard pay-in-full move
+
+  Most score-conscious users automate both: a recurring "balance check" payment 5 days before close, and an autopay for the full statement balance on the due date.
+
+  ## How the Bureaus See It
+
+  Your credit card issuer reports your statement-closing balance to the bureaus, usually within a few business days of close. Once reported:
+
+  - That balance is "your balance" for utilization purposes for the next ~30 days
+  - Your score reflects that balance until the next statement closes and reports
+  - Payments after the statement closes don't change the reported number for that month
+
+  Practical implication: a payment made on the 16th if your statement closed on the 15th has zero immediate effect on your reported utilization. The next statement will report next month's closing balance, and that's when the change shows up.
+
+  This is why "I paid off my card, why is my score still showing high utilization?" is the most common credit confusion. The answer is timing — your high balance was reported, your payment was after the report. Wait until the next statement closes for the change to flow through.
+
+  ## Common Misconceptions
+
+  ### Misconception 1: "I should carry a balance to build credit"
+  No. The bureaus don't track whether you carried a balance. They only see what was on your statement at close, regardless of whether you paid it in full or carried it. Carrying a balance just costs you interest with no credit benefit.
+
+  ### Misconception 2: "If I pay current balance, I avoid interest"
+  Sometimes, but not reliably. Interest is calculated on the **statement balance** that wasn't paid by the due date. If you pay your current balance (which may include new charges since the statement) but miss the statement balance amount, you can still owe interest.
+
+  Safer rule: pay the **statement balance** in full by the due date. New current charges roll into next month's statement and aren't yet subject to interest as long as you maintain the grace period.
+
+  ### Misconception 3: "Paying twice a month is better than once"
+  For utilization optimization, yes. For pure interest avoidance, no — one payment of the full statement balance by the due date is identical to ten smaller payments adding up to the same amount.
+
+  ### Misconception 4: "The balance shown on my mobile app is what gets reported"
+  Only on the day of statement close. Other days, the live app balance is the current balance, which is not what the bureaus see.
+
+  ### Misconception 5: "Paying off my card right after the statement closes saves my utilization"
+  No. Once the statement has closed, the balance has been reported. Payments after close apply to the next reporting cycle, not the current one. Pay BEFORE close to lower reported utilization.
+
+  ## The Five-Minute Setup
+
+  Here's the routine that handles both interest avoidance and utilization optimization:
+
+  ### Step 1: Find your statement closing date
+  In your card's app, the closing date is shown next to the next-statement-due section. Write it down for each card.
+
+  ### Step 2: Set a calendar reminder for 3–5 days before close
+  Recurring monthly. Title: "Pay [card] down to under 10%."
+
+  ### Step 3: Set autopay for full statement balance on the due date
+  In your card's app, find the autopay settings. Set to "Pay statement balance in full" rather than "minimum payment."
+
+  ### Step 4: Optionally — autopay a fixed % of credit limit
+  Some optimizers set up an automatic payment for a fixed amount equal to ~5% of their credit limit, scheduled 3 days before each statement closes. This automates the utilization-optimization payment without needing a calendar reminder.
+
+  ### Step 5: Check after each statement closes
+  Confirm the reported balance is in the under-10% range. If it isn't (e.g., a big purchase happened just before close), add a manual payment 2 days before next close to bring the reported balance down.
+
+  Once set up, this entire system runs itself. Score stays optimized automatically.
+
+  ## When Carrying a Balance Costs More Than You Think
+
+  If you don't pay your statement balance in full by the due date:
+
+  - Interest accrues from the **original purchase date** of every charge in the prior cycle, not just from the due date forward
+  - Your APR is typically 20–30% in 2026 for most major cards
+  - The "minimum payment" only covers a fraction of interest; the principal barely moves
+  - The grace period is forfeit until you've paid in full again — meaning new purchases also start accruing interest immediately
+
+  Practical math: a $5,000 balance at 24% APR with minimum payments only takes ~22 years to pay off and costs ~$8,000 in interest. The same balance paid off in 6 months costs about $370.
+
+  ## Edge Cases
+
+  ### Returns and credits processed after statement close
+  If you return an item after your statement closes, the credit applies to the next cycle's current balance, not the closed statement. You still owe the original statement balance to avoid interest. The credit will either reduce next month's statement or sit as a negative balance you can request a refund for.
+
+  ### Payments that arrive late
+  If your payment is processed on the due date or after, depending on the issuer's cutoff time (often 5pm ET), it may be considered late. Pay 1–2 days before the due date to avoid this risk. ACH transfers from external accounts can take 2–3 business days to clear.
+
+  ### Pending vs posted charges
+  Pending charges are temporarily authorized but haven't been billed. They count toward your available credit (you can't spend over the limit) but don't count toward your statement balance until they post. A pending charge that posts after statement close goes on the next statement.
+
+  ### The negative-balance situation
+  If you pay more than your statement balance (e.g., autopay set to "current balance" and you paid before new charges posted), you can have a negative current balance — the issuer owes you. Future purchases will draw down the credit. You can also request a refund, usually as a check or ACH.
+
+  ## FAQ
+
+  ### Which one do I have to pay to avoid interest?
+  Statement balance. Paying the full statement balance by the due date avoids all interest charges. Paying current balance is fine too if it's higher (you're paying ahead) but the threshold is statement balance.
+
+  ### Which one do credit bureaus see?
+  Statement balance, as of the statement closing date. Current balance is invisible to the bureaus.
+
+  ### Can I make my reported utilization 0% by paying everything off?
+  Yes — pay all your card balances to $0 before each statement closes, and your reported utilization will be 0%. Note: pure 0% across all cards may slightly underperform 1–9% on at least one card, because some scoring models reward "active use" of credit. Most score-optimizers leave 1–5% on one card and $0 on the rest.
+
+  ### What if I don't see my statement closing date in the app?
+  Look in the most recent statement PDF — closing date is in the top section. You can also call the issuer and ask: "What's my statement closing date for this card?" It's a fixed day of the month for each card.
+
+  ### Can I change my statement closing date?
+  Sometimes. Major issuers (Chase, Amex, Citi, Capital One) will let you change your closing date by phone. The change typically takes effect the following cycle. Useful if you want all your cards to close at similar times for easier tracking.
+
+  ### What happens if I pay too much?
+  You'll have a credit (negative balance) on the card. It draws down with future spending or you can request a refund. Doesn't hurt your score or your account standing.
+
+  ### If I never carry a balance, why does utilization matter?
+  Because the bureaus see your statement-closing balance whether you carry it or pay it. Even if you pay in full every month, your reported utilization can be high if your statements close with high balances. To optimize score, pay before close — even if you'd pay in full anyway.
+
+  ### Does the minimum payment have anything to do with this?
+  Minimum payment is the smallest amount the issuer will accept by the due date to keep the account in good standing. It's based on the statement balance, not the current balance. Paying just the minimum keeps you out of late status but accrues interest on the unpaid amount.
+
+  ### Why does my statement balance look smaller than what I spent?
+  Your statement balance is "what was owed on the card at close" — including any payments you made during the cycle. So if you spent $5,000 but also paid $3,000 mid-cycle, the statement balance might be $2,000.
+
+  ### Can paying current balance hurt me?
+  No. Paying any amount up to or beyond the current balance is fine. The risk is paying less than the statement balance (which leaves residual balance owing interest) or missing the due date entirely (late payment).
+
+  ## The Bottom Line
+
+  Statement balance and current balance look like two views of the same number, but they drive completely different things. Three rules:
+
+  1. **Pay statement balance in full by the due date.** This is the only number that triggers interest and the only number the bureaus see. Set autopay to "statement balance" not "minimum."
+  2. **For score optimization, pay 3–5 days before statement close** to a balance under 10% of your limit. This lowers reported utilization without paying interest.
+  3. **Current balance is your living spend total** — useful for budgeting and avoiding overspending, irrelevant to your score and your interest exposure.
+
+  Get the timing right and credit cards become a free tool — interest costs zero, score stays high, rewards accumulate. Get it wrong and you can pay 24% APR while looking maxed out to lenders.

--- a/data/articles/drafts/velocity-rules-by-issuer.yaml
+++ b/data/articles/drafts/velocity-rules-by-issuer.yaml
@@ -1,0 +1,234 @@
+id: "velocity-rules-by-issuer"
+slug: "velocity-rules-by-issuer"
+title: "Velocity Rules by Issuer: How Fast You Can Apply for New Credit Cards"
+date: "2026-07-06"
+author: "CreditOdds"
+summary: "The hard and soft velocity caps at every major credit card issuer in 2026, what each one counts, and how to plan applications across multiple banks without tripping any of them."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-sapphire-preferred
+  - american-express-gold-card
+  - citi-double-cash
+  - capital-one-venture-rewards
+  - bank-of-america-customized-cash-rewards
+seo_title: "Credit Card Velocity Rules by Issuer (2026) | CreditOdds"
+seo_description: "All the major credit card issuer velocity rules in 2026: Chase 5/24, BofA 2/3/4, Amex 1/5, Capital One 6-month, Citi 8/65/95. How each works and how to plan around them."
+social_title: "Credit Card Velocity Rules, by Issuer"
+content: |
+  Velocity rules are the speed limits on credit card applications. Each major issuer enforces caps on how fast you can open new cards, and crossing the line means auto-decline regardless of how strong your credit is.
+
+  These rules aren't usually published by the issuers themselves. They've been derived from thousands of community data points over many years and are remarkably stable. Here's the full set as of mid-2026, what each one counts, and how to plan a multi-card portfolio that respects all of them simultaneously.
+
+  ## The Master List
+
+  | Issuer | Rule | Scope | Effect |
+  |---|---|---|---|
+  | **Chase** | 5/24 | All issuers, personal cards | Auto-decline if 5+ accounts opened in 24 months |
+  | **Bank of America** | 2/3/4 | BofA personal cards only | 2 in 30d, 3 in 12m, 4 in 24m max approvals |
+  | **American Express** | 1/5 (rumored) | Amex personal cards | ~1 new Amex every 90 days, soft cap |
+  | **Capital One** | 1 in 6 months | All Capital One cards | 1 approval per 6 months |
+  | **Capital One** | 2 personal max | Capital One personal cards | Cap on total open Capital One personal cards |
+  | **Citi** | 1/8 rule | Same Citi card | 1 welcome bonus per card per 24 months |
+  | **Citi** | 8/65/95 (loose) | Citi family-of-cards | Various bonus eligibility windows |
+  | **Discover** | 1 every 12 months | Discover cards | 1 personal Discover card per 12 months |
+  | **Wells Fargo** | 6-month rule | Wells personal cards | 1 Wells card per 6 months |
+  | **Barclays** | 6/24 (soft) | All issuers | Soft cap, varies by card |
+  | **U.S. Bank** | 2 within 12m | U.S. Bank cards | Generally 2 per 12 months |
+
+  Below, what each of these means in practice.
+
+  ## Chase 5/24 (The Big One)
+
+  The most-discussed velocity rule. Auto-declines any new Chase personal credit card application if you have 5 or more new accounts on your personal credit report opened in the last 24 months.
+
+  - **What counts**: Personal credit cards from any issuer (not just Chase), authorized user accounts on others' personal cards, some store cards
+  - **What doesn't count**: Chase business cards (and most business cards from issuers that don't report to personal credit), auto loans, mortgages, personal loans
+  - **How it's enforced**: Hard rule, no reconsideration override
+
+  Workarounds:
+  - Wait — accounts age out at the 24-month anniversary
+  - Stack [business cards that don't report to personal credit](/articles/business-cards-not-on-personal-credit) — they don't count toward 5/24
+  - For Chase business cards specifically: 5/24 still applies (you must be under 5/24 to apply for any Chase card), but the new business card doesn't add to your count
+
+  See our [dedicated 5/24 article](/articles/chase-5-24-rule-explained) for full coverage.
+
+  ## Bank of America 2/3/4
+
+  Three rolling windows for BofA personal cards:
+
+  - **2 BofA personal cards approved in any 30-day window**
+  - **3 BofA personal cards approved in any 12-month window**
+  - **4 BofA personal cards approved in any 24-month window**
+
+  All three must be satisfied simultaneously. Crossing any one auto-declines.
+
+  - **What counts**: BofA-branded personal credit cards (Customized Cash, Premium Rewards, Travel Rewards, etc.)
+  - **What doesn't count**: BofA business cards, AU adds, BofA debit cards, mortgages
+
+  Loophole: Preferred Rewards Platinum Honors customers (and above) sometimes get exceptions to the 24-month cap, especially the 4th-card-in-24m limit. Not guaranteed, but worth applying if you're at that tier.
+
+  See [BofA 2/3/4 article](/articles/bank-of-america-2-3-4-rule).
+
+  ## American Express Velocity (1/5 rumored)
+
+  Amex's velocity rule is informal but consistently observed:
+
+  - Roughly **1 new Amex personal card every 90 days** without flagging
+  - Roughly **5 Amex card approvals total in any 12-month window** without triggering risk-system flags
+  - Crossing either tends to trigger denials, financial review (FR), or pop-up jail-style blocks on future Amex applications
+
+  - **What counts**: Amex-branded personal credit cards and charge cards
+  - **What doesn't count**: Amex business cards (separately tracked), Amex Membership Rewards-only products
+
+  Amex also has a separate "no SUB" rule per card (the [once-per-lifetime](/articles/amex-once-per-lifetime-rule) rule) — distinct from velocity.
+
+  Practical advice: don't apply for more than one Amex personal card per quarter, and don't have more than 4 active Amex personal cards at once unless you're consistently using all of them organically.
+
+  ## Capital One 1-in-6 + 2-Personal Max
+
+  Capital One has two distinct caps:
+
+  ### 1-in-6 month rule
+  - One Capital One credit card approval per 6 months (rolling)
+  - Applies across all Capital One cards (personal + business + co-brand)
+  - Crossing this auto-declines
+
+  ### 2-personal-card max
+  - You can have at most 2 Capital One personal credit cards open simultaneously
+  - Business cards are not counted toward this cap
+
+  Combined: you can hold 2 personal Capital One cards + multiple business cards, with new approvals spaced 6 months apart.
+
+  See [Capital One bucket article](/articles/capital-one-bucket-system) for the broader Capital One underwriting structure.
+
+  ## Citi 8/65/95 (Family-of-Cards Bonus Rules)
+
+  Citi's velocity rules are about welcome bonus eligibility within "card families":
+
+  - **24-month rule (within a family)**: You generally can't get the welcome bonus on a card if you've received the bonus on another card in the same family within 24 months
+  - **48-month rule (some products)**: Some Citi premium cards (especially the legacy AAdvantage Executive) have 48-month bonus restrictions
+
+  Card families:
+
+  - **Citi ThankYou Points family**: Strata Premier, Custom Cash, Double Cash, Rewards+
+  - **AAdvantage family**: AAdvantage MileUp, Platinum Select, Executive
+  - **Costco family**: Costco Anywhere Visa (separate from other Citi cards)
+
+  The "8/65/95" terminology is shorthand for the various rolling-window restrictions. Less commonly enforced than 5/24 or 2/3/4, but still significant for welcome-bonus optimization.
+
+  Citi will approve you for the card even if you're not bonus-eligible — the bonus simply won't post. Always check the offer terms before applying.
+
+  ## Discover 1-Every-12-Months
+
+  Discover limits applicants to one new Discover personal card every 12 months. Approvals on Discover cards are also relatively conservative for thin files; the velocity cap matters less than Discover's overall underwriting tilt.
+
+  - **What counts**: Discover It Cash Back, Discover It Miles, Discover It Chrome, Discover It Student variants
+  - **What doesn't count**: Discover business cards (rare, but exist)
+
+  Discover also automatically reviews secured cards for graduation to unsecured at month 7 — the graduated card doesn't count as a "new approval" toward the 12-month rule.
+
+  ## Wells Fargo 6-Month Rule
+
+  Wells Fargo limits applicants to one new Wells personal card every 6 months. Less strict than the issuers above, but a real constraint when stacking applications.
+
+  ## Barclays 6/24 (Soft)
+
+  Barclays has a less-rigid velocity rule that's observed but not always enforced. Applicants with 6+ new accounts on their report in the last 24 months are more likely to be declined for Barclays cards (especially the JetBlue Plus and AAdvantage Aviator products), but the rule isn't absolute. Approvals at 6/24 and 7/24 happen.
+
+  ## U.S. Bank 2-in-12
+
+  U.S. Bank generally approves a maximum of two of their cards per 12-month window. Less strict than peers but still a planning constraint.
+
+  ## How to Plan a Multi-Issuer Portfolio
+
+  Given all these rules simultaneously, the optimal approach is:
+
+  ### Year 1 strategy: prioritize Chase
+  Chase 5/24 is the most punishing rule. If you're under 5/24, prioritize Chase applications first — they have the strongest welcome bonuses (Sapphire Preferred 60K+, Sapphire Reserve 75K+) and the most restrictive velocity rule.
+
+  Sample first-year sequence (starting at 0/24):
+
+  - **Month 0**: Chase Sapphire Preferred (1/24)
+  - **Month 4**: Chase Freedom Flex or Freedom Unlimited (2/24)
+  - **Month 8**: Chase Ink Business Cash (still 2/24 — business doesn't count)
+  - **Month 12**: Amex Gold (3/24)
+
+  ### Year 2 strategy: stack Amex and BofA
+  Amex's velocity is per-issuer. BofA 2/3/4 is per-issuer. Both can run in parallel without affecting your other applications.
+
+  - **Month 13**: Amex Platinum (4/24)
+  - **Month 16**: BofA Premium Rewards (5/24 — but Chase isn't your target now)
+  - **Month 20**: Capital One Venture or Venture X (depending on bucket eligibility)
+  - **Month 24**: Citi Strata Premier or other ThankYou card
+
+  ### Always keep Chase 5/24 in mind
+  Even when not actively applying for Chase, the 5/24 rule constrains your overall pacing. Most rewards optimizers stay under 5/24 indefinitely, so they're always eligible to drop in a Chase application when desirable.
+
+  ## Cross-Issuer Velocity Patterns
+
+  Beyond per-issuer rules, your overall application velocity affects approvals at every issuer:
+
+  ### Pattern 1: 4+ new accounts in 6 months
+  Most issuers tolerate this but will flag risk. Approvals slow, credit limits decrease.
+
+  ### Pattern 2: 6+ new accounts in 12 months
+  Many issuers start declining outright (BofA, Barclays especially) regardless of which issuer the new accounts are from.
+
+  ### Pattern 3: 8+ new accounts in 24 months
+  You're at or above 5/24, hitting BofA and Barclays soft caps, and likely flagged at Capital One and Amex risk systems.
+
+  Practical advice: keep total new-credit velocity at most 4 personal cards per 12 months across all issuers, even when you have headroom at specific issuers.
+
+  ## Inquiries vs Account Openings
+
+  Velocity rules typically count **opened accounts**, not inquiries. So:
+
+  - A denied Chase application generates an inquiry but no account → doesn't add to 5/24
+  - An approved Capital One application generates 3 inquiries (triple-pull) but only 1 account → adds 1 to 5/24
+  - An AU add generates no inquiry (or soft pull) but adds 1 account → adds 1 to 5/24
+
+  Inquiries hurt your score and can affect approval odds at velocity-conscious issuers (BofA, Amex risk system), but they don't directly count against rule-based caps like 5/24.
+
+  ## FAQ
+
+  ### Are velocity rules officially documented?
+  No. None of the major issuers publish their rules. Numbers like "5/24" come from thousands of community data points and are stable enough to plan around.
+
+  ### Can velocity rules change?
+  Yes. They've shifted over the years. Chase 5/24 was first observed around 2016; before that, Chase had no velocity cap. BofA 2/3/4 has been stable since around 2018. Amex velocity has shifted multiple times. Always check community forums (CreditBoards, r/churning, FlyerTalk) for current data points before assuming.
+
+  ### Do velocity rules affect my credit score?
+  Velocity rules themselves don't appear on your credit report. The new accounts and inquiries that drive velocity rules do affect your score, but the rule-based caps are issuer-side decisions.
+
+  ### What if I'm at 5/24 but I really want a Chase card?
+  Two options: wait until your oldest of the 5 accounts ages out (24 months from opening), or apply for a Chase business card (which still requires you to be under 5/24, but can be obtained without adding to your 5/24 if you qualify for one).
+
+  ### Can I get an exception to velocity rules?
+  At BofA, sometimes (Preferred Rewards Platinum Honors+). At most other issuers, no — the rules are hard-coded into the underwriting system.
+
+  ### Do AU accounts count toward velocity rules?
+  Chase 5/24: yes. BofA 2/3/4: no. Amex velocity: typically no. Capital One: no. The general pattern is that AU adds count for "all-issuer" rules (5/24) but not for issuer-specific rules.
+
+  ### What's the cleanest way to track my own velocity?
+  Pull all three credit reports (annualcreditreport.com, free annually). For each open card, note the open date. Sort by open date. Anything in the last 24 months counts toward 5/24; anything in the last 12 months counts toward most other velocity rules.
+
+  ### Will charge cards (Amex Gold, Platinum) count toward 5/24?
+  Yes. If a card appears on your personal credit report, it counts toward 5/24, regardless of whether it's a credit card or charge card.
+
+  ### Are velocity rules different for business cards?
+  Mostly. Business cards from non-reporting issuers (Chase, Amex, BofA, Citi, US Bank, Wells) don't count toward 5/24. Capital One business cards do. Each issuer has its own internal velocity rule for business cards (e.g., Chase typically allows one Ink card per 90 days).
+
+  ### What's the maximum number of new cards per year before I'm "in trouble"?
+  Across all issuers, going above 4 new cards per 12 months starts triggering velocity-related declines and risk flags. Heavy churners with 6+ per year accept ongoing approval friction as a cost of optimization.
+
+  ## The Bottom Line
+
+  Velocity rules are the most important constraint in any multi-card strategy. Three rules:
+
+  1. **Stay under Chase 5/24 indefinitely.** The single most important rule. Every other velocity rule is per-issuer or per-card, but 5/24 affects approvals at the issuer with the strongest welcome bonuses.
+  2. **Plan 24 months ahead.** Velocity rules use 24-month windows almost universally. Map your applications onto a 24-month calendar before starting any optimization push.
+  3. **Use business cards to bypass.** Business cards from non-reporting issuers (Chase, Amex, BofA, Citi, US Bank, Wells) don't count toward 5/24. They're the most effective velocity workaround.
+
+  Done well, you can apply for 4–6 cards per year and hit major welcome bonuses without ever tripping a velocity decline.

--- a/scripts/publish-scheduled-articles.js
+++ b/scripts/publish-scheduled-articles.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const DRAFTS_DIR = path.join(__dirname, '..', 'data', 'articles', 'drafts');
+const ARTICLES_DIR = path.join(__dirname, '..', 'data', 'articles');
+
+function todayUTC() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function main() {
+  if (!fs.existsSync(DRAFTS_DIR)) {
+    console.log('No drafts directory; nothing to publish.');
+    return;
+  }
+
+  const today = todayUTC();
+  const files = fs
+    .readdirSync(DRAFTS_DIR)
+    .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+
+  if (files.length === 0) {
+    console.log('No draft articles found.');
+    return;
+  }
+
+  let moved = 0;
+
+  for (const file of files) {
+    const draftPath = path.join(DRAFTS_DIR, file);
+    const content = fs.readFileSync(draftPath, 'utf8');
+
+    let parsed;
+    try {
+      parsed = yaml.load(content);
+    } catch (err) {
+      console.error(`Skipping ${file}: invalid YAML — ${err.message}`);
+      continue;
+    }
+
+    if (!parsed || !parsed.date) {
+      console.error(`Skipping ${file}: missing date field`);
+      continue;
+    }
+
+    if (parsed.date > today) {
+      console.log(`Holding ${file} — scheduled for ${parsed.date} (today is ${today})`);
+      continue;
+    }
+
+    const targetPath = path.join(ARTICLES_DIR, file);
+    if (fs.existsSync(targetPath)) {
+      console.error(`Skipping ${file}: target already exists at ${targetPath}`);
+      continue;
+    }
+
+    fs.writeFileSync(targetPath, content);
+    fs.unlinkSync(draftPath);
+    console.log(`Published ${file} (date: ${parsed.date})`);
+    moved++;
+  }
+
+  console.log(`\nPublished ${moved} article(s).`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `data/articles/drafts/` folder where articles wait until their `date` field arrives
- New daily GitHub Actions cron (`publish-scheduled-articles.yml`, 14:00 UTC) moves any drafts whose date has been reached into `data/articles/` and pushes — firing the existing build pipeline so each article publishes itself end-to-end (S3 upload, image sync, social post, IndexNow) with no manual action
- Queues 20 articles on a Mon/Thu cadence from 2026-05-11 through 2026-07-16

## How the scheduling works

The article build script (`scripts/build-articles.js`) only reads `*.yaml` files directly in `data/articles/` — its filter naturally skips subdirectories, so drafts stay invisible to `articles.json` until they're promoted out of the folder.

`scripts/publish-scheduled-articles.js` runs daily, parses each draft's `date` field, and moves it (write + unlink, not git-mv) only when `date <= today (UTC)`. The resulting commit's added file is detected by the existing `build-articles.yml` workflow's `git diff --diff-filter=A HEAD~1` step, so social-media auto-posting and IndexNow submission still fire correctly.

## The 20 articles (Mon/Thu cadence)

| # | Date | Article |
|---|---|---|
| 1 | Mon May 11 | Hard inquiries explained |
| 2 | Thu May 14 | Denial reasons + reconsideration scripts |
| 3 | Mon May 18 | Pre-approval vs pre-qualification |
| 4 | Thu May 21 | What income to put on a CC application |
| 5 | Mon May 25 | Amex once-per-lifetime rule |
| 6 | Thu May 28 | Capital One bucket system |
| 7 | Mon Jun 1 | Bank of America 2/3/4 rule |
| 8 | Thu Jun 4 | Chase pop-up jail |
| 9 | Mon Jun 8 | How many credit cards is too many |
| 10 | Thu Jun 11 | Closing a credit card without tanking score |
| 11 | Mon Jun 15 | Authorized user strategy |
| 12 | Thu Jun 18 | Business cards that don't report to personal |
| 13 | Mon Jun 22 | Statement balance vs current balance |
| 14 | Thu Jun 25 | Best first credit card with no credit history |
| 15 | Mon Jun 29 | Retention offers + scripts |
| 16 | Thu Jul 2 | Credit limit increases |
| 17 | Mon Jul 6 | Velocity rules by issuer |
| 18 | Thu Jul 9 | Annual fee math |
| 19 | Mon Jul 13 | FICO vs VantageScore |
| 20 | Thu Jul 16 | Foreign transaction fees |

## Test plan

- [x] `npm run build:articles` still builds only the 7 existing articles — drafts invisible
- [x] All 20 draft YAMLs parse and have all required schema fields
- [x] `node scripts/publish-scheduled-articles.js` correctly holds all 20 (today is May 10; earliest publish is May 11)
- [ ] After merge: confirm next-day cron publishes article 1 on May 11 and the existing build pipeline fires social-post + IndexNow as expected
- [ ] If cadence needs adjusting: just edit `date:` fields in any draft and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)