### PR TITLE
card-wire: hatch superseded entries for older changes

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -127,6 +127,23 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
     return c;
   }, [entries]);
 
+  const supersededIds = useMemo(() => {
+    const seen = new Set<string>();
+    const superseded = new Set<number>();
+    const sorted = [...entries].sort(
+      (a, b) => new Date(b.changed_at).getTime() - new Date(a.changed_at).getTime()
+    );
+    for (const e of sorted) {
+      const key = `${e.card_name}::${e.field}`;
+      if (seen.has(key)) {
+        superseded.add(e.id);
+      } else {
+        seen.add(key);
+      }
+    }
+    return superseded;
+  }, [entries]);
+
   const filtered = useMemo(() => {
     if (filter === 'all') return entries;
     return entries.filter((e) => fieldGroup(e.field) === filter);
@@ -233,6 +250,7 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
                   entries={group.entries}
                   slugMap={slugMap}
                   bonusTypeMap={bonusTypeMap}
+                  supersededIds={supersededIds}
                 />
               ))}
             </div>
@@ -271,11 +289,13 @@ function GroupRows({
   entries,
   slugMap,
   bonusTypeMap,
+  supersededIds,
 }: {
   date: string;
   entries: CardWireEntry[];
   slugMap: Record<string, string>;
   bonusTypeMap: Record<string, string>;
+  supersededIds: Set<number>;
 }) {
   return (
     <>
@@ -293,6 +313,7 @@ function GroupRows({
         const oldFmt = formatValue(entry.field, entry.old_value, bonusType);
         const newFmt = formatValue(entry.field, entry.new_value, bonusType);
         const dir = changeDirection(entry.field, entry.old_value, entry.new_value);
+        const isSuperseded = supersededIds.has(entry.id);
         const cardInner = (
           <span className="wire-card">
             <span className="wire-thumb">
@@ -315,10 +336,19 @@ function GroupRows({
             <span className="old">{oldFmt}</span>
             <span className="arrow" aria-hidden="true">→</span>
             <span className="new">{newFmt}</span>
+            {isSuperseded && (
+              <span className="wire-superseded-tag" title="A newer change exists for this field">
+                superseded
+              </span>
+            )}
           </span>
         );
         return (
-          <div key={entry.id} className="wire-row" role="row">
+          <div
+            key={entry.id}
+            className={'wire-row' + (isSuperseded ? ' superseded' : '')}
+            role="row"
+          >
             <span className="wire-row-card" role="cell">
               {slug ? (
                 <Link href={`/card/${slug}`} className="wire-card-link">

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2877,6 +2877,65 @@
 }
 .landing-v2.wire-v2 .wire-row:hover { background: var(--paper-2); }
 
+/* Superseded rows — older changes for a card+field that have been replaced by
+   a newer entry. Diagonal hatch overlay keeps them visible but de-emphasized. */
+.landing-v2.wire-v2 .wire-row.superseded {
+  position: relative;
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0,
+    transparent 6px,
+    rgba(15, 23, 42, 0.055) 6px,
+    rgba(15, 23, 42, 0.055) 7px
+  );
+}
+.landing-v2.wire-v2 .wire-row.superseded:hover {
+  background-color: var(--paper-2);
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0,
+    transparent 6px,
+    rgba(15, 23, 42, 0.045) 6px,
+    rgba(15, 23, 42, 0.045) 7px
+  );
+}
+.landing-v2.wire-v2 .wire-row.superseded .wire-card-name,
+.landing-v2.wire-v2 .wire-row.superseded .wire-field-chip,
+.landing-v2.wire-v2 .wire-row.superseded .wire-change .new,
+.landing-v2.wire-v2 .wire-row.superseded .wire-change .old,
+.landing-v2.wire-v2 .wire-row.superseded .wire-change .arrow {
+  color: var(--muted);
+}
+.landing-v2.wire-v2 .wire-row.superseded .wire-change.pos .new,
+.landing-v2.wire-v2 .wire-row.superseded .wire-change.neg .new {
+  color: var(--muted);
+  font-weight: 500;
+}
+.landing-v2.wire-v2 .wire-row.superseded .wire-thumb {
+  opacity: 0.55;
+  filter: grayscale(0.4);
+}
+.landing-v2.wire-v2 .wire-row.superseded .wire-field-chip {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.landing-v2.wire-v2 .wire-superseded-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  margin-left: 4px;
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  font-family: 'Inter', sans-serif;
+}
+
 .landing-v2.wire-v2 .wire-card {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- On the card wire feed, when a card+field has a newer change in view, the older entry is now rendered with a diagonal-line hatch overlay, muted text, grayscale thumbnail, and a "SUPERSEDED" tag.
- The direction (old → new, pos/neg color) is still readable, just clearly de-emphasized so it's obvious it's not the latest update for that card.

## Test plan
- [x] Load `/card-wire` locally — superseded rows render with the hatch overlay and `SUPERSEDED` tag (verified 9/50 rows on default page)
- [ ] Verify on Amplify preview that superseded rows are visible but visually demoted vs current rows
- [ ] Spot-check filter tabs (Annual fee / Sign-up bonus / APR / Applications) still surface superseded styling