### PR TITLE
Add auto-generated news items for 2026-05-15

### DIFF
--- a/data/news/2026-05-15-chase-paze-10x-points-promotion.yaml
+++ b/data/news/2026-05-15-chase-paze-10x-points-promotion.yaml
@@ -1,0 +1,29 @@
+id: "chase-paze-10x-points-promotion"
+title: "Chase Cards Offer 10x Points on Paze Purchases Through December 31, 2026"
+summary: "Chase Sapphire Reserve, Freedom Flex, Freedom Unlimited, and Sapphire Preferred cardholders can earn **10x points on Paze purchases** with a **$1,500 monthly cap** through **December 31, 2026**. The promotion applies to eligible Chase cards and can be used at retailers like United Airlines and Newegg."
+tags:
+  - "limited-time"
+  - "benefit-change"
+bank: "Chase"
+card_slugs:
+  - "chase-sapphire-reserve"
+  - "chase-freedom-flex"
+  - "chase-freedom-unlimited"
+  - "chase-sapphire-preferred"
+card_names:
+  - "Chase Sapphire Reserve"
+  - "Chase Freedom Flex"
+  - "Chase Freedom Unlimited"
+  - "Chase Sapphire Preferred"
+source: "Upgraded Points"
+source_url: "https://upgradedpoints.com/news/chase-sapphire-freedom-10x-paze-purchases/"
+date: "2026-05-15"
+body: |
+  Chase cardholders can now benefit from an elevated earning rate on Paze purchases. The **10x points promotion** is available on select Chase cards including the Sapphire Reserve, Freedom Flex, Freedom Unlimited, and Sapphire Preferred.
+  
+  The promotion carries a **$1,500 monthly spending cap**, meaning cardholders can earn the elevated rate on up to $1,500 in Paze purchases each month. The offer runs through **December 31, 2026**.
+  
+  Paze is a digital payments platform that can be used at various retailers. Cardholders looking to maximize this benefit should note that **United Airlines and Newegg** are among the useful retailers accepting Paze. Additionally, gift cards to other retailers can be purchased through these platforms, potentially expanding the earning opportunities beyond direct merchant purchases.
+  
+  This limited-time promotion provides a significant bonus earning opportunity for eligible Chase cardholders, particularly those planning travel or electronics purchases.
+  

--- a/data/news/2026-05-15-discover-it-miles-capital-one-migration.yaml
+++ b/data/news/2026-05-15-discover-it-miles-capital-one-migration.yaml
@@ -1,0 +1,20 @@
+id: "discover-it-miles-capital-one-migration"
+title: "Discover it Miles Card Moving to Capital One App and Website"
+summary: "Starting **July 27, 2026**, Discover it Miles Card holders will manage their accounts through Capital One's app and website instead of Discover's platform. Cardholders will retain their rewards structure and no annual fee, and will gain access to Capital One's Offers, Travel, and Entertainment features."
+tags:
+  - "policy-change"
+bank: "Discover"
+card_slug: "discover-it-miles"
+card_name: "Discover it Miles"
+source: "Discover"
+source_url: "https://card.discover.com/integration-faq/html/integration-faq.html"
+date: "2026-05-15"
+body: |
+  Discover has announced that cardholders of the Discover it Miles Card will soon manage their accounts through Capital One's digital platforms. The transition takes effect **July 27, 2026**.
+  
+  According to an email sent to cardholders, account management will shift to the **Capital One app and Capital One website**. The company emphasized that existing benefits remain unchanged—cardholders will continue earning the same rewards and maintain the card's no annual fee feature.
+  
+  Beyond existing benefits, the migration also grants cardholders access to Capital One's suite of additional features, including **Offers, Travel, and Entertainment** services.
+  
+  Discover indicated that no immediate action is required from cardholders. Card usage should continue normally, and Discover will provide further instructions when the migration period approaches. This change reflects Discover's integration into Capital One following the company's acquisition.
+  


### PR DESCRIPTION
## Summary
- Auto-generated from r/churning via `scripts/auto-news-from-reddit.js`
- 2 survivors made it past Tier A/B verification (1 candidate dropped — Amex restrictive language claim could not be corroborated)
- Sources swapped to first-party / reputable third-party where possible:
  - Chase 10x Paze promotion → Upgraded Points (Tier B corroboration)
  - Discover it Miles → Capital One migration → Discover's own integration FAQ (first-party)

## News items
- `2026-05-15-chase-paze-10x-points-promotion.yaml` — Chase Sapphire Reserve / Freedom Flex / Freedom Unlimited / Sapphire Preferred earn 10x on Paze purchases, $1,500/mo cap, through Dec 31, 2026
- `2026-05-15-discover-it-miles-capital-one-migration.yaml` — Discover it Miles account management moves to Capital One app/website starting July 27, 2026

## Test plan
- [ ] YAML files parse cleanly and render on `/news`
- [ ] `card_slugs` resolve to real cards (chase-sapphire-reserve, chase-freedom-flex, chase-freedom-unlimited, chase-sapphire-preferred, discover-it-miles)
- [ ] Each article page loads at `/news/<id>` with correct linked cards
- [ ] `date: 2026-05-15` matches PR submission date

🤖 Generated with [Claude Code](https://claude.com/claude-code)