### PR TITLE
ci: fix git pathspec so subdirectories don't match in new-file detection

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -89,7 +89,11 @@ jobs:
       - name: Detect new article files
         id: new-files
         run: |
-          NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- 'data/articles/*.yaml' 'data/articles/*.yml' 2>/dev/null | tr '\n' ' ' | xargs)
+          # `:(glob)` magic uses shell-style globbing — `*` matches a single path
+          # component and does NOT cross `/`, so files under data/articles/drafts/
+          # are correctly excluded. Without it, git's default pathspec would treat
+          # `*.yaml` as fnmatch and match nested paths too.
+          NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- ':(glob)data/articles/*.yaml' ':(glob)data/articles/*.yml' 2>/dev/null | tr '\n' ' ' | xargs)
           echo "files=$NEW_FILES" >> $GITHUB_OUTPUT
           if [ -n "$NEW_FILES" ]; then
             echo "New article files detected:"

--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -75,7 +75,10 @@ jobs:
             echo "Test mode: using provided file"
             echo "files=${{ inputs.test_post_file }}" >> $GITHUB_OUTPUT
           else
-            NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- 'data/news/*.yaml' 'data/news/*.yml' 2>/dev/null | tr '\n' ' ' | xargs)
+            # `:(glob)` magic uses shell-style globbing — `*` matches a single path
+            # component and does NOT cross `/`, so any subdirectory under data/news/
+            # is correctly excluded.
+            NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- ':(glob)data/news/*.yaml' ':(glob)data/news/*.yml' 2>/dev/null | tr '\n' ' ' | xargs)
             echo "files=$NEW_FILES" >> $GITHUB_OUTPUT
             if [ -n "$NEW_FILES" ]; then
               echo "New news files detected:"


### PR DESCRIPTION
## Summary

- git pathspec wildcards match across `/` by default, so `'data/articles/*.yaml'` matched `data/articles/drafts/*.yaml` too
- That's how merging [#1153](https://github.com/CreditOdds/creditodds/pull/1153) caused the social-posting workflow to queue tweets for all 20 scheduled drafts (post IDs 121–140) and submit 20 IndexNow URLs for articles that weren't live yet
- The build script's own JS filter correctly ignored subdirectories — only the workflow's `git diff` step had the bug
- Fix: switch to `:(glob)` magic, which uses shell-style globbing where `*` matches a single path component and does NOT cross `/`

## Verification

Against the original problem commit `c8042353`:
- Buggy pattern `'data/articles/*.yaml'`: **20 matches** (all 20 drafts)
- Fixed pattern `':(glob)data/articles/*.yaml'`: **0 matches** ✅

## Why also patch build-news.yml

Same bug pattern. No `data/news/` subdirectory exists today, but defensive — anyone adding one (e.g., a `drafts/` for scheduled news in the future) would hit the same problem.

## Test plan

- [x] Verified buggy pattern matches 20 drafts on the problem commit
- [x] Verified fixed pattern matches 0
- [ ] After merge: next time the daily promotion cron pushes a draft into `data/articles/`, only that one file should appear in `NEW_FILES`, not the remaining drafts

🤖 Generated with [Claude Code](https://claude.com/claude-code)