### PR TITLE
seo: add FlexOffers site verification meta tag

### DIFF
--- a/apps/web-next/src/app/page.tsx
+++ b/apps/web-next/src/app/page.tsx
@@ -27,6 +27,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://creditodds.com",
   },
+  verification: {
+    other: {
+      "fo-verify": "5b12ca5b-a770-4878-b243-1ab993769bde",
+    },
+  },
 };
 
 // Project a Card down to only the fields the landing page reads.


### PR DESCRIPTION
## Summary
- Adds `<meta name="fo-verify" content="...">` to the homepage so FlexOffers can verify ownership of creditodds.com.
- Implemented via Next.js `metadata.verification.other` in [apps/web-next/src/app/page.tsx](apps/web-next/src/app/page.tsx) — scoped to `/` only.

## Test plan
- [x] Verified locally: `fetch('/')` returns 200 with the exact tag in the rendered HTML.
- [ ] After deploy, click Verify in FlexOffers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)