### PR TITLE
stores: add 200 new merchants to /best-card-for

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-07T15:23:57.568Z",
-  "count": 158,
+  "generated_at": "2026-05-17T23:57:39.684Z",
+  "count": 358,
   "stores": [
     {
       "name": "7-Eleven",
@@ -14,6 +14,32 @@
       ],
       "website": "https://www.7-eleven.com",
       "intro": "7-Eleven runs about 9,500 U.S. convenience stores, many with attached gas pumps. The\npumps code as gas on every card we track. In-store purchases (snacks, drinks, hot food)\ntypically code as convenience stores rather than as groceries or dining, which means\nmost 3-5% category bonuses don't apply to non-fuel purchases at 7-Eleven.\n"
+    },
+    {
+      "name": "Abercrombie & Fitch",
+      "slug": "abercrombie-and-fitch",
+      "aliases": [
+        "Abercrombie"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.abercrombie.com",
+      "intro": "Abercrombie & Fitch is the namesake adult apparel chain of Abercrombie & Fitch Co,\nwhich also owns Hollister and the kids brand abercrombie kids. Stores run in roughly\n200 U.S. mall locations alongside a strong online business at abercrombie.com. There\nis no current open co-brand credit card after the prior program ended, so shoppers\ntypically lean on department store category bonuses in person and online shopping\nmultipliers for site purchases.\n"
+    },
+    {
+      "name": "Accor",
+      "slug": "accor",
+      "aliases": [
+        "Accor Hotels"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://all.accor.com",
+      "intro": "Accor is the Paris-based global hotel group that operates more than 5,500 properties across\nbrands including Raffles, Fairmont, Sofitel, Pullman, Mövenpick, Novotel, Mercure, ibis, and\nthe lifestyle SO/, 25hours, and Mama Shelter labels. The ALL (Accor Live Limitless) loyalty\nprogram is a transfer partner of Bilt at 1:3, making it one of the few ways US cardholders\nearn meaningful Accor status. Accor stays code as lodging/hotels on every US card. Hotel-bonus\ncards earn full rate: Chase Sapphire Reserve 4x direct, Capital One Venture X 2x base.\n"
     },
     {
       "name": "Ace Hardware",
@@ -36,6 +62,15 @@
       "intro": "Ace Hardware is a cooperative of about 5,000 independently-owned hardware stores in the\nU.S., smaller and more service-oriented than Home Depot or Lowe's. Ace's own Ace Rewards\nloyalty program layers on top of card cashback. Notably, Ace Hardware is one of the\nmerchants that earns 3% on the Apple Card via Apple Pay, alongside the home-improvement\ncategory match on general-purpose cards.\n"
     },
     {
+      "name": "Acme Markets",
+      "slug": "acme-markets",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.acmemarkets.com",
+      "intro": "Acme Markets is the Mid-Atlantic banner of Albertsons Companies, with around 160\nstores across Pennsylvania, New Jersey, Delaware, Maryland, and New York. The chain\ncodes as a U.S. supermarket for credit cards, so a grocery rewards card (Amex Gold,\nBlue Cash Preferred, Citi Custom Cash) earns its posted multiplier at checkout. Acme\nparticipates in the Albertsons for U loyalty program and stocks a wide gift-card rack\nat the service desk, which is occasionally useful for extending a grocery multiplier\ninto adjacent spending categories.\n"
+    },
+    {
       "name": "Adidas",
       "slug": "adidas",
       "categories": [
@@ -44,6 +79,15 @@
       ],
       "website": "https://www.adidas.com",
       "intro": "Adidas is the second-largest global athletic apparel brand. Adidas.com codes as\nonline shopping; in-store charges code as department stores. The adiClub loyalty\nprogram issues spend-tier credits and member-exclusive product drops. Strongest\npairings are an online-shopping-bonus card for adidas.com or flat-rate cashback\nfor in-store.\n"
+    },
+    {
+      "name": "Adorama",
+      "slug": "adorama",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.adorama.com",
+      "intro": "Adorama is a New York City photo, video, audio, and computer retailer that competes\ndirectly with B&H Photo, operating both a Manhattan showroom and a large\ne-commerce store at adorama.com. Adorama is known for its EDU pricing, used gear\nmarketplace, and Adorama Rewards loyalty program. Purchases typically code as\nonline shopping or electronics on most credit card networks.\n\nCards with selectable online shopping bonuses, including the Bank of America\nCustomized Cash and U.S. Bank Cash+, can earn 3 to 5 percent on Adorama orders, and\nthe Chase Freedom Flex occasionally features online shopping in its rotating\nquarters. Adorama also accepts Affirm financing on larger camera bodies and lenses.\n"
     },
     {
       "name": "Advance Auto Parts",
@@ -56,6 +100,41 @@
       ],
       "website": "https://shop.advanceautoparts.com",
       "intro": "Advance Auto Parts is a U.S. auto parts retailer with about 4,700 domestic\nstores plus the Carquest commercial parts network. In-store charges code as\nauto parts; advance auto parts.com codes as online shopping. The Speed Perks\nloyalty program is free and issues percent-back rewards in store credit. Pair\nwith flat-rate cashback or an online-shopping-bonus card for digital orders.\n"
+    },
+    {
+      "name": "Aerie",
+      "slug": "aerie",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.ae.com/us/en/aerie",
+      "intro": "Aerie is American Eagle Outfitters' intimates, loungewear, and activewear sub-brand,\nwith hundreds of standalone stores and a heavy presence on ae.com. The Real Rewards\ncredit card from Synchrony covers both American Eagle and Aerie, paying boosted points\non every purchase. On most general-purpose cards, Aerie purchases code as department\nstore in person and online shopping when checking out through the AE site or app.\n"
+    },
+    {
+      "name": "Air Canada",
+      "slug": "air-canada",
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.aircanada.com",
+      "intro": "Air Canada is Canada's flag carrier and a Star Alliance founding member, operating hubs at\nToronto Pearson, Montreal-Trudeau, and Vancouver with an extensive transborder, transatlantic,\nand transpacific network plus regional service through Air Canada Express. The Aeroplan\nloyalty program is one of the strongest airline currencies in North America, with transfer\npartners across Amex Membership Rewards, Capital One miles, Chase Ultimate Rewards, and Bilt.\nAir Canada ticket purchases code as airlines/airfare, so airfare-bonus cards earn full rate.\n"
+    },
+    {
+      "name": "Air France / KLM",
+      "slug": "air-france-klm",
+      "aliases": [
+        "Air France",
+        "KLM",
+        "Flying Blue"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.airfrance.us",
+      "intro": "Air France-KLM is the Franco-Dutch parent of Air France (hubbed at Paris-Charles de Gaulle)\nand KLM Royal Dutch Airlines (hubbed at Amsterdam-Schiphol), both SkyTeam members with a\nshared Flying Blue loyalty program. Flying Blue partners with Amex Membership Rewards, Chase\nUltimate Rewards, Capital One miles, Bilt, and Citi ThankYou Points as a 1:1 transfer\npartner, plus periodic transfer bonuses. Air France and KLM ticket purchases code as\nairlines/airfare on US cards, earning the full airfare bonus on any card with that category.\n"
     },
     {
       "name": "Airbnb",
@@ -122,6 +201,28 @@
       ],
       "website": "https://www.aldi.us",
       "intro": "Aldi is the discount-focused private-label grocer with about 2,400 U.S. stores and a\nsharply lower price floor than full-line supermarkets. Average tickets are smaller, so\nthe absolute dollar value of a 3-6% grocery card is lower per visit, but the rate still\napplies. Aldi codes as groceries on every card we track. Note: Aldi historically only\naccepted debit and SNAP, but all U.S. stores now accept credit cards.\n"
+    },
+    {
+      "name": "AliExpress",
+      "slug": "aliexpress",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.aliexpress.com",
+      "intro": "AliExpress is Alibaba's consumer-facing global marketplace, connecting Chinese\nmanufacturers and merchants with international buyers. The platform sells everything\nfrom electronics and apparel to home goods at low price points, with shipping times\nthat vary widely by item. Purchases code as online shopping for credit card networks,\nso an online-shopping category bonus card earns its multiplier. Some AliExpress sellers\ninvoice through international processors, so foreign transaction fees can apply on\ncards without an FTF waiver, which is worth checking before a large order.\n"
+    },
+    {
+      "name": "Allegiant Air",
+      "slug": "allegiant-air",
+      "aliases": [
+        "Allegiant"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.allegiantair.com",
+      "intro": "Allegiant Air is a Las Vegas-based ultra-low-cost carrier that connects small and mid-sized\nUS cities to leisure destinations like Las Vegas, Orlando-Sanford, Phoenix-Mesa, and Florida\nGulf Coast airports, flying point-to-point on a fleet of Airbus A319/A320 aircraft. Like\nother ULCCs, Allegiant unbundles fares: bags, seat assignments, and printed boarding passes\nare all add-ons. Allegiant purchases code as airlines/airfare on every card network. Travel\ncards with airfare bonuses (Amex Gold 3x on flights booked direct, Chase Sapphire Reserve 4x,\nCapital One Venture X 2x) all earn their full rate on Allegiant tickets and ancillary fees.\n"
     },
     {
       "name": "Amazon",
@@ -252,6 +353,67 @@
       "intro": "Arby's is a U.S. fast-food chain with about 3,300 domestic locations, focused on\nroast beef and deli sandwiches. Charges code as dining on every card we track,\nso any dining-bonus card (Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%)\napplies. The Arby's Rewards app issues per-purchase points redeemable for menu\nitems, stackable with card bonuses.\n"
     },
     {
+      "name": "Arhaus",
+      "slug": "arhaus",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.arhaus.com",
+      "intro": "Arhaus is a premium home furnishings retailer based in Boston Heights, Ohio, with\naround 100 large-format Showrooms and Design Studios plus arhaus.com. The brand\nemphasizes hand-crafted, artisan-sourced furniture and recently expanded its outdoor\nand rug categories. The Arhaus Archcharge credit card from Comenity offers\npromotional financing on big purchases, and general-purpose cards typically code\nArhaus as home improvement or department store in person and online shopping for\nweb orders.\n"
+    },
+    {
+      "name": "Ashley Furniture HomeStore",
+      "slug": "ashley-furniture",
+      "aliases": [
+        "Ashley HomeStore"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.ashleyfurniture.com",
+      "intro": "Ashley Furniture HomeStore is the largest furniture retailer in the United States by\nstore count, selling sofas, dining sets, mattresses, and bedroom collections through\nmore than 1,000 corporate and licensed locations. Furniture purchases generally code\nas general retail on Visa, Mastercard, and Amex networks, so they do not trigger\nthe home improvement bonus that covers only Home Depot and Lowe's.\n\nBig-ticket furniture buys are a natural fit for signup bonus minimum spend on cards\nlike the Chase Sapphire Preferred or Amex Gold. Ashley also pushes its own Ashley\nAdvantage financing card with deferred-interest promotions, though paying with a\nrewards card and avoiding interest usually beats the financing math.\n"
+    },
+    {
+      "name": "ASOS",
+      "slug": "asos",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.asos.com",
+      "intro": "ASOS is a UK-based online-only fashion retailer that ships globally and serves the U.S.\nthrough asos.com, with no physical stores. Because every purchase is online, cards with\na strong online shopping or general everyday multiplier almost always win at checkout.\nASOS does not offer a U.S. branded credit card, so loyal customers rely on either the\nfree Premier delivery membership or rotating category bonuses from issuers like Chase\nFreedom and Discover when online shopping is featured.\n"
+    },
+    {
+      "name": "At Home",
+      "slug": "at-home",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.athome.com",
+      "intro": "At Home operates over 260 big-box home decor superstores stocking patio furniture,\nseasonal decor, wall art, and bedding at warehouse-style pricing. Most major credit\ncards code At Home as general retail, so it sits outside the typical home improvement\nbonus that covers only Lowe's and Home Depot on cards like the Wells Fargo Bilt or\nChase Freedom rotating quarters.\n\nOnline orders through athome.com can hit online shopping bonuses on cards like the\nCapital One SavorOne and Bank of America Customized Cash when that category is\nselected. At Home Insider Perks members also stack store coupons with credit card\ncash back, which matters on big-ticket patio and Christmas decor seasons.\n"
+    },
+    {
+      "name": "Athleta",
+      "slug": "athleta",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://athleta.gap.com",
+      "intro": "Athleta is Gap Inc's women's performance and athleisure brand and one of the company's\nfastest-growing banners, with around 270 U.S. stores plus a strong DTC channel. Most\ngeneral-purpose cards code in-store purchases as department store and athleta.gap.com\norders as online shopping. The Gap Inc Barclays cards earn elevated points across\nAthleta, Old Navy, Gap, and Banana Republic, so loyal shoppers usually consolidate\nspend on that program.\n"
+    },
+    {
+      "name": "Auntie Anne's",
+      "slug": "auntie-annes",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.auntieannes.com",
+      "intro": "Auntie Anne's is the mall and airport hand-rolled soft pretzel chain with roughly 1,800\nUS locations under Focus Brands. Beyond the Original and Cinnamon Sugar pretzels, the menu\nincludes Pretzel Dogs, Mini Pretzel Dogs, and Lemonade Mixers. Auntie Anne's transactions\ncode as dining/restaurants whether you order at the counter or through the My Pretzel\nPerks app. That makes any dining-bonus card a fit: Amex Gold (4x Membership Rewards), Chase\nSapphire Preferred (3x Ultimate Rewards), and Capital One SavorOne (3% cash) earn full rate.\n"
+    },
+    {
       "name": "AutoZone",
       "slug": "autozone",
       "categories": [
@@ -275,6 +437,72 @@
       "intro": "Avis is one of the three large U.S. car-rental brands, sister company to Budget under\nAvis Budget Group. Rentals code as car rentals on every card we track. Several\npremium cards confer Avis President's Club status (Amex Platinum, Capital One Venture\nX) which adds a guaranteed upgrade plus free additional driver. Booking via a card's\ntravel portal earns the portal bonus rate but may forfeit Avis Preferred earnings\nand direct-booking promo codes.\n"
     },
     {
+      "name": "B&H Photo",
+      "slug": "b-and-h-photo",
+      "aliases": [
+        "B&H",
+        "BH Photo"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.bhphotovideo.com",
+      "intro": "B&H Photo Video is a New York City professional photo, video, and audio retailer\nwith a single SuperStore in Manhattan and a major e-commerce operation at\nbhphotovideo.com. The retailer is the go-to for cameras, lenses, lighting, computers,\nand pro audio gear. Most credit cards treat B&H purchases as online shopping or\ngeneral electronics rather than a dedicated category.\n\nBank of America Customized Cash and U.S. Bank Cash+ can route B&H orders into a\nselectable 5 percent online shopping bonus, while the Chase Freedom Flex sometimes\nfeatures online shopping in its rotating quarters. B&H also issues its own Payboo\ncard that rebates sales tax in many states, which can outweigh credit card rewards\non large camera and lens purchases.\n"
+    },
+    {
+      "name": "Banana Republic",
+      "slug": "banana-republic",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://bananarepublic.gap.com",
+      "intro": "Banana Republic is the upscale apparel brand within Gap Inc, positioned above Gap and\nOld Navy with workwear, suiting, and elevated basics across roughly 400 stores plus a\ngrowing factory outlet network. The in-house Banana Republic Rewards Mastercard from\nBarclays earns accelerated points across all Gap Inc banners, while general-purpose\ncards typically code purchases as department store in-mall and online shopping for\nbananarepublic.gap.com orders.\n"
+    },
+    {
+      "name": "BarkBox",
+      "slug": "barkbox",
+      "aliases": [
+        "Bark"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.barkbox.com",
+      "intro": "BarkBox is the flagship subscription service from Bark, sending a themed monthly box\nof toys, treats, and chews tailored to a dog's size. Bark also operates Super Chewer\nfor heavy chewers, Bright dental subscriptions, and Bark Food. As a recurring online\nsubscription, BarkBox charges typically code as online shopping or direct marketing\non most credit card networks.\n\nCards with online shopping bonuses can pay better on BarkBox renewals. Bank of\nAmerica Customized Cash and U.S. Bank Cash+ both offer selectable online shopping\ncategories worth 3 to 5 percent, and the Chase Freedom Flex sometimes features\nonline shopping in its rotating 5 percent quarter. BarkBox also frequently appears\nin shopping portals like Rakuten with stacking cash back.\n"
+    },
+    {
+      "name": "Barnes & Noble",
+      "slug": "barnes-and-noble",
+      "aliases": [
+        "B&N",
+        "Barnes Noble"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.barnesandnoble.com",
+      "intro": "Barnes & Noble is the largest bookstore chain in the United States, operating\nover 600 superstores plus a major e-commerce site at barnesandnoble.com and the\nNook digital reading platform. In-store and online book purchases generally code as\nbookstore or general retail on Visa, Mastercard, and Amex networks rather than\ntriggering a dedicated bonus category.\n\nCards with selectable online shopping categories, including Bank of America\nCustomized Cash and U.S. Bank Cash+, can earn 3 to 5 percent on barnesandnoble.com\norders. The B&N Premium Membership runs about $40 a year and includes 10 percent\noff in store and free shipping online, which can stack with credit card rewards on\nfrequent buyers' purchases.\n"
+    },
+    {
+      "name": "Bartell Drugs",
+      "slug": "bartell-drugs",
+      "categories": [
+        "drugstores"
+      ],
+      "website": "https://www.bartelldrugs.com",
+      "intro": "Bartell Drugs is a Pacific Northwest pharmacy chain founded in 1890, with roughly 65\nlocations clustered in the Seattle metro and Puget Sound region. Owned by Rite Aid\nsince 2020, Bartell still operates under its own banner with its own pharmacy and\nloyalty program. Stores code as drugstores for credit card networks, so a drugstore\ncategory bonus card (Amex Blue Cash Preferred, Citi Custom Cash on drugstores, Chase\nFreedom Flex when activated) earns its full multiplier on prescriptions and front-of-\nstore purchases.\n"
+    },
+    {
+      "name": "Baskin-Robbins",
+      "slug": "baskin-robbins",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.baskinrobbins.com",
+      "intro": "Baskin-Robbins, the 31 Flavors ice cream chain owned by Inspire Brands (the same parent as\nDunkin'), operates roughly 2,300 US scoop shops along with a global footprint exceeding\n7,000 locations. The menu spans hand-packed pints, ice cream cakes, Cappuccino Blasts, and\nrotating monthly flavors. Baskin-Robbins purchases code as dining/restaurants on every US\ncredit card, so cards with dining bonuses earn their full multiplier: Amex Gold at 4x\nMembership Rewards, Chase Sapphire Preferred at 3x, and Capital One SavorOne at 3% cash back.\n"
+    },
+    {
       "name": "Bath & Body Works",
       "slug": "bath-and-body-works",
       "aliases": [
@@ -287,6 +515,25 @@
       ],
       "website": "https://www.bathandbodyworks.com",
       "intro": "Bath & Body Works is a U.S. personal-care chain with about 1,800 domestic stores,\nselling soaps, lotions, candles, and home fragrance. In-store charges code as\ndepartment stores; bathandbodyworks.com codes as online shopping. The My Bath &\nBody Works Rewards program issues a free reward at sign-up plus per-spend points;\na Comenity Bank-issued co-branded credit card layers additional cashback for\nheavy shoppers.\n"
+    },
+    {
+      "name": "Belk",
+      "slug": "belk",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.belk.com",
+      "intro": "Belk is a Southeast U.S. department store chain with about 290 locations across 16\nstates, anchored in the Carolinas. The merchandise mix is comparable to a regional\nMacy's: apparel, cosmetics, accessories, and home goods, with a focus on national and\nprivate-label brands. Belk codes as a department store, so a department-store\ncategory bonus card earns its full rate. The Belk Rewards Mastercard (issued by\nSynchrony) layers store-specific Belk Rewards points on top, with extra earn during\npromotional events.\n"
+    },
+    {
+      "name": "Benjamin Moore",
+      "slug": "benjamin-moore",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.benjaminmoore.com",
+      "intro": "Benjamin Moore is a premium U.S. paint manufacturer sold through more than 5,000\nindependent retailers including Aubuchon, Ace Hardware, and dedicated Benjamin Moore\nshops. Because purchases happen at independent dealers, merchant category coding\nvaries, with some locations coding as home improvement and others as general\nhardware retail.\n\nWhen a dealer codes as home improvement, cards like the Wells Fargo Bilt and U.S.\nBank Cash+ can deliver elevated rewards on Aura, Regal Select, and Advance lines.\nAce Hardware locations selling Benjamin Moore can stack ACE Rewards points with\ncredit card cash back, while professional contractors with a Benjamin Moore PRO\naccount get tiered discounts that layer on top of any card rewards.\n"
     },
     {
       "name": "Best Buy",
@@ -324,6 +571,15 @@
       "intro": "Best Western Hotels & Resorts runs about 4,000 properties globally under a member-owned\ncooperative structure that's unusual in the major-chain landscape. The portfolio spans\nBest Western, Best Western Plus, and Best Western Premier on the core brand, with\nVīb, GLō, Aiden, Sadie, and Executive Residency rounding out boutique and extended-stay\nsegments, plus the SureStay budget brands. There's no Best Western co-brand credit\ncard in the U.S. market today, so the right play is a strong general hotel-category\ncard — Sapphire Reserve, Venture X, Amex Gold, or a flat-rate cashback card if you\nprefer simplicity. Best Western Rewards points are earned only on direct bookings at\nbestwestern.com or in-app; OTA stays earn nothing in the program.\n"
     },
     {
+      "name": "Big Lots",
+      "slug": "big-lots",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.biglots.com",
+      "intro": "Big Lots is a closeout and discount retailer with roughly 1,300 stores across the U.S.,\nselling furniture, seasonal goods, food and consumables, and an ever-rotating mix of\ncloseout merchandise. The chain went through bankruptcy and a restructuring under\nVariety Wholesalers in 2025. Big Lots typically codes as a department store or\ndiscount retailer for credit card networks. The Big Lots Credit Card (issued by\nComenity Capital Bank) offers store-only financing and points on Big Lots purchases,\nthough a general 2-5% department-store card from a major issuer is often more useful.\n"
+    },
+    {
       "name": "BJ's Wholesale Club",
       "slug": "bjs-wholesale",
       "aliases": [
@@ -352,6 +608,56 @@
       "intro": "Bloomingdale's is a luxury-leaning department store with about 30 full-line locations\nin the U.S., plus the higher-end Bloomingdale's by Bloomingdale's outlet stores. Most\nshoppers are paying full price on apparel, beauty, and home goods, so the cashback rate\non your card matters more here than at a discount retailer.\n\nBloomingdale's accepts all four major networks (Visa, Mastercard, Amex, Discover) and\nApple Pay in stores. There is a co-branded Bloomingdale's American Express that earns\nLoyallist points, but most general-purpose cards will pay you better in cashback unless\nyou spend several thousand dollars a year at Bloomingdale's specifically.\n"
     },
     {
+      "name": "Blue Apron",
+      "slug": "blue-apron",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.blueapron.com",
+      "intro": "Blue Apron pioneered the US meal-kit category in 2012 and remains a recognizable subscription\nbrand offering chef-designed recipes with pre-portioned ingredients shipped weekly, plus a\nHeat & Eat line of prepared meals. The company was acquired by Wonder Group in 2023. Blue\nApron charges typically code as online retail or direct-marketing food, not in-store groceries\nor restaurants, so dining and grocery category bonuses generally do not apply. The best\nreturns come from flat-rate cards (Citi Double Cash, Wells Fargo Active Cash, both at 2%).\n"
+    },
+    {
+      "name": "Bluemercury",
+      "slug": "bluemercury",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://bluemercury.com",
+      "intro": "Bluemercury is a prestige beauty chain owned by Macy's Inc, with around 160 U.S.\nboutiques plus bluemercury.com selling skincare, makeup, fragrance, and the in-house\nM-61 and Lune+Aster brands. Direct purchases typically code as department store in\nperson and online shopping for web orders. Because Bluemercury is part of Macy's, the\nfree BlueRewards program is paired with Macy's Star Rewards and the Macy's\nCiti-issued credit cards earn elevated points on Bluemercury spend.\n"
+    },
+    {
+      "name": "Bob's Discount Furniture",
+      "slug": "bobs-discount-furniture",
+      "aliases": [
+        "Bobs Furniture"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.mybobs.com",
+      "intro": "Bob's Discount Furniture is a value-focused furniture chain with over 175 stores\nacross the Northeast, Mid-Atlantic, Midwest, and Southwest. The retailer is known\nfor its Goof Proof protection plan, free in-store Bob-O-Pedic samples, and pricing\nthat undercuts traditional furniture stores. Purchases code as general retail on\nVisa, Mastercard, and Amex, not as home improvement.\n\nSectionals and bedroom sets at Bob's frequently run $1,500 to $3,000, which makes\nthe chain a strong venue for credit card signup bonus minimum spend. Flat-rate\nearners like the Wells Fargo Active Cash and Citi Double Cash handle furniture spend\ncleanly, while occasional Amex Offers on home retailers can stack additional\nstatement credits on top.\n"
+    },
+    {
+      "name": "Bojangles",
+      "slug": "bojangles",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.bojangles.com",
+      "intro": "Bojangles is a Southeast U.S. quick-service chain founded in Charlotte, North\nCarolina in 1977, known for Cajun-seasoned fried chicken, made-from-scratch\nbiscuits, Bo-Berry Biscuits, and sweet tea. The chain operates over 800 restaurants\nconcentrated in the Carolinas, Tennessee, Virginia, and the broader Southeast.\nBojangles transactions code as restaurants on most credit card networks.\n\nThe Amex Gold pays 4x points on U.S. restaurants and is the top earner for daily\nbiscuit runs. The Chase Sapphire Preferred earns 3x on dining and pairs well with\ntravel redemptions. No-annual-fee dining cards including the Capital One SavorOne\nat 3 percent and Wells Fargo Autograph at 3x are strong defaults. Bojangles also\nruns the Bojangles Rewards program, layered on top of credit card cash back.\n"
+    },
+    {
+      "name": "Bonefish Grill",
+      "slug": "bonefish-grill",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.bonefishgrill.com",
+      "intro": "Bonefish Grill is Bloomin' Brands' wood-grilled seafood concept (alongside Outback Steakhouse,\nCarrabba's, and Fleming's) with about 175 US locations specializing in fresh fish flown in\nseveral times a week, plus signature Bang Bang Shrimp and craft cocktails. Bonefish Grill\ncharges code as dining/restaurants on every card network, and Dine Rewards loyalty stacks\non top of credit card rewards. Cards with strong dining multipliers (Amex Gold 4x, Chase\nSapphire Preferred 3x, Capital One SavorOne 3% cash) earn at the full bonus on every visit.\n"
+    },
+    {
       "name": "Booking.com",
       "slug": "booking-com",
       "aliases": [
@@ -362,6 +668,18 @@
       ],
       "website": "https://www.booking.com",
       "intro": "Booking.com is one of the largest global online travel agencies, owned by Booking\nHoldings (which also owns Priceline, Kayak, and Agoda). Bookings code as travel\non every card we track. The honest catch: hotel chains typically do NOT credit\nBooking.com stays toward elite-night or status counts, and many properties\nexclude OTA stays from earning their loyalty points — so a Hilton/Marriott/Hyatt\nloyalist almost always books direct. Booking's own Genius rewards tier and\noccasional 10% off promos can still beat direct on price for one-off stays.\n"
+    },
+    {
+      "name": "Books-A-Million",
+      "slug": "books-a-million",
+      "aliases": [
+        "BAM!"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.booksamillion.com",
+      "intro": "Books-A-Million, branded as BAM!, is the second-largest brick-and-mortar bookstore\nchain in the United States with around 250 stores concentrated in the Southeast.\nThe retailer carries books, toys, gifts, magazines, and operates the Joe Muggs cafe\ninside larger stores. BAM! purchases generally code as bookstore or general retail\nrather than as a dedicated bonus category on most cards.\n\nCards with online shopping bonuses can earn better on booksamillion.com orders.\nBank of America Customized Cash and U.S. Bank Cash+ both offer selectable online\nshopping categories worth 3 to 5 percent, and Chase Freedom Flex sometimes features\nonline shopping in its rotating quarters. The Millionaire's Club membership stacks\nadditional discounts with credit card cash back for frequent buyers.\n"
     },
     {
       "name": "BP",
@@ -375,6 +693,57 @@
       ],
       "website": "https://www.bp.com",
       "intro": "BP and its Amoco-branded stations cover roughly 7,000 U.S. locations. Pumps code\ncleanly as gas on every card we track. BP runs the BPme app and a separate BP\nVisa with cash-back at BP/Amoco; in absolute cents most general-purpose 4-5% gas\ncards beat it. The bigger swing for heavy BP buyers is the BPme Rewards loyalty\nprogram, which stacks on top of any card's gas bonus.\n"
+    },
+    {
+      "name": "Breeze Airways",
+      "slug": "breeze-airways",
+      "aliases": [
+        "Breeze"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.flybreeze.com",
+      "intro": "Breeze Airways is the low-cost startup launched by JetBlue founder David Neeleman in 2021,\nflying a mix of Airbus A220-300s and Embraer E-Jets on underserved point-to-point routes\nbetween small and mid-sized US cities. Breeze sells Nice, Nicer, and Nicest fare bundles\nplus the premium Nicest cabin with extra-legroom seats. Breeze ticket purchases code as\nairlines/airfare on every card. Cards with airfare bonuses (Chase Sapphire Reserve at 4x\non direct, Amex Gold at 3x on direct, Capital One Venture X at 2x base) all earn full rate.\n"
+    },
+    {
+      "name": "British Airways",
+      "slug": "british-airways",
+      "aliases": [
+        "BA"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.britishairways.com",
+      "intro": "British Airways is the UK flag carrier and a oneworld founding member, hubbed at London\nHeathrow with significant operations from London Gatwick and London City. The carrier's\nExecutive Club loyalty program (Avios) is a transfer partner of Amex Membership Rewards,\nChase Ultimate Rewards, Capital One miles, Bilt, and Citi ThankYou Points, which makes\nAvios one of the most liquid airline currencies for transatlantic and short-haul oneworld\nredemptions. British Airways tickets code as airlines/airfare, earning airfare bonuses fully.\n"
+    },
+    {
+      "name": "Buc-ee's",
+      "slug": "buc-ees",
+      "aliases": [
+        "Bucees"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://buc-ees.com",
+      "intro": "Buc-ee's is a Texas-born travel center chain known for enormous footprints (often 50+\ngas pumps and 50,000+ square feet of store), branded jerky and snacks, and a cult road\ntrip following. The chain has been expanding aggressively into the Southeast and\nbeyond. Fuel purchases at Buc-ee's pumps code as gas, while everything bought inside\n(food, apparel, souvenirs) typically codes as convenience store or general\nmerchandise. Buc-ee's does not run its own credit card, so a strong gas-category card\nis the cleanest way to earn rewards at the pump.\n"
+    },
+    {
+      "name": "Buckle",
+      "slug": "buckle",
+      "aliases": [
+        "The Buckle"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.buckle.com",
+      "intro": "Buckle is a denim-led specialty apparel chain with about 440 U.S. stores, heavily\nweighted toward the Midwest and South and known for carrying premium jean brands. The\nBuckle Black Card store credit card from Comenity offers rewards on Buckle purchases\nand is paired with the free B-Rewards program. General-purpose cards usually code\nBuckle as department store at the register and online shopping for buckle.com orders.\n"
     },
     {
       "name": "Budget",
@@ -427,6 +796,55 @@
       "intro": "Burlington is a U.S. off-price retail chain with about 1,000 stores selling\napparel, home, and baby goods at discount prices. Codes as department stores on\nmost cards. There's no co-branded Burlington credit card, so the strongest\npairings are department-store-bonus or flat-rate cashback cards. Burlington\ndoesn't run a high-volume loyalty program.\n"
     },
     {
+      "name": "California Pizza Kitchen",
+      "slug": "california-pizza-kitchen",
+      "aliases": [
+        "CPK"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.cpk.com",
+      "intro": "California Pizza Kitchen operates about 170 casual-dining restaurants known for hearth-baked\npizzas with creative toppings like the original BBQ Chicken, Thai Chicken, and California\nVeggie, plus a broader menu of pastas and entree salads. CPK transactions, whether dine-in,\ntakeout, or through CPK Rewards online ordering, code as restaurants/dining. That means\ncards offering elevated dining multipliers (Amex Gold at 4x Membership Rewards, Chase\nSapphire Reserve at 4x Ultimate Rewards, Capital One SavorOne at 3% cash) earn full rate.\n"
+    },
+    {
+      "name": "Carhartt",
+      "slug": "carhartt",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.carhartt.com",
+      "intro": "Carhartt is a private, family-owned workwear brand based in Dearborn, Michigan, with\nabout 30 company stores plus wide distribution through Tractor Supply, farm and ranch\nretailers, and carhartt.com. Most cards code direct purchases at company stores or the\nwebsite as department store or online shopping, while buying Carhartt at a tractor or\nfarm supply retailer typically codes under that merchant's category. There is no\nCarhartt branded credit card today.\n"
+    },
+    {
+      "name": "Caribou Coffee",
+      "slug": "caribou-coffee",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.cariboucoffee.com",
+      "intro": "Caribou Coffee, founded in Minnesota in 1992, runs about 700 cafes concentrated in the Upper\nMidwest plus a growing licensed presence in airports, hospitals, and grocery stores.\nSignature drinks include the Caribou Cooler frozen blends, Northern Lite sugar-free options,\nand seasonal Pumpkin White Mocha. Every Caribou purchase, whether at a corporate cafe or\nthrough the Caribou Perks app, codes as dining. That means strong dining cards (Amex Gold\n4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3% unlimited) all hit the full bonus.\n"
+    },
+    {
+      "name": "Carl's Jr.",
+      "slug": "carls-jr",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.carlsjr.com",
+      "intro": "Carl's Jr. is the western US half of CKE Restaurants, known for charbroiled burgers like\nthe Western Bacon Cheeseburger and the Famous Star. The chain runs about 1,000 domestic\nlocations, mostly west of the Mississippi, alongside sister brand Hardee's in the east.\nIn-store, drive-thru, and Carl's Jr. app purchases all code as fast-food/restaurants on\nevery credit card network, so cards paying elevated rates on dining (Chase Sapphire\nPreferred at 3x, Amex Gold at 4x, Capital One Savor at 3%) all earn their full bonus here.\n"
+    },
+    {
+      "name": "CarMax",
+      "slug": "carmax",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.carmax.com",
+      "intro": "CarMax is the largest used-car retailer in the United States, with over 240\nstores and a national online buying platform at carmax.com. The company offers\nno-haggle pricing, seven-day returns, and home delivery on used vehicles. Credit\ncards generally cap how much can go toward a vehicle purchase, with $1,000 to\n$5,000 typical limits, and the transaction codes as a vehicle dealer rather than a\nrewards category.\n\nDown payments at CarMax are useful for clearing signup bonus minimums on cards like\nthe Chase Sapphire Preferred or Amex Gold. Some cardholders also use CarMax for\nmanufactured spend on Visa or Mastercard rewards cards. Service and parts visits at\nCarMax service centers code separately and may earn standard retail rates.\n"
+    },
+    {
       "name": "Carnival Cruise Line",
       "slug": "carnival-cruise",
       "aliases": [
@@ -438,6 +856,46 @@
       ],
       "website": "https://www.carnival.com",
       "intro": "Carnival Cruise Line is the largest U.S. cruise operator by passenger volume,\nowned by Carnival Corporation (which also owns Princess, Holland America, and\nCunard). Cruise bookings code as travel on every card we track. Pre-booked\nshore excursions, drink packages, and gratuities purchased through the cruise\nline generally code as travel as well. Onboard charges (folio purchases) often\ncode as travel but sometimes as cruise-specific — worth confirming on a small\ncharge before relying on a 3x travel multiplier.\n"
+    },
+    {
+      "name": "Carvana",
+      "slug": "carvana",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.carvana.com",
+      "intro": "Carvana is an online-only used-car retailer known for its glass-block car vending\nmachine towers and same-week home delivery model. Customers shop, finance, and\nbuy entirely through carvana.com or the Carvana app. Credit cards are accepted only\nfor down payments, typically capped around $2,000 to $5,000, and the charge codes\nas a vehicle dealer rather than online shopping.\n\nCarvana down payments work well for clearing signup bonus minimums on cards like\nthe Capital One Venture X or the Citi Strata Premier. Cards with selectable online\nshopping categories generally do not capture Carvana transactions because of the\nvehicle dealer MCC, so flat-rate earners like the Citi Double Cash often produce\nthe most predictable rewards.\n"
+    },
+    {
+      "name": "Casey's",
+      "slug": "caseys",
+      "aliases": [
+        "Casey's General Store"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.caseys.com",
+      "intro": "Casey's is a Midwest convenience-store and pizza giant with more than 2,600 locations\nacross 17 states, anchored in Iowa and the surrounding farm belt. Fuel pumps code as\ngas, while in-store purchases (including the famously good made-to-order pizza) can\ncode as convenience or restaurant depending on the location. Casey's runs its own\nCasey's Rewards loyalty program and issues a Casey's Visa co-brand card with elevated\nearn on Casey's purchases, including pizza and gas at the pump.\n"
+    },
+    {
+      "name": "Casper",
+      "slug": "casper",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://casper.com",
+      "intro": "Casper is a direct-to-consumer mattress brand that helped define the bed-in-a-box\ncategory, with foam, hybrid, and Wave mattress lines plus pillows, sheets, and\nbedroom furniture. Most Casper purchases happen online at casper.com, which means\nrewards cards that pay bonuses for online shopping see the most upside.\n\nBank of America Customized Cash and U.S. Bank Cash+ can route Casper orders into a\nselectable 5 percent online shopping category, while the Capital One SavorOne pays\n3 percent on entertainment, dining, and streaming but only base earn on mattresses.\nCasper occasionally appears in shopping portals like Rakuten or Capital One\nShopping, where portal cash back can stack with credit card rewards.\n"
+    },
+    {
+      "name": "CB2",
+      "slug": "cb2",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.cb2.com",
+      "intro": "CB2 is the modern, design-forward offshoot of Crate & Barrel under Otto family-owned\nEuromarket Designs, with about 25 U.S. stores plus cb2.com selling contemporary\nfurniture, lighting, and decor. The Crate & Barrel credit card from Comenity covers\nCB2 purchases too and earns rewards across the family of brands. General-purpose\ncards typically code CB2 as home improvement or department store in person and\nonline shopping for web orders.\n"
     },
     {
       "name": "Chevron",
@@ -531,6 +989,15 @@
       "intro": "Choice Hotels operates roughly 7,500 properties worldwide, dominated by mid-scale and\neconomy brands — Comfort Inn, Quality Inn, Sleep Inn, Clarion — with the Cambria and\nAscend Hotel Collection covering its upscale push. The 2022 acquisition of Radisson\nAmericas folded Country Inn & Suites and Park Plaza into Choice Privileges, broadening\nthe footprint considerably. Award nights start as low as 6,000 points, and the program\nis one of the better economy-tier values on a cents-per-point basis. The Wells Fargo\nChoice Privileges co-brand cards earn elevated points on Choice stays and gas, with\nthe Select tier adding automatic Platinum elite status and an annual bonus night.\nDirect bookings earn points; OTA stays do not.\n"
     },
     {
+      "name": "Cinnabon",
+      "slug": "cinnabon",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.cinnabon.com",
+      "intro": "Cinnabon, part of the Focus Brands family alongside Auntie Anne's and Jamba, operates more\nthan 1,500 worldwide bakeries famous for the Classic Roll, MiniBon, and Cinnabon Stix made\nwith Makara cinnamon. Most US locations are in malls, airports, and travel plazas. Every\nCinnabon purchase codes as a dining/restaurant transaction, so dining bonus cards return\ntheir full rate here. Amex Gold earns 4x Membership Rewards, Chase Sapphire Preferred earns\n3x, and the Capital One SavorOne earns 3% cash back on every cinnamon roll order.\n"
+    },
+    {
       "name": "Circle K",
       "slug": "circle-k",
       "categories": [
@@ -538,6 +1005,50 @@
       ],
       "website": "https://www.circlek.com",
       "intro": "Circle K is one of the largest U.S. convenience-store chains, with about 7,000\ndomestic locations operating both branded fuel and convenience retail. Fuel\npurchases code as gas on every card we track; in-store purchases code as\nconvenience or grocery depending on the bank. The Inner Circle membership\n($1.99/mo) layers on per-gallon discounts and is usually a stronger rebate per\nvisit than any Circle K-specific credit card.\n"
+    },
+    {
+      "name": "Citgo",
+      "slug": "citgo",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.citgo.com",
+      "intro": "Citgo operates roughly 4,200 branded gas stations across the United States, owned by\nVenezuelan state oil company PDVSA. Fuel at Citgo pumps codes as gas for credit card\nnetworks, so any gas category bonus card will earn its full rate. The Citgo Rewards\nCard (issued by Citibank Retail Services) offers a small per-gallon discount or\nstatement credit on Citgo fuel and a sign-up bonus, though a general-purpose 3-5x gas\ncard from a major issuer will typically out-earn the closed-loop product.\n"
+    },
+    {
+      "name": "Coach",
+      "slug": "coach",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.coach.com",
+      "intro": "Coach is the flagship leather goods brand of Tapestry Inc, which also owns Kate Spade\nand Stuart Weitzman. The U.S. footprint includes around 360 full-price and outlet\nstores plus coach.com. Direct purchases typically code as department store in person\nand online shopping for web orders, while Coach handbags bought at Macy's, Nordstrom,\nor Bloomingdale's code under those host retailers. The free Coach Insider loyalty\nprogram stacks with credit card multipliers.\n"
+    },
+    {
+      "name": "Cold Stone Creamery",
+      "slug": "cold-stone-creamery",
+      "aliases": [
+        "Cold Stone"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.coldstonecreamery.com",
+      "intro": "Cold Stone Creamery runs about 1,000 US shops centered on premium ice cream that's mixed\non a frozen granite stone with customer-selected mix-ins, plus signature Creations like\nBirthday Cake Remix, Founder's Favorite, and Strawberry Blonde. Cold Stone is part of the\nKahala Brands portfolio. Every Cold Stone transaction codes as dining/restaurants, including\nice cream cakes ordered through the My Cold Stone Club app. Dining-bonus cards like the Amex\nGold (4x), Chase Sapphire Preferred (3x), and Capital One SavorOne (3% cash) earn full rate.\n"
+    },
+    {
+      "name": "Columbia Sportswear",
+      "slug": "columbia-sportswear",
+      "aliases": [
+        "Columbia"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.columbia.com",
+      "intro": "Columbia Sportswear is a Portland, Oregon outdoor apparel and footwear company that\nalso owns Mountain Hardwear, Sorel, and prAna. Direct sales run through roughly 130\nbranded and outlet stores plus columbia.com, while a heavy wholesale footprint puts\nColumbia gear in REI, Dick's, and big-box sporting goods. Direct purchases typically\ncode as department store or online shopping. The free Greater Rewards loyalty program\nstacks with credit card multipliers.\n"
     },
     {
       "name": "Costco",
@@ -564,6 +1075,18 @@
       "intro": "Costco Wholesale runs about 600 warehouses worldwide and a sizable online catalog at\ncostco.com. The pricing model revolves around member-only bulk buying, so card choice\nmatters most for people running weekly grocery and gas trips through the warehouse. Two\nquirks worth knowing: Costco accepts only Visa cards in-warehouse (no Mastercard, Amex,\nor Discover), and Costco gas pumps code as wholesale clubs — not gas — so a 5% gas card\nwill not trigger at the pump here.\n"
     },
     {
+      "name": "Cracker Barrel",
+      "slug": "cracker-barrel",
+      "aliases": [
+        "Cracker Barrel Old Country Store"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.crackerbarrel.com",
+      "intro": "Cracker Barrel Old Country Store operates about 660 restaurants in 45 states, pairing a\nSouthern country-style restaurant with an attached retail country store stocked with candy,\ntoys, and home goods. Menu staples include Chicken n Dumplins, Hashbrown Casserole, and\nSunday Homestyle Chicken. Restaurant charges code as dining; retail-store purchases generally\ncode as general merchandise/department stores. Dining cards like Amex Gold (4x), Chase\nSapphire Preferred (3x), and Capital One SavorOne (3% cash) hit the full bonus on meals.\n"
+    },
+    {
       "name": "Crate & Barrel",
       "slug": "crate-and-barrel",
       "aliases": [
@@ -577,6 +1100,34 @@
       "intro": "Crate & Barrel is a U.S. home furnishings retailer with about 100 stores plus\nthe CB2 modern-design sister brand. In-store charges code as furniture; online\norders code as online shopping. The Crate & Barrel Credit Card and Reward\nMastercard issue percent-back in store credit on Crate & Barrel-family purchases;\nthe Reward Mastercard adds a flat rate on everyday spend. Pair otherwise with\nan online-shopping-bonus card.\n"
     },
     {
+      "name": "Crocs",
+      "slug": "crocs",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.crocs.com",
+      "intro": "Crocs Inc is a Broomfield, Colorado footwear company best known for its foam clogs and\nJibbitz charms, plus the HEYDUDE acquisition. The U.S. footprint includes about 150\noutlet and full-price stores along with a strong DTC business at crocs.com. Direct\npurchases typically code as department store in person and online shopping for web\norders. The free Crocs Club loyalty program offers points and member discounts that\nstack with credit card rewards.\n"
+    },
+    {
+      "name": "Culver's",
+      "slug": "culvers",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.culvers.com",
+      "intro": "Culver's is a Wisconsin-based quick-service chain known for ButterBurgers, fresh\nfrozen custard with a rotating Flavor of the Day, and Wisconsin cheese curds. The\nfamily-owned business operates over 950 restaurants concentrated in the Midwest\nand Sun Belt. Culver's transactions code as restaurants on all major credit card\nnetworks, which makes them eligible for standard dining bonus categories.\n\nThe Amex Gold leads on Culver's spending at 4x points per dollar on U.S.\nrestaurants, while the Chase Sapphire Reserve and Capital One Savor both pay 3x or\nmore on dining. No-annual-fee dining cards including the Capital One SavorOne and\nWells Fargo Autograph each earn 3 percent or 3x on restaurants, which makes them\npractical defaults for everyday Culver's visits and family dinners.\n"
+    },
+    {
+      "name": "Cumberland Farms",
+      "slug": "cumberland-farms",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.cumberlandfarms.com",
+      "intro": "Cumberland Farms is a Northeast U.S. convenience and gas chain with about 600 stores\nacross New England, New York, Florida, and parts of the Mid-Atlantic, now operated by\nEG Group. Fuel at Cumberland Farms pumps codes as gas, so any gas category bonus card\nwill earn its multiplier. The chain's signature SmartPay program is an ACH-linked\ndebit option offering a flat 10 cents per gallon discount, which generally beats most\ncredit-card gas rewards in absolute cents-per-gallon terms but does not earn credit\ncard points.\n"
+    },
+    {
       "name": "CVS",
       "slug": "cvs",
       "aliases": [
@@ -587,6 +1138,18 @@
       ],
       "website": "https://www.cvs.com",
       "intro": "CVS is the largest U.S. pharmacy chain by store count (about 9,000 locations) and a\nmajor convenience-goods retailer alongside the prescription business. CVS codes as a\ndrugstore on every card we track, so any 3-5% drugstore-category card will earn here.\nCVS's own ExtraCare loyalty program runs in parallel and stacks with card cashback.\n"
+    },
+    {
+      "name": "Dairy Queen",
+      "slug": "dairy-queen",
+      "aliases": [
+        "DQ"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.dairyqueen.com",
+      "intro": "Dairy Queen is the Berkshire Hathaway-owned QSR with more than 4,300 US locations split\nbetween traditional treat-only stores and full-menu DQ Grill & Chill outlets serving Blizzards,\nsoft-serve cones, dipped cones, burgers, and chicken strip baskets. Whether you order at a\nwalk-up window, drive-thru, or through the DQ Rewards mobile app, the transaction codes as\ndining/restaurants. Cards with strong dining multipliers (Amex Gold at 4x, Chase Sapphire\nPreferred at 3x, Capital One SavorOne at 3% cash) all earn at the full bonus rate on DQ.\n"
     },
     {
       "name": "Delta Air Lines",
@@ -609,6 +1172,15 @@
       "intro": "Delta Air Lines runs one of the strongest U.S. domestic networks and the SkyMiles\nloyalty program. Delta tickets code as airfare across all major cards. Co-branded\nSkyMiles Amex cards add extra miles per dollar on Delta plus perks like a free\nchecked bag, Sky Club access (Reserve only), and Medallion-status boost spend.\nGeneral travel cards usually beat them on raw cash-equivalent value, but the\nReserve's lounge access and MQD-waiver path can swing the math for frequent flyers.\nOTA bookings still earn miles when your SkyMiles number is attached.\n"
     },
     {
+      "name": "Denny's",
+      "slug": "dennys",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.dennys.com",
+      "intro": "Denny's operates roughly 1,500 US diners famous for 24-hour service, the Grand Slam breakfast,\nMoons Over My Hammy, and a value-driven all-day menu that draws road-trippers, third-shift\nworkers, and late-night crowds. Most Denny's are highway-adjacent or in travel-corridor\nsuburbs. Denny's transactions code as dining/restaurants on every credit card, including\norders through the Denny's Rewards app and Denny's On Demand delivery portal. Dining-bonus\ncards earn full rate: Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne 3%.\n"
+    },
+    {
       "name": "Dick's Sporting Goods",
       "slug": "dicks-sporting-goods",
       "aliases": [
@@ -621,6 +1193,27 @@
       ],
       "website": "https://www.dickssportinggoods.com",
       "intro": "Dick's Sporting Goods is the largest U.S. sporting goods retailer with about\n720 namesake stores plus Public Lands, Field & Stream, Going Going Gone, and\nGolf Galaxy banners. In-store charges code as department stores; online orders\ncode as online shopping. The free ScoreCard loyalty program issues 1 point per\n$1 plus periodic 2-3x bonus events redeemable for store credit, stackable with\ncard bonuses. There's a Dick's-branded Synchrony credit card with 8% in-store\ncashback for cardholders.\n"
+    },
+    {
+      "name": "Dillard's",
+      "slug": "dillards",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.dillards.com",
+      "intro": "Dillard's is a mid-tier to upscale department store chain with about 270 locations\nprimarily in the South, Midwest, and Sun Belt. The merchandise mix leans heavily into\napparel, shoes, cosmetics, and home goods. Dillard's codes as a department store, so\nany department-store category bonus card will earn its multiplier. The Dillard's\nAmerican Express card (issued by Wells Fargo) offers elevated rewards on Dillard's\npurchases plus general earn elsewhere, and Dillard's also issues a closed-loop store\ncard with lower earn but more accessible approval.\n"
+    },
+    {
+      "name": "Discount Tire",
+      "slug": "discount-tire",
+      "aliases": [
+        "America's Tire"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.discounttire.com",
+      "intro": "Discount Tire, doing business as America's Tire in California, is the largest\nindependent tire and wheel retailer in the United States with more than 1,200\nstores. The chain sells passenger, truck, performance, and trailer tires plus wheels\nand TPMS service. Tire purchases generally code as auto services or general retail\nrather than as a dedicated bonus category on most cards.\n\nCards with selectable categories such as Citi Custom Cash and Bank of America\nCustomized Cash can reach tire purchases when the right category is active. A new\nset of four tires plus installation often runs $800 to $1,500, which makes\nDiscount Tire useful for clearing signup bonus minimums on cards like the Wells\nFargo Autograph or Chase Freedom Unlimited.\n"
     },
     {
       "name": "Disney+",
@@ -681,6 +1274,41 @@
       "intro": "DoorDash is the largest U.S. food-delivery service by market share, covering both\nrestaurant delivery and (via DashMart and grocery partners) household goods. Restaurant\norders code as dining/restaurants on every card we track, and several cards specifically\ncall out DoorDash for elevated dining bonuses or DashPass perks. DashMart and\ngrocery-partner orders typically code as the underlying merchant rather than as dining.\n"
     },
     {
+      "name": "Drury Hotels",
+      "slug": "drury-hotels",
+      "aliases": [
+        "Drury Inn"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.druryhotels.com",
+      "intro": "Drury Hotels is a privately held family-owned chain operating about 150 mid-tier hotels\nconcentrated across the Midwest, South, and Southwest under the Drury Inn, Drury Inn & Suites,\nDrury Plaza Hotel, and Pear Tree Inn brands. The chain is best known for the 5:30 Kickback\nhot food and drinks reception and free hot breakfast included with every stay. Drury charges\ncode as lodging/hotels on every card. Cards with hotel bonuses (Chase Sapphire Reserve 4x on\ndirect, Amex Platinum 5x on Amex Travel prepaid, Capital One Venture X 2x base) earn full rate.\n"
+    },
+    {
+      "name": "DSW",
+      "slug": "dsw",
+      "aliases": [
+        "Designer Shoe Warehouse"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.dsw.com",
+      "intro": "DSW, short for Designer Shoe Warehouse, is the flagship footwear retailer of Designer\nBrands Inc, with around 500 U.S. stores and dsw.com. The DSW VIP loyalty program is\nfree, offers tiered rewards and a birthday gift, and stacks with credit card earnings.\nThe DSW Visa from Comenity adds elevated points on DSW spend and a base earn rate\neverywhere else, while general purpose cards code DSW as department store in person\nand online shopping on the web.\n"
+    },
+    {
+      "name": "Duane Reade",
+      "slug": "duane-reade",
+      "categories": [
+        "drugstores"
+      ],
+      "website": "https://www.duanereade.com",
+      "intro": "Duane Reade is the New York City banner of Walgreens, with roughly 250 locations\nconcentrated in the five boroughs and surrounding suburbs. The format is essentially\na Walgreens drugstore adapted to dense urban real estate, often with a heavier prepared\nfood and convenience selection. Duane Reade codes as a drugstore, so any drugstore\ncategory bonus card (Amex Blue Cash Preferred, Citi Custom Cash on drugstores) will\nearn its full multiplier. The myWalgreens loyalty program works at Duane Reade\nregisters as well.\n"
+    },
+    {
       "name": "Dunkin'",
       "slug": "dunkin",
       "aliases": [
@@ -695,6 +1323,18 @@
       "intro": "Dunkin' is a U.S. coffee-and-donut chain with about 9,000 domestic locations.\nCharges code as dining on every card we track, so any restaurant-bonus card\napplies — Amex Gold's 4x dining (capped), Capital One SavorOne's 3%, Sapphire\nPreferred's 3x. Heavy regulars also use the free DD Perks/Dunkin' Rewards app\nfor free drinks and bonus-point promotions, which stack on top of card bonuses.\n"
     },
     {
+      "name": "Dutch Bros",
+      "slug": "dutch-bros",
+      "aliases": [
+        "Dutch Bros Coffee"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.dutchbros.com",
+      "intro": "Dutch Bros Coffee has grown from a single Oregon pushcart in 1992 to more than 950 drive-thru\ncoffee shops across roughly 18 states, with a menu that leans heavily on flavored Rebel\nenergy drinks, blended Freezes, and customizable lattes. Every Dutch Bros purchase codes as\ndining/restaurants regardless of whether you swipe in the drive-thru lane or reload your\nDutch Rewards account in the app. Cards with strong dining multipliers (Amex Gold at 4x,\nCapital One SavorOne at 3%, Chase Sapphire Preferred at 3x) all earn full bonus rewards.\n"
+    },
+    {
       "name": "eBay",
       "slug": "ebay",
       "aliases": [
@@ -705,6 +1345,28 @@
       ],
       "website": "https://www.ebay.com",
       "intro": "eBay is the largest U.S. online auction and resale marketplace and codes as online\nshopping on essentially every credit card we track. Unlike Amazon, eBay rarely has a\ncard-specific bonus carve-out, so the right card here is the strongest generic\nonline-shopping earner you carry. Watch for cards with a U.S. online retail cap — eBay\npayments via PayPal still count as eBay for category coding, but third-party processor\npurchases on eBay's classifieds side may not.\n"
+    },
+    {
+      "name": "Eddie Bauer",
+      "slug": "eddie-bauer",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.eddiebauer.com",
+      "intro": "Eddie Bauer is an outdoor and casual apparel brand now under Sparc Group, with a long\ncatalog heritage, roughly 250 stores and outlets, and a steady online business at\neddiebauer.com. Direct purchases typically code as department store in person and\nonline shopping for web orders. The free Adventure Rewards loyalty program offers\npoints and birthday perks, but there is no current Eddie Bauer branded credit card in\nthe U.S. market.\n"
+    },
+    {
+      "name": "Einstein Bros. Bagels",
+      "slug": "einstein-bros-bagels",
+      "aliases": [
+        "Einstein Bros"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.einsteinbros.com",
+      "intro": "Einstein Bros. Bagels operates about 700 US bakery-cafes serving fresh-baked bagels, shmears,\negg sandwiches, and coffee, with most locations in college towns, hospital campuses, and\nsuburban shopping centers. The chain is owned by Bagel Brands alongside Bruegger's. Every\nEinstein Bros. purchase codes as dining/restaurants, including orders placed through the\nEinstein Bros. Rewards app. Cards with strong breakfast and dining bonuses (Amex Gold at 4x,\nChase Sapphire Preferred at 3x, Capital One SavorOne at 3%) all earn at full multiplier.\n"
     },
     {
       "name": "Enterprise",
@@ -746,6 +1408,29 @@
       "intro": "Expedia is one of the largest online travel agencies, owned by Expedia Group\n(which also owns Hotels.com, Vrbo, and Travelocity). Bookings code as travel on\nevery card we track. The honest catch: hotel and airline programs typically do\nNOT credit Expedia bookings toward elite-night or elite-qualifying-mile counts,\nand many properties exclude OTA stays from earning their own loyalty points —\nso booking direct usually wins for status-conscious travelers. The Expedia\nRewards Cards from Citi layer extra OneKeyCash on Expedia-family bookings.\n"
     },
     {
+      "name": "Express",
+      "slug": "express",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.express.com",
+      "intro": "Express is a mall-based apparel chain known for workwear and going out looks for men\nand women, operating through a mix of full-line stores, Express Factory Outlet, and\nexpress.com after the brand emerged from Chapter 11 restructuring. The Express Next\nstore credit card from Comenity earns A-List points on every purchase and pairs with\nthe free loyalty tier. General-purpose cards typically code Express as department\nstore at the register and online shopping for web orders.\n"
+    },
+    {
+      "name": "Extended Stay America",
+      "slug": "extended-stay-america",
+      "aliases": [
+        "ESA"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.extendedstayamerica.com",
+      "intro": "Extended Stay America operates more than 600 budget long-stay hotels across the US, each\nroom equipped with a full kitchen, dishware, and weekly housekeeping options, targeting\nbusiness travelers, contractors, and relocating families who need stays of a week or longer.\nThe chain also runs Extended Stay America Suites and Extended Stay America Premier Suites.\nESA charges code as lodging/hotels on every credit card. Hotel-bonus cards earn full rate:\nChase Sapphire Reserve at 4x direct, Capital One Venture X at 2x base, Amex Platinum at 5x prepaid.\n"
+    },
+    {
       "name": "ExxonMobil",
       "slug": "exxonmobil",
       "aliases": [
@@ -767,6 +1452,75 @@
       "intro": "ExxonMobil operates Exxon and Mobil-branded stations at about 11,500 U.S. locations,\nplus the ExxonMobil Rewards+ app for in-station discounts. ExxonMobil pumps code as gas\non every card we track, and one merchant-specific note: ExxonMobil purchases earn 3% on\nthe Apple Card when paid via Apple Pay.\n"
     },
     {
+      "name": "Family Dollar",
+      "slug": "family-dollar",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.familydollar.com",
+      "intro": "Family Dollar is a discount variety chain with roughly 8,000 stores across the U.S.,\nowned by Dollar Tree (which announced plans to sell the banner in 2025). The format\ncarries a mix of groceries, household basics, apparel, and seasonal goods at low price\npoints. Family Dollar typically codes as a discount store or department store for\ncredit card networks, not as a supermarket, so a grocery rewards card will generally\nnot earn its bonus here. A department-store or general 1.5-2% cash back card is the\npractical pick.\n"
+    },
+    {
+      "name": "Famous Footwear",
+      "slug": "famous-footwear",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.famousfootwear.com",
+      "intro": "Famous Footwear is the family footwear chain of Caleres Inc, with about 850 U.S.\nstores and famousfootwear.com, selling athletic and casual shoes from Nike, Adidas,\nSkechers, and others. The free Famously You Rewards program offers tiered cashback\nand a birthday gift, layering on top of credit card rewards. Direct purchases\ntypically code as department store at the register and online shopping for web\norders, and there is no current branded credit card.\n"
+    },
+    {
+      "name": "FedEx Office",
+      "slug": "fedex-office",
+      "aliases": [
+        "FedEx Print",
+        "Kinko's"
+      ],
+      "categories": [
+        "office_supplies"
+      ],
+      "website": "https://www.fedex.com/office",
+      "intro": "FedEx Office, formerly Kinko's, operates around 2,000 U.S. retail locations\noffering shipping, printing, copying, signage, packing, and computer rental. Most\nFedEx Office stores code as office supplies or stationery on Visa, Mastercard, and\nAmex networks, which makes spending eligible for office supply bonus categories on\nsmall business cards.\n\nThe Chase Ink Business Cash pays 5 percent on the first $25,000 in combined office\nsupplies and select utilities each year, making it the standard pick for printing\nand shipping spend. The Amex Business Gold also includes U.S. office supply\nretailers as a top-two category. Personal cards with selectable office supply\nbuckets, including U.S. Bank Cash+, can match those rates.\n"
+    },
+    {
+      "name": "Ferguson",
+      "slug": "ferguson",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.ferguson.com",
+      "intro": "Ferguson is the largest U.S. wholesale distributor of plumbing, HVAC, lighting,\nappliances, and waterworks products, with over 1,600 locations including Ferguson\nBath, Kitchen & Lighting Gallery showrooms. Many Ferguson locations code as home\nimprovement on credit card networks, which makes large remodel and new construction\npurchases eligible for home improvement bonus categories.\n\nCards like the U.S. Bank Cash+ with home improvement selected and the Bank of\nAmerica Customized Cash can earn 3 to 5 percent on Ferguson invoices. Kitchen and\nbath renovations frequently run five figures, which makes the retailer useful for\nclearing premium signup bonus minimums on the Capital One Venture X or the Chase\nSapphire Reserve.\n"
+    },
+    {
+      "name": "Firehouse Subs",
+      "slug": "firehouse-subs",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.firehousesubs.com",
+      "intro": "Firehouse Subs is a Jacksonville-based sub sandwich chain with over 1,200\nrestaurants across the United States, owned by Restaurant Brands International\nalongside Burger King and Popeyes. The chain is known for steamed meat subs like\nthe Hook & Ladder and Italian, plus the Firehouse Subs Public Safety Foundation\nthat funds first responder equipment. Transactions code as restaurants on most\ncredit card networks.\n\nThe Amex Gold earns 4x on U.S. restaurants, the highest baseline rate available\non Firehouse Subs orders, while the Chase Sapphire Reserve pays 3x on dining. No\nannual fee dining picks include the Capital One SavorOne at 3 percent and Wells\nFargo Autograph at 3x. The Firehouse Rewards program adds points that stack with\ncredit card cash back, and rounding up at the register supports the Foundation.\n"
+    },
+    {
+      "name": "First Watch",
+      "slug": "first-watch",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.firstwatch.com",
+      "intro": "First Watch operates more than 540 daytime-only restaurants serving breakfast, brunch, and\nlunch, with menu staples like Avocado Toast, the Chickichanga, lemon-ricotta pancakes, and\nfresh-pressed juices. Locations close mid-afternoon, distinguishing First Watch from all-day\nbreakfast chains like IHOP and Denny's. First Watch transactions code as dining/restaurants\non every US card. Dining-bonus cards earn full rate: Amex Gold at 4x Membership Rewards,\nChase Sapphire Preferred at 3x, Chase Sapphire Reserve at 4x, Capital One SavorOne at 3% cash.\n"
+    },
+    {
+      "name": "Five Below",
+      "slug": "five-below",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.fivebelow.com",
+      "intro": "Five Below is a discount retailer with more than 1,700 stores across the U.S., built\naround items priced at $5 or less, plus a Five Beyond section with goods up to $25.\nThe merchandise mix skews toward tweens and teens (candy, tech accessories, beauty,\nhobby, seasonal). Stores typically code as a discount or department store for credit\ncard networks, so a department-store category bonus card can earn its multiplier\nhere. Five Below does not issue its own credit card, so a general 2-5% category card\nis the cleanest play.\n"
+    },
+    {
       "name": "Five Guys",
       "slug": "five-guys",
       "categories": [
@@ -776,6 +1530,16 @@
       "intro": "Five Guys is a U.S. fast-casual burger chain with about 1,700 domestic locations,\nknown for hand-formed patties and unlimited toppings. Charges code as dining on\nevery card we track, so any dining-bonus card applies (Amex Gold 4x within cap,\nSapphire Preferred 3x, SavorOne 3%). Average ticket sizes are higher than typical\nfast-food, which makes the dining multiplier more meaningful per visit.\n"
     },
     {
+      "name": "Floor & Decor",
+      "slug": "floor-and-decor",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.flooranddecor.com",
+      "intro": "Floor & Decor is a hard surface flooring warehouse with over 240 U.S. stores\ncarrying tile, wood, laminate, vinyl, stone, and installation accessories at\ncontractor-friendly pricing. The retailer generally codes as home improvement on\nVisa, Mastercard, and Amex networks, which means it can earn the home improvement\nbonus on cards that include the category.\n\nU.S. Bank Cash+ can deliver 5 percent on Floor & Decor when home improvement is one\nof the two selected categories, and the Bank of America Customized Cash offers a\nsimilar 3 percent. Floor & Decor PRO members can layer trade discounts on top of\ncredit card rewards, and large flooring projects easily clear signup bonus minimums.\n"
+    },
+    {
       "name": "Food Lion",
       "slug": "food-lion",
       "categories": [
@@ -783,6 +1547,39 @@
       ],
       "website": "https://www.foodlion.com",
       "intro": "Food Lion is a Southeastern U.S. grocery chain with about 1,100 stores, owned by\nAhold Delhaize. Codes cleanly as groceries on every card we track. Strongest\npairings are Blue Cash Preferred (6% on U.S. supermarkets), the Capital One SavorOne\n(3% groceries), and U.S. Bank Shopper Cash Rewards if Food Lion is one of the two\nselected retailers. The MVP loyalty program runs separate digital coupons that\nstack on top of any card's bonus rate.\n"
+    },
+    {
+      "name": "Foot Locker",
+      "slug": "foot-locker",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.footlocker.com",
+      "intro": "Foot Locker is the flagship sneaker and athletic apparel banner of Foot Locker Inc,\nwhich also runs Champs Sports, Kids Foot Locker, and WSS. The chain operates about\n900 U.S. stores plus footlocker.com. The FLX Rewards Visa from Bread Financial earns\nelevated XPoints on FLX-family purchases that can be redeemed for sneaker drops and\nshoes. General-purpose cards code Foot Locker as department store in person and online\nshopping for web orders.\n"
+    },
+    {
+      "name": "Forever 21",
+      "slug": "forever-21",
+      "aliases": [
+        "Forever21"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.forever21.com",
+      "intro": "Forever 21 is a fast fashion chain operated under Sparc Group with about 380 U.S.\nstores plus forever21.com after returning from bankruptcy in 2020. Pricing skews very\nlow so category bonuses matter less in absolute dollars, but most cards still code in\nperson purchases as department store and web orders as online shopping. There is no\ncurrent Forever 21 branded credit card, so the free F21 Rewards program is the only\nstacking option beyond credit card rewards.\n"
+    },
+    {
+      "name": "Free People",
+      "slug": "free-people",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.freepeople.com",
+      "intro": "Free People is the bohemian women's brand under URBN and includes the FP Movement\nactivewear line, with roughly 150 retail stores plus a sizeable online presence at\nfreepeople.com. Most credit cards code in-store transactions as department store and\nweb orders as online shopping. Free People does not currently issue a co-brand credit\ncard, so shoppers usually optimize with rotating category cards or a flat-rate\nonline-shopping multiplier.\n"
     },
     {
       "name": "Frontier Airlines",
@@ -818,6 +1615,16 @@
       "intro": "Gap is a U.S. apparel retailer with about 500 domestic stores plus a sister\nbrand portfolio (Old Navy, Banana Republic, Athleta) under Gap Inc. In-store\ncharges code as department stores or apparel; gap.com codes as online shopping.\nThe Gap Good Rewards co-branded Mastercard offers tiered cashback at Gap-family\nbrands. For non-cardholders, an online-shopping-bonus card or U.S. Bank Shopper\nCash Rewards (if Gap is selected) is the strongest pairing.\n"
     },
     {
+      "name": "Giant Eagle",
+      "slug": "giant-eagle",
+      "categories": [
+        "groceries",
+        "gas"
+      ],
+      "website": "https://www.gianteagle.com",
+      "intro": "Giant Eagle is a Pittsburgh-based supermarket chain with roughly 200 stores across\nPennsylvania, Ohio, West Virginia, Indiana, and Maryland, plus its GetGo fuel and\nconvenience arm. The supermarkets code as U.S. groceries (full multiplier for Amex\nGold, Blue Cash Preferred, Citi Custom Cash), while GetGo gas stations typically code\nas gas. The chain's fuelperks+ program lets shoppers turn grocery spend into pennies\noff per gallon at GetGo, which can stack with a gas-category card at the pump.\n"
+    },
+    {
       "name": "Giant Food",
       "slug": "giant-food",
       "aliases": [
@@ -828,6 +1635,39 @@
       ],
       "website": "https://giantfood.com",
       "intro": "Giant Food is the Mid-Atlantic flagship of Ahold Delhaize's U.S. grocery group, with\nabout 165 stores across DC, Maryland, Virginia, and Delaware. Codes cleanly as\ngroceries on every card we track. Best pairings are Blue Cash Preferred (6%),\nCapital One SavorOne (3%), and U.S. Bank Shopper Cash Rewards (6% if selected).\nThe Giant Flexible Rewards program issues per-gallon fuel savings at participating\nShell and Giant stations that stack on top of card bonuses.\n"
+    },
+    {
+      "name": "GOAT",
+      "slug": "goat",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.goat.com",
+      "intro": "GOAT is a sneaker and apparel resale marketplace operated by GOAT Group, which also\nruns Flight Club. The platform authenticates every shoe and item before shipping to\nthe buyer, and lists both new and used pairs from hyped releases alongside everyday\nretro and lifestyle styles. GOAT codes as online shopping for credit card networks,\nso an online-shopping category bonus card will earn its full multiplier. Buyer fees\nare added at checkout and post to the card as part of the transaction total.\n"
+    },
+    {
+      "name": "Grubhub",
+      "slug": "grubhub",
+      "aliases": [
+        "GrubHub"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.grubhub.com",
+      "intro": "Grubhub is one of the three major US food-delivery marketplaces alongside DoorDash and Uber\nEats, connecting customers to roughly 365,000 restaurants and operating Seamless in the\nNortheast under the same parent. Grubhub charges code as dining/restaurants on most card\nnetworks, which means dining-bonus cards earn full rate. Amex Gold pays 4x Membership Rewards,\nChase Sapphire Reserve pays 4x Ultimate Rewards, and the Capital One SavorOne pays 3% cash.\nSeveral cards also offer Grubhub-specific credits or Grubhub+ memberships as a perk.\n"
+    },
+    {
+      "name": "H Mart",
+      "slug": "h-mart",
+      "aliases": [
+        "HMart"
+      ],
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.hmart.com",
+      "intro": "H Mart is the largest Korean-American supermarket chain in the U.S., with roughly 100\nstores concentrated in major metros with significant Asian-American populations\n(Northeast, California, Texas, Georgia, Pacific Northwest). The chain specializes in\nKorean and broader East Asian grocery, fresh seafood, and prepared foods, and most\nlocations include a food court. H Mart codes as a U.S. supermarket, so grocery\ncategory bonus cards (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earn their\nfull multiplier at the register.\n"
     },
     {
       "name": "H-E-B",
@@ -857,6 +1697,15 @@
       "intro": "H&M is a Swedish-headquartered fast-fashion chain with about 540 U.S. stores.\nIn-store charges code as department stores or apparel; hm.com codes as online\nshopping. The H&M Member program is free and issues birthday gifts plus tiered\nperks; H&M's co-branded U.S. credit card layers an additional discount on top\nof the loyalty program. For non-cardholders, an online-shopping-bonus card is\nthe strongest pairing.\n"
     },
     {
+      "name": "Half Price Books",
+      "slug": "half-price-books",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hpb.com",
+      "intro": "Half Price Books is a Dallas-based used and new book retailer with over 120 stores\nacross the United States, also selling vinyl records, movies, video games, and\ncollectibles. The chain is known for buying back books, music, and games from\ncustomers in addition to its retail operation. Purchases typically code as bookstore\nor general retail on most credit card networks.\n\nCards with selectable categories can sometimes capture bookstore purchases. U.S.\nBank Cash+ includes bookstores as one of its selectable 5 percent categories, which\ncan deliver meaningful value for heavy readers. Online orders at hpb.com may also\ntrigger online shopping bonuses on cards like Bank of America Customized Cash and\nChase Freedom Flex during rotating online quarters.\n"
+    },
+    {
       "name": "Hannaford",
       "slug": "hannaford",
       "aliases": [
@@ -867,6 +1716,28 @@
       ],
       "website": "https://www.hannaford.com",
       "intro": "Hannaford is a New England grocery chain with about 185 stores, owned by Ahold\nDelhaize. Codes cleanly as groceries on every card we track. Strongest pairings\nare Blue Cash Preferred (6%), Capital One SavorOne (3% groceries with no cap),\nand U.S. Bank Shopper Cash Rewards (6% on selected retailers). Hannaford runs\nthe My Hannaford Rewards program with personalized digital coupons on top of\nany card's earn rate.\n"
+    },
+    {
+      "name": "Harbor Freight Tools",
+      "slug": "harbor-freight",
+      "aliases": [
+        "Harbor Freight"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.harborfreight.com",
+      "intro": "Harbor Freight Tools is a discount tool retailer with over 1,500 U.S. stores selling\nhand tools, power tools, generators, and shop equipment under house brands such as\nBauer, Hercules, and Icon. Most card networks code Harbor Freight as a home\nimprovement merchant, which means cards with a home improvement bonus like the Wells\nFargo Bilt can earn elevated rewards on purchases.\n\nThe Harbor Freight Inside Track Club membership stacks deep coupon discounts with\ncredit card rewards, and online orders through harborfreight.com may also qualify\nfor rotating online shopping bonuses on Chase Freedom Flex and Discover it. Big\ngenerator and welder purchases are useful for signup bonus spend.\n"
+    },
+    {
+      "name": "Hardee's",
+      "slug": "hardees",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.hardees.com",
+      "intro": "Hardee's is the eastern and southern US counterpart to Carl's Jr. under the CKE Restaurants\numbrella, with around 1,700 domestic locations. The menu skews toward charbroiled Thickburgers,\nMade From Scratch Biscuits at breakfast, and hand-breaded chicken tenders. Purchases at\nHardee's, including those routed through the Hardee's mobile app, code as fast-food dining,\nwhich means cards like the Capital One SavorOne (3% unlimited on dining), Chase Sapphire\nPreferred (3x), and Amex Gold (4x) earn at the full dining multiplier on every order.\n"
     },
     {
       "name": "Harris Teeter",
@@ -893,6 +1764,18 @@
         "hawaiian-airlines-world-elite-mastercard"
       ],
       "intro": "Hawaiian Airlines is the dominant carrier between the U.S. mainland and Hawaii, plus\ninter-island routes. Tickets code as airfare on every card we track. The co-branded\nHawaiian Airlines World Elite Mastercard offers a discount on round-trip companion\ntickets to Hawaii each year and bonus miles on the airline. With Alaska Airlines'\nacquisition closed, Hawaiian's loyalty program is integrating with Alaska's Mileage\nPlan, so long-term value will increasingly route through Alaska's award chart.\n"
+    },
+    {
+      "name": "HelloFresh",
+      "slug": "hellofresh",
+      "aliases": [
+        "Hello Fresh"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hellofresh.com",
+      "intro": "HelloFresh is the largest meal-kit delivery service in the United States, shipping pre-portioned\ningredients and recipe cards weekly to subscribers across most ZIP codes. The HelloFresh\ngroup also operates Factor (prepared meals), Green Chef, and EveryPlate. HelloFresh charges\ntypically code as online retail or grocery delivery, not dining or in-store groceries, which\naffects which cards earn bonus. Online-shopping bonuses (Chase Freedom Flex rotating quarters,\nDiscover it 5% categories) and flat-rate cards (Citi Double Cash 2%) are usually the best fit.\n"
     },
     {
       "name": "Hertz",
@@ -954,6 +1837,25 @@
       "intro": "Hobby Lobby is a U.S. arts-and-crafts retailer with about 1,000 stores, selling\nfabric, home decor, art supplies, and seasonal goods. In-store charges code as\ndepartment stores or specialty retail; hobbylobby.com codes as online shopping.\nHobby Lobby doesn't run a loyalty program but consistently posts a 40%-off-one-\nitem coupon that's the main rewards lever per visit. Pair with a flat-rate\ncashback card or department-store-bonus card.\n"
     },
     {
+      "name": "Hollister",
+      "slug": "hollister",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.hollisterco.com",
+      "intro": "Hollister is the teen and young adult apparel brand under Abercrombie & Fitch Co, with\na Southern California beach identity and around 500 stores worldwide. Most general\npurpose cards code Hollister purchases as department store in mall and as online\nshopping for hollisterco.com checkouts. The Club Cali loyalty program is free and\nlayers on top of credit card rewards, but Hollister does not currently offer its own\nbranded credit card.\n"
+    },
+    {
+      "name": "Home Chef",
+      "slug": "home-chef",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.homechef.com",
+      "intro": "Home Chef is the meal-kit subscription owned by Kroger since 2018, offering customizable\nrecipes including Fresh and Easy 15-minute kits, Family Menu portions, and the Express line\nof microwavable meals. Home Chef kits also sell through Kroger-banner grocery stores. When\nordered online, Home Chef charges typically code as online retail or direct food shipping\nrather than groceries or dining, so flat-rate cards (Citi Double Cash 2%, Wells Fargo Active\nCash 2%) often beat category cards. In-store purchases at Kroger code as supermarkets.\n"
+    },
+    {
       "name": "Home Depot",
       "slug": "home-depot",
       "aliases": [
@@ -976,6 +1878,16 @@
       "intro": "HomeGoods is the home-furnishings off-price chain owned by TJX Companies, with\nabout 900 U.S. stores selling discount furniture, decor, and bath. Codes as\ndepartment stores on most cards. The TJX Rewards Mastercard offers 5% back at\nHomeGoods and the rest of the TJX family. For everyone else, a department-store\ncategory card (Wells Fargo Active Cash, Citi Custom Cash if it's your top\ncategory) or flat-rate cashback card is the standard pairing.\n"
     },
     {
+      "name": "Hot Topic",
+      "slug": "hot-topic",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.hottopic.com",
+      "intro": "Hot Topic is a mall-based specialty retailer focused on pop culture apparel, music\nmerch, and fandom licensed goods, with around 600 U.S. stores plus a sister chain\nBoxLunch. The Hot Cash loyalty program runs seasonally with print and digital\ncertificates that stack with credit card rewards. Most cards code Hot Topic as\ndepartment store in person and online shopping for hottopic.com checkouts, and there\nis no Hot Topic branded credit card today.\n"
+    },
+    {
       "name": "Hotels.com",
       "slug": "hotels-com",
       "aliases": [
@@ -989,6 +1901,18 @@
       "intro": "Hotels.com is one of the largest global online travel agencies, owned by Expedia\nGroup. Bookings code as travel on every card we track. The honest catch: hotel\nchains typically do NOT credit Hotels.com stays toward elite-night or status\ncounts, and many properties exclude OTA stays from earning their loyalty points\n— so a Hilton/Marriott/Hyatt loyalist almost always books direct. Hotels.com's\nown One Key Rewards (formerly Hotels.com Rewards) is now unified with Expedia's\nOneKeyCash and stacks across the Expedia family.\n"
     },
     {
+      "name": "HSN",
+      "slug": "hsn",
+      "aliases": [
+        "Home Shopping Network"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hsn.com",
+      "intro": "HSN, the Home Shopping Network, is a multichannel retailer selling via 24-hour\ntelevision, hsn.com, and mobile, owned by Qurate Retail Group alongside sister\nbrand QVC. The product mix covers beauty, fashion, jewelry, kitchen, and home goods,\nwith a heavy emphasis on live demonstrations and host-led pitches. HSN purchases code\nas online shopping or general merchandise for credit card networks, so an\nonline-shopping category bonus card will earn its multiplier. The FlexPay installment\nprogram is available at checkout against the saved card.\n"
+    },
+    {
       "name": "Hulu",
       "slug": "hulu",
       "categories": [
@@ -996,6 +1920,15 @@
       ],
       "website": "https://www.hulu.com",
       "intro": "Hulu is a U.S. streaming-video service offering on-demand library content and a\nlive-TV bundle, owned by Disney. Monthly subscriptions code as streaming on\nevery card we track. Streaming-bonus cards (Blue Cash Preferred 6%, U.S. Bank\nCash+ 5% on selected categories) are the strongest pairings. Hulu (with-ads)\nis also bundled with Disney+ and ESPN+ as the Disney Bundle for the lowest\nper-service cost.\n"
+    },
+    {
+      "name": "Hy-Vee",
+      "slug": "hy-vee",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.hy-vee.com",
+      "intro": "Hy-Vee is a Midwest, employee-owned supermarket chain with roughly 280 stores across\nIowa, Illinois, Kansas, Minnesota, Missouri, Nebraska, South Dakota, and Wisconsin.\nStores are large-format and often include pharmacies, food courts, and Hy-Vee Fuel\nSaver gas stations in some markets. Hy-Vee supermarkets code as U.S. groceries, so any\ngrocery category card (Amex Gold, Blue Cash Preferred, Citi Custom Cash) will earn its\nposted multiplier. The Fuel Saver + Perks loyalty program is a useful supplement when\nshoppers also fill up at participating Casey's or Hy-Vee Fast & Fresh locations.\n"
     },
     {
       "name": "Hyatt",
@@ -1060,6 +1993,18 @@
       "intro": "IHG Hotels & Resorts spans about 6,000 properties across 19 brands, anchored by Holiday\nInn and Holiday Inn Express on the mass-market end and InterContinental, Regent, and\nSix Senses on the luxury end. The Chase IHG One Rewards Premier card is one of the\nhighest-leverage hotel co-brands available — its annual free-night certificate (good\nat any property up to 40,000 points) often pays back the annual fee on a single use,\nand the fourth-night-free benefit on award stays effectively cuts redemption costs by\n25%. Direct bookings at ihg.com or in-app earn points and elite-night credits; OTA\nstays generally earn nothing. Points value lands around 0.5 cents but redemptions can\nexceed that on aspirational properties.\n"
     },
     {
+      "name": "IHOP",
+      "slug": "ihop",
+      "aliases": [
+        "International House of Pancakes"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.ihop.com",
+      "intro": "IHOP, owned by Dine Brands Global alongside Applebee's, operates about 1,700 US restaurants\nbest known for buttermilk pancakes, the Rooty Tooty Fresh 'N Fruity breakfast, and a 24-hour\nservice model at many locations. The menu also covers omelets, French toast, burgers, and\ndinner entrees. IHOP transactions code as dining/restaurants whether dine-in, To Go, or\nvia the International Bank of Pancakes loyalty app. Cards with strong dining bonuses (Amex\nGold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash) earn full rate.\n"
+    },
+    {
       "name": "IKEA",
       "slug": "ikea",
       "categories": [
@@ -1068,6 +2013,18 @@
       ],
       "website": "https://www.ikea.com",
       "intro": "IKEA is the largest global home-furnishings retailer with about 50 U.S. warehouse\nstores plus a planning-studio network. In-store charges typically code as\nfurniture or home improvement; ikea.com codes as online shopping. The IKEA\nFamily loyalty program is free and issues member-only pricing plus a free\ncoffee/tea on store visits. The IKEA Visa Credit Card offers 5% back at IKEA\non purchases — typically the strongest rate for heavy buyers.\n"
+    },
+    {
+      "name": "In-N-Out Burger",
+      "slug": "in-n-out-burger",
+      "aliases": [
+        "In-N-Out"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.in-n-out.com",
+      "intro": "In-N-Out Burger is a West Coast cult favorite founded in Baldwin Park, California\nin 1948, with around 400 locations across California, Nevada, Arizona, Utah,\nTexas, Oregon, Colorado, and Idaho. The minimalist menu of Double-Doubles, fries,\nand shakes plus the off-menu Animal Style ordering is the chain's identity. In-N-Out\ntransactions code as restaurants on Visa, Mastercard, and Amex networks.\n\nDining rewards cards capture In-N-Out well. The Amex Gold earns 4x points on U.S.\nrestaurants and is the top earner for frequent visitors, while the Chase Sapphire\nReserve pays 3x. No-annual-fee dining picks include the Capital One SavorOne at 3\npercent and Wells Fargo Autograph at 3x. In-N-Out does not run a customer rewards\nprogram, so credit card rewards are the only structured path to cash back.\n"
     },
     {
       "name": "Instacart",
@@ -1097,6 +2054,40 @@
       "intro": "J.Crew is a U.S. apparel retailer with about 130 stores plus a strong online\npresence. In-store codes as department stores; jcrew.com codes as online\nshopping. The J.Crew Rewards loyalty program issues credits at spend tiers\nseparate from any card bonus. Strongest pairings are an online-shopping-bonus\ncard or flat-rate cashback for in-store purchases.\n"
     },
     {
+      "name": "Jack in the Box",
+      "slug": "jack-in-the-box",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.jackinthebox.com",
+      "intro": "Jack in the Box operates roughly 2,200 locations concentrated in the western United States,\nbuilt around a 24-hour menu that mixes burgers, tacos, breakfast sandwiches, and late-night\nmunchie meals. Drive-thru and mobile-app orders code as standard quick-service restaurants,\nso any card paying a dining bonus (3-5% on cards like the Capital One Savor or Amex Gold)\nearns full rate. The Jack app supports Apple Pay and Google Pay funding, which lets you\nstack a card's dining multiplier with mobile-wallet bonuses on cards that offer them.\n"
+    },
+    {
+      "name": "Jamba",
+      "slug": "jamba",
+      "aliases": [
+        "Jamba Juice"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.jamba.com",
+      "intro": "Jamba, rebranded from Jamba Juice and now part of Focus Brands, operates about 750 US\nlocations focused on real fruit smoothies, fresh juices, bowls, and plant-based options.\nSignature blends include the Strawberry Surf Rider, Razzmatazz, and Aloha Pineapple. Jamba\npurchases at standalone stores, mall locations, or through the Jamba app code as\ndining/restaurants. That makes any dining-bonus card a fit: the Amex Gold earns 4x Membership\nRewards, Chase Sapphire Preferred earns 3x, and the Capital One SavorOne earns 3% cash back.\n"
+    },
+    {
+      "name": "Jared",
+      "slug": "jared",
+      "aliases": [
+        "Jared The Galleria of Jewelry"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.jared.com",
+      "intro": "Jared, formally Jared The Galleria of Jewelry, is the upscale destination banner of\nSignet Jewelers, with around 240 standalone stores featuring on-site design and repair\nservices plus jared.com. The Jared Diamond credit card from Comenity offers\npromotional financing for high-ticket purchases. General-purpose cards typically code\nJared as department store in person and online shopping for web orders, and the free\nVault Rewards program is shared across Signet.\n"
+    },
+    {
       "name": "JCPenney",
       "slug": "jcpenney",
       "aliases": [
@@ -1109,6 +2100,18 @@
       ],
       "website": "https://www.jcpenney.com",
       "intro": "JCPenney is a mid-tier department store with about 660 stores and a smaller online\ncatalog at jcpenney.com. Like other mid-tier department chains, the bulk of purchases\nhappen at promotional discount, so card rewards stack on already-reduced prices.\nJCPenney codes as a department store in-store and online shopping on the website, so\ncards bonusing on either category will trigger here.\n"
+    },
+    {
+      "name": "Jersey Mike's Subs",
+      "slug": "jersey-mikes",
+      "aliases": [
+        "Jersey Mike's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.jerseymikes.com",
+      "intro": "Jersey Mike's Subs is a fast-growing sub sandwich chain founded in Point Pleasant,\nNew Jersey in 1956, with more than 2,800 locations across the United States. The\nchain is known for cold subs sliced to order, hot Philly cheesesteaks and Chicken\nPhilly options, and the annual Month of Giving charitable campaign. Transactions\ncode as restaurants on most credit card networks.\n\nThe Amex Gold leads at 4x points on U.S. restaurants and is the highest base\nearner for regular Jersey Mike's visits, while the Chase Sapphire Reserve pays 3x\non dining. No-annual-fee picks like the Capital One SavorOne at 3 percent and\nWells Fargo Autograph at 3x are practical defaults. Jersey Mike's also runs the\nShore Points loyalty program, which layers in-app rewards on top of credit card\ncash back.\n"
     },
     {
       "name": "JetBlue",
@@ -1129,6 +2132,37 @@
         "jetblue-business-card"
       ],
       "intro": "JetBlue runs an East Coast and Caribbean network with TrueBlue as its loyalty program.\nTrueBlue points are revenue-based — about 1.3 cents each — so they're easy to value\nbut rarely produce outsized award redemptions. JetBlue tickets code as airfare on\nevery card we track. The co-branded Plus and Premier cards bundle a 5,000-point\nanniversary bonus, free checked bag, and Mosaic-status accelerators that can swing\nthe math for regulars; the Premier adds a Mint upgrade benefit on transcons.\n"
+    },
+    {
+      "name": "Jiffy Lube",
+      "slug": "jiffy-lube",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.jiffylube.com",
+      "intro": "Jiffy Lube is the largest quick-lube franchise in North America with over 2,000\nservice centers offering oil changes, tire rotations, fluid services, and air\nfilter replacements. Most Jiffy Lube transactions code as auto services rather than\na dedicated rewards category, so flat-rate cards like the Citi Double Cash often\nwin on simplicity.\n\nCards with selectable categories that include auto can do better. Citi Custom Cash\npays 5 percent on the top eligible category and may capture Jiffy Lube for drivers\nwhose top monthly spend is auto services. The U.S. Bank Cash+ also offers wider\nauto-related categories. Jiffy Lube's loyalty program does not currently offer\nsignificant points that stack with credit card rewards.\n"
+    },
+    {
+      "name": "Jimmy John's",
+      "slug": "jimmy-johns",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.jimmyjohns.com",
+      "intro": "Jimmy John's is an Illinois-based sub sandwich chain known for its \"Freaky Fast\"\ndelivery, day-baked French bread, and a streamlined menu of cold subs including\nthe Vito, Turkey Tom, and Italian Night Club. The chain operates over 2,600\nlocations nationwide and is owned by Inspire Brands. Jimmy John's transactions code\nas restaurants on Visa, Mastercard, and Amex networks.\n\nThe Amex Gold pays 4x points on U.S. restaurants and leads the field for daily\nJimmy John's lunches, while the Chase Sapphire Reserve pays 3x on dining and\nincludes travel-friendly redemptions. No-annual-fee dining picks like the Capital\nOne SavorOne and Wells Fargo Autograph each earn 3 percent or 3x on restaurants.\nThe Freaky Fast Rewards program adds points and free sandwiches on top of credit\ncard cash back.\n"
+    },
+    {
+      "name": "Kay Jewelers",
+      "slug": "kay-jewelers",
+      "aliases": [
+        "Kay"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.kay.com",
+      "intro": "Kay Jewelers is the largest banner inside Signet Jewelers, with around 850 U.S. stores\nplus kay.com selling engagement rings, fashion jewelry, and watches. The Kay Jewelers\nLong-Term Financing credit card from Comenity offers promotional financing on bigger\npurchases. General-purpose cards typically code Kay as department store in person and\nonline shopping for web orders, and the free Vault Rewards program stacks with credit\ncard earnings.\n"
     },
     {
       "name": "KFC",
@@ -1156,6 +2190,18 @@
       "intro": "Kohl's is a mid-tier department store with about 1,150 stores and an aggressive Kohl's\nCash rewards program. Most regular shoppers stack manufacturer sales, Kohl's coupons,\nand Kohl's Cash, so card cashback is the smallest of several layers. The Kohl's Card\n(issued by Capital One) gives in-house discounts but no MasterCard/Visa-network rewards.\nFor most shoppers, a department-store-bonus general-purpose card is the right answer.\n"
     },
     {
+      "name": "Krispy Kreme",
+      "slug": "krispy-kreme",
+      "aliases": [
+        "Krispy Kreme Doughnuts"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.krispykreme.com",
+      "intro": "Krispy Kreme operates around 380 US shops plus thousands of grocery and convenience-store\ncabinets, with the chain's Hot Light signaling fresh Original Glazed doughnuts coming off\nthe line. Purchases at a Krispy Kreme storefront or drive-thru, including dozens ordered\nvia the Krispy Kreme Rewards app, code as dining/restaurants. Cards with elevated dining\nbonuses earn at full rate: Amex Gold (4x Membership Rewards), Chase Sapphire Preferred (3x\nUltimate Rewards), and Capital One SavorOne (3% unlimited cash back) are all strong picks.\n"
+    },
+    {
       "name": "Kroger",
       "slug": "kroger",
       "categories": [
@@ -1163,6 +2209,116 @@
       ],
       "website": "https://www.kroger.com",
       "intro": "Kroger is the largest dedicated U.S. supermarket operator, running about 2,700 stores\nunder Kroger and a stack of regional banners (Ralphs, Fred Meyer, Smith's, King Soopers,\nHarris Teeter, Fry's, and others). All code as groceries at the register and most do\nonline shopping via the Kroger app/site. Any standard supermarket-bonus card earns here.\nKroger's own fuel-points program layers on top of card cashback.\n"
+    },
+    {
+      "name": "Kwik Trip",
+      "slug": "kwik-trip",
+      "aliases": [
+        "Kwik Star"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.kwiktrip.com",
+      "intro": "Kwik Trip (branded Kwik Star in Iowa) is a family-owned convenience and fuel chain\nwith more than 800 stores across Wisconsin, Minnesota, Iowa, Illinois, Michigan, and\nSouth Dakota. The chain is known for its in-house bakery, dairy, and prepared foods\nalongside a busy fuel operation. Pumps code as gas for credit card networks, so a gas\ncategory bonus card will earn its multiplier. The Kwik Rewards loyalty program adds\nper-gallon discounts and points on food, which can stack with a separate rewards card\nat the pump.\n"
+    },
+    {
+      "name": "L.L.Bean",
+      "slug": "ll-bean",
+      "aliases": [
+        "LL Bean"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.llbean.com",
+      "intro": "L.L.Bean is a Maine-based outdoor retailer famous for its Freeport flagship and the\nBean Boot, operating about 60 U.S. stores plus a heavy catalog and DTC business at\nllbean.com. The L.L.Bean Mastercard from Citi earns elevated points on direct L.L.Bean\npurchases and offers a free shipping perk for cardholders, while general-purpose cards\ncode in-store visits as department store and web checkouts as online shopping.\n"
+    },
+    {
+      "name": "Lands' End",
+      "slug": "lands-end",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.landsend.com",
+      "intro": "Lands' End is a casual classics apparel brand with deep catalog roots, sold mostly\nthrough landsend.com and via shop-in-shop counters that were historically inside many\nKohl's department stores. Direct site purchases typically code as online shopping,\nwhile Lands' End merchandise bought at Kohl's codes under the host retailer and earns\nKohl's Rewards. There is no current standalone Lands' End branded credit card in the\nU.S. market.\n"
+    },
+    {
+      "name": "Levi's",
+      "slug": "levis",
+      "aliases": [
+        "Levi Strauss"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.levi.com",
+      "intro": "Levi's is the flagship denim brand of Levi Strauss & Co, sold through about 200 U.S.\ncompany stores, levi.com, and a wide wholesale footprint at department stores and\nspecialty retailers. Direct purchases at Levi's stores or the website typically code\nas department store or online shopping, while buying Levi's at Macy's or Kohl's codes\nunder that retailer. The free Levi's Red Tab membership stacks with credit card\nrewards, and there is no Levi's branded credit card.\n"
+    },
+    {
+      "name": "Lidl",
+      "slug": "lidl",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.lidl.com",
+      "intro": "Lidl is a German discount grocer that has expanded across the U.S. East Coast since\n2017, with roughly 175 stores stretching from Georgia up to New York. The format is\nsmall-footprint and private-label-heavy, comparable to Aldi. Lidl codes as a U.S.\nsupermarket for credit card networks, so grocery category bonuses (Amex Gold, Blue\nCash Preferred, Citi Custom Cash) earn their full multiplier. The chain accepts mobile\nwallets and standard major networks.\n"
+    },
+    {
+      "name": "Little Caesars",
+      "slug": "little-caesars",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://littlecaesars.com",
+      "intro": "Little Caesars is the third-largest pizza chain in the United States with more than 4,000\ndomestic locations, built around the Hot-N-Ready model that lets customers walk in and grab\na fresh pepperoni or cheese pizza without ordering ahead. The chain remains family-owned\nby the Ilitch group. Little Caesars transactions, whether in-store, drive-thru Pizza Portal\npickup, or app delivery, all code as dining/restaurants. Top dining cards earn full bonus\nhere: Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash.\n"
+    },
+    {
+      "name": "Living Spaces",
+      "slug": "living-spaces",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.livingspaces.com",
+      "intro": "Living Spaces is a West Coast furniture chain with around 40 large-format showrooms\nacross California, Texas, Arizona, Nevada, and a growing East Coast footprint. The\nretailer is known for in-stock sofas with same-week delivery and a wide rug\nassortment. Furniture purchases code as general retail, not as a home improvement\nbonus category on most rewards cards.\n\nBecause Living Spaces orders frequently run into four figures, sofas and bedroom\nsets are excellent for clearing signup bonus minimum spend. Cards with strong base\nearn rates, including the Citi Double Cash and Capital One Venture X, are the\npractical default. Living Spaces also offers in-house financing through Synchrony for\npromotional zero-interest terms.\n"
+    },
+    {
+      "name": "LL Flooring",
+      "slug": "ll-flooring",
+      "aliases": [
+        "Lumber Liquidators"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.llflooring.com",
+      "intro": "LL Flooring, formerly known as Lumber Liquidators, is a flooring specialty retailer\nwith over 400 U.S. stores selling hardwood, bamboo, vinyl plank, laminate, and tile\nflooring along with installation supplies. The chain typically codes as home\nimprovement on most credit card networks, which makes it eligible for cards that\ncarry a home improvement bonus category.\n\nCards like the U.S. Bank Cash+ and Bank of America Customized Cash can route LL\nFlooring purchases into a selectable bonus, while the Chase Freedom Flex sometimes\nfeatures home improvement in its 5 percent rotating quarters. Whole-house flooring\nprojects are large enough to clear most credit card signup bonus minimums in a\nsingle transaction.\n"
+    },
+    {
+      "name": "LongHorn Steakhouse",
+      "slug": "longhorn-steakhouse",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.longhornsteakhouse.com",
+      "intro": "LongHorn Steakhouse is Darden Restaurants' Western-themed steak concept with about 580 US\nlocations, sitting just below the chain's Capital Grille tier and offering fire-grilled steaks\nlike the Outlaw Ribeye and Flo's Filet plus chicken, salmon, and ribs. LongHorn participates\nin the cross-Darden eGift card program with Olive Garden and others. LongHorn transactions\ncode as dining/restaurants. Cards with strong dining multipliers (Amex Gold 4x, Chase\nSapphire Preferred 3x, Capital One SavorOne 3% cash) earn full rate on every steak dinner.\n"
+    },
+    {
+      "name": "Love's Travel Stops",
+      "slug": "loves-travel-stops",
+      "aliases": [
+        "Love's"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.loves.com",
+      "intro": "Love's Travel Stops runs more than 650 locations across 42 states, serving both\npassenger drivers and commercial truckers with fuel, food, showers, and tire service.\nStandard fuel pumps code as gas, so any gas category bonus card will earn its full\nmultiplier at the pump. Inside-store food and merchandise can code as convenience\nstore or restaurant depending on the format. The MyLove's Rewards program offers\nper-gallon discounts and points redeemable on food and showers, which stacks\ncleanly with a separate gas rewards card.\n"
     },
     {
       "name": "Lowe's",
@@ -1189,6 +2345,16 @@
       "intro": "Lululemon is the dominant U.S. athletic-apparel brand with about 700 stores and a heavy\nlululemon.com presence. Like other apparel retailers, Lululemon doesn't fall into a card\nbonus category in-store — the right answer there is a strong flat-rate cashback card.\nOnline purchases at lululemon.com code as online shopping, which opens up a different\nset of category bonuses.\n"
     },
     {
+      "name": "Lush",
+      "slug": "lush",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.lushusa.com",
+      "intro": "Lush Fresh Handmade Cosmetics is a British beauty brand best known for bath bombs,\nshampoo bars, and packaging-light skincare. The U.S. footprint covers about 200 mall\nand street-front stores plus lushusa.com. Direct purchases typically code as\ndepartment store in person and online shopping for web orders, while the free Lush\nRewards program offers points and member perks that stack with credit card earnings.\nLush does not run a U.S. branded credit card.\n"
+    },
+    {
       "name": "Lyft",
       "slug": "lyft",
       "categories": [
@@ -1196,6 +2362,19 @@
       ],
       "website": "https://www.lyft.com",
       "intro": "Lyft is the second-largest U.S. rideshare service after Uber. Rides code under\nthe transit category on most cards. The Chase Sapphire Reserve historically pays\n10x on Lyft rides through 2027, and Lyft Pink (Lyft's premium membership) is\ncomped with several Chase cards. Sapphire Preferred, Venture X, and SavorOne all\nearn elevated transit/rideshare rates without the Lyft-specific multipliers.\n"
+    },
+    {
+      "name": "MAC Cosmetics",
+      "slug": "mac-cosmetics",
+      "aliases": [
+        "MAC"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.maccosmetics.com",
+      "intro": "MAC Cosmetics is a prestige color cosmetics brand owned by The Estée Lauder Companies,\nsold through about 100 U.S. freestanding stores, maccosmetics.com, and a wide\ndepartment store and Ulta wholesale footprint. Direct purchases at MAC stores or the\nwebsite typically code as department store or online shopping, while MAC bought at\nMacy's or Ulta codes under that retailer. The free MAC Lover loyalty program offers\ntiered points and stacks with credit card multipliers.\n"
     },
     {
       "name": "Macy's",
@@ -1211,6 +2390,28 @@
       "intro": "Macy's is the largest U.S. mid-tier department store, with about 500 full-line stores\nplus Backstage outlets and a heavy promotional calendar. Most shoppers buy at heavy\ndiscount, so the cashback rate stacks on already-reduced prices. Macy's codes as a\ndepartment store at the register and as online shopping on macys.com, which means cards\nbonusing on either category can earn here. The Macy's American Express has its own\nLoyallist points layer for shoppers doing several thousand a year at Macy's\nspecifically.\n"
     },
     {
+      "name": "Madewell",
+      "slug": "madewell",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.madewell.com",
+      "intro": "Madewell is the denim-led casualwear brand spun out of J.Crew, with about 140 U.S.\nstores and a strong DTC site at madewell.com. The Madewell Insider loyalty program is\nfree and offers a denim recycling perk for old jeans. General-purpose credit cards\ntypically code Madewell as department store in person and online shopping for web\ncheckouts, and the brand does not currently have its own branded credit card.\n"
+    },
+    {
+      "name": "Maggiano's Little Italy",
+      "slug": "maggianos",
+      "aliases": [
+        "Maggiano's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.maggianos.com",
+      "intro": "Maggiano's Little Italy, owned by Brinker International (Chili's parent), runs about 50\nupscale-casual Italian restaurants known for family-style portions, the Chocolate Zuccotto\nCake, and the Classic Pastas program where guests take home a second pasta with each entree.\nMaggiano's transactions code as dining/restaurants on every credit card. With higher check\naverages than typical casual dining, top dining cards meaningfully boost return: Amex Gold\nat 4x, Chase Sapphire Reserve at 4x, Chase Sapphire Preferred at 3x, Capital One Savor at 3%.\n"
+    },
+    {
       "name": "Marathon",
       "slug": "marathon",
       "aliases": [
@@ -1222,6 +2423,18 @@
       ],
       "website": "https://www.marathonbrand.com",
       "intro": "Marathon-branded stations cover about 7,000 U.S. locations primarily across the\nMidwest and Southeast. Pumps code cleanly as gas on every card we track. The\nMakeItCount Rewards program offers cents-per-gallon savings that stack with\nwhatever card you swipe; absolute cashback usually wins with a 4-5% general gas\ncard rather than a Marathon-only co-brand.\n"
+    },
+    {
+      "name": "Marco's Pizza",
+      "slug": "marcos-pizza",
+      "aliases": [
+        "Marco's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.marcos.com",
+      "intro": "Marco's Pizza, founded in Ohio in 1978, runs about 1,200 US locations with a delivery and\ncarryout model emphasizing fresh dough made in-store, three-cheese blends, and a private\npizza sauce recipe. The chain has grown rapidly across the South and Midwest. Marco's\ntransactions code as dining/restaurants whether you order at the counter, online, or through\nthe Marco's Rewards app. Dining-bonus cards earn their full rate here: Amex Gold pays 4x,\nChase Sapphire Preferred pays 3x, and the Capital One SavorOne pays 3% unlimited cash back.\n"
     },
     {
       "name": "Marriott",
@@ -1272,6 +2485,25 @@
       "intro": "Marshalls is an off-price retail chain owned by TJX Companies, with about 1,200\nU.S. stores selling apparel, home, and accessories at discount prices. Codes as\ndepartment stores on most cards. The TJX Rewards Mastercard offers 5% back at\nMarshalls, TJ Maxx, HomeGoods, Sierra, and Homesense — typically the best rate\nfor heavy TJX shoppers. Otherwise pair with a department-store-bonus card or a\nflat-rate cashback card.\n"
     },
     {
+      "name": "Mattress Firm",
+      "slug": "mattress-firm",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.mattressfirm.com",
+      "intro": "Mattress Firm is the largest U.S. mattress specialty chain with more than 2,300\nstores, carrying Sealy, Serta, Tempur-Pedic, Purple, and its private-label brands.\nMattress purchases code as general retail on most credit card networks, which means\nno automatic 5 percent home improvement bonus and no grocery category overlap.\n\nKing-size mattress sets routinely cross $2,000, making Mattress Firm useful for\nclearing signup bonus minimums on cards like the Amex Gold or Chase Sapphire\nPreferred. The retailer also offers Synchrony-issued financing with promotional\nzero-interest windows. Paying with a 2 percent flat-rate card such as the Citi\nDouble Cash and avoiding interest charges typically produces a better net outcome.\n"
+    },
+    {
+      "name": "Maverik",
+      "slug": "maverik",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://maverik.com",
+      "intro": "Maverik, branded \"Adventure's First Stop,\" is a Mountain West convenience-store and\nfuel chain with around 400 locations spread across Utah, Idaho, Wyoming, Nevada,\nColorado, Arizona, and surrounding states. Fuel pumps code as gas, so any gas category\nrewards card will earn its full bonus. The Adventure Club loyalty program (and the\nrelated Adventure Club Visa, issued via First Bankcard) adds per-gallon discounts and\nelevated earn on Maverik in-store purchases including the chain's BonFire food\nprogram.\n"
+    },
+    {
       "name": "Max",
       "slug": "max",
       "aliases": [
@@ -1316,6 +2548,25 @@
       "intro": "Menards is a Midwest-focused home-improvement chain with about 350 stores, well-known\nfor its 11% mail-in rebate promotions that effectively act as in-house cashback on top\nof card rewards. The math here is interesting: an 11% Menards rebate stacked with a 2%\nflat-rate cashback card often beats most home-improvement category cards on net. Menards\ncodes as home improvement at the register and on menards.com.\n"
     },
     {
+      "name": "Mercari",
+      "slug": "mercari",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.mercari.com",
+      "intro": "Mercari is a Japan-founded peer-to-peer marketplace where individual users list and\nship secondhand and new items across electronics, apparel, collectibles, and home\ngoods. The U.S. arm operates similarly to eBay but with a simpler flat-fee structure\nand shipping label integration. Mercari purchases code as online shopping for credit\ncard networks, so an online-shopping category bonus card will earn its multiplier on\nbuyer-side transactions. Mercari does not issue a co-brand card.\n"
+    },
+    {
+      "name": "Michael Kors",
+      "slug": "michael-kors",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.michaelkors.com",
+      "intro": "Michael Kors is the flagship accessible luxury brand under Capri Holdings, which also\nowns Versace and Jimmy Choo. The U.S. footprint includes hundreds of Lifestyle and\noutlet stores plus michaelkors.com selling handbags, watches, footwear, and ready to\nwear. Direct purchases typically code as department store in person and online\nshopping for web orders, while MK bought at department stores codes under the host\nretailer. The free KORSVIP loyalty program stacks with credit card earnings.\n"
+    },
+    {
       "name": "Michaels",
       "slug": "michaels",
       "categories": [
@@ -1324,6 +2575,79 @@
       ],
       "website": "https://www.michaels.com",
       "intro": "Michaels is the largest U.S. arts-and-crafts retailer with about 1,300 stores,\nselling beads, yarn, frames, and seasonal decor. In-store charges code as\ndepartment stores or specialty retail; michaels.com codes as online shopping.\nThe Michaels Rewards program is free and issues per-spend points redeemable\nfor in-store credit. Pair with a flat-rate cashback or department-store-bonus\ncard; there's no widely-recommended Michaels-specific credit card.\n"
+    },
+    {
+      "name": "Micro Center",
+      "slug": "micro-center",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.microcenter.com",
+      "intro": "Micro Center is a specialty computer and electronics retailer with around 25 large\nU.S. stores known for in-stock PC components, aggressive CPU and motherboard combo\npricing, and a deep selection of GPUs, 3D printers, and DIY parts. Most credit cards\ncode Micro Center as electronics or general retail rather than as a dedicated\ncategory, so flat-rate cards often do the heavy lifting.\n\nOnline orders through microcenter.com qualify for online shopping bonuses on the\nBank of America Customized Cash, Chase Freedom Flex when online shopping is the\nrotating quarter, and U.S. Bank Cash+. Custom PC builds can run thousands of\ndollars, making Micro Center a useful target for clearing signup bonus minimums.\n"
+    },
+    {
+      "name": "Microsoft Store",
+      "slug": "microsoft-store",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.microsoft.com/store",
+      "intro": "The Microsoft Store is Microsoft's online retail destination for Surface laptops,\nXbox consoles and games, Windows software, Microsoft 365 subscriptions, and Office\nproducts. Following the closure of all physical Microsoft Stores in 2020, all U.S.\nconsumer shopping happens through microsoft.com/store. Purchases code as online\nshopping or software on most credit card networks.\n\nCards with online shopping bonuses can deliver strong returns on Surface and Xbox\npurchases. The Bank of America Customized Cash, U.S. Bank Cash+, and Chase Freedom\nFlex rotating quarters can all push these orders to 5 percent back. Microsoft 365\nand Xbox Game Pass recurring subscriptions may code as software or streaming\nservices, which can trigger streaming category bonuses on cards like the Amex Blue\nCash Preferred.\n"
+    },
+    {
+      "name": "Midas",
+      "slug": "midas",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.midas.com",
+      "intro": "Midas is a global auto service franchise with around 1,200 U.S. locations\nspecializing in exhaust, brakes, tires, suspension, and routine maintenance. Most\nMidas franchisees code transactions as auto services on Visa, Mastercard, and Amex\nnetworks, which typically falls outside dedicated rewards categories on consumer\ncards.\n\nBig-ticket brake jobs and exhaust work often run $500 to $1,500, which is enough\nto make MID category selection worthwhile on cards like Citi Custom Cash when auto\nservices is the top monthly category. U.S. Bank Cash+ also offers wider auto\ncategories. For everyday simplicity, the Wells Fargo Active Cash and Citi Double\nCash pay a clean 2 percent on every Midas invoice.\n"
+    },
+    {
+      "name": "Moe's Southwest Grill",
+      "slug": "moes-southwest-grill",
+      "aliases": [
+        "Moe's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.moes.com",
+      "intro": "Moe's Southwest Grill, owned by Focus Brands, runs about 600 fast-casual locations centered\non burritos, bowls, quesadillas, and the chain's signature free chips and salsa with every\nentree. Every Moe's transaction, whether in-store, drive-thru, or through the Moe's Rewards\napp, codes as a dining/restaurant charge. Pair a top dining card here for the best return:\nAmex Gold pays 4x Membership Rewards, Chase Sapphire Preferred pays 3x Ultimate Rewards,\nand Capital One SavorOne pays 3% cash back on every Welcome to Moe's order.\n"
+    },
+    {
+      "name": "Motel 6",
+      "slug": "motel-6",
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.motel6.com",
+      "intro": "Motel 6 operates roughly 1,400 budget motels across the US and Canada, distinguishable by\nthe We'll leave the light on for you tagline and consistently low nightly rates that have\nanchored the chain at the bottom of the lodging price spectrum since 1962. Motel 6 was\nacquired by Oyo's parent in 2025. Sister brand Studio 6 offers extended-stay options. Motel 6\ncharges code as lodging/hotels on every card. Hotel-bonus cards earn full rate: Chase\nSapphire Reserve at 4x direct, Capital One Venture X at 2x base, Amex Platinum at 5x prepaid.\n"
+    },
+    {
+      "name": "Murphy USA",
+      "slug": "murphy-usa",
+      "aliases": [
+        "Murphy Express"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.murphyusa.com",
+      "intro": "Murphy USA runs about 1,700 low-price gas and convenience stations across the U.S.,\nmany of them sited in Walmart parking lots under the Murphy USA or Murphy Express\nbanners. The chain competes primarily on price per gallon. Fuel codes as gas at the\npump, so any gas category bonus card will earn its full multiplier. The Murphy Drive\nRewards loyalty app and Murphy USA Visa add per-gallon discounts that can stack with a\nmajor-issuer gas card if used carefully.\n"
+    },
+    {
+      "name": "NAPA Auto Parts",
+      "slug": "napa-auto-parts",
+      "aliases": [
+        "NAPA"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.napaonline.com",
+      "intro": "NAPA Auto Parts is one of the largest independent auto parts networks in North\nAmerica, with roughly 6,000 U.S. stores operated by independent jobbers and Genuine\nParts Company. NAPA carries replacement parts, batteries, tools, and chemicals for\nDIY drivers and professional repair shops. Auto parts purchases typically code as\ngeneral retail rather than triggering a dedicated bonus category.\n\nCards with selectable cash back categories can sometimes treat NAPA as an auto\ncategory, with Citi Custom Cash and Bank of America Customized Cash both rewarding\nthe top-spend or selected category. Online orders through napaonline.com may also\nqualify for online shopping bonuses on the Chase Freedom Flex when that category\nrotates in.\n"
     },
     {
       "name": "National Car Rental",
@@ -1362,6 +2686,25 @@
       "intro": "Netflix is the largest U.S. streaming-video service. Monthly subscriptions code\ncleanly as streaming on every card we track. Several mid-tier rewards cards earn\nelevated rates on streaming (Blue Cash Preferred 6% on select streaming including\nNetflix, U.S. Bank Cash+ 5% if streaming is a chosen category). Card-issued\nNetflix credits are rare; the simplest play is pairing the subscription with\nwhichever streaming-bonus card you already carry.\n"
     },
     {
+      "name": "New Balance",
+      "slug": "new-balance",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.newbalance.com",
+      "intro": "New Balance is a privately held Boston-based athletic footwear and apparel company\nwith about 100 U.S. brand and factory stores plus a strong DTC channel at\nnewbalance.com. Direct purchases typically code as department store in person and\nonline shopping for web orders, while New Balance gear bought at Dick's, Foot Locker,\nor running specialty stores codes under that retailer. The free New Balance Rewards\nprogram stacks with credit card multipliers.\n"
+    },
+    {
+      "name": "Newegg",
+      "slug": "newegg",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.newegg.com",
+      "intro": "Newegg is an online retailer focused on consumer electronics, PC components, and\ngaming gear, with a long history of catering to enthusiast PC builders. The site also\nhosts a third-party marketplace for adjacent categories. Newegg codes as online\nshopping, so any online-shopping category bonus card (Chase Freedom Flex when\nactivated, Citi Custom Cash on online shopping, Capital One SavorOne promotions) will\nearn its multiplier. Newegg has issued co-brand financing cards in the past (Newegg\nStore Card via Comenity, Visa via Synchrony), so check the current offering at\ncheckout if 0% APR financing is the goal.\n"
+    },
+    {
       "name": "Nike",
       "slug": "nike",
       "categories": [
@@ -1383,6 +2726,15 @@
       ],
       "website": "https://www.nordstrom.com",
       "intro": "Nordstrom is a higher-end department store with about 100 full-line stores and a much\nlarger Nordstrom Rack outlet network. Pricing skews full-retail at the flagship\nlocations and steeply discounted at Rack, so the right card depends partly on which\nchannel you're shopping. Both code as department stores at the register and online\nshopping on nordstrom.com / nordstromrack.com. Nordstrom's own Nordy Club rewards layer\nin on top of card cashback.\n"
+    },
+    {
+      "name": "Nordstrom Rack",
+      "slug": "nordstrom-rack",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.nordstromrack.com",
+      "intro": "Nordstrom Rack is the off-price arm of Nordstrom, with about 240 stores nationwide\nplus the nordstromrack.com site. The format sells the same designer and contemporary\nbrands as the parent department store at marked-down prices, sourced from previous\nseason inventory and direct buys. Nordstrom Rack purchases earn Nordy Club points\nalongside the main Nordstrom store, and the Nordstrom credit and debit cards\n(Visa-branded variants issued by TD Bank) earn elevated points at both Nordstrom and\nNordstrom Rack. Department-store category bonus cards also apply at the register.\n"
     },
     {
       "name": "O'Reilly Auto Parts",
@@ -1431,6 +2783,31 @@
       "intro": "Olive Garden is a U.S. casual-dining chain with about 900 domestic locations,\nowned by Darden Restaurants. Charges code as dining on every card we track, so\nAmex Gold 4x (capped), Sapphire Preferred 3x, and SavorOne 3% all earn the\ndining bonus. Eligible Darden gift cards purchased through the My Olive Garden\nRewards or Darden portals occasionally code as gift cards rather than dining,\nworth checking before bulk-buying.\n"
     },
     {
+      "name": "Ollie's Bargain Outlet",
+      "slug": "ollies-bargain-outlet",
+      "aliases": [
+        "Ollies"
+      ],
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.ollies.us",
+      "intro": "Ollie's Bargain Outlet is a closeout retailer with more than 550 stores across the\nEastern and Central U.S., selling brand-name merchandise (books, household goods,\nfurniture, food, seasonal items) acquired from manufacturer overstock and store\ncloseouts. The chain's tagline \"Good Stuff Cheap\" captures the model. Ollie's\ntypically codes as a department store or discount retailer for credit card networks,\nso a department-store category bonus card can earn its multiplier. The free Ollie's\nArmy loyalty program adds member-only discounts but is not a credit card product.\n"
+    },
+    {
+      "name": "Omni Hotels",
+      "slug": "omni-hotels",
+      "aliases": [
+        "Omni Hotels & Resorts"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.omnihotels.com",
+      "intro": "Omni Hotels & Resorts is a privately held US luxury and upper-upscale hotel chain with about\n50 properties spanning convention-center anchors like the Omni Atlanta and Omni Dallas, resort\ndestinations like the Omni Grove Park Inn and Omni Bedford Springs, and downtown business\nhotels. The Select Guest loyalty program offers free WiFi, beverages, and morning coffee at\nevery tier. Omni charges code as lodging/hotels. Hotel-bonus cards earn full rate: Chase\nSapphire Reserve at 4x direct, Amex Platinum at 5x prepaid, Capital One Venture X at 2x base.\n"
+    },
+    {
       "name": "Outback Steakhouse",
       "slug": "outback-steakhouse",
       "aliases": [
@@ -1441,6 +2818,43 @@
       ],
       "website": "https://www.outback.com",
       "intro": "Outback Steakhouse is a U.S. casual-dining steakhouse chain with about 700\ndomestic locations, owned by Bloomin' Brands (also Carrabba's, Bonefish Grill).\nCharges code as dining on every card we track. Any dining-bonus card applies\n(Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%). The Dine Rewards program\nspans Bloomin' Brands sister concepts and stacks on top of card bonuses.\n"
+    },
+    {
+      "name": "P.F. Chang's",
+      "slug": "pf-changs",
+      "aliases": [
+        "PF Changs",
+        "P.F. Chang's China Bistro"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.pfchangs.com",
+      "intro": "P.F. Chang's China Bistro operates roughly 200 US upscale-casual restaurants known for the\nChang's Spicy Chicken, Mongolian Beef, Dynamite Shrimp, and signature lettuce wraps in a\npan-Asian table-service format. Most locations sit in upscale shopping centers or near\nhigh-end malls. P.F. Chang's transactions code as dining/restaurants, including delivery and\ntakeout orders. Cards offering elevated dining bonuses (Amex Gold at 4x Membership Rewards,\nChase Sapphire Reserve at 4x Ultimate Rewards, Capital One Savor at 3% cash) earn full rate.\n"
+    },
+    {
+      "name": "Pacsun",
+      "slug": "pacsun",
+      "aliases": [
+        "PacSun",
+        "Pacific Sunwear"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.pacsun.com",
+      "intro": "Pacsun is a California-rooted apparel chain catering to teens and young adults, with\nabout 325 mall-based stores and a strong online business at pacsun.com. Most cards\ncode in-store transactions as department store and web orders as online shopping. The\nPacsun Rewards program is free and points-based, layering on top of credit card\nearnings since the chain does not run a branded credit card in the U.S.\n"
+    },
+    {
+      "name": "Pandora",
+      "slug": "pandora",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://us.pandora.net",
+      "intro": "Pandora is a Danish jewelry company best known for its customizable charm bracelets\nplus rings, earrings, and lab-grown diamond collections. The U.S. footprint covers\nabout 360 concept stores and shop-in-shops plus us.pandora.net. Direct purchases\ntypically code as department store in person and online shopping for web orders. The\nfree Pandora Club loyalty program offers points and a birthday gift, but Pandora does\nnot run a U.S. branded credit card.\n"
     },
     {
       "name": "Panera Bread",
@@ -1467,6 +2881,25 @@
       "intro": "Papa John's is a U.S. pizza-delivery chain with about 3,300 domestic locations.\nCharges code as dining on every card we track. Any dining-bonus card (Amex Gold\n4x, Sapphire Preferred 3x, SavorOne 3%) applies. The Papa Rewards loyalty\nprogram in the app issues recurring points-for-pizza promotions that stack on\ntop of card bonuses.\n"
     },
     {
+      "name": "Patagonia",
+      "slug": "patagonia",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.patagonia.com",
+      "intro": "Patagonia is a privately held outdoor and performance apparel brand owned by the\nHoldfast Collective, with about 40 U.S. retail stores plus a strong DTC business at\npatagonia.com. Direct purchases typically code as department store in person and\nonline shopping for web orders, while the Worn Wear resale platform issues store\ncredit for trade-ins. Patagonia does not offer a U.S. branded credit card, so most\nshoppers rely on a strong online or everyday multiplier for full-price gear.\n"
+    },
+    {
+      "name": "Pavilions",
+      "slug": "pavilions",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.pavilions.com",
+      "intro": "Pavilions is the upscale Albertsons banner serving affluent Southern California\nneighborhoods, with a focus on prepared foods, wine, and specialty grocery. It codes as\na U.S. supermarket, so any grocery category bonus (Amex Gold, Blue Cash Preferred, Citi\nCustom Cash) applies at the register. Like other Albertsons banners, Pavilions runs the\nAlbertsons for U loyalty program, and the broad gift-card rack at the service counter\nis worth knowing about if you want to extend a 4x or 6x grocery multiplier into other\nspending.\n"
+    },
+    {
       "name": "Peet's Coffee",
       "slug": "peets-coffee",
       "aliases": [
@@ -1477,6 +2910,33 @@
       ],
       "website": "https://www.peets.com",
       "intro": "Peet's Coffee is a specialty coffee roaster and cafe chain with about 200 U.S.\ncafes, primarily in California. In-cafe charges code as dining on every card we\ntrack. Bagged-bean orders shipped from peets.com sometimes code as online shopping\nrather than dining — worth checking before relying on a 4x dining card. Heavy\nregulars stack the Peetnik Rewards loyalty program on top of card bonuses.\n"
+    },
+    {
+      "name": "Pep Boys",
+      "slug": "pep-boys",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.pepboys.com",
+      "intro": "Pep Boys operates roughly 800 auto parts and service centers across the United\nStates, combining a parts counter with tire installation, oil changes, brake work,\nand full-service mechanical repair. Most credit cards code Pep Boys purchases as\nauto services or general retail rather than as a dedicated bonus category, so\nflat-rate cards like the Citi Double Cash often deliver the cleanest 2 percent.\n\nCards with selectable categories can reach Pep Boys when the right bucket is\nchosen. Bank of America Customized Cash and U.S. Bank Cash+ both have wider\ncategories that may capture auto service spending, and Citi Custom Cash pays 5\npercent on the top eligible spending category for cardholders whose monthly spend\nskews toward vehicle maintenance.\n"
+    },
+    {
+      "name": "Pet Supermarket",
+      "slug": "pet-supermarket",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.petsupermarket.com",
+      "intro": "Pet Supermarket is a Southeast U.S. pet specialty chain with around 200 stores\nacross Florida, Georgia, the Carolinas, Alabama, and neighboring states. The\nretailer carries dog and cat food, small animal supplies, fish, reptiles, and live\nbird departments. Most Pet Supermarket locations code as pet shops or general\nretail on credit card networks, not as a standalone rewards category.\n\nCards with selectable categories like U.S. Bank Cash+ can include pet shops in\ntheir lineup, while flat-rate cards such as the Citi Double Cash or Wells Fargo\nActive Cash deliver a steady 2 percent on every pet food run. Online orders\nthrough petsupermarket.com may trigger online shopping bonuses on Bank of America\nCustomized Cash and Chase Freedom Flex rotating quarters.\n"
+    },
+    {
+      "name": "Pet Supplies Plus",
+      "slug": "pet-supplies-plus",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.petsuppliesplus.com",
+      "intro": "Pet Supplies Plus is the third-largest pet specialty chain in the United States\nwith over 700 neighborhood stores carrying food, treats, toys, and grooming\nservices for dogs, cats, fish, reptiles, and small animals. Most Pet Supplies Plus\nlocations code as pet shops or general retail on credit card networks, not as a\ncategory that triggers standard rewards bonuses.\n\nCards with selectable categories sometimes include pet shops, with U.S. Bank Cash+\noffering pet-related categories in its lineup. Online orders placed through\npetsuppliesplus.com may also trigger online shopping bonuses on cards like Bank of\nAmerica Customized Cash and Chase Freedom Flex. The free Preferred Pet Club\nloyalty program adds points on top of credit card rewards.\n"
     },
     {
       "name": "Petco",
@@ -1497,6 +2957,41 @@
       "intro": "PetSmart is the largest U.S. pet specialty retailer by store count at about 1,650\nlocations, with a sizable petsmart.com online catalog. Pet-supply purchases don't have a\ndedicated category on most credit cards, so in-store purchases generally fall back to a\nflat-rate cashback card. Online purchases at petsmart.com code as online shopping. The\nTreats Rewards loyalty program stacks on top of card cashback.\n"
     },
     {
+      "name": "Phillips 66",
+      "slug": "phillips-66",
+      "aliases": [
+        "76",
+        "Conoco"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.phillips66.com",
+      "intro": "Phillips 66 is a U.S. refiner whose retail footprint covers more than 7,000 branded\ngas stations across three names: Phillips 66 in the central U.S., 76 on the West\nCoast, and Conoco in the Mountain West. All three brands code as gas at the pump, so\nany gas category bonus card (Costco Anywhere Visa, Citi Custom Cash on gas, Sam's\nClub Mastercard) will earn its multiplier. The KickBack Rewards loyalty app offers\nper-gallon discounts that stack with rewards card earn at participating sites.\n"
+    },
+    {
+      "name": "Philz Coffee",
+      "slug": "philz-coffee",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.philzcoffee.com",
+      "intro": "Philz Coffee is a San Francisco-born specialty chain of about 70 cafes across California,\nthe East Coast, and the DC region, built around custom pour-over brews like Tesora, Ether,\nand the Mint Mojito iced coffee. Orders placed in-cafe, in the Philz app, or ahead via\ncurbside all code as dining/restaurants. Top dining cards earn their full rate at Philz:\nAmex Gold pays 4x Membership Rewards, Chase Sapphire Reserve pays 4x Ultimate Rewards,\nand Capital One SavorOne pays 3% unlimited cash back on every order.\n"
+    },
+    {
+      "name": "Pilot Flying J",
+      "slug": "pilot-flying-j",
+      "aliases": [
+        "Pilot",
+        "Flying J"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://pilotflyingj.com",
+      "intro": "Pilot Flying J operates more than 750 travel centers across the U.S. and Canada,\nmaking it the largest truck stop network in North America. The chain serves both\nlong-haul truckers (with high-flow diesel lanes, showers, and driver lounges) and\npassenger drivers at standard gas pumps. Fuel at Pilot Flying J pumps codes as gas, so\nany card with a gas category bonus will earn its rate. The myRewards Plus loyalty\nprogram adds per-gallon discounts and points on in-store food, which can stack with a\nseparate gas rewards card.\n"
+    },
+    {
       "name": "Pizza Hut",
       "slug": "pizza-hut",
       "categories": [
@@ -1504,6 +2999,32 @@
       ],
       "website": "https://www.pizzahut.com",
       "intro": "Pizza Hut is a U.S. pizza chain with about 6,500 domestic locations, owned by\nYum! Brands. Charges code as dining on every card we track. Any dining-bonus card\napplies. The Hut Rewards loyalty program in the app issues per-dollar points\nredeemable for free items, stackable with card bonuses.\n"
+    },
+    {
+      "name": "PlayStation Store",
+      "slug": "playstation-store",
+      "aliases": [
+        "PSN Store"
+      ],
+      "categories": [
+        "online_shopping",
+        "entertainment"
+      ],
+      "website": "https://store.playstation.com",
+      "intro": "The PlayStation Store is Sony's digital storefront for PS4 and PS5 games, downloadable\ncontent, PlayStation Plus subscriptions, and movies. Purchases happen directly through\nthe console or on store.playstation.com. Card networks often code PlayStation Store\ncharges as digital goods or entertainment, which can trigger entertainment category\nbonuses on cards like the Capital One SavorOne.\n\nPlayStation Plus subscription tiers and Game Pass-style game catalogs may also fall\nunder streaming services coding on some issuers, which means the Amex Blue Cash\nPreferred can occasionally earn 6 percent. Online shopping bonus cards such as Bank\nof America Customized Cash and Chase Freedom Flex during rotating online quarters\nremain reliable defaults for game and DLC purchases.\n"
+    },
+    {
+      "name": "Polo Ralph Lauren",
+      "slug": "polo-ralph-lauren",
+      "aliases": [
+        "Ralph Lauren"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.ralphlauren.com",
+      "intro": "Polo Ralph Lauren is the flagship label of Ralph Lauren Corporation, sold through\nabout 140 U.S. full-price, factory, and Rugby-style stores along with ralphlauren.com\nand an extensive department store wholesale presence. Direct purchases typically code\nas department store in person and online shopping for web orders. The free Ralph\nLauren Rewards program offers points and member perks, but the brand does not run a\nconsumer co-brand credit card in the U.S.\n"
     },
     {
       "name": "Popeyes",
@@ -1518,6 +3039,15 @@
       "intro": "Popeyes is a U.S. Louisiana-style fried chicken chain with about 3,000 domestic\nlocations, owned by Restaurant Brands International. Charges code as dining on\nevery card we track. Any dining-bonus card (Amex Gold 4x, Sapphire Preferred 3x,\nSavorOne 3%) applies. The Popeyes Rewards app issues per-purchase points\nredeemable for free items, stackable with card bonuses.\n"
     },
     {
+      "name": "Poshmark",
+      "slug": "poshmark",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://poshmark.com",
+      "intro": "Poshmark is a social commerce marketplace focused on secondhand fashion, beauty, and\naccessories, where individual sellers list items and ship through prepaid Poshmark\nlabels. The platform was acquired by Korean tech company Naver in 2023. Buyer\npurchases code as online shopping for credit card networks, so any online-shopping\ncategory bonus card will earn its full multiplier. Poshmark does not have a co-brand\ncredit card, so the best earn comes from a general 3-5x online-shopping rewards card.\n"
+    },
+    {
       "name": "Pottery Barn",
       "slug": "pottery-barn",
       "categories": [
@@ -1526,6 +3056,31 @@
       ],
       "website": "https://www.potterybarn.com",
       "intro": "Pottery Barn is a U.S. home furnishings retailer with about 200 stores, owned by\nWilliams-Sonoma Inc. (also West Elm, Pottery Barn Kids). Stores code as\nfurniture/home improvement; potterybarn.com codes as online shopping. The Key\nRewards loyalty program is free, spans all Williams-Sonoma sister brands, and\nearns 2% in Key Rewards points; pairing it with the Key Rewards co-branded\nMastercard adds an additional 5% on Williams-Sonoma family purchases.\n"
+    },
+    {
+      "name": "Pottery Barn Kids",
+      "slug": "pottery-barn-kids",
+      "aliases": [
+        "PB Kids"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.potterybarnkids.com",
+      "intro": "Pottery Barn Kids is the kids and baby furnishings banner of Williams-Sonoma Inc, with\nabout 80 U.S. stores plus potterybarnkids.com selling cribs, bedding, nursery decor,\nand gear. The Key Rewards Visa from Capital One earns elevated points across all WSI\nbrands and stacks with the free Key Rewards program, which is helpful for big-ticket\nnursery setups. General-purpose cards typically code purchases as home improvement or\ndepartment store in person and online shopping on the web.\n"
+    },
+    {
+      "name": "Price Chopper",
+      "slug": "price-chopper",
+      "aliases": [
+        "Market 32"
+      ],
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.pricechopper.com",
+      "intro": "Price Chopper, operated by Northeast Grocery, runs about 130 supermarkets across New\nYork, Vermont, Connecticut, Pennsylvania, Massachusetts, and New Hampshire. Many\nremodeled locations carry the sister Market 32 banner. Both code as U.S. supermarkets,\nso grocery rewards cards (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earn full\nmultipliers. The AdvantEdge loyalty program ties shoppers into fuel discount partners\nlike Sunoco, which can stack with a separate gas-category card at the pump.\n"
     },
     {
       "name": "Publix",
@@ -1540,6 +3095,18 @@
       "intro": "Publix is the largest employee-owned U.S. supermarket chain, with about 1,400 stores\nconcentrated in the Southeast. Pricing skews higher than at mass-market grocers like\nWalmart Neighborhood Market or Aldi, which makes a strong grocery-category card more\nvaluable per visit. Publix codes cleanly as groceries on every card we track.\n"
     },
     {
+      "name": "Qdoba",
+      "slug": "qdoba",
+      "aliases": [
+        "Qdoba Mexican Eats"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.qdoba.com",
+      "intro": "Qdoba Mexican Eats operates roughly 750 fast-casual locations, competing directly with\nChipotle in the burritos-bowls-tacos lane while differentiating with free queso and\nguacamole on entrees. Orders placed in-store, at the counter, or through the Qdoba Rewards\napp all code as dining/restaurants. That makes any card with a dining bonus a strong fit:\nthe Chase Sapphire Reserve earns 4x on dining, Amex Gold earns 4x, and the Capital One\nSavorOne earns 3% unlimited cash back on every Qdoba purchase.\n"
+    },
+    {
       "name": "QuikTrip",
       "slug": "quiktrip",
       "aliases": [
@@ -1550,6 +3117,79 @@
       ],
       "website": "https://www.quiktrip.com",
       "intro": "QuikTrip is a South-and-Midwest gas-and-convenience chain with about 1,000 stores,\nconsistently ranked among the highest customer-satisfaction convenience operators\nin the U.S. Fuel codes as gas on every card we track; in-store purchases typically\ncode as convenience. The QT Rewards app offers per-gallon savings; pair it with a\n4-5% general gas card for the cleanest stack.\n"
+    },
+    {
+      "name": "QVC",
+      "slug": "qvc",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.qvc.com",
+      "intro": "QVC is a multichannel retailer that sells via live television broadcasts, qvc.com, and\nmobile apps, owned by Qurate Retail Group (which also runs HSN). The merchandise mix\nspans apparel, jewelry, beauty, kitchen, electronics, and home goods, often pitched\nby celebrity hosts in real time. QVC purchases code as online shopping or general\nmerchandise for credit card networks, so an online-shopping category bonus card will\ngenerally earn its multiplier. QVC also offers its Easy Pay installment program at\ncheckout, billed against the saved card on file.\n"
+    },
+    {
+      "name": "RaceTrac",
+      "slug": "racetrac",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.racetrac.com",
+      "intro": "RaceTrac is a family-owned Southeast U.S. convenience and fuel chain with more than\n800 stores across Georgia, Florida, Texas, Tennessee, Louisiana, and surrounding\nstates. Fuel pumps code as gas, so any gas category bonus card will earn its\nmultiplier. Inside-store food and drinks (the chain leans heavily on coffee and\nprepared foods) typically code as convenience store. The RaceTrac Rewards loyalty\nprogram adds per-gallon discounts and points on food that stack with a separate gas\nrewards card.\n"
+    },
+    {
+      "name": "Radisson Hotel Group",
+      "slug": "radisson",
+      "aliases": [
+        "Radisson Hotels"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.radissonhotels.com",
+      "intro": "Radisson Hotel Group operates a global portfolio that includes Radisson Collection, Radisson\nBlu, Radisson, Radisson RED, Park Plaza, Park Inn, and Country Inn & Suites, spanning roughly\n1,100 hotels worldwide. In the Americas, Radisson Hotels Americas was sold to Choice Hotels\nin 2022, which complicates loyalty mapping: US stays now mostly earn Choice Privileges,\nwhile EMEA/APAC stays earn Radisson Rewards. Radisson stays code as lodging/hotels. Travel\ncards with hotel bonuses (Amex Gold 3x on prepaid, Chase Sapphire Reserve 4x direct) earn full rate.\n"
+    },
+    {
+      "name": "Raising Cane's",
+      "slug": "raising-canes",
+      "aliases": [
+        "Canes"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.raisingcanes.com",
+      "intro": "Raising Cane's Chicken Fingers is a Baton Rouge-based quick-service chain serving\na focused menu of chicken finger combos, Texas toast, crinkle-cut fries, and the\nsignature Cane's Sauce. The chain has expanded from a single Louisiana location to\nover 800 restaurants nationwide. Raising Cane's transactions code as restaurants\non Visa, Mastercard, and Amex networks, which lights up most dining bonus\ncategories.\n\nThe Amex Gold pays 4x points on U.S. restaurants for one of the highest dining\nrates available, while the Chase Sapphire Reserve and Capital One Savor both pay\n3x or more. The Capital One SavorOne is a strong no-annual-fee pick at 3 percent\non dining. Cane's runs no in-house loyalty program of its own, so credit card\nrewards are the primary cash back path.\n"
+    },
+    {
+      "name": "Raley's",
+      "slug": "raleys",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.raleys.com",
+      "intro": "Raley's is a family-owned, Northern California based supermarket chain with about 120\nstores across California and Nevada, including the Bel Air, Nob Hill Foods, and Raley's\nO-N-E Market banners. The chain emphasizes fresh produce, in-house meat and seafood,\nand a strong private-label program. Raley's codes as a U.S. supermarket, so any\ngrocery category card (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earns full\nmultipliers. The Something Extra loyalty program adds digital coupon savings and\noccasional fuel discounts at partner stations.\n"
+    },
+    {
+      "name": "Ralphs",
+      "slug": "ralphs",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.ralphs.com",
+      "intro": "Ralphs is the Southern California banner of Kroger, operating roughly 180 stores across\nthe Los Angeles and San Diego areas. It codes cleanly as a U.S. supermarket for credit\ncard networks, so grocery bonus cards earn their full rate. Ralphs is also part of the\nKroger fuel points program (the chain runs co-located fuel centers in some locations),\nand the store sells third-party gift cards that can stretch a grocery multiplier into\nother spending categories.\n"
+    },
+    {
+      "name": "Red Robin",
+      "slug": "red-robin",
+      "aliases": [
+        "Red Robin Gourmet Burgers"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.redrobin.com",
+      "intro": "Red Robin Gourmet Burgers operates about 500 casual-dining restaurants centered on\ncustomizable burgers like the Royal Red Robin and Banzai Burger, plus Bottomless Steak Fries\nrefills that anchor the brand's table-service value pitch. The chain skews family-friendly\nwith a kids menu and milkshake program. Red Robin transactions code as dining/restaurants\non every card, including orders placed through Red Robin Royalty loyalty. Dining-bonus\ncards earn full rate: Amex Gold (4x), Chase Sapphire Reserve (4x), Capital One SavorOne (3%).\n"
     },
     {
       "name": "REI",
@@ -1566,6 +3206,19 @@
       "intro": "REI is a member-owned outdoor co-op with about 180 U.S. stores, selling apparel,\ncamping, climbing, and cycling gear. REI codes under its own merchant category\non several cards (notably the Co-op Mastercard, which earns 5% back at REI for\nCo-op Members) and as online shopping for rei.com purchases otherwise. The $30\none-time Co-op membership earns an annual member dividend (~10% of purchases),\nplus member-only sales — typically the most valuable lever for heavy REI buyers\nbeyond any card bonus.\n"
     },
     {
+      "name": "Restoration Hardware",
+      "slug": "restoration-hardware",
+      "aliases": [
+        "RH"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://rh.com",
+      "intro": "Restoration Hardware, now branded as RH, is an upscale home furnishings retailer with\naround 70 large-format Galleries plus rh.com selling furniture, lighting, textiles,\nand outdoor. The RH Members Program is a paid annual membership that grants 25 percent\noff most full-price items and stacks with credit card rewards. General-purpose cards\ntypically code RH as home improvement or department store in person and online\nshopping for web orders.\n"
+    },
+    {
       "name": "Rite Aid",
       "slug": "rite-aid",
       "categories": [
@@ -1573,6 +3226,16 @@
       ],
       "website": "https://www.riteaid.com",
       "intro": "Rite Aid is the third-largest U.S. pharmacy chain at about 1,700 stores, primarily in\nthe Northeast and West Coast. Rite Aid codes cleanly as a drugstore on every card we\ntrack, so any drugstore-bonus card will earn here. The chain's BonusCash and wellness+\nrewards programs layer on top of card cashback.\n"
+    },
+    {
+      "name": "Rooms To Go",
+      "slug": "rooms-to-go",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.roomstogo.com",
+      "intro": "Rooms To Go is a Florida-based furniture retailer that pioneered the room-package\nconcept, bundling sofa, loveseat, tables, lamps, and rug into a single price. The\nchain runs over 250 showrooms across the Southeast, Texas, and Puerto Rico. Furniture\npurchases code as general retail on most rewards cards, so they sit outside dedicated\nhome improvement bonuses.\n\nFive-piece living room packages and bedroom sets often clear $2,000, making Rooms To\nGo a useful place to hit signup bonus thresholds on cards like the Chase Sapphire\nPreferred or Capital One Venture. The retailer also markets a Synchrony-issued Rooms\nTo Go credit card with deferred-interest financing, but a rewards card paid in full\ngenerally produces more value.\n"
     },
     {
       "name": "Ross Dress for Less",
@@ -1585,6 +3248,18 @@
       ],
       "website": "https://www.rossstores.com",
       "intro": "Ross Dress for Less is a U.S. off-price retail chain with about 1,800 stores\nselling apparel, accessories, and home goods at discount prices. Codes as\ndepartment stores on most cards. There's no co-branded Ross credit card, so the\nbest pairings are general department-store-bonus cards (Wells Fargo Active Cash\nflat 2%, U.S. Bank Shopper Cash Rewards if Ross is selected) or flat-rate\ncashback cards. Ross doesn't run a loyalty program.\n"
+    },
+    {
+      "name": "Ruth's Chris Steak House",
+      "slug": "ruths-chris-steak-house",
+      "aliases": [
+        "Ruth's Chris"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.ruthschris.com",
+      "intro": "Ruth's Chris Steak House, now owned by Darden Restaurants, operates about 150 upscale\nsteakhouses known for USDA Prime steaks served on 500-degree plates with sizzling butter,\nplus signature sides like the Sweet Potato Casserole. Average check sizes run high enough\nthat a well-chosen dining card meaningfully changes the bill economics. Ruth's Chris codes\nas dining/restaurants on every credit card. Top picks here include the Amex Gold (4x\nMembership Rewards), Chase Sapphire Reserve (4x Ultimate Rewards), and Capital One Savor (3%).\n"
     },
     {
       "name": "Safeway",
@@ -1610,6 +3285,28 @@
       "intro": "Saks Fifth Avenue is a high-end department store with about 40 full-line stores plus the\nmuch larger Saks Off 5th outlet network. Average ticket sizes are higher than at\nmass-market department chains, which makes a high-rate department-store category card\nmore valuable here than at, say, JCPenney. Saks codes as a department store in-store and\nonline shopping on saksfifthavenue.com, so general-purpose category bonuses apply.\n"
     },
     {
+      "name": "Saks OFF 5TH",
+      "slug": "saks-off-5th",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.saksoff5th.com",
+      "intro": "Saks OFF 5TH is the off-price arm of Saks Fifth Avenue, with about 90 outlet stores\nacross the U.S. and Canada plus its own e-commerce site. The format carries designer\napparel, shoes, and accessories at substantial discounts to the parent retailer. Saks\nOFF 5TH codes as a department store, so a department-store category bonus card will\nearn its multiplier. The SaksFirst Mastercard (issued by Capital One) earns elevated\npoints at both Saks Fifth Avenue and Saks OFF 5TH, with tiered status benefits at\nhigher spend thresholds.\n"
+    },
+    {
+      "name": "Sally Beauty",
+      "slug": "sally-beauty",
+      "aliases": [
+        "Sally Beauty Supply"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.sallybeauty.com",
+      "intro": "Sally Beauty is the U.S. retail banner of Sally Beauty Holdings, with about 2,400\nstores plus sallybeauty.com selling professional hair color, salon supplies, and at\nhome beauty products. The free Sally Beauty Rewards program offers points and member\npricing, while a separate Pro Card serves licensed cosmetologists. General-purpose\ncards typically code Sally Beauty as department store in person and online shopping\nfor web orders.\n"
+    },
+    {
       "name": "Sam's Club",
       "slug": "sams-club",
       "aliases": [
@@ -1621,6 +3318,15 @@
       "website": "https://www.samsclub.com",
       "parent_company": "Walmart, Inc.",
       "intro": "Sam's Club is Walmart's warehouse-club arm, with about 600 U.S. clubs and a steadily\ngrowing online and Scan & Go catalog. Member tiers (Club vs. Plus) affect free-shipping\nand curbside perks but not the rewards math at the register. Sam's accepts Visa,\nMastercard, Amex, and Discover, and Sam's Club gas pumps code as wholesale clubs rather\nthan gas stations — the same rule as Costco.\n"
+    },
+    {
+      "name": "Schnucks",
+      "slug": "schnucks",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.schnucks.com",
+      "intro": "Schnucks is a St. Louis based regional supermarket chain with around 110 stores across\nMissouri, Illinois, Indiana, and Wisconsin. The family-owned chain codes as a U.S.\nsupermarket, so a card with a grocery bonus (Amex Gold, Blue Cash Preferred, Citi\nCustom Cash) will earn its full rate at the register. Schnucks runs its own loyalty\nprogram with fuel rewards redeemable at participating gas stations, which can stack\nwith a separate gas-category card at the pump.\n"
     },
     {
       "name": "Sephora",
@@ -1650,6 +3356,15 @@
       "intro": "Sheetz is a Mid-Atlantic gas-and-convenience chain known for its made-to-order food\n(\"MTO\" subs, sides, smoothies). Fuel codes as gas on every card we track; in-store\nfood typically codes as gas or convenience and only rarely as dining. The free\nSheetz Rewardz app stacks per-gallon discounts and free food rewards on top of any\ncard's bonus rate, which usually beats hunting for a Sheetz-specific credit card.\n"
     },
     {
+      "name": "Shein",
+      "slug": "shein",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.shein.com",
+      "intro": "Shein is a Singapore-headquartered fast-fashion retailer that sells direct to U.S.\nconsumers, mostly shipped from China and other manufacturing hubs. The model is built\non extremely fast trend cycles, low prices, and a constant churn of new SKUs. Shein\npurchases code as online shopping for credit card networks, so any online-shopping\ncategory bonus card will earn its multiplier. There is no Shein co-brand credit card,\nso the best play is a general 3-5x online-shopping rewards card or a rotating-bonus\ncard during an online-shopping quarter.\n"
+    },
+    {
       "name": "Shell",
       "slug": "shell",
       "aliases": [
@@ -1663,6 +3378,16 @@
       "intro": "Shell is one of the largest U.S. gasoline retailers by station count (about 13,000\nlocations), with a Fuel Rewards loyalty program tied to the Shell app. Shell pumps code\ncleanly as gas on every card we track. The Shell Fuel Rewards program offers stackable\nper-gallon discounts that are calculated separately from card cashback.\n"
     },
     {
+      "name": "Sherwin-Williams",
+      "slug": "sherwin-williams",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.sherwin-williams.com",
+      "intro": "Sherwin-Williams is the largest U.S. paint manufacturer and retailer, with over\n4,700 company-owned stores serving residential painters, contractors, and designers.\nSherwin-Williams typically codes as home improvement on Visa, Mastercard, and Amex\nnetworks, which makes paint purchases eligible for the home improvement bonus on\ncards that carry the category.\n\nThe U.S. Bank Cash+ and Bank of America Customized Cash can both route Sherwin\npurchases into a selectable 3 to 5 percent bonus. The chain runs frequent 30 to 40\npercent off paint promotions that stack with credit card cash back, and Sherwin's\nPaintPerks loyalty program adds member pricing on top of any rewards a credit card\ndelivers.\n"
+    },
+    {
       "name": "Shipt",
       "slug": "shipt",
       "categories": [
@@ -1672,6 +3397,16 @@
       "intro": "Shipt is a same-day delivery service owned by Target, with grocery, household, and\nsome specialty retail (Petco, CVS) partners. Most Shipt charges code as groceries\nor as the underlying merchant — worth checking your statement before relying on\na category-bonus card. Shipt is bundled into Target Circle 360 (Target's premium\nmembership), so heavy Target shoppers often pair it with a Target REDcard for\nthe in-store discount.\n"
     },
     {
+      "name": "Shoe Carnival",
+      "slug": "shoe-carnival",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.shoecarnival.com",
+      "intro": "Shoe Carnival is a value-oriented family footwear chain with about 380 stores\nconcentrated in the Midwest, South, and Southeast plus shoecarnival.com. The retailer\nrecently acquired Rogan's Shoes and now also operates Shoe Station. The Shoe Perks\nloyalty program is free and offers points and birthday bonuses that stack with credit\ncard rewards. Most cards code purchases as department store in person and online\nshopping for web checkouts.\n"
+    },
+    {
       "name": "ShopRite",
       "slug": "shoprite",
       "categories": [
@@ -1679,6 +3414,26 @@
       ],
       "website": "https://www.shoprite.com",
       "intro": "ShopRite is a cooperative grocery chain with about 280 stores across the Northeast\nand Mid-Atlantic. Codes cleanly as groceries on every card we track. Strongest\npairings are Blue Cash Preferred (6%), Capital One SavorOne (3%), and U.S. Bank\nShopper Cash Rewards (6% if ShopRite is one of the two selected retailers). The\nPrice Plus Club loyalty program runs digital coupons and per-gallon fuel savings\nat participating partner stations on top of card bonuses.\n"
+    },
+    {
+      "name": "Skechers",
+      "slug": "skechers",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.skechers.com",
+      "intro": "Skechers is a comfort and lifestyle footwear brand with around 550 U.S. concept,\nfactory outlet, and warehouse stores plus skechers.com. Direct purchases typically\ncode as department store in person and online shopping for web orders, while Skechers\nbought at Famous Footwear, DSW, or Kohl's codes under those host retailers. The free\nSkechers Plus loyalty program offers points and a birthday reward and stacks with\ncredit card earnings.\n"
+    },
+    {
+      "name": "Smart & Final",
+      "slug": "smart-and-final",
+      "categories": [
+        "groceries",
+        "wholesale_clubs"
+      ],
+      "website": "https://www.smartandfinal.com",
+      "intro": "Smart & Final is a California-based hybrid warehouse/grocery chain with about 250\nstores across the Western U.S. and Mexico. Unlike Costco or Sam's, no membership is\nrequired, so any shopper can walk in and buy bulk packaged goods alongside normal\ngrocery items. Merchant category coding is the gotcha here: most Smart & Final stores\nhistorically code as warehouse club rather than supermarket, which means a grocery\nbonus card (Amex Gold, Blue Cash Preferred) may not trigger its multiplier. Coding can\nvary by location, so check a recent statement before assuming a category bonus applies.\n"
     },
     {
       "name": "Sonic Drive-In",
@@ -1781,6 +3536,15 @@
       "intro": "Starbucks runs about 16,500 U.S. stores plus the Starbucks app, which is itself one of\nthe largest closed-loop payment systems in the country. Whether you pay through the app,\nwith a physical Starbucks card, or directly with a credit card, the underlying Starbucks\ntransaction codes as dining/restaurants on every card we track. Reloading your Starbucks\nbalance via card is the cleanest way to capture the dining bonus on cards that pay 3-5%\non dining.\n"
     },
     {
+      "name": "StockX",
+      "slug": "stockx",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://stockx.com",
+      "intro": "StockX is a resale marketplace built around sneakers, streetwear, watches, handbags,\nand collectibles, with a bid/ask exchange model and mandatory authentication of every\nitem before it ships to the buyer. The platform is a primary secondary market for\nhyped sneaker releases. StockX codes as online shopping for credit card networks, so\nan online-shopping category bonus card will earn its multiplier. Buyer fees are baked\ninto the transaction price, which is the figure that posts to the card.\n"
+    },
+    {
       "name": "Stop & Shop",
       "slug": "stop-and-shop",
       "aliases": [
@@ -1800,6 +3564,19 @@
       ],
       "website": "https://www.subway.com",
       "intro": "Subway is the largest restaurant chain in the U.S. by store count, with about\n20,000 domestic locations. Charges code as dining on every card we track. Standard\nhigh-bonus dining cards (Amex Gold 4x capped, Sapphire Preferred 3x, Capital One\nSavorOne 3%) are the obvious pairings. The MyWay Rewards loyalty program and\nrecurring digital coupons in the Subway app stack on top of card bonuses.\n"
+    },
+    {
+      "name": "Sun Country Airlines",
+      "slug": "sun-country-airlines",
+      "aliases": [
+        "Sun Country"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.suncountry.com",
+      "intro": "Sun Country Airlines is a Minneapolis/St. Paul-based ultra-low-cost carrier with a hybrid\nbusiness model that combines scheduled leisure flights, cargo flying for Amazon, and ad-hoc\ncharters for sports teams and casinos. Routes mostly connect MSP to warm-weather US and\nMexico destinations during peak seasons. Sun Country purchases code as airlines/airfare on\nevery credit card. Cards with airfare bonus categories all earn full rate: the Chase\nSapphire Reserve at 4x, Amex Gold at 3x on direct-booked flights, Capital One Venture X at 2x.\n"
     },
     {
       "name": "Sunoco",
@@ -1823,6 +3600,15 @@
       "intro": "Taco Bell is a U.S. fast-food chain with about 7,500 domestic locations, owned by\nYum! Brands. Charges code as dining on every card we track. Standard dining cards\n(Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%) earn the bonus. The Taco Bell\nRewards app issues frequent free-item promotions and limited-time member-exclusive\nmenu items that stack on top of any card's bonus rate.\n"
     },
     {
+      "name": "Take 5 Oil Change",
+      "slug": "take-5-oil-change",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.take5oilchange.com",
+      "intro": "Take 5 Oil Change is a drive-through oil change chain operated by Driven Brands,\nwith over 1,000 U.S. locations. Drivers stay in the car while technicians complete\nthe oil change in about five to ten minutes. Most card networks code Take 5 as auto\nservices rather than as a dedicated bonus category, which puts the chain outside\nmost rotating and selectable bonus rewards.\n\nFor cardholders who want elevated rewards on routine maintenance, Citi Custom Cash\ncan pay 5 percent if auto services is the top eligible spending category in a given\nmonth. Otherwise, a flat-rate card like the Citi Double Cash, Wells Fargo Active\nCash, or PayPal Cashback Mastercard delivers consistent 2 percent on every Take 5\nvisit.\n"
+    },
+    {
       "name": "Target",
       "slug": "target",
       "aliases": [
@@ -1843,6 +3629,15 @@
       "intro": "Target sits in the same awkward bucket as Walmart for general-purpose credit cards: it\ncodes as a discount store rather than a supermarket or department store, so most cards'\nbonus categories (grocery, dining, department stores) miss it entirely. Target.com\npurchases code as online shopping on most cards, which is where the highest\nnon-co-branded earn rates show up. In-store, you're typically falling back to a strong\nflat-rate card unless you carry a Target-issued card for the 5% RedCard discount applied\nat checkout.\n"
     },
     {
+      "name": "Temu",
+      "slug": "temu",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.temu.com",
+      "intro": "Temu is a U.S.-facing online marketplace owned by Chinese e-commerce giant PDD\nHoldings, launched stateside in 2022 and aggressively marketed on ultra-low prices and\ndirect-from-manufacturer shipping. Purchases typically code as online shopping or\nmerchandise, so a card with an online-shopping category bonus (Capital One SavorOne\npromotions, Chase Freedom Flex when activated, Citi Custom Cash on online shopping\nmonth) will earn its full multiplier. Temu has no co-brand credit card, so the best\nearn comes from a general online-shopping bonus.\n"
+    },
+    {
       "name": "Texas Roadhouse",
       "slug": "texas-roadhouse",
       "categories": [
@@ -1850,6 +3645,29 @@
       ],
       "website": "https://www.texasroadhouse.com",
       "intro": "Texas Roadhouse is a U.S. casual-dining steakhouse chain with about 700 domestic\nlocations. Charges code as dining on every card we track. Any dining-bonus card\nearns the bonus (Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%). The chain\ndoesn't run a high-volume loyalty program, so the card bonus is the main\nrewards lever per visit.\n"
+    },
+    {
+      "name": "TGI Fridays",
+      "slug": "tgi-fridays",
+      "aliases": [
+        "Fridays",
+        "T.G.I. Friday's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.tgifridays.com",
+      "intro": "TGI Fridays operates around 350 US casual-dining restaurants with a bar-and-grill format that\nhelped define the category, anchored by Loaded Potato Skins, Jack Daniel's Sesame Chicken\nStrips, and a full cocktail program. The chain has contracted from its 1990s peak but\nremains a recognizable airport and suburban brand. Fridays transactions code as dining/\nrestaurants on every credit card, including bar tabs and to-go orders. Dining-bonus cards\nearn full rate: Amex Gold at 4x, Chase Sapphire Reserve at 4x, Capital One SavorOne at 3% cash.\n"
+    },
+    {
+      "name": "The Body Shop",
+      "slug": "the-body-shop",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.thebodyshop.com",
+      "intro": "The Body Shop is a British natural beauty and skincare brand known for body butters,\nethical sourcing, and animal-testing-free positioning. The U.S. footprint runs through\na smaller set of mall-based stores plus thebodyshop.com after the parent restructured\nin 2024. Direct purchases typically code as department store in person and online\nshopping for web orders, and the free Love Your Body Club loyalty program stacks\nalongside credit card rewards.\n"
     },
     {
       "name": "The Cheesecake Factory",
@@ -1862,6 +3680,25 @@
       ],
       "website": "https://www.thecheesecakefactory.com",
       "intro": "The Cheesecake Factory is a U.S. casual-dining chain with about 220 domestic\nlocations, with notably higher average tickets than typical casual dining.\nCharges code as dining on every card we track, so any dining-bonus card applies\n(Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%). The chain runs Cheesecake\nRewards in its app, with free slices on birthdays and milestone visits.\n"
+    },
+    {
+      "name": "The Container Store",
+      "slug": "the-container-store",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.containerstore.com",
+      "intro": "The Container Store is the leading U.S. specialty retailer for organization and\nstorage, known for The Elfa custom closet system, kitchen organizers, and Russell\n+ Hazel desk goods. Purchases typically code as general retail, so flat-rate cards\nlike the Citi Double Cash earn the same 2 percent as on most shopping.\n\nBig custom closet installations can run into the thousands, which makes signup bonus\nminimum spend a useful angle. Cards with rotating online shopping quarters, such as\nChase Freedom Flex, occasionally lift containerstore.com orders to 5 percent, and the\nfree Organized Insider loyalty program adds tiered discounts on top of card rewards.\n"
+    },
+    {
+      "name": "The Fresh Market",
+      "slug": "the-fresh-market",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.thefreshmarket.com",
+      "intro": "The Fresh Market is an upscale specialty grocer with around 160 stores, primarily in\nthe Southeast and along the Eastern Seaboard. The format leans into prepared meals,\nbutcher and seafood counters, and a curated wine and cheese selection. The Fresh\nMarket codes as a U.S. supermarket, so grocery category cards (Amex Gold, Blue Cash\nPreferred, Citi Custom Cash) earn their normal multiplier here. Given the higher\naverage ticket compared to mainstream chains, a 4x or 6x grocery card can produce\noutsized rewards on a typical trip.\n"
     },
     {
       "name": "The North Face",
@@ -1878,6 +3715,61 @@
       "intro": "The North Face is a U.S. outdoor-apparel brand owned by VF Corporation, with\nabout 150 retail stores plus extensive third-party distribution at REI, Dick's,\nBackcountry, and more. Direct purchases at thenorthface.com code as online\nshopping; in-store charges code as department stores or apparel. The XPLR Pass\nloyalty program is free and issues spend rewards plus first-access to limited\ndrops. Pair with an online-shopping-bonus card or flat-rate cashback.\n"
     },
     {
+      "name": "The RealReal",
+      "slug": "the-realreal",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.therealreal.com",
+      "intro": "The RealReal is an authenticated luxury consignment marketplace selling pre-owned\ndesigner apparel, handbags, watches, jewelry, and home goods online and through a\nhandful of physical stores. Every item is inspected and authenticated by in-house\nexperts before listing, which is the platform's main differentiator versus\npeer-to-peer resale. Purchases code as online shopping for credit card networks, so\nan online-shopping category bonus card will earn its multiplier. Given the higher\naverage ticket on luxury items, 3-5x earn rates can produce meaningful rewards.\n"
+    },
+    {
+      "name": "The UPS Store",
+      "slug": "the-ups-store",
+      "categories": [
+        "office_supplies"
+      ],
+      "website": "https://www.theupsstore.com",
+      "intro": "The UPS Store is a franchise network of more than 5,000 U.S. locations offering\nshipping, printing, mailbox services, packing, notary, and small business support.\nMost The UPS Store locations code as office supplies or stationery on Visa,\nMastercard, and Amex networks, which makes shipping and print purchases eligible\nfor office supply bonus categories.\n\nBusiness cards with office supply bonuses are the natural fit. The Chase Ink\nBusiness Cash pays 5 percent on the first $25,000 in combined office supply and\ninternet, cable, and phone purchases each year, and the Amex Business Gold also\noffers office supplies as a top-two category. Personal cards with selectable office\nsupply categories, like U.S. Bank Cash+, can capture the same MCC.\n"
+    },
+    {
+      "name": "ThredUp",
+      "slug": "thredup",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.thredup.com",
+      "intro": "ThredUp is an online consignment and thrift store that processes secondhand women's\nand kids' clothing on behalf of sellers and sells to buyers through its website. The\nmodel differs from peer-to-peer platforms (Poshmark, Mercari) in that ThredUp itself\nauthenticates, photographs, and warehouses inventory before listing. Purchases code\nas online shopping for credit card networks, so an online-shopping category bonus\ncard will earn its multiplier. ThredUp does not issue a co-brand credit card.\n"
+    },
+    {
+      "name": "Thrive Market",
+      "slug": "thrive-market",
+      "categories": [
+        "groceries",
+        "online_shopping"
+      ],
+      "website": "https://thrivemarket.com",
+      "intro": "Thrive Market is a membership-based online grocery and wellness retailer focused on organic,\nnon-GMO, and specialty-diet pantry items (keto, paleo, gluten-free), shipped to subscribers\nfrom regional fulfillment centers. The annual membership funds member-only pricing on\nshelf-stable groceries, supplements, and clean-beauty products. Thrive Market charges\ngenerally code as online retail or supermarkets depending on the issuer's processor mapping,\nso results vary: cards with online-shopping bonuses (Chase Freedom Flex quarters, Capital One\nSavorOne online grocery) often earn more than flat-rate cards on Thrive Market orders.\n"
+    },
+    {
+      "name": "Tim Hortons",
+      "slug": "tim-hortons",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.timhortons.com",
+      "intro": "Tim Hortons is the Canadian coffee and donut institution owned by Restaurant Brands\nInternational (the same parent as Burger King and Popeyes), with roughly 4,000 Canadian\nstores plus a smaller US footprint of about 600 locations. Beyond brewed coffee and Timbits,\nthe menu now spans breakfast sandwiches, soups, and lunch wraps. Tim Hortons purchases code\nas dining/restaurants on US-issued cards, so cards offering elevated dining rewards (Amex\nGold 4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3%) all earn at the full multiplier.\n"
+    },
+    {
+      "name": "Tire Rack",
+      "slug": "tire-rack",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.tirerack.com",
+      "intro": "Tire Rack is a direct-to-consumer online tire retailer that ships tires to a nearby\ninstaller in its recommended installer network. The company carries an extensive\nselection of passenger, performance, winter, and truck tires plus wheels and\nperformance brake components. Most credit card networks code Tire Rack as online\nshopping or auto parts rather than as a dedicated bonus category.\n\nCards with online shopping bonuses fit Tire Rack purchases well. Bank of America\nCustomized Cash and U.S. Bank Cash+ can earn 3 to 5 percent when online shopping is\nselected, and Chase Freedom Flex rotates online shopping in some quarters. Tire\nRack also occasionally appears in shopping portals like Rakuten with cash back that\nstacks on top of credit card rewards.\n"
+    },
+    {
       "name": "TJ Maxx",
       "slug": "tj-maxx",
       "aliases": [
@@ -1891,6 +3783,41 @@
       "intro": "TJ Maxx is the flagship off-price retail brand of TJX Companies, with about 1,300\nU.S. stores selling apparel, home goods, and accessories at discount prices.\nCodes as department stores on most cards, so a department-store-bonus card\n(Sapphire Preferred 3x on online department stores via portal, U.S. Bank Shopper\nCash Rewards if selected) is the strongest pairing. The TJX Rewards co-branded\nMastercard offers 5% back at TJ Maxx, Marshalls, HomeGoods, Sierra, and\nHomesense — typically the best rate for heavy TJX shoppers.\n"
     },
     {
+      "name": "Tommy Hilfiger",
+      "slug": "tommy-hilfiger",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://usa.tommy.com",
+      "intro": "Tommy Hilfiger is a flagship apparel brand owned by PVH Corp, with about 60 U.S.\nfull-line and outlet stores plus a strong online presence at usa.tommy.com. Direct\npurchases at Tommy stores or the website typically code as department store or online\nshopping, while Tommy goods bought at Macy's or Nordstrom code under that retailer.\nThe free Tommy Club loyalty program stacks with credit card rewards, and there is no\nTommy Hilfiger branded credit card today.\n"
+    },
+    {
+      "name": "Tops Friendly Markets",
+      "slug": "tops-friendly-markets",
+      "aliases": [
+        "Tops"
+      ],
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.topsmarkets.com",
+      "intro": "Tops Friendly Markets is a Western New York based supermarket chain with about 150\nstores across upstate New York, northern Pennsylvania, and Vermont. Now part of\nNortheast Grocery (the same parent that runs Price Chopper), Tops codes as a U.S.\nsupermarket for credit card networks. Standard grocery rewards cards (Amex Gold, Blue\nCash Preferred, Citi Custom Cash) will earn full multipliers, and the Tops BonusPlus\nloyalty card adds per-gallon fuel discounts at partner gas stations.\n"
+    },
+    {
+      "name": "Tractor Supply Co",
+      "slug": "tractor-supply",
+      "aliases": [
+        "Tractor Supply Company"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.tractorsupply.com",
+      "intro": "Tractor Supply Co is the largest rural lifestyle retailer in the United States,\noperating more than 2,200 stores stocked with livestock feed, fencing, riding mowers,\nworkwear, and pet supplies. Card networks sometimes code Tractor Supply as a farm\nsupply merchant rather than a home improvement store, which can keep it out of the\nHome Depot and Lowe's bonus on cards like the Wells Fargo Bilt.\n\nThe Tractor Supply Neighbor's Club loyalty program is one of the best in retail,\nlayering points-based rewards on top of credit card cash back. Cards with rotating\nonline shopping quarters, including Chase Freedom Flex and Discover it, occasionally\nbump tractorsupply.com orders to 5 percent for the quarter.\n"
+    },
+    {
       "name": "Trader Joe's",
       "slug": "trader-joes",
       "aliases": [
@@ -1902,6 +3829,25 @@
       ],
       "website": "https://www.traderjoes.com",
       "intro": "Trader Joe's is the smaller-format private-label grocer with about 600 stores\nnationwide, famous for store-brand goods and tight pricing. Average tickets are smaller\nthan at full-line supermarkets, but the visit frequency tends to be higher. TJ's codes\ncleanly as groceries (supermarket merchant code) on essentially every card we track, so\nany standard 3-6% grocery card will earn here.\n"
+    },
+    {
+      "name": "Tropical Smoothie Cafe",
+      "slug": "tropical-smoothie-cafe",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.tropicalsmoothiecafe.com",
+      "intro": "Tropical Smoothie Cafe runs more than 1,400 US locations combining made-to-order smoothies\nwith a wraps, flatbreads, and bowls menu, distinguishing itself from pure smoothie chains\nwith a full lunch offering. Popular smoothies include the Sunrise Sunset, Mango Magic, and\nIsland Green. Tropical Smoothie Cafe transactions code as dining/restaurants on every\nnetwork, including app and curbside orders through Tropic Rewards. Cards with elevated dining\nrates (Amex Gold 4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3% cash) earn full bonus.\n"
+    },
+    {
+      "name": "True Value",
+      "slug": "true-value",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.truevalue.com",
+      "intro": "True Value is a cooperative network of roughly 4,000 independent hardware stores\nacross the United States, offering paint, tools, lawn and garden goods, and\nneighborhood store service. Because individual stores set their own merchant\ncategory codes, True Value purchases may code as home improvement or as general\nretail depending on the location.\n\nCards with broad home improvement bonuses, including the Wells Fargo Bilt and U.S.\nBank Cash+ when home improvement is selected, can deliver 4 to 5 percent on True\nValue runs when the location codes correctly. Online orders placed through\ntruevalue.com for ship-to-store pickup may also trigger online shopping category\nbonuses on rotating quarter cards.\n"
     },
     {
       "name": "Uber",
@@ -1941,6 +3887,16 @@
       "intro": "Ulta Beauty is the largest U.S. beauty retailer by store count at about 1,400 locations,\ncovering both prestige and mass-market lines under one roof. Like Sephora, Ulta in-store\npurchases don't trigger a dedicated card category, so the right card there is usually a\nstrong flat-rate. Online purchases at ulta.com code as online shopping. Ultamate Rewards\nloyalty points stack with card cashback.\n"
     },
     {
+      "name": "Under Armour",
+      "slug": "under-armour",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.underarmour.com",
+      "intro": "Under Armour is a Baltimore-based athletic apparel and footwear brand sold through\nabout 175 U.S. Brand House and Factory House stores along with a strong online channel\nat underarmour.com. Direct purchases typically code as department store at the\nregister and online shopping for web orders, while Under Armour gear bought at Dick's\nor other retailers codes under that store. The free UA Rewards program layers on top\nof credit card earnings, and there is no Under Armour branded credit card.\n"
+    },
+    {
       "name": "Uniqlo",
       "slug": "uniqlo",
       "categories": [
@@ -1971,6 +3927,50 @@
       "intro": "United Airlines is one of the three U.S. legacy carriers and runs the MileagePlus\nloyalty program. United tickets code as airfare on every card we track. The Chase\nco-branded ladder ranges from no-fee Gateway to the $525 Club Infinite with United\nClub lounge membership; mid-tier Explorer adds free checked bag and 2 club passes,\nand Quest adds an annual flight credit. General travel cards often outperform on\ncash-equivalent value, but United co-brands waive close-in award fees and add\nstatus-credit boosts that frequent flyers value.\n"
     },
     {
+      "name": "Urban Outfitters",
+      "slug": "urban-outfitters",
+      "aliases": [
+        "UO"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.urbanoutfitters.com",
+      "intro": "Urban Outfitters is the flagship banner of URBN, which also operates Anthropologie and\nFree People, with about 240 stores selling apparel, home, and music gear targeted at\n20-somethings. The UO Rewards program is free and stacks with credit card multipliers.\nMost issuers code in-store visits as department store and urbanoutfitters.com orders as\nonline shopping, so a card with a strong online or department store bonus usually wins\nat checkout.\n"
+    },
+    {
+      "name": "Valero",
+      "slug": "valero",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.valero.com",
+      "intro": "Valero is a Texas-based independent refiner with roughly 7,000 branded gas stations\nacross the U.S., Canada, and the UK, concentrated heavily in the South and West. Fuel\nat Valero pumps codes as gas, so any gas category rewards card will earn its\nmultiplier. Valero runs the Valero Rewards loyalty app with per-gallon discounts and\nin-store deals, and the chain partners with Hy-Vee Fuel Saver in some markets, so\nHy-Vee shoppers can stack grocery loyalty rewards with a gas-category card at Valero\npumps.\n"
+    },
+    {
+      "name": "Valvoline Instant Oil Change",
+      "slug": "valvoline-instant-oil-change",
+      "aliases": [
+        "Valvoline"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.vioc.com",
+      "intro": "Valvoline Instant Oil Change is a drive-up oil change chain with more than 1,800\nservice centers, known for stay-in-your-car oil changes that typically finish in\nabout 15 minutes. Most card networks code Valvoline Instant Oil Change as auto\nservices, which sits outside dedicated rewards categories on most general consumer\ncredit cards.\n\nCards with selectable categories that include auto, including Citi Custom Cash\nand U.S. Bank Cash+, can route oil changes into a higher bonus rate. Drivers who\nspend heavily on gas may already carry the Costco Anywhere Visa or Sam's Club\nMastercard, both of which pay elevated rates on gasoline but only base earn on\nservice work like oil changes.\n"
+    },
+    {
+      "name": "Vans",
+      "slug": "vans",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.vans.com",
+      "intro": "Vans is the skate and lifestyle footwear and apparel brand owned by VF Corporation,\nwith several hundred U.S. stores and a strong DTC site at vans.com. Direct purchases\ntypically code as department store in person and online shopping for web orders,\nwhile Vans bought at Foot Locker, Journeys, or Zumiez codes under that retailer. The\nfree Vans Family loyalty program offers points, free shipping, and event perks, but\nVans does not run a U.S. branded credit card today.\n"
+    },
+    {
       "name": "Victoria's Secret",
       "slug": "victorias-secret",
       "aliases": [
@@ -1985,6 +3985,18 @@
       "intro": "Victoria's Secret is a U.S. lingerie and beauty retailer with about 800 domestic\nstores in its main brand plus the PINK youth-focused sister brand. In-store\ncharges code as department stores; victoriassecret.com codes as online shopping.\nThe Victoria's Secret Credit Card and Victoria's Secret Mastercard offer tiered\ncashback at VS, PINK, and Bath & Body Works (sister brands). The Love Rewards\nloyalty program is free and stacks with card cashback.\n"
     },
     {
+      "name": "Vons",
+      "slug": "vons",
+      "aliases": [
+        "Vons Supermarkets"
+      ],
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.vons.com",
+      "intro": "Vons is the Southern California banner of Albertsons Companies, with roughly 200 stores\nconcentrated in the Los Angeles, San Diego, and Las Vegas metros. For credit card\npurposes Vons codes as a U.S. supermarket, which means standard grocery bonus cards\n(Amex Gold, Amex Blue Cash Preferred, Citi Custom Cash on a chosen month) will earn\ntheir full multiplier. Vons also participates in the Albertsons for U loyalty program,\nand gift cards sold at the service desk can be a useful angle for category stacking.\n"
+    },
+    {
       "name": "Vrbo",
       "slug": "vrbo",
       "aliases": [
@@ -1997,6 +4009,15 @@
       ],
       "website": "https://www.vrbo.com",
       "intro": "Vrbo is the second-largest U.S. vacation-rental marketplace after Airbnb, owned\nby Expedia Group. Bookings code as travel on every card we track and as hotels\non a few. Unlike Airbnb, Vrbo focuses exclusively on whole-home rentals (no\nshared spaces). Vrbo bookings count for the Sapphire Reserve and Venture X\ntravel-credit categories. Booking through a card's travel portal earns the\nportal multiplier but typically loses Vrbo Boost host-program perks.\n"
+    },
+    {
+      "name": "Waffle House",
+      "slug": "waffle-house",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.wafflehouse.com",
+      "intro": "Waffle House runs about 2,000 24-hour diners across 25 states, concentrated heavily in the\nSoutheast, where the famously consistent grill menu spans waffles, hashbrowns scattered/smothered/\ncovered, T-bone steaks, and All-Star Specials. The chain's resilience during natural disasters\nspawned FEMA's unofficial Waffle House Index. Waffle House transactions code as dining/\nrestaurants on every US credit card. That means cards offering elevated dining multipliers\n(Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash) earn full rate.\n"
     },
     {
       "name": "Walgreens",
@@ -2082,6 +4103,25 @@
       "intro": "Wendy's is a U.S. fast-food chain with about 6,000 domestic locations, known for\nfresh-never-frozen beef and the Frosty. Charges code as dining on every card we\ntrack, so Amex Gold 4x (within $50K cap), Sapphire Preferred 3x, and SavorOne 3%\nall earn the dining bonus. The Wendy's Rewards program in the app issues frequent\nfree-item offers that stack on top of card bonuses.\n"
     },
     {
+      "name": "West Elm",
+      "slug": "west-elm",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.westelm.com",
+      "intro": "West Elm is the modern furniture and home decor banner of Williams-Sonoma Inc, with\nabout 130 U.S. stores plus westelm.com selling sofas, beds, lighting, rugs, and\ntabletop. The Key Rewards Visa from Capital One earns elevated points across West Elm,\nPottery Barn, and Williams-Sonoma and stacks with the free Key Rewards program. Most\ngeneral-purpose cards code West Elm as home improvement or department store in person\nand online shopping for web orders.\n"
+    },
+    {
+      "name": "Whataburger",
+      "slug": "whataburger",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.whataburger.com",
+      "intro": "Whataburger is a Texas-based burger chain founded in Corpus Christi in 1950 with\nover 1,000 restaurants across Texas, the Southwest, and an expanding Southeast\nfootprint. The orange-and-white striped roofs are the calling card, and the menu\ncenters on made-to-order burgers, breakfast taquitos, and honey butter chicken\nbiscuits. Whataburger transactions code as restaurants on most credit card\nnetworks.\n\nPremium dining cards capture the most value on Whataburger runs. The Amex Gold\nearns 4x points on U.S. restaurants, while the Chase Sapphire Reserve pays 3x on\ndining. No-annual-fee picks like the Capital One SavorOne and Wells Fargo Autograph\neach pay 3 percent or 3x on restaurants. The free Whataburger Rewards program\nstacks app-based rewards on top of credit card earn.\n"
+    },
+    {
       "name": "Whole Foods Market",
       "slug": "whole-foods-market",
       "aliases": [
@@ -2102,6 +4142,56 @@
         }
       ],
       "intro": "Whole Foods Market is Amazon's premium grocery arm, with about 530 U.S. stores. Pricing\nis higher than at mass-market supermarkets, which makes a strong grocery-category card\nmore valuable per visit. The standout here is the Amazon Prime Rewards Visa: it earns 5%\nat Whole Foods (with a Prime membership), which is the strongest non-promotional grocery\nrate available. Without Prime, fall back to whichever 3-6% supermarket card you carry.\n"
+    },
+    {
+      "name": "Williams-Sonoma",
+      "slug": "williams-sonoma",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.williams-sonoma.com",
+      "intro": "Williams-Sonoma is the flagship kitchen and cookware banner of Williams-Sonoma Inc,\nthe parent company of Pottery Barn, West Elm, and Rejuvenation. The U.S. footprint\ncovers around 180 stores plus williams-sonoma.com. The Key Rewards Visa from Capital\nOne earns elevated points across all WSI brands and stacks with the free Key Rewards\nprogram. General-purpose cards typically code Williams-Sonoma as home improvement or\ndepartment store in person and online shopping for web orders.\n"
+    },
+    {
+      "name": "WinCo Foods",
+      "slug": "winco-foods",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.wincofoods.com",
+      "intro": "WinCo Foods is an employee-owned, low-price supermarket chain with about 140 stores\nacross the Western and Mountain U.S. The format strips out a lot of typical grocery\noverhead (no baggers, bulk bins, limited frills) to keep shelf prices low. One major\nquirk for card users: WinCo historically did not accept credit cards at all, taking\nonly debit, cash, checks, and EBT. That policy still holds in most stores, which makes\na grocery rewards card essentially unusable here. Confirm payment policy at your local\nlocation before relying on a credit card.\n"
+    },
+    {
+      "name": "Wingstop",
+      "slug": "wingstop",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.wingstop.com",
+      "intro": "Wingstop is a Dallas-based wing-focused quick-service chain with more than 2,400\nrestaurants worldwide. The menu centers on classic and boneless wings in flavors\nlike Lemon Pepper, Louisiana Rub, and Mango Habanero plus signature seasoned\nfries. Wingstop transactions code as restaurants on Visa, Mastercard, and Amex\nnetworks, which makes them eligible for dining bonus categories.\n\nThe Amex Gold pays 4x on U.S. restaurants and is the highest standing earner for\nfrequent Wingstop ordering, while the Chase Sapphire Reserve pays 3x and includes\ntravel protection if redeemed through Chase. The Capital One SavorOne offers 3\npercent dining with no annual fee. Wingstop also runs the MyWingstop loyalty\nprogram with points that stack with credit card rewards on app and online orders.\n"
+    },
+    {
+      "name": "Winn-Dixie",
+      "slug": "winn-dixie",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.winndixie.com",
+      "intro": "Winn-Dixie is a Southeast U.S. supermarket chain with about 400 stores across Florida,\nAlabama, Georgia, Louisiana, and Mississippi. Now owned by Aldi after years under\nSoutheastern Grocers, Winn-Dixie still codes as a standard U.S. supermarket for credit\ncard networks, so grocery bonus cards (Amex Gold, Amex Blue Cash Preferred, Citi Custom\nCash on a chosen month) earn full multipliers. The chain runs its own rewards loyalty\nprogram with fuelperks at partner gas stations in some markets.\n"
+    },
+    {
+      "name": "World Market",
+      "slug": "world-market",
+      "aliases": [
+        "Cost Plus World Market"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.worldmarket.com",
+      "intro": "World Market, formerly Cost Plus World Market, sells globally sourced furniture, rugs,\ninternational foods, and wine across roughly 240 U.S. stores. Most credit cards code\nthese purchases as general retail or department store spending rather than a dedicated\nhome category, so shoppers usually fall back on flat-rate cards like the Citi Double\nCash or Wells Fargo Active Cash.\n\nCards that treat online shopping as a rotating or selectable category, including Chase\nFreedom Flex and U.S. Bank Cash+, can pay better when ordering rugs or furniture from\nworldmarket.com. The store also runs a free loyalty program with member coupons that\nstack with credit card rewards on alcohol and seasonal decor runs.\n"
     },
     {
       "name": "Wyndham",
@@ -2137,6 +4227,35 @@
         "wyndham-rewards-earner-business-card"
       ],
       "intro": "Wyndham Hotels & Resorts is the largest U.S. hotel chain by property count — about\n9,000 hotels — concentrated in mid-scale and economy brands like Days Inn, Super 8,\nLa Quinta, and Ramada, with a smaller upscale presence under Wyndham Grand and the\nRegistry Collection. Wyndham Rewards uses a flat or tiered award chart with redemptions\nstarting at 7,500 points per night, and the program partners with Vacasa for full\nvacation-rental redemptions — a quirk that gives Wyndham points unusual reach for an\neconomy-leaning chain. Direct bookings at wyndhamhotels.com or in the app earn points;\nOTA stays do not. Co-brand cards run lower annual fees than the major chains' cards,\nmatching the program's value-tier identity.\n"
+    },
+    {
+      "name": "Zales",
+      "slug": "zales",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.zales.com",
+      "intro": "Zales is a mid-tier diamond and fashion jewelry banner within Signet Jewelers, with\nabout 575 U.S. stores plus zales.com. The Zales Diamond credit card from Comenity\noffers promotional financing tiers on larger ticket purchases, and the free Vault\nRewards loyalty program is shared across Signet banners including Kay and Jared.\nGeneral-purpose cards typically code Zales as department store in person and online\nshopping for web orders.\n"
+    },
+    {
+      "name": "Zara",
+      "slug": "zara",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.zara.com",
+      "intro": "Zara is the flagship fast fashion banner of Spanish parent Inditex, with roughly 100\nU.S. stores in major markets plus a robust online business at zara.com. Most card\nissuers code in-store purchases as department store and online orders as online\nshopping. Zara does not run a branded credit card in the U.S., so a flat-rate online\nbonus or a rotating department store category is usually the best earn at checkout.\n"
+    },
+    {
+      "name": "Zaxby's",
+      "slug": "zaxbys",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.zaxbys.com",
+      "intro": "Zaxby's is a Georgia-based chicken-finger and wing quick-service chain with over\n900 restaurants concentrated in the Southeast. The menu features Chicken Finger\nPlates, Boneless and Traditional Wings, Zalads, and a lineup of signature sauces\nlike Zax Sauce and Tongue Torch. Zaxby's transactions code as restaurants on Visa,\nMastercard, and Amex networks.\n\nThe Amex Gold earns 4x points on U.S. restaurants and tops the cards for Zaxby's\nspending, while the Chase Sapphire Reserve pays 3x on dining and adds purchase\nprotection. The Capital One SavorOne and Wells Fargo Autograph each pay 3 percent\nor 3x on restaurants with no annual fee. The Zax Rewardz app program adds visit\npoints that stack with credit card cash back on every Big Zax Snak run.\n"
     }
   ]
 }

--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function BestCardForStorePage({ params }: PageProps) {
   const [store, allCards] = await Promise.all([getStore(slug), getAllCards()]);
   if (!store) notFound();
 
-  const picks = rankCards(store, allCards);
+  const picks = rankCards(store, allCards, { maxPicks: 20 });
   const usingFallback = picks.length > 0 && picks.every(p => p.source === 'flat_rate');
 
   return (

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-07T15:23:57.568Z",
-  "count": 158,
+  "generated_at": "2026-05-17T23:57:39.684Z",
+  "count": 358,
   "stores": [
     {
       "name": "7-Eleven",
@@ -14,6 +14,32 @@
       ],
       "website": "https://www.7-eleven.com",
       "intro": "7-Eleven runs about 9,500 U.S. convenience stores, many with attached gas pumps. The\npumps code as gas on every card we track. In-store purchases (snacks, drinks, hot food)\ntypically code as convenience stores rather than as groceries or dining, which means\nmost 3-5% category bonuses don't apply to non-fuel purchases at 7-Eleven.\n"
+    },
+    {
+      "name": "Abercrombie & Fitch",
+      "slug": "abercrombie-and-fitch",
+      "aliases": [
+        "Abercrombie"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.abercrombie.com",
+      "intro": "Abercrombie & Fitch is the namesake adult apparel chain of Abercrombie & Fitch Co,\nwhich also owns Hollister and the kids brand abercrombie kids. Stores run in roughly\n200 U.S. mall locations alongside a strong online business at abercrombie.com. There\nis no current open co-brand credit card after the prior program ended, so shoppers\ntypically lean on department store category bonuses in person and online shopping\nmultipliers for site purchases.\n"
+    },
+    {
+      "name": "Accor",
+      "slug": "accor",
+      "aliases": [
+        "Accor Hotels"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://all.accor.com",
+      "intro": "Accor is the Paris-based global hotel group that operates more than 5,500 properties across\nbrands including Raffles, Fairmont, Sofitel, Pullman, Mövenpick, Novotel, Mercure, ibis, and\nthe lifestyle SO/, 25hours, and Mama Shelter labels. The ALL (Accor Live Limitless) loyalty\nprogram is a transfer partner of Bilt at 1:3, making it one of the few ways US cardholders\nearn meaningful Accor status. Accor stays code as lodging/hotels on every US card. Hotel-bonus\ncards earn full rate: Chase Sapphire Reserve 4x direct, Capital One Venture X 2x base.\n"
     },
     {
       "name": "Ace Hardware",
@@ -36,6 +62,15 @@
       "intro": "Ace Hardware is a cooperative of about 5,000 independently-owned hardware stores in the\nU.S., smaller and more service-oriented than Home Depot or Lowe's. Ace's own Ace Rewards\nloyalty program layers on top of card cashback. Notably, Ace Hardware is one of the\nmerchants that earns 3% on the Apple Card via Apple Pay, alongside the home-improvement\ncategory match on general-purpose cards.\n"
     },
     {
+      "name": "Acme Markets",
+      "slug": "acme-markets",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.acmemarkets.com",
+      "intro": "Acme Markets is the Mid-Atlantic banner of Albertsons Companies, with around 160\nstores across Pennsylvania, New Jersey, Delaware, Maryland, and New York. The chain\ncodes as a U.S. supermarket for credit cards, so a grocery rewards card (Amex Gold,\nBlue Cash Preferred, Citi Custom Cash) earns its posted multiplier at checkout. Acme\nparticipates in the Albertsons for U loyalty program and stocks a wide gift-card rack\nat the service desk, which is occasionally useful for extending a grocery multiplier\ninto adjacent spending categories.\n"
+    },
+    {
       "name": "Adidas",
       "slug": "adidas",
       "categories": [
@@ -44,6 +79,15 @@
       ],
       "website": "https://www.adidas.com",
       "intro": "Adidas is the second-largest global athletic apparel brand. Adidas.com codes as\nonline shopping; in-store charges code as department stores. The adiClub loyalty\nprogram issues spend-tier credits and member-exclusive product drops. Strongest\npairings are an online-shopping-bonus card for adidas.com or flat-rate cashback\nfor in-store.\n"
+    },
+    {
+      "name": "Adorama",
+      "slug": "adorama",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.adorama.com",
+      "intro": "Adorama is a New York City photo, video, audio, and computer retailer that competes\ndirectly with B&H Photo, operating both a Manhattan showroom and a large\ne-commerce store at adorama.com. Adorama is known for its EDU pricing, used gear\nmarketplace, and Adorama Rewards loyalty program. Purchases typically code as\nonline shopping or electronics on most credit card networks.\n\nCards with selectable online shopping bonuses, including the Bank of America\nCustomized Cash and U.S. Bank Cash+, can earn 3 to 5 percent on Adorama orders, and\nthe Chase Freedom Flex occasionally features online shopping in its rotating\nquarters. Adorama also accepts Affirm financing on larger camera bodies and lenses.\n"
     },
     {
       "name": "Advance Auto Parts",
@@ -56,6 +100,41 @@
       ],
       "website": "https://shop.advanceautoparts.com",
       "intro": "Advance Auto Parts is a U.S. auto parts retailer with about 4,700 domestic\nstores plus the Carquest commercial parts network. In-store charges code as\nauto parts; advance auto parts.com codes as online shopping. The Speed Perks\nloyalty program is free and issues percent-back rewards in store credit. Pair\nwith flat-rate cashback or an online-shopping-bonus card for digital orders.\n"
+    },
+    {
+      "name": "Aerie",
+      "slug": "aerie",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.ae.com/us/en/aerie",
+      "intro": "Aerie is American Eagle Outfitters' intimates, loungewear, and activewear sub-brand,\nwith hundreds of standalone stores and a heavy presence on ae.com. The Real Rewards\ncredit card from Synchrony covers both American Eagle and Aerie, paying boosted points\non every purchase. On most general-purpose cards, Aerie purchases code as department\nstore in person and online shopping when checking out through the AE site or app.\n"
+    },
+    {
+      "name": "Air Canada",
+      "slug": "air-canada",
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.aircanada.com",
+      "intro": "Air Canada is Canada's flag carrier and a Star Alliance founding member, operating hubs at\nToronto Pearson, Montreal-Trudeau, and Vancouver with an extensive transborder, transatlantic,\nand transpacific network plus regional service through Air Canada Express. The Aeroplan\nloyalty program is one of the strongest airline currencies in North America, with transfer\npartners across Amex Membership Rewards, Capital One miles, Chase Ultimate Rewards, and Bilt.\nAir Canada ticket purchases code as airlines/airfare, so airfare-bonus cards earn full rate.\n"
+    },
+    {
+      "name": "Air France / KLM",
+      "slug": "air-france-klm",
+      "aliases": [
+        "Air France",
+        "KLM",
+        "Flying Blue"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.airfrance.us",
+      "intro": "Air France-KLM is the Franco-Dutch parent of Air France (hubbed at Paris-Charles de Gaulle)\nand KLM Royal Dutch Airlines (hubbed at Amsterdam-Schiphol), both SkyTeam members with a\nshared Flying Blue loyalty program. Flying Blue partners with Amex Membership Rewards, Chase\nUltimate Rewards, Capital One miles, Bilt, and Citi ThankYou Points as a 1:1 transfer\npartner, plus periodic transfer bonuses. Air France and KLM ticket purchases code as\nairlines/airfare on US cards, earning the full airfare bonus on any card with that category.\n"
     },
     {
       "name": "Airbnb",
@@ -122,6 +201,28 @@
       ],
       "website": "https://www.aldi.us",
       "intro": "Aldi is the discount-focused private-label grocer with about 2,400 U.S. stores and a\nsharply lower price floor than full-line supermarkets. Average tickets are smaller, so\nthe absolute dollar value of a 3-6% grocery card is lower per visit, but the rate still\napplies. Aldi codes as groceries on every card we track. Note: Aldi historically only\naccepted debit and SNAP, but all U.S. stores now accept credit cards.\n"
+    },
+    {
+      "name": "AliExpress",
+      "slug": "aliexpress",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.aliexpress.com",
+      "intro": "AliExpress is Alibaba's consumer-facing global marketplace, connecting Chinese\nmanufacturers and merchants with international buyers. The platform sells everything\nfrom electronics and apparel to home goods at low price points, with shipping times\nthat vary widely by item. Purchases code as online shopping for credit card networks,\nso an online-shopping category bonus card earns its multiplier. Some AliExpress sellers\ninvoice through international processors, so foreign transaction fees can apply on\ncards without an FTF waiver, which is worth checking before a large order.\n"
+    },
+    {
+      "name": "Allegiant Air",
+      "slug": "allegiant-air",
+      "aliases": [
+        "Allegiant"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.allegiantair.com",
+      "intro": "Allegiant Air is a Las Vegas-based ultra-low-cost carrier that connects small and mid-sized\nUS cities to leisure destinations like Las Vegas, Orlando-Sanford, Phoenix-Mesa, and Florida\nGulf Coast airports, flying point-to-point on a fleet of Airbus A319/A320 aircraft. Like\nother ULCCs, Allegiant unbundles fares: bags, seat assignments, and printed boarding passes\nare all add-ons. Allegiant purchases code as airlines/airfare on every card network. Travel\ncards with airfare bonuses (Amex Gold 3x on flights booked direct, Chase Sapphire Reserve 4x,\nCapital One Venture X 2x) all earn their full rate on Allegiant tickets and ancillary fees.\n"
     },
     {
       "name": "Amazon",
@@ -252,6 +353,67 @@
       "intro": "Arby's is a U.S. fast-food chain with about 3,300 domestic locations, focused on\nroast beef and deli sandwiches. Charges code as dining on every card we track,\nso any dining-bonus card (Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%)\napplies. The Arby's Rewards app issues per-purchase points redeemable for menu\nitems, stackable with card bonuses.\n"
     },
     {
+      "name": "Arhaus",
+      "slug": "arhaus",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.arhaus.com",
+      "intro": "Arhaus is a premium home furnishings retailer based in Boston Heights, Ohio, with\naround 100 large-format Showrooms and Design Studios plus arhaus.com. The brand\nemphasizes hand-crafted, artisan-sourced furniture and recently expanded its outdoor\nand rug categories. The Arhaus Archcharge credit card from Comenity offers\npromotional financing on big purchases, and general-purpose cards typically code\nArhaus as home improvement or department store in person and online shopping for\nweb orders.\n"
+    },
+    {
+      "name": "Ashley Furniture HomeStore",
+      "slug": "ashley-furniture",
+      "aliases": [
+        "Ashley HomeStore"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.ashleyfurniture.com",
+      "intro": "Ashley Furniture HomeStore is the largest furniture retailer in the United States by\nstore count, selling sofas, dining sets, mattresses, and bedroom collections through\nmore than 1,000 corporate and licensed locations. Furniture purchases generally code\nas general retail on Visa, Mastercard, and Amex networks, so they do not trigger\nthe home improvement bonus that covers only Home Depot and Lowe's.\n\nBig-ticket furniture buys are a natural fit for signup bonus minimum spend on cards\nlike the Chase Sapphire Preferred or Amex Gold. Ashley also pushes its own Ashley\nAdvantage financing card with deferred-interest promotions, though paying with a\nrewards card and avoiding interest usually beats the financing math.\n"
+    },
+    {
+      "name": "ASOS",
+      "slug": "asos",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.asos.com",
+      "intro": "ASOS is a UK-based online-only fashion retailer that ships globally and serves the U.S.\nthrough asos.com, with no physical stores. Because every purchase is online, cards with\na strong online shopping or general everyday multiplier almost always win at checkout.\nASOS does not offer a U.S. branded credit card, so loyal customers rely on either the\nfree Premier delivery membership or rotating category bonuses from issuers like Chase\nFreedom and Discover when online shopping is featured.\n"
+    },
+    {
+      "name": "At Home",
+      "slug": "at-home",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.athome.com",
+      "intro": "At Home operates over 260 big-box home decor superstores stocking patio furniture,\nseasonal decor, wall art, and bedding at warehouse-style pricing. Most major credit\ncards code At Home as general retail, so it sits outside the typical home improvement\nbonus that covers only Lowe's and Home Depot on cards like the Wells Fargo Bilt or\nChase Freedom rotating quarters.\n\nOnline orders through athome.com can hit online shopping bonuses on cards like the\nCapital One SavorOne and Bank of America Customized Cash when that category is\nselected. At Home Insider Perks members also stack store coupons with credit card\ncash back, which matters on big-ticket patio and Christmas decor seasons.\n"
+    },
+    {
+      "name": "Athleta",
+      "slug": "athleta",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://athleta.gap.com",
+      "intro": "Athleta is Gap Inc's women's performance and athleisure brand and one of the company's\nfastest-growing banners, with around 270 U.S. stores plus a strong DTC channel. Most\ngeneral-purpose cards code in-store purchases as department store and athleta.gap.com\norders as online shopping. The Gap Inc Barclays cards earn elevated points across\nAthleta, Old Navy, Gap, and Banana Republic, so loyal shoppers usually consolidate\nspend on that program.\n"
+    },
+    {
+      "name": "Auntie Anne's",
+      "slug": "auntie-annes",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.auntieannes.com",
+      "intro": "Auntie Anne's is the mall and airport hand-rolled soft pretzel chain with roughly 1,800\nUS locations under Focus Brands. Beyond the Original and Cinnamon Sugar pretzels, the menu\nincludes Pretzel Dogs, Mini Pretzel Dogs, and Lemonade Mixers. Auntie Anne's transactions\ncode as dining/restaurants whether you order at the counter or through the My Pretzel\nPerks app. That makes any dining-bonus card a fit: Amex Gold (4x Membership Rewards), Chase\nSapphire Preferred (3x Ultimate Rewards), and Capital One SavorOne (3% cash) earn full rate.\n"
+    },
+    {
       "name": "AutoZone",
       "slug": "autozone",
       "categories": [
@@ -275,6 +437,72 @@
       "intro": "Avis is one of the three large U.S. car-rental brands, sister company to Budget under\nAvis Budget Group. Rentals code as car rentals on every card we track. Several\npremium cards confer Avis President's Club status (Amex Platinum, Capital One Venture\nX) which adds a guaranteed upgrade plus free additional driver. Booking via a card's\ntravel portal earns the portal bonus rate but may forfeit Avis Preferred earnings\nand direct-booking promo codes.\n"
     },
     {
+      "name": "B&H Photo",
+      "slug": "b-and-h-photo",
+      "aliases": [
+        "B&H",
+        "BH Photo"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.bhphotovideo.com",
+      "intro": "B&H Photo Video is a New York City professional photo, video, and audio retailer\nwith a single SuperStore in Manhattan and a major e-commerce operation at\nbhphotovideo.com. The retailer is the go-to for cameras, lenses, lighting, computers,\nand pro audio gear. Most credit cards treat B&H purchases as online shopping or\ngeneral electronics rather than a dedicated category.\n\nBank of America Customized Cash and U.S. Bank Cash+ can route B&H orders into a\nselectable 5 percent online shopping bonus, while the Chase Freedom Flex sometimes\nfeatures online shopping in its rotating quarters. B&H also issues its own Payboo\ncard that rebates sales tax in many states, which can outweigh credit card rewards\non large camera and lens purchases.\n"
+    },
+    {
+      "name": "Banana Republic",
+      "slug": "banana-republic",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://bananarepublic.gap.com",
+      "intro": "Banana Republic is the upscale apparel brand within Gap Inc, positioned above Gap and\nOld Navy with workwear, suiting, and elevated basics across roughly 400 stores plus a\ngrowing factory outlet network. The in-house Banana Republic Rewards Mastercard from\nBarclays earns accelerated points across all Gap Inc banners, while general-purpose\ncards typically code purchases as department store in-mall and online shopping for\nbananarepublic.gap.com orders.\n"
+    },
+    {
+      "name": "BarkBox",
+      "slug": "barkbox",
+      "aliases": [
+        "Bark"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.barkbox.com",
+      "intro": "BarkBox is the flagship subscription service from Bark, sending a themed monthly box\nof toys, treats, and chews tailored to a dog's size. Bark also operates Super Chewer\nfor heavy chewers, Bright dental subscriptions, and Bark Food. As a recurring online\nsubscription, BarkBox charges typically code as online shopping or direct marketing\non most credit card networks.\n\nCards with online shopping bonuses can pay better on BarkBox renewals. Bank of\nAmerica Customized Cash and U.S. Bank Cash+ both offer selectable online shopping\ncategories worth 3 to 5 percent, and the Chase Freedom Flex sometimes features\nonline shopping in its rotating 5 percent quarter. BarkBox also frequently appears\nin shopping portals like Rakuten with stacking cash back.\n"
+    },
+    {
+      "name": "Barnes & Noble",
+      "slug": "barnes-and-noble",
+      "aliases": [
+        "B&N",
+        "Barnes Noble"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.barnesandnoble.com",
+      "intro": "Barnes & Noble is the largest bookstore chain in the United States, operating\nover 600 superstores plus a major e-commerce site at barnesandnoble.com and the\nNook digital reading platform. In-store and online book purchases generally code as\nbookstore or general retail on Visa, Mastercard, and Amex networks rather than\ntriggering a dedicated bonus category.\n\nCards with selectable online shopping categories, including Bank of America\nCustomized Cash and U.S. Bank Cash+, can earn 3 to 5 percent on barnesandnoble.com\norders. The B&N Premium Membership runs about $40 a year and includes 10 percent\noff in store and free shipping online, which can stack with credit card rewards on\nfrequent buyers' purchases.\n"
+    },
+    {
+      "name": "Bartell Drugs",
+      "slug": "bartell-drugs",
+      "categories": [
+        "drugstores"
+      ],
+      "website": "https://www.bartelldrugs.com",
+      "intro": "Bartell Drugs is a Pacific Northwest pharmacy chain founded in 1890, with roughly 65\nlocations clustered in the Seattle metro and Puget Sound region. Owned by Rite Aid\nsince 2020, Bartell still operates under its own banner with its own pharmacy and\nloyalty program. Stores code as drugstores for credit card networks, so a drugstore\ncategory bonus card (Amex Blue Cash Preferred, Citi Custom Cash on drugstores, Chase\nFreedom Flex when activated) earns its full multiplier on prescriptions and front-of-\nstore purchases.\n"
+    },
+    {
+      "name": "Baskin-Robbins",
+      "slug": "baskin-robbins",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.baskinrobbins.com",
+      "intro": "Baskin-Robbins, the 31 Flavors ice cream chain owned by Inspire Brands (the same parent as\nDunkin'), operates roughly 2,300 US scoop shops along with a global footprint exceeding\n7,000 locations. The menu spans hand-packed pints, ice cream cakes, Cappuccino Blasts, and\nrotating monthly flavors. Baskin-Robbins purchases code as dining/restaurants on every US\ncredit card, so cards with dining bonuses earn their full multiplier: Amex Gold at 4x\nMembership Rewards, Chase Sapphire Preferred at 3x, and Capital One SavorOne at 3% cash back.\n"
+    },
+    {
       "name": "Bath & Body Works",
       "slug": "bath-and-body-works",
       "aliases": [
@@ -287,6 +515,25 @@
       ],
       "website": "https://www.bathandbodyworks.com",
       "intro": "Bath & Body Works is a U.S. personal-care chain with about 1,800 domestic stores,\nselling soaps, lotions, candles, and home fragrance. In-store charges code as\ndepartment stores; bathandbodyworks.com codes as online shopping. The My Bath &\nBody Works Rewards program issues a free reward at sign-up plus per-spend points;\na Comenity Bank-issued co-branded credit card layers additional cashback for\nheavy shoppers.\n"
+    },
+    {
+      "name": "Belk",
+      "slug": "belk",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.belk.com",
+      "intro": "Belk is a Southeast U.S. department store chain with about 290 locations across 16\nstates, anchored in the Carolinas. The merchandise mix is comparable to a regional\nMacy's: apparel, cosmetics, accessories, and home goods, with a focus on national and\nprivate-label brands. Belk codes as a department store, so a department-store\ncategory bonus card earns its full rate. The Belk Rewards Mastercard (issued by\nSynchrony) layers store-specific Belk Rewards points on top, with extra earn during\npromotional events.\n"
+    },
+    {
+      "name": "Benjamin Moore",
+      "slug": "benjamin-moore",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.benjaminmoore.com",
+      "intro": "Benjamin Moore is a premium U.S. paint manufacturer sold through more than 5,000\nindependent retailers including Aubuchon, Ace Hardware, and dedicated Benjamin Moore\nshops. Because purchases happen at independent dealers, merchant category coding\nvaries, with some locations coding as home improvement and others as general\nhardware retail.\n\nWhen a dealer codes as home improvement, cards like the Wells Fargo Bilt and U.S.\nBank Cash+ can deliver elevated rewards on Aura, Regal Select, and Advance lines.\nAce Hardware locations selling Benjamin Moore can stack ACE Rewards points with\ncredit card cash back, while professional contractors with a Benjamin Moore PRO\naccount get tiered discounts that layer on top of any card rewards.\n"
     },
     {
       "name": "Best Buy",
@@ -324,6 +571,15 @@
       "intro": "Best Western Hotels & Resorts runs about 4,000 properties globally under a member-owned\ncooperative structure that's unusual in the major-chain landscape. The portfolio spans\nBest Western, Best Western Plus, and Best Western Premier on the core brand, with\nVīb, GLō, Aiden, Sadie, and Executive Residency rounding out boutique and extended-stay\nsegments, plus the SureStay budget brands. There's no Best Western co-brand credit\ncard in the U.S. market today, so the right play is a strong general hotel-category\ncard — Sapphire Reserve, Venture X, Amex Gold, or a flat-rate cashback card if you\nprefer simplicity. Best Western Rewards points are earned only on direct bookings at\nbestwestern.com or in-app; OTA stays earn nothing in the program.\n"
     },
     {
+      "name": "Big Lots",
+      "slug": "big-lots",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.biglots.com",
+      "intro": "Big Lots is a closeout and discount retailer with roughly 1,300 stores across the U.S.,\nselling furniture, seasonal goods, food and consumables, and an ever-rotating mix of\ncloseout merchandise. The chain went through bankruptcy and a restructuring under\nVariety Wholesalers in 2025. Big Lots typically codes as a department store or\ndiscount retailer for credit card networks. The Big Lots Credit Card (issued by\nComenity Capital Bank) offers store-only financing and points on Big Lots purchases,\nthough a general 2-5% department-store card from a major issuer is often more useful.\n"
+    },
+    {
       "name": "BJ's Wholesale Club",
       "slug": "bjs-wholesale",
       "aliases": [
@@ -352,6 +608,56 @@
       "intro": "Bloomingdale's is a luxury-leaning department store with about 30 full-line locations\nin the U.S., plus the higher-end Bloomingdale's by Bloomingdale's outlet stores. Most\nshoppers are paying full price on apparel, beauty, and home goods, so the cashback rate\non your card matters more here than at a discount retailer.\n\nBloomingdale's accepts all four major networks (Visa, Mastercard, Amex, Discover) and\nApple Pay in stores. There is a co-branded Bloomingdale's American Express that earns\nLoyallist points, but most general-purpose cards will pay you better in cashback unless\nyou spend several thousand dollars a year at Bloomingdale's specifically.\n"
     },
     {
+      "name": "Blue Apron",
+      "slug": "blue-apron",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.blueapron.com",
+      "intro": "Blue Apron pioneered the US meal-kit category in 2012 and remains a recognizable subscription\nbrand offering chef-designed recipes with pre-portioned ingredients shipped weekly, plus a\nHeat & Eat line of prepared meals. The company was acquired by Wonder Group in 2023. Blue\nApron charges typically code as online retail or direct-marketing food, not in-store groceries\nor restaurants, so dining and grocery category bonuses generally do not apply. The best\nreturns come from flat-rate cards (Citi Double Cash, Wells Fargo Active Cash, both at 2%).\n"
+    },
+    {
+      "name": "Bluemercury",
+      "slug": "bluemercury",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://bluemercury.com",
+      "intro": "Bluemercury is a prestige beauty chain owned by Macy's Inc, with around 160 U.S.\nboutiques plus bluemercury.com selling skincare, makeup, fragrance, and the in-house\nM-61 and Lune+Aster brands. Direct purchases typically code as department store in\nperson and online shopping for web orders. Because Bluemercury is part of Macy's, the\nfree BlueRewards program is paired with Macy's Star Rewards and the Macy's\nCiti-issued credit cards earn elevated points on Bluemercury spend.\n"
+    },
+    {
+      "name": "Bob's Discount Furniture",
+      "slug": "bobs-discount-furniture",
+      "aliases": [
+        "Bobs Furniture"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.mybobs.com",
+      "intro": "Bob's Discount Furniture is a value-focused furniture chain with over 175 stores\nacross the Northeast, Mid-Atlantic, Midwest, and Southwest. The retailer is known\nfor its Goof Proof protection plan, free in-store Bob-O-Pedic samples, and pricing\nthat undercuts traditional furniture stores. Purchases code as general retail on\nVisa, Mastercard, and Amex, not as home improvement.\n\nSectionals and bedroom sets at Bob's frequently run $1,500 to $3,000, which makes\nthe chain a strong venue for credit card signup bonus minimum spend. Flat-rate\nearners like the Wells Fargo Active Cash and Citi Double Cash handle furniture spend\ncleanly, while occasional Amex Offers on home retailers can stack additional\nstatement credits on top.\n"
+    },
+    {
+      "name": "Bojangles",
+      "slug": "bojangles",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.bojangles.com",
+      "intro": "Bojangles is a Southeast U.S. quick-service chain founded in Charlotte, North\nCarolina in 1977, known for Cajun-seasoned fried chicken, made-from-scratch\nbiscuits, Bo-Berry Biscuits, and sweet tea. The chain operates over 800 restaurants\nconcentrated in the Carolinas, Tennessee, Virginia, and the broader Southeast.\nBojangles transactions code as restaurants on most credit card networks.\n\nThe Amex Gold pays 4x points on U.S. restaurants and is the top earner for daily\nbiscuit runs. The Chase Sapphire Preferred earns 3x on dining and pairs well with\ntravel redemptions. No-annual-fee dining cards including the Capital One SavorOne\nat 3 percent and Wells Fargo Autograph at 3x are strong defaults. Bojangles also\nruns the Bojangles Rewards program, layered on top of credit card cash back.\n"
+    },
+    {
+      "name": "Bonefish Grill",
+      "slug": "bonefish-grill",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.bonefishgrill.com",
+      "intro": "Bonefish Grill is Bloomin' Brands' wood-grilled seafood concept (alongside Outback Steakhouse,\nCarrabba's, and Fleming's) with about 175 US locations specializing in fresh fish flown in\nseveral times a week, plus signature Bang Bang Shrimp and craft cocktails. Bonefish Grill\ncharges code as dining/restaurants on every card network, and Dine Rewards loyalty stacks\non top of credit card rewards. Cards with strong dining multipliers (Amex Gold 4x, Chase\nSapphire Preferred 3x, Capital One SavorOne 3% cash) earn at the full bonus on every visit.\n"
+    },
+    {
       "name": "Booking.com",
       "slug": "booking-com",
       "aliases": [
@@ -362,6 +668,18 @@
       ],
       "website": "https://www.booking.com",
       "intro": "Booking.com is one of the largest global online travel agencies, owned by Booking\nHoldings (which also owns Priceline, Kayak, and Agoda). Bookings code as travel\non every card we track. The honest catch: hotel chains typically do NOT credit\nBooking.com stays toward elite-night or status counts, and many properties\nexclude OTA stays from earning their loyalty points — so a Hilton/Marriott/Hyatt\nloyalist almost always books direct. Booking's own Genius rewards tier and\noccasional 10% off promos can still beat direct on price for one-off stays.\n"
+    },
+    {
+      "name": "Books-A-Million",
+      "slug": "books-a-million",
+      "aliases": [
+        "BAM!"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.booksamillion.com",
+      "intro": "Books-A-Million, branded as BAM!, is the second-largest brick-and-mortar bookstore\nchain in the United States with around 250 stores concentrated in the Southeast.\nThe retailer carries books, toys, gifts, magazines, and operates the Joe Muggs cafe\ninside larger stores. BAM! purchases generally code as bookstore or general retail\nrather than as a dedicated bonus category on most cards.\n\nCards with online shopping bonuses can earn better on booksamillion.com orders.\nBank of America Customized Cash and U.S. Bank Cash+ both offer selectable online\nshopping categories worth 3 to 5 percent, and Chase Freedom Flex sometimes features\nonline shopping in its rotating quarters. The Millionaire's Club membership stacks\nadditional discounts with credit card cash back for frequent buyers.\n"
     },
     {
       "name": "BP",
@@ -375,6 +693,57 @@
       ],
       "website": "https://www.bp.com",
       "intro": "BP and its Amoco-branded stations cover roughly 7,000 U.S. locations. Pumps code\ncleanly as gas on every card we track. BP runs the BPme app and a separate BP\nVisa with cash-back at BP/Amoco; in absolute cents most general-purpose 4-5% gas\ncards beat it. The bigger swing for heavy BP buyers is the BPme Rewards loyalty\nprogram, which stacks on top of any card's gas bonus.\n"
+    },
+    {
+      "name": "Breeze Airways",
+      "slug": "breeze-airways",
+      "aliases": [
+        "Breeze"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.flybreeze.com",
+      "intro": "Breeze Airways is the low-cost startup launched by JetBlue founder David Neeleman in 2021,\nflying a mix of Airbus A220-300s and Embraer E-Jets on underserved point-to-point routes\nbetween small and mid-sized US cities. Breeze sells Nice, Nicer, and Nicest fare bundles\nplus the premium Nicest cabin with extra-legroom seats. Breeze ticket purchases code as\nairlines/airfare on every card. Cards with airfare bonuses (Chase Sapphire Reserve at 4x\non direct, Amex Gold at 3x on direct, Capital One Venture X at 2x base) all earn full rate.\n"
+    },
+    {
+      "name": "British Airways",
+      "slug": "british-airways",
+      "aliases": [
+        "BA"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.britishairways.com",
+      "intro": "British Airways is the UK flag carrier and a oneworld founding member, hubbed at London\nHeathrow with significant operations from London Gatwick and London City. The carrier's\nExecutive Club loyalty program (Avios) is a transfer partner of Amex Membership Rewards,\nChase Ultimate Rewards, Capital One miles, Bilt, and Citi ThankYou Points, which makes\nAvios one of the most liquid airline currencies for transatlantic and short-haul oneworld\nredemptions. British Airways tickets code as airlines/airfare, earning airfare bonuses fully.\n"
+    },
+    {
+      "name": "Buc-ee's",
+      "slug": "buc-ees",
+      "aliases": [
+        "Bucees"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://buc-ees.com",
+      "intro": "Buc-ee's is a Texas-born travel center chain known for enormous footprints (often 50+\ngas pumps and 50,000+ square feet of store), branded jerky and snacks, and a cult road\ntrip following. The chain has been expanding aggressively into the Southeast and\nbeyond. Fuel purchases at Buc-ee's pumps code as gas, while everything bought inside\n(food, apparel, souvenirs) typically codes as convenience store or general\nmerchandise. Buc-ee's does not run its own credit card, so a strong gas-category card\nis the cleanest way to earn rewards at the pump.\n"
+    },
+    {
+      "name": "Buckle",
+      "slug": "buckle",
+      "aliases": [
+        "The Buckle"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.buckle.com",
+      "intro": "Buckle is a denim-led specialty apparel chain with about 440 U.S. stores, heavily\nweighted toward the Midwest and South and known for carrying premium jean brands. The\nBuckle Black Card store credit card from Comenity offers rewards on Buckle purchases\nand is paired with the free B-Rewards program. General-purpose cards usually code\nBuckle as department store at the register and online shopping for buckle.com orders.\n"
     },
     {
       "name": "Budget",
@@ -427,6 +796,55 @@
       "intro": "Burlington is a U.S. off-price retail chain with about 1,000 stores selling\napparel, home, and baby goods at discount prices. Codes as department stores on\nmost cards. There's no co-branded Burlington credit card, so the strongest\npairings are department-store-bonus or flat-rate cashback cards. Burlington\ndoesn't run a high-volume loyalty program.\n"
     },
     {
+      "name": "California Pizza Kitchen",
+      "slug": "california-pizza-kitchen",
+      "aliases": [
+        "CPK"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.cpk.com",
+      "intro": "California Pizza Kitchen operates about 170 casual-dining restaurants known for hearth-baked\npizzas with creative toppings like the original BBQ Chicken, Thai Chicken, and California\nVeggie, plus a broader menu of pastas and entree salads. CPK transactions, whether dine-in,\ntakeout, or through CPK Rewards online ordering, code as restaurants/dining. That means\ncards offering elevated dining multipliers (Amex Gold at 4x Membership Rewards, Chase\nSapphire Reserve at 4x Ultimate Rewards, Capital One SavorOne at 3% cash) earn full rate.\n"
+    },
+    {
+      "name": "Carhartt",
+      "slug": "carhartt",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.carhartt.com",
+      "intro": "Carhartt is a private, family-owned workwear brand based in Dearborn, Michigan, with\nabout 30 company stores plus wide distribution through Tractor Supply, farm and ranch\nretailers, and carhartt.com. Most cards code direct purchases at company stores or the\nwebsite as department store or online shopping, while buying Carhartt at a tractor or\nfarm supply retailer typically codes under that merchant's category. There is no\nCarhartt branded credit card today.\n"
+    },
+    {
+      "name": "Caribou Coffee",
+      "slug": "caribou-coffee",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.cariboucoffee.com",
+      "intro": "Caribou Coffee, founded in Minnesota in 1992, runs about 700 cafes concentrated in the Upper\nMidwest plus a growing licensed presence in airports, hospitals, and grocery stores.\nSignature drinks include the Caribou Cooler frozen blends, Northern Lite sugar-free options,\nand seasonal Pumpkin White Mocha. Every Caribou purchase, whether at a corporate cafe or\nthrough the Caribou Perks app, codes as dining. That means strong dining cards (Amex Gold\n4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3% unlimited) all hit the full bonus.\n"
+    },
+    {
+      "name": "Carl's Jr.",
+      "slug": "carls-jr",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.carlsjr.com",
+      "intro": "Carl's Jr. is the western US half of CKE Restaurants, known for charbroiled burgers like\nthe Western Bacon Cheeseburger and the Famous Star. The chain runs about 1,000 domestic\nlocations, mostly west of the Mississippi, alongside sister brand Hardee's in the east.\nIn-store, drive-thru, and Carl's Jr. app purchases all code as fast-food/restaurants on\nevery credit card network, so cards paying elevated rates on dining (Chase Sapphire\nPreferred at 3x, Amex Gold at 4x, Capital One Savor at 3%) all earn their full bonus here.\n"
+    },
+    {
+      "name": "CarMax",
+      "slug": "carmax",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.carmax.com",
+      "intro": "CarMax is the largest used-car retailer in the United States, with over 240\nstores and a national online buying platform at carmax.com. The company offers\nno-haggle pricing, seven-day returns, and home delivery on used vehicles. Credit\ncards generally cap how much can go toward a vehicle purchase, with $1,000 to\n$5,000 typical limits, and the transaction codes as a vehicle dealer rather than a\nrewards category.\n\nDown payments at CarMax are useful for clearing signup bonus minimums on cards like\nthe Chase Sapphire Preferred or Amex Gold. Some cardholders also use CarMax for\nmanufactured spend on Visa or Mastercard rewards cards. Service and parts visits at\nCarMax service centers code separately and may earn standard retail rates.\n"
+    },
+    {
       "name": "Carnival Cruise Line",
       "slug": "carnival-cruise",
       "aliases": [
@@ -438,6 +856,46 @@
       ],
       "website": "https://www.carnival.com",
       "intro": "Carnival Cruise Line is the largest U.S. cruise operator by passenger volume,\nowned by Carnival Corporation (which also owns Princess, Holland America, and\nCunard). Cruise bookings code as travel on every card we track. Pre-booked\nshore excursions, drink packages, and gratuities purchased through the cruise\nline generally code as travel as well. Onboard charges (folio purchases) often\ncode as travel but sometimes as cruise-specific — worth confirming on a small\ncharge before relying on a 3x travel multiplier.\n"
+    },
+    {
+      "name": "Carvana",
+      "slug": "carvana",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.carvana.com",
+      "intro": "Carvana is an online-only used-car retailer known for its glass-block car vending\nmachine towers and same-week home delivery model. Customers shop, finance, and\nbuy entirely through carvana.com or the Carvana app. Credit cards are accepted only\nfor down payments, typically capped around $2,000 to $5,000, and the charge codes\nas a vehicle dealer rather than online shopping.\n\nCarvana down payments work well for clearing signup bonus minimums on cards like\nthe Capital One Venture X or the Citi Strata Premier. Cards with selectable online\nshopping categories generally do not capture Carvana transactions because of the\nvehicle dealer MCC, so flat-rate earners like the Citi Double Cash often produce\nthe most predictable rewards.\n"
+    },
+    {
+      "name": "Casey's",
+      "slug": "caseys",
+      "aliases": [
+        "Casey's General Store"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.caseys.com",
+      "intro": "Casey's is a Midwest convenience-store and pizza giant with more than 2,600 locations\nacross 17 states, anchored in Iowa and the surrounding farm belt. Fuel pumps code as\ngas, while in-store purchases (including the famously good made-to-order pizza) can\ncode as convenience or restaurant depending on the location. Casey's runs its own\nCasey's Rewards loyalty program and issues a Casey's Visa co-brand card with elevated\nearn on Casey's purchases, including pizza and gas at the pump.\n"
+    },
+    {
+      "name": "Casper",
+      "slug": "casper",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://casper.com",
+      "intro": "Casper is a direct-to-consumer mattress brand that helped define the bed-in-a-box\ncategory, with foam, hybrid, and Wave mattress lines plus pillows, sheets, and\nbedroom furniture. Most Casper purchases happen online at casper.com, which means\nrewards cards that pay bonuses for online shopping see the most upside.\n\nBank of America Customized Cash and U.S. Bank Cash+ can route Casper orders into a\nselectable 5 percent online shopping category, while the Capital One SavorOne pays\n3 percent on entertainment, dining, and streaming but only base earn on mattresses.\nCasper occasionally appears in shopping portals like Rakuten or Capital One\nShopping, where portal cash back can stack with credit card rewards.\n"
+    },
+    {
+      "name": "CB2",
+      "slug": "cb2",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.cb2.com",
+      "intro": "CB2 is the modern, design-forward offshoot of Crate & Barrel under Otto family-owned\nEuromarket Designs, with about 25 U.S. stores plus cb2.com selling contemporary\nfurniture, lighting, and decor. The Crate & Barrel credit card from Comenity covers\nCB2 purchases too and earns rewards across the family of brands. General-purpose\ncards typically code CB2 as home improvement or department store in person and\nonline shopping for web orders.\n"
     },
     {
       "name": "Chevron",
@@ -531,6 +989,15 @@
       "intro": "Choice Hotels operates roughly 7,500 properties worldwide, dominated by mid-scale and\neconomy brands — Comfort Inn, Quality Inn, Sleep Inn, Clarion — with the Cambria and\nAscend Hotel Collection covering its upscale push. The 2022 acquisition of Radisson\nAmericas folded Country Inn & Suites and Park Plaza into Choice Privileges, broadening\nthe footprint considerably. Award nights start as low as 6,000 points, and the program\nis one of the better economy-tier values on a cents-per-point basis. The Wells Fargo\nChoice Privileges co-brand cards earn elevated points on Choice stays and gas, with\nthe Select tier adding automatic Platinum elite status and an annual bonus night.\nDirect bookings earn points; OTA stays do not.\n"
     },
     {
+      "name": "Cinnabon",
+      "slug": "cinnabon",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.cinnabon.com",
+      "intro": "Cinnabon, part of the Focus Brands family alongside Auntie Anne's and Jamba, operates more\nthan 1,500 worldwide bakeries famous for the Classic Roll, MiniBon, and Cinnabon Stix made\nwith Makara cinnamon. Most US locations are in malls, airports, and travel plazas. Every\nCinnabon purchase codes as a dining/restaurant transaction, so dining bonus cards return\ntheir full rate here. Amex Gold earns 4x Membership Rewards, Chase Sapphire Preferred earns\n3x, and the Capital One SavorOne earns 3% cash back on every cinnamon roll order.\n"
+    },
+    {
       "name": "Circle K",
       "slug": "circle-k",
       "categories": [
@@ -538,6 +1005,50 @@
       ],
       "website": "https://www.circlek.com",
       "intro": "Circle K is one of the largest U.S. convenience-store chains, with about 7,000\ndomestic locations operating both branded fuel and convenience retail. Fuel\npurchases code as gas on every card we track; in-store purchases code as\nconvenience or grocery depending on the bank. The Inner Circle membership\n($1.99/mo) layers on per-gallon discounts and is usually a stronger rebate per\nvisit than any Circle K-specific credit card.\n"
+    },
+    {
+      "name": "Citgo",
+      "slug": "citgo",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.citgo.com",
+      "intro": "Citgo operates roughly 4,200 branded gas stations across the United States, owned by\nVenezuelan state oil company PDVSA. Fuel at Citgo pumps codes as gas for credit card\nnetworks, so any gas category bonus card will earn its full rate. The Citgo Rewards\nCard (issued by Citibank Retail Services) offers a small per-gallon discount or\nstatement credit on Citgo fuel and a sign-up bonus, though a general-purpose 3-5x gas\ncard from a major issuer will typically out-earn the closed-loop product.\n"
+    },
+    {
+      "name": "Coach",
+      "slug": "coach",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.coach.com",
+      "intro": "Coach is the flagship leather goods brand of Tapestry Inc, which also owns Kate Spade\nand Stuart Weitzman. The U.S. footprint includes around 360 full-price and outlet\nstores plus coach.com. Direct purchases typically code as department store in person\nand online shopping for web orders, while Coach handbags bought at Macy's, Nordstrom,\nor Bloomingdale's code under those host retailers. The free Coach Insider loyalty\nprogram stacks with credit card multipliers.\n"
+    },
+    {
+      "name": "Cold Stone Creamery",
+      "slug": "cold-stone-creamery",
+      "aliases": [
+        "Cold Stone"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.coldstonecreamery.com",
+      "intro": "Cold Stone Creamery runs about 1,000 US shops centered on premium ice cream that's mixed\non a frozen granite stone with customer-selected mix-ins, plus signature Creations like\nBirthday Cake Remix, Founder's Favorite, and Strawberry Blonde. Cold Stone is part of the\nKahala Brands portfolio. Every Cold Stone transaction codes as dining/restaurants, including\nice cream cakes ordered through the My Cold Stone Club app. Dining-bonus cards like the Amex\nGold (4x), Chase Sapphire Preferred (3x), and Capital One SavorOne (3% cash) earn full rate.\n"
+    },
+    {
+      "name": "Columbia Sportswear",
+      "slug": "columbia-sportswear",
+      "aliases": [
+        "Columbia"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.columbia.com",
+      "intro": "Columbia Sportswear is a Portland, Oregon outdoor apparel and footwear company that\nalso owns Mountain Hardwear, Sorel, and prAna. Direct sales run through roughly 130\nbranded and outlet stores plus columbia.com, while a heavy wholesale footprint puts\nColumbia gear in REI, Dick's, and big-box sporting goods. Direct purchases typically\ncode as department store or online shopping. The free Greater Rewards loyalty program\nstacks with credit card multipliers.\n"
     },
     {
       "name": "Costco",
@@ -564,6 +1075,18 @@
       "intro": "Costco Wholesale runs about 600 warehouses worldwide and a sizable online catalog at\ncostco.com. The pricing model revolves around member-only bulk buying, so card choice\nmatters most for people running weekly grocery and gas trips through the warehouse. Two\nquirks worth knowing: Costco accepts only Visa cards in-warehouse (no Mastercard, Amex,\nor Discover), and Costco gas pumps code as wholesale clubs — not gas — so a 5% gas card\nwill not trigger at the pump here.\n"
     },
     {
+      "name": "Cracker Barrel",
+      "slug": "cracker-barrel",
+      "aliases": [
+        "Cracker Barrel Old Country Store"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.crackerbarrel.com",
+      "intro": "Cracker Barrel Old Country Store operates about 660 restaurants in 45 states, pairing a\nSouthern country-style restaurant with an attached retail country store stocked with candy,\ntoys, and home goods. Menu staples include Chicken n Dumplins, Hashbrown Casserole, and\nSunday Homestyle Chicken. Restaurant charges code as dining; retail-store purchases generally\ncode as general merchandise/department stores. Dining cards like Amex Gold (4x), Chase\nSapphire Preferred (3x), and Capital One SavorOne (3% cash) hit the full bonus on meals.\n"
+    },
+    {
       "name": "Crate & Barrel",
       "slug": "crate-and-barrel",
       "aliases": [
@@ -577,6 +1100,34 @@
       "intro": "Crate & Barrel is a U.S. home furnishings retailer with about 100 stores plus\nthe CB2 modern-design sister brand. In-store charges code as furniture; online\norders code as online shopping. The Crate & Barrel Credit Card and Reward\nMastercard issue percent-back in store credit on Crate & Barrel-family purchases;\nthe Reward Mastercard adds a flat rate on everyday spend. Pair otherwise with\nan online-shopping-bonus card.\n"
     },
     {
+      "name": "Crocs",
+      "slug": "crocs",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.crocs.com",
+      "intro": "Crocs Inc is a Broomfield, Colorado footwear company best known for its foam clogs and\nJibbitz charms, plus the HEYDUDE acquisition. The U.S. footprint includes about 150\noutlet and full-price stores along with a strong DTC business at crocs.com. Direct\npurchases typically code as department store in person and online shopping for web\norders. The free Crocs Club loyalty program offers points and member discounts that\nstack with credit card rewards.\n"
+    },
+    {
+      "name": "Culver's",
+      "slug": "culvers",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.culvers.com",
+      "intro": "Culver's is a Wisconsin-based quick-service chain known for ButterBurgers, fresh\nfrozen custard with a rotating Flavor of the Day, and Wisconsin cheese curds. The\nfamily-owned business operates over 950 restaurants concentrated in the Midwest\nand Sun Belt. Culver's transactions code as restaurants on all major credit card\nnetworks, which makes them eligible for standard dining bonus categories.\n\nThe Amex Gold leads on Culver's spending at 4x points per dollar on U.S.\nrestaurants, while the Chase Sapphire Reserve and Capital One Savor both pay 3x or\nmore on dining. No-annual-fee dining cards including the Capital One SavorOne and\nWells Fargo Autograph each earn 3 percent or 3x on restaurants, which makes them\npractical defaults for everyday Culver's visits and family dinners.\n"
+    },
+    {
+      "name": "Cumberland Farms",
+      "slug": "cumberland-farms",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.cumberlandfarms.com",
+      "intro": "Cumberland Farms is a Northeast U.S. convenience and gas chain with about 600 stores\nacross New England, New York, Florida, and parts of the Mid-Atlantic, now operated by\nEG Group. Fuel at Cumberland Farms pumps codes as gas, so any gas category bonus card\nwill earn its multiplier. The chain's signature SmartPay program is an ACH-linked\ndebit option offering a flat 10 cents per gallon discount, which generally beats most\ncredit-card gas rewards in absolute cents-per-gallon terms but does not earn credit\ncard points.\n"
+    },
+    {
       "name": "CVS",
       "slug": "cvs",
       "aliases": [
@@ -587,6 +1138,18 @@
       ],
       "website": "https://www.cvs.com",
       "intro": "CVS is the largest U.S. pharmacy chain by store count (about 9,000 locations) and a\nmajor convenience-goods retailer alongside the prescription business. CVS codes as a\ndrugstore on every card we track, so any 3-5% drugstore-category card will earn here.\nCVS's own ExtraCare loyalty program runs in parallel and stacks with card cashback.\n"
+    },
+    {
+      "name": "Dairy Queen",
+      "slug": "dairy-queen",
+      "aliases": [
+        "DQ"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.dairyqueen.com",
+      "intro": "Dairy Queen is the Berkshire Hathaway-owned QSR with more than 4,300 US locations split\nbetween traditional treat-only stores and full-menu DQ Grill & Chill outlets serving Blizzards,\nsoft-serve cones, dipped cones, burgers, and chicken strip baskets. Whether you order at a\nwalk-up window, drive-thru, or through the DQ Rewards mobile app, the transaction codes as\ndining/restaurants. Cards with strong dining multipliers (Amex Gold at 4x, Chase Sapphire\nPreferred at 3x, Capital One SavorOne at 3% cash) all earn at the full bonus rate on DQ.\n"
     },
     {
       "name": "Delta Air Lines",
@@ -609,6 +1172,15 @@
       "intro": "Delta Air Lines runs one of the strongest U.S. domestic networks and the SkyMiles\nloyalty program. Delta tickets code as airfare across all major cards. Co-branded\nSkyMiles Amex cards add extra miles per dollar on Delta plus perks like a free\nchecked bag, Sky Club access (Reserve only), and Medallion-status boost spend.\nGeneral travel cards usually beat them on raw cash-equivalent value, but the\nReserve's lounge access and MQD-waiver path can swing the math for frequent flyers.\nOTA bookings still earn miles when your SkyMiles number is attached.\n"
     },
     {
+      "name": "Denny's",
+      "slug": "dennys",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.dennys.com",
+      "intro": "Denny's operates roughly 1,500 US diners famous for 24-hour service, the Grand Slam breakfast,\nMoons Over My Hammy, and a value-driven all-day menu that draws road-trippers, third-shift\nworkers, and late-night crowds. Most Denny's are highway-adjacent or in travel-corridor\nsuburbs. Denny's transactions code as dining/restaurants on every credit card, including\norders through the Denny's Rewards app and Denny's On Demand delivery portal. Dining-bonus\ncards earn full rate: Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne 3%.\n"
+    },
+    {
       "name": "Dick's Sporting Goods",
       "slug": "dicks-sporting-goods",
       "aliases": [
@@ -621,6 +1193,27 @@
       ],
       "website": "https://www.dickssportinggoods.com",
       "intro": "Dick's Sporting Goods is the largest U.S. sporting goods retailer with about\n720 namesake stores plus Public Lands, Field & Stream, Going Going Gone, and\nGolf Galaxy banners. In-store charges code as department stores; online orders\ncode as online shopping. The free ScoreCard loyalty program issues 1 point per\n$1 plus periodic 2-3x bonus events redeemable for store credit, stackable with\ncard bonuses. There's a Dick's-branded Synchrony credit card with 8% in-store\ncashback for cardholders.\n"
+    },
+    {
+      "name": "Dillard's",
+      "slug": "dillards",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.dillards.com",
+      "intro": "Dillard's is a mid-tier to upscale department store chain with about 270 locations\nprimarily in the South, Midwest, and Sun Belt. The merchandise mix leans heavily into\napparel, shoes, cosmetics, and home goods. Dillard's codes as a department store, so\nany department-store category bonus card will earn its multiplier. The Dillard's\nAmerican Express card (issued by Wells Fargo) offers elevated rewards on Dillard's\npurchases plus general earn elsewhere, and Dillard's also issues a closed-loop store\ncard with lower earn but more accessible approval.\n"
+    },
+    {
+      "name": "Discount Tire",
+      "slug": "discount-tire",
+      "aliases": [
+        "America's Tire"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.discounttire.com",
+      "intro": "Discount Tire, doing business as America's Tire in California, is the largest\nindependent tire and wheel retailer in the United States with more than 1,200\nstores. The chain sells passenger, truck, performance, and trailer tires plus wheels\nand TPMS service. Tire purchases generally code as auto services or general retail\nrather than as a dedicated bonus category on most cards.\n\nCards with selectable categories such as Citi Custom Cash and Bank of America\nCustomized Cash can reach tire purchases when the right category is active. A new\nset of four tires plus installation often runs $800 to $1,500, which makes\nDiscount Tire useful for clearing signup bonus minimums on cards like the Wells\nFargo Autograph or Chase Freedom Unlimited.\n"
     },
     {
       "name": "Disney+",
@@ -681,6 +1274,41 @@
       "intro": "DoorDash is the largest U.S. food-delivery service by market share, covering both\nrestaurant delivery and (via DashMart and grocery partners) household goods. Restaurant\norders code as dining/restaurants on every card we track, and several cards specifically\ncall out DoorDash for elevated dining bonuses or DashPass perks. DashMart and\ngrocery-partner orders typically code as the underlying merchant rather than as dining.\n"
     },
     {
+      "name": "Drury Hotels",
+      "slug": "drury-hotels",
+      "aliases": [
+        "Drury Inn"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.druryhotels.com",
+      "intro": "Drury Hotels is a privately held family-owned chain operating about 150 mid-tier hotels\nconcentrated across the Midwest, South, and Southwest under the Drury Inn, Drury Inn & Suites,\nDrury Plaza Hotel, and Pear Tree Inn brands. The chain is best known for the 5:30 Kickback\nhot food and drinks reception and free hot breakfast included with every stay. Drury charges\ncode as lodging/hotels on every card. Cards with hotel bonuses (Chase Sapphire Reserve 4x on\ndirect, Amex Platinum 5x on Amex Travel prepaid, Capital One Venture X 2x base) earn full rate.\n"
+    },
+    {
+      "name": "DSW",
+      "slug": "dsw",
+      "aliases": [
+        "Designer Shoe Warehouse"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.dsw.com",
+      "intro": "DSW, short for Designer Shoe Warehouse, is the flagship footwear retailer of Designer\nBrands Inc, with around 500 U.S. stores and dsw.com. The DSW VIP loyalty program is\nfree, offers tiered rewards and a birthday gift, and stacks with credit card earnings.\nThe DSW Visa from Comenity adds elevated points on DSW spend and a base earn rate\neverywhere else, while general purpose cards code DSW as department store in person\nand online shopping on the web.\n"
+    },
+    {
+      "name": "Duane Reade",
+      "slug": "duane-reade",
+      "categories": [
+        "drugstores"
+      ],
+      "website": "https://www.duanereade.com",
+      "intro": "Duane Reade is the New York City banner of Walgreens, with roughly 250 locations\nconcentrated in the five boroughs and surrounding suburbs. The format is essentially\na Walgreens drugstore adapted to dense urban real estate, often with a heavier prepared\nfood and convenience selection. Duane Reade codes as a drugstore, so any drugstore\ncategory bonus card (Amex Blue Cash Preferred, Citi Custom Cash on drugstores) will\nearn its full multiplier. The myWalgreens loyalty program works at Duane Reade\nregisters as well.\n"
+    },
+    {
       "name": "Dunkin'",
       "slug": "dunkin",
       "aliases": [
@@ -695,6 +1323,18 @@
       "intro": "Dunkin' is a U.S. coffee-and-donut chain with about 9,000 domestic locations.\nCharges code as dining on every card we track, so any restaurant-bonus card\napplies — Amex Gold's 4x dining (capped), Capital One SavorOne's 3%, Sapphire\nPreferred's 3x. Heavy regulars also use the free DD Perks/Dunkin' Rewards app\nfor free drinks and bonus-point promotions, which stack on top of card bonuses.\n"
     },
     {
+      "name": "Dutch Bros",
+      "slug": "dutch-bros",
+      "aliases": [
+        "Dutch Bros Coffee"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.dutchbros.com",
+      "intro": "Dutch Bros Coffee has grown from a single Oregon pushcart in 1992 to more than 950 drive-thru\ncoffee shops across roughly 18 states, with a menu that leans heavily on flavored Rebel\nenergy drinks, blended Freezes, and customizable lattes. Every Dutch Bros purchase codes as\ndining/restaurants regardless of whether you swipe in the drive-thru lane or reload your\nDutch Rewards account in the app. Cards with strong dining multipliers (Amex Gold at 4x,\nCapital One SavorOne at 3%, Chase Sapphire Preferred at 3x) all earn full bonus rewards.\n"
+    },
+    {
       "name": "eBay",
       "slug": "ebay",
       "aliases": [
@@ -705,6 +1345,28 @@
       ],
       "website": "https://www.ebay.com",
       "intro": "eBay is the largest U.S. online auction and resale marketplace and codes as online\nshopping on essentially every credit card we track. Unlike Amazon, eBay rarely has a\ncard-specific bonus carve-out, so the right card here is the strongest generic\nonline-shopping earner you carry. Watch for cards with a U.S. online retail cap — eBay\npayments via PayPal still count as eBay for category coding, but third-party processor\npurchases on eBay's classifieds side may not.\n"
+    },
+    {
+      "name": "Eddie Bauer",
+      "slug": "eddie-bauer",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.eddiebauer.com",
+      "intro": "Eddie Bauer is an outdoor and casual apparel brand now under Sparc Group, with a long\ncatalog heritage, roughly 250 stores and outlets, and a steady online business at\neddiebauer.com. Direct purchases typically code as department store in person and\nonline shopping for web orders. The free Adventure Rewards loyalty program offers\npoints and birthday perks, but there is no current Eddie Bauer branded credit card in\nthe U.S. market.\n"
+    },
+    {
+      "name": "Einstein Bros. Bagels",
+      "slug": "einstein-bros-bagels",
+      "aliases": [
+        "Einstein Bros"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.einsteinbros.com",
+      "intro": "Einstein Bros. Bagels operates about 700 US bakery-cafes serving fresh-baked bagels, shmears,\negg sandwiches, and coffee, with most locations in college towns, hospital campuses, and\nsuburban shopping centers. The chain is owned by Bagel Brands alongside Bruegger's. Every\nEinstein Bros. purchase codes as dining/restaurants, including orders placed through the\nEinstein Bros. Rewards app. Cards with strong breakfast and dining bonuses (Amex Gold at 4x,\nChase Sapphire Preferred at 3x, Capital One SavorOne at 3%) all earn at full multiplier.\n"
     },
     {
       "name": "Enterprise",
@@ -746,6 +1408,29 @@
       "intro": "Expedia is one of the largest online travel agencies, owned by Expedia Group\n(which also owns Hotels.com, Vrbo, and Travelocity). Bookings code as travel on\nevery card we track. The honest catch: hotel and airline programs typically do\nNOT credit Expedia bookings toward elite-night or elite-qualifying-mile counts,\nand many properties exclude OTA stays from earning their own loyalty points —\nso booking direct usually wins for status-conscious travelers. The Expedia\nRewards Cards from Citi layer extra OneKeyCash on Expedia-family bookings.\n"
     },
     {
+      "name": "Express",
+      "slug": "express",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.express.com",
+      "intro": "Express is a mall-based apparel chain known for workwear and going out looks for men\nand women, operating through a mix of full-line stores, Express Factory Outlet, and\nexpress.com after the brand emerged from Chapter 11 restructuring. The Express Next\nstore credit card from Comenity earns A-List points on every purchase and pairs with\nthe free loyalty tier. General-purpose cards typically code Express as department\nstore at the register and online shopping for web orders.\n"
+    },
+    {
+      "name": "Extended Stay America",
+      "slug": "extended-stay-america",
+      "aliases": [
+        "ESA"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.extendedstayamerica.com",
+      "intro": "Extended Stay America operates more than 600 budget long-stay hotels across the US, each\nroom equipped with a full kitchen, dishware, and weekly housekeeping options, targeting\nbusiness travelers, contractors, and relocating families who need stays of a week or longer.\nThe chain also runs Extended Stay America Suites and Extended Stay America Premier Suites.\nESA charges code as lodging/hotels on every credit card. Hotel-bonus cards earn full rate:\nChase Sapphire Reserve at 4x direct, Capital One Venture X at 2x base, Amex Platinum at 5x prepaid.\n"
+    },
+    {
       "name": "ExxonMobil",
       "slug": "exxonmobil",
       "aliases": [
@@ -767,6 +1452,75 @@
       "intro": "ExxonMobil operates Exxon and Mobil-branded stations at about 11,500 U.S. locations,\nplus the ExxonMobil Rewards+ app for in-station discounts. ExxonMobil pumps code as gas\non every card we track, and one merchant-specific note: ExxonMobil purchases earn 3% on\nthe Apple Card when paid via Apple Pay.\n"
     },
     {
+      "name": "Family Dollar",
+      "slug": "family-dollar",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.familydollar.com",
+      "intro": "Family Dollar is a discount variety chain with roughly 8,000 stores across the U.S.,\nowned by Dollar Tree (which announced plans to sell the banner in 2025). The format\ncarries a mix of groceries, household basics, apparel, and seasonal goods at low price\npoints. Family Dollar typically codes as a discount store or department store for\ncredit card networks, not as a supermarket, so a grocery rewards card will generally\nnot earn its bonus here. A department-store or general 1.5-2% cash back card is the\npractical pick.\n"
+    },
+    {
+      "name": "Famous Footwear",
+      "slug": "famous-footwear",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.famousfootwear.com",
+      "intro": "Famous Footwear is the family footwear chain of Caleres Inc, with about 850 U.S.\nstores and famousfootwear.com, selling athletic and casual shoes from Nike, Adidas,\nSkechers, and others. The free Famously You Rewards program offers tiered cashback\nand a birthday gift, layering on top of credit card rewards. Direct purchases\ntypically code as department store at the register and online shopping for web\norders, and there is no current branded credit card.\n"
+    },
+    {
+      "name": "FedEx Office",
+      "slug": "fedex-office",
+      "aliases": [
+        "FedEx Print",
+        "Kinko's"
+      ],
+      "categories": [
+        "office_supplies"
+      ],
+      "website": "https://www.fedex.com/office",
+      "intro": "FedEx Office, formerly Kinko's, operates around 2,000 U.S. retail locations\noffering shipping, printing, copying, signage, packing, and computer rental. Most\nFedEx Office stores code as office supplies or stationery on Visa, Mastercard, and\nAmex networks, which makes spending eligible for office supply bonus categories on\nsmall business cards.\n\nThe Chase Ink Business Cash pays 5 percent on the first $25,000 in combined office\nsupplies and select utilities each year, making it the standard pick for printing\nand shipping spend. The Amex Business Gold also includes U.S. office supply\nretailers as a top-two category. Personal cards with selectable office supply\nbuckets, including U.S. Bank Cash+, can match those rates.\n"
+    },
+    {
+      "name": "Ferguson",
+      "slug": "ferguson",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.ferguson.com",
+      "intro": "Ferguson is the largest U.S. wholesale distributor of plumbing, HVAC, lighting,\nappliances, and waterworks products, with over 1,600 locations including Ferguson\nBath, Kitchen & Lighting Gallery showrooms. Many Ferguson locations code as home\nimprovement on credit card networks, which makes large remodel and new construction\npurchases eligible for home improvement bonus categories.\n\nCards like the U.S. Bank Cash+ with home improvement selected and the Bank of\nAmerica Customized Cash can earn 3 to 5 percent on Ferguson invoices. Kitchen and\nbath renovations frequently run five figures, which makes the retailer useful for\nclearing premium signup bonus minimums on the Capital One Venture X or the Chase\nSapphire Reserve.\n"
+    },
+    {
+      "name": "Firehouse Subs",
+      "slug": "firehouse-subs",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.firehousesubs.com",
+      "intro": "Firehouse Subs is a Jacksonville-based sub sandwich chain with over 1,200\nrestaurants across the United States, owned by Restaurant Brands International\nalongside Burger King and Popeyes. The chain is known for steamed meat subs like\nthe Hook & Ladder and Italian, plus the Firehouse Subs Public Safety Foundation\nthat funds first responder equipment. Transactions code as restaurants on most\ncredit card networks.\n\nThe Amex Gold earns 4x on U.S. restaurants, the highest baseline rate available\non Firehouse Subs orders, while the Chase Sapphire Reserve pays 3x on dining. No\nannual fee dining picks include the Capital One SavorOne at 3 percent and Wells\nFargo Autograph at 3x. The Firehouse Rewards program adds points that stack with\ncredit card cash back, and rounding up at the register supports the Foundation.\n"
+    },
+    {
+      "name": "First Watch",
+      "slug": "first-watch",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.firstwatch.com",
+      "intro": "First Watch operates more than 540 daytime-only restaurants serving breakfast, brunch, and\nlunch, with menu staples like Avocado Toast, the Chickichanga, lemon-ricotta pancakes, and\nfresh-pressed juices. Locations close mid-afternoon, distinguishing First Watch from all-day\nbreakfast chains like IHOP and Denny's. First Watch transactions code as dining/restaurants\non every US card. Dining-bonus cards earn full rate: Amex Gold at 4x Membership Rewards,\nChase Sapphire Preferred at 3x, Chase Sapphire Reserve at 4x, Capital One SavorOne at 3% cash.\n"
+    },
+    {
+      "name": "Five Below",
+      "slug": "five-below",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.fivebelow.com",
+      "intro": "Five Below is a discount retailer with more than 1,700 stores across the U.S., built\naround items priced at $5 or less, plus a Five Beyond section with goods up to $25.\nThe merchandise mix skews toward tweens and teens (candy, tech accessories, beauty,\nhobby, seasonal). Stores typically code as a discount or department store for credit\ncard networks, so a department-store category bonus card can earn its multiplier\nhere. Five Below does not issue its own credit card, so a general 2-5% category card\nis the cleanest play.\n"
+    },
+    {
       "name": "Five Guys",
       "slug": "five-guys",
       "categories": [
@@ -776,6 +1530,16 @@
       "intro": "Five Guys is a U.S. fast-casual burger chain with about 1,700 domestic locations,\nknown for hand-formed patties and unlimited toppings. Charges code as dining on\nevery card we track, so any dining-bonus card applies (Amex Gold 4x within cap,\nSapphire Preferred 3x, SavorOne 3%). Average ticket sizes are higher than typical\nfast-food, which makes the dining multiplier more meaningful per visit.\n"
     },
     {
+      "name": "Floor & Decor",
+      "slug": "floor-and-decor",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.flooranddecor.com",
+      "intro": "Floor & Decor is a hard surface flooring warehouse with over 240 U.S. stores\ncarrying tile, wood, laminate, vinyl, stone, and installation accessories at\ncontractor-friendly pricing. The retailer generally codes as home improvement on\nVisa, Mastercard, and Amex networks, which means it can earn the home improvement\nbonus on cards that include the category.\n\nU.S. Bank Cash+ can deliver 5 percent on Floor & Decor when home improvement is one\nof the two selected categories, and the Bank of America Customized Cash offers a\nsimilar 3 percent. Floor & Decor PRO members can layer trade discounts on top of\ncredit card rewards, and large flooring projects easily clear signup bonus minimums.\n"
+    },
+    {
       "name": "Food Lion",
       "slug": "food-lion",
       "categories": [
@@ -783,6 +1547,39 @@
       ],
       "website": "https://www.foodlion.com",
       "intro": "Food Lion is a Southeastern U.S. grocery chain with about 1,100 stores, owned by\nAhold Delhaize. Codes cleanly as groceries on every card we track. Strongest\npairings are Blue Cash Preferred (6% on U.S. supermarkets), the Capital One SavorOne\n(3% groceries), and U.S. Bank Shopper Cash Rewards if Food Lion is one of the two\nselected retailers. The MVP loyalty program runs separate digital coupons that\nstack on top of any card's bonus rate.\n"
+    },
+    {
+      "name": "Foot Locker",
+      "slug": "foot-locker",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.footlocker.com",
+      "intro": "Foot Locker is the flagship sneaker and athletic apparel banner of Foot Locker Inc,\nwhich also runs Champs Sports, Kids Foot Locker, and WSS. The chain operates about\n900 U.S. stores plus footlocker.com. The FLX Rewards Visa from Bread Financial earns\nelevated XPoints on FLX-family purchases that can be redeemed for sneaker drops and\nshoes. General-purpose cards code Foot Locker as department store in person and online\nshopping for web orders.\n"
+    },
+    {
+      "name": "Forever 21",
+      "slug": "forever-21",
+      "aliases": [
+        "Forever21"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.forever21.com",
+      "intro": "Forever 21 is a fast fashion chain operated under Sparc Group with about 380 U.S.\nstores plus forever21.com after returning from bankruptcy in 2020. Pricing skews very\nlow so category bonuses matter less in absolute dollars, but most cards still code in\nperson purchases as department store and web orders as online shopping. There is no\ncurrent Forever 21 branded credit card, so the free F21 Rewards program is the only\nstacking option beyond credit card rewards.\n"
+    },
+    {
+      "name": "Free People",
+      "slug": "free-people",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.freepeople.com",
+      "intro": "Free People is the bohemian women's brand under URBN and includes the FP Movement\nactivewear line, with roughly 150 retail stores plus a sizeable online presence at\nfreepeople.com. Most credit cards code in-store transactions as department store and\nweb orders as online shopping. Free People does not currently issue a co-brand credit\ncard, so shoppers usually optimize with rotating category cards or a flat-rate\nonline-shopping multiplier.\n"
     },
     {
       "name": "Frontier Airlines",
@@ -818,6 +1615,16 @@
       "intro": "Gap is a U.S. apparel retailer with about 500 domestic stores plus a sister\nbrand portfolio (Old Navy, Banana Republic, Athleta) under Gap Inc. In-store\ncharges code as department stores or apparel; gap.com codes as online shopping.\nThe Gap Good Rewards co-branded Mastercard offers tiered cashback at Gap-family\nbrands. For non-cardholders, an online-shopping-bonus card or U.S. Bank Shopper\nCash Rewards (if Gap is selected) is the strongest pairing.\n"
     },
     {
+      "name": "Giant Eagle",
+      "slug": "giant-eagle",
+      "categories": [
+        "groceries",
+        "gas"
+      ],
+      "website": "https://www.gianteagle.com",
+      "intro": "Giant Eagle is a Pittsburgh-based supermarket chain with roughly 200 stores across\nPennsylvania, Ohio, West Virginia, Indiana, and Maryland, plus its GetGo fuel and\nconvenience arm. The supermarkets code as U.S. groceries (full multiplier for Amex\nGold, Blue Cash Preferred, Citi Custom Cash), while GetGo gas stations typically code\nas gas. The chain's fuelperks+ program lets shoppers turn grocery spend into pennies\noff per gallon at GetGo, which can stack with a gas-category card at the pump.\n"
+    },
+    {
       "name": "Giant Food",
       "slug": "giant-food",
       "aliases": [
@@ -828,6 +1635,39 @@
       ],
       "website": "https://giantfood.com",
       "intro": "Giant Food is the Mid-Atlantic flagship of Ahold Delhaize's U.S. grocery group, with\nabout 165 stores across DC, Maryland, Virginia, and Delaware. Codes cleanly as\ngroceries on every card we track. Best pairings are Blue Cash Preferred (6%),\nCapital One SavorOne (3%), and U.S. Bank Shopper Cash Rewards (6% if selected).\nThe Giant Flexible Rewards program issues per-gallon fuel savings at participating\nShell and Giant stations that stack on top of card bonuses.\n"
+    },
+    {
+      "name": "GOAT",
+      "slug": "goat",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.goat.com",
+      "intro": "GOAT is a sneaker and apparel resale marketplace operated by GOAT Group, which also\nruns Flight Club. The platform authenticates every shoe and item before shipping to\nthe buyer, and lists both new and used pairs from hyped releases alongside everyday\nretro and lifestyle styles. GOAT codes as online shopping for credit card networks,\nso an online-shopping category bonus card will earn its full multiplier. Buyer fees\nare added at checkout and post to the card as part of the transaction total.\n"
+    },
+    {
+      "name": "Grubhub",
+      "slug": "grubhub",
+      "aliases": [
+        "GrubHub"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.grubhub.com",
+      "intro": "Grubhub is one of the three major US food-delivery marketplaces alongside DoorDash and Uber\nEats, connecting customers to roughly 365,000 restaurants and operating Seamless in the\nNortheast under the same parent. Grubhub charges code as dining/restaurants on most card\nnetworks, which means dining-bonus cards earn full rate. Amex Gold pays 4x Membership Rewards,\nChase Sapphire Reserve pays 4x Ultimate Rewards, and the Capital One SavorOne pays 3% cash.\nSeveral cards also offer Grubhub-specific credits or Grubhub+ memberships as a perk.\n"
+    },
+    {
+      "name": "H Mart",
+      "slug": "h-mart",
+      "aliases": [
+        "HMart"
+      ],
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.hmart.com",
+      "intro": "H Mart is the largest Korean-American supermarket chain in the U.S., with roughly 100\nstores concentrated in major metros with significant Asian-American populations\n(Northeast, California, Texas, Georgia, Pacific Northwest). The chain specializes in\nKorean and broader East Asian grocery, fresh seafood, and prepared foods, and most\nlocations include a food court. H Mart codes as a U.S. supermarket, so grocery\ncategory bonus cards (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earn their\nfull multiplier at the register.\n"
     },
     {
       "name": "H-E-B",
@@ -857,6 +1697,15 @@
       "intro": "H&M is a Swedish-headquartered fast-fashion chain with about 540 U.S. stores.\nIn-store charges code as department stores or apparel; hm.com codes as online\nshopping. The H&M Member program is free and issues birthday gifts plus tiered\nperks; H&M's co-branded U.S. credit card layers an additional discount on top\nof the loyalty program. For non-cardholders, an online-shopping-bonus card is\nthe strongest pairing.\n"
     },
     {
+      "name": "Half Price Books",
+      "slug": "half-price-books",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hpb.com",
+      "intro": "Half Price Books is a Dallas-based used and new book retailer with over 120 stores\nacross the United States, also selling vinyl records, movies, video games, and\ncollectibles. The chain is known for buying back books, music, and games from\ncustomers in addition to its retail operation. Purchases typically code as bookstore\nor general retail on most credit card networks.\n\nCards with selectable categories can sometimes capture bookstore purchases. U.S.\nBank Cash+ includes bookstores as one of its selectable 5 percent categories, which\ncan deliver meaningful value for heavy readers. Online orders at hpb.com may also\ntrigger online shopping bonuses on cards like Bank of America Customized Cash and\nChase Freedom Flex during rotating online quarters.\n"
+    },
+    {
       "name": "Hannaford",
       "slug": "hannaford",
       "aliases": [
@@ -867,6 +1716,28 @@
       ],
       "website": "https://www.hannaford.com",
       "intro": "Hannaford is a New England grocery chain with about 185 stores, owned by Ahold\nDelhaize. Codes cleanly as groceries on every card we track. Strongest pairings\nare Blue Cash Preferred (6%), Capital One SavorOne (3% groceries with no cap),\nand U.S. Bank Shopper Cash Rewards (6% on selected retailers). Hannaford runs\nthe My Hannaford Rewards program with personalized digital coupons on top of\nany card's earn rate.\n"
+    },
+    {
+      "name": "Harbor Freight Tools",
+      "slug": "harbor-freight",
+      "aliases": [
+        "Harbor Freight"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.harborfreight.com",
+      "intro": "Harbor Freight Tools is a discount tool retailer with over 1,500 U.S. stores selling\nhand tools, power tools, generators, and shop equipment under house brands such as\nBauer, Hercules, and Icon. Most card networks code Harbor Freight as a home\nimprovement merchant, which means cards with a home improvement bonus like the Wells\nFargo Bilt can earn elevated rewards on purchases.\n\nThe Harbor Freight Inside Track Club membership stacks deep coupon discounts with\ncredit card rewards, and online orders through harborfreight.com may also qualify\nfor rotating online shopping bonuses on Chase Freedom Flex and Discover it. Big\ngenerator and welder purchases are useful for signup bonus spend.\n"
+    },
+    {
+      "name": "Hardee's",
+      "slug": "hardees",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.hardees.com",
+      "intro": "Hardee's is the eastern and southern US counterpart to Carl's Jr. under the CKE Restaurants\numbrella, with around 1,700 domestic locations. The menu skews toward charbroiled Thickburgers,\nMade From Scratch Biscuits at breakfast, and hand-breaded chicken tenders. Purchases at\nHardee's, including those routed through the Hardee's mobile app, code as fast-food dining,\nwhich means cards like the Capital One SavorOne (3% unlimited on dining), Chase Sapphire\nPreferred (3x), and Amex Gold (4x) earn at the full dining multiplier on every order.\n"
     },
     {
       "name": "Harris Teeter",
@@ -893,6 +1764,18 @@
         "hawaiian-airlines-world-elite-mastercard"
       ],
       "intro": "Hawaiian Airlines is the dominant carrier between the U.S. mainland and Hawaii, plus\ninter-island routes. Tickets code as airfare on every card we track. The co-branded\nHawaiian Airlines World Elite Mastercard offers a discount on round-trip companion\ntickets to Hawaii each year and bonus miles on the airline. With Alaska Airlines'\nacquisition closed, Hawaiian's loyalty program is integrating with Alaska's Mileage\nPlan, so long-term value will increasingly route through Alaska's award chart.\n"
+    },
+    {
+      "name": "HelloFresh",
+      "slug": "hellofresh",
+      "aliases": [
+        "Hello Fresh"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hellofresh.com",
+      "intro": "HelloFresh is the largest meal-kit delivery service in the United States, shipping pre-portioned\ningredients and recipe cards weekly to subscribers across most ZIP codes. The HelloFresh\ngroup also operates Factor (prepared meals), Green Chef, and EveryPlate. HelloFresh charges\ntypically code as online retail or grocery delivery, not dining or in-store groceries, which\naffects which cards earn bonus. Online-shopping bonuses (Chase Freedom Flex rotating quarters,\nDiscover it 5% categories) and flat-rate cards (Citi Double Cash 2%) are usually the best fit.\n"
     },
     {
       "name": "Hertz",
@@ -954,6 +1837,25 @@
       "intro": "Hobby Lobby is a U.S. arts-and-crafts retailer with about 1,000 stores, selling\nfabric, home decor, art supplies, and seasonal goods. In-store charges code as\ndepartment stores or specialty retail; hobbylobby.com codes as online shopping.\nHobby Lobby doesn't run a loyalty program but consistently posts a 40%-off-one-\nitem coupon that's the main rewards lever per visit. Pair with a flat-rate\ncashback card or department-store-bonus card.\n"
     },
     {
+      "name": "Hollister",
+      "slug": "hollister",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.hollisterco.com",
+      "intro": "Hollister is the teen and young adult apparel brand under Abercrombie & Fitch Co, with\na Southern California beach identity and around 500 stores worldwide. Most general\npurpose cards code Hollister purchases as department store in mall and as online\nshopping for hollisterco.com checkouts. The Club Cali loyalty program is free and\nlayers on top of credit card rewards, but Hollister does not currently offer its own\nbranded credit card.\n"
+    },
+    {
+      "name": "Home Chef",
+      "slug": "home-chef",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.homechef.com",
+      "intro": "Home Chef is the meal-kit subscription owned by Kroger since 2018, offering customizable\nrecipes including Fresh and Easy 15-minute kits, Family Menu portions, and the Express line\nof microwavable meals. Home Chef kits also sell through Kroger-banner grocery stores. When\nordered online, Home Chef charges typically code as online retail or direct food shipping\nrather than groceries or dining, so flat-rate cards (Citi Double Cash 2%, Wells Fargo Active\nCash 2%) often beat category cards. In-store purchases at Kroger code as supermarkets.\n"
+    },
+    {
       "name": "Home Depot",
       "slug": "home-depot",
       "aliases": [
@@ -976,6 +1878,16 @@
       "intro": "HomeGoods is the home-furnishings off-price chain owned by TJX Companies, with\nabout 900 U.S. stores selling discount furniture, decor, and bath. Codes as\ndepartment stores on most cards. The TJX Rewards Mastercard offers 5% back at\nHomeGoods and the rest of the TJX family. For everyone else, a department-store\ncategory card (Wells Fargo Active Cash, Citi Custom Cash if it's your top\ncategory) or flat-rate cashback card is the standard pairing.\n"
     },
     {
+      "name": "Hot Topic",
+      "slug": "hot-topic",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.hottopic.com",
+      "intro": "Hot Topic is a mall-based specialty retailer focused on pop culture apparel, music\nmerch, and fandom licensed goods, with around 600 U.S. stores plus a sister chain\nBoxLunch. The Hot Cash loyalty program runs seasonally with print and digital\ncertificates that stack with credit card rewards. Most cards code Hot Topic as\ndepartment store in person and online shopping for hottopic.com checkouts, and there\nis no Hot Topic branded credit card today.\n"
+    },
+    {
       "name": "Hotels.com",
       "slug": "hotels-com",
       "aliases": [
@@ -989,6 +1901,18 @@
       "intro": "Hotels.com is one of the largest global online travel agencies, owned by Expedia\nGroup. Bookings code as travel on every card we track. The honest catch: hotel\nchains typically do NOT credit Hotels.com stays toward elite-night or status\ncounts, and many properties exclude OTA stays from earning their loyalty points\n— so a Hilton/Marriott/Hyatt loyalist almost always books direct. Hotels.com's\nown One Key Rewards (formerly Hotels.com Rewards) is now unified with Expedia's\nOneKeyCash and stacks across the Expedia family.\n"
     },
     {
+      "name": "HSN",
+      "slug": "hsn",
+      "aliases": [
+        "Home Shopping Network"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hsn.com",
+      "intro": "HSN, the Home Shopping Network, is a multichannel retailer selling via 24-hour\ntelevision, hsn.com, and mobile, owned by Qurate Retail Group alongside sister\nbrand QVC. The product mix covers beauty, fashion, jewelry, kitchen, and home goods,\nwith a heavy emphasis on live demonstrations and host-led pitches. HSN purchases code\nas online shopping or general merchandise for credit card networks, so an\nonline-shopping category bonus card will earn its multiplier. The FlexPay installment\nprogram is available at checkout against the saved card.\n"
+    },
+    {
       "name": "Hulu",
       "slug": "hulu",
       "categories": [
@@ -996,6 +1920,15 @@
       ],
       "website": "https://www.hulu.com",
       "intro": "Hulu is a U.S. streaming-video service offering on-demand library content and a\nlive-TV bundle, owned by Disney. Monthly subscriptions code as streaming on\nevery card we track. Streaming-bonus cards (Blue Cash Preferred 6%, U.S. Bank\nCash+ 5% on selected categories) are the strongest pairings. Hulu (with-ads)\nis also bundled with Disney+ and ESPN+ as the Disney Bundle for the lowest\nper-service cost.\n"
+    },
+    {
+      "name": "Hy-Vee",
+      "slug": "hy-vee",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.hy-vee.com",
+      "intro": "Hy-Vee is a Midwest, employee-owned supermarket chain with roughly 280 stores across\nIowa, Illinois, Kansas, Minnesota, Missouri, Nebraska, South Dakota, and Wisconsin.\nStores are large-format and often include pharmacies, food courts, and Hy-Vee Fuel\nSaver gas stations in some markets. Hy-Vee supermarkets code as U.S. groceries, so any\ngrocery category card (Amex Gold, Blue Cash Preferred, Citi Custom Cash) will earn its\nposted multiplier. The Fuel Saver + Perks loyalty program is a useful supplement when\nshoppers also fill up at participating Casey's or Hy-Vee Fast & Fresh locations.\n"
     },
     {
       "name": "Hyatt",
@@ -1060,6 +1993,18 @@
       "intro": "IHG Hotels & Resorts spans about 6,000 properties across 19 brands, anchored by Holiday\nInn and Holiday Inn Express on the mass-market end and InterContinental, Regent, and\nSix Senses on the luxury end. The Chase IHG One Rewards Premier card is one of the\nhighest-leverage hotel co-brands available — its annual free-night certificate (good\nat any property up to 40,000 points) often pays back the annual fee on a single use,\nand the fourth-night-free benefit on award stays effectively cuts redemption costs by\n25%. Direct bookings at ihg.com or in-app earn points and elite-night credits; OTA\nstays generally earn nothing. Points value lands around 0.5 cents but redemptions can\nexceed that on aspirational properties.\n"
     },
     {
+      "name": "IHOP",
+      "slug": "ihop",
+      "aliases": [
+        "International House of Pancakes"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.ihop.com",
+      "intro": "IHOP, owned by Dine Brands Global alongside Applebee's, operates about 1,700 US restaurants\nbest known for buttermilk pancakes, the Rooty Tooty Fresh 'N Fruity breakfast, and a 24-hour\nservice model at many locations. The menu also covers omelets, French toast, burgers, and\ndinner entrees. IHOP transactions code as dining/restaurants whether dine-in, To Go, or\nvia the International Bank of Pancakes loyalty app. Cards with strong dining bonuses (Amex\nGold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash) earn full rate.\n"
+    },
+    {
       "name": "IKEA",
       "slug": "ikea",
       "categories": [
@@ -1068,6 +2013,18 @@
       ],
       "website": "https://www.ikea.com",
       "intro": "IKEA is the largest global home-furnishings retailer with about 50 U.S. warehouse\nstores plus a planning-studio network. In-store charges typically code as\nfurniture or home improvement; ikea.com codes as online shopping. The IKEA\nFamily loyalty program is free and issues member-only pricing plus a free\ncoffee/tea on store visits. The IKEA Visa Credit Card offers 5% back at IKEA\non purchases — typically the strongest rate for heavy buyers.\n"
+    },
+    {
+      "name": "In-N-Out Burger",
+      "slug": "in-n-out-burger",
+      "aliases": [
+        "In-N-Out"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.in-n-out.com",
+      "intro": "In-N-Out Burger is a West Coast cult favorite founded in Baldwin Park, California\nin 1948, with around 400 locations across California, Nevada, Arizona, Utah,\nTexas, Oregon, Colorado, and Idaho. The minimalist menu of Double-Doubles, fries,\nand shakes plus the off-menu Animal Style ordering is the chain's identity. In-N-Out\ntransactions code as restaurants on Visa, Mastercard, and Amex networks.\n\nDining rewards cards capture In-N-Out well. The Amex Gold earns 4x points on U.S.\nrestaurants and is the top earner for frequent visitors, while the Chase Sapphire\nReserve pays 3x. No-annual-fee dining picks include the Capital One SavorOne at 3\npercent and Wells Fargo Autograph at 3x. In-N-Out does not run a customer rewards\nprogram, so credit card rewards are the only structured path to cash back.\n"
     },
     {
       "name": "Instacart",
@@ -1097,6 +2054,40 @@
       "intro": "J.Crew is a U.S. apparel retailer with about 130 stores plus a strong online\npresence. In-store codes as department stores; jcrew.com codes as online\nshopping. The J.Crew Rewards loyalty program issues credits at spend tiers\nseparate from any card bonus. Strongest pairings are an online-shopping-bonus\ncard or flat-rate cashback for in-store purchases.\n"
     },
     {
+      "name": "Jack in the Box",
+      "slug": "jack-in-the-box",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.jackinthebox.com",
+      "intro": "Jack in the Box operates roughly 2,200 locations concentrated in the western United States,\nbuilt around a 24-hour menu that mixes burgers, tacos, breakfast sandwiches, and late-night\nmunchie meals. Drive-thru and mobile-app orders code as standard quick-service restaurants,\nso any card paying a dining bonus (3-5% on cards like the Capital One Savor or Amex Gold)\nearns full rate. The Jack app supports Apple Pay and Google Pay funding, which lets you\nstack a card's dining multiplier with mobile-wallet bonuses on cards that offer them.\n"
+    },
+    {
+      "name": "Jamba",
+      "slug": "jamba",
+      "aliases": [
+        "Jamba Juice"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.jamba.com",
+      "intro": "Jamba, rebranded from Jamba Juice and now part of Focus Brands, operates about 750 US\nlocations focused on real fruit smoothies, fresh juices, bowls, and plant-based options.\nSignature blends include the Strawberry Surf Rider, Razzmatazz, and Aloha Pineapple. Jamba\npurchases at standalone stores, mall locations, or through the Jamba app code as\ndining/restaurants. That makes any dining-bonus card a fit: the Amex Gold earns 4x Membership\nRewards, Chase Sapphire Preferred earns 3x, and the Capital One SavorOne earns 3% cash back.\n"
+    },
+    {
+      "name": "Jared",
+      "slug": "jared",
+      "aliases": [
+        "Jared The Galleria of Jewelry"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.jared.com",
+      "intro": "Jared, formally Jared The Galleria of Jewelry, is the upscale destination banner of\nSignet Jewelers, with around 240 standalone stores featuring on-site design and repair\nservices plus jared.com. The Jared Diamond credit card from Comenity offers\npromotional financing for high-ticket purchases. General-purpose cards typically code\nJared as department store in person and online shopping for web orders, and the free\nVault Rewards program is shared across Signet.\n"
+    },
+    {
       "name": "JCPenney",
       "slug": "jcpenney",
       "aliases": [
@@ -1109,6 +2100,18 @@
       ],
       "website": "https://www.jcpenney.com",
       "intro": "JCPenney is a mid-tier department store with about 660 stores and a smaller online\ncatalog at jcpenney.com. Like other mid-tier department chains, the bulk of purchases\nhappen at promotional discount, so card rewards stack on already-reduced prices.\nJCPenney codes as a department store in-store and online shopping on the website, so\ncards bonusing on either category will trigger here.\n"
+    },
+    {
+      "name": "Jersey Mike's Subs",
+      "slug": "jersey-mikes",
+      "aliases": [
+        "Jersey Mike's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.jerseymikes.com",
+      "intro": "Jersey Mike's Subs is a fast-growing sub sandwich chain founded in Point Pleasant,\nNew Jersey in 1956, with more than 2,800 locations across the United States. The\nchain is known for cold subs sliced to order, hot Philly cheesesteaks and Chicken\nPhilly options, and the annual Month of Giving charitable campaign. Transactions\ncode as restaurants on most credit card networks.\n\nThe Amex Gold leads at 4x points on U.S. restaurants and is the highest base\nearner for regular Jersey Mike's visits, while the Chase Sapphire Reserve pays 3x\non dining. No-annual-fee picks like the Capital One SavorOne at 3 percent and\nWells Fargo Autograph at 3x are practical defaults. Jersey Mike's also runs the\nShore Points loyalty program, which layers in-app rewards on top of credit card\ncash back.\n"
     },
     {
       "name": "JetBlue",
@@ -1129,6 +2132,37 @@
         "jetblue-business-card"
       ],
       "intro": "JetBlue runs an East Coast and Caribbean network with TrueBlue as its loyalty program.\nTrueBlue points are revenue-based — about 1.3 cents each — so they're easy to value\nbut rarely produce outsized award redemptions. JetBlue tickets code as airfare on\nevery card we track. The co-branded Plus and Premier cards bundle a 5,000-point\nanniversary bonus, free checked bag, and Mosaic-status accelerators that can swing\nthe math for regulars; the Premier adds a Mint upgrade benefit on transcons.\n"
+    },
+    {
+      "name": "Jiffy Lube",
+      "slug": "jiffy-lube",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.jiffylube.com",
+      "intro": "Jiffy Lube is the largest quick-lube franchise in North America with over 2,000\nservice centers offering oil changes, tire rotations, fluid services, and air\nfilter replacements. Most Jiffy Lube transactions code as auto services rather than\na dedicated rewards category, so flat-rate cards like the Citi Double Cash often\nwin on simplicity.\n\nCards with selectable categories that include auto can do better. Citi Custom Cash\npays 5 percent on the top eligible category and may capture Jiffy Lube for drivers\nwhose top monthly spend is auto services. The U.S. Bank Cash+ also offers wider\nauto-related categories. Jiffy Lube's loyalty program does not currently offer\nsignificant points that stack with credit card rewards.\n"
+    },
+    {
+      "name": "Jimmy John's",
+      "slug": "jimmy-johns",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.jimmyjohns.com",
+      "intro": "Jimmy John's is an Illinois-based sub sandwich chain known for its \"Freaky Fast\"\ndelivery, day-baked French bread, and a streamlined menu of cold subs including\nthe Vito, Turkey Tom, and Italian Night Club. The chain operates over 2,600\nlocations nationwide and is owned by Inspire Brands. Jimmy John's transactions code\nas restaurants on Visa, Mastercard, and Amex networks.\n\nThe Amex Gold pays 4x points on U.S. restaurants and leads the field for daily\nJimmy John's lunches, while the Chase Sapphire Reserve pays 3x on dining and\nincludes travel-friendly redemptions. No-annual-fee dining picks like the Capital\nOne SavorOne and Wells Fargo Autograph each earn 3 percent or 3x on restaurants.\nThe Freaky Fast Rewards program adds points and free sandwiches on top of credit\ncard cash back.\n"
+    },
+    {
+      "name": "Kay Jewelers",
+      "slug": "kay-jewelers",
+      "aliases": [
+        "Kay"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.kay.com",
+      "intro": "Kay Jewelers is the largest banner inside Signet Jewelers, with around 850 U.S. stores\nplus kay.com selling engagement rings, fashion jewelry, and watches. The Kay Jewelers\nLong-Term Financing credit card from Comenity offers promotional financing on bigger\npurchases. General-purpose cards typically code Kay as department store in person and\nonline shopping for web orders, and the free Vault Rewards program stacks with credit\ncard earnings.\n"
     },
     {
       "name": "KFC",
@@ -1156,6 +2190,18 @@
       "intro": "Kohl's is a mid-tier department store with about 1,150 stores and an aggressive Kohl's\nCash rewards program. Most regular shoppers stack manufacturer sales, Kohl's coupons,\nand Kohl's Cash, so card cashback is the smallest of several layers. The Kohl's Card\n(issued by Capital One) gives in-house discounts but no MasterCard/Visa-network rewards.\nFor most shoppers, a department-store-bonus general-purpose card is the right answer.\n"
     },
     {
+      "name": "Krispy Kreme",
+      "slug": "krispy-kreme",
+      "aliases": [
+        "Krispy Kreme Doughnuts"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.krispykreme.com",
+      "intro": "Krispy Kreme operates around 380 US shops plus thousands of grocery and convenience-store\ncabinets, with the chain's Hot Light signaling fresh Original Glazed doughnuts coming off\nthe line. Purchases at a Krispy Kreme storefront or drive-thru, including dozens ordered\nvia the Krispy Kreme Rewards app, code as dining/restaurants. Cards with elevated dining\nbonuses earn at full rate: Amex Gold (4x Membership Rewards), Chase Sapphire Preferred (3x\nUltimate Rewards), and Capital One SavorOne (3% unlimited cash back) are all strong picks.\n"
+    },
+    {
       "name": "Kroger",
       "slug": "kroger",
       "categories": [
@@ -1163,6 +2209,116 @@
       ],
       "website": "https://www.kroger.com",
       "intro": "Kroger is the largest dedicated U.S. supermarket operator, running about 2,700 stores\nunder Kroger and a stack of regional banners (Ralphs, Fred Meyer, Smith's, King Soopers,\nHarris Teeter, Fry's, and others). All code as groceries at the register and most do\nonline shopping via the Kroger app/site. Any standard supermarket-bonus card earns here.\nKroger's own fuel-points program layers on top of card cashback.\n"
+    },
+    {
+      "name": "Kwik Trip",
+      "slug": "kwik-trip",
+      "aliases": [
+        "Kwik Star"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.kwiktrip.com",
+      "intro": "Kwik Trip (branded Kwik Star in Iowa) is a family-owned convenience and fuel chain\nwith more than 800 stores across Wisconsin, Minnesota, Iowa, Illinois, Michigan, and\nSouth Dakota. The chain is known for its in-house bakery, dairy, and prepared foods\nalongside a busy fuel operation. Pumps code as gas for credit card networks, so a gas\ncategory bonus card will earn its multiplier. The Kwik Rewards loyalty program adds\nper-gallon discounts and points on food, which can stack with a separate rewards card\nat the pump.\n"
+    },
+    {
+      "name": "L.L.Bean",
+      "slug": "ll-bean",
+      "aliases": [
+        "LL Bean"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.llbean.com",
+      "intro": "L.L.Bean is a Maine-based outdoor retailer famous for its Freeport flagship and the\nBean Boot, operating about 60 U.S. stores plus a heavy catalog and DTC business at\nllbean.com. The L.L.Bean Mastercard from Citi earns elevated points on direct L.L.Bean\npurchases and offers a free shipping perk for cardholders, while general-purpose cards\ncode in-store visits as department store and web checkouts as online shopping.\n"
+    },
+    {
+      "name": "Lands' End",
+      "slug": "lands-end",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.landsend.com",
+      "intro": "Lands' End is a casual classics apparel brand with deep catalog roots, sold mostly\nthrough landsend.com and via shop-in-shop counters that were historically inside many\nKohl's department stores. Direct site purchases typically code as online shopping,\nwhile Lands' End merchandise bought at Kohl's codes under the host retailer and earns\nKohl's Rewards. There is no current standalone Lands' End branded credit card in the\nU.S. market.\n"
+    },
+    {
+      "name": "Levi's",
+      "slug": "levis",
+      "aliases": [
+        "Levi Strauss"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.levi.com",
+      "intro": "Levi's is the flagship denim brand of Levi Strauss & Co, sold through about 200 U.S.\ncompany stores, levi.com, and a wide wholesale footprint at department stores and\nspecialty retailers. Direct purchases at Levi's stores or the website typically code\nas department store or online shopping, while buying Levi's at Macy's or Kohl's codes\nunder that retailer. The free Levi's Red Tab membership stacks with credit card\nrewards, and there is no Levi's branded credit card.\n"
+    },
+    {
+      "name": "Lidl",
+      "slug": "lidl",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.lidl.com",
+      "intro": "Lidl is a German discount grocer that has expanded across the U.S. East Coast since\n2017, with roughly 175 stores stretching from Georgia up to New York. The format is\nsmall-footprint and private-label-heavy, comparable to Aldi. Lidl codes as a U.S.\nsupermarket for credit card networks, so grocery category bonuses (Amex Gold, Blue\nCash Preferred, Citi Custom Cash) earn their full multiplier. The chain accepts mobile\nwallets and standard major networks.\n"
+    },
+    {
+      "name": "Little Caesars",
+      "slug": "little-caesars",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://littlecaesars.com",
+      "intro": "Little Caesars is the third-largest pizza chain in the United States with more than 4,000\ndomestic locations, built around the Hot-N-Ready model that lets customers walk in and grab\na fresh pepperoni or cheese pizza without ordering ahead. The chain remains family-owned\nby the Ilitch group. Little Caesars transactions, whether in-store, drive-thru Pizza Portal\npickup, or app delivery, all code as dining/restaurants. Top dining cards earn full bonus\nhere: Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash.\n"
+    },
+    {
+      "name": "Living Spaces",
+      "slug": "living-spaces",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.livingspaces.com",
+      "intro": "Living Spaces is a West Coast furniture chain with around 40 large-format showrooms\nacross California, Texas, Arizona, Nevada, and a growing East Coast footprint. The\nretailer is known for in-stock sofas with same-week delivery and a wide rug\nassortment. Furniture purchases code as general retail, not as a home improvement\nbonus category on most rewards cards.\n\nBecause Living Spaces orders frequently run into four figures, sofas and bedroom\nsets are excellent for clearing signup bonus minimum spend. Cards with strong base\nearn rates, including the Citi Double Cash and Capital One Venture X, are the\npractical default. Living Spaces also offers in-house financing through Synchrony for\npromotional zero-interest terms.\n"
+    },
+    {
+      "name": "LL Flooring",
+      "slug": "ll-flooring",
+      "aliases": [
+        "Lumber Liquidators"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.llflooring.com",
+      "intro": "LL Flooring, formerly known as Lumber Liquidators, is a flooring specialty retailer\nwith over 400 U.S. stores selling hardwood, bamboo, vinyl plank, laminate, and tile\nflooring along with installation supplies. The chain typically codes as home\nimprovement on most credit card networks, which makes it eligible for cards that\ncarry a home improvement bonus category.\n\nCards like the U.S. Bank Cash+ and Bank of America Customized Cash can route LL\nFlooring purchases into a selectable bonus, while the Chase Freedom Flex sometimes\nfeatures home improvement in its 5 percent rotating quarters. Whole-house flooring\nprojects are large enough to clear most credit card signup bonus minimums in a\nsingle transaction.\n"
+    },
+    {
+      "name": "LongHorn Steakhouse",
+      "slug": "longhorn-steakhouse",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.longhornsteakhouse.com",
+      "intro": "LongHorn Steakhouse is Darden Restaurants' Western-themed steak concept with about 580 US\nlocations, sitting just below the chain's Capital Grille tier and offering fire-grilled steaks\nlike the Outlaw Ribeye and Flo's Filet plus chicken, salmon, and ribs. LongHorn participates\nin the cross-Darden eGift card program with Olive Garden and others. LongHorn transactions\ncode as dining/restaurants. Cards with strong dining multipliers (Amex Gold 4x, Chase\nSapphire Preferred 3x, Capital One SavorOne 3% cash) earn full rate on every steak dinner.\n"
+    },
+    {
+      "name": "Love's Travel Stops",
+      "slug": "loves-travel-stops",
+      "aliases": [
+        "Love's"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.loves.com",
+      "intro": "Love's Travel Stops runs more than 650 locations across 42 states, serving both\npassenger drivers and commercial truckers with fuel, food, showers, and tire service.\nStandard fuel pumps code as gas, so any gas category bonus card will earn its full\nmultiplier at the pump. Inside-store food and merchandise can code as convenience\nstore or restaurant depending on the format. The MyLove's Rewards program offers\nper-gallon discounts and points redeemable on food and showers, which stacks\ncleanly with a separate gas rewards card.\n"
     },
     {
       "name": "Lowe's",
@@ -1189,6 +2345,16 @@
       "intro": "Lululemon is the dominant U.S. athletic-apparel brand with about 700 stores and a heavy\nlululemon.com presence. Like other apparel retailers, Lululemon doesn't fall into a card\nbonus category in-store — the right answer there is a strong flat-rate cashback card.\nOnline purchases at lululemon.com code as online shopping, which opens up a different\nset of category bonuses.\n"
     },
     {
+      "name": "Lush",
+      "slug": "lush",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.lushusa.com",
+      "intro": "Lush Fresh Handmade Cosmetics is a British beauty brand best known for bath bombs,\nshampoo bars, and packaging-light skincare. The U.S. footprint covers about 200 mall\nand street-front stores plus lushusa.com. Direct purchases typically code as\ndepartment store in person and online shopping for web orders, while the free Lush\nRewards program offers points and member perks that stack with credit card earnings.\nLush does not run a U.S. branded credit card.\n"
+    },
+    {
       "name": "Lyft",
       "slug": "lyft",
       "categories": [
@@ -1196,6 +2362,19 @@
       ],
       "website": "https://www.lyft.com",
       "intro": "Lyft is the second-largest U.S. rideshare service after Uber. Rides code under\nthe transit category on most cards. The Chase Sapphire Reserve historically pays\n10x on Lyft rides through 2027, and Lyft Pink (Lyft's premium membership) is\ncomped with several Chase cards. Sapphire Preferred, Venture X, and SavorOne all\nearn elevated transit/rideshare rates without the Lyft-specific multipliers.\n"
+    },
+    {
+      "name": "MAC Cosmetics",
+      "slug": "mac-cosmetics",
+      "aliases": [
+        "MAC"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.maccosmetics.com",
+      "intro": "MAC Cosmetics is a prestige color cosmetics brand owned by The Estée Lauder Companies,\nsold through about 100 U.S. freestanding stores, maccosmetics.com, and a wide\ndepartment store and Ulta wholesale footprint. Direct purchases at MAC stores or the\nwebsite typically code as department store or online shopping, while MAC bought at\nMacy's or Ulta codes under that retailer. The free MAC Lover loyalty program offers\ntiered points and stacks with credit card multipliers.\n"
     },
     {
       "name": "Macy's",
@@ -1211,6 +2390,28 @@
       "intro": "Macy's is the largest U.S. mid-tier department store, with about 500 full-line stores\nplus Backstage outlets and a heavy promotional calendar. Most shoppers buy at heavy\ndiscount, so the cashback rate stacks on already-reduced prices. Macy's codes as a\ndepartment store at the register and as online shopping on macys.com, which means cards\nbonusing on either category can earn here. The Macy's American Express has its own\nLoyallist points layer for shoppers doing several thousand a year at Macy's\nspecifically.\n"
     },
     {
+      "name": "Madewell",
+      "slug": "madewell",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.madewell.com",
+      "intro": "Madewell is the denim-led casualwear brand spun out of J.Crew, with about 140 U.S.\nstores and a strong DTC site at madewell.com. The Madewell Insider loyalty program is\nfree and offers a denim recycling perk for old jeans. General-purpose credit cards\ntypically code Madewell as department store in person and online shopping for web\ncheckouts, and the brand does not currently have its own branded credit card.\n"
+    },
+    {
+      "name": "Maggiano's Little Italy",
+      "slug": "maggianos",
+      "aliases": [
+        "Maggiano's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.maggianos.com",
+      "intro": "Maggiano's Little Italy, owned by Brinker International (Chili's parent), runs about 50\nupscale-casual Italian restaurants known for family-style portions, the Chocolate Zuccotto\nCake, and the Classic Pastas program where guests take home a second pasta with each entree.\nMaggiano's transactions code as dining/restaurants on every credit card. With higher check\naverages than typical casual dining, top dining cards meaningfully boost return: Amex Gold\nat 4x, Chase Sapphire Reserve at 4x, Chase Sapphire Preferred at 3x, Capital One Savor at 3%.\n"
+    },
+    {
       "name": "Marathon",
       "slug": "marathon",
       "aliases": [
@@ -1222,6 +2423,18 @@
       ],
       "website": "https://www.marathonbrand.com",
       "intro": "Marathon-branded stations cover about 7,000 U.S. locations primarily across the\nMidwest and Southeast. Pumps code cleanly as gas on every card we track. The\nMakeItCount Rewards program offers cents-per-gallon savings that stack with\nwhatever card you swipe; absolute cashback usually wins with a 4-5% general gas\ncard rather than a Marathon-only co-brand.\n"
+    },
+    {
+      "name": "Marco's Pizza",
+      "slug": "marcos-pizza",
+      "aliases": [
+        "Marco's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.marcos.com",
+      "intro": "Marco's Pizza, founded in Ohio in 1978, runs about 1,200 US locations with a delivery and\ncarryout model emphasizing fresh dough made in-store, three-cheese blends, and a private\npizza sauce recipe. The chain has grown rapidly across the South and Midwest. Marco's\ntransactions code as dining/restaurants whether you order at the counter, online, or through\nthe Marco's Rewards app. Dining-bonus cards earn their full rate here: Amex Gold pays 4x,\nChase Sapphire Preferred pays 3x, and the Capital One SavorOne pays 3% unlimited cash back.\n"
     },
     {
       "name": "Marriott",
@@ -1272,6 +2485,25 @@
       "intro": "Marshalls is an off-price retail chain owned by TJX Companies, with about 1,200\nU.S. stores selling apparel, home, and accessories at discount prices. Codes as\ndepartment stores on most cards. The TJX Rewards Mastercard offers 5% back at\nMarshalls, TJ Maxx, HomeGoods, Sierra, and Homesense — typically the best rate\nfor heavy TJX shoppers. Otherwise pair with a department-store-bonus card or a\nflat-rate cashback card.\n"
     },
     {
+      "name": "Mattress Firm",
+      "slug": "mattress-firm",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.mattressfirm.com",
+      "intro": "Mattress Firm is the largest U.S. mattress specialty chain with more than 2,300\nstores, carrying Sealy, Serta, Tempur-Pedic, Purple, and its private-label brands.\nMattress purchases code as general retail on most credit card networks, which means\nno automatic 5 percent home improvement bonus and no grocery category overlap.\n\nKing-size mattress sets routinely cross $2,000, making Mattress Firm useful for\nclearing signup bonus minimums on cards like the Amex Gold or Chase Sapphire\nPreferred. The retailer also offers Synchrony-issued financing with promotional\nzero-interest windows. Paying with a 2 percent flat-rate card such as the Citi\nDouble Cash and avoiding interest charges typically produces a better net outcome.\n"
+    },
+    {
+      "name": "Maverik",
+      "slug": "maverik",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://maverik.com",
+      "intro": "Maverik, branded \"Adventure's First Stop,\" is a Mountain West convenience-store and\nfuel chain with around 400 locations spread across Utah, Idaho, Wyoming, Nevada,\nColorado, Arizona, and surrounding states. Fuel pumps code as gas, so any gas category\nrewards card will earn its full bonus. The Adventure Club loyalty program (and the\nrelated Adventure Club Visa, issued via First Bankcard) adds per-gallon discounts and\nelevated earn on Maverik in-store purchases including the chain's BonFire food\nprogram.\n"
+    },
+    {
       "name": "Max",
       "slug": "max",
       "aliases": [
@@ -1316,6 +2548,25 @@
       "intro": "Menards is a Midwest-focused home-improvement chain with about 350 stores, well-known\nfor its 11% mail-in rebate promotions that effectively act as in-house cashback on top\nof card rewards. The math here is interesting: an 11% Menards rebate stacked with a 2%\nflat-rate cashback card often beats most home-improvement category cards on net. Menards\ncodes as home improvement at the register and on menards.com.\n"
     },
     {
+      "name": "Mercari",
+      "slug": "mercari",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.mercari.com",
+      "intro": "Mercari is a Japan-founded peer-to-peer marketplace where individual users list and\nship secondhand and new items across electronics, apparel, collectibles, and home\ngoods. The U.S. arm operates similarly to eBay but with a simpler flat-fee structure\nand shipping label integration. Mercari purchases code as online shopping for credit\ncard networks, so an online-shopping category bonus card will earn its multiplier on\nbuyer-side transactions. Mercari does not issue a co-brand card.\n"
+    },
+    {
+      "name": "Michael Kors",
+      "slug": "michael-kors",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.michaelkors.com",
+      "intro": "Michael Kors is the flagship accessible luxury brand under Capri Holdings, which also\nowns Versace and Jimmy Choo. The U.S. footprint includes hundreds of Lifestyle and\noutlet stores plus michaelkors.com selling handbags, watches, footwear, and ready to\nwear. Direct purchases typically code as department store in person and online\nshopping for web orders, while MK bought at department stores codes under the host\nretailer. The free KORSVIP loyalty program stacks with credit card earnings.\n"
+    },
+    {
       "name": "Michaels",
       "slug": "michaels",
       "categories": [
@@ -1324,6 +2575,79 @@
       ],
       "website": "https://www.michaels.com",
       "intro": "Michaels is the largest U.S. arts-and-crafts retailer with about 1,300 stores,\nselling beads, yarn, frames, and seasonal decor. In-store charges code as\ndepartment stores or specialty retail; michaels.com codes as online shopping.\nThe Michaels Rewards program is free and issues per-spend points redeemable\nfor in-store credit. Pair with a flat-rate cashback or department-store-bonus\ncard; there's no widely-recommended Michaels-specific credit card.\n"
+    },
+    {
+      "name": "Micro Center",
+      "slug": "micro-center",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.microcenter.com",
+      "intro": "Micro Center is a specialty computer and electronics retailer with around 25 large\nU.S. stores known for in-stock PC components, aggressive CPU and motherboard combo\npricing, and a deep selection of GPUs, 3D printers, and DIY parts. Most credit cards\ncode Micro Center as electronics or general retail rather than as a dedicated\ncategory, so flat-rate cards often do the heavy lifting.\n\nOnline orders through microcenter.com qualify for online shopping bonuses on the\nBank of America Customized Cash, Chase Freedom Flex when online shopping is the\nrotating quarter, and U.S. Bank Cash+. Custom PC builds can run thousands of\ndollars, making Micro Center a useful target for clearing signup bonus minimums.\n"
+    },
+    {
+      "name": "Microsoft Store",
+      "slug": "microsoft-store",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.microsoft.com/store",
+      "intro": "The Microsoft Store is Microsoft's online retail destination for Surface laptops,\nXbox consoles and games, Windows software, Microsoft 365 subscriptions, and Office\nproducts. Following the closure of all physical Microsoft Stores in 2020, all U.S.\nconsumer shopping happens through microsoft.com/store. Purchases code as online\nshopping or software on most credit card networks.\n\nCards with online shopping bonuses can deliver strong returns on Surface and Xbox\npurchases. The Bank of America Customized Cash, U.S. Bank Cash+, and Chase Freedom\nFlex rotating quarters can all push these orders to 5 percent back. Microsoft 365\nand Xbox Game Pass recurring subscriptions may code as software or streaming\nservices, which can trigger streaming category bonuses on cards like the Amex Blue\nCash Preferred.\n"
+    },
+    {
+      "name": "Midas",
+      "slug": "midas",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.midas.com",
+      "intro": "Midas is a global auto service franchise with around 1,200 U.S. locations\nspecializing in exhaust, brakes, tires, suspension, and routine maintenance. Most\nMidas franchisees code transactions as auto services on Visa, Mastercard, and Amex\nnetworks, which typically falls outside dedicated rewards categories on consumer\ncards.\n\nBig-ticket brake jobs and exhaust work often run $500 to $1,500, which is enough\nto make MID category selection worthwhile on cards like Citi Custom Cash when auto\nservices is the top monthly category. U.S. Bank Cash+ also offers wider auto\ncategories. For everyday simplicity, the Wells Fargo Active Cash and Citi Double\nCash pay a clean 2 percent on every Midas invoice.\n"
+    },
+    {
+      "name": "Moe's Southwest Grill",
+      "slug": "moes-southwest-grill",
+      "aliases": [
+        "Moe's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.moes.com",
+      "intro": "Moe's Southwest Grill, owned by Focus Brands, runs about 600 fast-casual locations centered\non burritos, bowls, quesadillas, and the chain's signature free chips and salsa with every\nentree. Every Moe's transaction, whether in-store, drive-thru, or through the Moe's Rewards\napp, codes as a dining/restaurant charge. Pair a top dining card here for the best return:\nAmex Gold pays 4x Membership Rewards, Chase Sapphire Preferred pays 3x Ultimate Rewards,\nand Capital One SavorOne pays 3% cash back on every Welcome to Moe's order.\n"
+    },
+    {
+      "name": "Motel 6",
+      "slug": "motel-6",
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.motel6.com",
+      "intro": "Motel 6 operates roughly 1,400 budget motels across the US and Canada, distinguishable by\nthe We'll leave the light on for you tagline and consistently low nightly rates that have\nanchored the chain at the bottom of the lodging price spectrum since 1962. Motel 6 was\nacquired by Oyo's parent in 2025. Sister brand Studio 6 offers extended-stay options. Motel 6\ncharges code as lodging/hotels on every card. Hotel-bonus cards earn full rate: Chase\nSapphire Reserve at 4x direct, Capital One Venture X at 2x base, Amex Platinum at 5x prepaid.\n"
+    },
+    {
+      "name": "Murphy USA",
+      "slug": "murphy-usa",
+      "aliases": [
+        "Murphy Express"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.murphyusa.com",
+      "intro": "Murphy USA runs about 1,700 low-price gas and convenience stations across the U.S.,\nmany of them sited in Walmart parking lots under the Murphy USA or Murphy Express\nbanners. The chain competes primarily on price per gallon. Fuel codes as gas at the\npump, so any gas category bonus card will earn its full multiplier. The Murphy Drive\nRewards loyalty app and Murphy USA Visa add per-gallon discounts that can stack with a\nmajor-issuer gas card if used carefully.\n"
+    },
+    {
+      "name": "NAPA Auto Parts",
+      "slug": "napa-auto-parts",
+      "aliases": [
+        "NAPA"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.napaonline.com",
+      "intro": "NAPA Auto Parts is one of the largest independent auto parts networks in North\nAmerica, with roughly 6,000 U.S. stores operated by independent jobbers and Genuine\nParts Company. NAPA carries replacement parts, batteries, tools, and chemicals for\nDIY drivers and professional repair shops. Auto parts purchases typically code as\ngeneral retail rather than triggering a dedicated bonus category.\n\nCards with selectable cash back categories can sometimes treat NAPA as an auto\ncategory, with Citi Custom Cash and Bank of America Customized Cash both rewarding\nthe top-spend or selected category. Online orders through napaonline.com may also\nqualify for online shopping bonuses on the Chase Freedom Flex when that category\nrotates in.\n"
     },
     {
       "name": "National Car Rental",
@@ -1362,6 +2686,25 @@
       "intro": "Netflix is the largest U.S. streaming-video service. Monthly subscriptions code\ncleanly as streaming on every card we track. Several mid-tier rewards cards earn\nelevated rates on streaming (Blue Cash Preferred 6% on select streaming including\nNetflix, U.S. Bank Cash+ 5% if streaming is a chosen category). Card-issued\nNetflix credits are rare; the simplest play is pairing the subscription with\nwhichever streaming-bonus card you already carry.\n"
     },
     {
+      "name": "New Balance",
+      "slug": "new-balance",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.newbalance.com",
+      "intro": "New Balance is a privately held Boston-based athletic footwear and apparel company\nwith about 100 U.S. brand and factory stores plus a strong DTC channel at\nnewbalance.com. Direct purchases typically code as department store in person and\nonline shopping for web orders, while New Balance gear bought at Dick's, Foot Locker,\nor running specialty stores codes under that retailer. The free New Balance Rewards\nprogram stacks with credit card multipliers.\n"
+    },
+    {
+      "name": "Newegg",
+      "slug": "newegg",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.newegg.com",
+      "intro": "Newegg is an online retailer focused on consumer electronics, PC components, and\ngaming gear, with a long history of catering to enthusiast PC builders. The site also\nhosts a third-party marketplace for adjacent categories. Newegg codes as online\nshopping, so any online-shopping category bonus card (Chase Freedom Flex when\nactivated, Citi Custom Cash on online shopping, Capital One SavorOne promotions) will\nearn its multiplier. Newegg has issued co-brand financing cards in the past (Newegg\nStore Card via Comenity, Visa via Synchrony), so check the current offering at\ncheckout if 0% APR financing is the goal.\n"
+    },
+    {
       "name": "Nike",
       "slug": "nike",
       "categories": [
@@ -1383,6 +2726,15 @@
       ],
       "website": "https://www.nordstrom.com",
       "intro": "Nordstrom is a higher-end department store with about 100 full-line stores and a much\nlarger Nordstrom Rack outlet network. Pricing skews full-retail at the flagship\nlocations and steeply discounted at Rack, so the right card depends partly on which\nchannel you're shopping. Both code as department stores at the register and online\nshopping on nordstrom.com / nordstromrack.com. Nordstrom's own Nordy Club rewards layer\nin on top of card cashback.\n"
+    },
+    {
+      "name": "Nordstrom Rack",
+      "slug": "nordstrom-rack",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.nordstromrack.com",
+      "intro": "Nordstrom Rack is the off-price arm of Nordstrom, with about 240 stores nationwide\nplus the nordstromrack.com site. The format sells the same designer and contemporary\nbrands as the parent department store at marked-down prices, sourced from previous\nseason inventory and direct buys. Nordstrom Rack purchases earn Nordy Club points\nalongside the main Nordstrom store, and the Nordstrom credit and debit cards\n(Visa-branded variants issued by TD Bank) earn elevated points at both Nordstrom and\nNordstrom Rack. Department-store category bonus cards also apply at the register.\n"
     },
     {
       "name": "O'Reilly Auto Parts",
@@ -1431,6 +2783,31 @@
       "intro": "Olive Garden is a U.S. casual-dining chain with about 900 domestic locations,\nowned by Darden Restaurants. Charges code as dining on every card we track, so\nAmex Gold 4x (capped), Sapphire Preferred 3x, and SavorOne 3% all earn the\ndining bonus. Eligible Darden gift cards purchased through the My Olive Garden\nRewards or Darden portals occasionally code as gift cards rather than dining,\nworth checking before bulk-buying.\n"
     },
     {
+      "name": "Ollie's Bargain Outlet",
+      "slug": "ollies-bargain-outlet",
+      "aliases": [
+        "Ollies"
+      ],
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.ollies.us",
+      "intro": "Ollie's Bargain Outlet is a closeout retailer with more than 550 stores across the\nEastern and Central U.S., selling brand-name merchandise (books, household goods,\nfurniture, food, seasonal items) acquired from manufacturer overstock and store\ncloseouts. The chain's tagline \"Good Stuff Cheap\" captures the model. Ollie's\ntypically codes as a department store or discount retailer for credit card networks,\nso a department-store category bonus card can earn its multiplier. The free Ollie's\nArmy loyalty program adds member-only discounts but is not a credit card product.\n"
+    },
+    {
+      "name": "Omni Hotels",
+      "slug": "omni-hotels",
+      "aliases": [
+        "Omni Hotels & Resorts"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.omnihotels.com",
+      "intro": "Omni Hotels & Resorts is a privately held US luxury and upper-upscale hotel chain with about\n50 properties spanning convention-center anchors like the Omni Atlanta and Omni Dallas, resort\ndestinations like the Omni Grove Park Inn and Omni Bedford Springs, and downtown business\nhotels. The Select Guest loyalty program offers free WiFi, beverages, and morning coffee at\nevery tier. Omni charges code as lodging/hotels. Hotel-bonus cards earn full rate: Chase\nSapphire Reserve at 4x direct, Amex Platinum at 5x prepaid, Capital One Venture X at 2x base.\n"
+    },
+    {
       "name": "Outback Steakhouse",
       "slug": "outback-steakhouse",
       "aliases": [
@@ -1441,6 +2818,43 @@
       ],
       "website": "https://www.outback.com",
       "intro": "Outback Steakhouse is a U.S. casual-dining steakhouse chain with about 700\ndomestic locations, owned by Bloomin' Brands (also Carrabba's, Bonefish Grill).\nCharges code as dining on every card we track. Any dining-bonus card applies\n(Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%). The Dine Rewards program\nspans Bloomin' Brands sister concepts and stacks on top of card bonuses.\n"
+    },
+    {
+      "name": "P.F. Chang's",
+      "slug": "pf-changs",
+      "aliases": [
+        "PF Changs",
+        "P.F. Chang's China Bistro"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.pfchangs.com",
+      "intro": "P.F. Chang's China Bistro operates roughly 200 US upscale-casual restaurants known for the\nChang's Spicy Chicken, Mongolian Beef, Dynamite Shrimp, and signature lettuce wraps in a\npan-Asian table-service format. Most locations sit in upscale shopping centers or near\nhigh-end malls. P.F. Chang's transactions code as dining/restaurants, including delivery and\ntakeout orders. Cards offering elevated dining bonuses (Amex Gold at 4x Membership Rewards,\nChase Sapphire Reserve at 4x Ultimate Rewards, Capital One Savor at 3% cash) earn full rate.\n"
+    },
+    {
+      "name": "Pacsun",
+      "slug": "pacsun",
+      "aliases": [
+        "PacSun",
+        "Pacific Sunwear"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.pacsun.com",
+      "intro": "Pacsun is a California-rooted apparel chain catering to teens and young adults, with\nabout 325 mall-based stores and a strong online business at pacsun.com. Most cards\ncode in-store transactions as department store and web orders as online shopping. The\nPacsun Rewards program is free and points-based, layering on top of credit card\nearnings since the chain does not run a branded credit card in the U.S.\n"
+    },
+    {
+      "name": "Pandora",
+      "slug": "pandora",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://us.pandora.net",
+      "intro": "Pandora is a Danish jewelry company best known for its customizable charm bracelets\nplus rings, earrings, and lab-grown diamond collections. The U.S. footprint covers\nabout 360 concept stores and shop-in-shops plus us.pandora.net. Direct purchases\ntypically code as department store in person and online shopping for web orders. The\nfree Pandora Club loyalty program offers points and a birthday gift, but Pandora does\nnot run a U.S. branded credit card.\n"
     },
     {
       "name": "Panera Bread",
@@ -1467,6 +2881,25 @@
       "intro": "Papa John's is a U.S. pizza-delivery chain with about 3,300 domestic locations.\nCharges code as dining on every card we track. Any dining-bonus card (Amex Gold\n4x, Sapphire Preferred 3x, SavorOne 3%) applies. The Papa Rewards loyalty\nprogram in the app issues recurring points-for-pizza promotions that stack on\ntop of card bonuses.\n"
     },
     {
+      "name": "Patagonia",
+      "slug": "patagonia",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.patagonia.com",
+      "intro": "Patagonia is a privately held outdoor and performance apparel brand owned by the\nHoldfast Collective, with about 40 U.S. retail stores plus a strong DTC business at\npatagonia.com. Direct purchases typically code as department store in person and\nonline shopping for web orders, while the Worn Wear resale platform issues store\ncredit for trade-ins. Patagonia does not offer a U.S. branded credit card, so most\nshoppers rely on a strong online or everyday multiplier for full-price gear.\n"
+    },
+    {
+      "name": "Pavilions",
+      "slug": "pavilions",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.pavilions.com",
+      "intro": "Pavilions is the upscale Albertsons banner serving affluent Southern California\nneighborhoods, with a focus on prepared foods, wine, and specialty grocery. It codes as\na U.S. supermarket, so any grocery category bonus (Amex Gold, Blue Cash Preferred, Citi\nCustom Cash) applies at the register. Like other Albertsons banners, Pavilions runs the\nAlbertsons for U loyalty program, and the broad gift-card rack at the service counter\nis worth knowing about if you want to extend a 4x or 6x grocery multiplier into other\nspending.\n"
+    },
+    {
       "name": "Peet's Coffee",
       "slug": "peets-coffee",
       "aliases": [
@@ -1477,6 +2910,33 @@
       ],
       "website": "https://www.peets.com",
       "intro": "Peet's Coffee is a specialty coffee roaster and cafe chain with about 200 U.S.\ncafes, primarily in California. In-cafe charges code as dining on every card we\ntrack. Bagged-bean orders shipped from peets.com sometimes code as online shopping\nrather than dining — worth checking before relying on a 4x dining card. Heavy\nregulars stack the Peetnik Rewards loyalty program on top of card bonuses.\n"
+    },
+    {
+      "name": "Pep Boys",
+      "slug": "pep-boys",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.pepboys.com",
+      "intro": "Pep Boys operates roughly 800 auto parts and service centers across the United\nStates, combining a parts counter with tire installation, oil changes, brake work,\nand full-service mechanical repair. Most credit cards code Pep Boys purchases as\nauto services or general retail rather than as a dedicated bonus category, so\nflat-rate cards like the Citi Double Cash often deliver the cleanest 2 percent.\n\nCards with selectable categories can reach Pep Boys when the right bucket is\nchosen. Bank of America Customized Cash and U.S. Bank Cash+ both have wider\ncategories that may capture auto service spending, and Citi Custom Cash pays 5\npercent on the top eligible spending category for cardholders whose monthly spend\nskews toward vehicle maintenance.\n"
+    },
+    {
+      "name": "Pet Supermarket",
+      "slug": "pet-supermarket",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.petsupermarket.com",
+      "intro": "Pet Supermarket is a Southeast U.S. pet specialty chain with around 200 stores\nacross Florida, Georgia, the Carolinas, Alabama, and neighboring states. The\nretailer carries dog and cat food, small animal supplies, fish, reptiles, and live\nbird departments. Most Pet Supermarket locations code as pet shops or general\nretail on credit card networks, not as a standalone rewards category.\n\nCards with selectable categories like U.S. Bank Cash+ can include pet shops in\ntheir lineup, while flat-rate cards such as the Citi Double Cash or Wells Fargo\nActive Cash deliver a steady 2 percent on every pet food run. Online orders\nthrough petsupermarket.com may trigger online shopping bonuses on Bank of America\nCustomized Cash and Chase Freedom Flex rotating quarters.\n"
+    },
+    {
+      "name": "Pet Supplies Plus",
+      "slug": "pet-supplies-plus",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.petsuppliesplus.com",
+      "intro": "Pet Supplies Plus is the third-largest pet specialty chain in the United States\nwith over 700 neighborhood stores carrying food, treats, toys, and grooming\nservices for dogs, cats, fish, reptiles, and small animals. Most Pet Supplies Plus\nlocations code as pet shops or general retail on credit card networks, not as a\ncategory that triggers standard rewards bonuses.\n\nCards with selectable categories sometimes include pet shops, with U.S. Bank Cash+\noffering pet-related categories in its lineup. Online orders placed through\npetsuppliesplus.com may also trigger online shopping bonuses on cards like Bank of\nAmerica Customized Cash and Chase Freedom Flex. The free Preferred Pet Club\nloyalty program adds points on top of credit card rewards.\n"
     },
     {
       "name": "Petco",
@@ -1497,6 +2957,41 @@
       "intro": "PetSmart is the largest U.S. pet specialty retailer by store count at about 1,650\nlocations, with a sizable petsmart.com online catalog. Pet-supply purchases don't have a\ndedicated category on most credit cards, so in-store purchases generally fall back to a\nflat-rate cashback card. Online purchases at petsmart.com code as online shopping. The\nTreats Rewards loyalty program stacks on top of card cashback.\n"
     },
     {
+      "name": "Phillips 66",
+      "slug": "phillips-66",
+      "aliases": [
+        "76",
+        "Conoco"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.phillips66.com",
+      "intro": "Phillips 66 is a U.S. refiner whose retail footprint covers more than 7,000 branded\ngas stations across three names: Phillips 66 in the central U.S., 76 on the West\nCoast, and Conoco in the Mountain West. All three brands code as gas at the pump, so\nany gas category bonus card (Costco Anywhere Visa, Citi Custom Cash on gas, Sam's\nClub Mastercard) will earn its multiplier. The KickBack Rewards loyalty app offers\nper-gallon discounts that stack with rewards card earn at participating sites.\n"
+    },
+    {
+      "name": "Philz Coffee",
+      "slug": "philz-coffee",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.philzcoffee.com",
+      "intro": "Philz Coffee is a San Francisco-born specialty chain of about 70 cafes across California,\nthe East Coast, and the DC region, built around custom pour-over brews like Tesora, Ether,\nand the Mint Mojito iced coffee. Orders placed in-cafe, in the Philz app, or ahead via\ncurbside all code as dining/restaurants. Top dining cards earn their full rate at Philz:\nAmex Gold pays 4x Membership Rewards, Chase Sapphire Reserve pays 4x Ultimate Rewards,\nand Capital One SavorOne pays 3% unlimited cash back on every order.\n"
+    },
+    {
+      "name": "Pilot Flying J",
+      "slug": "pilot-flying-j",
+      "aliases": [
+        "Pilot",
+        "Flying J"
+      ],
+      "categories": [
+        "gas"
+      ],
+      "website": "https://pilotflyingj.com",
+      "intro": "Pilot Flying J operates more than 750 travel centers across the U.S. and Canada,\nmaking it the largest truck stop network in North America. The chain serves both\nlong-haul truckers (with high-flow diesel lanes, showers, and driver lounges) and\npassenger drivers at standard gas pumps. Fuel at Pilot Flying J pumps codes as gas, so\nany card with a gas category bonus will earn its rate. The myRewards Plus loyalty\nprogram adds per-gallon discounts and points on in-store food, which can stack with a\nseparate gas rewards card.\n"
+    },
+    {
       "name": "Pizza Hut",
       "slug": "pizza-hut",
       "categories": [
@@ -1504,6 +2999,32 @@
       ],
       "website": "https://www.pizzahut.com",
       "intro": "Pizza Hut is a U.S. pizza chain with about 6,500 domestic locations, owned by\nYum! Brands. Charges code as dining on every card we track. Any dining-bonus card\napplies. The Hut Rewards loyalty program in the app issues per-dollar points\nredeemable for free items, stackable with card bonuses.\n"
+    },
+    {
+      "name": "PlayStation Store",
+      "slug": "playstation-store",
+      "aliases": [
+        "PSN Store"
+      ],
+      "categories": [
+        "online_shopping",
+        "entertainment"
+      ],
+      "website": "https://store.playstation.com",
+      "intro": "The PlayStation Store is Sony's digital storefront for PS4 and PS5 games, downloadable\ncontent, PlayStation Plus subscriptions, and movies. Purchases happen directly through\nthe console or on store.playstation.com. Card networks often code PlayStation Store\ncharges as digital goods or entertainment, which can trigger entertainment category\nbonuses on cards like the Capital One SavorOne.\n\nPlayStation Plus subscription tiers and Game Pass-style game catalogs may also fall\nunder streaming services coding on some issuers, which means the Amex Blue Cash\nPreferred can occasionally earn 6 percent. Online shopping bonus cards such as Bank\nof America Customized Cash and Chase Freedom Flex during rotating online quarters\nremain reliable defaults for game and DLC purchases.\n"
+    },
+    {
+      "name": "Polo Ralph Lauren",
+      "slug": "polo-ralph-lauren",
+      "aliases": [
+        "Ralph Lauren"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.ralphlauren.com",
+      "intro": "Polo Ralph Lauren is the flagship label of Ralph Lauren Corporation, sold through\nabout 140 U.S. full-price, factory, and Rugby-style stores along with ralphlauren.com\nand an extensive department store wholesale presence. Direct purchases typically code\nas department store in person and online shopping for web orders. The free Ralph\nLauren Rewards program offers points and member perks, but the brand does not run a\nconsumer co-brand credit card in the U.S.\n"
     },
     {
       "name": "Popeyes",
@@ -1518,6 +3039,15 @@
       "intro": "Popeyes is a U.S. Louisiana-style fried chicken chain with about 3,000 domestic\nlocations, owned by Restaurant Brands International. Charges code as dining on\nevery card we track. Any dining-bonus card (Amex Gold 4x, Sapphire Preferred 3x,\nSavorOne 3%) applies. The Popeyes Rewards app issues per-purchase points\nredeemable for free items, stackable with card bonuses.\n"
     },
     {
+      "name": "Poshmark",
+      "slug": "poshmark",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://poshmark.com",
+      "intro": "Poshmark is a social commerce marketplace focused on secondhand fashion, beauty, and\naccessories, where individual sellers list items and ship through prepaid Poshmark\nlabels. The platform was acquired by Korean tech company Naver in 2023. Buyer\npurchases code as online shopping for credit card networks, so any online-shopping\ncategory bonus card will earn its full multiplier. Poshmark does not have a co-brand\ncredit card, so the best earn comes from a general 3-5x online-shopping rewards card.\n"
+    },
+    {
       "name": "Pottery Barn",
       "slug": "pottery-barn",
       "categories": [
@@ -1526,6 +3056,31 @@
       ],
       "website": "https://www.potterybarn.com",
       "intro": "Pottery Barn is a U.S. home furnishings retailer with about 200 stores, owned by\nWilliams-Sonoma Inc. (also West Elm, Pottery Barn Kids). Stores code as\nfurniture/home improvement; potterybarn.com codes as online shopping. The Key\nRewards loyalty program is free, spans all Williams-Sonoma sister brands, and\nearns 2% in Key Rewards points; pairing it with the Key Rewards co-branded\nMastercard adds an additional 5% on Williams-Sonoma family purchases.\n"
+    },
+    {
+      "name": "Pottery Barn Kids",
+      "slug": "pottery-barn-kids",
+      "aliases": [
+        "PB Kids"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.potterybarnkids.com",
+      "intro": "Pottery Barn Kids is the kids and baby furnishings banner of Williams-Sonoma Inc, with\nabout 80 U.S. stores plus potterybarnkids.com selling cribs, bedding, nursery decor,\nand gear. The Key Rewards Visa from Capital One earns elevated points across all WSI\nbrands and stacks with the free Key Rewards program, which is helpful for big-ticket\nnursery setups. General-purpose cards typically code purchases as home improvement or\ndepartment store in person and online shopping on the web.\n"
+    },
+    {
+      "name": "Price Chopper",
+      "slug": "price-chopper",
+      "aliases": [
+        "Market 32"
+      ],
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.pricechopper.com",
+      "intro": "Price Chopper, operated by Northeast Grocery, runs about 130 supermarkets across New\nYork, Vermont, Connecticut, Pennsylvania, Massachusetts, and New Hampshire. Many\nremodeled locations carry the sister Market 32 banner. Both code as U.S. supermarkets,\nso grocery rewards cards (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earn full\nmultipliers. The AdvantEdge loyalty program ties shoppers into fuel discount partners\nlike Sunoco, which can stack with a separate gas-category card at the pump.\n"
     },
     {
       "name": "Publix",
@@ -1540,6 +3095,18 @@
       "intro": "Publix is the largest employee-owned U.S. supermarket chain, with about 1,400 stores\nconcentrated in the Southeast. Pricing skews higher than at mass-market grocers like\nWalmart Neighborhood Market or Aldi, which makes a strong grocery-category card more\nvaluable per visit. Publix codes cleanly as groceries on every card we track.\n"
     },
     {
+      "name": "Qdoba",
+      "slug": "qdoba",
+      "aliases": [
+        "Qdoba Mexican Eats"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.qdoba.com",
+      "intro": "Qdoba Mexican Eats operates roughly 750 fast-casual locations, competing directly with\nChipotle in the burritos-bowls-tacos lane while differentiating with free queso and\nguacamole on entrees. Orders placed in-store, at the counter, or through the Qdoba Rewards\napp all code as dining/restaurants. That makes any card with a dining bonus a strong fit:\nthe Chase Sapphire Reserve earns 4x on dining, Amex Gold earns 4x, and the Capital One\nSavorOne earns 3% unlimited cash back on every Qdoba purchase.\n"
+    },
+    {
       "name": "QuikTrip",
       "slug": "quiktrip",
       "aliases": [
@@ -1550,6 +3117,79 @@
       ],
       "website": "https://www.quiktrip.com",
       "intro": "QuikTrip is a South-and-Midwest gas-and-convenience chain with about 1,000 stores,\nconsistently ranked among the highest customer-satisfaction convenience operators\nin the U.S. Fuel codes as gas on every card we track; in-store purchases typically\ncode as convenience. The QT Rewards app offers per-gallon savings; pair it with a\n4-5% general gas card for the cleanest stack.\n"
+    },
+    {
+      "name": "QVC",
+      "slug": "qvc",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.qvc.com",
+      "intro": "QVC is a multichannel retailer that sells via live television broadcasts, qvc.com, and\nmobile apps, owned by Qurate Retail Group (which also runs HSN). The merchandise mix\nspans apparel, jewelry, beauty, kitchen, electronics, and home goods, often pitched\nby celebrity hosts in real time. QVC purchases code as online shopping or general\nmerchandise for credit card networks, so an online-shopping category bonus card will\ngenerally earn its multiplier. QVC also offers its Easy Pay installment program at\ncheckout, billed against the saved card on file.\n"
+    },
+    {
+      "name": "RaceTrac",
+      "slug": "racetrac",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.racetrac.com",
+      "intro": "RaceTrac is a family-owned Southeast U.S. convenience and fuel chain with more than\n800 stores across Georgia, Florida, Texas, Tennessee, Louisiana, and surrounding\nstates. Fuel pumps code as gas, so any gas category bonus card will earn its\nmultiplier. Inside-store food and drinks (the chain leans heavily on coffee and\nprepared foods) typically code as convenience store. The RaceTrac Rewards loyalty\nprogram adds per-gallon discounts and points on food that stack with a separate gas\nrewards card.\n"
+    },
+    {
+      "name": "Radisson Hotel Group",
+      "slug": "radisson",
+      "aliases": [
+        "Radisson Hotels"
+      ],
+      "categories": [
+        "hotels",
+        "travel"
+      ],
+      "website": "https://www.radissonhotels.com",
+      "intro": "Radisson Hotel Group operates a global portfolio that includes Radisson Collection, Radisson\nBlu, Radisson, Radisson RED, Park Plaza, Park Inn, and Country Inn & Suites, spanning roughly\n1,100 hotels worldwide. In the Americas, Radisson Hotels Americas was sold to Choice Hotels\nin 2022, which complicates loyalty mapping: US stays now mostly earn Choice Privileges,\nwhile EMEA/APAC stays earn Radisson Rewards. Radisson stays code as lodging/hotels. Travel\ncards with hotel bonuses (Amex Gold 3x on prepaid, Chase Sapphire Reserve 4x direct) earn full rate.\n"
+    },
+    {
+      "name": "Raising Cane's",
+      "slug": "raising-canes",
+      "aliases": [
+        "Canes"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.raisingcanes.com",
+      "intro": "Raising Cane's Chicken Fingers is a Baton Rouge-based quick-service chain serving\na focused menu of chicken finger combos, Texas toast, crinkle-cut fries, and the\nsignature Cane's Sauce. The chain has expanded from a single Louisiana location to\nover 800 restaurants nationwide. Raising Cane's transactions code as restaurants\non Visa, Mastercard, and Amex networks, which lights up most dining bonus\ncategories.\n\nThe Amex Gold pays 4x points on U.S. restaurants for one of the highest dining\nrates available, while the Chase Sapphire Reserve and Capital One Savor both pay\n3x or more. The Capital One SavorOne is a strong no-annual-fee pick at 3 percent\non dining. Cane's runs no in-house loyalty program of its own, so credit card\nrewards are the primary cash back path.\n"
+    },
+    {
+      "name": "Raley's",
+      "slug": "raleys",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.raleys.com",
+      "intro": "Raley's is a family-owned, Northern California based supermarket chain with about 120\nstores across California and Nevada, including the Bel Air, Nob Hill Foods, and Raley's\nO-N-E Market banners. The chain emphasizes fresh produce, in-house meat and seafood,\nand a strong private-label program. Raley's codes as a U.S. supermarket, so any\ngrocery category card (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earns full\nmultipliers. The Something Extra loyalty program adds digital coupon savings and\noccasional fuel discounts at partner stations.\n"
+    },
+    {
+      "name": "Ralphs",
+      "slug": "ralphs",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.ralphs.com",
+      "intro": "Ralphs is the Southern California banner of Kroger, operating roughly 180 stores across\nthe Los Angeles and San Diego areas. It codes cleanly as a U.S. supermarket for credit\ncard networks, so grocery bonus cards earn their full rate. Ralphs is also part of the\nKroger fuel points program (the chain runs co-located fuel centers in some locations),\nand the store sells third-party gift cards that can stretch a grocery multiplier into\nother spending categories.\n"
+    },
+    {
+      "name": "Red Robin",
+      "slug": "red-robin",
+      "aliases": [
+        "Red Robin Gourmet Burgers"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.redrobin.com",
+      "intro": "Red Robin Gourmet Burgers operates about 500 casual-dining restaurants centered on\ncustomizable burgers like the Royal Red Robin and Banzai Burger, plus Bottomless Steak Fries\nrefills that anchor the brand's table-service value pitch. The chain skews family-friendly\nwith a kids menu and milkshake program. Red Robin transactions code as dining/restaurants\non every card, including orders placed through Red Robin Royalty loyalty. Dining-bonus\ncards earn full rate: Amex Gold (4x), Chase Sapphire Reserve (4x), Capital One SavorOne (3%).\n"
     },
     {
       "name": "REI",
@@ -1566,6 +3206,19 @@
       "intro": "REI is a member-owned outdoor co-op with about 180 U.S. stores, selling apparel,\ncamping, climbing, and cycling gear. REI codes under its own merchant category\non several cards (notably the Co-op Mastercard, which earns 5% back at REI for\nCo-op Members) and as online shopping for rei.com purchases otherwise. The $30\none-time Co-op membership earns an annual member dividend (~10% of purchases),\nplus member-only sales — typically the most valuable lever for heavy REI buyers\nbeyond any card bonus.\n"
     },
     {
+      "name": "Restoration Hardware",
+      "slug": "restoration-hardware",
+      "aliases": [
+        "RH"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://rh.com",
+      "intro": "Restoration Hardware, now branded as RH, is an upscale home furnishings retailer with\naround 70 large-format Galleries plus rh.com selling furniture, lighting, textiles,\nand outdoor. The RH Members Program is a paid annual membership that grants 25 percent\noff most full-price items and stacks with credit card rewards. General-purpose cards\ntypically code RH as home improvement or department store in person and online\nshopping for web orders.\n"
+    },
+    {
       "name": "Rite Aid",
       "slug": "rite-aid",
       "categories": [
@@ -1573,6 +3226,16 @@
       ],
       "website": "https://www.riteaid.com",
       "intro": "Rite Aid is the third-largest U.S. pharmacy chain at about 1,700 stores, primarily in\nthe Northeast and West Coast. Rite Aid codes cleanly as a drugstore on every card we\ntrack, so any drugstore-bonus card will earn here. The chain's BonusCash and wellness+\nrewards programs layer on top of card cashback.\n"
+    },
+    {
+      "name": "Rooms To Go",
+      "slug": "rooms-to-go",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.roomstogo.com",
+      "intro": "Rooms To Go is a Florida-based furniture retailer that pioneered the room-package\nconcept, bundling sofa, loveseat, tables, lamps, and rug into a single price. The\nchain runs over 250 showrooms across the Southeast, Texas, and Puerto Rico. Furniture\npurchases code as general retail on most rewards cards, so they sit outside dedicated\nhome improvement bonuses.\n\nFive-piece living room packages and bedroom sets often clear $2,000, making Rooms To\nGo a useful place to hit signup bonus thresholds on cards like the Chase Sapphire\nPreferred or Capital One Venture. The retailer also markets a Synchrony-issued Rooms\nTo Go credit card with deferred-interest financing, but a rewards card paid in full\ngenerally produces more value.\n"
     },
     {
       "name": "Ross Dress for Less",
@@ -1585,6 +3248,18 @@
       ],
       "website": "https://www.rossstores.com",
       "intro": "Ross Dress for Less is a U.S. off-price retail chain with about 1,800 stores\nselling apparel, accessories, and home goods at discount prices. Codes as\ndepartment stores on most cards. There's no co-branded Ross credit card, so the\nbest pairings are general department-store-bonus cards (Wells Fargo Active Cash\nflat 2%, U.S. Bank Shopper Cash Rewards if Ross is selected) or flat-rate\ncashback cards. Ross doesn't run a loyalty program.\n"
+    },
+    {
+      "name": "Ruth's Chris Steak House",
+      "slug": "ruths-chris-steak-house",
+      "aliases": [
+        "Ruth's Chris"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.ruthschris.com",
+      "intro": "Ruth's Chris Steak House, now owned by Darden Restaurants, operates about 150 upscale\nsteakhouses known for USDA Prime steaks served on 500-degree plates with sizzling butter,\nplus signature sides like the Sweet Potato Casserole. Average check sizes run high enough\nthat a well-chosen dining card meaningfully changes the bill economics. Ruth's Chris codes\nas dining/restaurants on every credit card. Top picks here include the Amex Gold (4x\nMembership Rewards), Chase Sapphire Reserve (4x Ultimate Rewards), and Capital One Savor (3%).\n"
     },
     {
       "name": "Safeway",
@@ -1610,6 +3285,28 @@
       "intro": "Saks Fifth Avenue is a high-end department store with about 40 full-line stores plus the\nmuch larger Saks Off 5th outlet network. Average ticket sizes are higher than at\nmass-market department chains, which makes a high-rate department-store category card\nmore valuable here than at, say, JCPenney. Saks codes as a department store in-store and\nonline shopping on saksfifthavenue.com, so general-purpose category bonuses apply.\n"
     },
     {
+      "name": "Saks OFF 5TH",
+      "slug": "saks-off-5th",
+      "categories": [
+        "department_stores"
+      ],
+      "website": "https://www.saksoff5th.com",
+      "intro": "Saks OFF 5TH is the off-price arm of Saks Fifth Avenue, with about 90 outlet stores\nacross the U.S. and Canada plus its own e-commerce site. The format carries designer\napparel, shoes, and accessories at substantial discounts to the parent retailer. Saks\nOFF 5TH codes as a department store, so a department-store category bonus card will\nearn its multiplier. The SaksFirst Mastercard (issued by Capital One) earns elevated\npoints at both Saks Fifth Avenue and Saks OFF 5TH, with tiered status benefits at\nhigher spend thresholds.\n"
+    },
+    {
+      "name": "Sally Beauty",
+      "slug": "sally-beauty",
+      "aliases": [
+        "Sally Beauty Supply"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.sallybeauty.com",
+      "intro": "Sally Beauty is the U.S. retail banner of Sally Beauty Holdings, with about 2,400\nstores plus sallybeauty.com selling professional hair color, salon supplies, and at\nhome beauty products. The free Sally Beauty Rewards program offers points and member\npricing, while a separate Pro Card serves licensed cosmetologists. General-purpose\ncards typically code Sally Beauty as department store in person and online shopping\nfor web orders.\n"
+    },
+    {
       "name": "Sam's Club",
       "slug": "sams-club",
       "aliases": [
@@ -1621,6 +3318,15 @@
       "website": "https://www.samsclub.com",
       "parent_company": "Walmart, Inc.",
       "intro": "Sam's Club is Walmart's warehouse-club arm, with about 600 U.S. clubs and a steadily\ngrowing online and Scan & Go catalog. Member tiers (Club vs. Plus) affect free-shipping\nand curbside perks but not the rewards math at the register. Sam's accepts Visa,\nMastercard, Amex, and Discover, and Sam's Club gas pumps code as wholesale clubs rather\nthan gas stations — the same rule as Costco.\n"
+    },
+    {
+      "name": "Schnucks",
+      "slug": "schnucks",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.schnucks.com",
+      "intro": "Schnucks is a St. Louis based regional supermarket chain with around 110 stores across\nMissouri, Illinois, Indiana, and Wisconsin. The family-owned chain codes as a U.S.\nsupermarket, so a card with a grocery bonus (Amex Gold, Blue Cash Preferred, Citi\nCustom Cash) will earn its full rate at the register. Schnucks runs its own loyalty\nprogram with fuel rewards redeemable at participating gas stations, which can stack\nwith a separate gas-category card at the pump.\n"
     },
     {
       "name": "Sephora",
@@ -1650,6 +3356,15 @@
       "intro": "Sheetz is a Mid-Atlantic gas-and-convenience chain known for its made-to-order food\n(\"MTO\" subs, sides, smoothies). Fuel codes as gas on every card we track; in-store\nfood typically codes as gas or convenience and only rarely as dining. The free\nSheetz Rewardz app stacks per-gallon discounts and free food rewards on top of any\ncard's bonus rate, which usually beats hunting for a Sheetz-specific credit card.\n"
     },
     {
+      "name": "Shein",
+      "slug": "shein",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.shein.com",
+      "intro": "Shein is a Singapore-headquartered fast-fashion retailer that sells direct to U.S.\nconsumers, mostly shipped from China and other manufacturing hubs. The model is built\non extremely fast trend cycles, low prices, and a constant churn of new SKUs. Shein\npurchases code as online shopping for credit card networks, so any online-shopping\ncategory bonus card will earn its multiplier. There is no Shein co-brand credit card,\nso the best play is a general 3-5x online-shopping rewards card or a rotating-bonus\ncard during an online-shopping quarter.\n"
+    },
+    {
       "name": "Shell",
       "slug": "shell",
       "aliases": [
@@ -1663,6 +3378,16 @@
       "intro": "Shell is one of the largest U.S. gasoline retailers by station count (about 13,000\nlocations), with a Fuel Rewards loyalty program tied to the Shell app. Shell pumps code\ncleanly as gas on every card we track. The Shell Fuel Rewards program offers stackable\nper-gallon discounts that are calculated separately from card cashback.\n"
     },
     {
+      "name": "Sherwin-Williams",
+      "slug": "sherwin-williams",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.sherwin-williams.com",
+      "intro": "Sherwin-Williams is the largest U.S. paint manufacturer and retailer, with over\n4,700 company-owned stores serving residential painters, contractors, and designers.\nSherwin-Williams typically codes as home improvement on Visa, Mastercard, and Amex\nnetworks, which makes paint purchases eligible for the home improvement bonus on\ncards that carry the category.\n\nThe U.S. Bank Cash+ and Bank of America Customized Cash can both route Sherwin\npurchases into a selectable 3 to 5 percent bonus. The chain runs frequent 30 to 40\npercent off paint promotions that stack with credit card cash back, and Sherwin's\nPaintPerks loyalty program adds member pricing on top of any rewards a credit card\ndelivers.\n"
+    },
+    {
       "name": "Shipt",
       "slug": "shipt",
       "categories": [
@@ -1672,6 +3397,16 @@
       "intro": "Shipt is a same-day delivery service owned by Target, with grocery, household, and\nsome specialty retail (Petco, CVS) partners. Most Shipt charges code as groceries\nor as the underlying merchant — worth checking your statement before relying on\na category-bonus card. Shipt is bundled into Target Circle 360 (Target's premium\nmembership), so heavy Target shoppers often pair it with a Target REDcard for\nthe in-store discount.\n"
     },
     {
+      "name": "Shoe Carnival",
+      "slug": "shoe-carnival",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.shoecarnival.com",
+      "intro": "Shoe Carnival is a value-oriented family footwear chain with about 380 stores\nconcentrated in the Midwest, South, and Southeast plus shoecarnival.com. The retailer\nrecently acquired Rogan's Shoes and now also operates Shoe Station. The Shoe Perks\nloyalty program is free and offers points and birthday bonuses that stack with credit\ncard rewards. Most cards code purchases as department store in person and online\nshopping for web checkouts.\n"
+    },
+    {
       "name": "ShopRite",
       "slug": "shoprite",
       "categories": [
@@ -1679,6 +3414,26 @@
       ],
       "website": "https://www.shoprite.com",
       "intro": "ShopRite is a cooperative grocery chain with about 280 stores across the Northeast\nand Mid-Atlantic. Codes cleanly as groceries on every card we track. Strongest\npairings are Blue Cash Preferred (6%), Capital One SavorOne (3%), and U.S. Bank\nShopper Cash Rewards (6% if ShopRite is one of the two selected retailers). The\nPrice Plus Club loyalty program runs digital coupons and per-gallon fuel savings\nat participating partner stations on top of card bonuses.\n"
+    },
+    {
+      "name": "Skechers",
+      "slug": "skechers",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.skechers.com",
+      "intro": "Skechers is a comfort and lifestyle footwear brand with around 550 U.S. concept,\nfactory outlet, and warehouse stores plus skechers.com. Direct purchases typically\ncode as department store in person and online shopping for web orders, while Skechers\nbought at Famous Footwear, DSW, or Kohl's codes under those host retailers. The free\nSkechers Plus loyalty program offers points and a birthday reward and stacks with\ncredit card earnings.\n"
+    },
+    {
+      "name": "Smart & Final",
+      "slug": "smart-and-final",
+      "categories": [
+        "groceries",
+        "wholesale_clubs"
+      ],
+      "website": "https://www.smartandfinal.com",
+      "intro": "Smart & Final is a California-based hybrid warehouse/grocery chain with about 250\nstores across the Western U.S. and Mexico. Unlike Costco or Sam's, no membership is\nrequired, so any shopper can walk in and buy bulk packaged goods alongside normal\ngrocery items. Merchant category coding is the gotcha here: most Smart & Final stores\nhistorically code as warehouse club rather than supermarket, which means a grocery\nbonus card (Amex Gold, Blue Cash Preferred) may not trigger its multiplier. Coding can\nvary by location, so check a recent statement before assuming a category bonus applies.\n"
     },
     {
       "name": "Sonic Drive-In",
@@ -1781,6 +3536,15 @@
       "intro": "Starbucks runs about 16,500 U.S. stores plus the Starbucks app, which is itself one of\nthe largest closed-loop payment systems in the country. Whether you pay through the app,\nwith a physical Starbucks card, or directly with a credit card, the underlying Starbucks\ntransaction codes as dining/restaurants on every card we track. Reloading your Starbucks\nbalance via card is the cleanest way to capture the dining bonus on cards that pay 3-5%\non dining.\n"
     },
     {
+      "name": "StockX",
+      "slug": "stockx",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://stockx.com",
+      "intro": "StockX is a resale marketplace built around sneakers, streetwear, watches, handbags,\nand collectibles, with a bid/ask exchange model and mandatory authentication of every\nitem before it ships to the buyer. The platform is a primary secondary market for\nhyped sneaker releases. StockX codes as online shopping for credit card networks, so\nan online-shopping category bonus card will earn its multiplier. Buyer fees are baked\ninto the transaction price, which is the figure that posts to the card.\n"
+    },
+    {
       "name": "Stop & Shop",
       "slug": "stop-and-shop",
       "aliases": [
@@ -1800,6 +3564,19 @@
       ],
       "website": "https://www.subway.com",
       "intro": "Subway is the largest restaurant chain in the U.S. by store count, with about\n20,000 domestic locations. Charges code as dining on every card we track. Standard\nhigh-bonus dining cards (Amex Gold 4x capped, Sapphire Preferred 3x, Capital One\nSavorOne 3%) are the obvious pairings. The MyWay Rewards loyalty program and\nrecurring digital coupons in the Subway app stack on top of card bonuses.\n"
+    },
+    {
+      "name": "Sun Country Airlines",
+      "slug": "sun-country-airlines",
+      "aliases": [
+        "Sun Country"
+      ],
+      "categories": [
+        "airlines",
+        "travel"
+      ],
+      "website": "https://www.suncountry.com",
+      "intro": "Sun Country Airlines is a Minneapolis/St. Paul-based ultra-low-cost carrier with a hybrid\nbusiness model that combines scheduled leisure flights, cargo flying for Amazon, and ad-hoc\ncharters for sports teams and casinos. Routes mostly connect MSP to warm-weather US and\nMexico destinations during peak seasons. Sun Country purchases code as airlines/airfare on\nevery credit card. Cards with airfare bonus categories all earn full rate: the Chase\nSapphire Reserve at 4x, Amex Gold at 3x on direct-booked flights, Capital One Venture X at 2x.\n"
     },
     {
       "name": "Sunoco",
@@ -1823,6 +3600,15 @@
       "intro": "Taco Bell is a U.S. fast-food chain with about 7,500 domestic locations, owned by\nYum! Brands. Charges code as dining on every card we track. Standard dining cards\n(Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%) earn the bonus. The Taco Bell\nRewards app issues frequent free-item promotions and limited-time member-exclusive\nmenu items that stack on top of any card's bonus rate.\n"
     },
     {
+      "name": "Take 5 Oil Change",
+      "slug": "take-5-oil-change",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.take5oilchange.com",
+      "intro": "Take 5 Oil Change is a drive-through oil change chain operated by Driven Brands,\nwith over 1,000 U.S. locations. Drivers stay in the car while technicians complete\nthe oil change in about five to ten minutes. Most card networks code Take 5 as auto\nservices rather than as a dedicated bonus category, which puts the chain outside\nmost rotating and selectable bonus rewards.\n\nFor cardholders who want elevated rewards on routine maintenance, Citi Custom Cash\ncan pay 5 percent if auto services is the top eligible spending category in a given\nmonth. Otherwise, a flat-rate card like the Citi Double Cash, Wells Fargo Active\nCash, or PayPal Cashback Mastercard delivers consistent 2 percent on every Take 5\nvisit.\n"
+    },
+    {
       "name": "Target",
       "slug": "target",
       "aliases": [
@@ -1843,6 +3629,15 @@
       "intro": "Target sits in the same awkward bucket as Walmart for general-purpose credit cards: it\ncodes as a discount store rather than a supermarket or department store, so most cards'\nbonus categories (grocery, dining, department stores) miss it entirely. Target.com\npurchases code as online shopping on most cards, which is where the highest\nnon-co-branded earn rates show up. In-store, you're typically falling back to a strong\nflat-rate card unless you carry a Target-issued card for the 5% RedCard discount applied\nat checkout.\n"
     },
     {
+      "name": "Temu",
+      "slug": "temu",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.temu.com",
+      "intro": "Temu is a U.S.-facing online marketplace owned by Chinese e-commerce giant PDD\nHoldings, launched stateside in 2022 and aggressively marketed on ultra-low prices and\ndirect-from-manufacturer shipping. Purchases typically code as online shopping or\nmerchandise, so a card with an online-shopping category bonus (Capital One SavorOne\npromotions, Chase Freedom Flex when activated, Citi Custom Cash on online shopping\nmonth) will earn its full multiplier. Temu has no co-brand credit card, so the best\nearn comes from a general online-shopping bonus.\n"
+    },
+    {
       "name": "Texas Roadhouse",
       "slug": "texas-roadhouse",
       "categories": [
@@ -1850,6 +3645,29 @@
       ],
       "website": "https://www.texasroadhouse.com",
       "intro": "Texas Roadhouse is a U.S. casual-dining steakhouse chain with about 700 domestic\nlocations. Charges code as dining on every card we track. Any dining-bonus card\nearns the bonus (Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%). The chain\ndoesn't run a high-volume loyalty program, so the card bonus is the main\nrewards lever per visit.\n"
+    },
+    {
+      "name": "TGI Fridays",
+      "slug": "tgi-fridays",
+      "aliases": [
+        "Fridays",
+        "T.G.I. Friday's"
+      ],
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.tgifridays.com",
+      "intro": "TGI Fridays operates around 350 US casual-dining restaurants with a bar-and-grill format that\nhelped define the category, anchored by Loaded Potato Skins, Jack Daniel's Sesame Chicken\nStrips, and a full cocktail program. The chain has contracted from its 1990s peak but\nremains a recognizable airport and suburban brand. Fridays transactions code as dining/\nrestaurants on every credit card, including bar tabs and to-go orders. Dining-bonus cards\nearn full rate: Amex Gold at 4x, Chase Sapphire Reserve at 4x, Capital One SavorOne at 3% cash.\n"
+    },
+    {
+      "name": "The Body Shop",
+      "slug": "the-body-shop",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.thebodyshop.com",
+      "intro": "The Body Shop is a British natural beauty and skincare brand known for body butters,\nethical sourcing, and animal-testing-free positioning. The U.S. footprint runs through\na smaller set of mall-based stores plus thebodyshop.com after the parent restructured\nin 2024. Direct purchases typically code as department store in person and online\nshopping for web orders, and the free Love Your Body Club loyalty program stacks\nalongside credit card rewards.\n"
     },
     {
       "name": "The Cheesecake Factory",
@@ -1862,6 +3680,25 @@
       ],
       "website": "https://www.thecheesecakefactory.com",
       "intro": "The Cheesecake Factory is a U.S. casual-dining chain with about 220 domestic\nlocations, with notably higher average tickets than typical casual dining.\nCharges code as dining on every card we track, so any dining-bonus card applies\n(Amex Gold 4x, Sapphire Preferred 3x, SavorOne 3%). The chain runs Cheesecake\nRewards in its app, with free slices on birthdays and milestone visits.\n"
+    },
+    {
+      "name": "The Container Store",
+      "slug": "the-container-store",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.containerstore.com",
+      "intro": "The Container Store is the leading U.S. specialty retailer for organization and\nstorage, known for The Elfa custom closet system, kitchen organizers, and Russell\n+ Hazel desk goods. Purchases typically code as general retail, so flat-rate cards\nlike the Citi Double Cash earn the same 2 percent as on most shopping.\n\nBig custom closet installations can run into the thousands, which makes signup bonus\nminimum spend a useful angle. Cards with rotating online shopping quarters, such as\nChase Freedom Flex, occasionally lift containerstore.com orders to 5 percent, and the\nfree Organized Insider loyalty program adds tiered discounts on top of card rewards.\n"
+    },
+    {
+      "name": "The Fresh Market",
+      "slug": "the-fresh-market",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.thefreshmarket.com",
+      "intro": "The Fresh Market is an upscale specialty grocer with around 160 stores, primarily in\nthe Southeast and along the Eastern Seaboard. The format leans into prepared meals,\nbutcher and seafood counters, and a curated wine and cheese selection. The Fresh\nMarket codes as a U.S. supermarket, so grocery category cards (Amex Gold, Blue Cash\nPreferred, Citi Custom Cash) earn their normal multiplier here. Given the higher\naverage ticket compared to mainstream chains, a 4x or 6x grocery card can produce\noutsized rewards on a typical trip.\n"
     },
     {
       "name": "The North Face",
@@ -1878,6 +3715,61 @@
       "intro": "The North Face is a U.S. outdoor-apparel brand owned by VF Corporation, with\nabout 150 retail stores plus extensive third-party distribution at REI, Dick's,\nBackcountry, and more. Direct purchases at thenorthface.com code as online\nshopping; in-store charges code as department stores or apparel. The XPLR Pass\nloyalty program is free and issues spend rewards plus first-access to limited\ndrops. Pair with an online-shopping-bonus card or flat-rate cashback.\n"
     },
     {
+      "name": "The RealReal",
+      "slug": "the-realreal",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.therealreal.com",
+      "intro": "The RealReal is an authenticated luxury consignment marketplace selling pre-owned\ndesigner apparel, handbags, watches, jewelry, and home goods online and through a\nhandful of physical stores. Every item is inspected and authenticated by in-house\nexperts before listing, which is the platform's main differentiator versus\npeer-to-peer resale. Purchases code as online shopping for credit card networks, so\nan online-shopping category bonus card will earn its multiplier. Given the higher\naverage ticket on luxury items, 3-5x earn rates can produce meaningful rewards.\n"
+    },
+    {
+      "name": "The UPS Store",
+      "slug": "the-ups-store",
+      "categories": [
+        "office_supplies"
+      ],
+      "website": "https://www.theupsstore.com",
+      "intro": "The UPS Store is a franchise network of more than 5,000 U.S. locations offering\nshipping, printing, mailbox services, packing, notary, and small business support.\nMost The UPS Store locations code as office supplies or stationery on Visa,\nMastercard, and Amex networks, which makes shipping and print purchases eligible\nfor office supply bonus categories.\n\nBusiness cards with office supply bonuses are the natural fit. The Chase Ink\nBusiness Cash pays 5 percent on the first $25,000 in combined office supply and\ninternet, cable, and phone purchases each year, and the Amex Business Gold also\noffers office supplies as a top-two category. Personal cards with selectable office\nsupply categories, like U.S. Bank Cash+, can capture the same MCC.\n"
+    },
+    {
+      "name": "ThredUp",
+      "slug": "thredup",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.thredup.com",
+      "intro": "ThredUp is an online consignment and thrift store that processes secondhand women's\nand kids' clothing on behalf of sellers and sells to buyers through its website. The\nmodel differs from peer-to-peer platforms (Poshmark, Mercari) in that ThredUp itself\nauthenticates, photographs, and warehouses inventory before listing. Purchases code\nas online shopping for credit card networks, so an online-shopping category bonus\ncard will earn its multiplier. ThredUp does not issue a co-brand credit card.\n"
+    },
+    {
+      "name": "Thrive Market",
+      "slug": "thrive-market",
+      "categories": [
+        "groceries",
+        "online_shopping"
+      ],
+      "website": "https://thrivemarket.com",
+      "intro": "Thrive Market is a membership-based online grocery and wellness retailer focused on organic,\nnon-GMO, and specialty-diet pantry items (keto, paleo, gluten-free), shipped to subscribers\nfrom regional fulfillment centers. The annual membership funds member-only pricing on\nshelf-stable groceries, supplements, and clean-beauty products. Thrive Market charges\ngenerally code as online retail or supermarkets depending on the issuer's processor mapping,\nso results vary: cards with online-shopping bonuses (Chase Freedom Flex quarters, Capital One\nSavorOne online grocery) often earn more than flat-rate cards on Thrive Market orders.\n"
+    },
+    {
+      "name": "Tim Hortons",
+      "slug": "tim-hortons",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.timhortons.com",
+      "intro": "Tim Hortons is the Canadian coffee and donut institution owned by Restaurant Brands\nInternational (the same parent as Burger King and Popeyes), with roughly 4,000 Canadian\nstores plus a smaller US footprint of about 600 locations. Beyond brewed coffee and Timbits,\nthe menu now spans breakfast sandwiches, soups, and lunch wraps. Tim Hortons purchases code\nas dining/restaurants on US-issued cards, so cards offering elevated dining rewards (Amex\nGold 4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3%) all earn at the full multiplier.\n"
+    },
+    {
+      "name": "Tire Rack",
+      "slug": "tire-rack",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.tirerack.com",
+      "intro": "Tire Rack is a direct-to-consumer online tire retailer that ships tires to a nearby\ninstaller in its recommended installer network. The company carries an extensive\nselection of passenger, performance, winter, and truck tires plus wheels and\nperformance brake components. Most credit card networks code Tire Rack as online\nshopping or auto parts rather than as a dedicated bonus category.\n\nCards with online shopping bonuses fit Tire Rack purchases well. Bank of America\nCustomized Cash and U.S. Bank Cash+ can earn 3 to 5 percent when online shopping is\nselected, and Chase Freedom Flex rotates online shopping in some quarters. Tire\nRack also occasionally appears in shopping portals like Rakuten with cash back that\nstacks on top of credit card rewards.\n"
+    },
+    {
       "name": "TJ Maxx",
       "slug": "tj-maxx",
       "aliases": [
@@ -1891,6 +3783,41 @@
       "intro": "TJ Maxx is the flagship off-price retail brand of TJX Companies, with about 1,300\nU.S. stores selling apparel, home goods, and accessories at discount prices.\nCodes as department stores on most cards, so a department-store-bonus card\n(Sapphire Preferred 3x on online department stores via portal, U.S. Bank Shopper\nCash Rewards if selected) is the strongest pairing. The TJX Rewards co-branded\nMastercard offers 5% back at TJ Maxx, Marshalls, HomeGoods, Sierra, and\nHomesense — typically the best rate for heavy TJX shoppers.\n"
     },
     {
+      "name": "Tommy Hilfiger",
+      "slug": "tommy-hilfiger",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://usa.tommy.com",
+      "intro": "Tommy Hilfiger is a flagship apparel brand owned by PVH Corp, with about 60 U.S.\nfull-line and outlet stores plus a strong online presence at usa.tommy.com. Direct\npurchases at Tommy stores or the website typically code as department store or online\nshopping, while Tommy goods bought at Macy's or Nordstrom code under that retailer.\nThe free Tommy Club loyalty program stacks with credit card rewards, and there is no\nTommy Hilfiger branded credit card today.\n"
+    },
+    {
+      "name": "Tops Friendly Markets",
+      "slug": "tops-friendly-markets",
+      "aliases": [
+        "Tops"
+      ],
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.topsmarkets.com",
+      "intro": "Tops Friendly Markets is a Western New York based supermarket chain with about 150\nstores across upstate New York, northern Pennsylvania, and Vermont. Now part of\nNortheast Grocery (the same parent that runs Price Chopper), Tops codes as a U.S.\nsupermarket for credit card networks. Standard grocery rewards cards (Amex Gold, Blue\nCash Preferred, Citi Custom Cash) will earn full multipliers, and the Tops BonusPlus\nloyalty card adds per-gallon fuel discounts at partner gas stations.\n"
+    },
+    {
+      "name": "Tractor Supply Co",
+      "slug": "tractor-supply",
+      "aliases": [
+        "Tractor Supply Company"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.tractorsupply.com",
+      "intro": "Tractor Supply Co is the largest rural lifestyle retailer in the United States,\noperating more than 2,200 stores stocked with livestock feed, fencing, riding mowers,\nworkwear, and pet supplies. Card networks sometimes code Tractor Supply as a farm\nsupply merchant rather than a home improvement store, which can keep it out of the\nHome Depot and Lowe's bonus on cards like the Wells Fargo Bilt.\n\nThe Tractor Supply Neighbor's Club loyalty program is one of the best in retail,\nlayering points-based rewards on top of credit card cash back. Cards with rotating\nonline shopping quarters, including Chase Freedom Flex and Discover it, occasionally\nbump tractorsupply.com orders to 5 percent for the quarter.\n"
+    },
+    {
       "name": "Trader Joe's",
       "slug": "trader-joes",
       "aliases": [
@@ -1902,6 +3829,25 @@
       ],
       "website": "https://www.traderjoes.com",
       "intro": "Trader Joe's is the smaller-format private-label grocer with about 600 stores\nnationwide, famous for store-brand goods and tight pricing. Average tickets are smaller\nthan at full-line supermarkets, but the visit frequency tends to be higher. TJ's codes\ncleanly as groceries (supermarket merchant code) on essentially every card we track, so\nany standard 3-6% grocery card will earn here.\n"
+    },
+    {
+      "name": "Tropical Smoothie Cafe",
+      "slug": "tropical-smoothie-cafe",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.tropicalsmoothiecafe.com",
+      "intro": "Tropical Smoothie Cafe runs more than 1,400 US locations combining made-to-order smoothies\nwith a wraps, flatbreads, and bowls menu, distinguishing itself from pure smoothie chains\nwith a full lunch offering. Popular smoothies include the Sunrise Sunset, Mango Magic, and\nIsland Green. Tropical Smoothie Cafe transactions code as dining/restaurants on every\nnetwork, including app and curbside orders through Tropic Rewards. Cards with elevated dining\nrates (Amex Gold 4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3% cash) earn full bonus.\n"
+    },
+    {
+      "name": "True Value",
+      "slug": "true-value",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.truevalue.com",
+      "intro": "True Value is a cooperative network of roughly 4,000 independent hardware stores\nacross the United States, offering paint, tools, lawn and garden goods, and\nneighborhood store service. Because individual stores set their own merchant\ncategory codes, True Value purchases may code as home improvement or as general\nretail depending on the location.\n\nCards with broad home improvement bonuses, including the Wells Fargo Bilt and U.S.\nBank Cash+ when home improvement is selected, can deliver 4 to 5 percent on True\nValue runs when the location codes correctly. Online orders placed through\ntruevalue.com for ship-to-store pickup may also trigger online shopping category\nbonuses on rotating quarter cards.\n"
     },
     {
       "name": "Uber",
@@ -1941,6 +3887,16 @@
       "intro": "Ulta Beauty is the largest U.S. beauty retailer by store count at about 1,400 locations,\ncovering both prestige and mass-market lines under one roof. Like Sephora, Ulta in-store\npurchases don't trigger a dedicated card category, so the right card there is usually a\nstrong flat-rate. Online purchases at ulta.com code as online shopping. Ultamate Rewards\nloyalty points stack with card cashback.\n"
     },
     {
+      "name": "Under Armour",
+      "slug": "under-armour",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.underarmour.com",
+      "intro": "Under Armour is a Baltimore-based athletic apparel and footwear brand sold through\nabout 175 U.S. Brand House and Factory House stores along with a strong online channel\nat underarmour.com. Direct purchases typically code as department store at the\nregister and online shopping for web orders, while Under Armour gear bought at Dick's\nor other retailers codes under that store. The free UA Rewards program layers on top\nof credit card earnings, and there is no Under Armour branded credit card.\n"
+    },
+    {
       "name": "Uniqlo",
       "slug": "uniqlo",
       "categories": [
@@ -1971,6 +3927,50 @@
       "intro": "United Airlines is one of the three U.S. legacy carriers and runs the MileagePlus\nloyalty program. United tickets code as airfare on every card we track. The Chase\nco-branded ladder ranges from no-fee Gateway to the $525 Club Infinite with United\nClub lounge membership; mid-tier Explorer adds free checked bag and 2 club passes,\nand Quest adds an annual flight credit. General travel cards often outperform on\ncash-equivalent value, but United co-brands waive close-in award fees and add\nstatus-credit boosts that frequent flyers value.\n"
     },
     {
+      "name": "Urban Outfitters",
+      "slug": "urban-outfitters",
+      "aliases": [
+        "UO"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.urbanoutfitters.com",
+      "intro": "Urban Outfitters is the flagship banner of URBN, which also operates Anthropologie and\nFree People, with about 240 stores selling apparel, home, and music gear targeted at\n20-somethings. The UO Rewards program is free and stacks with credit card multipliers.\nMost issuers code in-store visits as department store and urbanoutfitters.com orders as\nonline shopping, so a card with a strong online or department store bonus usually wins\nat checkout.\n"
+    },
+    {
+      "name": "Valero",
+      "slug": "valero",
+      "categories": [
+        "gas"
+      ],
+      "website": "https://www.valero.com",
+      "intro": "Valero is a Texas-based independent refiner with roughly 7,000 branded gas stations\nacross the U.S., Canada, and the UK, concentrated heavily in the South and West. Fuel\nat Valero pumps codes as gas, so any gas category rewards card will earn its\nmultiplier. Valero runs the Valero Rewards loyalty app with per-gallon discounts and\nin-store deals, and the chain partners with Hy-Vee Fuel Saver in some markets, so\nHy-Vee shoppers can stack grocery loyalty rewards with a gas-category card at Valero\npumps.\n"
+    },
+    {
+      "name": "Valvoline Instant Oil Change",
+      "slug": "valvoline-instant-oil-change",
+      "aliases": [
+        "Valvoline"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.vioc.com",
+      "intro": "Valvoline Instant Oil Change is a drive-up oil change chain with more than 1,800\nservice centers, known for stay-in-your-car oil changes that typically finish in\nabout 15 minutes. Most card networks code Valvoline Instant Oil Change as auto\nservices, which sits outside dedicated rewards categories on most general consumer\ncredit cards.\n\nCards with selectable categories that include auto, including Citi Custom Cash\nand U.S. Bank Cash+, can route oil changes into a higher bonus rate. Drivers who\nspend heavily on gas may already carry the Costco Anywhere Visa or Sam's Club\nMastercard, both of which pay elevated rates on gasoline but only base earn on\nservice work like oil changes.\n"
+    },
+    {
+      "name": "Vans",
+      "slug": "vans",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.vans.com",
+      "intro": "Vans is the skate and lifestyle footwear and apparel brand owned by VF Corporation,\nwith several hundred U.S. stores and a strong DTC site at vans.com. Direct purchases\ntypically code as department store in person and online shopping for web orders,\nwhile Vans bought at Foot Locker, Journeys, or Zumiez codes under that retailer. The\nfree Vans Family loyalty program offers points, free shipping, and event perks, but\nVans does not run a U.S. branded credit card today.\n"
+    },
+    {
       "name": "Victoria's Secret",
       "slug": "victorias-secret",
       "aliases": [
@@ -1985,6 +3985,18 @@
       "intro": "Victoria's Secret is a U.S. lingerie and beauty retailer with about 800 domestic\nstores in its main brand plus the PINK youth-focused sister brand. In-store\ncharges code as department stores; victoriassecret.com codes as online shopping.\nThe Victoria's Secret Credit Card and Victoria's Secret Mastercard offer tiered\ncashback at VS, PINK, and Bath & Body Works (sister brands). The Love Rewards\nloyalty program is free and stacks with card cashback.\n"
     },
     {
+      "name": "Vons",
+      "slug": "vons",
+      "aliases": [
+        "Vons Supermarkets"
+      ],
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.vons.com",
+      "intro": "Vons is the Southern California banner of Albertsons Companies, with roughly 200 stores\nconcentrated in the Los Angeles, San Diego, and Las Vegas metros. For credit card\npurposes Vons codes as a U.S. supermarket, which means standard grocery bonus cards\n(Amex Gold, Amex Blue Cash Preferred, Citi Custom Cash on a chosen month) will earn\ntheir full multiplier. Vons also participates in the Albertsons for U loyalty program,\nand gift cards sold at the service desk can be a useful angle for category stacking.\n"
+    },
+    {
       "name": "Vrbo",
       "slug": "vrbo",
       "aliases": [
@@ -1997,6 +4009,15 @@
       ],
       "website": "https://www.vrbo.com",
       "intro": "Vrbo is the second-largest U.S. vacation-rental marketplace after Airbnb, owned\nby Expedia Group. Bookings code as travel on every card we track and as hotels\non a few. Unlike Airbnb, Vrbo focuses exclusively on whole-home rentals (no\nshared spaces). Vrbo bookings count for the Sapphire Reserve and Venture X\ntravel-credit categories. Booking through a card's travel portal earns the\nportal multiplier but typically loses Vrbo Boost host-program perks.\n"
+    },
+    {
+      "name": "Waffle House",
+      "slug": "waffle-house",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.wafflehouse.com",
+      "intro": "Waffle House runs about 2,000 24-hour diners across 25 states, concentrated heavily in the\nSoutheast, where the famously consistent grill menu spans waffles, hashbrowns scattered/smothered/\ncovered, T-bone steaks, and All-Star Specials. The chain's resilience during natural disasters\nspawned FEMA's unofficial Waffle House Index. Waffle House transactions code as dining/\nrestaurants on every US credit card. That means cards offering elevated dining multipliers\n(Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash) earn full rate.\n"
     },
     {
       "name": "Walgreens",
@@ -2082,6 +4103,25 @@
       "intro": "Wendy's is a U.S. fast-food chain with about 6,000 domestic locations, known for\nfresh-never-frozen beef and the Frosty. Charges code as dining on every card we\ntrack, so Amex Gold 4x (within $50K cap), Sapphire Preferred 3x, and SavorOne 3%\nall earn the dining bonus. The Wendy's Rewards program in the app issues frequent\nfree-item offers that stack on top of card bonuses.\n"
     },
     {
+      "name": "West Elm",
+      "slug": "west-elm",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.westelm.com",
+      "intro": "West Elm is the modern furniture and home decor banner of Williams-Sonoma Inc, with\nabout 130 U.S. stores plus westelm.com selling sofas, beds, lighting, rugs, and\ntabletop. The Key Rewards Visa from Capital One earns elevated points across West Elm,\nPottery Barn, and Williams-Sonoma and stacks with the free Key Rewards program. Most\ngeneral-purpose cards code West Elm as home improvement or department store in person\nand online shopping for web orders.\n"
+    },
+    {
+      "name": "Whataburger",
+      "slug": "whataburger",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.whataburger.com",
+      "intro": "Whataburger is a Texas-based burger chain founded in Corpus Christi in 1950 with\nover 1,000 restaurants across Texas, the Southwest, and an expanding Southeast\nfootprint. The orange-and-white striped roofs are the calling card, and the menu\ncenters on made-to-order burgers, breakfast taquitos, and honey butter chicken\nbiscuits. Whataburger transactions code as restaurants on most credit card\nnetworks.\n\nPremium dining cards capture the most value on Whataburger runs. The Amex Gold\nearns 4x points on U.S. restaurants, while the Chase Sapphire Reserve pays 3x on\ndining. No-annual-fee picks like the Capital One SavorOne and Wells Fargo Autograph\neach pay 3 percent or 3x on restaurants. The free Whataburger Rewards program\nstacks app-based rewards on top of credit card earn.\n"
+    },
+    {
       "name": "Whole Foods Market",
       "slug": "whole-foods-market",
       "aliases": [
@@ -2102,6 +4142,56 @@
         }
       ],
       "intro": "Whole Foods Market is Amazon's premium grocery arm, with about 530 U.S. stores. Pricing\nis higher than at mass-market supermarkets, which makes a strong grocery-category card\nmore valuable per visit. The standout here is the Amazon Prime Rewards Visa: it earns 5%\nat Whole Foods (with a Prime membership), which is the strongest non-promotional grocery\nrate available. Without Prime, fall back to whichever 3-6% supermarket card you carry.\n"
+    },
+    {
+      "name": "Williams-Sonoma",
+      "slug": "williams-sonoma",
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.williams-sonoma.com",
+      "intro": "Williams-Sonoma is the flagship kitchen and cookware banner of Williams-Sonoma Inc,\nthe parent company of Pottery Barn, West Elm, and Rejuvenation. The U.S. footprint\ncovers around 180 stores plus williams-sonoma.com. The Key Rewards Visa from Capital\nOne earns elevated points across all WSI brands and stacks with the free Key Rewards\nprogram. General-purpose cards typically code Williams-Sonoma as home improvement or\ndepartment store in person and online shopping for web orders.\n"
+    },
+    {
+      "name": "WinCo Foods",
+      "slug": "winco-foods",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.wincofoods.com",
+      "intro": "WinCo Foods is an employee-owned, low-price supermarket chain with about 140 stores\nacross the Western and Mountain U.S. The format strips out a lot of typical grocery\noverhead (no baggers, bulk bins, limited frills) to keep shelf prices low. One major\nquirk for card users: WinCo historically did not accept credit cards at all, taking\nonly debit, cash, checks, and EBT. That policy still holds in most stores, which makes\na grocery rewards card essentially unusable here. Confirm payment policy at your local\nlocation before relying on a credit card.\n"
+    },
+    {
+      "name": "Wingstop",
+      "slug": "wingstop",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.wingstop.com",
+      "intro": "Wingstop is a Dallas-based wing-focused quick-service chain with more than 2,400\nrestaurants worldwide. The menu centers on classic and boneless wings in flavors\nlike Lemon Pepper, Louisiana Rub, and Mango Habanero plus signature seasoned\nfries. Wingstop transactions code as restaurants on Visa, Mastercard, and Amex\nnetworks, which makes them eligible for dining bonus categories.\n\nThe Amex Gold pays 4x on U.S. restaurants and is the highest standing earner for\nfrequent Wingstop ordering, while the Chase Sapphire Reserve pays 3x and includes\ntravel protection if redeemed through Chase. The Capital One SavorOne offers 3\npercent dining with no annual fee. Wingstop also runs the MyWingstop loyalty\nprogram with points that stack with credit card rewards on app and online orders.\n"
+    },
+    {
+      "name": "Winn-Dixie",
+      "slug": "winn-dixie",
+      "categories": [
+        "groceries"
+      ],
+      "website": "https://www.winndixie.com",
+      "intro": "Winn-Dixie is a Southeast U.S. supermarket chain with about 400 stores across Florida,\nAlabama, Georgia, Louisiana, and Mississippi. Now owned by Aldi after years under\nSoutheastern Grocers, Winn-Dixie still codes as a standard U.S. supermarket for credit\ncard networks, so grocery bonus cards (Amex Gold, Amex Blue Cash Preferred, Citi Custom\nCash on a chosen month) earn full multipliers. The chain runs its own rewards loyalty\nprogram with fuelperks at partner gas stations in some markets.\n"
+    },
+    {
+      "name": "World Market",
+      "slug": "world-market",
+      "aliases": [
+        "Cost Plus World Market"
+      ],
+      "categories": [
+        "home_improvement",
+        "online_shopping"
+      ],
+      "website": "https://www.worldmarket.com",
+      "intro": "World Market, formerly Cost Plus World Market, sells globally sourced furniture, rugs,\ninternational foods, and wine across roughly 240 U.S. stores. Most credit cards code\nthese purchases as general retail or department store spending rather than a dedicated\nhome category, so shoppers usually fall back on flat-rate cards like the Citi Double\nCash or Wells Fargo Active Cash.\n\nCards that treat online shopping as a rotating or selectable category, including Chase\nFreedom Flex and U.S. Bank Cash+, can pay better when ordering rugs or furniture from\nworldmarket.com. The store also runs a free loyalty program with member coupons that\nstack with credit card rewards on alcohol and seasonal decor runs.\n"
     },
     {
       "name": "Wyndham",
@@ -2137,6 +4227,35 @@
         "wyndham-rewards-earner-business-card"
       ],
       "intro": "Wyndham Hotels & Resorts is the largest U.S. hotel chain by property count — about\n9,000 hotels — concentrated in mid-scale and economy brands like Days Inn, Super 8,\nLa Quinta, and Ramada, with a smaller upscale presence under Wyndham Grand and the\nRegistry Collection. Wyndham Rewards uses a flat or tiered award chart with redemptions\nstarting at 7,500 points per night, and the program partners with Vacasa for full\nvacation-rental redemptions — a quirk that gives Wyndham points unusual reach for an\neconomy-leaning chain. Direct bookings at wyndhamhotels.com or in the app earn points;\nOTA stays do not. Co-brand cards run lower annual fees than the major chains' cards,\nmatching the program's value-tier identity.\n"
+    },
+    {
+      "name": "Zales",
+      "slug": "zales",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.zales.com",
+      "intro": "Zales is a mid-tier diamond and fashion jewelry banner within Signet Jewelers, with\nabout 575 U.S. stores plus zales.com. The Zales Diamond credit card from Comenity\noffers promotional financing tiers on larger ticket purchases, and the free Vault\nRewards loyalty program is shared across Signet banners including Kay and Jared.\nGeneral-purpose cards typically code Zales as department store in person and online\nshopping for web orders.\n"
+    },
+    {
+      "name": "Zara",
+      "slug": "zara",
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.zara.com",
+      "intro": "Zara is the flagship fast fashion banner of Spanish parent Inditex, with roughly 100\nU.S. stores in major markets plus a robust online business at zara.com. Most card\nissuers code in-store purchases as department store and online orders as online\nshopping. Zara does not run a branded credit card in the U.S., so a flat-rate online\nbonus or a rotating department store category is usually the best earn at checkout.\n"
+    },
+    {
+      "name": "Zaxby's",
+      "slug": "zaxbys",
+      "categories": [
+        "dining"
+      ],
+      "website": "https://www.zaxbys.com",
+      "intro": "Zaxby's is a Georgia-based chicken-finger and wing quick-service chain with over\n900 restaurants concentrated in the Southeast. The menu features Chicken Finger\nPlates, Boneless and Traditional Wings, Zalads, and a lineup of signature sauces\nlike Zax Sauce and Tongue Torch. Zaxby's transactions code as restaurants on Visa,\nMastercard, and Amex networks.\n\nThe Amex Gold earns 4x points on U.S. restaurants and tops the cards for Zaxby's\nspending, while the Chase Sapphire Reserve pays 3x on dining and adds purchase\nprotection. The Capital One SavorOne and Wells Fargo Autograph each pay 3 percent\nor 3x on restaurants with no annual fee. The Zax Rewardz app program adds visit\npoints that stack with credit card cash back on every Big Zax Snak run.\n"
     }
   ]
 }

--- a/data/stores/abercrombie-and-fitch.yaml
+++ b/data/stores/abercrombie-and-fitch.yaml
@@ -1,0 +1,15 @@
+name: "Abercrombie & Fitch"
+slug: "abercrombie-and-fitch"
+aliases:
+  - "Abercrombie"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.abercrombie.com"
+intro: |
+  Abercrombie & Fitch is the namesake adult apparel chain of Abercrombie & Fitch Co,
+  which also owns Hollister and the kids brand abercrombie kids. Stores run in roughly
+  200 U.S. mall locations alongside a strong online business at abercrombie.com. There
+  is no current open co-brand credit card after the prior program ended, so shoppers
+  typically lean on department store category bonuses in person and online shopping
+  multipliers for site purchases.

--- a/data/stores/accor.yaml
+++ b/data/stores/accor.yaml
@@ -1,0 +1,15 @@
+name: "Accor"
+slug: "accor"
+aliases:
+  - "Accor Hotels"
+categories:
+  - hotels
+  - travel
+website: "https://all.accor.com"
+intro: |
+  Accor is the Paris-based global hotel group that operates more than 5,500 properties across
+  brands including Raffles, Fairmont, Sofitel, Pullman, Mövenpick, Novotel, Mercure, ibis, and
+  the lifestyle SO/, 25hours, and Mama Shelter labels. The ALL (Accor Live Limitless) loyalty
+  program is a transfer partner of Bilt at 1:3, making it one of the few ways US cardholders
+  earn meaningful Accor status. Accor stays code as lodging/hotels on every US card. Hotel-bonus
+  cards earn full rate: Chase Sapphire Reserve 4x direct, Capital One Venture X 2x base.

--- a/data/stores/acme-markets.yaml
+++ b/data/stores/acme-markets.yaml
@@ -1,0 +1,13 @@
+name: "Acme Markets"
+slug: "acme-markets"
+categories:
+  - groceries
+website: "https://www.acmemarkets.com"
+intro: |
+  Acme Markets is the Mid-Atlantic banner of Albertsons Companies, with around 160
+  stores across Pennsylvania, New Jersey, Delaware, Maryland, and New York. The chain
+  codes as a U.S. supermarket for credit cards, so a grocery rewards card (Amex Gold,
+  Blue Cash Preferred, Citi Custom Cash) earns its posted multiplier at checkout. Acme
+  participates in the Albertsons for U loyalty program and stocks a wide gift-card rack
+  at the service desk, which is occasionally useful for extending a grocery multiplier
+  into adjacent spending categories.

--- a/data/stores/adorama.yaml
+++ b/data/stores/adorama.yaml
@@ -1,0 +1,16 @@
+name: "Adorama"
+slug: "adorama"
+categories:
+  - online_shopping
+website: "https://www.adorama.com"
+intro: |
+  Adorama is a New York City photo, video, audio, and computer retailer that competes
+  directly with B&H Photo, operating both a Manhattan showroom and a large
+  e-commerce store at adorama.com. Adorama is known for its EDU pricing, used gear
+  marketplace, and Adorama Rewards loyalty program. Purchases typically code as
+  online shopping or electronics on most credit card networks.
+
+  Cards with selectable online shopping bonuses, including the Bank of America
+  Customized Cash and U.S. Bank Cash+, can earn 3 to 5 percent on Adorama orders, and
+  the Chase Freedom Flex occasionally features online shopping in its rotating
+  quarters. Adorama also accepts Affirm financing on larger camera bodies and lenses.

--- a/data/stores/aerie.yaml
+++ b/data/stores/aerie.yaml
@@ -1,0 +1,12 @@
+name: "Aerie"
+slug: "aerie"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.ae.com/us/en/aerie"
+intro: |
+  Aerie is American Eagle Outfitters' intimates, loungewear, and activewear sub-brand,
+  with hundreds of standalone stores and a heavy presence on ae.com. The Real Rewards
+  credit card from Synchrony covers both American Eagle and Aerie, paying boosted points
+  on every purchase. On most general-purpose cards, Aerie purchases code as department
+  store in person and online shopping when checking out through the AE site or app.

--- a/data/stores/air-canada.yaml
+++ b/data/stores/air-canada.yaml
@@ -1,0 +1,13 @@
+name: "Air Canada"
+slug: "air-canada"
+categories:
+  - airlines
+  - travel
+website: "https://www.aircanada.com"
+intro: |
+  Air Canada is Canada's flag carrier and a Star Alliance founding member, operating hubs at
+  Toronto Pearson, Montreal-Trudeau, and Vancouver with an extensive transborder, transatlantic,
+  and transpacific network plus regional service through Air Canada Express. The Aeroplan
+  loyalty program is one of the strongest airline currencies in North America, with transfer
+  partners across Amex Membership Rewards, Capital One miles, Chase Ultimate Rewards, and Bilt.
+  Air Canada ticket purchases code as airlines/airfare, so airfare-bonus cards earn full rate.

--- a/data/stores/air-france-klm.yaml
+++ b/data/stores/air-france-klm.yaml
@@ -1,0 +1,17 @@
+name: "Air France / KLM"
+slug: "air-france-klm"
+aliases:
+  - "Air France"
+  - "KLM"
+  - "Flying Blue"
+categories:
+  - airlines
+  - travel
+website: "https://www.airfrance.us"
+intro: |
+  Air France-KLM is the Franco-Dutch parent of Air France (hubbed at Paris-Charles de Gaulle)
+  and KLM Royal Dutch Airlines (hubbed at Amsterdam-Schiphol), both SkyTeam members with a
+  shared Flying Blue loyalty program. Flying Blue partners with Amex Membership Rewards, Chase
+  Ultimate Rewards, Capital One miles, Bilt, and Citi ThankYou Points as a 1:1 transfer
+  partner, plus periodic transfer bonuses. Air France and KLM ticket purchases code as
+  airlines/airfare on US cards, earning the full airfare bonus on any card with that category.

--- a/data/stores/aliexpress.yaml
+++ b/data/stores/aliexpress.yaml
@@ -1,0 +1,13 @@
+name: "AliExpress"
+slug: "aliexpress"
+categories:
+  - online_shopping
+website: "https://www.aliexpress.com"
+intro: |
+  AliExpress is Alibaba's consumer-facing global marketplace, connecting Chinese
+  manufacturers and merchants with international buyers. The platform sells everything
+  from electronics and apparel to home goods at low price points, with shipping times
+  that vary widely by item. Purchases code as online shopping for credit card networks,
+  so an online-shopping category bonus card earns its multiplier. Some AliExpress sellers
+  invoice through international processors, so foreign transaction fees can apply on
+  cards without an FTF waiver, which is worth checking before a large order.

--- a/data/stores/allegiant-air.yaml
+++ b/data/stores/allegiant-air.yaml
@@ -1,0 +1,16 @@
+name: "Allegiant Air"
+slug: "allegiant-air"
+aliases:
+  - "Allegiant"
+categories:
+  - airlines
+  - travel
+website: "https://www.allegiantair.com"
+intro: |
+  Allegiant Air is a Las Vegas-based ultra-low-cost carrier that connects small and mid-sized
+  US cities to leisure destinations like Las Vegas, Orlando-Sanford, Phoenix-Mesa, and Florida
+  Gulf Coast airports, flying point-to-point on a fleet of Airbus A319/A320 aircraft. Like
+  other ULCCs, Allegiant unbundles fares: bags, seat assignments, and printed boarding passes
+  are all add-ons. Allegiant purchases code as airlines/airfare on every card network. Travel
+  cards with airfare bonuses (Amex Gold 3x on flights booked direct, Chase Sapphire Reserve 4x,
+  Capital One Venture X 2x) all earn their full rate on Allegiant tickets and ancillary fees.

--- a/data/stores/arhaus.yaml
+++ b/data/stores/arhaus.yaml
@@ -1,0 +1,14 @@
+name: "Arhaus"
+slug: "arhaus"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.arhaus.com"
+intro: |
+  Arhaus is a premium home furnishings retailer based in Boston Heights, Ohio, with
+  around 100 large-format Showrooms and Design Studios plus arhaus.com. The brand
+  emphasizes hand-crafted, artisan-sourced furniture and recently expanded its outdoor
+  and rug categories. The Arhaus Archcharge credit card from Comenity offers
+  promotional financing on big purchases, and general-purpose cards typically code
+  Arhaus as home improvement or department store in person and online shopping for
+  web orders.

--- a/data/stores/ashley-furniture.yaml
+++ b/data/stores/ashley-furniture.yaml
@@ -1,0 +1,19 @@
+name: "Ashley Furniture HomeStore"
+slug: "ashley-furniture"
+aliases:
+  - "Ashley HomeStore"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.ashleyfurniture.com"
+intro: |
+  Ashley Furniture HomeStore is the largest furniture retailer in the United States by
+  store count, selling sofas, dining sets, mattresses, and bedroom collections through
+  more than 1,000 corporate and licensed locations. Furniture purchases generally code
+  as general retail on Visa, Mastercard, and Amex networks, so they do not trigger
+  the home improvement bonus that covers only Home Depot and Lowe's.
+
+  Big-ticket furniture buys are a natural fit for signup bonus minimum spend on cards
+  like the Chase Sapphire Preferred or Amex Gold. Ashley also pushes its own Ashley
+  Advantage financing card with deferred-interest promotions, though paying with a
+  rewards card and avoiding interest usually beats the financing math.

--- a/data/stores/asos.yaml
+++ b/data/stores/asos.yaml
@@ -1,0 +1,12 @@
+name: "ASOS"
+slug: "asos"
+categories:
+  - online_shopping
+website: "https://www.asos.com"
+intro: |
+  ASOS is a UK-based online-only fashion retailer that ships globally and serves the U.S.
+  through asos.com, with no physical stores. Because every purchase is online, cards with
+  a strong online shopping or general everyday multiplier almost always win at checkout.
+  ASOS does not offer a U.S. branded credit card, so loyal customers rely on either the
+  free Premier delivery membership or rotating category bonuses from issuers like Chase
+  Freedom and Discover when online shopping is featured.

--- a/data/stores/at-home.yaml
+++ b/data/stores/at-home.yaml
@@ -1,0 +1,17 @@
+name: "At Home"
+slug: "at-home"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.athome.com"
+intro: |
+  At Home operates over 260 big-box home decor superstores stocking patio furniture,
+  seasonal decor, wall art, and bedding at warehouse-style pricing. Most major credit
+  cards code At Home as general retail, so it sits outside the typical home improvement
+  bonus that covers only Lowe's and Home Depot on cards like the Wells Fargo Bilt or
+  Chase Freedom rotating quarters.
+
+  Online orders through athome.com can hit online shopping bonuses on cards like the
+  Capital One SavorOne and Bank of America Customized Cash when that category is
+  selected. At Home Insider Perks members also stack store coupons with credit card
+  cash back, which matters on big-ticket patio and Christmas decor seasons.

--- a/data/stores/athleta.yaml
+++ b/data/stores/athleta.yaml
@@ -1,0 +1,13 @@
+name: "Athleta"
+slug: "athleta"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://athleta.gap.com"
+intro: |
+  Athleta is Gap Inc's women's performance and athleisure brand and one of the company's
+  fastest-growing banners, with around 270 U.S. stores plus a strong DTC channel. Most
+  general-purpose cards code in-store purchases as department store and athleta.gap.com
+  orders as online shopping. The Gap Inc Barclays cards earn elevated points across
+  Athleta, Old Navy, Gap, and Banana Republic, so loyal shoppers usually consolidate
+  spend on that program.

--- a/data/stores/auntie-annes.yaml
+++ b/data/stores/auntie-annes.yaml
@@ -1,0 +1,12 @@
+name: "Auntie Anne's"
+slug: "auntie-annes"
+categories:
+  - dining
+website: "https://www.auntieannes.com"
+intro: |
+  Auntie Anne's is the mall and airport hand-rolled soft pretzel chain with roughly 1,800
+  US locations under Focus Brands. Beyond the Original and Cinnamon Sugar pretzels, the menu
+  includes Pretzel Dogs, Mini Pretzel Dogs, and Lemonade Mixers. Auntie Anne's transactions
+  code as dining/restaurants whether you order at the counter or through the My Pretzel
+  Perks app. That makes any dining-bonus card a fit: Amex Gold (4x Membership Rewards), Chase
+  Sapphire Preferred (3x Ultimate Rewards), and Capital One SavorOne (3% cash) earn full rate.

--- a/data/stores/b-and-h-photo.yaml
+++ b/data/stores/b-and-h-photo.yaml
@@ -1,0 +1,20 @@
+name: "B&H Photo"
+slug: "b-and-h-photo"
+aliases:
+  - "B&H"
+  - "BH Photo"
+categories:
+  - online_shopping
+website: "https://www.bhphotovideo.com"
+intro: |
+  B&H Photo Video is a New York City professional photo, video, and audio retailer
+  with a single SuperStore in Manhattan and a major e-commerce operation at
+  bhphotovideo.com. The retailer is the go-to for cameras, lenses, lighting, computers,
+  and pro audio gear. Most credit cards treat B&H purchases as online shopping or
+  general electronics rather than a dedicated category.
+
+  Bank of America Customized Cash and U.S. Bank Cash+ can route B&H orders into a
+  selectable 5 percent online shopping bonus, while the Chase Freedom Flex sometimes
+  features online shopping in its rotating quarters. B&H also issues its own Payboo
+  card that rebates sales tax in many states, which can outweigh credit card rewards
+  on large camera and lens purchases.

--- a/data/stores/banana-republic.yaml
+++ b/data/stores/banana-republic.yaml
@@ -1,0 +1,13 @@
+name: "Banana Republic"
+slug: "banana-republic"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://bananarepublic.gap.com"
+intro: |
+  Banana Republic is the upscale apparel brand within Gap Inc, positioned above Gap and
+  Old Navy with workwear, suiting, and elevated basics across roughly 400 stores plus a
+  growing factory outlet network. The in-house Banana Republic Rewards Mastercard from
+  Barclays earns accelerated points across all Gap Inc banners, while general-purpose
+  cards typically code purchases as department store in-mall and online shopping for
+  bananarepublic.gap.com orders.

--- a/data/stores/barkbox.yaml
+++ b/data/stores/barkbox.yaml
@@ -1,0 +1,19 @@
+name: "BarkBox"
+slug: "barkbox"
+aliases:
+  - "Bark"
+categories:
+  - online_shopping
+website: "https://www.barkbox.com"
+intro: |
+  BarkBox is the flagship subscription service from Bark, sending a themed monthly box
+  of toys, treats, and chews tailored to a dog's size. Bark also operates Super Chewer
+  for heavy chewers, Bright dental subscriptions, and Bark Food. As a recurring online
+  subscription, BarkBox charges typically code as online shopping or direct marketing
+  on most credit card networks.
+
+  Cards with online shopping bonuses can pay better on BarkBox renewals. Bank of
+  America Customized Cash and U.S. Bank Cash+ both offer selectable online shopping
+  categories worth 3 to 5 percent, and the Chase Freedom Flex sometimes features
+  online shopping in its rotating 5 percent quarter. BarkBox also frequently appears
+  in shopping portals like Rakuten with stacking cash back.

--- a/data/stores/barnes-and-noble.yaml
+++ b/data/stores/barnes-and-noble.yaml
@@ -1,0 +1,20 @@
+name: "Barnes & Noble"
+slug: "barnes-and-noble"
+aliases:
+  - "B&N"
+  - "Barnes Noble"
+categories:
+  - online_shopping
+website: "https://www.barnesandnoble.com"
+intro: |
+  Barnes & Noble is the largest bookstore chain in the United States, operating
+  over 600 superstores plus a major e-commerce site at barnesandnoble.com and the
+  Nook digital reading platform. In-store and online book purchases generally code as
+  bookstore or general retail on Visa, Mastercard, and Amex networks rather than
+  triggering a dedicated bonus category.
+
+  Cards with selectable online shopping categories, including Bank of America
+  Customized Cash and U.S. Bank Cash+, can earn 3 to 5 percent on barnesandnoble.com
+  orders. The B&N Premium Membership runs about $40 a year and includes 10 percent
+  off in store and free shipping online, which can stack with credit card rewards on
+  frequent buyers' purchases.

--- a/data/stores/bartell-drugs.yaml
+++ b/data/stores/bartell-drugs.yaml
@@ -1,0 +1,13 @@
+name: "Bartell Drugs"
+slug: "bartell-drugs"
+categories:
+  - drugstores
+website: "https://www.bartelldrugs.com"
+intro: |
+  Bartell Drugs is a Pacific Northwest pharmacy chain founded in 1890, with roughly 65
+  locations clustered in the Seattle metro and Puget Sound region. Owned by Rite Aid
+  since 2020, Bartell still operates under its own banner with its own pharmacy and
+  loyalty program. Stores code as drugstores for credit card networks, so a drugstore
+  category bonus card (Amex Blue Cash Preferred, Citi Custom Cash on drugstores, Chase
+  Freedom Flex when activated) earns its full multiplier on prescriptions and front-of-
+  store purchases.

--- a/data/stores/baskin-robbins.yaml
+++ b/data/stores/baskin-robbins.yaml
@@ -1,0 +1,12 @@
+name: "Baskin-Robbins"
+slug: "baskin-robbins"
+categories:
+  - dining
+website: "https://www.baskinrobbins.com"
+intro: |
+  Baskin-Robbins, the 31 Flavors ice cream chain owned by Inspire Brands (the same parent as
+  Dunkin'), operates roughly 2,300 US scoop shops along with a global footprint exceeding
+  7,000 locations. The menu spans hand-packed pints, ice cream cakes, Cappuccino Blasts, and
+  rotating monthly flavors. Baskin-Robbins purchases code as dining/restaurants on every US
+  credit card, so cards with dining bonuses earn their full multiplier: Amex Gold at 4x
+  Membership Rewards, Chase Sapphire Preferred at 3x, and Capital One SavorOne at 3% cash back.

--- a/data/stores/belk.yaml
+++ b/data/stores/belk.yaml
@@ -1,0 +1,13 @@
+name: "Belk"
+slug: "belk"
+categories:
+  - department_stores
+website: "https://www.belk.com"
+intro: |
+  Belk is a Southeast U.S. department store chain with about 290 locations across 16
+  states, anchored in the Carolinas. The merchandise mix is comparable to a regional
+  Macy's: apparel, cosmetics, accessories, and home goods, with a focus on national and
+  private-label brands. Belk codes as a department store, so a department-store
+  category bonus card earns its full rate. The Belk Rewards Mastercard (issued by
+  Synchrony) layers store-specific Belk Rewards points on top, with extra earn during
+  promotional events.

--- a/data/stores/benjamin-moore.yaml
+++ b/data/stores/benjamin-moore.yaml
@@ -1,0 +1,18 @@
+name: "Benjamin Moore"
+slug: "benjamin-moore"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.benjaminmoore.com"
+intro: |
+  Benjamin Moore is a premium U.S. paint manufacturer sold through more than 5,000
+  independent retailers including Aubuchon, Ace Hardware, and dedicated Benjamin Moore
+  shops. Because purchases happen at independent dealers, merchant category coding
+  varies, with some locations coding as home improvement and others as general
+  hardware retail.
+
+  When a dealer codes as home improvement, cards like the Wells Fargo Bilt and U.S.
+  Bank Cash+ can deliver elevated rewards on Aura, Regal Select, and Advance lines.
+  Ace Hardware locations selling Benjamin Moore can stack ACE Rewards points with
+  credit card cash back, while professional contractors with a Benjamin Moore PRO
+  account get tiered discounts that layer on top of any card rewards.

--- a/data/stores/big-lots.yaml
+++ b/data/stores/big-lots.yaml
@@ -1,0 +1,13 @@
+name: "Big Lots"
+slug: "big-lots"
+categories:
+  - department_stores
+website: "https://www.biglots.com"
+intro: |
+  Big Lots is a closeout and discount retailer with roughly 1,300 stores across the U.S.,
+  selling furniture, seasonal goods, food and consumables, and an ever-rotating mix of
+  closeout merchandise. The chain went through bankruptcy and a restructuring under
+  Variety Wholesalers in 2025. Big Lots typically codes as a department store or
+  discount retailer for credit card networks. The Big Lots Credit Card (issued by
+  Comenity Capital Bank) offers store-only financing and points on Big Lots purchases,
+  though a general 2-5% department-store card from a major issuer is often more useful.

--- a/data/stores/blue-apron.yaml
+++ b/data/stores/blue-apron.yaml
@@ -1,0 +1,12 @@
+name: "Blue Apron"
+slug: "blue-apron"
+categories:
+  - online_shopping
+website: "https://www.blueapron.com"
+intro: |
+  Blue Apron pioneered the US meal-kit category in 2012 and remains a recognizable subscription
+  brand offering chef-designed recipes with pre-portioned ingredients shipped weekly, plus a
+  Heat & Eat line of prepared meals. The company was acquired by Wonder Group in 2023. Blue
+  Apron charges typically code as online retail or direct-marketing food, not in-store groceries
+  or restaurants, so dining and grocery category bonuses generally do not apply. The best
+  returns come from flat-rate cards (Citi Double Cash, Wells Fargo Active Cash, both at 2%).

--- a/data/stores/bluemercury.yaml
+++ b/data/stores/bluemercury.yaml
@@ -1,0 +1,13 @@
+name: "Bluemercury"
+slug: "bluemercury"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://bluemercury.com"
+intro: |
+  Bluemercury is a prestige beauty chain owned by Macy's Inc, with around 160 U.S.
+  boutiques plus bluemercury.com selling skincare, makeup, fragrance, and the in-house
+  M-61 and Lune+Aster brands. Direct purchases typically code as department store in
+  person and online shopping for web orders. Because Bluemercury is part of Macy's, the
+  free BlueRewards program is paired with Macy's Star Rewards and the Macy's
+  Citi-issued credit cards earn elevated points on Bluemercury spend.

--- a/data/stores/bobs-discount-furniture.yaml
+++ b/data/stores/bobs-discount-furniture.yaml
@@ -1,0 +1,20 @@
+name: "Bob's Discount Furniture"
+slug: "bobs-discount-furniture"
+aliases:
+  - "Bobs Furniture"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.mybobs.com"
+intro: |
+  Bob's Discount Furniture is a value-focused furniture chain with over 175 stores
+  across the Northeast, Mid-Atlantic, Midwest, and Southwest. The retailer is known
+  for its Goof Proof protection plan, free in-store Bob-O-Pedic samples, and pricing
+  that undercuts traditional furniture stores. Purchases code as general retail on
+  Visa, Mastercard, and Amex, not as home improvement.
+
+  Sectionals and bedroom sets at Bob's frequently run $1,500 to $3,000, which makes
+  the chain a strong venue for credit card signup bonus minimum spend. Flat-rate
+  earners like the Wells Fargo Active Cash and Citi Double Cash handle furniture spend
+  cleanly, while occasional Amex Offers on home retailers can stack additional
+  statement credits on top.

--- a/data/stores/bojangles.yaml
+++ b/data/stores/bojangles.yaml
@@ -1,0 +1,17 @@
+name: "Bojangles"
+slug: "bojangles"
+categories:
+  - dining
+website: "https://www.bojangles.com"
+intro: |
+  Bojangles is a Southeast U.S. quick-service chain founded in Charlotte, North
+  Carolina in 1977, known for Cajun-seasoned fried chicken, made-from-scratch
+  biscuits, Bo-Berry Biscuits, and sweet tea. The chain operates over 800 restaurants
+  concentrated in the Carolinas, Tennessee, Virginia, and the broader Southeast.
+  Bojangles transactions code as restaurants on most credit card networks.
+
+  The Amex Gold pays 4x points on U.S. restaurants and is the top earner for daily
+  biscuit runs. The Chase Sapphire Preferred earns 3x on dining and pairs well with
+  travel redemptions. No-annual-fee dining cards including the Capital One SavorOne
+  at 3 percent and Wells Fargo Autograph at 3x are strong defaults. Bojangles also
+  runs the Bojangles Rewards program, layered on top of credit card cash back.

--- a/data/stores/bonefish-grill.yaml
+++ b/data/stores/bonefish-grill.yaml
@@ -1,0 +1,12 @@
+name: "Bonefish Grill"
+slug: "bonefish-grill"
+categories:
+  - dining
+website: "https://www.bonefishgrill.com"
+intro: |
+  Bonefish Grill is Bloomin' Brands' wood-grilled seafood concept (alongside Outback Steakhouse,
+  Carrabba's, and Fleming's) with about 175 US locations specializing in fresh fish flown in
+  several times a week, plus signature Bang Bang Shrimp and craft cocktails. Bonefish Grill
+  charges code as dining/restaurants on every card network, and Dine Rewards loyalty stacks
+  on top of credit card rewards. Cards with strong dining multipliers (Amex Gold 4x, Chase
+  Sapphire Preferred 3x, Capital One SavorOne 3% cash) earn at the full bonus on every visit.

--- a/data/stores/books-a-million.yaml
+++ b/data/stores/books-a-million.yaml
@@ -1,0 +1,19 @@
+name: "Books-A-Million"
+slug: "books-a-million"
+aliases:
+  - "BAM!"
+categories:
+  - online_shopping
+website: "https://www.booksamillion.com"
+intro: |
+  Books-A-Million, branded as BAM!, is the second-largest brick-and-mortar bookstore
+  chain in the United States with around 250 stores concentrated in the Southeast.
+  The retailer carries books, toys, gifts, magazines, and operates the Joe Muggs cafe
+  inside larger stores. BAM! purchases generally code as bookstore or general retail
+  rather than as a dedicated bonus category on most cards.
+
+  Cards with online shopping bonuses can earn better on booksamillion.com orders.
+  Bank of America Customized Cash and U.S. Bank Cash+ both offer selectable online
+  shopping categories worth 3 to 5 percent, and Chase Freedom Flex sometimes features
+  online shopping in its rotating quarters. The Millionaire's Club membership stacks
+  additional discounts with credit card cash back for frequent buyers.

--- a/data/stores/breeze-airways.yaml
+++ b/data/stores/breeze-airways.yaml
@@ -1,0 +1,15 @@
+name: "Breeze Airways"
+slug: "breeze-airways"
+aliases:
+  - "Breeze"
+categories:
+  - airlines
+  - travel
+website: "https://www.flybreeze.com"
+intro: |
+  Breeze Airways is the low-cost startup launched by JetBlue founder David Neeleman in 2021,
+  flying a mix of Airbus A220-300s and Embraer E-Jets on underserved point-to-point routes
+  between small and mid-sized US cities. Breeze sells Nice, Nicer, and Nicest fare bundles
+  plus the premium Nicest cabin with extra-legroom seats. Breeze ticket purchases code as
+  airlines/airfare on every card. Cards with airfare bonuses (Chase Sapphire Reserve at 4x
+  on direct, Amex Gold at 3x on direct, Capital One Venture X at 2x base) all earn full rate.

--- a/data/stores/british-airways.yaml
+++ b/data/stores/british-airways.yaml
@@ -1,0 +1,15 @@
+name: "British Airways"
+slug: "british-airways"
+aliases:
+  - "BA"
+categories:
+  - airlines
+  - travel
+website: "https://www.britishairways.com"
+intro: |
+  British Airways is the UK flag carrier and a oneworld founding member, hubbed at London
+  Heathrow with significant operations from London Gatwick and London City. The carrier's
+  Executive Club loyalty program (Avios) is a transfer partner of Amex Membership Rewards,
+  Chase Ultimate Rewards, Capital One miles, Bilt, and Citi ThankYou Points, which makes
+  Avios one of the most liquid airline currencies for transatlantic and short-haul oneworld
+  redemptions. British Airways tickets code as airlines/airfare, earning airfare bonuses fully.

--- a/data/stores/buc-ees.yaml
+++ b/data/stores/buc-ees.yaml
@@ -1,0 +1,15 @@
+name: "Buc-ee's"
+slug: "buc-ees"
+aliases:
+  - "Bucees"
+categories:
+  - gas
+website: "https://buc-ees.com"
+intro: |
+  Buc-ee's is a Texas-born travel center chain known for enormous footprints (often 50+
+  gas pumps and 50,000+ square feet of store), branded jerky and snacks, and a cult road
+  trip following. The chain has been expanding aggressively into the Southeast and
+  beyond. Fuel purchases at Buc-ee's pumps code as gas, while everything bought inside
+  (food, apparel, souvenirs) typically codes as convenience store or general
+  merchandise. Buc-ee's does not run its own credit card, so a strong gas-category card
+  is the cleanest way to earn rewards at the pump.

--- a/data/stores/buckle.yaml
+++ b/data/stores/buckle.yaml
@@ -1,0 +1,14 @@
+name: "Buckle"
+slug: "buckle"
+aliases:
+  - "The Buckle"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.buckle.com"
+intro: |
+  Buckle is a denim-led specialty apparel chain with about 440 U.S. stores, heavily
+  weighted toward the Midwest and South and known for carrying premium jean brands. The
+  Buckle Black Card store credit card from Comenity offers rewards on Buckle purchases
+  and is paired with the free B-Rewards program. General-purpose cards usually code
+  Buckle as department store at the register and online shopping for buckle.com orders.

--- a/data/stores/california-pizza-kitchen.yaml
+++ b/data/stores/california-pizza-kitchen.yaml
@@ -1,0 +1,14 @@
+name: "California Pizza Kitchen"
+slug: "california-pizza-kitchen"
+aliases:
+  - "CPK"
+categories:
+  - dining
+website: "https://www.cpk.com"
+intro: |
+  California Pizza Kitchen operates about 170 casual-dining restaurants known for hearth-baked
+  pizzas with creative toppings like the original BBQ Chicken, Thai Chicken, and California
+  Veggie, plus a broader menu of pastas and entree salads. CPK transactions, whether dine-in,
+  takeout, or through CPK Rewards online ordering, code as restaurants/dining. That means
+  cards offering elevated dining multipliers (Amex Gold at 4x Membership Rewards, Chase
+  Sapphire Reserve at 4x Ultimate Rewards, Capital One SavorOne at 3% cash) earn full rate.

--- a/data/stores/carhartt.yaml
+++ b/data/stores/carhartt.yaml
@@ -1,0 +1,13 @@
+name: "Carhartt"
+slug: "carhartt"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.carhartt.com"
+intro: |
+  Carhartt is a private, family-owned workwear brand based in Dearborn, Michigan, with
+  about 30 company stores plus wide distribution through Tractor Supply, farm and ranch
+  retailers, and carhartt.com. Most cards code direct purchases at company stores or the
+  website as department store or online shopping, while buying Carhartt at a tractor or
+  farm supply retailer typically codes under that merchant's category. There is no
+  Carhartt branded credit card today.

--- a/data/stores/caribou-coffee.yaml
+++ b/data/stores/caribou-coffee.yaml
@@ -1,0 +1,12 @@
+name: "Caribou Coffee"
+slug: "caribou-coffee"
+categories:
+  - dining
+website: "https://www.cariboucoffee.com"
+intro: |
+  Caribou Coffee, founded in Minnesota in 1992, runs about 700 cafes concentrated in the Upper
+  Midwest plus a growing licensed presence in airports, hospitals, and grocery stores.
+  Signature drinks include the Caribou Cooler frozen blends, Northern Lite sugar-free options,
+  and seasonal Pumpkin White Mocha. Every Caribou purchase, whether at a corporate cafe or
+  through the Caribou Perks app, codes as dining. That means strong dining cards (Amex Gold
+  4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3% unlimited) all hit the full bonus.

--- a/data/stores/carls-jr.yaml
+++ b/data/stores/carls-jr.yaml
@@ -1,0 +1,12 @@
+name: "Carl's Jr."
+slug: "carls-jr"
+categories:
+  - dining
+website: "https://www.carlsjr.com"
+intro: |
+  Carl's Jr. is the western US half of CKE Restaurants, known for charbroiled burgers like
+  the Western Bacon Cheeseburger and the Famous Star. The chain runs about 1,000 domestic
+  locations, mostly west of the Mississippi, alongside sister brand Hardee's in the east.
+  In-store, drive-thru, and Carl's Jr. app purchases all code as fast-food/restaurants on
+  every credit card network, so cards paying elevated rates on dining (Chase Sapphire
+  Preferred at 3x, Amex Gold at 4x, Capital One Savor at 3%) all earn their full bonus here.

--- a/data/stores/carmax.yaml
+++ b/data/stores/carmax.yaml
@@ -1,0 +1,17 @@
+name: "CarMax"
+slug: "carmax"
+categories:
+  - online_shopping
+website: "https://www.carmax.com"
+intro: |
+  CarMax is the largest used-car retailer in the United States, with over 240
+  stores and a national online buying platform at carmax.com. The company offers
+  no-haggle pricing, seven-day returns, and home delivery on used vehicles. Credit
+  cards generally cap how much can go toward a vehicle purchase, with $1,000 to
+  $5,000 typical limits, and the transaction codes as a vehicle dealer rather than a
+  rewards category.
+
+  Down payments at CarMax are useful for clearing signup bonus minimums on cards like
+  the Chase Sapphire Preferred or Amex Gold. Some cardholders also use CarMax for
+  manufactured spend on Visa or Mastercard rewards cards. Service and parts visits at
+  CarMax service centers code separately and may earn standard retail rates.

--- a/data/stores/carvana.yaml
+++ b/data/stores/carvana.yaml
@@ -1,0 +1,17 @@
+name: "Carvana"
+slug: "carvana"
+categories:
+  - online_shopping
+website: "https://www.carvana.com"
+intro: |
+  Carvana is an online-only used-car retailer known for its glass-block car vending
+  machine towers and same-week home delivery model. Customers shop, finance, and
+  buy entirely through carvana.com or the Carvana app. Credit cards are accepted only
+  for down payments, typically capped around $2,000 to $5,000, and the charge codes
+  as a vehicle dealer rather than online shopping.
+
+  Carvana down payments work well for clearing signup bonus minimums on cards like
+  the Capital One Venture X or the Citi Strata Premier. Cards with selectable online
+  shopping categories generally do not capture Carvana transactions because of the
+  vehicle dealer MCC, so flat-rate earners like the Citi Double Cash often produce
+  the most predictable rewards.

--- a/data/stores/caseys.yaml
+++ b/data/stores/caseys.yaml
@@ -1,0 +1,14 @@
+name: "Casey's"
+slug: "caseys"
+aliases:
+  - "Casey's General Store"
+categories:
+  - gas
+website: "https://www.caseys.com"
+intro: |
+  Casey's is a Midwest convenience-store and pizza giant with more than 2,600 locations
+  across 17 states, anchored in Iowa and the surrounding farm belt. Fuel pumps code as
+  gas, while in-store purchases (including the famously good made-to-order pizza) can
+  code as convenience or restaurant depending on the location. Casey's runs its own
+  Casey's Rewards loyalty program and issues a Casey's Visa co-brand card with elevated
+  earn on Casey's purchases, including pizza and gas at the pump.

--- a/data/stores/casper.yaml
+++ b/data/stores/casper.yaml
@@ -1,0 +1,16 @@
+name: "Casper"
+slug: "casper"
+categories:
+  - online_shopping
+website: "https://casper.com"
+intro: |
+  Casper is a direct-to-consumer mattress brand that helped define the bed-in-a-box
+  category, with foam, hybrid, and Wave mattress lines plus pillows, sheets, and
+  bedroom furniture. Most Casper purchases happen online at casper.com, which means
+  rewards cards that pay bonuses for online shopping see the most upside.
+
+  Bank of America Customized Cash and U.S. Bank Cash+ can route Casper orders into a
+  selectable 5 percent online shopping category, while the Capital One SavorOne pays
+  3 percent on entertainment, dining, and streaming but only base earn on mattresses.
+  Casper occasionally appears in shopping portals like Rakuten or Capital One
+  Shopping, where portal cash back can stack with credit card rewards.

--- a/data/stores/cb2.yaml
+++ b/data/stores/cb2.yaml
@@ -1,0 +1,13 @@
+name: "CB2"
+slug: "cb2"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.cb2.com"
+intro: |
+  CB2 is the modern, design-forward offshoot of Crate & Barrel under Otto family-owned
+  Euromarket Designs, with about 25 U.S. stores plus cb2.com selling contemporary
+  furniture, lighting, and decor. The Crate & Barrel credit card from Comenity covers
+  CB2 purchases too and earns rewards across the family of brands. General-purpose
+  cards typically code CB2 as home improvement or department store in person and
+  online shopping for web orders.

--- a/data/stores/cinnabon.yaml
+++ b/data/stores/cinnabon.yaml
@@ -1,0 +1,12 @@
+name: "Cinnabon"
+slug: "cinnabon"
+categories:
+  - dining
+website: "https://www.cinnabon.com"
+intro: |
+  Cinnabon, part of the Focus Brands family alongside Auntie Anne's and Jamba, operates more
+  than 1,500 worldwide bakeries famous for the Classic Roll, MiniBon, and Cinnabon Stix made
+  with Makara cinnamon. Most US locations are in malls, airports, and travel plazas. Every
+  Cinnabon purchase codes as a dining/restaurant transaction, so dining bonus cards return
+  their full rate here. Amex Gold earns 4x Membership Rewards, Chase Sapphire Preferred earns
+  3x, and the Capital One SavorOne earns 3% cash back on every cinnamon roll order.

--- a/data/stores/citgo.yaml
+++ b/data/stores/citgo.yaml
@@ -1,0 +1,12 @@
+name: "Citgo"
+slug: "citgo"
+categories:
+  - gas
+website: "https://www.citgo.com"
+intro: |
+  Citgo operates roughly 4,200 branded gas stations across the United States, owned by
+  Venezuelan state oil company PDVSA. Fuel at Citgo pumps codes as gas for credit card
+  networks, so any gas category bonus card will earn its full rate. The Citgo Rewards
+  Card (issued by Citibank Retail Services) offers a small per-gallon discount or
+  statement credit on Citgo fuel and a sign-up bonus, though a general-purpose 3-5x gas
+  card from a major issuer will typically out-earn the closed-loop product.

--- a/data/stores/coach.yaml
+++ b/data/stores/coach.yaml
@@ -1,0 +1,13 @@
+name: "Coach"
+slug: "coach"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.coach.com"
+intro: |
+  Coach is the flagship leather goods brand of Tapestry Inc, which also owns Kate Spade
+  and Stuart Weitzman. The U.S. footprint includes around 360 full-price and outlet
+  stores plus coach.com. Direct purchases typically code as department store in person
+  and online shopping for web orders, while Coach handbags bought at Macy's, Nordstrom,
+  or Bloomingdale's code under those host retailers. The free Coach Insider loyalty
+  program stacks with credit card multipliers.

--- a/data/stores/cold-stone-creamery.yaml
+++ b/data/stores/cold-stone-creamery.yaml
@@ -1,0 +1,14 @@
+name: "Cold Stone Creamery"
+slug: "cold-stone-creamery"
+aliases:
+  - "Cold Stone"
+categories:
+  - dining
+website: "https://www.coldstonecreamery.com"
+intro: |
+  Cold Stone Creamery runs about 1,000 US shops centered on premium ice cream that's mixed
+  on a frozen granite stone with customer-selected mix-ins, plus signature Creations like
+  Birthday Cake Remix, Founder's Favorite, and Strawberry Blonde. Cold Stone is part of the
+  Kahala Brands portfolio. Every Cold Stone transaction codes as dining/restaurants, including
+  ice cream cakes ordered through the My Cold Stone Club app. Dining-bonus cards like the Amex
+  Gold (4x), Chase Sapphire Preferred (3x), and Capital One SavorOne (3% cash) earn full rate.

--- a/data/stores/columbia-sportswear.yaml
+++ b/data/stores/columbia-sportswear.yaml
@@ -1,0 +1,15 @@
+name: "Columbia Sportswear"
+slug: "columbia-sportswear"
+aliases:
+  - "Columbia"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.columbia.com"
+intro: |
+  Columbia Sportswear is a Portland, Oregon outdoor apparel and footwear company that
+  also owns Mountain Hardwear, Sorel, and prAna. Direct sales run through roughly 130
+  branded and outlet stores plus columbia.com, while a heavy wholesale footprint puts
+  Columbia gear in REI, Dick's, and big-box sporting goods. Direct purchases typically
+  code as department store or online shopping. The free Greater Rewards loyalty program
+  stacks with credit card multipliers.

--- a/data/stores/cracker-barrel.yaml
+++ b/data/stores/cracker-barrel.yaml
@@ -1,0 +1,14 @@
+name: "Cracker Barrel"
+slug: "cracker-barrel"
+aliases:
+  - "Cracker Barrel Old Country Store"
+categories:
+  - dining
+website: "https://www.crackerbarrel.com"
+intro: |
+  Cracker Barrel Old Country Store operates about 660 restaurants in 45 states, pairing a
+  Southern country-style restaurant with an attached retail country store stocked with candy,
+  toys, and home goods. Menu staples include Chicken n Dumplins, Hashbrown Casserole, and
+  Sunday Homestyle Chicken. Restaurant charges code as dining; retail-store purchases generally
+  code as general merchandise/department stores. Dining cards like Amex Gold (4x), Chase
+  Sapphire Preferred (3x), and Capital One SavorOne (3% cash) hit the full bonus on meals.

--- a/data/stores/crocs.yaml
+++ b/data/stores/crocs.yaml
@@ -1,0 +1,13 @@
+name: "Crocs"
+slug: "crocs"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.crocs.com"
+intro: |
+  Crocs Inc is a Broomfield, Colorado footwear company best known for its foam clogs and
+  Jibbitz charms, plus the HEYDUDE acquisition. The U.S. footprint includes about 150
+  outlet and full-price stores along with a strong DTC business at crocs.com. Direct
+  purchases typically code as department store in person and online shopping for web
+  orders. The free Crocs Club loyalty program offers points and member discounts that
+  stack with credit card rewards.

--- a/data/stores/culvers.yaml
+++ b/data/stores/culvers.yaml
@@ -1,0 +1,17 @@
+name: "Culver's"
+slug: "culvers"
+categories:
+  - dining
+website: "https://www.culvers.com"
+intro: |
+  Culver's is a Wisconsin-based quick-service chain known for ButterBurgers, fresh
+  frozen custard with a rotating Flavor of the Day, and Wisconsin cheese curds. The
+  family-owned business operates over 950 restaurants concentrated in the Midwest
+  and Sun Belt. Culver's transactions code as restaurants on all major credit card
+  networks, which makes them eligible for standard dining bonus categories.
+
+  The Amex Gold leads on Culver's spending at 4x points per dollar on U.S.
+  restaurants, while the Chase Sapphire Reserve and Capital One Savor both pay 3x or
+  more on dining. No-annual-fee dining cards including the Capital One SavorOne and
+  Wells Fargo Autograph each earn 3 percent or 3x on restaurants, which makes them
+  practical defaults for everyday Culver's visits and family dinners.

--- a/data/stores/cumberland-farms.yaml
+++ b/data/stores/cumberland-farms.yaml
@@ -1,0 +1,13 @@
+name: "Cumberland Farms"
+slug: "cumberland-farms"
+categories:
+  - gas
+website: "https://www.cumberlandfarms.com"
+intro: |
+  Cumberland Farms is a Northeast U.S. convenience and gas chain with about 600 stores
+  across New England, New York, Florida, and parts of the Mid-Atlantic, now operated by
+  EG Group. Fuel at Cumberland Farms pumps codes as gas, so any gas category bonus card
+  will earn its multiplier. The chain's signature SmartPay program is an ACH-linked
+  debit option offering a flat 10 cents per gallon discount, which generally beats most
+  credit-card gas rewards in absolute cents-per-gallon terms but does not earn credit
+  card points.

--- a/data/stores/dairy-queen.yaml
+++ b/data/stores/dairy-queen.yaml
@@ -1,0 +1,14 @@
+name: "Dairy Queen"
+slug: "dairy-queen"
+aliases:
+  - "DQ"
+categories:
+  - dining
+website: "https://www.dairyqueen.com"
+intro: |
+  Dairy Queen is the Berkshire Hathaway-owned QSR with more than 4,300 US locations split
+  between traditional treat-only stores and full-menu DQ Grill & Chill outlets serving Blizzards,
+  soft-serve cones, dipped cones, burgers, and chicken strip baskets. Whether you order at a
+  walk-up window, drive-thru, or through the DQ Rewards mobile app, the transaction codes as
+  dining/restaurants. Cards with strong dining multipliers (Amex Gold at 4x, Chase Sapphire
+  Preferred at 3x, Capital One SavorOne at 3% cash) all earn at the full bonus rate on DQ.

--- a/data/stores/dennys.yaml
+++ b/data/stores/dennys.yaml
@@ -1,0 +1,12 @@
+name: "Denny's"
+slug: "dennys"
+categories:
+  - dining
+website: "https://www.dennys.com"
+intro: |
+  Denny's operates roughly 1,500 US diners famous for 24-hour service, the Grand Slam breakfast,
+  Moons Over My Hammy, and a value-driven all-day menu that draws road-trippers, third-shift
+  workers, and late-night crowds. Most Denny's are highway-adjacent or in travel-corridor
+  suburbs. Denny's transactions code as dining/restaurants on every credit card, including
+  orders through the Denny's Rewards app and Denny's On Demand delivery portal. Dining-bonus
+  cards earn full rate: Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne 3%.

--- a/data/stores/dillards.yaml
+++ b/data/stores/dillards.yaml
@@ -1,0 +1,13 @@
+name: "Dillard's"
+slug: "dillards"
+categories:
+  - department_stores
+website: "https://www.dillards.com"
+intro: |
+  Dillard's is a mid-tier to upscale department store chain with about 270 locations
+  primarily in the South, Midwest, and Sun Belt. The merchandise mix leans heavily into
+  apparel, shoes, cosmetics, and home goods. Dillard's codes as a department store, so
+  any department-store category bonus card will earn its multiplier. The Dillard's
+  American Express card (issued by Wells Fargo) offers elevated rewards on Dillard's
+  purchases plus general earn elsewhere, and Dillard's also issues a closed-loop store
+  card with lower earn but more accessible approval.

--- a/data/stores/discount-tire.yaml
+++ b/data/stores/discount-tire.yaml
@@ -1,0 +1,19 @@
+name: "Discount Tire"
+slug: "discount-tire"
+aliases:
+  - "America's Tire"
+categories:
+  - online_shopping
+website: "https://www.discounttire.com"
+intro: |
+  Discount Tire, doing business as America's Tire in California, is the largest
+  independent tire and wheel retailer in the United States with more than 1,200
+  stores. The chain sells passenger, truck, performance, and trailer tires plus wheels
+  and TPMS service. Tire purchases generally code as auto services or general retail
+  rather than as a dedicated bonus category on most cards.
+
+  Cards with selectable categories such as Citi Custom Cash and Bank of America
+  Customized Cash can reach tire purchases when the right category is active. A new
+  set of four tires plus installation often runs $800 to $1,500, which makes
+  Discount Tire useful for clearing signup bonus minimums on cards like the Wells
+  Fargo Autograph or Chase Freedom Unlimited.

--- a/data/stores/drury-hotels.yaml
+++ b/data/stores/drury-hotels.yaml
@@ -1,0 +1,15 @@
+name: "Drury Hotels"
+slug: "drury-hotels"
+aliases:
+  - "Drury Inn"
+categories:
+  - hotels
+  - travel
+website: "https://www.druryhotels.com"
+intro: |
+  Drury Hotels is a privately held family-owned chain operating about 150 mid-tier hotels
+  concentrated across the Midwest, South, and Southwest under the Drury Inn, Drury Inn & Suites,
+  Drury Plaza Hotel, and Pear Tree Inn brands. The chain is best known for the 5:30 Kickback
+  hot food and drinks reception and free hot breakfast included with every stay. Drury charges
+  code as lodging/hotels on every card. Cards with hotel bonuses (Chase Sapphire Reserve 4x on
+  direct, Amex Platinum 5x on Amex Travel prepaid, Capital One Venture X 2x base) earn full rate.

--- a/data/stores/dsw.yaml
+++ b/data/stores/dsw.yaml
@@ -1,0 +1,15 @@
+name: "DSW"
+slug: "dsw"
+aliases:
+  - "Designer Shoe Warehouse"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.dsw.com"
+intro: |
+  DSW, short for Designer Shoe Warehouse, is the flagship footwear retailer of Designer
+  Brands Inc, with around 500 U.S. stores and dsw.com. The DSW VIP loyalty program is
+  free, offers tiered rewards and a birthday gift, and stacks with credit card earnings.
+  The DSW Visa from Comenity adds elevated points on DSW spend and a base earn rate
+  everywhere else, while general purpose cards code DSW as department store in person
+  and online shopping on the web.

--- a/data/stores/duane-reade.yaml
+++ b/data/stores/duane-reade.yaml
@@ -1,0 +1,13 @@
+name: "Duane Reade"
+slug: "duane-reade"
+categories:
+  - drugstores
+website: "https://www.duanereade.com"
+intro: |
+  Duane Reade is the New York City banner of Walgreens, with roughly 250 locations
+  concentrated in the five boroughs and surrounding suburbs. The format is essentially
+  a Walgreens drugstore adapted to dense urban real estate, often with a heavier prepared
+  food and convenience selection. Duane Reade codes as a drugstore, so any drugstore
+  category bonus card (Amex Blue Cash Preferred, Citi Custom Cash on drugstores) will
+  earn its full multiplier. The myWalgreens loyalty program works at Duane Reade
+  registers as well.

--- a/data/stores/dutch-bros.yaml
+++ b/data/stores/dutch-bros.yaml
@@ -1,0 +1,14 @@
+name: "Dutch Bros"
+slug: "dutch-bros"
+aliases:
+  - "Dutch Bros Coffee"
+categories:
+  - dining
+website: "https://www.dutchbros.com"
+intro: |
+  Dutch Bros Coffee has grown from a single Oregon pushcart in 1992 to more than 950 drive-thru
+  coffee shops across roughly 18 states, with a menu that leans heavily on flavored Rebel
+  energy drinks, blended Freezes, and customizable lattes. Every Dutch Bros purchase codes as
+  dining/restaurants regardless of whether you swipe in the drive-thru lane or reload your
+  Dutch Rewards account in the app. Cards with strong dining multipliers (Amex Gold at 4x,
+  Capital One SavorOne at 3%, Chase Sapphire Preferred at 3x) all earn full bonus rewards.

--- a/data/stores/eddie-bauer.yaml
+++ b/data/stores/eddie-bauer.yaml
@@ -1,0 +1,13 @@
+name: "Eddie Bauer"
+slug: "eddie-bauer"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.eddiebauer.com"
+intro: |
+  Eddie Bauer is an outdoor and casual apparel brand now under Sparc Group, with a long
+  catalog heritage, roughly 250 stores and outlets, and a steady online business at
+  eddiebauer.com. Direct purchases typically code as department store in person and
+  online shopping for web orders. The free Adventure Rewards loyalty program offers
+  points and birthday perks, but there is no current Eddie Bauer branded credit card in
+  the U.S. market.

--- a/data/stores/einstein-bros-bagels.yaml
+++ b/data/stores/einstein-bros-bagels.yaml
@@ -1,0 +1,14 @@
+name: "Einstein Bros. Bagels"
+slug: "einstein-bros-bagels"
+aliases:
+  - "Einstein Bros"
+categories:
+  - dining
+website: "https://www.einsteinbros.com"
+intro: |
+  Einstein Bros. Bagels operates about 700 US bakery-cafes serving fresh-baked bagels, shmears,
+  egg sandwiches, and coffee, with most locations in college towns, hospital campuses, and
+  suburban shopping centers. The chain is owned by Bagel Brands alongside Bruegger's. Every
+  Einstein Bros. purchase codes as dining/restaurants, including orders placed through the
+  Einstein Bros. Rewards app. Cards with strong breakfast and dining bonuses (Amex Gold at 4x,
+  Chase Sapphire Preferred at 3x, Capital One SavorOne at 3%) all earn at full multiplier.

--- a/data/stores/express.yaml
+++ b/data/stores/express.yaml
@@ -1,0 +1,13 @@
+name: "Express"
+slug: "express"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.express.com"
+intro: |
+  Express is a mall-based apparel chain known for workwear and going out looks for men
+  and women, operating through a mix of full-line stores, Express Factory Outlet, and
+  express.com after the brand emerged from Chapter 11 restructuring. The Express Next
+  store credit card from Comenity earns A-List points on every purchase and pairs with
+  the free loyalty tier. General-purpose cards typically code Express as department
+  store at the register and online shopping for web orders.

--- a/data/stores/extended-stay-america.yaml
+++ b/data/stores/extended-stay-america.yaml
@@ -1,0 +1,15 @@
+name: "Extended Stay America"
+slug: "extended-stay-america"
+aliases:
+  - "ESA"
+categories:
+  - hotels
+  - travel
+website: "https://www.extendedstayamerica.com"
+intro: |
+  Extended Stay America operates more than 600 budget long-stay hotels across the US, each
+  room equipped with a full kitchen, dishware, and weekly housekeeping options, targeting
+  business travelers, contractors, and relocating families who need stays of a week or longer.
+  The chain also runs Extended Stay America Suites and Extended Stay America Premier Suites.
+  ESA charges code as lodging/hotels on every credit card. Hotel-bonus cards earn full rate:
+  Chase Sapphire Reserve at 4x direct, Capital One Venture X at 2x base, Amex Platinum at 5x prepaid.

--- a/data/stores/family-dollar.yaml
+++ b/data/stores/family-dollar.yaml
@@ -1,0 +1,13 @@
+name: "Family Dollar"
+slug: "family-dollar"
+categories:
+  - department_stores
+website: "https://www.familydollar.com"
+intro: |
+  Family Dollar is a discount variety chain with roughly 8,000 stores across the U.S.,
+  owned by Dollar Tree (which announced plans to sell the banner in 2025). The format
+  carries a mix of groceries, household basics, apparel, and seasonal goods at low price
+  points. Family Dollar typically codes as a discount store or department store for
+  credit card networks, not as a supermarket, so a grocery rewards card will generally
+  not earn its bonus here. A department-store or general 1.5-2% cash back card is the
+  practical pick.

--- a/data/stores/famous-footwear.yaml
+++ b/data/stores/famous-footwear.yaml
@@ -1,0 +1,13 @@
+name: "Famous Footwear"
+slug: "famous-footwear"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.famousfootwear.com"
+intro: |
+  Famous Footwear is the family footwear chain of Caleres Inc, with about 850 U.S.
+  stores and famousfootwear.com, selling athletic and casual shoes from Nike, Adidas,
+  Skechers, and others. The free Famously You Rewards program offers tiered cashback
+  and a birthday gift, layering on top of credit card rewards. Direct purchases
+  typically code as department store at the register and online shopping for web
+  orders, and there is no current branded credit card.

--- a/data/stores/fedex-office.yaml
+++ b/data/stores/fedex-office.yaml
@@ -1,0 +1,20 @@
+name: "FedEx Office"
+slug: "fedex-office"
+aliases:
+  - "FedEx Print"
+  - "Kinko's"
+categories:
+  - office_supplies
+website: "https://www.fedex.com/office"
+intro: |
+  FedEx Office, formerly Kinko's, operates around 2,000 U.S. retail locations
+  offering shipping, printing, copying, signage, packing, and computer rental. Most
+  FedEx Office stores code as office supplies or stationery on Visa, Mastercard, and
+  Amex networks, which makes spending eligible for office supply bonus categories on
+  small business cards.
+
+  The Chase Ink Business Cash pays 5 percent on the first $25,000 in combined office
+  supplies and select utilities each year, making it the standard pick for printing
+  and shipping spend. The Amex Business Gold also includes U.S. office supply
+  retailers as a top-two category. Personal cards with selectable office supply
+  buckets, including U.S. Bank Cash+, can match those rates.

--- a/data/stores/ferguson.yaml
+++ b/data/stores/ferguson.yaml
@@ -1,0 +1,18 @@
+name: "Ferguson"
+slug: "ferguson"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.ferguson.com"
+intro: |
+  Ferguson is the largest U.S. wholesale distributor of plumbing, HVAC, lighting,
+  appliances, and waterworks products, with over 1,600 locations including Ferguson
+  Bath, Kitchen & Lighting Gallery showrooms. Many Ferguson locations code as home
+  improvement on credit card networks, which makes large remodel and new construction
+  purchases eligible for home improvement bonus categories.
+
+  Cards like the U.S. Bank Cash+ with home improvement selected and the Bank of
+  America Customized Cash can earn 3 to 5 percent on Ferguson invoices. Kitchen and
+  bath renovations frequently run five figures, which makes the retailer useful for
+  clearing premium signup bonus minimums on the Capital One Venture X or the Chase
+  Sapphire Reserve.

--- a/data/stores/firehouse-subs.yaml
+++ b/data/stores/firehouse-subs.yaml
@@ -1,0 +1,18 @@
+name: "Firehouse Subs"
+slug: "firehouse-subs"
+categories:
+  - dining
+website: "https://www.firehousesubs.com"
+intro: |
+  Firehouse Subs is a Jacksonville-based sub sandwich chain with over 1,200
+  restaurants across the United States, owned by Restaurant Brands International
+  alongside Burger King and Popeyes. The chain is known for steamed meat subs like
+  the Hook & Ladder and Italian, plus the Firehouse Subs Public Safety Foundation
+  that funds first responder equipment. Transactions code as restaurants on most
+  credit card networks.
+
+  The Amex Gold earns 4x on U.S. restaurants, the highest baseline rate available
+  on Firehouse Subs orders, while the Chase Sapphire Reserve pays 3x on dining. No
+  annual fee dining picks include the Capital One SavorOne at 3 percent and Wells
+  Fargo Autograph at 3x. The Firehouse Rewards program adds points that stack with
+  credit card cash back, and rounding up at the register supports the Foundation.

--- a/data/stores/first-watch.yaml
+++ b/data/stores/first-watch.yaml
@@ -1,0 +1,12 @@
+name: "First Watch"
+slug: "first-watch"
+categories:
+  - dining
+website: "https://www.firstwatch.com"
+intro: |
+  First Watch operates more than 540 daytime-only restaurants serving breakfast, brunch, and
+  lunch, with menu staples like Avocado Toast, the Chickichanga, lemon-ricotta pancakes, and
+  fresh-pressed juices. Locations close mid-afternoon, distinguishing First Watch from all-day
+  breakfast chains like IHOP and Denny's. First Watch transactions code as dining/restaurants
+  on every US card. Dining-bonus cards earn full rate: Amex Gold at 4x Membership Rewards,
+  Chase Sapphire Preferred at 3x, Chase Sapphire Reserve at 4x, Capital One SavorOne at 3% cash.

--- a/data/stores/five-below.yaml
+++ b/data/stores/five-below.yaml
@@ -1,0 +1,13 @@
+name: "Five Below"
+slug: "five-below"
+categories:
+  - department_stores
+website: "https://www.fivebelow.com"
+intro: |
+  Five Below is a discount retailer with more than 1,700 stores across the U.S., built
+  around items priced at $5 or less, plus a Five Beyond section with goods up to $25.
+  The merchandise mix skews toward tweens and teens (candy, tech accessories, beauty,
+  hobby, seasonal). Stores typically code as a discount or department store for credit
+  card networks, so a department-store category bonus card can earn its multiplier
+  here. Five Below does not issue its own credit card, so a general 2-5% category card
+  is the cleanest play.

--- a/data/stores/floor-and-decor.yaml
+++ b/data/stores/floor-and-decor.yaml
@@ -1,0 +1,17 @@
+name: "Floor & Decor"
+slug: "floor-and-decor"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.flooranddecor.com"
+intro: |
+  Floor & Decor is a hard surface flooring warehouse with over 240 U.S. stores
+  carrying tile, wood, laminate, vinyl, stone, and installation accessories at
+  contractor-friendly pricing. The retailer generally codes as home improvement on
+  Visa, Mastercard, and Amex networks, which means it can earn the home improvement
+  bonus on cards that include the category.
+
+  U.S. Bank Cash+ can deliver 5 percent on Floor & Decor when home improvement is one
+  of the two selected categories, and the Bank of America Customized Cash offers a
+  similar 3 percent. Floor & Decor PRO members can layer trade discounts on top of
+  credit card rewards, and large flooring projects easily clear signup bonus minimums.

--- a/data/stores/foot-locker.yaml
+++ b/data/stores/foot-locker.yaml
@@ -1,0 +1,13 @@
+name: "Foot Locker"
+slug: "foot-locker"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.footlocker.com"
+intro: |
+  Foot Locker is the flagship sneaker and athletic apparel banner of Foot Locker Inc,
+  which also runs Champs Sports, Kids Foot Locker, and WSS. The chain operates about
+  900 U.S. stores plus footlocker.com. The FLX Rewards Visa from Bread Financial earns
+  elevated XPoints on FLX-family purchases that can be redeemed for sneaker drops and
+  shoes. General-purpose cards code Foot Locker as department store in person and online
+  shopping for web orders.

--- a/data/stores/forever-21.yaml
+++ b/data/stores/forever-21.yaml
@@ -1,0 +1,15 @@
+name: "Forever 21"
+slug: "forever-21"
+aliases:
+  - "Forever21"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.forever21.com"
+intro: |
+  Forever 21 is a fast fashion chain operated under Sparc Group with about 380 U.S.
+  stores plus forever21.com after returning from bankruptcy in 2020. Pricing skews very
+  low so category bonuses matter less in absolute dollars, but most cards still code in
+  person purchases as department store and web orders as online shopping. There is no
+  current Forever 21 branded credit card, so the free F21 Rewards program is the only
+  stacking option beyond credit card rewards.

--- a/data/stores/free-people.yaml
+++ b/data/stores/free-people.yaml
@@ -1,0 +1,13 @@
+name: "Free People"
+slug: "free-people"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.freepeople.com"
+intro: |
+  Free People is the bohemian women's brand under URBN and includes the FP Movement
+  activewear line, with roughly 150 retail stores plus a sizeable online presence at
+  freepeople.com. Most credit cards code in-store transactions as department store and
+  web orders as online shopping. Free People does not currently issue a co-brand credit
+  card, so shoppers usually optimize with rotating category cards or a flat-rate
+  online-shopping multiplier.

--- a/data/stores/giant-eagle.yaml
+++ b/data/stores/giant-eagle.yaml
@@ -1,0 +1,13 @@
+name: "Giant Eagle"
+slug: "giant-eagle"
+categories:
+  - groceries
+  - gas
+website: "https://www.gianteagle.com"
+intro: |
+  Giant Eagle is a Pittsburgh-based supermarket chain with roughly 200 stores across
+  Pennsylvania, Ohio, West Virginia, Indiana, and Maryland, plus its GetGo fuel and
+  convenience arm. The supermarkets code as U.S. groceries (full multiplier for Amex
+  Gold, Blue Cash Preferred, Citi Custom Cash), while GetGo gas stations typically code
+  as gas. The chain's fuelperks+ program lets shoppers turn grocery spend into pennies
+  off per gallon at GetGo, which can stack with a gas-category card at the pump.

--- a/data/stores/goat.yaml
+++ b/data/stores/goat.yaml
@@ -1,0 +1,12 @@
+name: "GOAT"
+slug: "goat"
+categories:
+  - online_shopping
+website: "https://www.goat.com"
+intro: |
+  GOAT is a sneaker and apparel resale marketplace operated by GOAT Group, which also
+  runs Flight Club. The platform authenticates every shoe and item before shipping to
+  the buyer, and lists both new and used pairs from hyped releases alongside everyday
+  retro and lifestyle styles. GOAT codes as online shopping for credit card networks,
+  so an online-shopping category bonus card will earn its full multiplier. Buyer fees
+  are added at checkout and post to the card as part of the transaction total.

--- a/data/stores/grubhub.yaml
+++ b/data/stores/grubhub.yaml
@@ -1,0 +1,14 @@
+name: "Grubhub"
+slug: "grubhub"
+aliases:
+  - "GrubHub"
+categories:
+  - dining
+website: "https://www.grubhub.com"
+intro: |
+  Grubhub is one of the three major US food-delivery marketplaces alongside DoorDash and Uber
+  Eats, connecting customers to roughly 365,000 restaurants and operating Seamless in the
+  Northeast under the same parent. Grubhub charges code as dining/restaurants on most card
+  networks, which means dining-bonus cards earn full rate. Amex Gold pays 4x Membership Rewards,
+  Chase Sapphire Reserve pays 4x Ultimate Rewards, and the Capital One SavorOne pays 3% cash.
+  Several cards also offer Grubhub-specific credits or Grubhub+ memberships as a perk.

--- a/data/stores/h-mart.yaml
+++ b/data/stores/h-mart.yaml
@@ -1,0 +1,15 @@
+name: "H Mart"
+slug: "h-mart"
+aliases:
+  - "HMart"
+categories:
+  - groceries
+website: "https://www.hmart.com"
+intro: |
+  H Mart is the largest Korean-American supermarket chain in the U.S., with roughly 100
+  stores concentrated in major metros with significant Asian-American populations
+  (Northeast, California, Texas, Georgia, Pacific Northwest). The chain specializes in
+  Korean and broader East Asian grocery, fresh seafood, and prepared foods, and most
+  locations include a food court. H Mart codes as a U.S. supermarket, so grocery
+  category bonus cards (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earn their
+  full multiplier at the register.

--- a/data/stores/half-price-books.yaml
+++ b/data/stores/half-price-books.yaml
@@ -1,0 +1,17 @@
+name: "Half Price Books"
+slug: "half-price-books"
+categories:
+  - online_shopping
+website: "https://www.hpb.com"
+intro: |
+  Half Price Books is a Dallas-based used and new book retailer with over 120 stores
+  across the United States, also selling vinyl records, movies, video games, and
+  collectibles. The chain is known for buying back books, music, and games from
+  customers in addition to its retail operation. Purchases typically code as bookstore
+  or general retail on most credit card networks.
+
+  Cards with selectable categories can sometimes capture bookstore purchases. U.S.
+  Bank Cash+ includes bookstores as one of its selectable 5 percent categories, which
+  can deliver meaningful value for heavy readers. Online orders at hpb.com may also
+  trigger online shopping bonuses on cards like Bank of America Customized Cash and
+  Chase Freedom Flex during rotating online quarters.

--- a/data/stores/harbor-freight.yaml
+++ b/data/stores/harbor-freight.yaml
@@ -1,0 +1,19 @@
+name: "Harbor Freight Tools"
+slug: "harbor-freight"
+aliases:
+  - "Harbor Freight"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.harborfreight.com"
+intro: |
+  Harbor Freight Tools is a discount tool retailer with over 1,500 U.S. stores selling
+  hand tools, power tools, generators, and shop equipment under house brands such as
+  Bauer, Hercules, and Icon. Most card networks code Harbor Freight as a home
+  improvement merchant, which means cards with a home improvement bonus like the Wells
+  Fargo Bilt can earn elevated rewards on purchases.
+
+  The Harbor Freight Inside Track Club membership stacks deep coupon discounts with
+  credit card rewards, and online orders through harborfreight.com may also qualify
+  for rotating online shopping bonuses on Chase Freedom Flex and Discover it. Big
+  generator and welder purchases are useful for signup bonus spend.

--- a/data/stores/hardees.yaml
+++ b/data/stores/hardees.yaml
@@ -1,0 +1,12 @@
+name: "Hardee's"
+slug: "hardees"
+categories:
+  - dining
+website: "https://www.hardees.com"
+intro: |
+  Hardee's is the eastern and southern US counterpart to Carl's Jr. under the CKE Restaurants
+  umbrella, with around 1,700 domestic locations. The menu skews toward charbroiled Thickburgers,
+  Made From Scratch Biscuits at breakfast, and hand-breaded chicken tenders. Purchases at
+  Hardee's, including those routed through the Hardee's mobile app, code as fast-food dining,
+  which means cards like the Capital One SavorOne (3% unlimited on dining), Chase Sapphire
+  Preferred (3x), and Amex Gold (4x) earn at the full dining multiplier on every order.

--- a/data/stores/hellofresh.yaml
+++ b/data/stores/hellofresh.yaml
@@ -1,0 +1,14 @@
+name: "HelloFresh"
+slug: "hellofresh"
+aliases:
+  - "Hello Fresh"
+categories:
+  - online_shopping
+website: "https://www.hellofresh.com"
+intro: |
+  HelloFresh is the largest meal-kit delivery service in the United States, shipping pre-portioned
+  ingredients and recipe cards weekly to subscribers across most ZIP codes. The HelloFresh
+  group also operates Factor (prepared meals), Green Chef, and EveryPlate. HelloFresh charges
+  typically code as online retail or grocery delivery, not dining or in-store groceries, which
+  affects which cards earn bonus. Online-shopping bonuses (Chase Freedom Flex rotating quarters,
+  Discover it 5% categories) and flat-rate cards (Citi Double Cash 2%) are usually the best fit.

--- a/data/stores/hollister.yaml
+++ b/data/stores/hollister.yaml
@@ -1,0 +1,13 @@
+name: "Hollister"
+slug: "hollister"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.hollisterco.com"
+intro: |
+  Hollister is the teen and young adult apparel brand under Abercrombie & Fitch Co, with
+  a Southern California beach identity and around 500 stores worldwide. Most general
+  purpose cards code Hollister purchases as department store in mall and as online
+  shopping for hollisterco.com checkouts. The Club Cali loyalty program is free and
+  layers on top of credit card rewards, but Hollister does not currently offer its own
+  branded credit card.

--- a/data/stores/home-chef.yaml
+++ b/data/stores/home-chef.yaml
@@ -1,0 +1,12 @@
+name: "Home Chef"
+slug: "home-chef"
+categories:
+  - online_shopping
+website: "https://www.homechef.com"
+intro: |
+  Home Chef is the meal-kit subscription owned by Kroger since 2018, offering customizable
+  recipes including Fresh and Easy 15-minute kits, Family Menu portions, and the Express line
+  of microwavable meals. Home Chef kits also sell through Kroger-banner grocery stores. When
+  ordered online, Home Chef charges typically code as online retail or direct food shipping
+  rather than groceries or dining, so flat-rate cards (Citi Double Cash 2%, Wells Fargo Active
+  Cash 2%) often beat category cards. In-store purchases at Kroger code as supermarkets.

--- a/data/stores/hot-topic.yaml
+++ b/data/stores/hot-topic.yaml
@@ -1,0 +1,13 @@
+name: "Hot Topic"
+slug: "hot-topic"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.hottopic.com"
+intro: |
+  Hot Topic is a mall-based specialty retailer focused on pop culture apparel, music
+  merch, and fandom licensed goods, with around 600 U.S. stores plus a sister chain
+  BoxLunch. The Hot Cash loyalty program runs seasonally with print and digital
+  certificates that stack with credit card rewards. Most cards code Hot Topic as
+  department store in person and online shopping for hottopic.com checkouts, and there
+  is no Hot Topic branded credit card today.

--- a/data/stores/hsn.yaml
+++ b/data/stores/hsn.yaml
@@ -1,0 +1,15 @@
+name: "HSN"
+slug: "hsn"
+aliases:
+  - "Home Shopping Network"
+categories:
+  - online_shopping
+website: "https://www.hsn.com"
+intro: |
+  HSN, the Home Shopping Network, is a multichannel retailer selling via 24-hour
+  television, hsn.com, and mobile, owned by Qurate Retail Group alongside sister
+  brand QVC. The product mix covers beauty, fashion, jewelry, kitchen, and home goods,
+  with a heavy emphasis on live demonstrations and host-led pitches. HSN purchases code
+  as online shopping or general merchandise for credit card networks, so an
+  online-shopping category bonus card will earn its multiplier. The FlexPay installment
+  program is available at checkout against the saved card.

--- a/data/stores/hy-vee.yaml
+++ b/data/stores/hy-vee.yaml
@@ -1,0 +1,13 @@
+name: "Hy-Vee"
+slug: "hy-vee"
+categories:
+  - groceries
+website: "https://www.hy-vee.com"
+intro: |
+  Hy-Vee is a Midwest, employee-owned supermarket chain with roughly 280 stores across
+  Iowa, Illinois, Kansas, Minnesota, Missouri, Nebraska, South Dakota, and Wisconsin.
+  Stores are large-format and often include pharmacies, food courts, and Hy-Vee Fuel
+  Saver gas stations in some markets. Hy-Vee supermarkets code as U.S. groceries, so any
+  grocery category card (Amex Gold, Blue Cash Preferred, Citi Custom Cash) will earn its
+  posted multiplier. The Fuel Saver + Perks loyalty program is a useful supplement when
+  shoppers also fill up at participating Casey's or Hy-Vee Fast & Fresh locations.

--- a/data/stores/ihop.yaml
+++ b/data/stores/ihop.yaml
@@ -1,0 +1,14 @@
+name: "IHOP"
+slug: "ihop"
+aliases:
+  - "International House of Pancakes"
+categories:
+  - dining
+website: "https://www.ihop.com"
+intro: |
+  IHOP, owned by Dine Brands Global alongside Applebee's, operates about 1,700 US restaurants
+  best known for buttermilk pancakes, the Rooty Tooty Fresh 'N Fruity breakfast, and a 24-hour
+  service model at many locations. The menu also covers omelets, French toast, burgers, and
+  dinner entrees. IHOP transactions code as dining/restaurants whether dine-in, To Go, or
+  via the International Bank of Pancakes loyalty app. Cards with strong dining bonuses (Amex
+  Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash) earn full rate.

--- a/data/stores/in-n-out-burger.yaml
+++ b/data/stores/in-n-out-burger.yaml
@@ -1,0 +1,19 @@
+name: "In-N-Out Burger"
+slug: "in-n-out-burger"
+aliases:
+  - "In-N-Out"
+categories:
+  - dining
+website: "https://www.in-n-out.com"
+intro: |
+  In-N-Out Burger is a West Coast cult favorite founded in Baldwin Park, California
+  in 1948, with around 400 locations across California, Nevada, Arizona, Utah,
+  Texas, Oregon, Colorado, and Idaho. The minimalist menu of Double-Doubles, fries,
+  and shakes plus the off-menu Animal Style ordering is the chain's identity. In-N-Out
+  transactions code as restaurants on Visa, Mastercard, and Amex networks.
+
+  Dining rewards cards capture In-N-Out well. The Amex Gold earns 4x points on U.S.
+  restaurants and is the top earner for frequent visitors, while the Chase Sapphire
+  Reserve pays 3x. No-annual-fee dining picks include the Capital One SavorOne at 3
+  percent and Wells Fargo Autograph at 3x. In-N-Out does not run a customer rewards
+  program, so credit card rewards are the only structured path to cash back.

--- a/data/stores/jack-in-the-box.yaml
+++ b/data/stores/jack-in-the-box.yaml
@@ -1,0 +1,12 @@
+name: "Jack in the Box"
+slug: "jack-in-the-box"
+categories:
+  - dining
+website: "https://www.jackinthebox.com"
+intro: |
+  Jack in the Box operates roughly 2,200 locations concentrated in the western United States,
+  built around a 24-hour menu that mixes burgers, tacos, breakfast sandwiches, and late-night
+  munchie meals. Drive-thru and mobile-app orders code as standard quick-service restaurants,
+  so any card paying a dining bonus (3-5% on cards like the Capital One Savor or Amex Gold)
+  earns full rate. The Jack app supports Apple Pay and Google Pay funding, which lets you
+  stack a card's dining multiplier with mobile-wallet bonuses on cards that offer them.

--- a/data/stores/jamba.yaml
+++ b/data/stores/jamba.yaml
@@ -1,0 +1,14 @@
+name: "Jamba"
+slug: "jamba"
+aliases:
+  - "Jamba Juice"
+categories:
+  - dining
+website: "https://www.jamba.com"
+intro: |
+  Jamba, rebranded from Jamba Juice and now part of Focus Brands, operates about 750 US
+  locations focused on real fruit smoothies, fresh juices, bowls, and plant-based options.
+  Signature blends include the Strawberry Surf Rider, Razzmatazz, and Aloha Pineapple. Jamba
+  purchases at standalone stores, mall locations, or through the Jamba app code as
+  dining/restaurants. That makes any dining-bonus card a fit: the Amex Gold earns 4x Membership
+  Rewards, Chase Sapphire Preferred earns 3x, and the Capital One SavorOne earns 3% cash back.

--- a/data/stores/jared.yaml
+++ b/data/stores/jared.yaml
@@ -1,0 +1,15 @@
+name: "Jared"
+slug: "jared"
+aliases:
+  - "Jared The Galleria of Jewelry"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.jared.com"
+intro: |
+  Jared, formally Jared The Galleria of Jewelry, is the upscale destination banner of
+  Signet Jewelers, with around 240 standalone stores featuring on-site design and repair
+  services plus jared.com. The Jared Diamond credit card from Comenity offers
+  promotional financing for high-ticket purchases. General-purpose cards typically code
+  Jared as department store in person and online shopping for web orders, and the free
+  Vault Rewards program is shared across Signet.

--- a/data/stores/jersey-mikes.yaml
+++ b/data/stores/jersey-mikes.yaml
@@ -1,0 +1,20 @@
+name: "Jersey Mike's Subs"
+slug: "jersey-mikes"
+aliases:
+  - "Jersey Mike's"
+categories:
+  - dining
+website: "https://www.jerseymikes.com"
+intro: |
+  Jersey Mike's Subs is a fast-growing sub sandwich chain founded in Point Pleasant,
+  New Jersey in 1956, with more than 2,800 locations across the United States. The
+  chain is known for cold subs sliced to order, hot Philly cheesesteaks and Chicken
+  Philly options, and the annual Month of Giving charitable campaign. Transactions
+  code as restaurants on most credit card networks.
+
+  The Amex Gold leads at 4x points on U.S. restaurants and is the highest base
+  earner for regular Jersey Mike's visits, while the Chase Sapphire Reserve pays 3x
+  on dining. No-annual-fee picks like the Capital One SavorOne at 3 percent and
+  Wells Fargo Autograph at 3x are practical defaults. Jersey Mike's also runs the
+  Shore Points loyalty program, which layers in-app rewards on top of credit card
+  cash back.

--- a/data/stores/jiffy-lube.yaml
+++ b/data/stores/jiffy-lube.yaml
@@ -1,0 +1,17 @@
+name: "Jiffy Lube"
+slug: "jiffy-lube"
+categories:
+  - online_shopping
+website: "https://www.jiffylube.com"
+intro: |
+  Jiffy Lube is the largest quick-lube franchise in North America with over 2,000
+  service centers offering oil changes, tire rotations, fluid services, and air
+  filter replacements. Most Jiffy Lube transactions code as auto services rather than
+  a dedicated rewards category, so flat-rate cards like the Citi Double Cash often
+  win on simplicity.
+
+  Cards with selectable categories that include auto can do better. Citi Custom Cash
+  pays 5 percent on the top eligible category and may capture Jiffy Lube for drivers
+  whose top monthly spend is auto services. The U.S. Bank Cash+ also offers wider
+  auto-related categories. Jiffy Lube's loyalty program does not currently offer
+  significant points that stack with credit card rewards.

--- a/data/stores/jimmy-johns.yaml
+++ b/data/stores/jimmy-johns.yaml
@@ -1,0 +1,18 @@
+name: "Jimmy John's"
+slug: "jimmy-johns"
+categories:
+  - dining
+website: "https://www.jimmyjohns.com"
+intro: |
+  Jimmy John's is an Illinois-based sub sandwich chain known for its "Freaky Fast"
+  delivery, day-baked French bread, and a streamlined menu of cold subs including
+  the Vito, Turkey Tom, and Italian Night Club. The chain operates over 2,600
+  locations nationwide and is owned by Inspire Brands. Jimmy John's transactions code
+  as restaurants on Visa, Mastercard, and Amex networks.
+
+  The Amex Gold pays 4x points on U.S. restaurants and leads the field for daily
+  Jimmy John's lunches, while the Chase Sapphire Reserve pays 3x on dining and
+  includes travel-friendly redemptions. No-annual-fee dining picks like the Capital
+  One SavorOne and Wells Fargo Autograph each earn 3 percent or 3x on restaurants.
+  The Freaky Fast Rewards program adds points and free sandwiches on top of credit
+  card cash back.

--- a/data/stores/kay-jewelers.yaml
+++ b/data/stores/kay-jewelers.yaml
@@ -1,0 +1,15 @@
+name: "Kay Jewelers"
+slug: "kay-jewelers"
+aliases:
+  - "Kay"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.kay.com"
+intro: |
+  Kay Jewelers is the largest banner inside Signet Jewelers, with around 850 U.S. stores
+  plus kay.com selling engagement rings, fashion jewelry, and watches. The Kay Jewelers
+  Long-Term Financing credit card from Comenity offers promotional financing on bigger
+  purchases. General-purpose cards typically code Kay as department store in person and
+  online shopping for web orders, and the free Vault Rewards program stacks with credit
+  card earnings.

--- a/data/stores/krispy-kreme.yaml
+++ b/data/stores/krispy-kreme.yaml
@@ -1,0 +1,14 @@
+name: "Krispy Kreme"
+slug: "krispy-kreme"
+aliases:
+  - "Krispy Kreme Doughnuts"
+categories:
+  - dining
+website: "https://www.krispykreme.com"
+intro: |
+  Krispy Kreme operates around 380 US shops plus thousands of grocery and convenience-store
+  cabinets, with the chain's Hot Light signaling fresh Original Glazed doughnuts coming off
+  the line. Purchases at a Krispy Kreme storefront or drive-thru, including dozens ordered
+  via the Krispy Kreme Rewards app, code as dining/restaurants. Cards with elevated dining
+  bonuses earn at full rate: Amex Gold (4x Membership Rewards), Chase Sapphire Preferred (3x
+  Ultimate Rewards), and Capital One SavorOne (3% unlimited cash back) are all strong picks.

--- a/data/stores/kwik-trip.yaml
+++ b/data/stores/kwik-trip.yaml
@@ -1,0 +1,15 @@
+name: "Kwik Trip"
+slug: "kwik-trip"
+aliases:
+  - "Kwik Star"
+categories:
+  - gas
+website: "https://www.kwiktrip.com"
+intro: |
+  Kwik Trip (branded Kwik Star in Iowa) is a family-owned convenience and fuel chain
+  with more than 800 stores across Wisconsin, Minnesota, Iowa, Illinois, Michigan, and
+  South Dakota. The chain is known for its in-house bakery, dairy, and prepared foods
+  alongside a busy fuel operation. Pumps code as gas for credit card networks, so a gas
+  category bonus card will earn its multiplier. The Kwik Rewards loyalty program adds
+  per-gallon discounts and points on food, which can stack with a separate rewards card
+  at the pump.

--- a/data/stores/lands-end.yaml
+++ b/data/stores/lands-end.yaml
@@ -1,0 +1,13 @@
+name: "Lands' End"
+slug: "lands-end"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.landsend.com"
+intro: |
+  Lands' End is a casual classics apparel brand with deep catalog roots, sold mostly
+  through landsend.com and via shop-in-shop counters that were historically inside many
+  Kohl's department stores. Direct site purchases typically code as online shopping,
+  while Lands' End merchandise bought at Kohl's codes under the host retailer and earns
+  Kohl's Rewards. There is no current standalone Lands' End branded credit card in the
+  U.S. market.

--- a/data/stores/levis.yaml
+++ b/data/stores/levis.yaml
@@ -1,0 +1,15 @@
+name: "Levi's"
+slug: "levis"
+aliases:
+  - "Levi Strauss"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.levi.com"
+intro: |
+  Levi's is the flagship denim brand of Levi Strauss & Co, sold through about 200 U.S.
+  company stores, levi.com, and a wide wholesale footprint at department stores and
+  specialty retailers. Direct purchases at Levi's stores or the website typically code
+  as department store or online shopping, while buying Levi's at Macy's or Kohl's codes
+  under that retailer. The free Levi's Red Tab membership stacks with credit card
+  rewards, and there is no Levi's branded credit card.

--- a/data/stores/lidl.yaml
+++ b/data/stores/lidl.yaml
@@ -1,0 +1,12 @@
+name: "Lidl"
+slug: "lidl"
+categories:
+  - groceries
+website: "https://www.lidl.com"
+intro: |
+  Lidl is a German discount grocer that has expanded across the U.S. East Coast since
+  2017, with roughly 175 stores stretching from Georgia up to New York. The format is
+  small-footprint and private-label-heavy, comparable to Aldi. Lidl codes as a U.S.
+  supermarket for credit card networks, so grocery category bonuses (Amex Gold, Blue
+  Cash Preferred, Citi Custom Cash) earn their full multiplier. The chain accepts mobile
+  wallets and standard major networks.

--- a/data/stores/little-caesars.yaml
+++ b/data/stores/little-caesars.yaml
@@ -1,0 +1,12 @@
+name: "Little Caesars"
+slug: "little-caesars"
+categories:
+  - dining
+website: "https://littlecaesars.com"
+intro: |
+  Little Caesars is the third-largest pizza chain in the United States with more than 4,000
+  domestic locations, built around the Hot-N-Ready model that lets customers walk in and grab
+  a fresh pepperoni or cheese pizza without ordering ahead. The chain remains family-owned
+  by the Ilitch group. Little Caesars transactions, whether in-store, drive-thru Pizza Portal
+  pickup, or app delivery, all code as dining/restaurants. Top dining cards earn full bonus
+  here: Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash.

--- a/data/stores/living-spaces.yaml
+++ b/data/stores/living-spaces.yaml
@@ -1,0 +1,18 @@
+name: "Living Spaces"
+slug: "living-spaces"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.livingspaces.com"
+intro: |
+  Living Spaces is a West Coast furniture chain with around 40 large-format showrooms
+  across California, Texas, Arizona, Nevada, and a growing East Coast footprint. The
+  retailer is known for in-stock sofas with same-week delivery and a wide rug
+  assortment. Furniture purchases code as general retail, not as a home improvement
+  bonus category on most rewards cards.
+
+  Because Living Spaces orders frequently run into four figures, sofas and bedroom
+  sets are excellent for clearing signup bonus minimum spend. Cards with strong base
+  earn rates, including the Citi Double Cash and Capital One Venture X, are the
+  practical default. Living Spaces also offers in-house financing through Synchrony for
+  promotional zero-interest terms.

--- a/data/stores/ll-bean.yaml
+++ b/data/stores/ll-bean.yaml
@@ -1,0 +1,14 @@
+name: "L.L.Bean"
+slug: "ll-bean"
+aliases:
+  - "LL Bean"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.llbean.com"
+intro: |
+  L.L.Bean is a Maine-based outdoor retailer famous for its Freeport flagship and the
+  Bean Boot, operating about 60 U.S. stores plus a heavy catalog and DTC business at
+  llbean.com. The L.L.Bean Mastercard from Citi earns elevated points on direct L.L.Bean
+  purchases and offers a free shipping perk for cardholders, while general-purpose cards
+  code in-store visits as department store and web checkouts as online shopping.

--- a/data/stores/ll-flooring.yaml
+++ b/data/stores/ll-flooring.yaml
@@ -1,0 +1,20 @@
+name: "LL Flooring"
+slug: "ll-flooring"
+aliases:
+  - "Lumber Liquidators"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.llflooring.com"
+intro: |
+  LL Flooring, formerly known as Lumber Liquidators, is a flooring specialty retailer
+  with over 400 U.S. stores selling hardwood, bamboo, vinyl plank, laminate, and tile
+  flooring along with installation supplies. The chain typically codes as home
+  improvement on most credit card networks, which makes it eligible for cards that
+  carry a home improvement bonus category.
+
+  Cards like the U.S. Bank Cash+ and Bank of America Customized Cash can route LL
+  Flooring purchases into a selectable bonus, while the Chase Freedom Flex sometimes
+  features home improvement in its 5 percent rotating quarters. Whole-house flooring
+  projects are large enough to clear most credit card signup bonus minimums in a
+  single transaction.

--- a/data/stores/longhorn-steakhouse.yaml
+++ b/data/stores/longhorn-steakhouse.yaml
@@ -1,0 +1,12 @@
+name: "LongHorn Steakhouse"
+slug: "longhorn-steakhouse"
+categories:
+  - dining
+website: "https://www.longhornsteakhouse.com"
+intro: |
+  LongHorn Steakhouse is Darden Restaurants' Western-themed steak concept with about 580 US
+  locations, sitting just below the chain's Capital Grille tier and offering fire-grilled steaks
+  like the Outlaw Ribeye and Flo's Filet plus chicken, salmon, and ribs. LongHorn participates
+  in the cross-Darden eGift card program with Olive Garden and others. LongHorn transactions
+  code as dining/restaurants. Cards with strong dining multipliers (Amex Gold 4x, Chase
+  Sapphire Preferred 3x, Capital One SavorOne 3% cash) earn full rate on every steak dinner.

--- a/data/stores/loves-travel-stops.yaml
+++ b/data/stores/loves-travel-stops.yaml
@@ -1,0 +1,15 @@
+name: "Love's Travel Stops"
+slug: "loves-travel-stops"
+aliases:
+  - "Love's"
+categories:
+  - gas
+website: "https://www.loves.com"
+intro: |
+  Love's Travel Stops runs more than 650 locations across 42 states, serving both
+  passenger drivers and commercial truckers with fuel, food, showers, and tire service.
+  Standard fuel pumps code as gas, so any gas category bonus card will earn its full
+  multiplier at the pump. Inside-store food and merchandise can code as convenience
+  store or restaurant depending on the format. The MyLove's Rewards program offers
+  per-gallon discounts and points redeemable on food and showers, which stacks
+  cleanly with a separate gas rewards card.

--- a/data/stores/lush.yaml
+++ b/data/stores/lush.yaml
@@ -1,0 +1,13 @@
+name: "Lush"
+slug: "lush"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.lushusa.com"
+intro: |
+  Lush Fresh Handmade Cosmetics is a British beauty brand best known for bath bombs,
+  shampoo bars, and packaging-light skincare. The U.S. footprint covers about 200 mall
+  and street-front stores plus lushusa.com. Direct purchases typically code as
+  department store in person and online shopping for web orders, while the free Lush
+  Rewards program offers points and member perks that stack with credit card earnings.
+  Lush does not run a U.S. branded credit card.

--- a/data/stores/mac-cosmetics.yaml
+++ b/data/stores/mac-cosmetics.yaml
@@ -1,0 +1,15 @@
+name: "MAC Cosmetics"
+slug: "mac-cosmetics"
+aliases:
+  - "MAC"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.maccosmetics.com"
+intro: |
+  MAC Cosmetics is a prestige color cosmetics brand owned by The Estée Lauder Companies,
+  sold through about 100 U.S. freestanding stores, maccosmetics.com, and a wide
+  department store and Ulta wholesale footprint. Direct purchases at MAC stores or the
+  website typically code as department store or online shopping, while MAC bought at
+  Macy's or Ulta codes under that retailer. The free MAC Lover loyalty program offers
+  tiered points and stacks with credit card multipliers.

--- a/data/stores/madewell.yaml
+++ b/data/stores/madewell.yaml
@@ -1,0 +1,12 @@
+name: "Madewell"
+slug: "madewell"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.madewell.com"
+intro: |
+  Madewell is the denim-led casualwear brand spun out of J.Crew, with about 140 U.S.
+  stores and a strong DTC site at madewell.com. The Madewell Insider loyalty program is
+  free and offers a denim recycling perk for old jeans. General-purpose credit cards
+  typically code Madewell as department store in person and online shopping for web
+  checkouts, and the brand does not currently have its own branded credit card.

--- a/data/stores/maggianos.yaml
+++ b/data/stores/maggianos.yaml
@@ -1,0 +1,14 @@
+name: "Maggiano's Little Italy"
+slug: "maggianos"
+aliases:
+  - "Maggiano's"
+categories:
+  - dining
+website: "https://www.maggianos.com"
+intro: |
+  Maggiano's Little Italy, owned by Brinker International (Chili's parent), runs about 50
+  upscale-casual Italian restaurants known for family-style portions, the Chocolate Zuccotto
+  Cake, and the Classic Pastas program where guests take home a second pasta with each entree.
+  Maggiano's transactions code as dining/restaurants on every credit card. With higher check
+  averages than typical casual dining, top dining cards meaningfully boost return: Amex Gold
+  at 4x, Chase Sapphire Reserve at 4x, Chase Sapphire Preferred at 3x, Capital One Savor at 3%.

--- a/data/stores/marcos-pizza.yaml
+++ b/data/stores/marcos-pizza.yaml
@@ -1,0 +1,14 @@
+name: "Marco's Pizza"
+slug: "marcos-pizza"
+aliases:
+  - "Marco's"
+categories:
+  - dining
+website: "https://www.marcos.com"
+intro: |
+  Marco's Pizza, founded in Ohio in 1978, runs about 1,200 US locations with a delivery and
+  carryout model emphasizing fresh dough made in-store, three-cheese blends, and a private
+  pizza sauce recipe. The chain has grown rapidly across the South and Midwest. Marco's
+  transactions code as dining/restaurants whether you order at the counter, online, or through
+  the Marco's Rewards app. Dining-bonus cards earn their full rate here: Amex Gold pays 4x,
+  Chase Sapphire Preferred pays 3x, and the Capital One SavorOne pays 3% unlimited cash back.

--- a/data/stores/mattress-firm.yaml
+++ b/data/stores/mattress-firm.yaml
@@ -1,0 +1,17 @@
+name: "Mattress Firm"
+slug: "mattress-firm"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.mattressfirm.com"
+intro: |
+  Mattress Firm is the largest U.S. mattress specialty chain with more than 2,300
+  stores, carrying Sealy, Serta, Tempur-Pedic, Purple, and its private-label brands.
+  Mattress purchases code as general retail on most credit card networks, which means
+  no automatic 5 percent home improvement bonus and no grocery category overlap.
+
+  King-size mattress sets routinely cross $2,000, making Mattress Firm useful for
+  clearing signup bonus minimums on cards like the Amex Gold or Chase Sapphire
+  Preferred. The retailer also offers Synchrony-issued financing with promotional
+  zero-interest windows. Paying with a 2 percent flat-rate card such as the Citi
+  Double Cash and avoiding interest charges typically produces a better net outcome.

--- a/data/stores/maverik.yaml
+++ b/data/stores/maverik.yaml
@@ -1,0 +1,13 @@
+name: "Maverik"
+slug: "maverik"
+categories:
+  - gas
+website: "https://maverik.com"
+intro: |
+  Maverik, branded "Adventure's First Stop," is a Mountain West convenience-store and
+  fuel chain with around 400 locations spread across Utah, Idaho, Wyoming, Nevada,
+  Colorado, Arizona, and surrounding states. Fuel pumps code as gas, so any gas category
+  rewards card will earn its full bonus. The Adventure Club loyalty program (and the
+  related Adventure Club Visa, issued via First Bankcard) adds per-gallon discounts and
+  elevated earn on Maverik in-store purchases including the chain's BonFire food
+  program.

--- a/data/stores/mercari.yaml
+++ b/data/stores/mercari.yaml
@@ -1,0 +1,12 @@
+name: "Mercari"
+slug: "mercari"
+categories:
+  - online_shopping
+website: "https://www.mercari.com"
+intro: |
+  Mercari is a Japan-founded peer-to-peer marketplace where individual users list and
+  ship secondhand and new items across electronics, apparel, collectibles, and home
+  goods. The U.S. arm operates similarly to eBay but with a simpler flat-fee structure
+  and shipping label integration. Mercari purchases code as online shopping for credit
+  card networks, so an online-shopping category bonus card will earn its multiplier on
+  buyer-side transactions. Mercari does not issue a co-brand card.

--- a/data/stores/michael-kors.yaml
+++ b/data/stores/michael-kors.yaml
@@ -1,0 +1,13 @@
+name: "Michael Kors"
+slug: "michael-kors"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.michaelkors.com"
+intro: |
+  Michael Kors is the flagship accessible luxury brand under Capri Holdings, which also
+  owns Versace and Jimmy Choo. The U.S. footprint includes hundreds of Lifestyle and
+  outlet stores plus michaelkors.com selling handbags, watches, footwear, and ready to
+  wear. Direct purchases typically code as department store in person and online
+  shopping for web orders, while MK bought at department stores codes under the host
+  retailer. The free KORSVIP loyalty program stacks with credit card earnings.

--- a/data/stores/micro-center.yaml
+++ b/data/stores/micro-center.yaml
@@ -1,0 +1,16 @@
+name: "Micro Center"
+slug: "micro-center"
+categories:
+  - online_shopping
+website: "https://www.microcenter.com"
+intro: |
+  Micro Center is a specialty computer and electronics retailer with around 25 large
+  U.S. stores known for in-stock PC components, aggressive CPU and motherboard combo
+  pricing, and a deep selection of GPUs, 3D printers, and DIY parts. Most credit cards
+  code Micro Center as electronics or general retail rather than as a dedicated
+  category, so flat-rate cards often do the heavy lifting.
+
+  Online orders through microcenter.com qualify for online shopping bonuses on the
+  Bank of America Customized Cash, Chase Freedom Flex when online shopping is the
+  rotating quarter, and U.S. Bank Cash+. Custom PC builds can run thousands of
+  dollars, making Micro Center a useful target for clearing signup bonus minimums.

--- a/data/stores/microsoft-store.yaml
+++ b/data/stores/microsoft-store.yaml
@@ -1,0 +1,18 @@
+name: "Microsoft Store"
+slug: "microsoft-store"
+categories:
+  - online_shopping
+website: "https://www.microsoft.com/store"
+intro: |
+  The Microsoft Store is Microsoft's online retail destination for Surface laptops,
+  Xbox consoles and games, Windows software, Microsoft 365 subscriptions, and Office
+  products. Following the closure of all physical Microsoft Stores in 2020, all U.S.
+  consumer shopping happens through microsoft.com/store. Purchases code as online
+  shopping or software on most credit card networks.
+
+  Cards with online shopping bonuses can deliver strong returns on Surface and Xbox
+  purchases. The Bank of America Customized Cash, U.S. Bank Cash+, and Chase Freedom
+  Flex rotating quarters can all push these orders to 5 percent back. Microsoft 365
+  and Xbox Game Pass recurring subscriptions may code as software or streaming
+  services, which can trigger streaming category bonuses on cards like the Amex Blue
+  Cash Preferred.

--- a/data/stores/midas.yaml
+++ b/data/stores/midas.yaml
@@ -1,0 +1,17 @@
+name: "Midas"
+slug: "midas"
+categories:
+  - online_shopping
+website: "https://www.midas.com"
+intro: |
+  Midas is a global auto service franchise with around 1,200 U.S. locations
+  specializing in exhaust, brakes, tires, suspension, and routine maintenance. Most
+  Midas franchisees code transactions as auto services on Visa, Mastercard, and Amex
+  networks, which typically falls outside dedicated rewards categories on consumer
+  cards.
+
+  Big-ticket brake jobs and exhaust work often run $500 to $1,500, which is enough
+  to make MID category selection worthwhile on cards like Citi Custom Cash when auto
+  services is the top monthly category. U.S. Bank Cash+ also offers wider auto
+  categories. For everyday simplicity, the Wells Fargo Active Cash and Citi Double
+  Cash pay a clean 2 percent on every Midas invoice.

--- a/data/stores/moes-southwest-grill.yaml
+++ b/data/stores/moes-southwest-grill.yaml
@@ -1,0 +1,14 @@
+name: "Moe's Southwest Grill"
+slug: "moes-southwest-grill"
+aliases:
+  - "Moe's"
+categories:
+  - dining
+website: "https://www.moes.com"
+intro: |
+  Moe's Southwest Grill, owned by Focus Brands, runs about 600 fast-casual locations centered
+  on burritos, bowls, quesadillas, and the chain's signature free chips and salsa with every
+  entree. Every Moe's transaction, whether in-store, drive-thru, or through the Moe's Rewards
+  app, codes as a dining/restaurant charge. Pair a top dining card here for the best return:
+  Amex Gold pays 4x Membership Rewards, Chase Sapphire Preferred pays 3x Ultimate Rewards,
+  and Capital One SavorOne pays 3% cash back on every Welcome to Moe's order.

--- a/data/stores/motel-6.yaml
+++ b/data/stores/motel-6.yaml
@@ -1,0 +1,13 @@
+name: "Motel 6"
+slug: "motel-6"
+categories:
+  - hotels
+  - travel
+website: "https://www.motel6.com"
+intro: |
+  Motel 6 operates roughly 1,400 budget motels across the US and Canada, distinguishable by
+  the We'll leave the light on for you tagline and consistently low nightly rates that have
+  anchored the chain at the bottom of the lodging price spectrum since 1962. Motel 6 was
+  acquired by Oyo's parent in 2025. Sister brand Studio 6 offers extended-stay options. Motel 6
+  charges code as lodging/hotels on every card. Hotel-bonus cards earn full rate: Chase
+  Sapphire Reserve at 4x direct, Capital One Venture X at 2x base, Amex Platinum at 5x prepaid.

--- a/data/stores/murphy-usa.yaml
+++ b/data/stores/murphy-usa.yaml
@@ -1,0 +1,14 @@
+name: "Murphy USA"
+slug: "murphy-usa"
+aliases:
+  - "Murphy Express"
+categories:
+  - gas
+website: "https://www.murphyusa.com"
+intro: |
+  Murphy USA runs about 1,700 low-price gas and convenience stations across the U.S.,
+  many of them sited in Walmart parking lots under the Murphy USA or Murphy Express
+  banners. The chain competes primarily on price per gallon. Fuel codes as gas at the
+  pump, so any gas category bonus card will earn its full multiplier. The Murphy Drive
+  Rewards loyalty app and Murphy USA Visa add per-gallon discounts that can stack with a
+  major-issuer gas card if used carefully.

--- a/data/stores/napa-auto-parts.yaml
+++ b/data/stores/napa-auto-parts.yaml
@@ -1,0 +1,19 @@
+name: "NAPA Auto Parts"
+slug: "napa-auto-parts"
+aliases:
+  - "NAPA"
+categories:
+  - online_shopping
+website: "https://www.napaonline.com"
+intro: |
+  NAPA Auto Parts is one of the largest independent auto parts networks in North
+  America, with roughly 6,000 U.S. stores operated by independent jobbers and Genuine
+  Parts Company. NAPA carries replacement parts, batteries, tools, and chemicals for
+  DIY drivers and professional repair shops. Auto parts purchases typically code as
+  general retail rather than triggering a dedicated bonus category.
+
+  Cards with selectable cash back categories can sometimes treat NAPA as an auto
+  category, with Citi Custom Cash and Bank of America Customized Cash both rewarding
+  the top-spend or selected category. Online orders through napaonline.com may also
+  qualify for online shopping bonuses on the Chase Freedom Flex when that category
+  rotates in.

--- a/data/stores/new-balance.yaml
+++ b/data/stores/new-balance.yaml
@@ -1,0 +1,13 @@
+name: "New Balance"
+slug: "new-balance"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.newbalance.com"
+intro: |
+  New Balance is a privately held Boston-based athletic footwear and apparel company
+  with about 100 U.S. brand and factory stores plus a strong DTC channel at
+  newbalance.com. Direct purchases typically code as department store in person and
+  online shopping for web orders, while New Balance gear bought at Dick's, Foot Locker,
+  or running specialty stores codes under that retailer. The free New Balance Rewards
+  program stacks with credit card multipliers.

--- a/data/stores/newegg.yaml
+++ b/data/stores/newegg.yaml
@@ -1,0 +1,14 @@
+name: "Newegg"
+slug: "newegg"
+categories:
+  - online_shopping
+website: "https://www.newegg.com"
+intro: |
+  Newegg is an online retailer focused on consumer electronics, PC components, and
+  gaming gear, with a long history of catering to enthusiast PC builders. The site also
+  hosts a third-party marketplace for adjacent categories. Newegg codes as online
+  shopping, so any online-shopping category bonus card (Chase Freedom Flex when
+  activated, Citi Custom Cash on online shopping, Capital One SavorOne promotions) will
+  earn its multiplier. Newegg has issued co-brand financing cards in the past (Newegg
+  Store Card via Comenity, Visa via Synchrony), so check the current offering at
+  checkout if 0% APR financing is the goal.

--- a/data/stores/nordstrom-rack.yaml
+++ b/data/stores/nordstrom-rack.yaml
@@ -1,0 +1,13 @@
+name: "Nordstrom Rack"
+slug: "nordstrom-rack"
+categories:
+  - department_stores
+website: "https://www.nordstromrack.com"
+intro: |
+  Nordstrom Rack is the off-price arm of Nordstrom, with about 240 stores nationwide
+  plus the nordstromrack.com site. The format sells the same designer and contemporary
+  brands as the parent department store at marked-down prices, sourced from previous
+  season inventory and direct buys. Nordstrom Rack purchases earn Nordy Club points
+  alongside the main Nordstrom store, and the Nordstrom credit and debit cards
+  (Visa-branded variants issued by TD Bank) earn elevated points at both Nordstrom and
+  Nordstrom Rack. Department-store category bonus cards also apply at the register.

--- a/data/stores/ollies-bargain-outlet.yaml
+++ b/data/stores/ollies-bargain-outlet.yaml
@@ -1,0 +1,15 @@
+name: "Ollie's Bargain Outlet"
+slug: "ollies-bargain-outlet"
+aliases:
+  - "Ollies"
+categories:
+  - department_stores
+website: "https://www.ollies.us"
+intro: |
+  Ollie's Bargain Outlet is a closeout retailer with more than 550 stores across the
+  Eastern and Central U.S., selling brand-name merchandise (books, household goods,
+  furniture, food, seasonal items) acquired from manufacturer overstock and store
+  closeouts. The chain's tagline "Good Stuff Cheap" captures the model. Ollie's
+  typically codes as a department store or discount retailer for credit card networks,
+  so a department-store category bonus card can earn its multiplier. The free Ollie's
+  Army loyalty program adds member-only discounts but is not a credit card product.

--- a/data/stores/omni-hotels.yaml
+++ b/data/stores/omni-hotels.yaml
@@ -1,0 +1,15 @@
+name: "Omni Hotels"
+slug: "omni-hotels"
+aliases:
+  - "Omni Hotels & Resorts"
+categories:
+  - hotels
+  - travel
+website: "https://www.omnihotels.com"
+intro: |
+  Omni Hotels & Resorts is a privately held US luxury and upper-upscale hotel chain with about
+  50 properties spanning convention-center anchors like the Omni Atlanta and Omni Dallas, resort
+  destinations like the Omni Grove Park Inn and Omni Bedford Springs, and downtown business
+  hotels. The Select Guest loyalty program offers free WiFi, beverages, and morning coffee at
+  every tier. Omni charges code as lodging/hotels. Hotel-bonus cards earn full rate: Chase
+  Sapphire Reserve at 4x direct, Amex Platinum at 5x prepaid, Capital One Venture X at 2x base.

--- a/data/stores/pacsun.yaml
+++ b/data/stores/pacsun.yaml
@@ -1,0 +1,15 @@
+name: "Pacsun"
+slug: "pacsun"
+aliases:
+  - "PacSun"
+  - "Pacific Sunwear"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.pacsun.com"
+intro: |
+  Pacsun is a California-rooted apparel chain catering to teens and young adults, with
+  about 325 mall-based stores and a strong online business at pacsun.com. Most cards
+  code in-store transactions as department store and web orders as online shopping. The
+  Pacsun Rewards program is free and points-based, layering on top of credit card
+  earnings since the chain does not run a branded credit card in the U.S.

--- a/data/stores/pandora.yaml
+++ b/data/stores/pandora.yaml
@@ -1,0 +1,13 @@
+name: "Pandora"
+slug: "pandora"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://us.pandora.net"
+intro: |
+  Pandora is a Danish jewelry company best known for its customizable charm bracelets
+  plus rings, earrings, and lab-grown diamond collections. The U.S. footprint covers
+  about 360 concept stores and shop-in-shops plus us.pandora.net. Direct purchases
+  typically code as department store in person and online shopping for web orders. The
+  free Pandora Club loyalty program offers points and a birthday gift, but Pandora does
+  not run a U.S. branded credit card.

--- a/data/stores/patagonia.yaml
+++ b/data/stores/patagonia.yaml
@@ -1,0 +1,13 @@
+name: "Patagonia"
+slug: "patagonia"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.patagonia.com"
+intro: |
+  Patagonia is a privately held outdoor and performance apparel brand owned by the
+  Holdfast Collective, with about 40 U.S. retail stores plus a strong DTC business at
+  patagonia.com. Direct purchases typically code as department store in person and
+  online shopping for web orders, while the Worn Wear resale platform issues store
+  credit for trade-ins. Patagonia does not offer a U.S. branded credit card, so most
+  shoppers rely on a strong online or everyday multiplier for full-price gear.

--- a/data/stores/pavilions.yaml
+++ b/data/stores/pavilions.yaml
@@ -1,0 +1,13 @@
+name: "Pavilions"
+slug: "pavilions"
+categories:
+  - groceries
+website: "https://www.pavilions.com"
+intro: |
+  Pavilions is the upscale Albertsons banner serving affluent Southern California
+  neighborhoods, with a focus on prepared foods, wine, and specialty grocery. It codes as
+  a U.S. supermarket, so any grocery category bonus (Amex Gold, Blue Cash Preferred, Citi
+  Custom Cash) applies at the register. Like other Albertsons banners, Pavilions runs the
+  Albertsons for U loyalty program, and the broad gift-card rack at the service counter
+  is worth knowing about if you want to extend a 4x or 6x grocery multiplier into other
+  spending.

--- a/data/stores/pep-boys.yaml
+++ b/data/stores/pep-boys.yaml
@@ -1,0 +1,17 @@
+name: "Pep Boys"
+slug: "pep-boys"
+categories:
+  - online_shopping
+website: "https://www.pepboys.com"
+intro: |
+  Pep Boys operates roughly 800 auto parts and service centers across the United
+  States, combining a parts counter with tire installation, oil changes, brake work,
+  and full-service mechanical repair. Most credit cards code Pep Boys purchases as
+  auto services or general retail rather than as a dedicated bonus category, so
+  flat-rate cards like the Citi Double Cash often deliver the cleanest 2 percent.
+
+  Cards with selectable categories can reach Pep Boys when the right bucket is
+  chosen. Bank of America Customized Cash and U.S. Bank Cash+ both have wider
+  categories that may capture auto service spending, and Citi Custom Cash pays 5
+  percent on the top eligible spending category for cardholders whose monthly spend
+  skews toward vehicle maintenance.

--- a/data/stores/pet-supermarket.yaml
+++ b/data/stores/pet-supermarket.yaml
@@ -1,0 +1,17 @@
+name: "Pet Supermarket"
+slug: "pet-supermarket"
+categories:
+  - online_shopping
+website: "https://www.petsupermarket.com"
+intro: |
+  Pet Supermarket is a Southeast U.S. pet specialty chain with around 200 stores
+  across Florida, Georgia, the Carolinas, Alabama, and neighboring states. The
+  retailer carries dog and cat food, small animal supplies, fish, reptiles, and live
+  bird departments. Most Pet Supermarket locations code as pet shops or general
+  retail on credit card networks, not as a standalone rewards category.
+
+  Cards with selectable categories like U.S. Bank Cash+ can include pet shops in
+  their lineup, while flat-rate cards such as the Citi Double Cash or Wells Fargo
+  Active Cash deliver a steady 2 percent on every pet food run. Online orders
+  through petsupermarket.com may trigger online shopping bonuses on Bank of America
+  Customized Cash and Chase Freedom Flex rotating quarters.

--- a/data/stores/pet-supplies-plus.yaml
+++ b/data/stores/pet-supplies-plus.yaml
@@ -1,0 +1,17 @@
+name: "Pet Supplies Plus"
+slug: "pet-supplies-plus"
+categories:
+  - online_shopping
+website: "https://www.petsuppliesplus.com"
+intro: |
+  Pet Supplies Plus is the third-largest pet specialty chain in the United States
+  with over 700 neighborhood stores carrying food, treats, toys, and grooming
+  services for dogs, cats, fish, reptiles, and small animals. Most Pet Supplies Plus
+  locations code as pet shops or general retail on credit card networks, not as a
+  category that triggers standard rewards bonuses.
+
+  Cards with selectable categories sometimes include pet shops, with U.S. Bank Cash+
+  offering pet-related categories in its lineup. Online orders placed through
+  petsuppliesplus.com may also trigger online shopping bonuses on cards like Bank of
+  America Customized Cash and Chase Freedom Flex. The free Preferred Pet Club
+  loyalty program adds points on top of credit card rewards.

--- a/data/stores/pf-changs.yaml
+++ b/data/stores/pf-changs.yaml
@@ -1,0 +1,15 @@
+name: "P.F. Chang's"
+slug: "pf-changs"
+aliases:
+  - "PF Changs"
+  - "P.F. Chang's China Bistro"
+categories:
+  - dining
+website: "https://www.pfchangs.com"
+intro: |
+  P.F. Chang's China Bistro operates roughly 200 US upscale-casual restaurants known for the
+  Chang's Spicy Chicken, Mongolian Beef, Dynamite Shrimp, and signature lettuce wraps in a
+  pan-Asian table-service format. Most locations sit in upscale shopping centers or near
+  high-end malls. P.F. Chang's transactions code as dining/restaurants, including delivery and
+  takeout orders. Cards offering elevated dining bonuses (Amex Gold at 4x Membership Rewards,
+  Chase Sapphire Reserve at 4x Ultimate Rewards, Capital One Savor at 3% cash) earn full rate.

--- a/data/stores/phillips-66.yaml
+++ b/data/stores/phillips-66.yaml
@@ -1,0 +1,15 @@
+name: "Phillips 66"
+slug: "phillips-66"
+aliases:
+  - "76"
+  - "Conoco"
+categories:
+  - gas
+website: "https://www.phillips66.com"
+intro: |
+  Phillips 66 is a U.S. refiner whose retail footprint covers more than 7,000 branded
+  gas stations across three names: Phillips 66 in the central U.S., 76 on the West
+  Coast, and Conoco in the Mountain West. All three brands code as gas at the pump, so
+  any gas category bonus card (Costco Anywhere Visa, Citi Custom Cash on gas, Sam's
+  Club Mastercard) will earn its multiplier. The KickBack Rewards loyalty app offers
+  per-gallon discounts that stack with rewards card earn at participating sites.

--- a/data/stores/philz-coffee.yaml
+++ b/data/stores/philz-coffee.yaml
@@ -1,0 +1,12 @@
+name: "Philz Coffee"
+slug: "philz-coffee"
+categories:
+  - dining
+website: "https://www.philzcoffee.com"
+intro: |
+  Philz Coffee is a San Francisco-born specialty chain of about 70 cafes across California,
+  the East Coast, and the DC region, built around custom pour-over brews like Tesora, Ether,
+  and the Mint Mojito iced coffee. Orders placed in-cafe, in the Philz app, or ahead via
+  curbside all code as dining/restaurants. Top dining cards earn their full rate at Philz:
+  Amex Gold pays 4x Membership Rewards, Chase Sapphire Reserve pays 4x Ultimate Rewards,
+  and Capital One SavorOne pays 3% unlimited cash back on every order.

--- a/data/stores/pilot-flying-j.yaml
+++ b/data/stores/pilot-flying-j.yaml
@@ -1,0 +1,16 @@
+name: "Pilot Flying J"
+slug: "pilot-flying-j"
+aliases:
+  - "Pilot"
+  - "Flying J"
+categories:
+  - gas
+website: "https://pilotflyingj.com"
+intro: |
+  Pilot Flying J operates more than 750 travel centers across the U.S. and Canada,
+  making it the largest truck stop network in North America. The chain serves both
+  long-haul truckers (with high-flow diesel lanes, showers, and driver lounges) and
+  passenger drivers at standard gas pumps. Fuel at Pilot Flying J pumps codes as gas, so
+  any card with a gas category bonus will earn its rate. The myRewards Plus loyalty
+  program adds per-gallon discounts and points on in-store food, which can stack with a
+  separate gas rewards card.

--- a/data/stores/playstation-store.yaml
+++ b/data/stores/playstation-store.yaml
@@ -1,0 +1,20 @@
+name: "PlayStation Store"
+slug: "playstation-store"
+aliases:
+  - "PSN Store"
+categories:
+  - online_shopping
+  - entertainment
+website: "https://store.playstation.com"
+intro: |
+  The PlayStation Store is Sony's digital storefront for PS4 and PS5 games, downloadable
+  content, PlayStation Plus subscriptions, and movies. Purchases happen directly through
+  the console or on store.playstation.com. Card networks often code PlayStation Store
+  charges as digital goods or entertainment, which can trigger entertainment category
+  bonuses on cards like the Capital One SavorOne.
+
+  PlayStation Plus subscription tiers and Game Pass-style game catalogs may also fall
+  under streaming services coding on some issuers, which means the Amex Blue Cash
+  Preferred can occasionally earn 6 percent. Online shopping bonus cards such as Bank
+  of America Customized Cash and Chase Freedom Flex during rotating online quarters
+  remain reliable defaults for game and DLC purchases.

--- a/data/stores/polo-ralph-lauren.yaml
+++ b/data/stores/polo-ralph-lauren.yaml
@@ -1,0 +1,15 @@
+name: "Polo Ralph Lauren"
+slug: "polo-ralph-lauren"
+aliases:
+  - "Ralph Lauren"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.ralphlauren.com"
+intro: |
+  Polo Ralph Lauren is the flagship label of Ralph Lauren Corporation, sold through
+  about 140 U.S. full-price, factory, and Rugby-style stores along with ralphlauren.com
+  and an extensive department store wholesale presence. Direct purchases typically code
+  as department store in person and online shopping for web orders. The free Ralph
+  Lauren Rewards program offers points and member perks, but the brand does not run a
+  consumer co-brand credit card in the U.S.

--- a/data/stores/poshmark.yaml
+++ b/data/stores/poshmark.yaml
@@ -1,0 +1,12 @@
+name: "Poshmark"
+slug: "poshmark"
+categories:
+  - online_shopping
+website: "https://poshmark.com"
+intro: |
+  Poshmark is a social commerce marketplace focused on secondhand fashion, beauty, and
+  accessories, where individual sellers list items and ship through prepaid Poshmark
+  labels. The platform was acquired by Korean tech company Naver in 2023. Buyer
+  purchases code as online shopping for credit card networks, so any online-shopping
+  category bonus card will earn its full multiplier. Poshmark does not have a co-brand
+  credit card, so the best earn comes from a general 3-5x online-shopping rewards card.

--- a/data/stores/pottery-barn-kids.yaml
+++ b/data/stores/pottery-barn-kids.yaml
@@ -1,0 +1,15 @@
+name: "Pottery Barn Kids"
+slug: "pottery-barn-kids"
+aliases:
+  - "PB Kids"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.potterybarnkids.com"
+intro: |
+  Pottery Barn Kids is the kids and baby furnishings banner of Williams-Sonoma Inc, with
+  about 80 U.S. stores plus potterybarnkids.com selling cribs, bedding, nursery decor,
+  and gear. The Key Rewards Visa from Capital One earns elevated points across all WSI
+  brands and stacks with the free Key Rewards program, which is helpful for big-ticket
+  nursery setups. General-purpose cards typically code purchases as home improvement or
+  department store in person and online shopping on the web.

--- a/data/stores/price-chopper.yaml
+++ b/data/stores/price-chopper.yaml
@@ -1,0 +1,14 @@
+name: "Price Chopper"
+slug: "price-chopper"
+aliases:
+  - "Market 32"
+categories:
+  - groceries
+website: "https://www.pricechopper.com"
+intro: |
+  Price Chopper, operated by Northeast Grocery, runs about 130 supermarkets across New
+  York, Vermont, Connecticut, Pennsylvania, Massachusetts, and New Hampshire. Many
+  remodeled locations carry the sister Market 32 banner. Both code as U.S. supermarkets,
+  so grocery rewards cards (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earn full
+  multipliers. The AdvantEdge loyalty program ties shoppers into fuel discount partners
+  like Sunoco, which can stack with a separate gas-category card at the pump.

--- a/data/stores/qdoba.yaml
+++ b/data/stores/qdoba.yaml
@@ -1,0 +1,14 @@
+name: "Qdoba"
+slug: "qdoba"
+aliases:
+  - "Qdoba Mexican Eats"
+categories:
+  - dining
+website: "https://www.qdoba.com"
+intro: |
+  Qdoba Mexican Eats operates roughly 750 fast-casual locations, competing directly with
+  Chipotle in the burritos-bowls-tacos lane while differentiating with free queso and
+  guacamole on entrees. Orders placed in-store, at the counter, or through the Qdoba Rewards
+  app all code as dining/restaurants. That makes any card with a dining bonus a strong fit:
+  the Chase Sapphire Reserve earns 4x on dining, Amex Gold earns 4x, and the Capital One
+  SavorOne earns 3% unlimited cash back on every Qdoba purchase.

--- a/data/stores/qvc.yaml
+++ b/data/stores/qvc.yaml
@@ -1,0 +1,13 @@
+name: "QVC"
+slug: "qvc"
+categories:
+  - online_shopping
+website: "https://www.qvc.com"
+intro: |
+  QVC is a multichannel retailer that sells via live television broadcasts, qvc.com, and
+  mobile apps, owned by Qurate Retail Group (which also runs HSN). The merchandise mix
+  spans apparel, jewelry, beauty, kitchen, electronics, and home goods, often pitched
+  by celebrity hosts in real time. QVC purchases code as online shopping or general
+  merchandise for credit card networks, so an online-shopping category bonus card will
+  generally earn its multiplier. QVC also offers its Easy Pay installment program at
+  checkout, billed against the saved card on file.

--- a/data/stores/racetrac.yaml
+++ b/data/stores/racetrac.yaml
@@ -1,0 +1,13 @@
+name: "RaceTrac"
+slug: "racetrac"
+categories:
+  - gas
+website: "https://www.racetrac.com"
+intro: |
+  RaceTrac is a family-owned Southeast U.S. convenience and fuel chain with more than
+  800 stores across Georgia, Florida, Texas, Tennessee, Louisiana, and surrounding
+  states. Fuel pumps code as gas, so any gas category bonus card will earn its
+  multiplier. Inside-store food and drinks (the chain leans heavily on coffee and
+  prepared foods) typically code as convenience store. The RaceTrac Rewards loyalty
+  program adds per-gallon discounts and points on food that stack with a separate gas
+  rewards card.

--- a/data/stores/radisson.yaml
+++ b/data/stores/radisson.yaml
@@ -1,0 +1,15 @@
+name: "Radisson Hotel Group"
+slug: "radisson"
+aliases:
+  - "Radisson Hotels"
+categories:
+  - hotels
+  - travel
+website: "https://www.radissonhotels.com"
+intro: |
+  Radisson Hotel Group operates a global portfolio that includes Radisson Collection, Radisson
+  Blu, Radisson, Radisson RED, Park Plaza, Park Inn, and Country Inn & Suites, spanning roughly
+  1,100 hotels worldwide. In the Americas, Radisson Hotels Americas was sold to Choice Hotels
+  in 2022, which complicates loyalty mapping: US stays now mostly earn Choice Privileges,
+  while EMEA/APAC stays earn Radisson Rewards. Radisson stays code as lodging/hotels. Travel
+  cards with hotel bonuses (Amex Gold 3x on prepaid, Chase Sapphire Reserve 4x direct) earn full rate.

--- a/data/stores/raising-canes.yaml
+++ b/data/stores/raising-canes.yaml
@@ -1,0 +1,20 @@
+name: "Raising Cane's"
+slug: "raising-canes"
+aliases:
+  - "Canes"
+categories:
+  - dining
+website: "https://www.raisingcanes.com"
+intro: |
+  Raising Cane's Chicken Fingers is a Baton Rouge-based quick-service chain serving
+  a focused menu of chicken finger combos, Texas toast, crinkle-cut fries, and the
+  signature Cane's Sauce. The chain has expanded from a single Louisiana location to
+  over 800 restaurants nationwide. Raising Cane's transactions code as restaurants
+  on Visa, Mastercard, and Amex networks, which lights up most dining bonus
+  categories.
+
+  The Amex Gold pays 4x points on U.S. restaurants for one of the highest dining
+  rates available, while the Chase Sapphire Reserve and Capital One Savor both pay
+  3x or more. The Capital One SavorOne is a strong no-annual-fee pick at 3 percent
+  on dining. Cane's runs no in-house loyalty program of its own, so credit card
+  rewards are the primary cash back path.

--- a/data/stores/raleys.yaml
+++ b/data/stores/raleys.yaml
@@ -1,0 +1,13 @@
+name: "Raley's"
+slug: "raleys"
+categories:
+  - groceries
+website: "https://www.raleys.com"
+intro: |
+  Raley's is a family-owned, Northern California based supermarket chain with about 120
+  stores across California and Nevada, including the Bel Air, Nob Hill Foods, and Raley's
+  O-N-E Market banners. The chain emphasizes fresh produce, in-house meat and seafood,
+  and a strong private-label program. Raley's codes as a U.S. supermarket, so any
+  grocery category card (Amex Gold, Blue Cash Preferred, Citi Custom Cash) earns full
+  multipliers. The Something Extra loyalty program adds digital coupon savings and
+  occasional fuel discounts at partner stations.

--- a/data/stores/ralphs.yaml
+++ b/data/stores/ralphs.yaml
@@ -1,0 +1,12 @@
+name: "Ralphs"
+slug: "ralphs"
+categories:
+  - groceries
+website: "https://www.ralphs.com"
+intro: |
+  Ralphs is the Southern California banner of Kroger, operating roughly 180 stores across
+  the Los Angeles and San Diego areas. It codes cleanly as a U.S. supermarket for credit
+  card networks, so grocery bonus cards earn their full rate. Ralphs is also part of the
+  Kroger fuel points program (the chain runs co-located fuel centers in some locations),
+  and the store sells third-party gift cards that can stretch a grocery multiplier into
+  other spending categories.

--- a/data/stores/red-robin.yaml
+++ b/data/stores/red-robin.yaml
@@ -1,0 +1,14 @@
+name: "Red Robin"
+slug: "red-robin"
+aliases:
+  - "Red Robin Gourmet Burgers"
+categories:
+  - dining
+website: "https://www.redrobin.com"
+intro: |
+  Red Robin Gourmet Burgers operates about 500 casual-dining restaurants centered on
+  customizable burgers like the Royal Red Robin and Banzai Burger, plus Bottomless Steak Fries
+  refills that anchor the brand's table-service value pitch. The chain skews family-friendly
+  with a kids menu and milkshake program. Red Robin transactions code as dining/restaurants
+  on every card, including orders placed through Red Robin Royalty loyalty. Dining-bonus
+  cards earn full rate: Amex Gold (4x), Chase Sapphire Reserve (4x), Capital One SavorOne (3%).

--- a/data/stores/restoration-hardware.yaml
+++ b/data/stores/restoration-hardware.yaml
@@ -1,0 +1,15 @@
+name: "Restoration Hardware"
+slug: "restoration-hardware"
+aliases:
+  - "RH"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://rh.com"
+intro: |
+  Restoration Hardware, now branded as RH, is an upscale home furnishings retailer with
+  around 70 large-format Galleries plus rh.com selling furniture, lighting, textiles,
+  and outdoor. The RH Members Program is a paid annual membership that grants 25 percent
+  off most full-price items and stacks with credit card rewards. General-purpose cards
+  typically code RH as home improvement or department store in person and online
+  shopping for web orders.

--- a/data/stores/rooms-to-go.yaml
+++ b/data/stores/rooms-to-go.yaml
@@ -1,0 +1,18 @@
+name: "Rooms To Go"
+slug: "rooms-to-go"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.roomstogo.com"
+intro: |
+  Rooms To Go is a Florida-based furniture retailer that pioneered the room-package
+  concept, bundling sofa, loveseat, tables, lamps, and rug into a single price. The
+  chain runs over 250 showrooms across the Southeast, Texas, and Puerto Rico. Furniture
+  purchases code as general retail on most rewards cards, so they sit outside dedicated
+  home improvement bonuses.
+
+  Five-piece living room packages and bedroom sets often clear $2,000, making Rooms To
+  Go a useful place to hit signup bonus thresholds on cards like the Chase Sapphire
+  Preferred or Capital One Venture. The retailer also markets a Synchrony-issued Rooms
+  To Go credit card with deferred-interest financing, but a rewards card paid in full
+  generally produces more value.

--- a/data/stores/ruths-chris-steak-house.yaml
+++ b/data/stores/ruths-chris-steak-house.yaml
@@ -1,0 +1,14 @@
+name: "Ruth's Chris Steak House"
+slug: "ruths-chris-steak-house"
+aliases:
+  - "Ruth's Chris"
+categories:
+  - dining
+website: "https://www.ruthschris.com"
+intro: |
+  Ruth's Chris Steak House, now owned by Darden Restaurants, operates about 150 upscale
+  steakhouses known for USDA Prime steaks served on 500-degree plates with sizzling butter,
+  plus signature sides like the Sweet Potato Casserole. Average check sizes run high enough
+  that a well-chosen dining card meaningfully changes the bill economics. Ruth's Chris codes
+  as dining/restaurants on every credit card. Top picks here include the Amex Gold (4x
+  Membership Rewards), Chase Sapphire Reserve (4x Ultimate Rewards), and Capital One Savor (3%).

--- a/data/stores/saks-off-5th.yaml
+++ b/data/stores/saks-off-5th.yaml
@@ -1,0 +1,13 @@
+name: "Saks OFF 5TH"
+slug: "saks-off-5th"
+categories:
+  - department_stores
+website: "https://www.saksoff5th.com"
+intro: |
+  Saks OFF 5TH is the off-price arm of Saks Fifth Avenue, with about 90 outlet stores
+  across the U.S. and Canada plus its own e-commerce site. The format carries designer
+  apparel, shoes, and accessories at substantial discounts to the parent retailer. Saks
+  OFF 5TH codes as a department store, so a department-store category bonus card will
+  earn its multiplier. The SaksFirst Mastercard (issued by Capital One) earns elevated
+  points at both Saks Fifth Avenue and Saks OFF 5TH, with tiered status benefits at
+  higher spend thresholds.

--- a/data/stores/sally-beauty.yaml
+++ b/data/stores/sally-beauty.yaml
@@ -1,0 +1,15 @@
+name: "Sally Beauty"
+slug: "sally-beauty"
+aliases:
+  - "Sally Beauty Supply"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.sallybeauty.com"
+intro: |
+  Sally Beauty is the U.S. retail banner of Sally Beauty Holdings, with about 2,400
+  stores plus sallybeauty.com selling professional hair color, salon supplies, and at
+  home beauty products. The free Sally Beauty Rewards program offers points and member
+  pricing, while a separate Pro Card serves licensed cosmetologists. General-purpose
+  cards typically code Sally Beauty as department store in person and online shopping
+  for web orders.

--- a/data/stores/schnucks.yaml
+++ b/data/stores/schnucks.yaml
@@ -1,0 +1,12 @@
+name: "Schnucks"
+slug: "schnucks"
+categories:
+  - groceries
+website: "https://www.schnucks.com"
+intro: |
+  Schnucks is a St. Louis based regional supermarket chain with around 110 stores across
+  Missouri, Illinois, Indiana, and Wisconsin. The family-owned chain codes as a U.S.
+  supermarket, so a card with a grocery bonus (Amex Gold, Blue Cash Preferred, Citi
+  Custom Cash) will earn its full rate at the register. Schnucks runs its own loyalty
+  program with fuel rewards redeemable at participating gas stations, which can stack
+  with a separate gas-category card at the pump.

--- a/data/stores/shein.yaml
+++ b/data/stores/shein.yaml
@@ -1,0 +1,13 @@
+name: "Shein"
+slug: "shein"
+categories:
+  - online_shopping
+website: "https://www.shein.com"
+intro: |
+  Shein is a Singapore-headquartered fast-fashion retailer that sells direct to U.S.
+  consumers, mostly shipped from China and other manufacturing hubs. The model is built
+  on extremely fast trend cycles, low prices, and a constant churn of new SKUs. Shein
+  purchases code as online shopping for credit card networks, so any online-shopping
+  category bonus card will earn its multiplier. There is no Shein co-brand credit card,
+  so the best play is a general 3-5x online-shopping rewards card or a rotating-bonus
+  card during an online-shopping quarter.

--- a/data/stores/sherwin-williams.yaml
+++ b/data/stores/sherwin-williams.yaml
@@ -1,0 +1,18 @@
+name: "Sherwin-Williams"
+slug: "sherwin-williams"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.sherwin-williams.com"
+intro: |
+  Sherwin-Williams is the largest U.S. paint manufacturer and retailer, with over
+  4,700 company-owned stores serving residential painters, contractors, and designers.
+  Sherwin-Williams typically codes as home improvement on Visa, Mastercard, and Amex
+  networks, which makes paint purchases eligible for the home improvement bonus on
+  cards that carry the category.
+
+  The U.S. Bank Cash+ and Bank of America Customized Cash can both route Sherwin
+  purchases into a selectable 3 to 5 percent bonus. The chain runs frequent 30 to 40
+  percent off paint promotions that stack with credit card cash back, and Sherwin's
+  PaintPerks loyalty program adds member pricing on top of any rewards a credit card
+  delivers.

--- a/data/stores/shoe-carnival.yaml
+++ b/data/stores/shoe-carnival.yaml
@@ -1,0 +1,13 @@
+name: "Shoe Carnival"
+slug: "shoe-carnival"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.shoecarnival.com"
+intro: |
+  Shoe Carnival is a value-oriented family footwear chain with about 380 stores
+  concentrated in the Midwest, South, and Southeast plus shoecarnival.com. The retailer
+  recently acquired Rogan's Shoes and now also operates Shoe Station. The Shoe Perks
+  loyalty program is free and offers points and birthday bonuses that stack with credit
+  card rewards. Most cards code purchases as department store in person and online
+  shopping for web checkouts.

--- a/data/stores/skechers.yaml
+++ b/data/stores/skechers.yaml
@@ -1,0 +1,13 @@
+name: "Skechers"
+slug: "skechers"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.skechers.com"
+intro: |
+  Skechers is a comfort and lifestyle footwear brand with around 550 U.S. concept,
+  factory outlet, and warehouse stores plus skechers.com. Direct purchases typically
+  code as department store in person and online shopping for web orders, while Skechers
+  bought at Famous Footwear, DSW, or Kohl's codes under those host retailers. The free
+  Skechers Plus loyalty program offers points and a birthday reward and stacks with
+  credit card earnings.

--- a/data/stores/smart-and-final.yaml
+++ b/data/stores/smart-and-final.yaml
@@ -1,0 +1,14 @@
+name: "Smart & Final"
+slug: "smart-and-final"
+categories:
+  - groceries
+  - wholesale_clubs
+website: "https://www.smartandfinal.com"
+intro: |
+  Smart & Final is a California-based hybrid warehouse/grocery chain with about 250
+  stores across the Western U.S. and Mexico. Unlike Costco or Sam's, no membership is
+  required, so any shopper can walk in and buy bulk packaged goods alongside normal
+  grocery items. Merchant category coding is the gotcha here: most Smart & Final stores
+  historically code as warehouse club rather than supermarket, which means a grocery
+  bonus card (Amex Gold, Blue Cash Preferred) may not trigger its multiplier. Coding can
+  vary by location, so check a recent statement before assuming a category bonus applies.

--- a/data/stores/stockx.yaml
+++ b/data/stores/stockx.yaml
@@ -1,0 +1,12 @@
+name: "StockX"
+slug: "stockx"
+categories:
+  - online_shopping
+website: "https://stockx.com"
+intro: |
+  StockX is a resale marketplace built around sneakers, streetwear, watches, handbags,
+  and collectibles, with a bid/ask exchange model and mandatory authentication of every
+  item before it ships to the buyer. The platform is a primary secondary market for
+  hyped sneaker releases. StockX codes as online shopping for credit card networks, so
+  an online-shopping category bonus card will earn its multiplier. Buyer fees are baked
+  into the transaction price, which is the figure that posts to the card.

--- a/data/stores/sun-country-airlines.yaml
+++ b/data/stores/sun-country-airlines.yaml
@@ -1,0 +1,15 @@
+name: "Sun Country Airlines"
+slug: "sun-country-airlines"
+aliases:
+  - "Sun Country"
+categories:
+  - airlines
+  - travel
+website: "https://www.suncountry.com"
+intro: |
+  Sun Country Airlines is a Minneapolis/St. Paul-based ultra-low-cost carrier with a hybrid
+  business model that combines scheduled leisure flights, cargo flying for Amazon, and ad-hoc
+  charters for sports teams and casinos. Routes mostly connect MSP to warm-weather US and
+  Mexico destinations during peak seasons. Sun Country purchases code as airlines/airfare on
+  every credit card. Cards with airfare bonus categories all earn full rate: the Chase
+  Sapphire Reserve at 4x, Amex Gold at 3x on direct-booked flights, Capital One Venture X at 2x.

--- a/data/stores/take-5-oil-change.yaml
+++ b/data/stores/take-5-oil-change.yaml
@@ -1,0 +1,17 @@
+name: "Take 5 Oil Change"
+slug: "take-5-oil-change"
+categories:
+  - online_shopping
+website: "https://www.take5oilchange.com"
+intro: |
+  Take 5 Oil Change is a drive-through oil change chain operated by Driven Brands,
+  with over 1,000 U.S. locations. Drivers stay in the car while technicians complete
+  the oil change in about five to ten minutes. Most card networks code Take 5 as auto
+  services rather than as a dedicated bonus category, which puts the chain outside
+  most rotating and selectable bonus rewards.
+
+  For cardholders who want elevated rewards on routine maintenance, Citi Custom Cash
+  can pay 5 percent if auto services is the top eligible spending category in a given
+  month. Otherwise, a flat-rate card like the Citi Double Cash, Wells Fargo Active
+  Cash, or PayPal Cashback Mastercard delivers consistent 2 percent on every Take 5
+  visit.

--- a/data/stores/temu.yaml
+++ b/data/stores/temu.yaml
@@ -1,0 +1,13 @@
+name: "Temu"
+slug: "temu"
+categories:
+  - online_shopping
+website: "https://www.temu.com"
+intro: |
+  Temu is a U.S.-facing online marketplace owned by Chinese e-commerce giant PDD
+  Holdings, launched stateside in 2022 and aggressively marketed on ultra-low prices and
+  direct-from-manufacturer shipping. Purchases typically code as online shopping or
+  merchandise, so a card with an online-shopping category bonus (Capital One SavorOne
+  promotions, Chase Freedom Flex when activated, Citi Custom Cash on online shopping
+  month) will earn its full multiplier. Temu has no co-brand credit card, so the best
+  earn comes from a general online-shopping bonus.

--- a/data/stores/tgi-fridays.yaml
+++ b/data/stores/tgi-fridays.yaml
@@ -1,0 +1,15 @@
+name: "TGI Fridays"
+slug: "tgi-fridays"
+aliases:
+  - "Fridays"
+  - "T.G.I. Friday's"
+categories:
+  - dining
+website: "https://www.tgifridays.com"
+intro: |
+  TGI Fridays operates around 350 US casual-dining restaurants with a bar-and-grill format that
+  helped define the category, anchored by Loaded Potato Skins, Jack Daniel's Sesame Chicken
+  Strips, and a full cocktail program. The chain has contracted from its 1990s peak but
+  remains a recognizable airport and suburban brand. Fridays transactions code as dining/
+  restaurants on every credit card, including bar tabs and to-go orders. Dining-bonus cards
+  earn full rate: Amex Gold at 4x, Chase Sapphire Reserve at 4x, Capital One SavorOne at 3% cash.

--- a/data/stores/the-body-shop.yaml
+++ b/data/stores/the-body-shop.yaml
@@ -1,0 +1,13 @@
+name: "The Body Shop"
+slug: "the-body-shop"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.thebodyshop.com"
+intro: |
+  The Body Shop is a British natural beauty and skincare brand known for body butters,
+  ethical sourcing, and animal-testing-free positioning. The U.S. footprint runs through
+  a smaller set of mall-based stores plus thebodyshop.com after the parent restructured
+  in 2024. Direct purchases typically code as department store in person and online
+  shopping for web orders, and the free Love Your Body Club loyalty program stacks
+  alongside credit card rewards.

--- a/data/stores/the-container-store.yaml
+++ b/data/stores/the-container-store.yaml
@@ -1,0 +1,16 @@
+name: "The Container Store"
+slug: "the-container-store"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.containerstore.com"
+intro: |
+  The Container Store is the leading U.S. specialty retailer for organization and
+  storage, known for The Elfa custom closet system, kitchen organizers, and Russell
+  + Hazel desk goods. Purchases typically code as general retail, so flat-rate cards
+  like the Citi Double Cash earn the same 2 percent as on most shopping.
+
+  Big custom closet installations can run into the thousands, which makes signup bonus
+  minimum spend a useful angle. Cards with rotating online shopping quarters, such as
+  Chase Freedom Flex, occasionally lift containerstore.com orders to 5 percent, and the
+  free Organized Insider loyalty program adds tiered discounts on top of card rewards.

--- a/data/stores/the-fresh-market.yaml
+++ b/data/stores/the-fresh-market.yaml
@@ -1,0 +1,13 @@
+name: "The Fresh Market"
+slug: "the-fresh-market"
+categories:
+  - groceries
+website: "https://www.thefreshmarket.com"
+intro: |
+  The Fresh Market is an upscale specialty grocer with around 160 stores, primarily in
+  the Southeast and along the Eastern Seaboard. The format leans into prepared meals,
+  butcher and seafood counters, and a curated wine and cheese selection. The Fresh
+  Market codes as a U.S. supermarket, so grocery category cards (Amex Gold, Blue Cash
+  Preferred, Citi Custom Cash) earn their normal multiplier here. Given the higher
+  average ticket compared to mainstream chains, a 4x or 6x grocery card can produce
+  outsized rewards on a typical trip.

--- a/data/stores/the-realreal.yaml
+++ b/data/stores/the-realreal.yaml
@@ -1,0 +1,13 @@
+name: "The RealReal"
+slug: "the-realreal"
+categories:
+  - online_shopping
+website: "https://www.therealreal.com"
+intro: |
+  The RealReal is an authenticated luxury consignment marketplace selling pre-owned
+  designer apparel, handbags, watches, jewelry, and home goods online and through a
+  handful of physical stores. Every item is inspected and authenticated by in-house
+  experts before listing, which is the platform's main differentiator versus
+  peer-to-peer resale. Purchases code as online shopping for credit card networks, so
+  an online-shopping category bonus card will earn its multiplier. Given the higher
+  average ticket on luxury items, 3-5x earn rates can produce meaningful rewards.

--- a/data/stores/the-ups-store.yaml
+++ b/data/stores/the-ups-store.yaml
@@ -1,0 +1,17 @@
+name: "The UPS Store"
+slug: "the-ups-store"
+categories:
+  - office_supplies
+website: "https://www.theupsstore.com"
+intro: |
+  The UPS Store is a franchise network of more than 5,000 U.S. locations offering
+  shipping, printing, mailbox services, packing, notary, and small business support.
+  Most The UPS Store locations code as office supplies or stationery on Visa,
+  Mastercard, and Amex networks, which makes shipping and print purchases eligible
+  for office supply bonus categories.
+
+  Business cards with office supply bonuses are the natural fit. The Chase Ink
+  Business Cash pays 5 percent on the first $25,000 in combined office supply and
+  internet, cable, and phone purchases each year, and the Amex Business Gold also
+  offers office supplies as a top-two category. Personal cards with selectable office
+  supply categories, like U.S. Bank Cash+, can capture the same MCC.

--- a/data/stores/thredup.yaml
+++ b/data/stores/thredup.yaml
@@ -1,0 +1,12 @@
+name: "ThredUp"
+slug: "thredup"
+categories:
+  - online_shopping
+website: "https://www.thredup.com"
+intro: |
+  ThredUp is an online consignment and thrift store that processes secondhand women's
+  and kids' clothing on behalf of sellers and sells to buyers through its website. The
+  model differs from peer-to-peer platforms (Poshmark, Mercari) in that ThredUp itself
+  authenticates, photographs, and warehouses inventory before listing. Purchases code
+  as online shopping for credit card networks, so an online-shopping category bonus
+  card will earn its multiplier. ThredUp does not issue a co-brand credit card.

--- a/data/stores/thrive-market.yaml
+++ b/data/stores/thrive-market.yaml
@@ -1,0 +1,14 @@
+name: "Thrive Market"
+slug: "thrive-market"
+categories:
+  - groceries
+  - online_shopping
+website: "https://thrivemarket.com"
+intro: |
+  Thrive Market is a membership-based online grocery and wellness retailer focused on organic,
+  non-GMO, and specialty-diet pantry items (keto, paleo, gluten-free), shipped to subscribers
+  from regional fulfillment centers. The annual membership funds member-only pricing on
+  shelf-stable groceries, supplements, and clean-beauty products. Thrive Market charges
+  generally code as online retail or supermarkets depending on the issuer's processor mapping,
+  so results vary: cards with online-shopping bonuses (Chase Freedom Flex quarters, Capital One
+  SavorOne online grocery) often earn more than flat-rate cards on Thrive Market orders.

--- a/data/stores/tim-hortons.yaml
+++ b/data/stores/tim-hortons.yaml
@@ -1,0 +1,12 @@
+name: "Tim Hortons"
+slug: "tim-hortons"
+categories:
+  - dining
+website: "https://www.timhortons.com"
+intro: |
+  Tim Hortons is the Canadian coffee and donut institution owned by Restaurant Brands
+  International (the same parent as Burger King and Popeyes), with roughly 4,000 Canadian
+  stores plus a smaller US footprint of about 600 locations. Beyond brewed coffee and Timbits,
+  the menu now spans breakfast sandwiches, soups, and lunch wraps. Tim Hortons purchases code
+  as dining/restaurants on US-issued cards, so cards offering elevated dining rewards (Amex
+  Gold 4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3%) all earn at the full multiplier.

--- a/data/stores/tire-rack.yaml
+++ b/data/stores/tire-rack.yaml
@@ -1,0 +1,17 @@
+name: "Tire Rack"
+slug: "tire-rack"
+categories:
+  - online_shopping
+website: "https://www.tirerack.com"
+intro: |
+  Tire Rack is a direct-to-consumer online tire retailer that ships tires to a nearby
+  installer in its recommended installer network. The company carries an extensive
+  selection of passenger, performance, winter, and truck tires plus wheels and
+  performance brake components. Most credit card networks code Tire Rack as online
+  shopping or auto parts rather than as a dedicated bonus category.
+
+  Cards with online shopping bonuses fit Tire Rack purchases well. Bank of America
+  Customized Cash and U.S. Bank Cash+ can earn 3 to 5 percent when online shopping is
+  selected, and Chase Freedom Flex rotates online shopping in some quarters. Tire
+  Rack also occasionally appears in shopping portals like Rakuten with cash back that
+  stacks on top of credit card rewards.

--- a/data/stores/tommy-hilfiger.yaml
+++ b/data/stores/tommy-hilfiger.yaml
@@ -1,0 +1,13 @@
+name: "Tommy Hilfiger"
+slug: "tommy-hilfiger"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://usa.tommy.com"
+intro: |
+  Tommy Hilfiger is a flagship apparel brand owned by PVH Corp, with about 60 U.S.
+  full-line and outlet stores plus a strong online presence at usa.tommy.com. Direct
+  purchases at Tommy stores or the website typically code as department store or online
+  shopping, while Tommy goods bought at Macy's or Nordstrom code under that retailer.
+  The free Tommy Club loyalty program stacks with credit card rewards, and there is no
+  Tommy Hilfiger branded credit card today.

--- a/data/stores/tops-friendly-markets.yaml
+++ b/data/stores/tops-friendly-markets.yaml
@@ -1,0 +1,14 @@
+name: "Tops Friendly Markets"
+slug: "tops-friendly-markets"
+aliases:
+  - "Tops"
+categories:
+  - groceries
+website: "https://www.topsmarkets.com"
+intro: |
+  Tops Friendly Markets is a Western New York based supermarket chain with about 150
+  stores across upstate New York, northern Pennsylvania, and Vermont. Now part of
+  Northeast Grocery (the same parent that runs Price Chopper), Tops codes as a U.S.
+  supermarket for credit card networks. Standard grocery rewards cards (Amex Gold, Blue
+  Cash Preferred, Citi Custom Cash) will earn full multipliers, and the Tops BonusPlus
+  loyalty card adds per-gallon fuel discounts at partner gas stations.

--- a/data/stores/tractor-supply.yaml
+++ b/data/stores/tractor-supply.yaml
@@ -1,0 +1,19 @@
+name: "Tractor Supply Co"
+slug: "tractor-supply"
+aliases:
+  - "Tractor Supply Company"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.tractorsupply.com"
+intro: |
+  Tractor Supply Co is the largest rural lifestyle retailer in the United States,
+  operating more than 2,200 stores stocked with livestock feed, fencing, riding mowers,
+  workwear, and pet supplies. Card networks sometimes code Tractor Supply as a farm
+  supply merchant rather than a home improvement store, which can keep it out of the
+  Home Depot and Lowe's bonus on cards like the Wells Fargo Bilt.
+
+  The Tractor Supply Neighbor's Club loyalty program is one of the best in retail,
+  layering points-based rewards on top of credit card cash back. Cards with rotating
+  online shopping quarters, including Chase Freedom Flex and Discover it, occasionally
+  bump tractorsupply.com orders to 5 percent for the quarter.

--- a/data/stores/tropical-smoothie-cafe.yaml
+++ b/data/stores/tropical-smoothie-cafe.yaml
@@ -1,0 +1,12 @@
+name: "Tropical Smoothie Cafe"
+slug: "tropical-smoothie-cafe"
+categories:
+  - dining
+website: "https://www.tropicalsmoothiecafe.com"
+intro: |
+  Tropical Smoothie Cafe runs more than 1,400 US locations combining made-to-order smoothies
+  with a wraps, flatbreads, and bowls menu, distinguishing itself from pure smoothie chains
+  with a full lunch offering. Popular smoothies include the Sunrise Sunset, Mango Magic, and
+  Island Green. Tropical Smoothie Cafe transactions code as dining/restaurants on every
+  network, including app and curbside orders through Tropic Rewards. Cards with elevated dining
+  rates (Amex Gold 4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3% cash) earn full bonus.

--- a/data/stores/true-value.yaml
+++ b/data/stores/true-value.yaml
@@ -1,0 +1,18 @@
+name: "True Value"
+slug: "true-value"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.truevalue.com"
+intro: |
+  True Value is a cooperative network of roughly 4,000 independent hardware stores
+  across the United States, offering paint, tools, lawn and garden goods, and
+  neighborhood store service. Because individual stores set their own merchant
+  category codes, True Value purchases may code as home improvement or as general
+  retail depending on the location.
+
+  Cards with broad home improvement bonuses, including the Wells Fargo Bilt and U.S.
+  Bank Cash+ when home improvement is selected, can deliver 4 to 5 percent on True
+  Value runs when the location codes correctly. Online orders placed through
+  truevalue.com for ship-to-store pickup may also trigger online shopping category
+  bonuses on rotating quarter cards.

--- a/data/stores/under-armour.yaml
+++ b/data/stores/under-armour.yaml
@@ -1,0 +1,13 @@
+name: "Under Armour"
+slug: "under-armour"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.underarmour.com"
+intro: |
+  Under Armour is a Baltimore-based athletic apparel and footwear brand sold through
+  about 175 U.S. Brand House and Factory House stores along with a strong online channel
+  at underarmour.com. Direct purchases typically code as department store at the
+  register and online shopping for web orders, while Under Armour gear bought at Dick's
+  or other retailers codes under that store. The free UA Rewards program layers on top
+  of credit card earnings, and there is no Under Armour branded credit card.

--- a/data/stores/urban-outfitters.yaml
+++ b/data/stores/urban-outfitters.yaml
@@ -1,0 +1,15 @@
+name: "Urban Outfitters"
+slug: "urban-outfitters"
+aliases:
+  - "UO"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.urbanoutfitters.com"
+intro: |
+  Urban Outfitters is the flagship banner of URBN, which also operates Anthropologie and
+  Free People, with about 240 stores selling apparel, home, and music gear targeted at
+  20-somethings. The UO Rewards program is free and stacks with credit card multipliers.
+  Most issuers code in-store visits as department store and urbanoutfitters.com orders as
+  online shopping, so a card with a strong online or department store bonus usually wins
+  at checkout.

--- a/data/stores/valero.yaml
+++ b/data/stores/valero.yaml
@@ -1,0 +1,13 @@
+name: "Valero"
+slug: "valero"
+categories:
+  - gas
+website: "https://www.valero.com"
+intro: |
+  Valero is a Texas-based independent refiner with roughly 7,000 branded gas stations
+  across the U.S., Canada, and the UK, concentrated heavily in the South and West. Fuel
+  at Valero pumps codes as gas, so any gas category rewards card will earn its
+  multiplier. Valero runs the Valero Rewards loyalty app with per-gallon discounts and
+  in-store deals, and the chain partners with Hy-Vee Fuel Saver in some markets, so
+  Hy-Vee shoppers can stack grocery loyalty rewards with a gas-category card at Valero
+  pumps.

--- a/data/stores/valvoline-instant-oil-change.yaml
+++ b/data/stores/valvoline-instant-oil-change.yaml
@@ -1,0 +1,19 @@
+name: "Valvoline Instant Oil Change"
+slug: "valvoline-instant-oil-change"
+aliases:
+  - "Valvoline"
+categories:
+  - online_shopping
+website: "https://www.vioc.com"
+intro: |
+  Valvoline Instant Oil Change is a drive-up oil change chain with more than 1,800
+  service centers, known for stay-in-your-car oil changes that typically finish in
+  about 15 minutes. Most card networks code Valvoline Instant Oil Change as auto
+  services, which sits outside dedicated rewards categories on most general consumer
+  credit cards.
+
+  Cards with selectable categories that include auto, including Citi Custom Cash
+  and U.S. Bank Cash+, can route oil changes into a higher bonus rate. Drivers who
+  spend heavily on gas may already carry the Costco Anywhere Visa or Sam's Club
+  Mastercard, both of which pay elevated rates on gasoline but only base earn on
+  service work like oil changes.

--- a/data/stores/vans.yaml
+++ b/data/stores/vans.yaml
@@ -1,0 +1,13 @@
+name: "Vans"
+slug: "vans"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.vans.com"
+intro: |
+  Vans is the skate and lifestyle footwear and apparel brand owned by VF Corporation,
+  with several hundred U.S. stores and a strong DTC site at vans.com. Direct purchases
+  typically code as department store in person and online shopping for web orders,
+  while Vans bought at Foot Locker, Journeys, or Zumiez codes under that retailer. The
+  free Vans Family loyalty program offers points, free shipping, and event perks, but
+  Vans does not run a U.S. branded credit card today.

--- a/data/stores/vons.yaml
+++ b/data/stores/vons.yaml
@@ -1,0 +1,14 @@
+name: "Vons"
+slug: "vons"
+aliases:
+  - "Vons Supermarkets"
+categories:
+  - groceries
+website: "https://www.vons.com"
+intro: |
+  Vons is the Southern California banner of Albertsons Companies, with roughly 200 stores
+  concentrated in the Los Angeles, San Diego, and Las Vegas metros. For credit card
+  purposes Vons codes as a U.S. supermarket, which means standard grocery bonus cards
+  (Amex Gold, Amex Blue Cash Preferred, Citi Custom Cash on a chosen month) will earn
+  their full multiplier. Vons also participates in the Albertsons for U loyalty program,
+  and gift cards sold at the service desk can be a useful angle for category stacking.

--- a/data/stores/waffle-house.yaml
+++ b/data/stores/waffle-house.yaml
@@ -1,0 +1,12 @@
+name: "Waffle House"
+slug: "waffle-house"
+categories:
+  - dining
+website: "https://www.wafflehouse.com"
+intro: |
+  Waffle House runs about 2,000 24-hour diners across 25 states, concentrated heavily in the
+  Southeast, where the famously consistent grill menu spans waffles, hashbrowns scattered/smothered/
+  covered, T-bone steaks, and All-Star Specials. The chain's resilience during natural disasters
+  spawned FEMA's unofficial Waffle House Index. Waffle House transactions code as dining/
+  restaurants on every US credit card. That means cards offering elevated dining multipliers
+  (Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne at 3% cash) earn full rate.

--- a/data/stores/west-elm.yaml
+++ b/data/stores/west-elm.yaml
@@ -1,0 +1,13 @@
+name: "West Elm"
+slug: "west-elm"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.westelm.com"
+intro: |
+  West Elm is the modern furniture and home decor banner of Williams-Sonoma Inc, with
+  about 130 U.S. stores plus westelm.com selling sofas, beds, lighting, rugs, and
+  tabletop. The Key Rewards Visa from Capital One earns elevated points across West Elm,
+  Pottery Barn, and Williams-Sonoma and stacks with the free Key Rewards program. Most
+  general-purpose cards code West Elm as home improvement or department store in person
+  and online shopping for web orders.

--- a/data/stores/whataburger.yaml
+++ b/data/stores/whataburger.yaml
@@ -1,0 +1,18 @@
+name: "Whataburger"
+slug: "whataburger"
+categories:
+  - dining
+website: "https://www.whataburger.com"
+intro: |
+  Whataburger is a Texas-based burger chain founded in Corpus Christi in 1950 with
+  over 1,000 restaurants across Texas, the Southwest, and an expanding Southeast
+  footprint. The orange-and-white striped roofs are the calling card, and the menu
+  centers on made-to-order burgers, breakfast taquitos, and honey butter chicken
+  biscuits. Whataburger transactions code as restaurants on most credit card
+  networks.
+
+  Premium dining cards capture the most value on Whataburger runs. The Amex Gold
+  earns 4x points on U.S. restaurants, while the Chase Sapphire Reserve pays 3x on
+  dining. No-annual-fee picks like the Capital One SavorOne and Wells Fargo Autograph
+  each pay 3 percent or 3x on restaurants. The free Whataburger Rewards program
+  stacks app-based rewards on top of credit card earn.

--- a/data/stores/williams-sonoma.yaml
+++ b/data/stores/williams-sonoma.yaml
@@ -1,0 +1,13 @@
+name: "Williams-Sonoma"
+slug: "williams-sonoma"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.williams-sonoma.com"
+intro: |
+  Williams-Sonoma is the flagship kitchen and cookware banner of Williams-Sonoma Inc,
+  the parent company of Pottery Barn, West Elm, and Rejuvenation. The U.S. footprint
+  covers around 180 stores plus williams-sonoma.com. The Key Rewards Visa from Capital
+  One earns elevated points across all WSI brands and stacks with the free Key Rewards
+  program. General-purpose cards typically code Williams-Sonoma as home improvement or
+  department store in person and online shopping for web orders.

--- a/data/stores/winco-foods.yaml
+++ b/data/stores/winco-foods.yaml
@@ -1,0 +1,13 @@
+name: "WinCo Foods"
+slug: "winco-foods"
+categories:
+  - groceries
+website: "https://www.wincofoods.com"
+intro: |
+  WinCo Foods is an employee-owned, low-price supermarket chain with about 140 stores
+  across the Western and Mountain U.S. The format strips out a lot of typical grocery
+  overhead (no baggers, bulk bins, limited frills) to keep shelf prices low. One major
+  quirk for card users: WinCo historically did not accept credit cards at all, taking
+  only debit, cash, checks, and EBT. That policy still holds in most stores, which makes
+  a grocery rewards card essentially unusable here. Confirm payment policy at your local
+  location before relying on a credit card.

--- a/data/stores/wingstop.yaml
+++ b/data/stores/wingstop.yaml
@@ -1,0 +1,17 @@
+name: "Wingstop"
+slug: "wingstop"
+categories:
+  - dining
+website: "https://www.wingstop.com"
+intro: |
+  Wingstop is a Dallas-based wing-focused quick-service chain with more than 2,400
+  restaurants worldwide. The menu centers on classic and boneless wings in flavors
+  like Lemon Pepper, Louisiana Rub, and Mango Habanero plus signature seasoned
+  fries. Wingstop transactions code as restaurants on Visa, Mastercard, and Amex
+  networks, which makes them eligible for dining bonus categories.
+
+  The Amex Gold pays 4x on U.S. restaurants and is the highest standing earner for
+  frequent Wingstop ordering, while the Chase Sapphire Reserve pays 3x and includes
+  travel protection if redeemed through Chase. The Capital One SavorOne offers 3
+  percent dining with no annual fee. Wingstop also runs the MyWingstop loyalty
+  program with points that stack with credit card rewards on app and online orders.

--- a/data/stores/winn-dixie.yaml
+++ b/data/stores/winn-dixie.yaml
@@ -1,0 +1,12 @@
+name: "Winn-Dixie"
+slug: "winn-dixie"
+categories:
+  - groceries
+website: "https://www.winndixie.com"
+intro: |
+  Winn-Dixie is a Southeast U.S. supermarket chain with about 400 stores across Florida,
+  Alabama, Georgia, Louisiana, and Mississippi. Now owned by Aldi after years under
+  Southeastern Grocers, Winn-Dixie still codes as a standard U.S. supermarket for credit
+  card networks, so grocery bonus cards (Amex Gold, Amex Blue Cash Preferred, Citi Custom
+  Cash on a chosen month) earn full multipliers. The chain runs its own rewards loyalty
+  program with fuelperks at partner gas stations in some markets.

--- a/data/stores/world-market.yaml
+++ b/data/stores/world-market.yaml
@@ -1,0 +1,19 @@
+name: "World Market"
+slug: "world-market"
+aliases:
+  - "Cost Plus World Market"
+categories:
+  - home_improvement
+  - online_shopping
+website: "https://www.worldmarket.com"
+intro: |
+  World Market, formerly Cost Plus World Market, sells globally sourced furniture, rugs,
+  international foods, and wine across roughly 240 U.S. stores. Most credit cards code
+  these purchases as general retail or department store spending rather than a dedicated
+  home category, so shoppers usually fall back on flat-rate cards like the Citi Double
+  Cash or Wells Fargo Active Cash.
+
+  Cards that treat online shopping as a rotating or selectable category, including Chase
+  Freedom Flex and U.S. Bank Cash+, can pay better when ordering rugs or furniture from
+  worldmarket.com. The store also runs a free loyalty program with member coupons that
+  stack with credit card rewards on alcohol and seasonal decor runs.

--- a/data/stores/zales.yaml
+++ b/data/stores/zales.yaml
@@ -1,0 +1,13 @@
+name: "Zales"
+slug: "zales"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.zales.com"
+intro: |
+  Zales is a mid-tier diamond and fashion jewelry banner within Signet Jewelers, with
+  about 575 U.S. stores plus zales.com. The Zales Diamond credit card from Comenity
+  offers promotional financing tiers on larger ticket purchases, and the free Vault
+  Rewards loyalty program is shared across Signet banners including Kay and Jared.
+  General-purpose cards typically code Zales as department store in person and online
+  shopping for web orders.

--- a/data/stores/zara.yaml
+++ b/data/stores/zara.yaml
@@ -1,0 +1,12 @@
+name: "Zara"
+slug: "zara"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.zara.com"
+intro: |
+  Zara is the flagship fast fashion banner of Spanish parent Inditex, with roughly 100
+  U.S. stores in major markets plus a robust online business at zara.com. Most card
+  issuers code in-store purchases as department store and online orders as online
+  shopping. Zara does not run a branded credit card in the U.S., so a flat-rate online
+  bonus or a rotating department store category is usually the best earn at checkout.

--- a/data/stores/zaxbys.yaml
+++ b/data/stores/zaxbys.yaml
@@ -1,0 +1,17 @@
+name: "Zaxby's"
+slug: "zaxbys"
+categories:
+  - dining
+website: "https://www.zaxbys.com"
+intro: |
+  Zaxby's is a Georgia-based chicken-finger and wing quick-service chain with over
+  900 restaurants concentrated in the Southeast. The menu features Chicken Finger
+  Plates, Boneless and Traditional Wings, Zalads, and a lineup of signature sauces
+  like Zax Sauce and Tongue Torch. Zaxby's transactions code as restaurants on Visa,
+  Mastercard, and Amex networks.
+
+  The Amex Gold earns 4x points on U.S. restaurants and tops the cards for Zaxby's
+  spending, while the Chase Sapphire Reserve pays 3x on dining and adds purchase
+  protection. The Capital One SavorOne and Wells Fargo Autograph each pay 3 percent
+  or 3x on restaurants with no annual fee. The Zax Rewardz app program adds visit
+  points that stack with credit card cash back on every Big Zax Snak run.


### PR DESCRIPTION
## Summary
- Adds 200 high-search-volume merchants under `data/stores/`, taking total coverage from 158 to 358 `/best-card-for/[slug]` pages.
- Categories used (existing IDs only): groceries, gas, drugstores, wholesale_clubs, department_stores, online_shopping, home_improvement, office_supplies, dining, airlines, hotels, travel.
- Each YAML carries a 200+ char distinctive intro (no em dashes per house style).
- Regenerated `data/stores.json` and the Lambda mirror at `apps/api/src/lib/ranker/stores.json`.

## Coverage by group
| Group | Count | Examples |
| --- | --- | --- |
| Grocery (regional) | 16 | Vons, Ralphs, Hy-Vee, Lidl, H Mart, Price Chopper |
| Gas / C-Store | 12 | Casey's, Buc-ee's, Pilot Flying J, Phillips 66, Murphy USA |
| Drugstore | 2 | Duane Reade, Bartell Drugs |
| Off-Price / Discount / Dept | 8 | Big Lots, Five Below, Dillard's, Belk, Nordstrom Rack |
| Online / Marketplace | 12 | Temu, Shein, AliExpress, Newegg, StockX, QVC |
| Apparel | 25 | Banana Republic, Athleta, Forever 21, Carhartt, Patagonia |
| Footwear | 8 | DSW, Foot Locker, Vans, New Balance, Crocs |
| Beauty | 5 | MAC, Bluemercury, Sally Beauty, The Body Shop, Lush |
| Jewelry / Accessories | 6 | Kay Jewelers, Zales, Pandora, Coach, Michael Kors |
| Furniture / Home | 15 | Williams-Sonoma, West Elm, RH, Ashley, Mattress Firm |
| Hardware / Home Improvement | 8 | Tractor Supply, Harbor Freight, Floor & Decor, Sherwin-Williams |
| Electronics | 5 | Micro Center, B&H Photo, Adorama, Microsoft Store |
| Auto Parts / Services | 10 | NAPA, CarMax, Carvana, Discount Tire, Jiffy Lube |
| Pet | 3 | Pet Supplies Plus, BarkBox, Pet Supermarket |
| Books / Office Services | 5 | Barnes & Noble, Books-A-Million, UPS Store, FedEx Office |
| QSR | 23 | Raising Cane's, Whataburger, In-N-Out, Wingstop, Jersey Mike's |
| Coffee / Bakery / Frozen | 16 | Dutch Bros, Tim Hortons, Krispy Kreme, DQ, Cold Stone |
| Casual Dining | 12 | IHOP, Denny's, Cracker Barrel, LongHorn, Ruth's Chris |
| Meal Kits / Delivery | 5 | Grubhub, HelloFresh, Blue Apron, Home Chef, Thrive Market |
| Airlines | 6 | Allegiant, Sun Country, Breeze, Air Canada, BA, AF/KLM |
| Hotels | 6 | Radisson, Drury, Extended Stay America, Motel 6, Omni, Accor |

## Notes
- No `co_brand_cards` or `also_earns` entries (those need card-slug validation; can be added in follow-up PRs once we map issuer programs to existing card slugs).
- A small set of pre-existing store YAMLs already contain em dashes; no new files do.

## Test plan
- [x] `node scripts/build-stores.js` builds 358 stores with zero validation errors.
- [x] Spot-checked `/best-card-for/{temu,raising-canes,buc-ees,kay-jewelers,air-france-klm,whataburger}` locally — all return 200 and rank up to 20 cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)