### PR TITLE
Card page: fix stale FICO bars after switching chart tabs

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1321,7 +1321,7 @@ export default function CardClient({
                           ))}
                         </div>
                       )}
-                      <div className="cj-chart-body">
+                      <div className="cj-chart-body" key={current.id}>
                         <ErrorBoundary fallback={<ChartErrorFallback />}>
                           {current.chart}
                         </ErrorBoundary>


### PR DESCRIPTION
## Summary
- The "Approval rate by FICO score" bars on the card page corrupt themselves after a sequence of chart-tab clicks (e.g. Score/Income → Income/Limit → Score/Income) — buckets collapse to "no data" and `<670` shows phantom 0% / 86% values.
- Root cause: `<HighchartsReact>` is reused across all three tabs. When the series count shrinks (2 → 1 going to Income/Limit) then grows back (1 → 2 going back to Score/Income), `chart.update({series: […]})` reconciliation keeps the first series' previous data reference and splice-overwrites the contents of the prop array in place. The bars at `CardClient.tsx:370-371` then `bucketize` the corrupted array and produce nonsense (e.g. an income of `129000` bucketed as a FICO score).
- Fix: add `key={current.id}` to the chart-body div so React unmounts and remounts the chart subtree on every tab change. Each tab gets a fresh Highcharts instance with no carry-over.

## Test plan
- [x] Repro confirmed locally on `/card/chase-sapphire-reserve`: bars correct on initial load, then break after Income/Limit → Score/Income round trip
- [x] After fix, bars stay at the correct 100% / 50% / 100% / 100% / — / — across 9 tab clicks (3 full cycles)
- [x] Highcharts internal series data reads back correctly (`[805, 129000]`) instead of stale `[129000, 21400]` after the round trip
- [ ] Spot check a card with no rejections (Income/Limit only) and a card with very few records that hides the chart entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)