### PR TITLE
seo: add author OG image + twitter.site for branded unfurls

### DIFF
--- a/apps/web-next/src/app/articles/author/[slug]/opengraph-image.tsx
+++ b/apps/web-next/src/app/articles/author/[slug]/opengraph-image.tsx
@@ -1,0 +1,126 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGLogo, loadInterFonts, OG_CACHE_HEADERS } from '@/components/og/og-utils';
+import { getArticles, getUniqueAuthors } from '@/lib/articles';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'nodejs';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+export default async function AuthorOGImage({ params }: Props) {
+  const { slug } = await params;
+  const fonts = await loadInterFonts();
+  const articles = await getArticles();
+  const author = getUniqueAuthors(articles).find((a) => a.slug === slug);
+
+  const name = author?.name ?? 'CreditOdds Author';
+  const count = author?.count ?? 0;
+  const subtitle = author
+    ? `${count} article${count !== 1 ? 's' : ''} on credit card strategy`
+    : 'Long-form credit card content from the CreditOdds editorial team';
+
+  return new ImageResponse(
+    (
+      <OGBackground>
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 60,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 140,
+              height: 140,
+              background: 'rgba(255,255,255,0.15)',
+              borderRadius: 70,
+              marginBottom: 36,
+              boxShadow: '0 20px 50px rgba(0,0,0,0.2)',
+              color: 'white',
+              fontSize: 56,
+              fontWeight: 700,
+              letterSpacing: -1,
+            }}
+          >
+            {initials(name) || 'CO'}
+          </div>
+
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.85)',
+              fontSize: 22,
+              letterSpacing: 2,
+              textTransform: 'uppercase',
+              marginBottom: 14,
+            }}
+          >
+            Articles · Author
+          </div>
+
+          <div
+            style={{
+              color: 'white',
+              fontSize: 84,
+              fontWeight: 'bold',
+              letterSpacing: -2,
+              textAlign: 'center',
+              marginBottom: 18,
+              lineHeight: 1.05,
+            }}
+          >
+            {name}
+          </div>
+
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.9)',
+              fontSize: 26,
+              textAlign: 'center',
+              maxWidth: 880,
+              lineHeight: 1.4,
+            }}
+          >
+            {subtitle}
+          </div>
+        </div>
+
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 30,
+            left: 40,
+            display: 'flex',
+          }}
+        >
+          <OGLogo size={40} />
+        </div>
+      </OGBackground>
+    ),
+    { ...size, fonts, headers: OG_CACHE_HEADERS }
+  );
+}

--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -26,6 +26,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
+    site: "@creditodds",
     creator: "@MaxwellMelcher",
   },
   authors: [{ name: "Maxwell Melcher" }],


### PR DESCRIPTION
## Summary
A targeted SEO sweep — the larger TODO list from memory turned out to already be resolved (every page on the list has `openGraph`, `alternates.canonical`, and a sibling `opengraph-image.tsx`). Two real gaps remained:

- `/articles/author/[slug]` had no `opengraph-image.tsx`, so author-page unfurls fell through to the root-level image instead of an author-specific card. Added one that mirrors the existing category OG image — initials avatar, author name, article count.
- Root layout's `twitter` metadata had `creator` (`@MaxwellMelcher`) but no `site`, so brand-handle attribution on Twitter unfurls was missing. Added `site: "@creditodds"`.

Notes on what *isn't* in this PR but was flagged by the audit and intentionally left alone:
- Several static pages (about / how / privacy / terms / contact / category / author) were flagged for "missing twitter card object". Next.js inherits the root layout's `twitter.card` and falls back to `og:image` for the image when no per-page `twitter.images` is set, so unfurls already work correctly on those pages.
- A few pages were flagged for "missing `openGraph.images`", but Next.js auto-populates that field from a sibling `opengraph-image.tsx` — all those pages have one.
- `BreadcrumbSchema` on `/compare` was flagged as missing but is already present at line 81.

## Test plan
- [ ] Visit `/articles/author/<some-slug>` and `View Page Source` — confirm `<meta property="og:image">` resolves to the new author image.
- [ ] Hit `/articles/author/<some-slug>/opengraph-image` directly in a browser — confirm a 1200×630 PNG renders with the author's initials and name.
- [ ] Inspect any page's `<head>` — confirm `<meta name="twitter:site" content="@creditodds">` is present.
- [ ] Run an unfurl preview (e.g. opengraph.xyz or Twitter Card Validator) on an author URL post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)