### PR TITLE
seo: richer search-result presence (sitelinks search, sameAs, news sitemap, sharper meta)

### DIFF
--- a/apps/web-next/src/app/check-odds/page.tsx
+++ b/apps/web-next/src/app/check-odds/page.tsx
@@ -7,10 +7,10 @@ import "../landing.css";
 
 export const metadata: Metadata = {
   title: "Check Your Odds",
-  description: "Enter your credit profile and see how you compare against approved applicants for every credit card. Find out which cards you're most likely to be approved for.",
+  description: "Enter your credit profile and see your approval odds for every credit card, based on real data from thousands of past applications.",
   openGraph: {
     title: "Check Your Odds | CreditOdds",
-    description: "See your approval chances across all credit cards based on your credit profile.",
+    description: "Enter your credit profile and see your approval odds for every credit card, based on real data from thousands of past applications.",
     url: "https://creditodds.com/check-odds",
     type: "website",
   },

--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -279,6 +279,11 @@ function TopRewardCell({ card }: { card: Card }) {
 
 export default function ExploreV2Client({ cards, trendingViews }: ExploreV2ClientProps) {
   const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('q');
+    if (q) setQuery(q);
+  }, []);
   const [sort, setSort] = useState<SortKey>('trending');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [includeArchived, setIncludeArchived] = useState(false);

--- a/apps/web-next/src/app/explore/page.tsx
+++ b/apps/web-next/src/app/explore/page.tsx
@@ -8,10 +8,10 @@ export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: "Explore Credit Cards",
-  description: "Browse all credit cards and their approval odds. Compare credit scores, income requirements, and approval rates across different banks.",
+  description: "Browse every credit card with approval odds, average approved scores, and income data. Sortable by issuer, fee, and rewards type.",
   openGraph: {
     title: "Explore Credit Cards | CreditOdds",
-    description: "Browse all credit cards and compare approval odds.",
+    description: "Browse every credit card with approval odds, average approved scores, and income data.",
     url: "https://creditodds.com/explore",
     type: "website",
   },

--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -16,11 +16,11 @@ export const metadata: Metadata = {
     default: "CreditOdds: Credit Card Approval Odds",
     template: "%s | CreditOdds",
   },
-  description: "Explore what it takes to get approved for credit cards. See user-reported approval data.",
+  description: "Real approval data from thousands of applications. Find the best card for every store, compare rewards, and follow card news from major issuers. Apply and spend smarter.",
   metadataBase: new URL("https://creditodds.com"),
   openGraph: {
     title: "CreditOdds: Credit Card Approval Odds",
-    description: "Explore what it takes to get approved for credit cards",
+    description: "Real approval data plus the best card for every store. Apply and spend smarter.",
     url: "https://creditodds.com",
     siteName: "CreditOdds",
     type: "website",

--- a/apps/web-next/src/app/news-sitemap.xml/route.ts
+++ b/apps/web-next/src/app/news-sitemap.xml/route.ts
@@ -1,0 +1,61 @@
+import { getNews } from '@/lib/news';
+
+export const dynamic = 'force-static';
+export const revalidate = 3600;
+
+const BASE_URL = 'https://creditodds.com';
+const PUBLICATION_NAME = 'CreditOdds';
+const LANGUAGE = 'en';
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export async function GET() {
+  const items = await getNews().catch(() => []);
+
+  const twoDaysAgo = Date.now() - 1000 * 60 * 60 * 48;
+  const recent = items
+    .filter((item) => Boolean(item.body))
+    .filter((item) => {
+      const t = new Date(item.date).getTime();
+      return Number.isFinite(t) && t >= twoDaysAgo;
+    })
+    .slice(0, 1000);
+
+  const urls = recent
+    .map((item) => {
+      const loc = `${BASE_URL}/news/${item.id}`;
+      const pubDate = new Date(item.date).toISOString();
+      return `  <url>
+    <loc>${escapeXml(loc)}</loc>
+    <news:news>
+      <news:publication>
+        <news:name>${PUBLICATION_NAME}</news:name>
+        <news:language>${LANGUAGE}</news:language>
+      </news:publication>
+      <news:publication_date>${pubDate}</news:publication_date>
+      <news:title>${escapeXml(item.title)}</news:title>
+    </news:news>
+  </url>`;
+    })
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+${urls}
+</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}

--- a/apps/web-next/src/app/news/page.tsx
+++ b/apps/web-next/src/app/news/page.tsx
@@ -5,10 +5,10 @@ import NewsV2Client from "./NewsV2Client";
 
 export const metadata: Metadata = {
   title: "Card News - Credit Card Updates",
-  description: "Stay up to date with the latest credit card news, bonus changes, new card launches, and policy updates from major banks.",
+  description: "Latest credit card news. Bonus changes, new launches, fee updates, and policy shifts from Chase, Amex, Capital One, and more.",
   openGraph: {
     title: "Card News | CreditOdds",
-    description: "Latest credit card news, bonus changes, and updates from major banks.",
+    description: "Latest credit card news. Bonus changes, new launches, fee updates, and policy shifts from Chase, Amex, Capital One, and more.",
     url: "https://creditodds.com/news",
     type: "website",
   },
@@ -27,7 +27,7 @@ export default async function NewsPage() {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     name: "Card News",
-    description: "Stay up to date with the latest credit card news, bonus changes, new card launches, and policy updates from major banks.",
+    description: "Latest credit card news. Bonus changes, new launches, fee updates, and policy shifts from Chase, Amex, Capital One, and more.",
     url: "https://creditodds.com/news",
     mainEntity: {
       "@type": "ItemList",

--- a/apps/web-next/src/app/page.tsx
+++ b/apps/web-next/src/app/page.tsx
@@ -12,17 +12,17 @@ import LandingClient, {
 
 export const metadata: Metadata = {
   title: "CreditOdds - See Your Credit Card Approval Odds",
-  description: "Check your approval odds before applying for credit cards. Real data from thousands of applications showing credit scores, income levels, and approval rates.",
+  description: "Real approval data from thousands of applications. Find the best card for every store, compare rewards, and follow card news from major issuers. Apply and spend smarter.",
   openGraph: {
     title: "CreditOdds - See Your Credit Card Approval Odds",
-    description: "Check your approval odds before applying for credit cards. Real data from thousands of applications.",
+    description: "Real approval data from thousands of applications. Find the best card for every store, compare rewards, and follow card news from major issuers. Apply and spend smarter.",
     url: "https://creditodds.com",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "CreditOdds - See Your Credit Card Approval Odds",
-    description: "Check your approval odds before applying for credit cards. Real data from thousands of applications.",
+    description: "Real approval data from thousands of applications. Find the best card for every store, compare rewards, and follow card news from major issuers. Apply and spend smarter.",
   },
   alternates: {
     canonical: "https://creditodds.com",

--- a/apps/web-next/src/app/privacy/page.tsx
+++ b/apps/web-next/src/app/privacy/page.tsx
@@ -6,10 +6,10 @@ import "../static-pages.css";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
-  description: "CreditOdds Use of Private Information Policy",
+  description: "How CreditOdds collects, stores, and uses the credit data you share. We never sell user data and only store the minimum needed to compute approval odds.",
   openGraph: {
     title: "Privacy Policy | CreditOdds",
-    description: "CreditOdds Use of Private Information Policy",
+    description: "How CreditOdds collects, stores, and uses the credit data you share. We never sell user data and only store the minimum needed to compute approval odds.",
     url: "https://creditodds.com/privacy",
     type: "website",
   },

--- a/apps/web-next/src/app/robots.ts
+++ b/apps/web-next/src/app/robots.ts
@@ -45,7 +45,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/profile', '/admin', '/api/', '/auth/'],
       })),
     ],
-    sitemap: `${baseUrl}/sitemap.xml`,
+    sitemap: [`${baseUrl}/sitemap.xml`, `${baseUrl}/news-sitemap.xml`],
     host: baseUrl,
   };
 }

--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -20,7 +20,11 @@ export function OrganizationSchema({
     name,
     url,
     logo: `${url}/logo.png`,
-    sameAs: [],
+    sameAs: [
+      'https://x.com/creditodds',
+      'https://github.com/CreditOdds',
+      'https://www.linkedin.com/company/creditodds',
+    ],
   };
 
   return (
@@ -50,7 +54,7 @@ export function WebsiteSchema({
       '@type': 'SearchAction',
       target: {
         '@type': 'EntryPoint',
-        urlTemplate: `${url}/card/{search_term_string}`,
+        urlTemplate: `${url}/explore?q={search_term_string}`,
       },
       'query-input': 'required name=search_term_string',
     },


### PR DESCRIPTION
## Summary

Sharpens how CreditOdds appears in Google/Bing search results, in four small parts:

- **Sitelinks search box**: the `WebSite` schema's `SearchAction` was pointing at `/card/{search_term_string}` (broken — card URLs are slugs, not free text). Repointed at `/explore?q={search_term_string}` and wired the `q` param into `ExploreV2Client` so the URL actually returns filtered results. This is the prerequisite for Google to render a search box inside our search result.
- **Knowledge Graph signals**: filled the empty `sameAs` array on `OrganizationSchema` with the X (`@creditodds`), GitHub org, and LinkedIn company URLs. These are the cross-references Google uses to match the website to a brand entity.
- **News carousel eligibility**: new `/news-sitemap.xml` route that emits Google News' `<news:news>` markup for articles from the last 48h, ISR-cached for 1h. Registered in `robots.ts` alongside the main sitemap. This is the technical prerequisite for the "News from creditodds.com" carousel that competitors like NerdWallet have. Still needs submission in Google Publisher Center after deploy.
- **Sharper meta descriptions** on homepage, `/privacy`, `/explore`, `/news`, and `/check-odds`. Homepage now leads with the data claim and names Wallet/news so we don't read as odds-only. Privacy went from "CreditOdds Use of Private Information Policy" to something informative. Em dashes removed throughout per the no-em-dashes rule.

## Test plan

- [ ] After deploy, visit `https://creditodds.com/news-sitemap.xml` and confirm valid XML with the `news:` namespace
- [ ] Visit `https://creditodds.com/explore?q=chase` and confirm the search box is pre-filled and results are filtered
- [ ] Validate the homepage with [Google Rich Results Test](https://search.google.com/test/rich-results?url=https%3A%2F%2Fcreditodds.com) — `WebSite` and `Organization` schemas should parse with no errors
- [ ] In Search Console, submit the new `news-sitemap.xml` as a sitemap
- [ ] In Publisher Center, paste `https://creditodds.com/news-sitemap.xml` into the publication's Google News config

🤖 Generated with [Claude Code](https://claude.com/claude-code)