### PR TITLE
best-card-for: ItemList JSON-LD, dateModified, related stores

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { getAllStores, getStore } from "@/lib/stores";
+import { getAllStores, getStore, getStoresGeneratedAt } from "@/lib/stores";
 import { getAllCards } from "@/lib/api";
 import { rankCards, formatRate, labelForCategory } from "@/lib/storeRanking";
-import { BreadcrumbSchema, FAQSchema } from "@/components/seo/JsonLd";
+import { BreadcrumbSchema, FAQSchema, CollectionPageSchema } from "@/components/seo/JsonLd";
 import CardImage from "@/components/ui/CardImage";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import { PencilSquareIcon, ExclamationTriangleIcon, CalendarDaysIcon } from "@heroicons/react/24/outline";
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const store = await getStore(slug);
   if (!store) return {};
   const title = `Best Credit Card to Use at ${store.name}`;
-  const description = `The best credit cards for ${store.name} purchases — co-branded options, category bonuses, and flat-rate cashback picks compared.`;
+  const description = `Find the best credit card for ${store.name}. Compare co-branded cards, category bonuses, and flat-rate cashback to see which earns the highest rate at checkout at ${store.name}.`;
   const url = `https://creditodds.com/best-card-for/${store.slug}`;
   return {
     title,
@@ -60,20 +60,43 @@ function tagLabelForCategory(id: string): string {
 
 export default async function BestCardForStorePage({ params }: PageProps) {
   const { slug } = await params;
-  const [store, allCards] = await Promise.all([getStore(slug), getAllCards()]);
+  const [store, allCards, allStores, generatedAt] = await Promise.all([
+    getStore(slug),
+    getAllCards(),
+    getAllStores(),
+    getStoresGeneratedAt(),
+  ]);
   if (!store) notFound();
 
   const picks = rankCards(store, allCards);
   const usingFallback = picks.length > 0 && picks.every(p => p.source === 'flat_rate');
+  const pageUrl = `https://creditodds.com/best-card-for/${store.slug}`;
+
+  const relatedStores = allStores
+    .filter(s => s.slug !== store.slug)
+    .filter(s => s.categories.some(c => store.categories.includes(c)))
+    .slice(0, 8);
 
   return (
     <div className="landing-v2 store-v2">
       <BreadcrumbSchema
         items={[
           { name: 'Home', url: 'https://creditodds.com' },
-          { name: `Best Credit Card for ${store.name}`, url: `https://creditodds.com/best-card-for/${store.slug}` },
+          { name: `Best Credit Card for ${store.name}`, url: pageUrl },
         ]}
       />
+      {picks.length > 0 && (
+        <CollectionPageSchema
+          url={pageUrl}
+          name={`Best Credit Cards for ${store.name}`}
+          description={`Ranked credit card picks for purchases at ${store.name}, including co-branded cards, category bonuses, and flat-rate cashback.`}
+          dateModified={generatedAt}
+          items={picks.map(p => ({
+            name: p.card.card_name,
+            url: `https://creditodds.com/card/${p.card.slug}`,
+          }))}
+        />
+      )}
       {store.faq && store.faq.length > 0 && (
         <FAQSchema questions={store.faq.map(f => ({ question: f.q, answer: f.a }))} />
       )}
@@ -236,6 +259,30 @@ export default async function BestCardForStorePage({ params }: PageProps) {
             </div>
           </section>
         )}
+
+        {relatedStores.length > 0 && (
+          <section className="store-related">
+            <h2 className="store-related-title">Related stores</h2>
+            <ul className="store-related-list">
+              {relatedStores.map(s => (
+                <li key={s.slug} className="store-related-item">
+                  <Link href={`/best-card-for/${s.slug}`} className="store-related-link">
+                    Best credit card for {s.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <p className="store-updated">
+          Last updated{' '}
+          {new Date(generatedAt).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}
+        </p>
 
         <div className="store-meta">
           <a

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -8338,11 +8338,50 @@
   color: var(--ink-2);
   line-height: 1.6;
 }
+.landing-v2.store-v2 .store-related {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+}
+.landing-v2.store-v2 .store-related-title {
+  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin-bottom: 16px;
+}
+.landing-v2.store-v2 .store-related-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 24px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+@media (max-width: 640px) {
+  .landing-v2.store-v2 .store-related-list {
+    grid-template-columns: 1fr;
+  }
+}
+.landing-v2.store-v2 .store-related-link {
+  font-size: 15px;
+  color: var(--accent);
+  text-decoration: none;
+}
+.landing-v2.store-v2 .store-related-link:hover {
+  text-decoration: underline;
+}
+.landing-v2.store-v2 .store-updated {
+  margin-top: 32px;
+  font-size: 13px;
+  color: var(--muted);
+}
 .landing-v2.store-v2 .store-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 18px;
-  margin-top: 48px;
+  margin-top: 24px;
   padding-top: 20px;
   border-top: 1px solid var(--line);
 }

--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -176,6 +176,52 @@ export function BreadcrumbSchema({ items }: BreadcrumbSchemaProps) {
   );
 }
 
+interface CollectionPageSchemaProps {
+  url: string;
+  name: string;
+  description?: string;
+  dateModified?: string;
+  datePublished?: string;
+  items: { name: string; url: string }[];
+}
+
+export function CollectionPageSchema({
+  url,
+  name,
+  description,
+  dateModified,
+  datePublished,
+  items,
+}: CollectionPageSchemaProps) {
+  const schema: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    url,
+    name,
+    ...(description ? { description } : {}),
+    ...(datePublished ? { datePublished } : {}),
+    ...(dateModified ? { dateModified } : {}),
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListOrder: 'https://schema.org/ItemListOrderDescending',
+      numberOfItems: items.length,
+      itemListElement: items.map((item, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: item.name,
+        url: item.url,
+      })),
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
 interface FAQSchemaProps {
   questions: { question: string; answer: string }[];
 }

--- a/apps/web-next/src/lib/stores.ts
+++ b/apps/web-next/src/lib/stores.ts
@@ -34,22 +34,26 @@ interface StoresFile {
   stores: Store[];
 }
 
-let cached: Store[] | null = null;
+let cached: { stores: Store[]; generatedAt: string } | null = null;
 
-async function loadStores(): Promise<Store[]> {
+async function loadStores(): Promise<{ stores: Store[]; generatedAt: string }> {
   if (cached) return cached;
   const filePath = path.join(process.cwd(), '..', '..', 'data', 'stores.json');
   const fileContent = await fs.readFile(filePath, 'utf8');
   const data: StoresFile = JSON.parse(fileContent);
-  cached = data.stores || [];
+  cached = { stores: data.stores || [], generatedAt: data.generated_at };
   return cached;
 }
 
 export async function getAllStores(): Promise<Store[]> {
-  return loadStores();
+  return (await loadStores()).stores;
+}
+
+export async function getStoresGeneratedAt(): Promise<string> {
+  return (await loadStores()).generatedAt;
 }
 
 export async function getStore(slug: string): Promise<Store | null> {
-  const stores = await loadStores();
+  const { stores } = await loadStores();
   return stores.find(s => s.slug === slug) || null;
 }


### PR DESCRIPTION
## Summary
- Adds `CollectionPageSchema` (CollectionPage + nested ItemList) to `/best-card-for/[slug]` so Google can formally pick up the ranked cards for "Best X" rich results instead of half-parsing the `<ol>`.
- Wires `dateModified` from `stores.json#generated_at` for freshness signaling, plus a visible "Last updated [date]" line above the footer.
- Adds a "Related stores" section at the bottom auto-derived from shared categories (e.g. Albertsons → Aldi, Kroger, H-E-B, ...) for internal linking + crawl depth.
- Rewrites the meta description to be action-oriented and removes the em dash (per project rule).

## Test plan
- [x] Verified live at `/best-card-for/albertsons`: JSON-LD types now include `CollectionPage` with 10 ranked `ListItem`s and a populated `dateModified`.
- [x] Verified the "Related stores" section renders 8 grocery-category siblings with real internal links.
- [x] Verified the "Last updated May 7, 2026" line renders.
- [x] Confirmed meta description has no em dash and references the store name.
- [ ] After deploy: validate the page in Google Rich Results Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)