### PR TITLE
profile: re-roll avatar from settings tab

### DIFF
--- a/apps/api/migrations/034_add_avatar_seed_to_user_settings.sql
+++ b/apps/api/migrations/034_add_avatar_seed_to_user_settings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_settings ADD COLUMN avatar_seed VARCHAR(64) DEFAULT NULL;

--- a/apps/api/src/handlers/user-settings.js
+++ b/apps/api/src/handlers/user-settings.js
@@ -1,14 +1,17 @@
-// GET /user-settings — returns the authenticated user's per-account flags.
-// Frontend reads this to decide whether to render Plaid (and future) beta UI.
-// Falls back to defaults (all flags false) if no row exists yet.
+// /user-settings — per-user flags (plaid beta, avatar seed, future toggles).
+// GET returns the authenticated user's settings, falling back to defaults if no row exists.
+// PUT upserts updatable fields (currently: avatar_seed).
 
 const mysql = require('../db');
 
 const responseHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
-  'Access-Control-Allow-Methods': 'GET,OPTIONS',
+  'Access-Control-Allow-Methods': 'GET,PUT,OPTIONS',
 };
+
+const MAX_AVATAR_SEED_LENGTH = 64;
+const AVATAR_SEED_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 exports.UserSettingsHandler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
@@ -21,16 +24,63 @@ exports.UserSettingsHandler = async (event) => {
   }
 
   try {
-    const rows = await mysql.query(
-      'SELECT plaid_beta_enabled FROM user_settings WHERE user_id = ? LIMIT 1',
-      [userId]
-    );
-    await mysql.end();
+    if (event.httpMethod === 'GET') {
+      const rows = await mysql.query(
+        'SELECT plaid_beta_enabled, avatar_seed FROM user_settings WHERE user_id = ? LIMIT 1',
+        [userId]
+      );
+      await mysql.end();
+      const settings = {
+        plaid_beta_enabled: rows.length > 0 ? Boolean(rows[0].plaid_beta_enabled) : false,
+        avatar_seed: rows.length > 0 ? rows[0].avatar_seed : null,
+      };
+      return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(settings) };
+    }
 
-    const settings = {
-      plaid_beta_enabled: rows.length > 0 ? Boolean(rows[0].plaid_beta_enabled) : false,
-    };
-    return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(settings) };
+    if (event.httpMethod === 'PUT') {
+      let body;
+      try {
+        body = event.body ? JSON.parse(event.body) : {};
+      } catch {
+        await mysql.end();
+        return { statusCode: 400, headers: responseHeaders, body: JSON.stringify({ error: 'Invalid JSON body' }) };
+      }
+
+      if (!Object.prototype.hasOwnProperty.call(body, 'avatar_seed')) {
+        await mysql.end();
+        return { statusCode: 400, headers: responseHeaders, body: JSON.stringify({ error: 'No updatable fields provided' }) };
+      }
+
+      const rawSeed = body.avatar_seed;
+      let avatarSeed = null;
+      if (rawSeed !== null && rawSeed !== undefined && rawSeed !== '') {
+        if (typeof rawSeed !== 'string' || rawSeed.length > MAX_AVATAR_SEED_LENGTH || !AVATAR_SEED_PATTERN.test(rawSeed)) {
+          await mysql.end();
+          return { statusCode: 400, headers: responseHeaders, body: JSON.stringify({ error: 'Invalid avatar_seed' }) };
+        }
+        avatarSeed = rawSeed;
+      }
+
+      await mysql.query(
+        `INSERT INTO user_settings (user_id, avatar_seed)
+         VALUES (?, ?)
+         ON DUPLICATE KEY UPDATE avatar_seed = VALUES(avatar_seed)`,
+        [userId, avatarSeed]
+      );
+      const rows = await mysql.query(
+        'SELECT plaid_beta_enabled, avatar_seed FROM user_settings WHERE user_id = ? LIMIT 1',
+        [userId]
+      );
+      await mysql.end();
+      const settings = {
+        plaid_beta_enabled: rows.length > 0 ? Boolean(rows[0].plaid_beta_enabled) : false,
+        avatar_seed: rows.length > 0 ? rows[0].avatar_seed : null,
+      };
+      return { statusCode: 200, headers: responseHeaders, body: JSON.stringify(settings) };
+    }
+
+    await mysql.end();
+    return { statusCode: 405, headers: responseHeaders, body: JSON.stringify({ error: 'Method not allowed' }) };
   } catch (error) {
     console.error('user-settings error:', error);
     await mysql.end();

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -1240,6 +1240,12 @@ Resources:
             Path: /user-settings
             Method: GET
             RestApiId: !Ref CreditCardOddsAPI
+        PutUserSettings:
+          Type: Api
+          Properties:
+            Path: /user-settings
+            Method: PUT
+            RestApiId: !Ref CreditCardOddsAPI
         UserSettingsOptions:
           Type: Api
           Properties:

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4093,6 +4093,47 @@
   letter-spacing: 0.02em;
   padding: 0;
 }
