### PR TITLE
web-next: render navbar avatar without waiting on /user-settings

### DIFF
--- a/apps/web-next/src/components/layout/Navbar.tsx
+++ b/apps/web-next/src/components/layout/Navbar.tsx
@@ -103,15 +103,10 @@ export default function Navbar() {
   const { authState, logout } = useAuth();
   const { settings } = useUserSettings();
   const pathname = usePathname();
-  // Hold the avatar render until /user-settings has resolved so we don't
-  // briefly show the UID-seeded fallback and then snap to the user's saved
-  // seed (avatar flicker). settings === null means the GET hasn't returned
-  // yet; once it has, we either use the saved avatar_seed or fall back to
-  // the UID for users who haven't customised.
-  const settingsLoaded = settings !== null;
-  const avatarSeed = settingsLoaded
-    ? settings.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null
-    : null;
+  // Render the avatar immediately with the UID fallback; once settings load
+  // (from localStorage cache or the GET), the `key={avatarSeed}` swap triggers
+  // the existing fade animation if the saved seed differs.
+  const avatarSeed = settings?.avatar_seed ?? authState.user?.uid ?? authState.user?.email ?? null;
 
   const isActive = (item: NavItem) => item.matches(pathname);
   const isProfileActive = pathname === "/profile" || pathname.startsWith("/profile/");
@@ -172,15 +167,13 @@ export default function Navbar() {
                         <>
                           <Menu.Button className="inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-[3px] border border-[#ddd7ec] bg-white p-0 text-sm transition-colors hover:border-[#1a1330] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6d3fe8] focus-visible:ring-offset-2">
                             <span className="sr-only">Open user menu</span>
-                            {settingsLoaded && (
-                              <span key={avatarSeed ?? 'guest'} className="cj-avatar-fade-in">
-                                <UserAvatar
-                                  seed={avatarSeed}
-                                  size={32}
-                                  title="Account menu"
-                                />
-                              </span>
-                            )}
+                            <span key={avatarSeed ?? 'guest'} className="cj-avatar-fade-in">
+                              <UserAvatar
+                                seed={avatarSeed}
+                                size={32}
+                                title="Account menu"
+                              />
+                            </span>
                           </Menu.Button>
                           <Transition
                             show={menuOpen}

--- a/apps/web-next/src/user-settings/UserSettingsProvider.tsx
+++ b/apps/web-next/src/user-settings/UserSettingsProvider.tsx
@@ -30,6 +30,29 @@ const DEFAULT_SETTINGS: UserSettings = {
   avatar_seed: null,
 };
 
+const STORAGE_PREFIX = 'cj:user-settings:';
+
+function readCache(uid: string): UserSettings | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + uid);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<UserSettings>;
+    return { ...DEFAULT_SETTINGS, ...parsed };
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(uid: string, value: UserSettings) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_PREFIX + uid, JSON.stringify(value));
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
 const UserSettingsContext = createContext<UserSettingsContextType | undefined>(undefined);
 
 export function UserSettingsProvider({ children }: { children: ReactNode }) {
@@ -47,6 +70,11 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
     if (fetchedForUserRef.current === authState.user.uid) return;
     fetchedForUserRef.current = authState.user.uid;
 
+    const uid = authState.user.uid;
+    // Hydrate from cache so the avatar renders without waiting on the GET.
+    const cached = readCache(uid);
+    if (cached) setSettings(cached);
+
     let cancelled = false;
     (async () => {
       setIsLoading(true);
@@ -58,10 +86,14 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
         });
         if (!res.ok) throw new Error(`user-settings GET ${res.status}`);
         const data = (await res.json()) as UserSettings;
-        if (!cancelled) setSettings({ ...DEFAULT_SETTINGS, ...data });
+        const merged = { ...DEFAULT_SETTINGS, ...data };
+        if (!cancelled) {
+          setSettings(merged);
+          writeCache(uid, merged);
+        }
       } catch (err) {
         console.error('Failed to load user settings:', err);
-        if (!cancelled) setSettings(DEFAULT_SETTINGS);
+        if (!cancelled && !cached) setSettings(DEFAULT_SETTINGS);
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -75,7 +107,12 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
   const setAvatarSeed = useCallback(
     async (seed: string) => {
       const prev = settings;
-      setSettings((s) => ({ ...(s ?? DEFAULT_SETTINGS), avatar_seed: seed }));
+      const uid = authState.user?.uid;
+      setSettings((s) => {
+        const next = { ...(s ?? DEFAULT_SETTINGS), avatar_seed: seed };
+        if (uid) writeCache(uid, next);
+        return next;
+      });
       try {
         const token = await getToken();
         if (!token) throw new Error('Not authenticated');
@@ -86,13 +123,16 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
         });
         if (!res.ok) throw new Error(`user-settings PUT ${res.status}`);
         const data = (await res.json()) as UserSettings;
-        setSettings({ ...DEFAULT_SETTINGS, ...data });
+        const merged = { ...DEFAULT_SETTINGS, ...data };
+        setSettings(merged);
+        if (uid) writeCache(uid, merged);
       } catch (err) {
         setSettings(prev);
+        if (uid && prev) writeCache(uid, prev);
         throw err;
       }
     },
-    [settings, getToken]
+    [settings, getToken, authState.user?.uid]
   );
 
   const value = useMemo<UserSettingsContextType>(


### PR DESCRIPTION
## Summary
- Add a localStorage cache (`cj:user-settings:{uid}`) to `UserSettingsProvider` and hydrate from it synchronously inside the auth effect, then refresh in the background (stale-while-revalidate).
- Drop the `settingsLoaded` gate in the Navbar so the avatar renders immediately with the UID fallback; the existing `key={avatarSeed}` + `.cj-avatar-fade-in` smoothly swaps to the saved seed once settings arrive.

## Why
The "profile picture" is a `boring-avatars` SVG generated client-side, but the Navbar was holding its render until `GET /user-settings` resolved (to avoid a UID→saved-seed flicker). That Lambda round-trip is what felt like a slow-loading pfp on every page load.

- **First-ever load**: avatar appears as soon as `authState` resolves; fades to saved seed when the fetch returns.
- **Repeat loads**: cache hydrates synchronously → saved seed renders with no flicker; background GET still runs.

The Profile page's gate is left in place — it keeps the re-roll button disabled until we know the current seed, preventing an in-flight GET from clobbering a fresh PUT. With the cache, that's effectively instant for repeat visitors.

## Test plan
- [ ] Sign in, reload — Navbar avatar renders immediately (no blank button while `/user-settings` is in flight).
- [ ] Sign in on a fresh browser/profile — avatar shows the UID-seeded fallback first, then fades to the saved seed.
- [ ] Re-roll on `/profile`, reload — saved seed appears instantly on next load (served from cache).
- [ ] Re-roll PUT failure path — cache rolls back to the previous value (no stale optimistic seed lingering).
- [ ] Sign out / sign in as a different user — cache is keyed by uid, so no leakage between accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)