### PR TITLE
landing: hide inactive cards from search dropdown

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -179,6 +179,7 @@ function Hero({ cards }: { cards: LandingCard[] }) {
     const q = query.trim();
     if (!q) return [];
     return cards
+      .filter((c) => c.accepting_applications)
       .filter((c) => cardMatchesSearch(c.card_name, c.bank, q))
       .map((c) => ({ c, s: searchRelevance(c, q) }))
       .sort((a, b) => b.s - a.s || a.c.card_name.localeCompare(b.c.card_name))

--- a/apps/web-next/src/components/ui/CardSelect.tsx
+++ b/apps/web-next/src/components/ui/CardSelect.tsx
@@ -76,17 +76,13 @@ export default function CardSelect({ allCards }: CardSelectProps) {
         selectedItem,
         getRootProps,
       }) => {
-        // Filter cards based on input (with alias support), then sort with archived cards at the bottom
+        // Filter to active cards only, match against input (with alias support), sort business lower
         const filteredCards = allCards
+          .filter((item) => item.accepting_applications)
           .filter(
             (item) => cardMatchesSearch(item.card_name, item.bank, inputValue || '')
           )
           .sort((a, b) => {
-            // Active cards first, archived cards last
-            if (a.accepting_applications !== b.accepting_applications) {
-              return a.accepting_applications ? -1 : 1;
-            }
-            // Business cards lower in results
             const aIsBusiness = /business/i.test(a.card_name);
             const bIsBusiness = /business/i.test(b.card_name);
             if (aIsBusiness !== bIsBusiness) {
@@ -95,9 +91,10 @@ export default function CardSelect({ allCards }: CardSelectProps) {
             return 0;
           });
 
-        // Show recent searches when input is empty, otherwise show filtered results
-        const showRecent = isOpen && !inputValue && recentSearches.length > 0;
-        const displayCards = showRecent ? recentSearches : filteredCards;
+        // Show recent searches when input is empty, otherwise show filtered results (active only)
+        const activeRecentSearches = recentSearches.filter((c) => c.accepting_applications);
+        const showRecent = isOpen && !inputValue && activeRecentSearches.length > 0;
+        const displayCards = showRecent ? activeRecentSearches : filteredCards;
 
         return (
           <div className="mt-1 relative">


### PR DESCRIPTION
## Summary
- Landing page search (`Hero` in `LandingClient.tsx`) now filters out archived cards (`accepting_applications: false`) before scoring/sorting
- Same filter added to the unused `CardSelect` component for consistency

## Test plan
- [x] Verified locally: searching "Bilt" no longer surfaces the archived "Bilt Mastercard"; only active Bilt cards appear
- [x] Searching "Amex Everyday" (archived) no longer matches that card

🤖 Generated with [Claude Code](https://claude.com/claude-code)