### PR TITLE
Venmo card: split top-spend into 3% + 2% tiers

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -946,9 +946,19 @@ export default function CardClient({
                       {sortedRewards.map((r) => {
                         let lbl: string;
                         if (r.category === "top_category") {
-                          lbl = r.choices && r.choices > 1
-                            ? `Top ${r.choices} spend categories`
-                            : "Top spend category";
+                          // When a card has multiple top_category blocks (Venmo:
+                          // 3% top, 2% second-highest), label them by tier rather
+                          // than duplicating "Top spend category".
+                          const topBlocks = sortedRewards.filter((x) => x.category === "top_category");
+                          const tierIdx = topBlocks.findIndex((x) => x === r);
+                          if (r.choices && r.choices > 1) {
+                            lbl = `Top ${r.choices} spend categories`;
+                          } else if (topBlocks.length > 1) {
+                            const tierLabels = ["Top spend category", "2nd-highest spend category", "3rd-highest spend category"];
+                            lbl = tierLabels[tierIdx] ?? `${tierIdx + 1}th-highest spend category`;
+                          } else {
+                            lbl = "Top spend category";
+                          }
                         } else if (r.category === "selected_categories") {
                           lbl = r.choices === 1
                             ? "Choose 1 category"

--- a/apps/web-next/src/components/wallet/SelectCategoriesModal.tsx
+++ b/apps/web-next/src/components/wallet/SelectCategoriesModal.tsx
@@ -113,15 +113,23 @@ export default function SelectCategoriesModal({
   const togglePick = (blockIdx: number, category: string) => {
     setBlocks((prev) =>
       prev.map((b, i) => {
-        if (i !== blockIdx) return b;
-        const has = b.selected.includes(category);
-        if (has) return { ...b, selected: b.selected.filter((c) => c !== category) };
-        if (b.selected.length >= b.picks) {
-          // Bump the oldest pick out so the click feels responsive — the user
-          // is replacing one of their picks rather than hitting a hard cap.
-          return { ...b, selected: [...b.selected.slice(1), category] };
+        if (i === blockIdx) {
+          const has = b.selected.includes(category);
+          if (has) return { ...b, selected: b.selected.filter((c) => c !== category) };
+          if (b.selected.length >= b.picks) {
+            // Bump the oldest pick out so the click feels responsive — the user
+            // is replacing one of their picks rather than hitting a hard cap.
+            return { ...b, selected: [...b.selected.slice(1), category] };
+          }
+          return { ...b, selected: [...b.selected, category] };
         }
-        return { ...b, selected: [...b.selected, category] };
+        // Cross-block dedup: a category claimed in one block (e.g. Venmo's 3%
+        // tier) can't also be the pick for a sibling block (the 2% tier),
+        // since the issuer ranks tiers off the user's actual spend.
+        if (b.selected.includes(category)) {
+          return { ...b, selected: b.selected.filter((c) => c !== category) };
+        }
+        return b;
       }),
     );
   };
@@ -218,7 +226,24 @@ export default function SelectCategoriesModal({
             ) : (
               blocks.map((b, idx) => {
                 const cad = cadenceLabel(b.reward);
-                const heading = `${b.reward_rate}% — pick ${b.picks}${cad ? ` ${cad}` : ''}`;
+                // Tier-aware heading when a card has multiple top_category
+                // blocks (Venmo: 3% top tier, 2% second tier). Each tier
+                // earns at a different rate on a distinct user-picked category.
+                const topTierBlocks = blocks.filter(
+                  (x) => x.reward_category === 'top_category',
+                );
+                const isTopTier = b.reward_category === 'top_category' && topTierBlocks.length > 1;
+                const tierIdx = isTopTier
+                  ? topTierBlocks.findIndex((x) => x === b)
+                  : -1;
+                const tierPrefix = isTopTier
+                  ? tierIdx === 0
+                    ? 'top tier — '
+                    : tierIdx === 1
+                      ? '2nd tier — '
+                      : `${tierIdx + 1}th tier — `
+                  : '';
+                const heading = `${tierPrefix}${b.reward_rate}% — pick ${b.picks}${cad ? ` ${cad}` : ''}`;
                 return (
                   <div className="cj-modal-section" key={`${b.reward_category}-${b.reward_rate}`}>
                     <label className="cj-modal-label">{heading}</label>

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -206,6 +206,31 @@ export async function getAllBanks(): Promise<string[]> {
 }
 
 export async function getCard(cardName: string): Promise<Card> {
+  // Dev fallback: mirror getAllCards so YAML edits show on /card/[slug] without
+  // waiting for build → S3 → CloudFront → DB-sync. The deployed handler accepts
+  // either a slug or card_name; locally we match both against the same record.
+  if (!isBrowser && process.env.NODE_ENV === 'development') {
+    try {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const filePath = path.join(process.cwd(), '..', '..', 'data', 'cards.json');
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      const data = JSON.parse(fileContent) as { cards: LocalCard[] };
+      const match = (data.cards || []).find(
+        (c) => c.slug === cardName || c.name === cardName,
+      );
+      if (match) {
+        return {
+          ...match,
+          card_id: match.card_id ?? match.slug,
+          card_name: match.card_name ?? match.name ?? '',
+          card_image_link: match.card_image_link ?? match.image,
+        } as Card;
+      }
+    } catch {
+      // Fall through to network fetch when local file isn't built yet.
+    }
+  }
   const res = await fetch(`${API_BASE}/card?card_name=${encodeURIComponent(cardName)}`, {
     next: { revalidate: 300 },
   });

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-09T21:33:01.508Z",
+  "generated_at": "2026-05-10T21:46:06.191Z",
   "count": 162,
   "categories": [
     {
@@ -870,6 +870,7 @@
       "image": "citi-att-points-plus.png",
       "accepting_applications": true,
       "apply_link": "https://www.citi.com/credit-cards/citi-att-pointsplus-credit-card",
+      "foreign_transaction_fee": false,
       "annual_fee": 0,
       "reward_type": "points",
       "tags": [
@@ -5066,6 +5067,7 @@
         }
       },
       "apply_link": "https://www.discover.com/credit-cards/student/chrome-card.html",
+      "foreign_transaction_fee": false,
       "card_id": "discover-it-student-chrome-card",
       "card_name": "Discover it Student Chrome"
     },
@@ -9557,7 +9559,24 @@
             "drugstores",
             "gas"
           ],
-          "note": "3% on your top spend category and 2% on your second-highest each statement period (from 8 eligible: transportation, travel, groceries, entertainment, dining & nightlife, bills & utilities, health & beauty, gas). Drugstores here represents health & beauty; bills & utilities maps to utilities."
+          "note": "Automatically on your highest-spend eligible category each statement period (8 eligible: transportation, travel, groceries, entertainment, dining & nightlife, bills & utilities, health & beauty, gas). Drugstores here represents health & beauty; bills & utilities maps to utilities."
+        },
+        {
+          "category": "top_category",
+          "value": 2,
+          "unit": "percent",
+          "mode": "auto_top_spend",
+          "eligible_categories": [
+            "transit",
+            "travel",
+            "groceries",
+            "entertainment",
+            "dining",
+            "utilities",
+            "drugstores",
+            "gas"
+          ],
+          "note": "Automatically on your second-highest eligible category each statement period (same 8-category list)."
         },
         {
           "category": "everything_else",

--- a/data/cards/venmo-credit-card.yaml
+++ b/data/cards/venmo-credit-card.yaml
@@ -23,7 +23,21 @@ rewards:
       - "utilities"
       - "drugstores"
       - "gas"
-    note: "3% on your top spend category and 2% on your second-highest each statement period (from 8 eligible: transportation, travel, groceries, entertainment, dining & nightlife, bills & utilities, health & beauty, gas). Drugstores here represents health & beauty; bills & utilities maps to utilities."
+    note: "Automatically on your highest-spend eligible category each statement period (8 eligible: transportation, travel, groceries, entertainment, dining & nightlife, bills & utilities, health & beauty, gas). Drugstores here represents health & beauty; bills & utilities maps to utilities."
+  - category: "top_category"
+    value: 2
+    unit: "percent"
+    mode: auto_top_spend
+    eligible_categories:
+      - "transit"
+      - "travel"
+      - "groceries"
+      - "entertainment"
+      - "dining"
+      - "utilities"
+      - "drugstores"
+      - "gas"
+    note: "Automatically on your second-highest eligible category each statement period (same 8-category list)."
   - category: "everything_else"
     value: 1
     unit: "percent"


### PR DESCRIPTION
## Summary
- Venmo's real reward structure is 3% on your top-spend eligible category and 2% on your second-highest. The YAML had it as a single 3% block with the 2% mentioned only in the note. Now there are two `top_category` / `auto_top_spend` blocks so each tier is a first-class row.
- Card page labels multiple `top_category` blocks by tier ("Top spend category", "2nd-highest spend category") instead of duplicating "Top spend category" twice.
- Wallet selection modal: heading prefixes "top tier" / "2nd tier" when there are multiple `top_category` blocks, and picking a category in one tier removes it from the other so a user can't pick "dining" for both 3% and 2%.
- Dev-only fallback added to `getCard()` mirroring the existing `getAllCards()` pattern, so YAML edits show on `/card/[slug]` in dev without waiting for the build → S3 → CloudFront → DB-sync pipeline.

## Test plan
- [x] `/card/venmo-credit-card` shows three rows: 3% top tier, 2% 2nd-highest, 1% everything else
- [x] `node scripts/build-cards.js` rebuild succeeds with both blocks present
- [ ] Wallet modal: add Venmo to wallet, confirm both tiers appear with distinct chips and that selecting "dining" for tier 1 then "dining" for tier 2 clears it from tier 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)