### PR TITLE
ci: add manual_queue_files dispatch input to build-articles

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: boolean
         default: false
+      manual_queue_files:
+        description: "Space-separated YAML paths to force-queue social posts + IndexNow for (recovery lever when auto-detection misses). Example: data/articles/foo.yaml data/articles/bar.yaml"
+        required: false
+        type: string
 
 permissions:
   id-token: write
@@ -89,11 +93,21 @@ jobs:
       - name: Detect new article files
         id: new-files
         run: |
-          # `:(glob)` magic uses shell-style globbing — `*` matches a single path
-          # component and does NOT cross `/`, so files under data/articles/drafts/
-          # are correctly excluded. Without it, git's default pathspec would treat
-          # `*.yaml` as fnmatch and match nested paths too.
-          NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- ':(glob)data/articles/*.yaml' ':(glob)data/articles/*.yml' 2>/dev/null | tr '\n' ' ' | xargs)
+          # If the workflow was dispatched with `manual_queue_files` set, that
+          # input wins — it's the recovery lever for cases where auto-detection
+          # misses (e.g., the workflow was dispatched far from the promotion
+          # commit, so `git diff HEAD~1` doesn't see the article as added).
+          if [ -n "${{ inputs.manual_queue_files }}" ]; then
+            NEW_FILES="${{ inputs.manual_queue_files }}"
+            echo "Using manually specified files (manual_queue_files input)"
+          else
+            # `:(glob)` magic uses shell-style globbing — `*` matches a single
+            # path component and does NOT cross `/`, so files under
+            # data/articles/drafts/ are correctly excluded. Without it, git's
+            # default pathspec would treat `*.yaml` as fnmatch and match nested
+            # paths too.
+            NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 -- ':(glob)data/articles/*.yaml' ':(glob)data/articles/*.yml' 2>/dev/null | tr '\n' ' ' | xargs)
+          fi
           echo "files=$NEW_FILES" >> $GITHUB_OUTPUT
           if [ -n "$NEW_FILES" ]; then
             echo "New article files detected:"


### PR DESCRIPTION
## Why

When `build-articles.yml` is dispatched far from the promotion commit — e.g., today's manual recovery for the May 11 article — `git diff HEAD~1` doesn't see the previously-promoted article as newly-added, so the social-queue and IndexNow steps no-op.

## What

Adds a `manual_queue_files` workflow_dispatch input. When set, it overrides the git diff detection and feeds the listed YAML paths directly to `queue-social.js` and `submit-indexnow.js`. Auto-detection still runs when the input is empty, so cron-driven runs are unaffected.

## Usage

```bash
gh workflow run build-articles.yml \
  --field manual_queue_files="data/articles/hard-inquiries-explained.yaml"
```

## Immediate use

Going to use this to recover the missing May 11 tweet (`hard-inquiries-explained`) as soon as it merges.

## Test plan

- [x] Auto-detection path unchanged when input is empty
- [ ] After merge: dispatch with `manual_queue_files="data/articles/hard-inquiries-explained.yaml"`, verify the social-queue and IndexNow steps fire for that file

🤖 Generated with [Claude Code](https://claude.com/claude-code)