### PR TITLE
Card page: stop ghost vertical scrollbar on chart tab bar

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1249,7 +1249,7 @@ export default function CardClient({
                   if (hasChartOne) {
                     tabs.push({
                       id: "score",
-                      label: "Score / Income",
+                      label: "Credit Score / Income",
                       chart: (
                         <ScatterPlot
                           title="Credit Score vs Income"
@@ -1267,7 +1267,7 @@ export default function CardClient({
                   if (hasChartTwo) {
                     tabs.push({
                       id: "history",
-                      label: "History / Score",
+                      label: "Length of Credit / Credit Score",
                       chart: (
                         <ScatterPlot
                           title="Length of Credit vs Credit Score"
@@ -1285,7 +1285,7 @@ export default function CardClient({
                   if (hasChartThree) {
                     tabs.push({
                       id: "limit",
-                      label: "Income / Limit",
+                      label: "Income / Credit Limit",
                       chart: (
                         <ScatterPlot
                           title="Income vs Starting Credit Limit"

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1321,7 +1321,7 @@ export default function CardClient({
                           ))}
                         </div>
                       )}
-                      <div className="cj-chart-body">
+                      <div className="cj-chart-body" key={current.id}>
                         <ErrorBoundary fallback={<ChartErrorFallback />}>
                           {current.chart}
                         </ErrorBoundary>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7192,6 +7192,10 @@
     align-self: start;
     max-height: calc(100vh - 40px);
     overflow-y: auto;
+    scrollbar-width: none;
+  }
+  .landing-v2 .cj-rail::-webkit-scrollbar {
+    display: none;
   }
 }
 .landing-v2 .cj-apply {

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -6895,6 +6895,11 @@
   background: var(--paper-2);
   border-bottom: 1px solid var(--line);
   overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+.landing-v2 .cj-graph-tabs::-webkit-scrollbar {
+  display: none;
 }
 .landing-v2 .cj-graph-tab {
   padding: 10px 16px;


### PR DESCRIPTION
## Summary
- The chart tab bar (\`.cj-graph-tabs\`) set \`overflow-x: auto\` so labels can scroll horizontally on mobile. Per CSS spec, when one overflow axis is non-\`visible\` the unset axis silently becomes \`auto\` as well — so \`overflow-y\` was effectively auto.
- The active tab's \`border-bottom: 2px solid\` plus \`margin-bottom: -1px\` made the bar's \`scrollHeight\` exactly 1px taller than its \`clientHeight\`, which on macOS triggered a thin overlay vertical scrollbar against the right edge of the tab bar — visually identical to a chart-area scrollbar.
- Fix: pin \`overflow-y: hidden\` (so the harmless 1px is clipped instead of treated as scrollable) and hide the horizontal scroll thumb on mobile too with \`scrollbar-width: none\` + \`::-webkit-scrollbar { display: none }\`.

## Test plan
- [x] Desktop 1440px: no offenders detected on the page (besides the rail, already handled). \`overflow-x: auto\`, \`overflow-y: hidden\`.
- [x] Mobile 375px: horizontal tab scroll still works — \`scrollLeft = 50\` takes effect, \`scrollWidth\` 542 > \`clientWidth\` 332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)