+.landing-v2.profile-v2 .cj-avatar-reroll {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  overflow: hidden;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font: inherit;
+  transition: border-color 120ms ease;
+}
+.landing-v2.profile-v2 .cj-avatar-reroll:hover,
+.landing-v2.profile-v2 .cj-avatar-reroll:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.landing-v2.profile-v2 .cj-avatar-reroll-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(26, 19, 48, 0.78);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+}
+.landing-v2.profile-v2 .cj-avatar-reroll:hover .cj-avatar-reroll-overlay,
+.landing-v2.profile-v2 .cj-avatar-reroll:focus-visible .cj-avatar-reroll-overlay {
+  opacity: 1;
+}
 
 /* Right rail — apply block, dashed lists, news */
 .landing-v2.profile-v2 .cj-rail {

--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { AuthProvider } from "@/auth/AuthProvider";
+import { UserSettingsProvider } from "@/user-settings/UserSettingsProvider";
 import { ConditionalNavbar } from "@/components/layout/ConditionalChrome";
 import SkipLink from "@/components/ui/SkipLink";
 import WebVitalsReporter from "@/components/ui/WebVitalsReporter";
@@ -65,17 +66,19 @@ export default function RootLayout({
         <OrganizationSchema />
         <WebsiteSchema />
         <AuthProvider>
-          <SkipLink />
-          <ConditionalNavbar />
-          <main id="main-content" className="flex-grow">
-            {children}
-            <DataPointPrompt />
-          </main>
-          {/* Footer is rendered per-page via <V2Footer /> from
-              @/components/landing-v2/Chrome — no global footer here. */}
-          <ToastContainer />
-          <WebVitalsReporter />
-          <LogRocketInit />
+          <UserSettingsProvider>
+            <SkipLink />
+            <ConditionalNavbar />
+            <main id="main-content" className="flex-grow">
+              {children}
+              <DataPointPrompt />
+            </main>
+            {/* Footer is rendered per-page via <V2Footer /> from
+                @/components/landing-v2/Chrome — no global footer here. */}
+            <ToastContainer />
+            <WebVitalsReporter />
+            <LogRocketInit />
+          </UserSettingsProvider>
         </AuthProvider>
       </body>
     </html>

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -6,6 +6,8 @@ import CardImage from "@/components/ui/CardImage";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useAuth } from "@/auth/AuthProvider";
+import { useUserSettings } from "@/user-settings/UserSettingsProvider";
+import UserAvatar from "@/components/user/UserAvatar";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import { getAllCards, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, deleteAccount, reorderWallet, WalletCard, Card } from "@/lib/api";
 import "../landing.css";
@@ -1432,6 +1434,27 @@ interface SettingsTabProps {
 
 function SettingsTab(props: SettingsTabProps) {
   const { email, handle, confirmingDelete, setConfirmingDelete, deleteConfirmText, setDeleteConfirmText, deletingAccount, onDeleteAccount, onLogout } = props;
+  const { authState } = useAuth();
+  const { settings, setAvatarSeed } = useUserSettings();
+  const [isRerolling, setIsRerolling] = useState(false);
+  const [rerollError, setRerollError] = useState<string | null>(null);
+
+  const avatarSeed = settings?.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null;
+
+  const handleReroll = async () => {
+    setRerollError(null);
+    setIsRerolling(true);
+    try {
+      const newSeed = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      await setAvatarSeed(newSeed);
+    } catch {
+      setRerollError('Could not save — try again');
+    } finally {
+      setIsRerolling(false);
+    }
+  };
 
   const rows = [
     { k: 'Email', v: email || '—' },
@@ -1441,6 +1464,26 @@ function SettingsTab(props: SettingsTabProps) {
   return (
     <section className="cj-section">
       <div>
+        <div className="cj-settings-list">
+          <div className="cj-settings-k">Avatar</div>
+          <div className="cj-settings-v" style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <span style={{ display: 'inline-flex', overflow: 'hidden', borderRadius: 4, border: '1px solid var(--line)' }}>
+              <UserAvatar seed={avatarSeed} size={48} />
+            </span>
+            {rerollError && (
+              <span style={{ fontSize: 11.5, color: 'var(--warn)' }}>{rerollError}</span>
+            )}
+          </div>
+          <button
+            type="button"
+            className="cj-settings-edit"
+            onClick={handleReroll}
+            disabled={isRerolling}
+            style={{ opacity: isRerolling ? 0.5 : 1, cursor: isRerolling ? 'wait' : 'pointer' }}
+          >
+            {isRerolling ? 'rolling…' : 're-roll →'}
+          </button>
+        </div>
         {rows.map((r, i) => (
           <div key={i} className="cj-settings-list">
             <div className="cj-settings-k">{r.k}</div>

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -1436,24 +1436,41 @@ function SettingsTab(props: SettingsTabProps) {
   const { email, handle, confirmingDelete, setConfirmingDelete, deleteConfirmText, setDeleteConfirmText, deletingAccount, onDeleteAccount, onLogout } = props;
   const { authState } = useAuth();
   const { settings, setAvatarSeed } = useUserSettings();
-  const [isRerolling, setIsRerolling] = useState(false);
-  const [rerollError, setRerollError] = useState<string | null>(null);
+  const [pendingSeed, setPendingSeed] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
-  const avatarSeed = settings?.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null;
+  const savedSeed = settings?.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null;
+  const displayedSeed = pendingSeed ?? savedSeed;
+  const hasPending = pendingSeed !== null;
 
-  const handleReroll = async () => {
-    setRerollError(null);
-    setIsRerolling(true);
+  const generateSeed = () =>
+    (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+  const handleReroll = () => {
+    setSaveError(null);
+    setPendingSeed(generateSeed());
+  };
+
+  const handleSave = async () => {
+    if (pendingSeed === null) return;
+    setSaveError(null);
+    setIsSaving(true);
     try {
-      const newSeed = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-      await setAvatarSeed(newSeed);
+      await setAvatarSeed(pendingSeed);
+      setPendingSeed(null);
     } catch {
-      setRerollError('Could not save — try again');
+      setSaveError('Could not save — try again');
     } finally {
-      setIsRerolling(false);
+      setIsSaving(false);
     }
+  };
+
+  const handleCancel = () => {
+    setPendingSeed(null);
+    setSaveError(null);
   };
 
   const rows = [
@@ -1466,23 +1483,56 @@ function SettingsTab(props: SettingsTabProps) {
       <div>
         <div className="cj-settings-list">
           <div className="cj-settings-k">Avatar</div>
-          <div className="cj-settings-v" style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <span style={{ display: 'inline-flex', overflow: 'hidden', borderRadius: 4, border: '1px solid var(--line)' }}>
-              <UserAvatar seed={avatarSeed} size={48} />
-            </span>
-            {rerollError && (
-              <span style={{ fontSize: 11.5, color: 'var(--warn)' }}>{rerollError}</span>
+          <div className="cj-settings-v" style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              className="cj-avatar-reroll"
+              onClick={handleReroll}
+              aria-label="Re-roll avatar"
+              title="Re-roll"
+            >
+              <UserAvatar seed={displayedSeed} size={48} />
+              <span className="cj-avatar-reroll-overlay">Re-roll</span>
+            </button>
+            {hasPending && (
+              <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>
+                preview — unsaved
+              </span>
+            )}
+            {saveError && (
+              <span style={{ fontSize: 11.5, color: 'var(--warn)' }}>{saveError}</span>
             )}
           </div>
-          <button
-            type="button"
-            className="cj-settings-edit"
-            onClick={handleReroll}
-            disabled={isRerolling}
-            style={{ opacity: isRerolling ? 0.5 : 1, cursor: isRerolling ? 'wait' : 'pointer' }}
-          >
-            {isRerolling ? 'rolling…' : 're-roll →'}
-          </button>
+          {hasPending ? (
+            <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+              <button
+                type="button"
+                className="cj-settings-edit"
+                onClick={handleSave}
+                disabled={isSaving}
+                style={{ opacity: isSaving ? 0.5 : 1, cursor: isSaving ? 'wait' : 'pointer' }}
+              >
+                {isSaving ? 'saving…' : 'save →'}
+              </button>
+              <button
+                type="button"
+                className="cj-settings-edit"
+                onClick={handleCancel}
+                disabled={isSaving}
+                style={{ color: 'var(--muted)', opacity: isSaving ? 0.5 : 1, cursor: isSaving ? 'wait' : 'pointer' }}
+              >
+                cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="cj-settings-edit"
+              onClick={handleReroll}
+            >
+              re-roll →
+            </button>
+          )}
         </div>
         {rows.map((r, i) => (
           <div key={i} className="cj-settings-list">

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { Disclosure, Menu, Transition } from "@headlessui/react";
 import { Bars3Icon, WalletIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useAuth } from "@/auth/AuthProvider";
+import { useUserSettings } from "@/user-settings/UserSettingsProvider";
 import UserAvatar from "@/components/user/UserAvatar";
 
 type NavItem = {
@@ -100,7 +101,9 @@ function MobileNavLink({
 
 export default function Navbar() {
   const { authState, logout } = useAuth();
+  const { settings } = useUserSettings();
   const pathname = usePathname();
+  const avatarSeed = settings?.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null;
 
   const isActive = (item: NavItem) => item.matches(pathname);
   const isProfileActive = pathname === "/profile" || pathname.startsWith("/profile/");
@@ -162,7 +165,7 @@ export default function Navbar() {
                           <Menu.Button className="inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-[3px] border border-[#ddd7ec] bg-white p-0 text-sm transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
                             <span className="sr-only">Open user menu</span>
                             <UserAvatar
-                              seed={authState.user?.uid ?? authState.user?.email}
+                              seed={avatarSeed}
                               size={32}
                               title="Account menu"
                             />

--- a/apps/web-next/src/user-settings/UserSettingsProvider.tsx
+++ b/apps/web-next/src/user-settings/UserSettingsProvider.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useAuth } from '@/auth/AuthProvider';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
+
+export interface UserSettings {
+  plaid_beta_enabled: boolean;
+  avatar_seed: string | null;
+}
+
+interface UserSettingsContextType {
+  settings: UserSettings | null;
+  isLoading: boolean;
+  setAvatarSeed: (seed: string) => Promise<void>;
+}
+
+const DEFAULT_SETTINGS: UserSettings = {
+  plaid_beta_enabled: false,
+  avatar_seed: null,
+};
+
+const UserSettingsContext = createContext<UserSettingsContextType | undefined>(undefined);
+
+export function UserSettingsProvider({ children }: { children: ReactNode }) {
+  const { authState, getToken } = useAuth();
+  const [settings, setSettings] = useState<UserSettings | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const fetchedForUserRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!authState.isAuthenticated || !authState.user) {
+      setSettings(null);
+      fetchedForUserRef.current = null;
+      return;
+    }
+    if (fetchedForUserRef.current === authState.user.uid) return;
+    fetchedForUserRef.current = authState.user.uid;
+
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      try {
+        const token = await getToken();
+        if (!token) return;
+        const res = await fetch(`${API_BASE}/user-settings`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error(`user-settings GET ${res.status}`);
+        const data = (await res.json()) as UserSettings;
+        if (!cancelled) setSettings({ ...DEFAULT_SETTINGS, ...data });
+      } catch (err) {
+        console.error('Failed to load user settings:', err);
+        if (!cancelled) setSettings(DEFAULT_SETTINGS);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authState.isAuthenticated, authState.user, getToken]);
+
+  const setAvatarSeed = useCallback(
+    async (seed: string) => {
+      const prev = settings;
+      setSettings((s) => ({ ...(s ?? DEFAULT_SETTINGS), avatar_seed: seed }));
+      try {
+        const token = await getToken();
+        if (!token) throw new Error('Not authenticated');
+        const res = await fetch(`${API_BASE}/user-settings`, {
+          method: 'PUT',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ avatar_seed: seed }),
+        });
+        if (!res.ok) throw new Error(`user-settings PUT ${res.status}`);
+        const data = (await res.json()) as UserSettings;
+        setSettings({ ...DEFAULT_SETTINGS, ...data });
+      } catch (err) {
+        setSettings(prev);
+        throw err;
+      }
+    },
+    [settings, getToken]
+  );
+
+  const value = useMemo<UserSettingsContextType>(
+    () => ({ settings, isLoading, setAvatarSeed }),
+    [settings, isLoading, setAvatarSeed]
+  );
+
+  return <UserSettingsContext.Provider value={value}>{children}</UserSettingsContext.Provider>;
+}
+
+export function useUserSettings(): UserSettingsContextType {
+  const ctx = useContext(UserSettingsContext);
+  if (!ctx) throw new Error('useUserSettings must be used within UserSettingsProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- Adds an **Avatar** row to the profile **Settings** tab with a "re-roll" button that generates a fresh UUID seed and persists it per-user.
- New `UserSettingsProvider` context fetches `/user-settings` once after auth resolves; both the navbar avatar and the settings tab read from it so a re-roll updates both in the same render.
- Variant stays locked to `beam` — every roll is guaranteed to render a face.
- Backend: migration 034 adds `user_settings.avatar_seed VARCHAR(64) NULL`. The `/user-settings` handler now accepts PUT with seed validation (length ≤ 64, charset `[A-Za-z0-9_-]`) and upserts via `INSERT … ON DUPLICATE KEY UPDATE`.

## ⚠️ Deploy steps (in order)
1. **Merge this PR.**
2. **`sam build && sam deploy`** from `apps/api/` — picks up the PUT route and the updated handler.
3. **Run migration 034** via `RunMigrationHandler` (DB is in a private VPC — can't run locally). Until the column exists, the GET will 500 on the new `SELECT avatar_seed` and the navbar avatar will fall back silently to the UID-seeded default, but the re-roll button will show "Could not save — try again".

## Test plan
- [x] Verified locally: re-roll cycles the seed and the beam-face avatar swaps to a new color/shape (every roll is still a face).
- [ ] After deploy + migration: log in on Amplify preview, open Profile → Settings, click re-roll, confirm the navbar avatar updates in the same render.
- [ ] Refresh the page and confirm the seed persists (the rolled face stays).
- [ ] Sign out → confirm no errors in the UserSettingsProvider when `authState.user` is null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)