### PR TITLE
wallet-picks: enrich cards from DB so card_image_link is populated

### DIFF
--- a/apps/api/src/lib/ranker/data-loaders.js
+++ b/apps/api/src/lib/ranker/data-loaders.js
@@ -10,6 +10,7 @@
 const https = require("https");
 const path = require("path");
 const fs = require("fs");
+const mysql = require("../../db");
 
 const CARDS_URL =
   process.env.CARDS_JSON_URL || "https://d2hxvzw7msbtvt.cloudfront.net/cards.json";
@@ -36,14 +37,62 @@ function fetchCardsFromCDN() {
   });
 }
 
+// Merge in the same DB-sourced fields that `all-cards.js` exposes — the
+// frontend expects `card_image_link` (used by <CardImage>) and
+// `db_card_id` (used by the BCH merchant-report payload). Without this
+// merge the wallet-picks responses are missing the image URL and
+// CardImage falls back to the generic SVG.
+//
+// The DB lookup is wrapped in try/catch so a transient failure degrades
+// to "no images" rather than 500ing the whole wallet-picks call. Stays
+// in sync with all-cards.js: DB-side `card_image_link` wins, with
+// `card.image` (the YAML filename in cards.json) as the CDN fallback.
+async function fetchCardDbMetadata() {
+  try {
+    const rows = await mysql.query(
+      `SELECT card_id, card_name, card_image_link, accepting_applications FROM cards`,
+    );
+    // Connection release stays with the handler — running `mysql.end()` here
+    // while `loadUserWallet` is mid-flight (via Promise.all) can yank the
+    // pool out from under it.
+    const byName = new Map();
+    for (const row of rows) {
+      byName.set(row.card_name, {
+        db_card_id: row.card_id,
+        card_image_link: row.card_image_link,
+        accepting_applications: row.accepting_applications === 1,
+      });
+    }
+    return byName;
+  } catch (err) {
+    console.error("fetchCardDbMetadata failed (continuing without enrichment):", err.message);
+    return new Map();
+  }
+}
+
 async function getAllCards() {
   const now = Date.now();
   if (cardsCache && cardsCache.expiresAt > now) {
     return cardsCache.data;
   }
-  const cards = await fetchCardsFromCDN();
-  cardsCache = { expiresAt: now + CARDS_CACHE_TTL_MS, data: cards };
-  return cards;
+  const [cdnCards, dbByName] = await Promise.all([
+    fetchCardsFromCDN(),
+    fetchCardDbMetadata(),
+  ]);
+  const enriched = cdnCards.map((c) => {
+    const db = dbByName.get(c.card_name) || dbByName.get(c.name) || {};
+    return {
+      ...c,
+      db_card_id: db.db_card_id ?? null,
+      card_image_link: db.card_image_link || c.image || null,
+      accepting_applications:
+        db.accepting_applications !== undefined
+          ? db.accepting_applications
+          : c.accepting_applications,
+    };
+  });
+  cardsCache = { expiresAt: now + CARDS_CACHE_TTL_MS, data: enriched };
+  return enriched;
 }
 
 // stores.json — bundled in CodeUri, loaded once at module init.


### PR DESCRIPTION
## Summary

Hotfix for the regression you spotted post-#1166: BCH and store-page wallet rows were showing the fallback generic-card SVG instead of the real card images.

## Root cause
The wallet-picks handlers fetch `cards.json` directly from CloudFront via `data-loaders.js → getAllCards()`. The CDN shape exposes `image` (the YAML filename like `"aer-lingus.png"`) but **not** `card_image_link`. The frontend's `<CardImage>` reads `card.card_image_link` and prepends the card-images CDN URL — so with the field missing, every pick fell back to `/assets/generic-card.svg`.

The existing [all-cards.js handler (line 101)](apps/api/src/handlers/all-cards.js#L101) has always solved this by SELECTing card metadata from MySQL and overlaying it onto the CDN cards. The new wallet-picks `getAllCards()` was skipping that step.

## Fix
Mirror the same DB merge in `apps/api/src/lib/ranker/data-loaders.js`:

```sql
SELECT card_id, card_name, card_image_link, accepting_applications FROM cards
```

Key by `card_name`, overlay onto CDN cards. Same precedence as all-cards.js: DB-side `card_image_link` wins, CDN's `image` field as fallback. Also exposes `db_card_id` (used by BCH's merchant-report payload, which was silently dropping it before).

The DB query is wrapped in `try/catch` so a transient failure degrades to "no images" rather than 500ing wallet-picks. `mysql.end()` deliberately stays in the handler — calling it inside `fetchCardDbMetadata` would yank the pool while `loadUserWallet` is mid-flight via `Promise.all`.

## Verification
- `sam build` + `sam deploy` — Lambda is already live with this code.
- Refresh `/profile` Rewards → Find Best Near Me; card images should populate.

## Test plan
- [ ] BCH renders card thumbnails on the merchant rows.
- [ ] `/best-card-for/marriott` "From your wallet" row shows card thumbnails.
- [ ] Reporting a merchant from BCH includes the card's numeric `db_card_id` in the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)