### PR TITLE
ios: add SwiftUI app porting /profile (Cards + Earn tabs)

### DIFF
--- a/apps/ios/.gitignore
+++ b/apps/ios/.gitignore
@@ -1,0 +1,21 @@
+# XcodeGen-managed; regenerate with `xcodegen` instead of committing
+*.xcodeproj/
+*.xcworkspace/
+
+# Build artifacts
+build/
+DerivedData/
+*.xcuserstate
+xcuserdata/
+
+# Firebase config (contains app-specific keys; commit only after reviewing)
+# Comment this line out once you've added GoogleService-Info.plist and verified
+# it doesn't contain anything you want to keep out of git.
+CreditOdds/Resources/GoogleService-Info.plist
+
+# SwiftPM
+.swiftpm/
+Package.resolved
+
+# macOS
+.DS_Store

--- a/apps/ios/CreditOdds/CreditOdds.entitlements
+++ b/apps/ios/CreditOdds/CreditOdds.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.creditodds.app</string>
+    </array>
+</dict>
+</plist>

--- a/apps/ios/CreditOdds/CreditOddsApp.swift
+++ b/apps/ios/CreditOdds/CreditOddsApp.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import FirebaseCore
+
+@main
+struct CreditOddsApp: App {
+    @StateObject private var auth = AuthViewModel()
+
+    init() {
+        FirebaseApp.configure()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(auth)
+                .tint(Color(red: 0.42, green: 0.31, blue: 0.91))
+        }
+    }
+}

--- a/apps/ios/CreditOdds/Info.plist
+++ b/apps/ios/CreditOdds/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>CreditOdds</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+	</dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>CreditOdds uses your location to recommend the best card from your wallet for nearby merchants.</string>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string></string>
+	</dict>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/CreditOdds/Models/Card.swift
+++ b/apps/ios/CreditOdds/Models/Card.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct Card: Identifiable, Decodable, Hashable {
+    let cardName: String
+    let bank: String?
+    let slug: String?
+    let cardImageLink: String?
+    let annualFee: Double?
+    let acceptingApplications: Bool?
+    let rewards: [Reward]?
+
+    var id: String { cardName }
+
+    enum CodingKeys: String, CodingKey {
+        case cardName = "card_name"
+        case bank
+        case slug
+        case cardImageLink = "card_image_link"
+        case annualFee = "annual_fee"
+        case acceptingApplications = "accepting_applications"
+        case rewards
+    }
+}

--- a/apps/ios/CreditOdds/Models/NearbyPlace.swift
+++ b/apps/ios/CreditOdds/Models/NearbyPlace.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct NearbyPlace: Decodable, Identifiable, Hashable {
+    let id: String
+    let name: String
+    let primaryType: String?
+    let types: [String]?
+    let address: String?
+    let lat: Double?
+    let lng: Double?
+}
+
+struct NearbyResponse: Decodable {
+    let places: [NearbyPlace]
+}

--- a/apps/ios/CreditOdds/Models/Reward.swift
+++ b/apps/ios/CreditOdds/Models/Reward.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct Reward: Decodable, Hashable {
+    let category: String
+    let value: Double
+    let unit: String          // "percent" | "points_per_dollar" | "miles_per_dollar"
+    let note: String?
+    let mode: String?         // "quarterly_rotating" | "user_choice" | "auto_top_spend"
+    let currentCategories: [RotatingSlot]?
+    let currentPeriod: String?
+    let merchantSpecific: Bool?
+    let spendCap: Double?
+    let capPeriod: String?
+    let rateAfterCap: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case category, value, unit, note, mode
+        case currentCategories = "current_categories"
+        case currentPeriod = "current_period"
+        case merchantSpecific = "merchant_specific"
+        case spendCap = "spend_cap"
+        case capPeriod = "cap_period"
+        case rateAfterCap = "rate_after_cap"
+    }
+}
+
+// Rotating-category slot: either a bare category string, or {category, note}.
+struct RotatingSlot: Decodable, Hashable {
+    let category: String
+    let note: String?
+
+    init(from decoder: Decoder) throws {
+        if let container = try? decoder.singleValueContainer(),
+           let str = try? container.decode(String.self) {
+            self.category = str
+            self.note = nil
+            return
+        }
+        let keyed = try decoder.container(keyedBy: CodingKeys.self)
+        self.category = try keyed.decode(String.self, forKey: .category)
+        self.note = try keyed.decodeIfPresent(String.self, forKey: .note)
+    }
+
+    private enum CodingKeys: String, CodingKey { case category, note }
+}

--- a/apps/ios/CreditOdds/Models/WalletCard.swift
+++ b/apps/ios/CreditOdds/Models/WalletCard.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct WalletCard: Identifiable, Decodable, Hashable {
+    let id: Int
+    let cardId: Int
+    let cardName: String
+    let bank: String
+    let cardImageLink: String?
+    let acquiredMonth: Int?
+    let acquiredYear: Int?
+    let sortOrder: Int?
+    let createdAt: String
+    let userRating: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case cardId = "card_id"
+        case cardName = "card_name"
+        case bank
+        case cardImageLink = "card_image_link"
+        case acquiredMonth = "acquired_month"
+        case acquiredYear = "acquired_year"
+        case sortOrder = "sort_order"
+        case createdAt = "created_at"
+        case userRating = "user_rating"
+    }
+}

