### PR TITLE
card-check: stop skipping signup_bonus.value when a note exists

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -319,10 +319,6 @@ function detectChanges(card, extracted) {
     const cur = current.signup_bonus;
 
     for (const key of ['value', 'spend_requirement', 'timeframe_months']) {
-      // Skip value comparison when a note exists — the value was manually
-      // curated to account for tiered/combined bonuses that Haiku misreads.
-      if (key === 'value' && cur.note) continue;
-
       if (sb[key] !== null && sb[key] !== undefined && cur[key] !== undefined) {
         const field = `signup_bonus.${key}`;
         if (sb[key] !== cur[key] && !ignoreFields.has(field)) {


### PR DESCRIPTION
## Summary
- Removes the global `if (key === 'value' && cur.note) continue;` skip in [scripts/check-card-pages.js](scripts/check-card-pages.js) introduced in #370
- That rule silenced real bonus changes on cards with a curated note — most recently the Disney Inspire Visa dropping from $600 → $500 was never caught
- The defensive case it was protecting (tiered/combined bonuses where Haiku extracts only the base tier) is now handled explicitly by prompt rules (base-tier-only for tiered bonuses, cash separate from points, AU bonus excluded). If a specific card still needs the value check suppressed, use per-card `check_ignore: [signup_bonus.value]`.

## Test plan
- [ ] Trigger the `Check Card Pages` workflow with `card_slug=disney-inspire-visa` and confirm the run flags the $600 → $500 change
- [ ] Watch the next scheduled run for false positives on Marriott Boundless, Bilt Palladium, and other cards with notes; add `check_ignore` only if Haiku diverges from the curated YAML value

🤖 Generated with [Claude Code](https://claude.com/claude-code)