### PR TITLE
card-page: add Raw data table view alongside the approval-odds charts

### DIFF
--- a/apps/api/src/handlers/card-records.js
+++ b/apps/api/src/handlers/card-records.js
@@ -1,0 +1,120 @@
+// GET /card-records?card_name=<slug-or-name>
+// Returns the raw approval-records for a card, projected to the public
+// (non-PII) columns. Same admin_review=1 AND active=1 filter as /graphs.
+// Used by the card-page "Raw data" view to back the table that's an
+// alternative to the scatter-plot charts.
+
+const https = require('https');
+const mysql = require('../db');
+
+const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
+
+const responseHeaders = {
+  'Access-Control-Allow-Origin': '*',
+};
+
+function fetchCardsFromCDN() {
+  return new Promise((resolve, reject) => {
+    https.get(CARDS_URL, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          resolve(json.cards || []);
+        } catch (err) {
+          reject(new Error('Failed to parse cards.json'));
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+exports.CardRecordsHandler = async (event) => {
+  if (event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      headers: responseHeaders,
+      body: 'Method not allowed',
+    };
+  }
+
+  const cardNameParam = event.queryStringParameters && event.queryStringParameters.card_name;
+  if (!cardNameParam) {
+    return {
+      statusCode: 400,
+      headers: responseHeaders,
+      body: 'You must provide a card_name (slug or full name).',
+    };
+  }
+
+  try {
+    const cards = await fetchCardsFromCDN();
+    const cdnCard = cards.find(
+      (c) => c.card_name === cardNameParam || c.name === cardNameParam || c.slug === cardNameParam,
+    );
+    const card_name = cdnCard ? cdnCard.card_name || cdnCard.name : cardNameParam;
+
+    const cardResult = await mysql.query(
+      `SELECT card_id FROM cards
+       WHERE card_name = ? OR card_name = ? OR ? LIKE CONCAT(card_name, '%')
+       ORDER BY
+         CASE WHEN card_name = ? THEN 0
+              WHEN card_name = ? THEN 1
+              ELSE 2 END,
+         card_id ASC
+       LIMIT 1`,
+      [card_name, card_name.replace(/ Card$/, ''), card_name, card_name, card_name.replace(/ Card$/, '')],
+    );
+
+    if (!cardResult || cardResult.length === 0) {
+      await mysql.end();
+      return {
+        statusCode: 404,
+        headers: responseHeaders,
+        body: `Card not found: ${card_name}`,
+      };
+    }
+
+    const card_id = cardResult[0].card_id;
+
+    // Explicit column list — keep submitter_id and submitter_ip_address out
+    // of the public response.
+    const records = await mysql.query(
+      `SELECT
+         record_id,
+         credit_score,
+         credit_score_source,
+         result,
+         listed_income,
+         length_credit,
+         starting_credit_limit,
+         reason_denied,
+         bank_customer,
+         inquiries_3,
+         inquiries_12,
+         inquiries_24,
+         submit_datetime,
+         date_applied
+       FROM records
+       WHERE card_id = ? AND admin_review = 1 AND active = 1
+       ORDER BY submit_datetime DESC`,
+      [card_id],
+    );
+    await mysql.end();
+
+    return {
+      statusCode: 200,
+      headers: { ...responseHeaders, 'Content-Type': 'application/json' },
+      body: JSON.stringify(records),
+    };
+  } catch (error) {
+    console.error('card-records error:', error);
+    try { await mysql.end(); } catch {}
+    return {
+      statusCode: 500,
+      headers: responseHeaders,
+      body: `There was an error with the query: ${error.message || error}`,
+    };
+  }
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -176,6 +176,30 @@ Resources:
             RestApiId:
               Ref: CreditCardOddsAPI
 
+  CardRecordsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/card-records.CardRecordsHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 30
+      Description: Returns raw approval-records for a card (PII columns stripped) — backs the card-page "Raw data" table view.
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetCardRecords:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /card-records
+            Method: GET
+            RestApiId: !Ref CreditCardOddsAPI
+
   UserRecordsFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -14,6 +14,7 @@ import {
 import { useAuth } from "@/auth/AuthProvider";
 import {
   Card,
+  CardRecord,
   GraphData,
   Reward,
   trackCardApplyClick,
@@ -32,6 +33,7 @@ import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { categoryLabels, CategoryIcon } from "@/lib/cardDisplayUtils";
 import { withApplySource } from "@/lib/applyLink";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import CardRecordsTable from "./CardRecordsTable";
 import "../../landing.css";
 
 const ScatterPlot = dynamic(() => import("@/components/charts/ScatterPlot"), {
@@ -230,6 +232,7 @@ function WireChip({
 interface CardClientProps {
   card: Card;
   graphData: GraphData[];
+  records: CardRecord[];
   news: NewsItem[];
   articles: Article[];
   ratings: { count: number; average: number | null };
@@ -258,6 +261,7 @@ function SubmitParamWatcher({ slug, onTrigger }: { slug: string; onTrigger: () =
 export default function CardClient({
   card,
   graphData,
+  records,
   news,
   articles,
   ratings,
@@ -270,6 +274,7 @@ export default function CardClient({
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [copiedShareLink, setCopiedShareLink] = useState(false);
   const [activeChart, setActiveChart] = useState<"score" | "history" | "limit">("score");
+  const [oddsView, setOddsView] = useState<"charts" | "data">("charts");
   const shareMenuRef = useRef<HTMLDivElement | null>(null);
   const { authState } = useAuth();
   const router = useRouter();
@@ -1165,6 +1170,33 @@ export default function CardClient({
 
             {(card.total_records || 0) >= MIN_DATA_POINTS_FOR_CHARTS && (card.approved_count || 0) > 0 ? (
               <>
+                <div className="cj-graph-tabs cj-odds-view-tabs" role="tablist" style={{ marginTop: 8 }}>
+                  <button
+                    role="tab"
+                    type="button"
+                    aria-selected={oddsView === 'charts'}
+                    className={`cj-graph-tab${oddsView === 'charts' ? ' active' : ''}`}
+                    onClick={() => setOddsView('charts')}
+                  >
+                    Charts
+                  </button>
+                  <button
+                    role="tab"
+                    type="button"
+                    aria-selected={oddsView === 'data'}
+                    className={`cj-graph-tab${oddsView === 'data' ? ' active' : ''}`}
+                    onClick={() => setOddsView('data')}
+                  >
+                    Raw data
+                    {records.length > 0 && (
+                      <span style={{ opacity: 0.6, marginLeft: 6 }}>
+                        ({records.length})
+                      </span>
+                    )}
+                  </button>
+                </div>
+                {oddsView === 'charts' ? (
+                <>
                 <div className="cj-stat-strip">
                   <div className="cj-stat">
                     <div className="cj-stat-k">Median FICO</div>
@@ -1339,6 +1371,10 @@ export default function CardClient({
                     </div>
                   );
                 })()}
+                </>
+                ) : (
+                  <CardRecordsTable records={records} />
+                )}
 
                 {card.accepting_applications && (
                   <div className="cj-verdict" style={{ marginTop: 20 }}>

--- a/apps/web-next/src/app/card/[name]/CardRecordsTable.tsx
+++ b/apps/web-next/src/app/card/[name]/CardRecordsTable.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import type { CardRecord } from '@/lib/api';
+
+interface CardRecordsTableProps {
+  records: CardRecord[];
+}
+
+function formatMonth(dateStr: string | null): string {
+  if (!dateStr) return '—';
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
+}
+
+function formatInquiries(r: CardRecord): string {
+  const parts = [r.inquiries_3, r.inquiries_12, r.inquiries_24];
+  if (parts.every((p) => p === null || p === undefined)) return '—';
+  return parts.map((p) => (p === null || p === undefined ? '?' : String(p))).join(' / ');
+}
+
+function formatCurrency(n: number | null): string {
+  if (n === null || n === undefined) return '—';
+  return `$${n.toLocaleString()}`;
+}
+
+function formatYears(n: number | null): string {
+  if (n === null || n === undefined) return '—';
+  return `${n} yr${n === 1 ? '' : 's'}`;
+}
+
+export default function CardRecordsTable({ records }: CardRecordsTableProps) {
+  if (records.length === 0) {
+    return (
+      <div className="cj-verdict" style={{ marginTop: 16 }}>
+        No data points to show yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="cj-records-wrap" style={{ marginTop: 16 }}>
+      <div className="cj-records-scroll">
+        <table className="cj-records-table">
+          <thead>
+            <tr>
+              <th>Result</th>
+              <th>Credit Score</th>
+              <th>Income</th>
+              <th>History</th>
+              <th title="Hard inquiries in the last 3 / 12 / 24 months">Inq. 3/12/24</th>
+              <th>Bank cust.</th>
+              <th>Outcome</th>
+              <th>Applied</th>
+            </tr>
+          </thead>
+          <tbody>
+            {records.map((r) => {
+              const approved = r.result === 1;
+              return (
+                <tr key={r.record_id}>
+                  <td>
+                    <span className={`cj-records-pill ${approved ? 'is-approved' : 'is-denied'}`}>
+                      {approved ? 'Approved' : 'Denied'}
+                    </span>
+                  </td>
+                  <td className="num">{r.credit_score ?? '—'}</td>
+                  <td className="num">{formatCurrency(r.listed_income)}</td>
+                  <td className="num">{formatYears(r.length_credit)}</td>
+                  <td className="num">{formatInquiries(r)}</td>
+                  <td>
+                    {r.bank_customer === null || r.bank_customer === undefined
+                      ? '—'
+                      : r.bank_customer
+                        ? 'Yes'
+                        : 'No'}
+                  </td>
+                  <td>
+                    {approved
+                      ? formatCurrency(r.starting_credit_limit)
+                      : r.reason_denied || '—'}
+                  </td>
+                  <td>{formatMonth(r.date_applied || r.submit_datetime)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Card, CardBenefit, getCard, getCardGraphs, getAllCards, getCardRatings, getCardWire, getComparePartners, GraphData, CardWireEntry } from "@/lib/api";
+import { Card, CardBenefit, getCard, getCardGraphs, getCardRecords, getAllCards, getCardRatings, getCardWire, getComparePartners, GraphData, CardRecord, CardWireEntry } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import { categoryLabels, pickHeadlineReward } from "@/lib/cardDisplayUtils";
@@ -164,13 +164,14 @@ export default async function CardPage({ params }: CardPageProps) {
   try {
     // Fetch all data in parallel — chain getCard → getCardRatings together
     // so ratings fetches concurrently with graphs/news/articles instead of after them all
-    const [cardWithRatingsAndWire, graphData, allNews, allArticles, allCards, comparePartners] = await Promise.all([
+    const [cardWithRatingsAndWire, graphData, records, allNews, allArticles, allCards, comparePartners] = await Promise.all([
       getCard(slug).then(async (card) => ({
         card,
         ratings: await getCardRatings(card.card_name).catch(() => ({ count: 0, average: null })),
         wire: await getCardWire(Number(card.card_id)).catch(() => [] as CardWireEntry[]),
       })),
       getCardGraphs(slug).catch(() => [] as GraphData[]),
+      getCardRecords(slug).catch(() => [] as CardRecord[]),
       getNews().catch(() => [] as NewsItem[]),
       getArticles().catch(() => [] as Article[]),
       getAllCards().catch(() => [] as Card[]),
@@ -221,7 +222,7 @@ export default async function CardPage({ params }: CardPageProps) {
       .filter((c): c is Card => c !== undefined && c.active !== false)
       .slice(0, 3);
 
-    return <CardClient card={card} graphData={graphData} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} frequentlyComparedCards={frequentlyComparedCards} />;
+    return <CardClient card={card} graphData={graphData} records={records} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} frequentlyComparedCards={frequentlyComparedCards} />;
   } catch {
     notFound();
   }

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -6963,6 +6963,63 @@
   border-bottom-color: var(--accent);
   font-weight: 600;
 }
+
+/* Raw-data table view for the approval-odds section (toggled via cj-odds-view-tabs) */
+.landing-v2 .cj-records-wrap {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.landing-v2 .cj-records-scroll {
+  overflow-x: auto;
+}
+.landing-v2 .cj-records-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+  font-family: 'Inter', sans-serif;
+  min-width: 720px;
+}
+.landing-v2 .cj-records-table th,
+.landing-v2 .cj-records-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px dashed var(--line);
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.landing-v2 .cj-records-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.landing-v2 .cj-records-table th {
+  background: var(--surface-2, #f7f5fc);
+  color: var(--muted);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--line);
+}
+.landing-v2 .cj-records-table td.num {
+  font-variant-numeric: tabular-nums;
+}
+.landing-v2 .cj-records-table tbody tr:hover { background: rgba(109, 63, 232, 0.04); }
+.landing-v2 .cj-records-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.landing-v2 .cj-records-pill.is-approved {
+  background: rgba(109, 63, 232, 0.12);
+  color: var(--accent);
+}
+.landing-v2 .cj-records-pill.is-denied {
+  background: rgba(210, 58, 98, 0.12);
+  color: var(--warn);
+}
 .landing-v2 .cj-chart-stage > .cj-chart-body {
   padding: 12px;
   min-width: 0;

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -246,6 +246,33 @@ export async function getCardGraphs(cardName: string): Promise<GraphData[]> {
   return res.json();
 }
 
+// Raw record row exposed publicly (PII columns submitter_id / submitter_ip
+// are stripped server-side). Used by the card-page "Raw data" table view.
+export interface CardRecord {
+  record_id: number;
+  credit_score: number | null;
+  credit_score_source: number | null;
+  result: 0 | 1;
+  listed_income: number | null;
+  length_credit: number | null;
+  starting_credit_limit: number | null;
+  reason_denied: string | null;
+  bank_customer: 0 | 1 | null;
+  inquiries_3: number | null;
+  inquiries_12: number | null;
+  inquiries_24: number | null;
+  submit_datetime: string;
+  date_applied: string | null;
+}
+
+export async function getCardRecords(cardName: string): Promise<CardRecord[]> {
+  const res = await fetch(`${API_BASE}/card-records?card_name=${encodeURIComponent(cardName)}`, {
+    next: { revalidate: 300 },
+  });
+  if (!res.ok) throw new Error('Failed to fetch card records');
+  return res.json();
+}
+
 // Client-side authenticated API calls
 export async function getRecords(token: string) {
   const res = await fetch(`${API_BASE}/records`, {


### PR DESCRIPTION
## Summary
The approval-odds section on `/card/[slug]` now has a **Charts | Raw data** toggle. Charts stays the default; **Raw data** swaps in a table of individual submitted records with the columns the scatter plots can't show.

### Table columns
- Result (Approved / Denied pill)
- Credit score
- Income
- Length of credit
- Hard inquiries — 3 / 12 / 24 mo
- Bank customer (Yes / No)
- Outcome — starting credit limit when approved, denial reason when denied
- Applied (month / year)

Horizontally scrolls on mobile (table has a 720px min-width inside a `.cj-records-scroll` overflow container).

### Backend
- New public endpoint `GET /card-records?card_name=<slug>` (handler [card-records.js](apps/api/src/handlers/card-records.js)) — mirrors the same `admin_review=1 AND active=1` filter as `/graphs` but projects an explicit column list, **stripping `submitter_id` and `submitter_ip_address`**. No new DB migration.

## ⚠️ Deploy step
After merge, run `cd apps/api && sam build && sam deploy` to expose the new `/card-records` route. The frontend gracefully degrades to an empty table (with "No data points to show yet") if the endpoint 404s.

## Test plan
- [x] Verified locally with mock data: toggle switches, both Approved (purple) and Denied (red) pills render, denial reasons fit inline, inquiries show as "3 / 12 / 24" format, horizontal scroll engages below 720px.
- [ ] After `sam deploy`: hit `/card/chase-sapphire-preferred?tab=data` (or click "Raw data" toggle), confirm real records load.
- [ ] Spot-check that **no** `submitter_id` or `submitter_ip_address` appears in the response (open devtools → network → `/card-records`).
- [ ] Verify on a card with `total_records < 5` — toggle should NOT render (gated on existing chart-display condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)