### PR TITLE
ci: chain build-articles via workflow_dispatch after cron promotion

### DIFF
--- a/.github/workflows/publish-scheduled-articles.yml
+++ b/.github/workflows/publish-scheduled-articles.yml
@@ -1,10 +1,12 @@
 name: Publish Scheduled Articles
 
 # Daily cron that promotes any article in data/articles/drafts/ whose `date`
-# field has arrived into data/articles/. The resulting commit triggers the
-# normal build-articles.yml pipeline (S3 upload, image sync, social post,
-# IndexNow), so a scheduled article publishes itself end-to-end with no
-# manual action.
+# field has arrived into data/articles/. After pushing the promotion commit,
+# this workflow explicitly dispatches build-articles.yml — because pushes
+# made with the default GITHUB_TOKEN do not trigger downstream workflows
+# (GitHub Actions safety against recursive runs), but workflow_dispatch
+# events do, so this is the supported way to chain into the normal build
+# pipeline (S3 upload, image sync, social post, IndexNow).
 
 on:
   schedule:
@@ -14,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  actions: write  # required to call `gh workflow run` against build-articles.yml
 
 jobs:
   publish:
@@ -38,9 +41,11 @@ jobs:
         run: node scripts/publish-scheduled-articles.js
 
       - name: Commit and push if anything moved
+        id: commit
         run: |
           if git diff --quiet && git diff --cached --quiet; then
             echo "No articles ready to publish today."
+            echo "moved=false" >> $GITHUB_OUTPUT
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -48,3 +53,13 @@ jobs:
           git add -A data/articles/
           git commit -m "articles: publish scheduled articles for $(date -u +%Y-%m-%d)"
           git push
+          echo "moved=true" >> $GITHUB_OUTPUT
+
+      - name: Dispatch build-articles workflow
+        if: steps.commit.outputs.moved == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GITHUB_TOKEN pushes don't trigger downstream workflows, but
+          # workflow_dispatch events do — so we chain explicitly.
+          gh workflow run build-articles.yml --ref main


### PR DESCRIPTION
## What broke

The Monday May 11 article ([hard-inquiries-explained](https://github.com/CreditOdds/creditodds/blob/main/data/articles/hard-inquiries-explained.yaml)) didn't publish. The cron's promotion commit ([ab51325f](https://github.com/CreditOdds/creditodds/commit/ab51325f)) landed correctly — the file moved from \`drafts/\` to \`data/articles/\` — but \`build-articles.yml\` never ran for that push.

## Why

GitHub Actions has a safety against recursive workflow runs: **pushes made with the default \`GITHUB_TOKEN\` do not trigger downstream workflows**. The cron uses \`GITHUB_TOKEN\` for its push, so the resulting commit on main was invisible to \`build-articles.yml\`'s push trigger.

This means: no articles.json rebuild, no OpenAI image generation, no S3 upload, no Amplify rebuild, no social-queue, no IndexNow. The article was promoted into place but never actually published.

## The fix

After the cron's commit + push, explicitly call \`gh workflow run build-articles.yml\`. \`workflow_dispatch\` events **are** allowed to start runs when triggered via \`GITHUB_TOKEN\` — it's the documented exception to the recursion guard.

Adds:
- \`actions: write\` permission (required for \`gh workflow run\`)
- An \`id: commit\` step output so the dispatch only fires when articles actually moved (no-op on days with nothing scheduled)
- The dispatch step itself

## Recovery for the May 11 article

I manually dispatched \`build-articles.yml\` against main right before opening this PR — that should publish hard-inquiries-explained and queue its tweet. Confirm in the next ~10 min that:
- [ ] [https://creditodds.com/articles/hard-inquiries-explained](https://creditodds.com/articles/hard-inquiries-explained) resolves
- [ ] A tweet appears in your social-posting queue

## Test plan

- [x] Verified that the cron's commit \`ab51325f\` is on main with the article at top-level but no corresponding build-articles run
- [x] Manually dispatched build-articles.yml to recover the May 11 article ([run 25741593871](https://github.com/CreditOdds/creditodds/actions/runs/25741593871))
- [ ] After merge: Thursday May 14's cron run should automatically chain into a build-articles run, publishing [credit-card-denied-reconsideration](data/articles/drafts/credit-card-denied-reconsideration.yaml) end-to-end with no manual action

## Must-merge-by

This needs to land before **Thursday May 14, 14:00 UTC** for the next scheduled article to publish itself automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)