### PR TITLE
profile/applications: rules above records

### DIFF
--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -1192,9 +1192,27 @@ function ApplicationsTab(props: ApplicationsTabProps) {
 
   return (
     <section className="cj-section">
+      {walletCards.length > 0 && (
+        <>
+          <div className="cj-table-label">Application rules</div>
+          {cardsMissingDates > 0 && (
+            <div className="cj-verdict" style={{ marginTop: 0, marginBottom: 16, background: '#fef9e8', borderLeftColor: '#a8792a', color: '#5c4318' }}>
+              <ExclamationTriangleIcon style={{ width: 16, height: 16, display: 'inline', marginRight: 6, verticalAlign: '-3px' }} />
+              <b style={{ color: '#a8792a' }}>{cardsMissingDates} card{cardsMissingDates === 1 ? '' : 's'} missing acquisition dates.</b>{' '}
+              For accurate rule tracking, edit each card to add when you got it.
+            </div>
+          )}
+          <div className="cj-rule-grid">
+            {applicationRules.map((rule) => (
+              <RuleProgressChart key={rule.ruleName} rule={rule} />
+            ))}
+          </div>
+        </>
+      )}
+
       {records.length > 0 ? (
         <>
-          <div className="cj-table-label">Your applications, with the score and income at the time of each.</div>
+          <div className="cj-table-label" style={walletCards.length > 0 ? { marginTop: 24 } : undefined}>Your applications, with the score and income at the time of each.</div>
           <div className="cj-tape cj-tape-records">
             <div className="cj-tape-head">
               <div>Applied</div>
@@ -1275,24 +1293,6 @@ function ApplicationsTab(props: ApplicationsTabProps) {
                 </button>
               </>}
         </div>
-      )}
-
-      {walletCards.length > 0 && (
-        <>
-          <div className="cj-table-label" style={{ marginTop: 24 }}>Application rules</div>
-          {cardsMissingDates > 0 && (
-            <div className="cj-verdict" style={{ marginTop: 0, marginBottom: 16, background: '#fef9e8', borderLeftColor: '#a8792a', color: '#5c4318' }}>
-              <ExclamationTriangleIcon style={{ width: 16, height: 16, display: 'inline', marginRight: 6, verticalAlign: '-3px' }} />
-              <b style={{ color: '#a8792a' }}>{cardsMissingDates} card{cardsMissingDates === 1 ? '' : 's'} missing acquisition dates.</b>{' '}
-              For accurate rule tracking, edit each card to add when you got it.
-            </div>
-          )}
-          <div className="cj-rule-grid">
-            {applicationRules.map((rule) => (
-              <RuleProgressChart key={rule.ruleName} rule={rule} />
-            ))}
-          </div>
-        </>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
- Reorders the profile Applications tab: **Application rules** now renders first, with the **records table** (user-submitted application results) below
- Adds `marginTop: 24` to the records label only when the rules block is rendered above, preserving spacing when there's no wallet
- Empty-state "No records yet" message also moves below the rules block

## Test plan
- [ ] Sign in, visit /profile → Applications tab
- [ ] With wallet cards: rules grid + any "missing acquisition dates" warning appears at the top; records table follows
- [ ] With records but no wallet (edge): records render flush to the top, no leftover top margin
- [ ] With wallet but no records: rules show, "No records yet" verdict appears below

🤖 Generated with [Claude Code](https://claude.com/claude-code)