### PR TITLE
wallet: collapse storeRanking twin — single JS source of truth

### DIFF
--- a/apps/web-next/src/lib/storeRanking.ts
+++ b/apps/web-next/src/lib/storeRanking.ts
@@ -1,12 +1,18 @@
-// ⚠️ TWIN FILE: apps/api/src/lib/ranker/storeRanking.js
-// This file feeds the public SSR page at /best-card-for/[slug].
-// The Lambda wallet endpoints (/wallet-picks/store, /wallet-picks/nearby)
-// use the JS twin. Keep them behaviourally identical — any change here
-// must land in the twin in the same PR.
+// TypeScript surface for the ranker. The implementation lives in
+// apps/api/src/lib/ranker/storeRanking.js (single source of truth, shared
+// with the Lambda wallet-picks handlers). This file imports those runtime
+// functions via the `@ranker/*` tsconfig alias and re-exports them with
+// proper TypeScript types so the public SSR page on /best-card-for/[slug]
+// gets the same engine the wallet endpoints use.
+//
+// The JS module has no JSDoc types — type assertions on the re-exports are
+// the spec. If you change a signature, update both this file AND the JS
+// twin's runtime behaviour to match.
 
-import type { Card, Reward, WalletCardSelection } from '@/lib/api';
+import type { Card, WalletCardSelection } from '@/lib/api';
 import type { Store } from '@/lib/stores';
-import { getValuation } from '@/lib/valuations';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import * as ranker from '@ranker/storeRanking';
 
 export type MatchMode =
   | 'direct'
@@ -33,12 +39,6 @@ export interface RankedPick {
   note?: string;
 }
 
