### PR TITLE
ios: move Earn tab to far left and swap to a filled-style icon

### DIFF
--- a/apps/ios/CreditOdds/Views/ProfileView.swift
+++ b/apps/ios/CreditOdds/Views/ProfileView.swift
@@ -3,11 +3,11 @@ import SwiftUI
 struct ProfileView: View {
     var body: some View {
         TabView {
+            EarnTab()
+                .tabItem { Label("Earn", systemImage: "dollarsign.circle.fill") }
+
             WalletTab()
                 .tabItem { Label("Cards", systemImage: "creditcard.fill") }
-
-            EarnTab()
-                .tabItem { Label("Earn", systemImage: "percent") }
 
             SettingsTab()
                 .tabItem { Label("Settings", systemImage: "gearshape.fill") }


### PR DESCRIPTION
## Summary

Two small SwiftUI tweaks in [apps/ios/CreditOdds/Views/ProfileView.swift](apps/ios/CreditOdds/Views/ProfileView.swift):

- **Tab order**: Earn → Cards → Settings (was Cards → Earn → Settings). Earn is now the far-left tab.
- **Icon**: `percent` → `dollarsign.circle.fill`. The previous outline-style `percent` symbol stuck out next to the filled `creditcard.fill` and `gearshape.fill`. The filled dollar-in-circle matches the visual weight and keeps the financial/earnings semantics.

No behaviour change.

## Verification
- Built in Xcode on iPhone 17 Pro simulator; tabs reorder correctly, new icon renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)