### PR TITLE
navbar: per-user boring-avatars face icon

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -19,6 +19,7 @@
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
     "axios": "^1.13.2",
+    "boring-avatars": "^2.0.4",
     "canvas-confetti": "^1.9.4",
     "downshift": "^9.0.13",
     "firebase": "^12.8.0",

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { Disclosure, Menu, Transition } from "@headlessui/react";
 import { Bars3Icon, WalletIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
+import UserAvatar from "@/components/user/UserAvatar";
 
 type NavItem = {
   href: string;
@@ -158,14 +159,12 @@ export default function Navbar() {
                     <Menu as="div" className="relative z-10">
                       {({ open: menuOpen }) => (
                         <>
-                          <Menu.Button className="inline-flex h-9 w-9 items-center justify-center rounded-[3px] border border-[#ddd7ec] bg-white p-0 text-sm transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
+                          <Menu.Button className="inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-[3px] border border-[#ddd7ec] bg-white p-0 text-sm transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
                             <span className="sr-only">Open user menu</span>
-                            <Image
-                              className="h-8 w-8 rounded-[2px]"
-                              src="https://d3ay3etzd1512y.cloudfront.net/other/profile_pic.svg"
-                              alt="Account menu"
-                              width={32}
-                              height={32}
+                            <UserAvatar
+                              seed={authState.user?.uid ?? authState.user?.email}
+                              size={32}
+                              title="Account menu"
                             />
                           </Menu.Button>
                           <Transition

--- a/apps/web-next/src/components/user/UserAvatar.tsx
+++ b/apps/web-next/src/components/user/UserAvatar.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Avatar from 'boring-avatars';
+
+const BRAND_PALETTE = ['#6d3fe8', '#1a1330', '#a78bfa', '#fde68a', '#fef3c7'];
+
+export type UserAvatarVariant =
+  | 'marble'
+  | 'beam'
+  | 'pixel'
+  | 'sunset'
+  | 'ring'
+  | 'bauhaus'
+  | 'geometric'
+  | 'abstract';
+
+type UserAvatarProps = {
+  seed?: string | null;
+  size?: number;
+  variant?: UserAvatarVariant;
+  square?: boolean;
+  className?: string;
+  title?: string;
+};
+
+export default function UserAvatar({
+  seed,
+  size = 32,
+  variant = 'beam',
+  square = true,
+  className,
+  title,
+}: UserAvatarProps) {
+  const name = seed && seed.length > 0 ? seed : 'guest';
+  return (
+    <Avatar
+      name={name}
+      variant={variant}
+      colors={BRAND_PALETTE}
+      size={size}
+      square={square}
+      title={title}
+      className={className}
+    />
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.19",
         "axios": "^1.13.2",
+        "boring-avatars": "^2.0.4",
         "canvas-confetti": "^1.9.4",
         "downshift": "^9.0.13",
         "firebase": "^12.8.0",
@@ -7396,6 +7397,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/boring-avatars": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/boring-avatars/-/boring-avatars-2.0.4.tgz",
+      "integrity": "sha512-xhZO/w/6aFmRfkaWohcl2NfyIy87gK5SBbys8kctZeTGF1Apjpv/10pfUuv+YEfVPkESU/h2Y6tt/Dwp+bIZPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",


### PR DESCRIPTION
## Summary
- Replaces the static `profile_pic.svg` in the navbar with a deterministic [boring-avatars](https://github.com/boringdesigners/boring-avatars) face seeded on the Firebase UID, so every signed-in user gets a stable, unique avatar.
- New `UserAvatar` wrapper component in `apps/web-next/src/components/user/UserAvatar.tsx` — defaults to the `beam` variant (faces) with the brand palette (`#6d3fe8 / #1a1330 / #a78bfa / #fde68a / #fef3c7`); accepts size/variant/square overrides for reuse elsewhere.

## Test plan
- [x] Verified locally that the beam variant always renders a face across multiple seed values (face shape and colors vary; eyes + mouth always present).
- [ ] Sign in on Amplify preview → confirm the navbar avatar renders as a colored face instead of the generic SVG.
- [ ] Sign out → confirm Sign In / Sign Up buttons still render normally (no regression on the unauthenticated nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)