### PR TITLE
cards: normalize "U.S. Bank" to "US Bank" for searchability

### DIFF
--- a/apps/api/migrations/036a_rename_us_bank_altitude_go.sql
+++ b/apps/api/migrations/036a_rename_us_bank_altitude_go.sql
@@ -1,0 +1,2 @@
+-- Searchability fix: "U.S. Bank" -> "US Bank" (Altitude Go)
+UPDATE cards SET card_name = 'US Bank Altitude Go Visa Signature' WHERE card_name = 'U.S. Bank Altitude Go Visa Signature';

--- a/apps/api/migrations/036b_rename_us_bank_altitude_reserve.sql
+++ b/apps/api/migrations/036b_rename_us_bank_altitude_reserve.sql
@@ -1,0 +1,2 @@
+-- Searchability fix: "U.S. Bank" -> "US Bank" (Altitude Reserve)
+UPDATE cards SET card_name = 'US Bank Altitude Reserve Visa Infinite' WHERE card_name = 'U.S. Bank Altitude Reserve Visa Infinite';

--- a/apps/api/migrations/036c_rename_us_bank_cash_plus.sql
+++ b/apps/api/migrations/036c_rename_us_bank_cash_plus.sql
@@ -1,0 +1,2 @@
+-- Searchability fix: "U.S. Bank" -> "US Bank" (Cash+)
+UPDATE cards SET card_name = 'US Bank Cash+ Visa Signature' WHERE card_name = 'U.S. Bank Cash+ Visa Signature';

--- a/data/cards/us-bank-altitude-go-visa-signature.yaml
+++ b/data/cards/us-bank-altitude-go-visa-signature.yaml
@@ -1,4 +1,4 @@
-name: "U.S. Bank Altitude Go Visa Signature"
+name: "US Bank Altitude Go Visa Signature"
 bank: "U.S. Bank"
 slug: "us-bank-altitude-go-visa-signature"
 accepting_applications: true

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -1,4 +1,4 @@
-name: "U.S. Bank Altitude Reserve Visa Infinite"
+name: "US Bank Altitude Reserve Visa Infinite"
 bank: "U.S. Bank"
 slug: "us-bank-altitude-reserve-visa-infinite"
 accepting_applications: false

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -1,4 +1,4 @@
-name: "U.S. Bank Cash+ Visa Signature"
+name: "US Bank Cash+ Visa Signature"
 bank: "U.S. Bank"
 slug: "us-bank-cash-plus-visa-signature"
 accepting_applications: true


### PR DESCRIPTION
## Summary
- Renames 3 cards (Altitude Go, Altitude Reserve, Cash+) from "U.S. Bank ..." to "US Bank ..." so they match the spelling used on the other 6 US Bank cards and are easier to search.
- Adds migrations 036a/036b/036c to update `cards.card_name` in MySQL — must run before the next cards sync since `update-cards-github.js` joins YAML to DB by `card_name`.

## Test plan
- [ ] Run migrations 036a/b/c before merging cards data to main
- [ ] Verify search finds each renamed card by typing "US Bank"
- [ ] Verify card detail pages still resolve at their unchanged slugs