### PR TITLE
logrocket: rotate project key to rxckob/creditodds

### DIFF
--- a/apps/web-next/src/components/ui/LogRocketInit.tsx
+++ b/apps/web-next/src/components/ui/LogRocketInit.tsx
@@ -11,7 +11,7 @@ export default function LogRocketInit() {
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production' && !initialized) {
-      LogRocket.init('2k1opa/creditodds');
+      LogRocket.init('rxckob/creditodds');
       initialized = true;
     }
   }, []);


### PR DESCRIPTION
## Summary
- Replaces the LogRocket project slug `2k1opa/creditodds` with `rxckob/creditodds` in [LogRocketInit.tsx](apps/web-next/src/components/ui/LogRocketInit.tsx).

## Test plan
- [ ] After Amplify deploys, confirm new sessions show up under the `rxckob/creditodds` LogRocket project and the old project stops receiving traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)