--- a/apps/ios/CreditOdds/Services/APIClient.swift
+++ b/apps/ios/CreditOdds/Services/APIClient.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+enum APIError: LocalizedError {
+    case invalidURL
+    case http(Int, String)
+    case decoding(Error)
+    case transport(Error)
+    case unauthenticated
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid URL."
+        case .http(let code, let body): return "HTTP \(code): \(body)"
+        case .decoding(let err): return "Decoding error: \(err.localizedDescription)"
+        case .transport(let err): return "Network error: \(err.localizedDescription)"
+        case .unauthenticated: return "You're signed out."
+        }
+    }
+}
+
+actor APIClient {
+    static let shared = APIClient()
+
+    private let baseURL: URL
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    init(baseURL: URL = URL(string: "https://d2ojrhbh2dincr.cloudfront.net")!,
+         session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+        let dec = JSONDecoder()
+        self.decoder = dec
+    }
+
+    func get<T: Decodable>(_ path: String,
+                           query: [URLQueryItem] = [],
+                           token: String? = nil) async throws -> T {
+        try await request(path: path, method: "GET", query: query, token: token, body: nil)
+    }
+
+    func post<T: Decodable, B: Encodable>(_ path: String,
+                                          body: B,
+                                          token: String? = nil) async throws -> T {
+        let data = try JSONEncoder().encode(body)
+        return try await request(path: path, method: "POST", query: [], token: token, body: data)
+    }
+
+    func put<T: Decodable, B: Encodable>(_ path: String,
+                                         body: B,
+                                         token: String? = nil) async throws -> T {
+        let data = try JSONEncoder().encode(body)
+        return try await request(path: path, method: "PUT", query: [], token: token, body: data)
+    }
+
+    func delete<T: Decodable>(_ path: String, token: String? = nil) async throws -> T {
+        try await request(path: path, method: "DELETE", query: [], token: token, body: nil)
+    }
+
+    private func request<T: Decodable>(path: String,
+                                       method: String,
+                                       query: [URLQueryItem],
+                                       token: String?,
+                                       body: Data?) async throws -> T {
+        var components = URLComponents(url: baseURL.appendingPathComponent(path),
+                                       resolvingAgainstBaseURL: false)
+        if !query.isEmpty { components?.queryItems = query }
+        guard let url = components?.url else { throw APIError.invalidURL }
+
+        var req = URLRequest(url: url)
+        req.httpMethod = method
+        req.cachePolicy = .reloadIgnoringLocalCacheData
+        if let token { req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        if let body {
+            req.httpBody = body
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        do {
+            let (data, response) = try await session.data(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                throw APIError.http(-1, "No HTTP response")
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                let bodyText = String(data: data, encoding: .utf8) ?? ""
+                throw APIError.http(http.statusCode, bodyText)
+            }
+            if T.self == EmptyResponse.self {
+                return EmptyResponse() as! T
+            }
+            do {
+                return try decoder.decode(T.self, from: data)
+            } catch {
+                throw APIError.decoding(error)
+            }
+        } catch let err as APIError {
+            throw err
+        } catch {
+            throw APIError.transport(error)
+        }
+    }
+}
+
+struct EmptyResponse: Decodable {}

--- a/apps/ios/CreditOdds/Services/AuthService.swift
+++ b/apps/ios/CreditOdds/Services/AuthService.swift
@@ -1,0 +1,40 @@
+import Foundation
+import FirebaseAuth
+
+enum AuthService {
+    static func currentUser() -> User? {
+        Auth.auth().currentUser
+    }
+
+    static func idToken(forceRefresh: Bool = false) async throws -> String? {
+        guard let user = Auth.auth().currentUser else { return nil }
+        return try await user.getIDToken(forcingRefresh: forceRefresh)
+    }
+
+    static func sendSignInLink(to email: String,
+                               continueURL: String = "https://creditodds.com/login") async throws {
+        let settings = ActionCodeSettings()
+        settings.url = URL(string: continueURL)
+        settings.handleCodeInApp = true
+        settings.setIOSBundleID(Bundle.main.bundleIdentifier ?? "com.creditodds.app")
+        try await Auth.auth().sendSignInLink(toEmail: email, actionCodeSettings: settings)
+        UserDefaults.standard.set(email, forKey: "emailForSignIn")
+    }
+
+    static func completeSignIn(with link: String) async throws {
+        guard let email = UserDefaults.standard.string(forKey: "emailForSignIn") else {
+            throw NSError(domain: "AuthService", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Email not found on this device."])
+        }
+        guard Auth.auth().isSignIn(withEmailLink: link) else {
+            throw NSError(domain: "AuthService", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "Invalid sign-in link."])
+        }
+        _ = try await Auth.auth().signIn(withEmail: email, link: link)
+        UserDefaults.standard.removeObject(forKey: "emailForSignIn")
+    }
+
+    static func signOut() throws {
+        try Auth.auth().signOut()
+    }
+}

--- a/apps/ios/CreditOdds/Services/BestHereRanker.swift
+++ b/apps/ios/CreditOdds/Services/BestHereRanker.swift
@@ -1,0 +1,85 @@
+import Foundation
+import CoreLocation
+
+struct MerchantPick: Identifiable, Hashable {
+    let placeId: String
+    let placeName: String
+    let address: String?
+    let categoryLabel: String
+    let categoryId: String
+    let distanceMeters: Double?
+    let primary: EarnPick
+    let alternative: EarnPick?
+
+    var id: String { placeId }
+
+    var distanceText: String? {
+        guard let m = distanceMeters else { return nil }
+        let mi = m / 1609.34
+        if mi < 0.1 { return "<0.1 mi" }
+        return String(format: "%.1f mi", mi)
+    }
+}
+
+/// Lightweight "best card here" ranker. For each nearby place, maps the
+/// Google Places type to a reward category and reuses the wallet-wide
+/// EarnRanker to pick the best wallet card. Does NOT yet handle brand-gated
+/// rewards (e.g. Marriott Bonvoy at Marriott hotels) — that needs the brand
+/// index + merchant_gate logic from the web's storeRanking.
+enum BestHereRanker {
+    static func picks(for places: [NearbyPlace],
+                      walletCards: [WalletCard],
+                      allCards: [Card],
+                      userLocation: CLLocation) -> [MerchantPick] {
+        guard !walletCards.isEmpty, !allCards.isEmpty else { return [] }
+        let categoryBests = EarnRanker.bestByCategory(walletCards: walletCards,
+                                                      allCards: allCards)
+        let bestByCategory = Dictionary(uniqueKeysWithValues:
+            categoryBests.map { ($0.category, $0) })
+
+        var results: [MerchantPick] = []
+        for place in places {
+            let match = PlaceTypeMapping.match(place)
+            // Try the categories in order — primary first, then issuer subtypes.
+            // First category that has a wallet pick wins.
+            var chosen: CategoryBest?
+            var chosenCat: String = match.primary
+            for cat in match.categories {
+                if let entry = bestByCategory[cat] {
+                    chosen = entry
+                    chosenCat = cat
+                    break
+                }
+            }
+            guard let entry = chosen else { continue }
+
+            let dist: Double? = {
+                guard let lat = place.lat, let lng = place.lng else { return nil }
+                let p = CLLocation(latitude: lat, longitude: lng)
+                return userLocation.distance(from: p)
+            }()
+
+            results.append(
+                MerchantPick(
+                    placeId: place.id,
+                    placeName: place.name,
+                    address: place.address?.split(separator: ",").first.map(String.init),
+                    categoryLabel: CategoryLabels.label(chosenCat),
+                    categoryId: chosenCat,
+                    distanceMeters: dist,
+                    primary: entry.primary,
+                    alternative: entry.alternative
+                )
+            )
+        }
+
+        return results.sorted {
+            switch ($0.distanceMeters, $1.distanceMeters) {
+            case let (a?, b?): return a < b
+            case (nil, _?): return false
+            case (_?, nil): return true
+            default: return false
+            }
+        }
+    }
+}

--- a/apps/ios/CreditOdds/Services/CardService.swift
+++ b/apps/ios/CreditOdds/Services/CardService.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+enum CardService {
+    static func all() async throws -> [Card] {
+        try await APIClient.shared.get("/cards")
+    }
+}
+
+/// Process-wide cache for the full card catalog. The /cards response is
+/// large and rarely changes — the web side relies on Next.js ISR for the
+/// same effect. We hold one in-memory copy and let callers `await` it.
+@MainActor
+final class CardsRepository: ObservableObject {
+    static let shared = CardsRepository()
+
+    @Published private(set) var cards: [Card] = []
+    @Published private(set) var isLoading = false
+    @Published private(set) var errorMessage: String?
+
+    private var loadTask: Task<[Card], Error>?
+
+    func loadIfNeeded() async {
+        if !cards.isEmpty || isLoading { return }
+        await load()
+    }
+
+    func load() async {
+        if let existing = loadTask {
+            _ = try? await existing.value
+            return
+        }
+        isLoading = true
+        errorMessage = nil
+        let task = Task<[Card], Error> { try await CardService.all() }
+        loadTask = task
+        defer {
+            isLoading = false
+            loadTask = nil
+        }
+        do {
+            let result = try await task.value
+            self.cards = result
+        } catch {
+            self.errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/CreditOdds/Services/CategoryLabels.swift
+++ b/apps/ios/CreditOdds/Services/CategoryLabels.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum CategoryLabels {
+    static let labels: [String: String] = [
+        "dining": "Dining",
+        "groceries": "Groceries",
+        "travel": "Travel",
+        "gas": "Gas",
+        "streaming": "Streaming",
+        "transit": "Transit",
+        "drugstores": "Drugstores",
+        "home_improvement": "Home Improvement",
+        "online_shopping": "Online Shopping",
+        "hotels": "Hotels",
+        "airlines": "Airlines",
+        "car_rentals": "Car Rentals",
+        "entertainment": "Entertainment",
+        "rotating": "Rotating Categories",
+        "top_category": "Top Spend Category",
+        "selected_categories": "Selected Categories",
+        "travel_portal": "Travel (via Portal)",
+        "hotels_portal": "Hotels (via Portal)",
+        "flights_portal": "Flights (via Portal)",
+        "hotels_car_portal": "Hotels & Car Rentals (via Portal)",
+        "car_rentals_portal": "Car Rentals (via Portal)",
+        "amazon": "Amazon.com",
+        "rei": "REI",
+        "everything_else": "Everything Else",
+        "fast_food": "Fast Food",
+        "electronics_stores": "Electronics Stores",
+        "tv_internet_streaming": "TV, Internet & Streaming Services",
+        "home_utilities": "Home Utilities",
+        "cell_phone_providers": "Cell Phone Providers",
+        "furniture_stores": "Furniture Stores",
+        "department_stores": "Department Stores",
+        "ground_transportation": "Ground Transportation",
+        "gyms_fitness": "Gyms/Fitness Centers",
+        "select_clothing": "Select Clothing Stores",
+        "sporting_goods": "Sporting Goods Stores",
+        "movie_theaters": "Movie Theaters",
+    ]
+
+    /// Display order matching the web's canonical iteration: insertion order
+    /// of the dictionary literal above, minus `everything_else`.
+    static let canonicalOrder: [String] = [
+        "dining", "groceries", "travel", "gas", "streaming", "transit",
+        "drugstores", "home_improvement", "online_shopping", "hotels",
+        "airlines", "car_rentals", "entertainment", "rotating", "top_category",
+        "selected_categories", "travel_portal", "hotels_portal",
+        "flights_portal", "hotels_car_portal", "car_rentals_portal",
+        "amazon", "rei", "fast_food", "electronics_stores",
+        "tv_internet_streaming", "home_utilities", "cell_phone_providers",
+        "furniture_stores", "department_stores", "ground_transportation",
+        "gyms_fitness", "select_clothing", "sporting_goods", "movie_theaters",
+    ]
+
+    static func label(_ category: String) -> String {
+        labels[category] ?? category
+    }
+}

--- a/apps/ios/CreditOdds/Services/EarnRanker.swift
+++ b/apps/ios/CreditOdds/Services/EarnRanker.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+struct EarnPick: Hashable {
+    let card: Card
+    let reward: Reward
+    let usdRate: Double
+    let rotating: Bool
+    let staleRotation: Bool
+    let slotNote: String?
+
+    var isConditional: Bool {
+        if reward.merchantSpecific == true { return true }
+        if let note = reward.note, !note.trimmingCharacters(in: .whitespaces).isEmpty {
+            return true
+        }
+        return false
+    }
+}
+
+struct CategoryBest: Identifiable, Hashable {
+    let category: String
+    let label: String
+    let primary: EarnPick
+    let alternative: EarnPick?
+
+    var id: String { category }
+}
+
+enum EarnRanker {
+    /// Mirrors apps/web-next/src/components/wallet/BestCardByCategory.tsx.
+    /// Picks the highest USD-equivalent reward in the user's wallet for each
+    /// category, with a fallback "unrestricted" pick when the top earner is
+    /// merchant- or note-conditional.
+    static func bestByCategory(walletCards: [WalletCard], allCards: [Card]) -> [CategoryBest] {
+        guard !walletCards.isEmpty, !allCards.isEmpty else { return [] }
+
+        // Dedupe by card_name — a card can't beat itself.
+        var seenNames = Set<String>()
+        let uniqueWallet = walletCards.filter { wc in seenNames.insert(wc.cardName).inserted }
+
+        let cardsByName = Dictionary(uniqueKeysWithValues: allCards.map { ($0.cardName, $0) })
+        let walletDefs: [Card] = uniqueWallet.compactMap { wc in
+            guard let card = cardsByName[wc.cardName],
+                  let rewards = card.rewards, !rewards.isEmpty else { return nil }
+            return card
+        }
+        if walletDefs.isEmpty { return [] }
+
+        let expectedQuarter = currentQuarterLabel()
+        var picksByCategory: [String: [EarnPick]] = [:]
+
+        for card in walletDefs {
+            // Per-card permanent-rate map so a rotating slot can't beat a
+            // permanent earner on the same card.
+            var permanentRates: [String: Double] = [:]
+            for r in card.rewards ?? [] where r.mode != "quarterly_rotating" {
+                let rate = Valuations.usdRate(for: r, card: card)
+                if rate > (permanentRates[r.category] ?? 0) {
+                    permanentRates[r.category] = rate
+                }
+            }
+
+            for r in card.rewards ?? [] {
+                if r.category == "everything_else" { continue }
+                let rate = Valuations.usdRate(for: r, card: card)
+
+                if r.mode == "quarterly_rotating",
+                   let slots = r.currentCategories, !slots.isEmpty {
+                    let stale = isStaleRotation(r, expected: expectedQuarter)
+                    for slot in slots {
+                        let cat = slot.category
+                        if cat.isEmpty || cat == "everything_else" { continue }
+                        let perm = permanentRates[cat] ?? 0
+                        if perm >= rate { continue }
+                        picksByCategory[cat, default: []].append(
+                            EarnPick(card: card, reward: r, usdRate: rate,
+                                     rotating: true, staleRotation: stale,
+                                     slotNote: slot.note)
+                        )
+                    }
+                    continue
+                }
+
+                picksByCategory[r.category, default: []].append(
+                    EarnPick(card: card, reward: r, usdRate: rate,
+                             rotating: false, staleRotation: false, slotNote: nil)
+                )
+            }
+        }
+
+        func buildEntry(category: String) -> CategoryBest? {
+            guard let picks = picksByCategory[category], !picks.isEmpty else { return nil }
+            let sorted = picks.sorted { $0.usdRate > $1.usdRate }
+            let primary = sorted[0]
+            var alternative: EarnPick?
+            if primary.isConditional {
+                alternative = sorted.first { p in
+                    !p.isConditional && p.card.cardName != primary.card.cardName
+                }
+            }
+            return CategoryBest(category: category,
+                                label: CategoryLabels.label(category),
+                                primary: primary,
+                                alternative: alternative)
+        }
+
+        var seen = Set<String>()
+        var results: [CategoryBest] = []
+        for cat in CategoryLabels.canonicalOrder {
+            if let entry = buildEntry(category: cat) {
+                results.append(entry)
+                seen.insert(cat)
+            }
+        }
+        for cat in picksByCategory.keys where !seen.contains(cat) {
+            if let entry = buildEntry(category: cat) {
+                results.append(entry)
+            }
+        }
+        return results
+    }
+
+    private static func currentQuarterLabel(_ now: Date = Date()) -> String {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let comps = cal.dateComponents([.month, .year], from: now)
+        let q = ((comps.month ?? 1) - 1) / 3 + 1
+        return "Q\(q) \(comps.year ?? 0)"
+    }
+
+    private static func isStaleRotation(_ reward: Reward, expected: String) -> Bool {
+        guard reward.mode == "quarterly_rotating" else { return false }
+        guard let cur = reward.currentPeriod, !cur.isEmpty else { return true }
+        return cur.trimmingCharacters(in: .whitespaces).uppercased() != expected.uppercased()
+    }
+}

--- a/apps/ios/CreditOdds/Services/LocationService.swift
+++ b/apps/ios/CreditOdds/Services/LocationService.swift
@@ -1,0 +1,94 @@
+import Foundation
+import CoreLocation
+
+/// Async wrapper around CLLocationManager. One-shot location request that
+/// throws if permission is denied or the OS can't get a fix in time.
+@MainActor
+final class LocationService: NSObject, ObservableObject {
+    enum LocationError: LocalizedError {
+        case denied
+        case servicesDisabled
+        case timeout
+        case underlying(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .denied: return "Location access is off for CreditOdds. Enable it in Settings → Privacy & Security → Location Services."
+            case .servicesDisabled: return "Location Services are off device-wide. Enable them in Settings."
+            case .timeout: return "Couldn't get your location in time. Try again."
+            case .underlying(let err): return err.localizedDescription
+            }
+        }
+    }
+
+    private let manager = CLLocationManager()
+    private var continuation: CheckedContinuation<CLLocation, Error>?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+    }
+
+    func requestOnce() async throws -> CLLocation {
+        switch manager.authorizationStatus {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .denied, .restricted:
+            throw LocationError.denied
+        case .authorizedWhenInUse, .authorizedAlways:
+            break
+        @unknown default:
+            break
+        }
+
+        return try await withCheckedThrowingContinuation { cont in
+            self.continuation = cont
+            self.manager.requestLocation()
+        }
+    }
+}
+
+extension LocationService: CLLocationManagerDelegate {
+    nonisolated func locationManager(_ manager: CLLocationManager,
+                                     didUpdateLocations locations: [CLLocation]) {
+        guard let last = locations.last else { return }
+        Task { @MainActor in
+            self.continuation?.resume(returning: last)
+            self.continuation = nil
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager,
+                                     didFailWithError error: Error) {
+        Task { @MainActor in
+            let mapped: Error
+            if (error as NSError).code == CLError.denied.rawValue {
+                mapped = LocationError.denied
+            } else {
+                mapped = LocationError.underlying(error)
+            }
+            self.continuation?.resume(throwing: mapped)
+            self.continuation = nil
+        }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in
+            switch status {
+            case .denied, .restricted:
+                if self.continuation != nil {
+                    self.continuation?.resume(throwing: LocationError.denied)
+                    self.continuation = nil
+                }
+            case .authorizedWhenInUse, .authorizedAlways:
+                if self.continuation != nil {
+                    manager.requestLocation()
+                }
+            default:
+                break
+            }
+        }
+    }
+}

--- a/apps/ios/CreditOdds/Services/NearbyService.swift
+++ b/apps/ios/CreditOdds/Services/NearbyService.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum NearbyService {
+    struct Body: Encodable {
+        let lat: Double
+        let lng: Double
+    }
+
+    static func fetch(lat: Double, lng: Double) async throws -> [NearbyPlace] {
+        guard let token = try await AuthService.idToken() else {
+            throw APIError.unauthenticated
+        }
+        let response: NearbyResponse = try await APIClient.shared.post(
+            "/nearby-recommendations",
+            body: Body(lat: lat, lng: lng),
+            token: token
+        )
+        return response.places
+    }
+}

--- a/apps/ios/CreditOdds/Services/PlaceTypeMapping.swift
+++ b/apps/ios/CreditOdds/Services/PlaceTypeMapping.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Maps Google Places API `primaryType` / `types` values to reward category
+/// slugs. Mirrors apps/web-next/src/lib/placeTypeMapping.ts.
+enum PlaceTypeMapping {
+    struct Match {
+        let primary: String
+        let categories: [String]
+        let matchedBy: MatchedBy
+        let matchedValue: String?
+    }
+
+    enum MatchedBy { case brand, primaryType, type, subtype, fallback }
+
+    private static let brandToCategory: [(match: String, category: String)] = [
+        ("whole foods", "amazon"),
+        ("amazon fresh", "amazon"),
+        ("amazon go", "amazon"),
+        ("rei", "rei"),
+    ]
+
+    private static let primaryTypeToCategory: [String: String] = [
+        // dining
+        "restaurant": "dining",
+        "cafe": "dining",
+        "coffee_shop": "dining",
+        "bar": "dining",
+        "meal_takeaway": "dining",
+        "meal_delivery": "dining",
+        "bakery": "dining",
+        "fast_food_restaurant": "dining",
+        "ice_cream_shop": "dining",
+        "pizza_restaurant": "dining",
+        "sandwich_shop": "dining",
+        // groceries
+        "supermarket": "groceries",
+        "grocery_store": "groceries",
+        "grocery_or_supermarket": "groceries",
+        // gas
+        "gas_station": "gas",
+        // drugstores
+        "pharmacy": "drugstores",
+        "drugstore": "drugstores",
+        // transit
+        "transit_station": "transit",
+        "bus_station": "transit",
+        "subway_station": "transit",
+        "train_station": "transit",
+        "taxi_stand": "transit",
+        "light_rail_station": "transit",
+        // hotels
+        "lodging": "hotels",
+        "hotel": "hotels",
+        "motel": "hotels",
+        "resort_hotel": "hotels",
+        "extended_stay_hotel": "hotels",
+        "inn": "hotels",
+        "bed_and_breakfast": "hotels",
+        // airlines / travel
+        "airport": "airlines",
+        "travel_agency": "travel",
+        // car rentals
+        "car_rental": "car_rentals",
+        // entertainment
+        "movie_theater": "entertainment",
+        "amusement_park": "entertainment",
+        "bowling_alley": "entertainment",
+        "zoo": "entertainment",
+        "aquarium": "entertainment",
+        "stadium": "entertainment",
+        "night_club": "entertainment",
+        // home improvement
+        "home_goods_store": "home_improvement",
+        "hardware_store": "home_improvement",
+    ]
+
+    private static let primaryTypeSubtypes: [String: [String]] = [
+        "fast_food_restaurant": ["fast_food"],
+        "meal_takeaway": ["fast_food"],
+        "movie_theater": ["movie_theaters"],
+        "electronics_store": ["electronics_stores"],
+        "furniture_store": ["furniture_stores"],
+        "gym": ["gyms_fitness"],
+        "fitness_center": ["gyms_fitness"],
+        "sporting_goods_store": ["sporting_goods"],
+        "taxi_stand": ["ground_transportation"],
+        "bus_station": ["ground_transportation"],
+        "subway_station": ["ground_transportation"],
+        "train_station": ["ground_transportation"],
+        "light_rail_station": ["ground_transportation"],
+        "transit_station": ["ground_transportation"],
+    ]
+
+    private static func withSubtypes(primary: String, sourceType: String?) -> [String] {
+        guard let sourceType,
+              let subs = primaryTypeSubtypes[sourceType] else { return [primary] }
+        return [primary] + subs
+    }
+
+    static func match(_ place: NearbyPlace) -> Match {
+        let lowerName = place.name.lowercased()
+        for entry in brandToCategory where lowerName.contains(entry.match) {
+            return Match(primary: entry.category,
+                         categories: [entry.category],
+                         matchedBy: .brand,
+                         matchedValue: entry.match)
+        }
+        if let pt = place.primaryType, let primary = primaryTypeToCategory[pt] {
+            return Match(primary: primary,
+                         categories: withSubtypes(primary: primary, sourceType: pt),
+                         matchedBy: .primaryType,
+                         matchedValue: pt)
+        }
+        if let types = place.types {
+            for t in types {
+                if let primary = primaryTypeToCategory[t] {
+                    return Match(primary: primary,
+                                 categories: withSubtypes(primary: primary, sourceType: t),
+                                 matchedBy: .type,
+                                 matchedValue: t)
+                }
+            }
+            for t in types {
+                if let subs = primaryTypeSubtypes[t], !subs.isEmpty {
+                    return Match(primary: subs[0],
+                                 categories: subs,
+                                 matchedBy: .subtype,
+                                 matchedValue: t)
+                }
+            }
+        }
+        return Match(primary: "everything_else",
+                     categories: ["everything_else"],
+                     matchedBy: .fallback,
+                     matchedValue: nil)
+    }
+}

--- a/apps/ios/CreditOdds/Services/Valuations.swift
+++ b/apps/ios/CreditOdds/Services/Valuations.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+// Cents-per-point estimates by program. Mirrors data/valuations.yaml in the
+// monorepo — keep these tables in sync. Match rules are name-substring based:
+// the first program whose `match` substring appears in the card name (and
+// none of whose `exclude` substrings appear) wins.
+enum Valuations {
+    private struct Program {
+        let cpp: Double
+        let match: [String]
+        let exclude: [String]
+    }
+
+    private static let defaultCpp: Double = 1.0
+
+    private static let programs: [Program] = [
+        Program(cpp: 1.25, match: ["chase sapphire", "freedom"], exclude: []),
+        Program(cpp: 1.20, match: ["american express", "amex", "gold card", "platinum card"],
+                exclude: ["delta", "hilton", "skymiles"]),
+        Program(cpp: 1.10, match: ["delta", "skymiles"], exclude: []),
+        Program(cpp: 1.20, match: ["united"], exclude: []),
+        Program(cpp: 0.50, match: ["hilton"], exclude: []),
+        Program(cpp: 2.00, match: ["hyatt"], exclude: []),
+        Program(cpp: 0.50, match: ["ihg"], exclude: []),
+        Program(cpp: 0.70, match: ["marriott", "bonvoy"], exclude: []),
+        Program(cpp: 1.00, match: ["capital one"], exclude: []),
+        Program(cpp: 1.50, match: ["bilt"], exclude: []),
+        Program(cpp: 1.00, match: ["citi"], exclude: []),
+        Program(cpp: 1.00, match: ["wells fargo"], exclude: []),
+        Program(cpp: 1.40, match: ["southwest"], exclude: []),
+    ]
+
+    static func cpp(for cardName: String) -> Double {
+        let lower = cardName.lowercased()
+        for p in programs {
+            let hit = p.match.contains { lower.contains($0) }
+            let blocked = p.exclude.contains { lower.contains($0) }
+            if hit && !blocked { return p.cpp }
+        }
+        return defaultCpp
+    }
+
+    /// Reward rate normalized to cash-equivalent percent (value per $1 spent).
+    /// 5x at 0.5 cpp -> 2.5%. Percent units pass through unchanged.
+    static func usdRate(for reward: Reward, card: Card) -> Double {
+        if reward.unit == "percent" { return reward.value }
+        return reward.value * cpp(for: card.cardName)
+    }
+}

--- a/apps/ios/CreditOdds/Services/WalletService.swift
+++ b/apps/ios/CreditOdds/Services/WalletService.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum WalletService {
+    static func fetch() async throws -> [WalletCard] {
+        guard let token = try await AuthService.idToken() else {
+            throw APIError.unauthenticated
+        }
+        return try await APIClient.shared.get("/wallet", token: token)
+    }
+
+    struct AddBody: Encodable {
+        let card_id: Int
+        let acquired_month: Int?
+        let acquired_year: Int?
+    }
+
+    @discardableResult
+    static func add(cardId: Int,
+                    month: Int? = nil,
+                    year: Int? = nil) async throws -> AddResponse {
+        guard let token = try await AuthService.idToken() else {
+            throw APIError.unauthenticated
+        }
+        let body = AddBody(card_id: cardId, acquired_month: month, acquired_year: year)
+        return try await APIClient.shared.post("/wallet", body: body, token: token)
+    }
+
+    @discardableResult
+    static func remove(walletRowId: Int) async throws -> MessageResponse {
+        guard let token = try await AuthService.idToken() else {
+            throw APIError.unauthenticated
+        }
+        return try await APIClient.shared.delete("/wallet/\(walletRowId)", token: token)
+    }
+
+    struct AddResponse: Decodable {
+        let message: String
+        let id: Int
+        let card_id: Int
+    }
+
+    struct MessageResponse: Decodable {
+        let message: String
+    }
+}

--- a/apps/ios/CreditOdds/ViewModels/AuthViewModel.swift
+++ b/apps/ios/CreditOdds/ViewModels/AuthViewModel.swift
@@ -1,0 +1,56 @@
+import Foundation
+import FirebaseAuth
+import Combine
+
+@MainActor
+final class AuthViewModel: ObservableObject {
+    @Published var user: User?
+    @Published var isLoading = true
+    @Published var pendingEmail: String?
+    @Published var errorMessage: String?
+
+    private var handle: AuthStateDidChangeListenerHandle?
+
+    init() {
+        handle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            Task { @MainActor in
+                self?.user = user
+                self?.isLoading = false
+            }
+        }
+    }
+
+    deinit {
+        if let handle { Auth.auth().removeStateDidChangeListener(handle) }
+    }
+
+    var isAuthenticated: Bool { user != nil }
+
+    func sendEmailLink(to email: String) async {
+        errorMessage = nil
+        do {
+            try await AuthService.sendSignInLink(to: email)
+            pendingEmail = email
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func handleIncomingLink(_ url: URL) async {
+        errorMessage = nil
+        do {
+            try await AuthService.completeSignIn(with: url.absoluteString)
+            pendingEmail = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func signOut() {
+        do {
+            try AuthService.signOut()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/CreditOdds/ViewModels/BestHereViewModel.swift
+++ b/apps/ios/CreditOdds/ViewModels/BestHereViewModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+import CoreLocation
+
+@MainActor
+final class BestHereViewModel: ObservableObject {
+    enum State {
+        case idle
+        case requesting
+        case loaded(picks: [MerchantPick], at: Date)
+        case empty(reason: String)
+        case error(String)
+    }
+
+    @Published var state: State = .idle
+    private let location = LocationService()
+
+    var canRefresh: Bool {
+        if case .requesting = state { return false }
+        return true
+    }
+
+    func refresh(walletCards: [WalletCard], allCards: [Card]) async {
+        guard !walletCards.isEmpty else {
+            state = .empty(reason: "Add cards to your wallet to see merchant recommendations.")
+            return
+        }
+        guard !allCards.isEmpty else {
+            state = .empty(reason: "Card catalog still loading…")
+            return
+        }
+        state = .requesting
+        do {
+            let loc = try await location.requestOnce()
+            let places = try await NearbyService.fetch(
+                lat: loc.coordinate.latitude,
+                lng: loc.coordinate.longitude
+            )
+            let picks = BestHereRanker.picks(
+                for: places,
+                walletCards: walletCards,
+                allCards: allCards,
+                userLocation: loc
+            )
+            if picks.isEmpty {
+                state = .empty(reason: "No nearby merchants matched a category your wallet earns on.")
+            } else {
+                state = .loaded(picks: picks, at: Date())
+            }
+        } catch let err as LocationService.LocationError {
+            state = .error(err.localizedDescription)
+        } catch {
+            state = .error(error.localizedDescription)
+        }
+    }
+}

--- a/apps/ios/CreditOdds/ViewModels/WalletViewModel.swift
+++ b/apps/ios/CreditOdds/ViewModels/WalletViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@MainActor
+final class WalletViewModel: ObservableObject {
+    @Published var cards: [WalletCard] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            cards = try await WalletService.fetch()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func remove(_ card: WalletCard) async {
+        do {
+            _ = try await WalletService.remove(walletRowId: card.id)
+            cards.removeAll { $0.id == card.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/CreditOdds/Views/CardThumb.swift
+++ b/apps/ios/CreditOdds/Views/CardThumb.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// CDN host for card images. Mirrors apps/web-next/src/components/ui/CardImage.tsx.
+private let cardImageCDN = "https://d3ay3etzd1512y.cloudfront.net/card_images"
+
+func cardImageURL(_ link: String?) -> URL? {
+    guard let link, !link.isEmpty else { return nil }
+    if link.hasPrefix("http://") || link.hasPrefix("https://") {
+        return URL(string: link)
+    }
+    return URL(string: "\(cardImageCDN)/\(link)")
+}
+
+struct CardThumb: View {
+    let link: String?
+    var contentMode: ContentMode = .fit
+
+    var body: some View {
+        if let url = cardImageURL(link) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let img):
+                    img.resizable().aspectRatio(contentMode: contentMode)
+                case .failure:
+                    placeholder
+                case .empty:
+                    placeholder.overlay(ProgressView().controlSize(.mini))
+                @unknown default:
+                    placeholder
+                }
+            }
+        } else {
+            placeholder
+        }
+    }
+
+    private var placeholder: some View {
+        Rectangle()
+            .fill(Color(.tertiarySystemFill))
+            .overlay(Image(systemName: "creditcard").foregroundStyle(.secondary))
+    }
+}

--- a/apps/ios/CreditOdds/Views/LoginView.swift
+++ b/apps/ios/CreditOdds/Views/LoginView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject private var auth: AuthViewModel
+    @State private var email = ""
+    @State private var sending = false
+    @State private var pastedLink = ""
+    @State private var completing = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            VStack(spacing: 8) {
+                Text("CreditOdds")
+                    .font(.system(size: 40, weight: .bold, design: .default))
+                Text("Approval odds. Wallet. Rewards.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let pending = auth.pendingEmail {
+                VStack(spacing: 12) {
+                    Image(systemName: "envelope.open.fill")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.tint)
+                    Text("Check \(pending)")
+                        .font(.headline)
+                    Text("Paste the link from the email below to finish sign-in.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    TextField("https://...firebaseapp.com/...", text: $pastedLink, axis: .vertical)
+                        .lineLimit(2...4)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .padding()
+                        .background(Color(.secondarySystemBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                    Button {
+                        guard let url = URL(string: pastedLink.trimmingCharacters(in: .whitespacesAndNewlines)) else { return }
+                        Task {
+                            completing = true
+                            await auth.handleIncomingLink(url)
+                            completing = false
+                        }
+                    } label: {
+                        if completing {
+                            ProgressView().tint(.white)
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            Text("Complete sign-in")
+                                .fontWeight(.semibold)
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(pastedLink.isEmpty || completing)
+                }
+                .padding(.vertical, 24)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    TextField("you@example.com", text: $email)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .padding()
+                        .background(Color(.secondarySystemBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                    Button {
+                        Task {
+                            sending = true
+                            await auth.sendEmailLink(to: email)
+                            sending = false
+                        }
+                    } label: {
+                        if sending {
+                            ProgressView().tint(.white)
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            Text("Send sign-in link")
+                                .fontWeight(.semibold)
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(email.isEmpty || sending)
+                }
+            }
+
+            if let err = auth.errorMessage {
+                Text(err)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+            }
+
+            Spacer()
+        }
+        .padding(24)
+    }
+}

--- a/apps/ios/CreditOdds/Views/ProfileView.swift
+++ b/apps/ios/CreditOdds/Views/ProfileView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        TabView {
+            WalletTab()
+                .tabItem { Label("Cards", systemImage: "creditcard.fill") }
+
+            EarnTab()
+                .tabItem { Label("Earn", systemImage: "star.fill") }
+
+            ApplicationsTabPlaceholder()
+                .tabItem { Label("Apps", systemImage: "doc.text.fill") }
+
+            SettingsTab()
+                .tabItem { Label("Settings", systemImage: "gearshape.fill") }
+        }
+    }
+}
+
+private struct ApplicationsTabPlaceholder: View {
+    var body: some View {
+        NavigationStack {
+            ContentUnavailableView("Applications",
+                                   systemImage: "doc.text",
+                                   description: Text("Coming soon."))
+                .navigationTitle("Applications")
+        }
+    }
+}

--- a/apps/ios/CreditOdds/Views/RootView.swift
+++ b/apps/ios/CreditOdds/Views/RootView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var auth: AuthViewModel
+
+    var body: some View {
+        Group {
+            if auth.isLoading {
+                ProgressView().controlSize(.large)
+            } else if auth.isAuthenticated {
+                ProfileView()
+            } else {
+                LoginView()
+            }
+        }
+        .onOpenURL { url in
+            Task { await auth.handleIncomingLink(url) }
+        }
+    }
+}

--- a/apps/ios/CreditOdds/Views/Tabs/EarnTab.swift
+++ b/apps/ios/CreditOdds/Views/Tabs/EarnTab.swift
@@ -1,0 +1,272 @@
+import SwiftUI
+
+struct EarnTab: View {
+    @StateObject private var walletVM = WalletViewModel()
+    @StateObject private var catalog = CardsRepository.shared
+    @StateObject private var bestHere = BestHereViewModel()
+
+    private var rankings: [CategoryBest] {
+        EarnRanker.bestByCategory(walletCards: walletVM.cards,
+                                  allCards: catalog.cards)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isInitialLoading {
+                    ProgressView()
+                        .controlSize(.large)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if walletVM.cards.isEmpty {
+                    ContentUnavailableView(
+                        "No cards in wallet",
+                        systemImage: "star",
+                        description: Text("Add cards on the Cards tab to see which one earns the most for each spending category.")
+                    )
+                } else {
+                    List {
+                        BestHereSection(
+                            vm: bestHere,
+                            onFind: {
+                                Task {
+                                    await bestHere.refresh(
+                                        walletCards: walletVM.cards,
+                                        allCards: catalog.cards
+                                    )
+                                }
+                            }
+                        )
+
+                        if !rankings.isEmpty {
+                            Section {
+                                ForEach(rankings) { entry in
+                                    CategoryRow(entry: entry)
+                                }
+                            } header: {
+                                Text("Best card per category")
+                            } footer: {
+                                Text("Derived from rewards on the cards you hold. When the top earner is brand- or merchant-restricted, an unrestricted alternative is shown below it.")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                    .refreshable {
+                        async let w: Void = walletVM.load()
+                        async let c: Void = catalog.load()
+                        _ = await (w, c)
+                    }
+                }
+            }
+            .navigationTitle("Earn")
+            .task {
+                async let w: Void = walletVM.load()
+                async let c: Void = catalog.loadIfNeeded()
+                _ = await (w, c)
+            }
+            .alert("Error",
+                   isPresented: .constant(walletVM.errorMessage != nil),
+                   actions: {
+                       Button("OK") { walletVM.errorMessage = nil }
+                   },
+                   message: { Text(walletVM.errorMessage ?? "") })
+        }
+    }
+
+    private var isInitialLoading: Bool {
+        (walletVM.isLoading && walletVM.cards.isEmpty) ||
+        (catalog.isLoading && catalog.cards.isEmpty)
+    }
+}
+
+private struct BestHereSection: View {
+    @ObservedObject var vm: BestHereViewModel
+    let onFind: () -> Void
+
+    var body: some View {
+        Section {
+            switch vm.state {
+            case .idle:
+                Button(action: onFind) {
+                    Label("Find best card here", systemImage: "location.fill")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .listRowBackground(Color.clear)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+            case .requesting:
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text("Looking up nearby merchants…")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+            case .empty(let reason):
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(reason)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Button("Try again", action: onFind)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                }
+
+            case .loaded(let picks, let at):
+                ForEach(picks) { p in MerchantRow(pick: p) }
+                HStack {
+                    Text("Updated \(at.formatted(date: .omitted, time: .shortened))")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Refresh", action: onFind)
+                        .font(.caption.weight(.semibold))
+                        .disabled(!vm.canRefresh)
+                }
+
+            case .error(let msg):
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(msg)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                    Button("Try again", action: onFind)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                }
+            }
+        } header: {
+            Text("Best card here")
+        } footer: {
+            Text("Uses your location and Google Places to find nearby merchants, then picks the highest-earning card from your wallet for each. Co-brand bonuses (e.g. Marriott Bonvoy at Marriott hotels) aren't surfaced yet.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct MerchantRow: View {
+    let pick: MerchantPick
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(pick.placeName)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                Spacer()
+                if let dist = pick.distanceText {
+                    Text(dist)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            HStack(spacing: 6) {
+                Text(pick.categoryLabel)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                if let addr = pick.address {
+                    Text("•").font(.caption2).foregroundStyle(.secondary)
+                    Text(addr)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            PickRow(pick: pick.primary)
+            if let alt = pick.alternative {
+                Divider().padding(.vertical, 2)
+                Text("Unrestricted alternative")
+                    .font(.caption2.weight(.semibold))
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
+                PickRow(pick: alt)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct CategoryRow: View {
+    let entry: CategoryBest
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(entry.label)
+                .font(.subheadline.weight(.semibold))
+
+            PickRow(pick: entry.primary)
+
+            if let alt = entry.alternative {
+                Divider()
+                    .padding(.vertical, 2)
+                Text("All \(entry.label.lowercased())")
+                    .font(.caption2.weight(.semibold))
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
+                PickRow(pick: alt)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct PickRow: View {
+    let pick: EarnPick
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            CardThumb(link: pick.card.cardImageLink, contentMode: .fit)
+                .frame(width: 44, height: 28)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+                .opacity(pick.staleRotation ? 0.5 : 1)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(pick.card.cardName)
+                    .font(.footnote.weight(.semibold))
+                    .lineLimit(2)
+                if let note = displayNote {
+                    Text(note)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                if pick.staleRotation {
+                    Text("Rotation may be out of date")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            Spacer()
+
+            Text(rateText)
+                .font(.subheadline.monospacedDigit().weight(.semibold))
+        }
+    }
+
+    private var displayNote: String? {
+        if let slot = pick.slotNote, !slot.isEmpty { return slot }
+        return pick.reward.note
+    }
+
+    private var rateText: String {
+        let raw = pick.reward.unit == "percent"
+            ? "\(formatNumber(pick.reward.value))%"
+            : "\(formatNumber(pick.reward.value))x"
+        if pick.reward.unit == "percent" { return raw }
+        let usd = formatNumber(pick.usdRate)
+        return "\(raw) (~\(usd)%)"
+    }
+
+    private func formatNumber(_ v: Double) -> String {
+        let rounded = (v * 100).rounded() / 100
+        if rounded.truncatingRemainder(dividingBy: 1) == 0 {
+            return String(Int(rounded))
+        }
+        return String(format: "%.2f", rounded)
+            .replacingOccurrences(of: #"0+$"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"\.$"#, with: "", options: .regularExpression)
+    }
+}

--- a/apps/ios/CreditOdds/Views/Tabs/SettingsTab.swift
+++ b/apps/ios/CreditOdds/Views/Tabs/SettingsTab.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct SettingsTab: View {
+    @EnvironmentObject private var auth: AuthViewModel
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Account") {
+                    if let email = auth.user?.email {
+                        LabeledContent("Email", value: email)
+                    }
+                    if let uid = auth.user?.uid {
+                        LabeledContent("User ID", value: uid)
+                            .font(.caption.monospaced())
+                    }
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        auth.signOut()
+                    } label: {
+                        Text("Sign out")
+                    }
+                }
+
+                Section {
+                    LabeledContent("Version",
+                                   value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—")
+                }
+            }
+            .navigationTitle("Settings")
+        }
+    }
+}

--- a/apps/ios/CreditOdds/Views/Tabs/WalletTab.swift
+++ b/apps/ios/CreditOdds/Views/Tabs/WalletTab.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct WalletTab: View {
+    @StateObject private var vm = WalletViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if vm.isLoading && vm.cards.isEmpty {
+                    ProgressView()
+                        .controlSize(.large)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if vm.cards.isEmpty {
+                    ContentUnavailableView(
+                        "No cards yet",
+                        systemImage: "creditcard",
+                        description: Text("Add a card to start tracking rewards and benefits.")
+                    )
+                } else {
+                    List {
+                        ForEach(vm.cards) { card in
+                            WalletCardRow(card: card)
+                        }
+                        .onDelete { offsets in
+                            Task {
+                                for index in offsets {
+                                    await vm.remove(vm.cards[index])
+                                }
+                            }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                    .refreshable { await vm.load() }
+                }
+            }
+            .navigationTitle("My Wallet")
+            .task { await vm.load() }
+            .alert("Error",
+                   isPresented: .constant(vm.errorMessage != nil),
+                   actions: {
+                       Button("OK") { vm.errorMessage = nil }
+                   },
+                   message: { Text(vm.errorMessage ?? "") })
+        }
+    }
+}
+
+private struct WalletCardRow: View {
+    let card: WalletCard
+
+    var body: some View {
+        HStack(spacing: 12) {
+            CardThumb(link: card.cardImageLink, contentMode: .fill)
+                .frame(width: 60, height: 38)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(card.cardName)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(2)
+                Text(card.bank)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let acquired = formattedAcquired {
+                    Text("Since \(acquired)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var formattedAcquired: String? {
+        guard let m = card.acquiredMonth, let y = card.acquiredYear else { return nil }
+        let months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+        guard (1...12).contains(m) else { return nil }
+        return "\(months[m-1]) \(y)"
+    }
+}
+

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,0 +1,89 @@
+# CreditOdds iOS
+
+SwiftUI iOS app porting the web `/profile` section.
+
+## First-time setup
+
+Prereqs: Xcode 26+, Homebrew.
+
+```bash
+brew install xcodegen     # if not already installed
+cd apps/ios
+xcodegen                  # generates CreditOdds.xcodeproj from project.yml
+```
+
+### Add Firebase config
+
+The app needs `GoogleService-Info.plist` from the Firebase console:
+
+1. Firebase Console → Project Settings → **Add iOS app**
+2. Bundle ID: `com.creditodds.app`
+3. Download `GoogleService-Info.plist`
+4. Drop it into `apps/ios/CreditOdds/Resources/`
+5. Re-run `xcodegen` so it gets bundled
+
+### Set the signing team
+
+`project.yml` leaves `DEVELOPMENT_TEAM` empty. Either:
+
+- Open `CreditOdds.xcodeproj` once in Xcode → select the target → Signing & Capabilities → pick your team. Xcode writes it into `project.pbxproj`, but `xcodegen` will overwrite it next time.
+- Better: add your team ID to `project.yml` under `settings.base.DEVELOPMENT_TEAM`.
+
+## Build & run
+
+```bash
+xcodegen
+open CreditOdds.xcodeproj
+```
+
+Then ⌘R in Xcode, or headless:
+
+```bash
+xcodebuild -project CreditOdds.xcodeproj \
+  -scheme CreditOdds \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  build
+```
+
+## Project layout
+
+```
+CreditOdds/
+  CreditOddsApp.swift      @main entry, FirebaseApp.configure()
+  Info.plist
+  Models/                  Card, WalletCard
+  Services/                APIClient, AuthService, WalletService, CardService
+  ViewModels/              AuthViewModel, WalletViewModel
+  Views/
+    RootView.swift         Auth gate
+    LoginView.swift        Email-link sign-in
+    ProfileView.swift      Tab container
+    Tabs/
+      WalletTab.swift      "Cards" tab — first port of the web profile
+      SettingsTab.swift
+  Resources/
+    GoogleService-Info.plist  ← add this manually (gitignored)
+```
+
+## What's ported so far
+
+- Email-link sign-in (matches the web `AuthProvider`)
+- `/wallet` GET + DELETE → "Cards" tab list with pull-to-refresh and swipe-to-delete
+
+## Not yet ported
+
+Rewards, Benefits, Applications (records), Referrals, News, More tabs. The
+Wallet tab is the headline; the rest follow the same pattern (a service file,
+a view model, a SwiftUI view) and can be added incrementally.
+
+## Universal Links / email-link sign-in
+
+The sign-in link Firebase sends opens `https://creditodds.com/login`. To make
+it open the iOS app instead:
+
+1. Add Associated Domains capability with `applinks:creditodds.com`.
+2. Host an `apple-app-site-association` JSON at `https://creditodds.com/.well-known/apple-app-site-association` mapping `/login` to this app's bundle ID + team ID.
+3. The `RootView.onOpenURL` handler is already wired up.
+
+Until that's done, the link opens in Safari and Firebase finishes sign-in
+on the web. Add the AASA file in the web-next public dir when ready.

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -1,0 +1,59 @@
+name: CreditOdds
+options:
+  bundleIdPrefix: com.creditodds
+  deploymentTarget:
+    iOS: "17.0"
+  createIntermediateGroups: true
+  generateEmptyDirectories: true
+
+settings:
+  base:
+    SWIFT_VERSION: "5.10"
+    DEVELOPMENT_TEAM: ""
+    CODE_SIGN_STYLE: Automatic
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "1"
+    ENABLE_USER_SCRIPT_SANDBOXING: NO
+
+packages:
+  Firebase:
+    url: https://github.com/firebase/firebase-ios-sdk
+    from: 11.0.0
+
+targets:
+  CreditOdds:
+    type: application
+    platform: iOS
+    sources:
+      - path: CreditOdds
+        excludes:
+          - "**/*.md"
+    resources:
+      - path: CreditOdds/Resources
+        optional: true
+    info:
+      path: CreditOdds/Info.plist
+      properties:
+        CFBundleDisplayName: CreditOdds
+        UILaunchScreen:
+          UIColorName: ""
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+        ITSAppUsesNonExemptEncryption: false
+        NSAppTransportSecurity:
+          NSAllowsArbitraryLoads: false
+        NSLocationWhenInUseUsageDescription: "CreditOdds uses your location to recommend the best card from your wallet for nearby merchants."
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.creditodds.app
+        TARGETED_DEVICE_FAMILY: "1,2"
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: CreditOdds/Info.plist
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        SWIFT_OBJC_BRIDGING_HEADER: ""
+        CODE_SIGN_ENTITLEMENTS: CreditOdds/CreditOdds.entitlements
+    dependencies:
+      - package: Firebase
+        product: FirebaseAuth
+      - package: Firebase
+        product: FirebaseCore


### PR DESCRIPTION
## Summary
- New `apps/ios/` SwiftUI app, sibling to `apps/api` and `apps/web-next`. Firebase email-link auth, hits the existing Lambda APIs.
- **Cards tab** — `GET`/`DELETE /wallet`, pull-to-refresh, swipe-to-delete.
- **Earn tab** — wallet-wide best-card-per-category (port of `BestCardByCategory.tsx`) plus a location-aware "Best card here" section that requests location, calls `POST /nearby-recommendations`, and ranks each merchant via a Google Places type → reward category map.
- XcodeGen-managed: `apps/ios/project.yml` is the source of truth. Generated `.xcodeproj` and `GoogleService-Info.plist` are gitignored.

## Known gaps (intentional)
- **Co-brand brand-gating not ported yet.** A Marriott Bonvoy Boundless cardholder near a Marriott will still see whatever their best generic `hotels` pick is, not the 6x. Needs the brand index + `merchant_gate` ranker (~500 lines covering `storeRanking.ts` / `storeFromPlace.ts` / `walletPicksForPlace.ts`).
- Other web profile tabs (Benefits, Applications, Referrals, News, More) — not started; same pattern as Wallet/Earn when added.
- No Universal Links — needs paid Apple Developer Team ID for the AASA file.

## CI/CD impact
- None. Amplify only triggers on `apps/web-next/**`; the (now-deleted) backend pipeline only watched `apps/api/**`. iOS releases happen out-of-band via TestFlight.

## Test plan
- [x] Builds clean: `xcodebuild -project CreditOdds.xcodeproj -scheme CreditOdds -destination 'platform=iOS Simulator,name=iPhone 17' build`
- [x] Runs in iPhone 17 simulator
- [x] Email-link sign-in completes (paste-link UX since Universal Links aren't set up)
- [x] Wallet list renders with card images from the CDN
- [x] Earn tab → wallet-wide rankings populate
- [x] Earn tab → "Find best card here" requests location, returns nearby merchants ranked
- [ ] Verify on a physical iPhone with free signing (requires opening in Xcode and selecting Personal Team)

🤖 Generated with [Claude Code](https://claude.com/claude-code)