### PR TITLE
Add news: U.S. Bank Kroger Credit Cards No Longer Accepting New Applications

### DIFF
--- a/data/news/2026-05-12-us-bank-kroger-cards-no-longer-accepting-applications.yaml
+++ b/data/news/2026-05-12-us-bank-kroger-cards-no-longer-accepting-applications.yaml
@@ -1,0 +1,21 @@
+id: "us-bank-kroger-cards-no-longer-accepting-applications"
+title: "U.S. Bank Kroger Credit Cards No Longer Accepting New Applications"
+summary: "U.S. Bank has stopped accepting applications for its Kroger co-branded credit cards, with reports indicating the cards have been unavailable for **approximately two weeks**. The exact status of the partnership remains unclear, though customer service representatives have suggested the change may be permanent."
+tags:
+  - "discontinued"
+  - "policy-change"
+bank: "U.S. Bank"
+source: "Doctor of Credit"
+source_url: "https://www.doctorofcredit.com/u-s-bank-kroger-cards-no-longer-accepting-applications/"
+date: "2026-05-12"
+body: |
+  U.S. Bank's Kroger credit card partnership appears to be winding down. The cards—which include versions of the Kroger cash rewards card—are **no longer accepting new applications**, according to multiple reports from the churning community.
+  
+  **Application availability ceased approximately two weeks ago**, though the exact timeline and reason for the halt remain unconfirmed. Customer service representatives contacted by cardholders have indicated the change may be permanent, though no official announcement has been made by U.S. Bank or Kroger.
+  
+  The future of existing Kroger cardholders is uncertain. Speculation suggests U.S. Bank could either convert the cards to a different product (such as a cash rewards card), allow them to remain in an inactive state similar to the discontinued U.S. Bank AAdvantage Rewards card, or sunset the product entirely.
+  
+  This continues a pattern of U.S. Bank scaling back its co-branded credit card portfolio in recent years. The bank has been selective about maintaining partnership agreements, and the Kroger partnership's discontinuation would represent another shift in its card offerings.
+  
+  Cardholders currently holding Kroger cards should monitor their accounts for communication from U.S. Bank regarding next steps.
+  


### PR DESCRIPTION
## Summary
- Auto-generated from r/churning via `scripts/auto-news-from-reddit.js` (daily scheduled run, 2026-05-12)
- Survivor: U.S. Bank Kroger co-branded credit cards no longer accepting new applications (~2 weeks); partnership status unclear
- Source swapped from r/churning to **Doctor of Credit** (first-party-ish corroboration the script verified against): https://www.doctorofcredit.com/u-s-bank-kroger-cards-no-longer-accepting-applications/
- One additional candidate (Chase business checking $500/$2k bonus) was dropped because it's a business checking promo, not a credit card news item, per project rules

## Test plan
- [ ] YAML parses + renders on `/news/us-bank-kroger-cards-no-longer-accepting-applications`
- [ ] `card_slugs` resolution (none included — issuer-level news, no specific cards referenced)
- [ ] Tags (`discontinued`, `policy-change`) render correctly
- [ ] OG image generates for the article

🤖 Generated with [Claude Code](https://claude.com/claude-code)