### PR TITLE
best-card-for: expand picks list from 10 to 20

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function BestCardForStorePage({ params }: PageProps) {
   const [store, allCards] = await Promise.all([getStore(slug), getAllCards()]);
   if (!store) notFound();
 
-  const picks = rankCards(store, allCards);
+  const picks = rankCards(store, allCards, { maxPicks: 20 });
   const usingFallback = picks.length > 0 && picks.every(p => p.source === 'flat_rate');
 
   return (


### PR DESCRIPTION
## Summary
- Pass `maxPicks: 20` to `rankCards` on `/best-card-for/[slug]` so the public store page shows up to 20 ranked cards instead of 10.

## Test plan
- [x] Verified locally: Starbucks now renders 20 picks; Amazon=14, Home Depot=15 (previously capped at 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)