### PR TITLE
check-card-pages: skip bundled-AU value bumps

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -333,7 +333,26 @@ function detectChanges(card, extracted) {
     const sb = extracted.signup_bonus;
     const cur = current.signup_bonus;
 
+    // Defensive: when Haiku reports both a value change and an authorized_user_bonus,
+    // and the value delta is exactly the AU bonus, the page's headline is bundling
+    // the AU bonus into the displayed total (e.g. Chase's United Gateway shows
+    // "40,000 bonus miles" = 30k base + 10k AU). Skip the value change — the AU
+    // split is already captured in signup_bonus.note.
+    const skipValueAsBundledAU =
+      sb.value != null &&
+      cur.value != null &&
+      sb.authorized_user_bonus != null &&
+      sb.authorized_user_bonus > 0 &&
+      sb.value - cur.value === sb.authorized_user_bonus;
+
+    if (skipValueAsBundledAU) {
+      console.log(
+        `  Ignoring value change ${cur.value} → ${sb.value}: matches base + authorized_user_bonus (${sb.authorized_user_bonus})`
+      );
+    }
+
     for (const key of ['value', 'spend_requirement', 'timeframe_months']) {
+      if (key === 'value' && skipValueAsBundledAU) continue;
       if (sb[key] !== null && sb[key] !== undefined && cur[key] !== undefined) {
         const field = `signup_bonus.${key}`;
         if (sb[key] !== cur[key] && !ignoreFields.has(field)) {


### PR DESCRIPTION
## Summary
- Daily card-page-check keeps proposing the same false-positive: United Gateway `signup_bonus.value` 30000 → 40000. The Chase apply page advertises "40,000 bonus miles" in the hero, but that's 30k base + 10k for adding an authorized user (already captured as `signup_bonus.note`).
- Haiku's prompt already tells it to exclude AU bonuses from `value`, but the bundled headline overrides the rule in practice.
- This adds a defensive guard in `detectChanges`: if Haiku returns both a value change AND an `authorized_user_bonus`, and the value delta equals the AU bonus exactly, the proposal is treated as a bundled-headline artifact and skipped.

## Why this is safe
- Legitimate value bumps still fire — e.g. if Chase moves United Gateway to 50k base + 10k AU (60k headline), `60000 - 30000 = 30000 ≠ 10000` and the change proceeds.
- Only triggers when Haiku itself surfaces the AU split, so the AU info is preserved in the existing note.

## Test plan
- [ ] Wait for tomorrow's scheduled `check-card-pages` cron run and confirm United Gateway is no longer in the auto-PR.
- [ ] Spot-check other cards with AU bonuses (none in YAML currently mention authorized user except United Gateway, but if any get added later, the guard will protect them too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)