### PR TITLE
wallet: collapse valuations twin — single JS source of truth

### DIFF
--- a/apps/web-next/src/lib/valuations.ts
+++ b/apps/web-next/src/lib/valuations.ts
@@ -1,4 +1,13 @@
-// Point/mile valuations — keep in sync with data/valuations.yaml
+// TypeScript surface for the points/miles valuation table. The implementation
+// lives in apps/api/src/lib/ranker/valuations.js (single source of truth,
+// shared with the Lambda wallet-picks handlers via the same `@ranker/*`
+// tsconfig alias used by storeRanking.ts).
+//
+// The JS module has no JSDoc types — the type assertions below are the spec.
+// If you change a signature, update both this file AND the JS twin to match.
+// Data edits (CPP, match strings, new programs) only happen in the JS module.
+
+import * as ranker from '@ranker/valuations';
 
 export interface Valuation {
   program: string;
@@ -6,44 +15,20 @@ export interface Valuation {
   cpp: number;
   match: string[];
   exclude?: string[];
-  toolSlug?: string; // path segment for /tools/<toolSlug>-to-usd
+  /** Path segment for /tools/<toolSlug>-to-usd. */
+  toolSlug?: string;
 }
 
-const valuations: Valuation[] = [
-  { program: "Chase Ultimate Rewards", slug: "chase-ultimate-rewards", cpp: 1.25, match: ["chase sapphire", "freedom"], toolSlug: "chase-ultimate-rewards" },
-  { program: "Amex Membership Rewards", slug: "amex-membership-rewards", cpp: 1.2, match: ["american express", "amex", "gold card", "platinum card"], exclude: ["delta", "hilton", "skymiles"], toolSlug: "amex-membership-rewards" },
-  { program: "Delta SkyMiles", slug: "delta-skymiles", cpp: 1.20, match: ["delta", "skymiles"], toolSlug: "delta-skymiles" },
-  { program: "United MileagePlus", slug: "united-mileageplus", cpp: 1.21, match: ["united"], toolSlug: "united-miles" },
-  { program: "Hilton Honors", slug: "hilton-honors", cpp: 0.5, match: ["hilton"], toolSlug: "hilton-honors-points" },
-  { program: "World of Hyatt", slug: "world-of-hyatt", cpp: 2.0, match: ["hyatt"], toolSlug: "world-of-hyatt-points" },
-  { program: "IHG One Rewards", slug: "ihg-one-rewards", cpp: 0.5, match: ["ihg"], toolSlug: "ihg-one-rewards-points" },
-  { program: "Marriott Bonvoy", slug: "marriott-bonvoy", cpp: 0.7, match: ["marriott", "bonvoy"], toolSlug: "marriott-bonvoy-points" },
-  { program: "Capital One Miles", slug: "capital-one-miles", cpp: 1.0, match: ["capital one"], toolSlug: "capital-one-miles" },
-  { program: "Bilt Rewards", slug: "bilt-rewards", cpp: 1.5, match: ["bilt"], toolSlug: "bilt-rewards-points" },
-  { program: "Citi ThankYou", slug: "citi-thankyou", cpp: 1.0, match: ["citi"], toolSlug: "citi-thankyou-points" },
-  { program: "Wells Fargo Rewards", slug: "wells-fargo-rewards", cpp: 1.0, match: ["wells fargo"] },
-  { program: "Southwest Rapid Rewards", slug: "southwest-rapid-rewards", cpp: 1.30, match: ["southwest"], toolSlug: "southwest-rapid-rewards" },
-];
+type ValuationsModule = {
+  getValuation: (cardName: string) => number;
+  getValuationDetails: (cardName: string) => Valuation | undefined;
+  getValuationBySlug: (slug: string) => Valuation | undefined;
+  getAllValuations: () => Valuation[];
+};
 
-const DEFAULT_CPP = 1.0;
+const typedRanker = ranker as unknown as ValuationsModule;
 
-export function getValuation(cardName: string): number {
-  return getValuationDetails(cardName)?.cpp ?? DEFAULT_CPP;
-}
-
-export function getValuationDetails(cardName: string): Valuation | undefined {
-  const name = cardName.toLowerCase();
-  for (const v of valuations) {
-    if (v.exclude && v.exclude.some(ex => name.includes(ex))) continue;
-    if (v.match.some(m => name.includes(m))) return v;
-  }
-  return undefined;
-}
-
-export function getValuationBySlug(slug: string): Valuation | undefined {
-  return valuations.find(v => v.slug === slug);
-}
-
-export function getAllValuations(): Valuation[] {
-  return valuations;
-}
+export const getValuation = typedRanker.getValuation;
+export const getValuationDetails = typedRanker.getValuationDetails;
+export const getValuationBySlug = typedRanker.getValuationBySlug;
+export const getAllValuations = typedRanker.getAllValuations;


### PR DESCRIPTION
## Summary

Same pattern as [#1167](https://github.com/CreditOdds/creditodds/pull/1167), now for valuations. [apps/web-next/src/lib/valuations.ts](apps/web-next/src/lib/valuations.ts) becomes a 32-line typed re-export of [apps/api/src/lib/ranker/valuations.js](apps/api/src/lib/ranker/valuations.js). One source of truth for points/mile CPP values across the Lambda ranker AND every web-next consumer.

## Why
After #1167, the Lambda + web-next's `/best-card-for/[slug]` already shared the JS valuations through `@ranker/storeRanking → require('./valuations')`. But the rest of web-next (`cardDisplayUtils`, `CardClient`, `RewardValueConverter`, the `/tools/[converter]` pages) still imported a parallel TS copy. Drift would have produced inconsistent CPP — e.g. ranking sees "0.7¢" while display sees "1.0¢" — silently miscalibrating every points-card recommendation.

## Verification
- `tsc --noEmit` clean.
- `next build` clean — 448 SSG pages generate including every `/tools/[converter]` route, which calls `getValuationBySlug` at request time through the cross-tree import.
- Zero behaviour change. JS data is identical to the TS data that was there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)