### PR TITLE
Compare popup: once-per-session + editorial v2 restyle

### DIFF
--- a/apps/web-next/src/components/ui/CardyComparePopup.tsx
+++ b/apps/web-next/src/components/ui/CardyComparePopup.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import CardyCharacter from './CardyCharacter';
 import CardImage from './CardImage';
 
 const VISITS_KEY = 'ccd_session_card_visits';
-const DISMISSED_KEY = 'ccd_session_compare_popup_dismissed';
+const SHOWN_KEY = 'ccd_session_compare_popup_shown';
 
 interface CardyComparePopupProps {
   currentSlug: string;
@@ -47,33 +46,31 @@ export default function CardyComparePopup({ currentSlug, currentName, currentIma
     if (typeof window === 'undefined') return;
 
     const visits = readVisits();
-    // Move current card to the end (most recent), de-duped.
     const filtered = visits.filter(v => v.slug !== currentSlug);
     const updated = [...filtered, { slug: currentSlug, name: currentName, image: currentImage ?? null }].slice(-10);
     writeVisits(updated);
 
-    if (sessionStorage.getItem(DISMISSED_KEY) === 'true') return;
+    if (sessionStorage.getItem(SHOWN_KEY) === 'true') return;
 
-    // Need at least one prior unique card to suggest a comparison.
     const priorUniques = filtered;
     if (priorUniques.length === 0) return;
 
-    // Suggest the most recently visited prior card.
     const prev = priorUniques[priorUniques.length - 1];
     setPreviousCard(prev);
 
-    // Small delay so it doesn't feel jarring on page load.
-    const timer = setTimeout(() => setVisible(true), 1200);
+    const timer = setTimeout(() => {
+      setVisible(true);
+      try {
+        sessionStorage.setItem(SHOWN_KEY, 'true');
+      } catch {
+        // ignore
+      }
+    }, 1200);
     return () => clearTimeout(timer);
   }, [currentSlug, currentName, currentImage]);
 
   const dismiss = () => {
     setVisible(false);
-    try {
-      sessionStorage.setItem(DISMISSED_KEY, 'true');
-    } catch {
-      // ignore
-    }
   };
 
   if (!visible || !previousCard) return null;
@@ -84,76 +81,195 @@ export default function CardyComparePopup({ currentSlug, currentName, currentIma
     <div
       role="dialog"
       aria-label="Compare these cards"
-      className="fixed bottom-4 right-4 z-40 w-[320px] max-w-[calc(100vw-2rem)] rounded-2xl bg-white shadow-2xl ring-1 ring-gray-200 p-4 animate-[cardy-pop_220ms_ease-out]"
-      style={{
-        // Keyframes inline so the component is self-contained.
-        // Tailwind doesn't have a built-in pop animation that matches.
-      }}
+      className="cmp-pop"
     >
-      <style jsx>{`
-        @keyframes cardy-pop {
-          0% { opacity: 0; transform: translateY(12px) scale(0.96); }
-          100% { opacity: 1; transform: translateY(0) scale(1); }
+      <style jsx global>{`
+        .cmp-pop {
+          position: fixed;
+          bottom: 20px;
+          right: 20px;
+          z-index: 40;
+          width: 340px;
+          max-width: calc(100vw - 32px);
+          background: #ffffff;
+          border: 1px solid #ddd7ec;
+          border-radius: 10px;
+          padding: 16px 16px 14px;
+          box-shadow:
+            0 1px 0 rgba(26, 19, 48, 0.04),
+            0 16px 40px -16px rgba(109, 63, 232, 0.22);
+          font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+          color: #1a1330;
+          animation: cmp-pop-in 220ms ease-out;
         }
+        @keyframes cmp-pop-in {
+          0%   { opacity: 0; transform: translateY(12px) scale(0.98); }
+          100% { opacity: 1; transform: translateY(0)    scale(1); }
+        }
+        .cmp-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 8px;
+          padding-bottom: 10px;
+          border-bottom: 1px solid #ece8f5;
+          margin-bottom: 12px;
+        }
+        .cmp-eyebrow {
+          font-size: 10.5px;
+          font-weight: 600;
+          letter-spacing: 0.14em;
+          text-transform: uppercase;
+          color: #6d3fe8;
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+        }
+        .cmp-eyebrow::before {
+          content: '';
+          width: 5px;
+          height: 5px;
+          border-radius: 50%;
+          background: #6d3fe8;
+          box-shadow: 0 0 0 3px rgba(109, 63, 232, 0.18);
+        }
+        .cmp-close {
+          appearance: none;
+          background: transparent;
+          border: none;
+          color: #6b6384;
+          cursor: pointer;
+          padding: 2px 4px;
+          font-size: 16px;
+          line-height: 1;
+          border-radius: 4px;
+        }
+        .cmp-close:hover { color: #1a1330; background: #f7f5fc; }
+        .cmp-row {
+          display: grid;
+          grid-template-columns: 1fr auto 1fr;
+          gap: 10px;
+          align-items: center;
+        }
+        .cmp-card {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          min-width: 0;
+        }
+        .cmp-img {
+          position: relative;
+          width: 100%;
+          aspect-ratio: 1.6 / 1;
+          background: #f7f5fc;
+          border: 1px solid #ece8f5;
+          border-radius: 6px;
+          overflow: hidden;
+        }
+        .cmp-name {
+          font-family: 'Inter Tight', 'Inter', sans-serif;
+          letter-spacing: -0.01em;
+          font-size: 13px;
+          font-weight: 600;
+          line-height: 1.25;
+          color: #1a1330;
+          text-align: center;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+        .cmp-vs {
+          font-size: 10.5px;
+          font-weight: 600;
+          letter-spacing: 0.16em;
+          text-transform: uppercase;
+          color: #a49fb8;
+          padding-top: 14px;
+        }
+        .cmp-prompt {
+          margin: 14px 0 12px;
+          font-family: 'Inter Tight', 'Inter', sans-serif;
+          letter-spacing: -0.01em;
+          font-size: 15px;
+          font-weight: 500;
+          line-height: 1.3;
+          color: #1a1330;
+        }
+        .cmp-actions {
+          display: flex;
+          gap: 8px;
+        }
+        .cmp-btn {
+          flex: 1;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 9px 14px;
+          border-radius: 8px;
+          font-size: 13.5px;
+          font-weight: 600;
+          text-decoration: none;
+          border: 1px solid transparent;
+          cursor: pointer;
+          transition: background 0.15s ease, border-color 0.15s ease, transform 0.08s ease;
+        }
+        .cmp-btn-primary {
+          background: #1a1330;
+          color: #ffffff;
+          border-color: #1a1330;
+        }
+        .cmp-btn-primary:hover { background: #3a2f55; }
+        .cmp-btn-primary:active { transform: translateY(1px); }
+        .cmp-btn-ghost {
+          background: #ffffff;
+          color: #1a1330;
+          border-color: #ddd7ec;
+          flex: 0 0 auto;
+        }
+        .cmp-btn-ghost:hover { border-color: #1a1330; }
       `}</style>
-      <div className="flex items-center justify-center gap-2">
-        <div className="flex flex-col items-center gap-1 min-w-0 flex-1">
-          <div className="relative w-full aspect-[1.6/1] max-w-[120px] bg-gray-50 rounded-md overflow-hidden ring-1 ring-gray-200">
+
+      <div className="cmp-head">
+        <span className="cmp-eyebrow">Compare</span>
+        <button onClick={dismiss} className="cmp-close" aria-label="Dismiss">×</button>
+      </div>
+
+      <div className="cmp-row">
+        <div className="cmp-card">
+          <div className="cmp-img">
             <CardImage
               cardImageLink={previousCard.image ?? undefined}
               alt={previousCard.name}
               fill
               className="object-contain p-1"
-              sizes="120px"
+              sizes="140px"
             />
           </div>
-          <div className="text-[11px] font-medium text-gray-700 text-center leading-tight line-clamp-2">
-            {previousCard.name}
-          </div>
+          <div className="cmp-name">{previousCard.name}</div>
         </div>
-        <div className="text-xs font-bold text-gray-400 uppercase tracking-wider px-1">vs</div>
-        <div className="flex flex-col items-center gap-1 min-w-0 flex-1">
-          <div className="relative w-full aspect-[1.6/1] max-w-[120px] bg-gray-50 rounded-md overflow-hidden ring-1 ring-gray-200">
+        <div className="cmp-vs">vs</div>
+        <div className="cmp-card">
+          <div className="cmp-img">
             <CardImage
               cardImageLink={currentImage ?? undefined}
               alt={currentName}
               fill
               className="object-contain p-1"
-              sizes="120px"
+              sizes="140px"
             />
           </div>
-          <div className="text-[11px] font-medium text-gray-700 text-center leading-tight line-clamp-2">
-            {currentName}
-          </div>
+          <div className="cmp-name">{currentName}</div>
         </div>
       </div>
 
-      <div className="mt-3 flex items-start gap-2">
-        <div className="flex-shrink-0 mt-0.5">
-          <CardyCharacter size="sm" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="text-[10px] font-semibold uppercase tracking-wide text-indigo-600 leading-tight">
-            Cardy says
-          </p>
-          <p className="text-sm text-gray-900 leading-snug">
-            Compare these two side by side?
-          </p>
-        </div>
-      </div>
+      <p className="cmp-prompt">See these two side by side?</p>
 
-      <div className="mt-3 flex gap-2">
-        <Link
-          href={compareHref}
-          onClick={dismiss}
-          className="flex-1 text-center rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-semibold px-3 py-2 transition-colors"
-        >
-          Compare them
+      <div className="cmp-actions">
+        <Link href={compareHref} onClick={dismiss} className="cmp-btn cmp-btn-primary">
+          Compare
         </Link>
-        <button
-          onClick={dismiss}
-          className="rounded-lg bg-white text-gray-700 text-sm font-medium px-3 py-2 ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-        >
+        <button onClick={dismiss} className="cmp-btn cmp-btn-ghost">
           Not now
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Compare popup now shows at most **once per session** instead of re-appearing on every card visit until explicitly dismissed. The session flag is set the moment the popup becomes visible, not only when the user clicks Compare / Not now.
- Restyles the surface to the editorial v2 theme: paper background, lavender border (`#ddd7ec`), purple accent eyebrow with pulse dot, Inter Tight headline, ink primary button + outlined ghost dismiss.
- Removes `CardyCharacter` from the popup.

## Test plan
- [x] Visit card A → no popup (first card, no prior visits)
- [x] Visit card B → popup appears after ~1.2s, `ccd_session_compare_popup_shown` set to `"true"`
- [x] Visit card C → popup does **not** reappear
- [x] Verified in browser at desktop viewport — styled-jsx primary button renders correctly (switched to `<style jsx global>` because Next.js `<Link>` doesn't forward the scope class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)