### PR TITLE
fix(UserAvatar): coerce title to boolean for boring-avatars

### DIFF
--- a/apps/web-next/src/components/user/UserAvatar.tsx
+++ b/apps/web-next/src/components/user/UserAvatar.tsx
@@ -39,7 +39,7 @@ export default function UserAvatar({
       colors={BRAND_PALETTE}
       size={size}
       square={square}
-      title={title}
+      title={Boolean(title)}
       className={className}
     />
   );


### PR DESCRIPTION
## Summary
- Coerces \`title\` to boolean before passing to \`boring-avatars\`. boring-avatars expects \`title: boolean\` (toggles a \`<title>\` element inside the SVG using the seed name), not a custom string.
- This has been a TypeScript error since [creditodds#1177](https://github.com/CreditOdds/creditodds/pull/1177) (09:46 ET today) and has blocked every Amplify production build since then — deploys #952, #953, #954 all failed on the same line.

## Behavior preservation
\`Boolean(title)\` preserves existing call-site behavior: any caller passing a string was already getting truthy via implicit coercion at runtime; this just makes the TypeScript types match.

## Test plan
- [x] \`npx tsc --noEmit\` is clean (the UserAvatar error is gone)
- [ ] Amplify deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)