-interface CardMatch {
-  reward: Reward;
-  matchedCategory: string;
-  mode: MatchMode;
-}
-
 export interface RankCardsOptions {
   /** Effective-rate floor for category-bonus picks. Default 1.5 (0 in wallet mode). */
   flatRateFloor?: number;
@@ -63,388 +63,24 @@ export interface RankCardsOptions {
   userSelections?: UserSelectionsByCard;
 }
 
-const CATEGORY_CHANNEL: Record<string, Channel> = {
-  online_shopping: 'online',
-  amazon: 'online',
-  rakuten: 'online',
-  rakuten_dining: 'online',
-  travel_portal: 'online',
-  hotels_portal: 'online',
-  flights_portal: 'online',
-  car_rentals_portal: 'online',
-  hotels_car_portal: 'online',
+// Typed runtime re-exports. The JS module has no .d.ts — the casts below
+// are the type contract.
+type RankerModule = {
+  rankCards: (store: Store, cards: Card[], options?: RankCardsOptions) => RankedPick[];
+  effectiveCashbackRate: (
+    rate: number,
+    unit: 'percent' | 'points_per_dollar',
+    cardName: string,
+  ) => number;
+  formatRate: (value: number, unit: 'percent' | 'points_per_dollar') => string;
+  labelForCategory: (id: string) => string;
+  channelForCategory: (categoryId: string) => Channel;
 };
 
-const CATEGORY_LABELS: Record<string, string> = {
-  department_stores: 'department stores',
-  online_shopping: 'online shopping',
-  groceries: 'groceries',
-  dining: 'dining',
-  gas: 'gas',
-  travel: 'travel',
-  everything_else: 'everything else',
-  home_improvement: 'home improvement',
-  drugstores: 'drugstores',
-  wholesale_clubs: 'wholesale clubs',
-};
+const typedRanker = ranker as unknown as RankerModule;
 
-export function labelForCategory(id: string): string {
-  return CATEGORY_LABELS[id] || id.replace(/_/g, ' ');
-}
-
-export function channelForCategory(categoryId: string): Channel {
-  return CATEGORY_CHANNEL[categoryId] || 'both';
-}
-
-export function effectiveCashbackRate(
-  rate: number,
-  unit: 'percent' | 'points_per_dollar',
-  cardName: string,
-): number {
-  if (unit === 'percent') return rate;
-  const cpp = getValuation(cardName);
-  return rate * cpp;
-}
-
-export function formatRate(value: number, unit: 'percent' | 'points_per_dollar'): string {
-  if (unit === 'percent') return `${value}%`;
-  return `${value}x points`;
-}
-
-function formatCap(reward: Reward): string {
-  if (!reward.spend_cap || !reward.cap_period) return '';
-  const period =
-    reward.cap_period === 'quarterly'
-      ? 'quarter'
-      : reward.cap_period === 'monthly'
-      ? 'month'
-      : reward.cap_period === 'annual'
-      ? 'year'
-      : reward.cap_period;
-  const after = reward.rate_after_cap !== undefined ? `, then ${reward.rate_after_cap}%` : '';
-  return ` (up to $${reward.spend_cap.toLocaleString()}/${period}${after})`;
-}
-
-function inferRewardMode(
-  r: Reward,
-): 'quarterly_rotating' | 'user_choice' | 'auto_top_spend' | 'direct' {
-  if (r.mode === 'quarterly_rotating' || r.current_categories || r.current_period) {
-    return 'quarterly_rotating';
-  }
-  if (r.mode === 'auto_top_spend' || r.category === 'top_category') {
-    return 'auto_top_spend';
-  }
-  if (r.mode === 'user_choice' || typeof r.choices === 'number') {
-    return 'user_choice';
-  }
-  return 'direct';
-}
-
-function compareMatches(a: CardMatch, b: CardMatch, modeRank: Record<MatchMode, number>): number {
-  if (a.reward.value !== b.reward.value) return a.reward.value - b.reward.value;
-  return modeRank[a.mode] - modeRank[b.mode];
-}
-
-export function findCategoryMatch(
-  card: Card,
-  categories: string[],
-  storeSlug: string | null,
-  includeMerchantSpecific = false,
-  userSelections?: WalletCardSelection[],
-): CardMatch | null {
-  if (!card.rewards) return null;
-  const modeRank: Record<MatchMode, number> = {
-    direct: 5,
-    user_selected: 5,
-    rotating_current: 4,
-    user_choice: 3,
-    top_spend: 2,
-    rotating_eligible: 1,
-  };
-  let best: CardMatch | null = null;
-
-  for (const r of card.rewards) {
-    // merchant_gate: explicit list of store slugs this reward applies to.
-    // If set, the reward earns ONLY at those stores and is skipped elsewhere
-    // — regardless of category match. This is the structured fix for
-    // co-brand cards whose airline/hotel rate is brand-gated (e.g. United
-    // Explorer 3x airlines is gated to ["united-airlines"], so it should
-    // not surface at JetBlue or Delta).
-    if (r.merchant_gate && r.merchant_gate.length > 0) {
-      if (!storeSlug || !r.merchant_gate.includes(storeSlug)) continue;
-      if (categories.includes(r.category)) {
-        const candidate: CardMatch = { reward: r, matchedCategory: r.category, mode: 'direct' };
-        if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
-      }
-      continue;
-    }
-
-    const inferred = inferRewardMode(r);
-
-    if (
-      inferred === 'direct' &&
-      categories.includes(r.category) &&
-      (!r.merchant_specific || includeMerchantSpecific)
-    ) {
-      const candidate: CardMatch = { reward: r, matchedCategory: r.category, mode: 'direct' };
-      if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
-      continue;
-    }
-
-    if (inferred === 'quarterly_rotating') {
-      const current = (r.current_categories || []).map((c) =>
-        typeof c === 'string' ? c : c.category,
-      );
-      const eligible = r.eligible_categories || [];
-      const inCurrent = categories.find((c) => current.includes(c));
-      const inEligible = !inCurrent ? categories.find((c) => eligible.includes(c)) : undefined;
-      if (inCurrent) {
-        const candidate: CardMatch = {
-          reward: r,
-          matchedCategory: inCurrent,
-          mode: 'rotating_current',
-        };
-        if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
-      } else if (inEligible) {
-        const candidate: CardMatch = {
-          reward: r,
-          matchedCategory: inEligible,
-          mode: 'rotating_eligible',
-        };
-        if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
-      }
-      continue;
-    }
-
-    if (inferred === 'auto_top_spend' || inferred === 'user_choice') {
-      const eligible = r.eligible_categories || [];
-
-      // Block-level selections for this reward, if the caller passed any.
-      const blockSelections = userSelections?.filter(
-        (s) => s.reward_category === r.category && s.reward_rate === r.value,
-      );
-
-      if (blockSelections && blockSelections.length > 0) {
-        // User has configured this reward block. Match ONLY their saved picks —
-        // speculative "if you select it" badges are suppressed.
-        const userPicks = new Set(blockSelections.map((s) => s.selected_category));
-        const matched = categories.find((c) => userPicks.has(c) && eligible.includes(c));
-        if (matched) {
-          const candidate: CardMatch = { reward: r, matchedCategory: matched, mode: 'user_selected' };
-          if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
-        }
-        continue;
-      }
-
-      // No selections (legacy path / non-wallet pages): show speculative match so
-      // /store pages still surface the card with a "if you select it" badge.
-      const matched = categories.find((c) => eligible.includes(c));
-      if (matched) {
-        const mode: MatchMode = inferred === 'auto_top_spend' ? 'top_spend' : 'user_choice';
-        const candidate: CardMatch = { reward: r, matchedCategory: matched, mode };
-        if (!best || compareMatches(candidate, best, modeRank) > 0) best = candidate;
-      }
-    }
-  }
-
-  return best;
-}
-
-function flatRateReward(card: Card): Reward | null {
-  if (!card.rewards) return null;
-  return card.rewards.find((r) => r.category === 'everything_else') || null;
-}
-
-function reasonAndBadgeForMatch(match: CardMatch): { reason: string; badge: string } {
-  const rateStr = formatRate(match.reward.value, match.reward.unit as 'percent' | 'points_per_dollar');
-  const catLabel = labelForCategory(match.matchedCategory);
-  const cap = formatCap(match.reward);
-  switch (match.mode) {
-    case 'direct':
-      return { reason: `${rateStr} on ${catLabel}${cap}`, badge: '' };
-    case 'rotating_current': {
-      const period = match.reward.current_period ? ` (${match.reward.current_period})` : '';
-      return {
-        reason: `${rateStr} on ${catLabel} this quarter${period}${cap}. Activation required each quarter.`,
-        badge: 'this quarter',
-      };
-    }
-    case 'user_choice':
-      return {
-        reason: `${rateStr} on ${catLabel} if you select it as a bonus category${cap}`,
-        badge: 'if you select it',
-      };
-    case 'user_selected':
-      return {
-        reason: `${rateStr} on ${catLabel} (your selected category)${cap}`,
-        badge: 'selected',
-      };
-    case 'top_spend':
-      return {
-        reason: `${rateStr} on ${catLabel} if it's your top eligible spend category that cycle${cap}`,
-        badge: 'if it’s your top category',
-      };
-    case 'rotating_eligible':
-      return {
-        reason: `Up to ${rateStr} on ${catLabel} when it rotates in. Not in this quarter's lineup — check before a trip.`,
-        badge: 'situational',
-      };
-  }
-}
-
-export function rankCards(
-  store: Store,
-  cards: Card[],
-  options: RankCardsOptions = {},
-): RankedPick[] {
-  const walletSet = options.walletCardSlugs ? new Set(options.walletCardSlugs) : null;
-  const isWalletMode = walletSet !== null;
-  const flatRateFloor = options.flatRateFloor ?? (isWalletMode ? 0 : 1.5);
-  const flatRateFillFloor = options.flatRateFillFloor ?? (isWalletMode ? 0 : 2);
-  const maxPicks = options.maxPicks ?? 10;
-
-  const active = cards.filter((c) =>
-    walletSet ? walletSet.has(c.slug) : c.accepting_applications !== false,
-  );
-  const cardsBySlug = new Map(active.map((c) => [c.slug, c]));
-  const used = new Set<string>();
-  const picks: RankedPick[] = [];
-
-  // 1. Co-brand
-  for (const slug of store.co_brand_cards || []) {
-    const card = cardsBySlug.get(slug);
-    if (!card || used.has(slug)) continue;
-    const match = findCategoryMatch(
-      card,
-      store.categories,
-      store.slug,
-      true,
-      options.userSelections?.get(card.slug),
-    );
-    const r = match?.reward || flatRateReward(card);
-    const rate = r?.value ?? 0;
-    const unit = (r?.unit as 'percent' | 'points_per_dollar') ?? 'percent';
-    picks.push({
-      card,
-      rate,
-      unit,
-      effectiveRate: effectiveCashbackRate(rate, unit, card.card_name),
-      reason: `Co-branded ${store.name} card`,
-      source: 'co_brand',
-      channel: 'both',
-      note: r?.note,
-    });
-    used.add(slug);
-  }
-
-  // 2. Build the rate-ranked group: also_earns + category bonuses competing on effective rate.
-  type RankedCandidate =
-    | {
-        kind: 'also_earns';
-        card: Card;
-        rate: number;
-        unit: 'percent' | 'points_per_dollar';
-        note?: string;
-        effective: number;
-      }
-    | { kind: 'category'; card: Card; match: CardMatch; effective: number };
-  const candidates: RankedCandidate[] = [];
-
-  for (const entry of store.also_earns || []) {
-    const card = cardsBySlug.get(entry.card);
-    if (!card || used.has(entry.card)) continue;
-    const eff = effectiveCashbackRate(entry.rate, entry.unit, card.card_name);
-    candidates.push({
-      kind: 'also_earns',
-      card,
-      rate: entry.rate,
-      unit: entry.unit,
-      note: entry.note,
-      effective: eff,
-    });
-  }
-
-  for (const card of active) {
-    if (used.has(card.slug)) continue;
-    if (candidates.some((c) => c.card.slug === card.slug)) continue;
-    const m = findCategoryMatch(
-      card,
-      store.categories,
-      store.slug,
-      false,
-      options.userSelections?.get(card.slug),
-    );
-    if (!m) continue;
-    const eff = effectiveCashbackRate(
-      m.reward.value,
-      m.reward.unit as 'percent' | 'points_per_dollar',
-      card.card_name,
-    );
-    if (eff <= flatRateFloor) continue;
-    const effective = m.mode === 'rotating_eligible' ? eff - 100 : eff;
-    candidates.push({ kind: 'category', card, match: m, effective });
-  }
-
-  candidates.sort((a, b) => b.effective - a.effective);
-
-  for (const c of candidates) {
-    if (c.kind === 'also_earns') {
-      picks.push({
-        card: c.card,
-        rate: c.rate,
-        unit: c.unit,
-        effectiveRate: effectiveCashbackRate(c.rate, c.unit, c.card.card_name),
-        reason: `Earns ${formatRate(c.rate, c.unit)} at ${store.name}`,
-        source: 'also_earns',
-        channel: 'both',
-        note: c.note,
-      });
-    } else {
-      const { reason, badge } = reasonAndBadgeForMatch(c.match);
-      picks.push({
-        card: c.card,
-        rate: c.match.reward.value,
-        unit: c.match.reward.unit as 'percent' | 'points_per_dollar',
-        effectiveRate: effectiveCashbackRate(
-          c.match.reward.value,
-          c.match.reward.unit as 'percent' | 'points_per_dollar',
-          c.card.card_name,
-        ),
-        reason,
-        badge: badge || undefined,
-        channel: channelForCategory(c.match.matchedCategory),
-        source: 'category',
-        matchMode: c.match.mode,
-        note: c.match.reward.note,
-      });
-    }
-    used.add(c.card.slug);
-  }
-
-  // 3. Flat-rate fallback fill.
-  if (picks.length < maxPicks) {
-    const flatPicks: { card: Card; reward: Reward }[] = [];
-    for (const card of active) {
-      if (used.has(card.slug)) continue;
-      const reward = flatRateReward(card);
-      if (reward && reward.unit === 'percent' && reward.value >= flatRateFillFloor) {
-        flatPicks.push({ card, reward });
-      }
-    }
-    flatPicks.sort((a, b) => b.reward.value - a.reward.value);
-    for (const { card, reward } of flatPicks.slice(0, maxPicks - picks.length)) {
-      picks.push({
-        card,
-        rate: reward.value,
-        unit: reward.unit as 'percent',
-        effectiveRate: reward.value,
-        reason: `${formatRate(reward.value, 'percent')} flat-rate cashback`,
-        source: 'flat_rate',
-        note: reward.note,
-      });
-      used.add(card.slug);
-    }
-  }
-
-  return picks.slice(0, maxPicks);
-}
+export const rankCards = typedRanker.rankCards;
+export const effectiveCashbackRate = typedRanker.effectiveCashbackRate;
+export const formatRate = typedRanker.formatRate;
+export const labelForCategory = typedRanker.labelForCategory;
+export const channelForCategory = typedRanker.channelForCategory;


### PR DESCRIPTION
## Summary

Follow-up to [#1166](https://github.com/CreditOdds/creditodds/pull/1166). Eliminates the `storeRanking.ts` ↔ `storeRanking.js` twin-file sync invariant by having web-next consume the Lambda's JS ranker via the `@ranker/*` tsconfig path alias that was set up but unused in #1166.

[apps/web-next/src/lib/storeRanking.ts](apps/web-next/src/lib/storeRanking.ts) goes from a 445-line copy to a 32-line typed re-export. The implementation in [apps/api/src/lib/ranker/storeRanking.js](apps/api/src/lib/ranker/storeRanking.js) is now the single source of truth for both the public SSR page on `/best-card-for/[slug]` and the Lambda wallet endpoints.

## Why
The twin in #1166 was deliberate — we accepted a temporary fork rather than wrestle with Next.js compiling JS from outside its tree. Turns out modern Next.js + `moduleResolution: bundler` handles this fine. The drift risk wasn't worth the one-line tsconfig change.

## Verification
- `npx tsc --noEmit` — clean.
- `npx next build` — clean. SSG generates all 448 pages, which includes every `/best-card-for/[slug]` route that calls `rankCards` at build/request time through the cross-tree import.
- Behaviour change: zero. The JS module is the exact same logic the wallet endpoints have been serving since #1166.

## Notes
- The 9 "Ecmascript file had an error" warnings in the `next build` output are pre-existing — they're Edge Runtime warnings about the dev-only `fs/promises` fallback in `api.ts`, unrelated to this change.
- No backend changes — no SAM deploy needed.

## Test plan
- [ ] Hit `/best-card-for/marriott` (logged out) — confirm public ranking renders.
- [ ] Hit `/best-card-for/marriott` (logged in) — confirm public ranking still renders AND the "From your wallet" overlay still works (the latter has been Lambda-served since #1166).
- [ ] Quick spot-check on another store: `/best-card-for/whole-foods`, `/best-card-for/costco`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)