### PR TITLE
best-card-for: SEO title to short form 'Best Credit Card for X'

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/opengraph-image.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/opengraph-image.tsx
@@ -47,8 +47,8 @@ export default async function StoreOGImage({ params }: Props) {
   // Defensive fallback so 404s during build don't blow up OG generation.
   const name =
     store?.name ?? slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-  const title = `Best card to use at ${name}`;
-  const description = `Top picks for earning rewards at ${name} — co-brands, category bonuses, and flat-rate fallbacks compared.`;
+  const title = `Best credit card for ${name}`;
+  const description = `Top picks for earning rewards at ${name}: co-brands, category bonuses, and flat-rate fallbacks compared.`;
   const tags = (store?.categories ?? []).map(tagLabelForCategory);
 
   // Auto-shrink title for long store names so it stays on one or two lines.

--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -24,8 +24,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { slug } = await params;
   const store = await getStore(slug);
   if (!store) return {};
-  const title = `Best Credit Card to Use at ${store.name}`;
-  const description = `Find the best credit card for ${store.name}. Compare co-branded cards, category bonuses, and flat-rate cashback to see which earns the highest rate at checkout at ${store.name}.`;
+  const title = `Best Credit Card for ${store.name}`;
+  const description = `The best credit card to use at ${store.name}. Compare co-branded cards, category bonuses, and flat-rate cashback to see which earns the highest rate at checkout at ${store.name}.`;
   const url = `https://creditodds.com/best-card-for/${store.slug}`;
   return {
     title,


### PR DESCRIPTION
## Summary
- Mobile users overwhelmingly type the shorter "best credit card for X" form, which also matches our URL slug `/best-card-for/[slug]`. Aligning the SEO title with that query should lift CTR on the higher-volume variant.
- New title: `Best Credit Card for {Store}` (was `Best Credit Card to Use at {Store}`).
- Meta description leads with `The best credit card to use at {Store}.` so the longer-form phrasing still has an exact-match somewhere in the page for the queries that do type the longer form.
- OG image title aligned to `Best credit card for {name}`. OG description em dash dropped (house rule: no em dashes in user-facing copy).
- H1 (`Best credit card to use at {Store}`) is unchanged — reads better editorially.

## Why this captures both queries
| Query intent | Field that matches | Match type |
| --- | --- | --- |
| "best credit card for amazon" | `<title>` + URL slug | exact |
| "best credit card to use at amazon" | meta description + H1 | exact |
| "best card for amazon" | `<title>` (substring) + URL slug | partial |

## Test plan
- [x] Built locally; `/best-card-for/amazon` now serves `<title>Best Credit Card for Amazon | CreditOdds</title>` and description `The best credit card to use at Amazon. Compare co-branded cards…`.
- [x] OG title visible on share-preview card now reads "Best credit card for Amazon" (matches metadata title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)