### PR TITLE
navbar+profile: hold avatar render until user_settings GET resolves (no flicker)

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4135,6 +4135,24 @@
   opacity: 1;
 }
 
+/* Avatar fade-in: applied to the wrapper around <UserAvatar> in both the
+   navbar and the profile Settings tab. We gate the render on settings
+   having loaded, then key the wrapper on the seed so the saved face fades
+   in (on first load) and re-fades on every re-roll save. The wrapper
+   itself doesn't need to be in .landing-v2 scope since the navbar is
+   outside it — keep this rule unscoped. */
+@keyframes cj-avatar-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.cj-avatar-fade-in {
+  display: inline-flex;
+  animation: cj-avatar-fade-in 240ms ease-out both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cj-avatar-fade-in { animation: none; }
+}
+
 /* Right rail — apply block, dashed lists, news */
 .landing-v2.profile-v2 .cj-rail {
   padding: 24px 18px 48px;

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -1497,7 +1497,11 @@ function SettingsTab(props: SettingsTabProps) {
               title="Re-roll"
               disabled={!settingsLoaded}
             >
-              {settingsLoaded && <UserAvatar seed={displayedSeed} size={48} />}
+              {settingsLoaded && (
+                <span key={displayedSeed ?? 'guest'} className="cj-avatar-fade-in">
+                  <UserAvatar seed={displayedSeed} size={48} />
+                </span>
+              )}
               <span className="cj-avatar-reroll-overlay">Re-roll</span>
             </button>
             {hasPending && (

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -1440,7 +1440,12 @@ function SettingsTab(props: SettingsTabProps) {
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  const savedSeed = settings?.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null;
+  // Same flicker guard as the Navbar: hold until /user-settings resolves so
+  // we don't render the UID-seeded fallback before the saved seed lands.
+  const settingsLoaded = settings !== null;
+  const savedSeed = settingsLoaded
+    ? settings.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null
+    : null;
   const displayedSeed = pendingSeed ?? savedSeed;
   const hasPending = pendingSeed !== null;
 
@@ -1490,8 +1495,9 @@ function SettingsTab(props: SettingsTabProps) {
               onClick={handleReroll}
               aria-label="Re-roll avatar"
               title="Re-roll"
+              disabled={!settingsLoaded}
             >
-              <UserAvatar seed={displayedSeed} size={48} />
+              {settingsLoaded && <UserAvatar seed={displayedSeed} size={48} />}
               <span className="cj-avatar-reroll-overlay">Re-roll</span>
             </button>
             {hasPending && (

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -173,11 +173,13 @@ export default function Navbar() {
                           <Menu.Button className="inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-[3px] border border-[#ddd7ec] bg-white p-0 text-sm transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
                             <span className="sr-only">Open user menu</span>
                             {settingsLoaded && (
-                              <UserAvatar
-                                seed={avatarSeed}
-                                size={32}
-                                title="Account menu"
-                              />
+                              <span key={avatarSeed ?? 'guest'} className="cj-avatar-fade-in">
+                                <UserAvatar
+                                  seed={avatarSeed}
+                                  size={32}
+                                  title="Account menu"
+                                />
+                              </span>
                             )}
                           </Menu.Button>
                           <Transition

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -103,7 +103,15 @@ export default function Navbar() {
   const { authState, logout } = useAuth();
   const { settings } = useUserSettings();
   const pathname = usePathname();
-  const avatarSeed = settings?.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null;
+  // Hold the avatar render until /user-settings has resolved so we don't
+  // briefly show the UID-seeded fallback and then snap to the user's saved
+  // seed (avatar flicker). settings === null means the GET hasn't returned
+  // yet; once it has, we either use the saved avatar_seed or fall back to
+  // the UID for users who haven't customised.
+  const settingsLoaded = settings !== null;
+  const avatarSeed = settingsLoaded
+    ? settings.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null
+    : null;
 
   const isActive = (item: NavItem) => item.matches(pathname);
   const isProfileActive = pathname === "/profile" || pathname.startsWith("/profile/");
@@ -164,11 +172,13 @@ export default function Navbar() {
                         <>
                           <Menu.Button className="inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-[3px] border border-[#ddd7ec] bg-white p-0 text-sm transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
                             <span className="sr-only">Open user menu</span>
-                            <UserAvatar
-                              seed={avatarSeed}
-                              size={32}
-                              title="Account menu"
-                            />
+                            {settingsLoaded && (
+                              <UserAvatar
+                                seed={avatarSeed}
+                                size={32}
+                                title="Account menu"
+                              />
+                            )}
                           </Menu.Button>
                           <Transition
                             show={menuOpen}

--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -157,7 +157,7 @@ export default function Navbar() {
                     <Link
                       href="/profile"
                       className={classNames(
-                        "inline-flex items-center gap-2 rounded-[3px] px-4 py-2 text-[13px] font-semibold tracking-[-0.005em] transition-colors",
+                        "inline-flex h-9 items-center gap-2 rounded-[3px] px-4 text-[13px] font-semibold tracking-[-0.005em] transition-colors",
                         isProfileActive
                           ? "bg-[#3a2f55] text-white"
                           : "bg-[#1a1330] text-white hover:bg-[#3a2f55]"


### PR DESCRIPTION
## Summary
Fixes the avatar flicker on page load. The fix is two layers:

1. **Gate the render** on `settings !== null` — until `UserSettingsProvider`'s GET `/user-settings` resolves, no `<UserAvatar>` is rendered. The wrong UID-seeded face never appears.
2. **Fade in** the saved face once settings load — 240ms ease-out. The fade is keyed on the seed, so a re-roll save also fades the new face in. Respects `prefers-reduced-motion`.

Same treatment in both [Navbar.tsx](apps/web-next/src/components/layout/Navbar.tsx) and the profile Settings tab in [ProfileClient.tsx](apps/web-next/src/app/profile/ProfileClient.tsx). Button shells (`<Menu.Button>`, `<button.cj-avatar-reroll>`) still render at full size so layout doesn't shift — they're empty for the ~tens-of-ms until the fetch lands, then the saved face fades in.

## Test plan
- [x] Page compiles cleanly in dev, no console errors.
- [ ] On live (after Amplify redeploy): hard-refresh while signed in — confirm the navbar avatar **does not** flash through the UID-seeded face. The saved face should fade in smoothly.
- [ ] Profile → Settings tab: same — the Avatar tile fades in.
- [ ] Re-roll → save → confirm the new face fades in (key change remounts the wrapper).
- [ ] First-time user (no `avatar_seed` stored): UID-seeded default fades in after fetch lands.
- [ ] Signed-out users: navbar shows Sign In / Sign Up as before, no regression.
- [ ] System "reduce motion" enabled: avatar appears without animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)