### PR TITLE
card page: add Our take block with Featured-in /best/ badges

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -239,6 +239,7 @@ interface CardClientProps {
   similarCards?: Card[];
   wire?: CardWireEntry[];
   frequentlyComparedCards?: Card[];
+  bestRankings?: Array<{ rank: number; title: string; slug: string }>;
 }
 
 // Isolated so useSearchParams doesn't bail the whole CardClient out of static
@@ -268,6 +269,7 @@ export default function CardClient({
   similarCards = [],
   wire = [],
   frequentlyComparedCards = [],
+  bestRankings = [],
 }: CardClientProps) {
   // ---------- State + chrome ----------
   const [showModal, setShowModal] = useState(false);
@@ -484,6 +486,8 @@ export default function CardClient({
     const sub = `After $${sb.spend_requirement.toLocaleString()} in ${sb.timeframe_months} mo${cashEquiv ? ` · ≈ $${cashEquiv.toLocaleString()}` : ""}`;
     return { value, sub };
   }, [card.card_name, card.signup_bonus]);
+
+  const ourTake = card.our_take?.trim() || null;
 
   const approvalRate =
     card.approved_count !== undefined &&
@@ -928,6 +932,46 @@ export default function CardClient({
                 <div className="cj-readoff-foot">Approved</div>
               </div>
             </div>
+
+            {ourTake ? (
+              <div className="cj-take">
+                <div className="cj-take-label">Our take</div>
+                <p className="cj-take-body">{ourTake}</p>
+                {bestRankings.length > 0 && (
+                  <div className="cj-take-awards" aria-label="Top placements on best-of lists">
+                    <span className="cj-take-awards-label">Featured in</span>
+                    <div className="cj-take-awards-list">
+                      {bestRankings.map((r) => (
+                        <Link
+                          key={r.slug}
+                          href={`/best/${r.slug}`}
+                          className={`cj-award-chip cj-award-chip-rank-${r.rank}`}
+                        >
+                          <span className="cj-award-rank">#{r.rank}</span>
+                          <span className="cj-award-title">{r.title}</span>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : bestRankings.length > 0 ? (
+              <div className="cj-featured" aria-label="Top placements on best-of lists">
+                <span className="cj-take-awards-label">Featured in</span>
+                <div className="cj-take-awards-list">
+                  {bestRankings.map((r) => (
+                    <Link
+                      key={r.slug}
+                      href={`/best/${r.slug}`}
+                      className={`cj-award-chip cj-award-chip-rank-${r.rank}`}
+                    >
+                      <span className="cj-award-rank">#{r.rank}</span>
+                      <span className="cj-award-title">{r.title}</span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : null}
           </section>
 
           {/* Mobile-only welcome offer / apply box, shown above section 02 */}

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { Card, CardBenefit, getCard, getCardGraphs, getCardRecords, getAllCards, getCardRatings, getCardWire, getComparePartners, GraphData, CardRecord, CardWireEntry } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
+import { getBestPages } from "@/lib/best";
 import { categoryLabels, pickHeadlineReward } from "@/lib/cardDisplayUtils";
 import { truncateTitle } from "@/lib/seo";
 import CardClient from "./CardClient";
@@ -164,7 +165,7 @@ export default async function CardPage({ params }: CardPageProps) {
   try {
     // Fetch all data in parallel — chain getCard → getCardRatings together
     // so ratings fetches concurrently with graphs/news/articles instead of after them all
-    const [cardWithRatingsAndWire, graphData, records, allNews, allArticles, allCards, comparePartners] = await Promise.all([
+    const [cardWithRatingsAndWire, graphData, records, allNews, allArticles, allCards, comparePartners, bestPages] = await Promise.all([
       getCard(slug).then(async (card) => ({
         card,
         ratings: await getCardRatings(card.card_name).catch(() => ({ count: 0, average: null })),
@@ -176,6 +177,7 @@ export default async function CardPage({ params }: CardPageProps) {
       getArticles().catch(() => [] as Article[]),
       getAllCards().catch(() => [] as Card[]),
       getComparePartners(slug, 20).catch(() => []),
+      getBestPages().catch(() => []),
     ]);
 
     const { card, ratings, wire } = cardWithRatingsAndWire;
@@ -222,7 +224,19 @@ export default async function CardPage({ params }: CardPageProps) {
       .filter((c): c is Card => c !== undefined && c.active !== false)
       .slice(0, 3);
 
-    return <CardClient card={card} graphData={graphData} records={records} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} frequentlyComparedCards={frequentlyComparedCards} />;
+    // Top-3 placements across the /best/* pages — surfaced as social-proof
+    // badges in the overview block, with deep links back to each list.
+    const bestRankings = bestPages
+      .map((page) => {
+        const idx = page.cards.findIndex((c) => c.slug === slug);
+        return idx >= 0 && idx < 3
+          ? { rank: idx + 1, title: page.title, slug: page.slug }
+          : null;
+      })
+      .filter((r): r is { rank: number; title: string; slug: string } => r !== null)
+      .sort((a, b) => a.rank - b.rank);
+
+    return <CardClient card={card} graphData={graphData} records={records} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} frequentlyComparedCards={frequentlyComparedCards} bestRankings={bestRankings} />;
   } catch {
     notFound();
   }

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -6794,6 +6794,102 @@
   color: var(--accent);
   border-bottom-color: var(--accent);
 }
+.landing-v2 .cj-take {
+  margin-top: 22px;
+  padding: 20px 22px;
+  background: color-mix(in oklab, var(--accent) 4%, #fff);
+  border: 1px solid var(--line-2);
+  border-left: 3px solid var(--accent);
+}
+.landing-v2 .cj-take-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.landing-v2 .cj-take-body {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink);
+  margin: 0;
+}
+.landing-v2 .cj-take-awards {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--line-2);
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+.landing-v2 .cj-featured {
+  margin-top: 22px;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+.landing-v2 .cj-take-awards-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.landing-v2 .cj-take-awards-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.landing-v2 .cj-award-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 4px 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink);
+  background: #fff;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  text-decoration: none;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.landing-v2 .cj-award-chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 5%, #fff);
+}
+.landing-v2 .cj-award-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #fff;
+  background: var(--ink);
+}
+.landing-v2 .cj-award-chip-rank-1 .cj-award-rank {
+  background: linear-gradient(135deg, #d4a017 0%, #b8860b 100%);
+}
+.landing-v2 .cj-award-chip-rank-2 .cj-award-rank {
+  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
+}
+.landing-v2 .cj-award-chip-rank-3 .cj-award-rank {
+  background: linear-gradient(135deg, #c97a52 0%, #a05a3a 100%);
+}
+.landing-v2 .cj-award-title {
+  line-height: 1.35;
+  flex: 1;
+  min-width: 0;
+}
 .landing-v2 .cj-overview-img {
   width: 100%;
   max-width: 260px;

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -147,6 +147,7 @@ export interface Card {
   signup_bonus?: SignupBonus;
   apr?: CardAPR;
   benefits?: CardBenefit[];
+  our_take?: string;
 }
 
 // GraphData is an array of series data

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -12,6 +12,10 @@
       "items": { "type": "string" },
       "description": "Prior names this card was known by, e.g. before a rebrand. Rendered on the card detail page."
     },
+    "our_take": {
+      "type": "string",
+      "description": "Editorial paragraph rendered in the 'Our take' block on the card detail page. Optional; when omitted the block is hidden (only the Featured-in chips render, if the card is top-3 on a /best/ list)."
+    },
     "bank": {
       "type": "string",
       "description": "Issuing bank or financial institution"


### PR DESCRIPTION
## Summary
- New optional **`our_take`** string field on the card YAML schema, rendered as an editorial paragraph in section 01 of the card detail page.
- New **Featured in** row showing top-3 placements across `/best/*` lists, with gold/silver/bronze rank medallions linking back to each list page.
- Layout: when `our_take` is populated, the "Our take" copy renders inside a light-purple panel with the Featured-in chips at the bottom (dashed separator); when `our_take` is empty but the card has at least one top-3 placement, just the slim Featured-in row renders; when neither, nothing renders.
- Top-3 placements are computed server-side in `apps/web-next/src/app/card/[name]/page.tsx` by reading `getBestPages()` alongside the existing parallel data fetches.

## Test plan
- [ ] `/card/chase-sapphire-reserve` shows the slim standalone Featured-in row (`#1 Best Travel Credit Cards`) below the readoff stats
- [ ] `/card/delta-skymiles-reserve-american-express-card` shows two chips (`#1 Best Airline Credit Cards`, `#2 Best Credit Card Signup Bonuses`)
- [ ] Adding `our_take: "..."` to a card YAML and running `npm run build:cards` renders the full "Our take" panel with the paragraph and chips
- [ ] A card with no `our_take` and no top-3 placement (e.g. a niche card) renders nothing in this slot
- [ ] Chips wrap cleanly on narrow viewports and link to `/best/<slug>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)