### PR TITLE
ios: pin DEVELOPMENT_TEAM so xcodegen preserves Signing & Capabilities

### DIFF
--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -9,7 +9,11 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.10"
-    DEVELOPMENT_TEAM: ""
+    # GDZZ7A27FL = Max Melcher personal team. Pinning so `xcodegen`
+    # regeneration doesn't wipe the Signing & Capabilities team field
+    # — that was the source of the Firebase Auth keychain failures on
+    # the simulator when rebuilding from a fresh clone.
+    DEVELOPMENT_TEAM: GDZZ7A27FL
     CODE_SIGN_STYLE: Automatic
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"


### PR DESCRIPTION
## Summary

[apps/ios/project.yml](apps/ios/project.yml): `DEVELOPMENT_TEAM: ""` → `DEVELOPMENT_TEAM: GDZZ7A27FL`.

## Why
Every time you run `xcodegen`, the Signing & Capabilities Team field on the CreditOdds target gets wiped because the YAML says blank. With no team, the `keychain-access-groups` entitlement (`$(AppIdentifierPrefix)com.creditodds.app`) doesn't resolve at codesign time, and Firebase Auth fails to access the keychain on the simulator — surfacing as the cryptic "Invalid key=value pair … in Authorization header" 403 from the API. We hit this twice today after the BCH backend cutover ([#1170](https://github.com/CreditOdds/creditodds/pull/1170)).

Pinning the team baked into `project.yml` keeps the field set across every regeneration.

## Verification
- `cd apps/ios && xcodegen` — clean.
- `grep -c "GDZZ7A27FL" CreditOdds.xcodeproj/project.pbxproj` → 3 (base + Debug + Release configurations).

## Follow-up if you add another iOS contributor
Swap this for a gitignored `Local.xcconfig` override so each contributor sets their own team locally. Single-contributor today, so the simpler pinned value wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)