### PR TITLE
card-page: shimmer referral button + YAML referral_bonus chip

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -590,9 +590,16 @@ export default function CardClient({
               target="_blank"
               rel="noopener noreferrer"
               onClick={handleReferralClick}
-              className="cj-apply-btn-outline"
+              className="cj-apply-btn-outline cj-apply-btn-referral"
             >
-              Apply with referral
+              <span className="cj-apply-btn-referral-label">
+                Apply with referral
+              </span>
+              {card.referral_bonus && (
+                <span className="cj-apply-btn-referral-bonus">
+                  {card.referral_bonus}
+                </span>
+              )}
             </a>
           )}
           {!card.apply_link && !randomReferralUrl && (

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7639,6 +7639,48 @@
   box-sizing: border-box;
 }
 .landing-v2 .cj-apply-btn-outline:hover { border-color: #fff; }
+.landing-v2 .cj-apply-btn-referral {
+  position: relative;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.landing-v2 .cj-apply-btn-referral::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    110deg,
+    transparent 0%,
+    transparent 35%,
+    rgba(255, 255, 255, 0.18) 50%,
+    transparent 65%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: cj-apply-shimmer 3.2s ease-in-out infinite;
+  pointer-events: none;
+}
+.landing-v2 .cj-apply-btn-referral-bonus {
+  position: relative;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--accent);
+  color: #fff;
+}
+@keyframes cj-apply-shimmer {
+  0% { transform: translateX(-100%); }
+  60%, 100% { transform: translateX(100%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .landing-v2 .cj-apply-btn-referral::before { animation: none; }
+}
 .landing-v2 .cj-apply-closed {
   padding: 12px;
   border: 1px dashed var(--muted);

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -141,6 +141,7 @@ export interface Card {
   foreign_transaction_fee?: boolean;
   apply_link?: string;
   card_referral_link?: string;
+  referral_bonus?: string;
   referrals?: CardReferral[];
   reward_type?: 'cashback' | 'points' | 'miles';
   rewards?: Reward[];
@@ -218,6 +219,7 @@ const DB_ONLY_CARD_FIELDS = [
   'approved_median_credit_score',
   'approved_median_income',
   'approved_median_length_credit',
+  'referrals',
 ] as const satisfies readonly (keyof Card)[];
 
 export async function getCard(cardName: string): Promise<Card> {

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -5,6 +5,7 @@ image: "discover_it_cash.png"
 accepting_applications: true
 annual_fee: 0
 card_referral_link: "https://refer.discover.com/"
+referral_bonus: "+$100"
 tags:
   - cashback
 reward_type: "cashback"

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -88,6 +88,10 @@
       "format": "uri",
       "description": "Base URL for referral links - user codes are appended to this (optional)"
     },
+    "referral_bonus": {
+      "type": "string",
+      "description": "Short bonus label shown on the 'Apply with referral' button, e.g. '+$100' (optional)"
+    },
     "reward_type": {
       "type": "string",
       "enum": ["cashback", "points", "miles"],


### PR DESCRIPTION
## Summary
- Adds optional `referral_bonus` string to the card YAML schema (e.g. `"+$100"` on Discover it) so cards that offer a referral incentive can advertise it on the apply button.
- "Apply with referral" button now renders the bonus as an accent-colored chip next to the label and gains a subtle ~3.2s shimmer sweep to draw the eye. Respects `prefers-reduced-motion`.
- Includes `referrals` in the dev API overlay so the button state matches production on local /card/[slug].

## Test plan
- [x] Visual check on `/card/discover-it-cash-back` — button renders with "+$100" chip and shimmer animation.
- [x] `referral_bonus` flows YAML → cards.json → CDN card spread (no API handler changes needed).
- [ ] After merge, `build-cards.yml` regenerates `data/cards.json` with the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)