### PR TITLE
card page: simplify Further reading list on mobile

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1561,9 +1561,9 @@ export default function CardClient({
               <h2 className="cj-section-h2">
                 Further <em className="cj-section-accent">reading</em>
               </h2>
-              <div className="cj-tape">
+              <div className="cj-tape cj-tape-reading">
                 <div className="cj-tape-head">
-                  <div>By</div>
+                  <div className="cj-tape-by">By</div>
                   <div>Title</div>
                   <div className="cj-tape-res">Read</div>
                 </div>
@@ -1573,7 +1573,7 @@ export default function CardClient({
                     href={`/articles/${a.slug}`}
                     className="cj-tape-row"
                   >
-                    <div className="cj-tape-when">{a.author}</div>
+                    <div className="cj-tape-when cj-tape-by">{a.author}</div>
                     <div className="cj-tape-event">
                       <span className="cj-tape-field">{a.title}</span>
                     </div>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7490,6 +7490,17 @@
 .landing-v2 .cj-tape-event .cj-tape-new.cj-pos { color: #0f8a5f; }
 .landing-v2 .cj-tape-event .cj-tape-new.cj-neg { color: var(--warn); }
 
+@media (max-width: 640px) {
+  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-head,
+  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-row {
+    grid-template-columns: 1fr;
+  }
+  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-by,
+  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-res {
+    display: none;
+  }
+}
+
 /* Right rail */
 .landing-v2 .cj-rail {
   padding: 4px 20px 56px;


### PR DESCRIPTION
## Summary
- Hide the **By** and **Read** columns of the "Further reading" tape under 640px so the article title gets the full row width.
- Adds a `cj-tape-reading` modifier so the override is scoped and doesn't affect the news tape (section 04) on the same page.

## Test plan
- [x] At 375px (mobile), only the Title column shows; row no longer wraps awkwardly.
- [x] At ≥641px, the original 3-column layout (By / Title / Read) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)