### PR TITLE
card: stack date under title on mobile for news and reading

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1541,6 +1541,12 @@ export default function CardClient({
                       <div className="cj-tape-when">{dateText}</div>
                       <div className="cj-tape-event">
                         <span className="cj-tape-field">{n.title}</span>
+                        <div className="cj-tape-mob-meta">
+                          <span className="cj-tape-mob-date">{dateText}</span>
+                          <span className="cj-news-tag">
+                            {tag ? tagLabels[tag] : "NEWS"}
+                          </span>
+                        </div>
                       </div>
                       <div className="cj-tape-res">
                         <span className="cj-news-tag">
@@ -1567,19 +1573,33 @@ export default function CardClient({
                   <div>Title</div>
                   <div className="cj-tape-res">Read</div>
                 </div>
-                {articles.slice(0, 8).map((a) => (
-                  <Link
-                    key={a.id}
-                    href={`/articles/${a.slug}`}
-                    className="cj-tape-row"
-                  >
-                    <div className="cj-tape-when cj-tape-by">{a.author}</div>
-                    <div className="cj-tape-event">
-                      <span className="cj-tape-field">{a.title}</span>
-                    </div>
-                    <div className="cj-tape-res">{a.reading_time} min</div>
-                  </Link>
-                ))}
+                {articles.slice(0, 8).map((a) => {
+                  const articleDateText = a.date
+                    ? new Date(a.date).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                      })
+                    : "";
+                  return (
+                    <Link
+                      key={a.id}
+                      href={`/articles/${a.slug}`}
+                      className="cj-tape-row"
+                    >
+                      <div className="cj-tape-when cj-tape-by">{a.author}</div>
+                      <div className="cj-tape-event">
+                        <span className="cj-tape-field">{a.title}</span>
+                        {articleDateText && (
+                          <span className="cj-tape-mob-date">
+                            {articleDateText}
+                          </span>
+                        )}
+                      </div>
+                      <div className="cj-tape-res">{a.reading_time} min</div>
+                    </Link>
+                  );
+                })}
               </div>
             </section>
           )}

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7490,6 +7490,9 @@
 .landing-v2 .cj-tape-event .cj-tape-new.cj-pos { color: #0f8a5f; }
 .landing-v2 .cj-tape-event .cj-tape-new.cj-neg { color: var(--warn); }
 
+.landing-v2 .cj-tape-mob-date,
+.landing-v2 .cj-tape-mob-meta { display: none; }
+
 @media (max-width: 640px) {
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-head,
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-row {
@@ -7498,6 +7501,36 @@
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-by,
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-res {
     display: none;
+  }
+  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-event .cj-tape-mob-date {
+    display: block;
+    margin-top: 4px;
+    color: var(--muted);
+    font-size: 11.5px;
+    font-family: 'Inter', sans-serif;
+  }
+
+  /* News tape: collapse to a single column on mobile, render date + tag under the title */
+  #wire .cj-tape .cj-tape-head,
+  #wire .cj-tape .cj-tape-row {
+    grid-template-columns: 1fr;
+  }
+  #wire .cj-tape .cj-tape-head > div,
+  #wire .cj-tape-row > .cj-tape-when,
+  #wire .cj-tape-row > .cj-tape-res {
+    display: none;
+  }
+  #wire .cj-tape-row .cj-tape-event .cj-tape-mob-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 4px;
+  }
+  #wire .cj-tape-row .cj-tape-event .cj-tape-mob-date {
+    display: inline;
+    color: var(--muted);
+    font-size: 11.5px;
+    font-family: 'Inter', sans-serif;
   }
 }
 


### PR DESCRIPTION
## Summary
- On mobile the **In the news** tape now collapses to a single column with the publish date and source tag rendered beneath the title (desktop layout unchanged).
- On mobile the **Further reading** tape now shows the article publish date beneath the title (desktop layout unchanged).

## Test plan
- [x] Verified on mobile viewport (375px) at `/card/chase-sapphire-preferred` — news rows show `<date> <tag>` under the title; reading rows show `<date>` under the title.
- [x] Verified at 1280px desktop — original When/Source columns for news and By/Read columns for reading still render; mobile-only spans are hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)