### PR TITLE
profile: roll renewal date forward to next anniversary

### DIFF
--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -84,7 +84,12 @@ const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'S
 
 function formatRenewal(month?: number, year?: number): { display: string; sortKey: number } | null {
   if (!month || !year) return null;
-  const renewalYear = year + 1;
+  const now = new Date();
+  const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  let renewalYear = year + 1;
+  while (new Date(renewalYear, month - 1, 1).getTime() < todayMidnight) {
+    renewalYear += 1;
+  }
   const date = new Date(renewalYear, month - 1, 1);
   return { display: `${MONTHS_SHORT[month - 1]} ${renewalYear}`, sortKey: date.getTime() };
 }


### PR DESCRIPTION
## Summary
- `formatRenewal` in `ProfileClient.tsx` hardcoded `year + 1`, so a card acquired in Feb 2024 always rendered as "Feb 2025" — even after the anniversary passed.
- Fix: loop forward to the next anniversary on or after today. Annual renewals now always show the upcoming date.
- Also corrects the "Next renewal" readoff and "Upcoming renewals" sort, which consumed the same stale date.

## Test plan
- [x] Verified logic against multiple inputs at today=2026-05-15: Feb 2024 → Feb 2027, Oct 2025 → Oct 2026, Mar 2026 → Mar 2027, May 2025 → May 2027 (rolls past today-mid-month).

🤖 Generated with [Claude Code](https://claude.com/claude-code)