### PR TITLE
explore: editorial v2 redesign

### DIFF
--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -392,18 +392,32 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
   }, [cards, query, sort, sortDir, includeArchived, trendingViews, rewardType, feeBucket, selectedBanks, businessOnly]);
 
   return (
-    <div className="landing-v2">
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          Every card. <em>Everything you need.</em>
+    <div className="landing-v2 explore-v2">
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <span className="cj-crumb cj-crumb-current">Explore</span>
+        </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
+          <span>
+            <span className="cj-status-dot" />
+            {totalCount.toLocaleString()} cards · live
+          </span>
+        </div>
+      </div>
+
+      <section className="explore-hero wrap">
+        <h1 className="cj-section-h1">
+          Every card.{' '}
+          <em className="cj-section-accent">Everything you need.</em>
         </h1>
-        <p className="page-sub">
-          The complete credit card catalog — rewards, fees, welcome bonuses, and real
+        <p className="explore-tagline">
+          The complete credit card catalog. Rewards, fees, welcome bonuses, and real
           approval odds from the community. No affiliate rankings, just the data.
         </p>
       </section>
 
-      <div className="wrap">
+      <div className="wrap explore-body">
         <div className="filter-bar">
           <div className="search-row">
             <div className="search-wrap">
@@ -538,16 +552,13 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
           </div>
         </div>
 
-        <div className="filter-results-bar">
-          <span className="filter-results-count">
-            Showing {filtered.length} of {totalCount} cards
-          </span>
-          {hasActiveFilters && (
+        {hasActiveFilters && (
+          <div className="filter-results-bar">
             <button type="button" className="filter-clear-btn" onClick={clearFilters}>
               Clear filters
             </button>
-          )}
-        </div>
+          </div>
+        )}
 
         {filtered.length === 0 ? (
           <div

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1374,6 +1374,40 @@
   margin: 0 0 12px;
 }
 
+/* ---------- Explore v2 (editorial / journal theme) ---------- */
+.landing-v2.explore-v2 .explore-hero {
+  padding-block: 28px 28px;
+  border-bottom: 1px solid var(--line);
+}
+.landing-v2.explore-v2 .explore-hero .cj-section-h1 {
+  margin: 0;
+}
+.landing-v2.explore-v2 .explore-tagline {
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  max-width: 56ch;
+  margin: 14px 0 0;
+}
+.landing-v2.explore-v2 .explore-body {
+  padding-block: 16px 0;
+}
+.landing-v2.explore-v2 .filter-bar {
+  border-bottom: 0;
+  padding-block: 0 16px;
+}
+.landing-v2.explore-v2 .card-table {
+  border-radius: 0;
+}
+@media (max-width: 640px) {
+  .landing-v2.explore-v2 .explore-hero {
+    padding-block: 20px 20px;
+  }
+  .landing-v2.explore-v2 .explore-tagline {
+    font-size: 15px;
+  }
+}
+
 /* ---------- Filter bar + chips ---------- */
 .landing-v2 .filter-bar {
   display: flex;


### PR DESCRIPTION
## Summary
- Apply the `/card/[slug]` + `/profile` journal aesthetic to `/explore`: dark `cj-terminal` breadcrumb strip, large `cj-section-h1` with em-accent headline, scoped to a new `explore-v2` class.
- Drop the table `border-radius` to match the flat editorial look used elsewhere.
- Trim the "Showing X of Y cards" row so the results table reaches the fold faster — Clear filters chip still appears when filters are active.

## Test plan
- [ ] `/explore` renders with the dark terminal bar at top showing "Explore · {count} cards · live"
- [ ] Headline reads "Every card. Everything you need." with purple accent on the second clause
- [ ] Filter chips + search + sort behave the same as before
- [ ] Card table has square corners
- [ ] Mobile (≤640px) still readable, no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)