### PR TITLE
docs: refresh README, CONTRIBUTING, and adding-cards guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ For code changes:
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/your-feature`
 3. Make your changes
-4. Run tests: `npm run test:web`
+4. Run tests for the workspace you touched (`cd apps/web-next && npm test`, or `npm run test:api`)
 5. Submit a Pull Request
 
 ## Development Setup
@@ -50,7 +50,7 @@ cd creditodds
 npm install
 
 # Run the web app
-npm run start:web
+npm run start:web-next
 
 # Build card data
 npm run build:cards
@@ -61,9 +61,12 @@ npm run build:cards
 ```
 creditodds/
 ├── apps/
-│   ├── api/          # Lambda API
-│   ├── shared/       # Shared code
+│   ├── api/          # AWS Lambda API
+│   ├── functions/    # Firebase Cloud Functions
+│   ├── ios/          # Native iOS app (SwiftUI)
 │   └── web-next/     # Next.js frontend
+├── packages/
+│   └── shared/       # Shared code
 ├── data/
 │   └── cards/        # Card YAML files
 │       └── images/   # Card images
@@ -106,10 +109,12 @@ User-submitted credit card application results.
 | `credit_score` | INT | 300–850 |
 | `credit_score_source` | INT | 0=Equifax, 1=Experian, 2=TransUnion, 3=other, 4=unknown |
 | `result` | BOOLEAN | 1=approved, 0=denied |
-| `listed_income` | INT | Annual income |
+| `listed_income` | INT (nullable) | Annual income |
 | `length_credit` | INT | Years of credit history |
 | `starting_credit_limit` | INT | Credit limit if approved |
-| `reason_denied` | VARCHAR | Denial reason if denied |
+| `total_open_cards` | SMALLINT UNSIGNED (nullable) | Number of open credit cards |
+| `reason_denied` | VARCHAR | Free-text denial reason if denied |
+| `reason_denied_code` | VARCHAR(40) | Standardized denial reason code |
 | `date_applied` | DATE | When the user applied |
 | `bank_customer` | BOOLEAN | Existing bank relationship |
 | `inquiries_3` | INT | Hard inquiries in last 3 months |
@@ -133,6 +138,10 @@ User-submitted referral links.
 | `submitter_ip_address` | VARCHAR | IP address |
 | `submit_datetime` | TIMESTAMP | Submission timestamp |
 | `admin_approved` | BOOLEAN | 0=pending, 1=approved |
+| `archived_at` | TIMESTAMP (nullable) | Set when the link is archived; stats are preserved |
+| `archived_reason` | VARCHAR(255) | Why the referral was archived |
+
+> **Note:** Referral links are archived, never hard-deleted, so submitted URLs are preserved permanently.
 
 #### `referral_stats`
 
@@ -145,11 +154,13 @@ Tracks impressions and clicks on referral links.
 | `event_type` | ENUM | `'impression'` or `'click'` |
 | `ip_address` | VARCHAR | Visitor IP |
 | `user_agent` | VARCHAR | Browser user agent |
+| `user_id` | VARCHAR(128) (nullable) | Firebase UID of the visitor, if signed in |
+| `ip_hash` | CHAR(64) (nullable) | Hashed visitor IP, used for deduplication |
 | `created_at` | TIMESTAMP | Event timestamp |
 
 #### `user_cards`
 
-User wallet — tracks which cards a user owns.
+User wallet. Tracks which cards a user owns.
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -158,6 +169,7 @@ User wallet — tracks which cards a user owns.
 | `card_id` | INT (FK) | References `cards.card_id` |
 | `acquired_month` | TINYINT | 1–12 (optional) |
 | `acquired_year` | SMALLINT | e.g., 2024 (optional) |
+| `sort_order` | INT (nullable) | Manual wallet ordering position |
 | `created_at` | TIMESTAMP | When the entry was added |
 
 #### `audit_log`
@@ -173,6 +185,24 @@ Tracks admin actions for accountability.
 | `entity_id` | INT | ID of affected row |
 | `details` | JSON | Additional context |
 | `created_at` | TIMESTAMP | Action timestamp |
+
+### Supporting Tables
+
+The schema also includes tables for analytics, ratings, and newer features:
+
+| Table | Purpose |
+|-------|---------|
+| `card_stats` | Precomputed per-card totals and median stats (refreshed on a schedule) |
+| `card_ratings` | User-submitted 1–5 star card ratings |
+| `card_wire` | Card change events (annual fee, bonus, reward, APR) for the Card Wire feed |
+| `card_view_counts` | Per-card page-view tallies |
+| `card_apply_clicks` / `card_apply_click_counts` | Apply-link click events and tallies |
+| `card_compare_pair_counts` | How often two cards are compared together |
+| `approval_searches` | Check-odds search queries |
+| `best_card_here_reports` | User reports on store-page card recommendations |
+| `user_settings` | Per-user preferences (avatar seed, beta flags, etc.) |
+| `user_card_selections` | Selected categories (Cash+, Custom Cash, etc.) per wallet card |
+| `user_plaid_items` / `user_plaid_accounts` | Plaid bank connections and linked accounts |
 
 ### Data Flow
 
@@ -190,49 +220,67 @@ All endpoints are served via AWS API Gateway + Lambda. Base path: `/Prod`.
 
 ### Authentication
 
-Most endpoints require a Firebase auth token in the `Authorization: Bearer {token}` header. Admin endpoints additionally check for an `admin: 'true'` custom claim.
+Authenticated endpoints require a Firebase auth token in the `Authorization: Bearer {token}` header. Admin endpoints additionally check for an `admin: 'true'` custom claim.
 
 ### Public Endpoints
 
-#### `GET /cards` — List All Cards
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/cards` | List all cards with approval stats (explore + landing search) |
+| `GET` | `/card?card_name={name}` | Card detail with median stats and referral links |
+| `GET` | `/card-records?card_id={id}` | Approved records for a single card |
+| `GET` | `/graphs?card_id={id}` | Chart data for approval-odds visualization |
+| `GET` | `/card-wire` | Feed of recent card term changes |
+| `GET` | `/ratings?card_id={id}` | Aggregate star rating for a card |
+| `GET` | `/leaderboard?limit={n}` | Top contributors by submission count (default 25, max 100) |
+| `GET` | `/recent-records` | Most recent approved records for the homepage ticker |
+| `GET` `POST` | `/check-odds` | Estimate approval odds for a card |
+| `POST` | `/referral-stats` | Log a referral impression or click |
+| `GET` `POST` | `/card-view` | Read or increment a card's view count |
+| `GET` `POST` | `/card-apply-click` | Read or log an apply-link click |
+| `GET` `POST` | `/card-compare-event` | Read or log a card-comparison event |
+| `POST` | `/best-card-here-report` | Report an incorrect store-page recommendation |
+| `POST` | `/wallet-picks/store` | Best card from a wallet for a given store |
+| `POST` | `/wallet-picks/nearby` | Best wallet cards for nearby places |
 
-Returns all cards with approval stats. Used by the explore page and landing page search.
+#### `GET /cards`
 
-**Response:** Array of card objects with `card_id` (slug), `db_card_id` (numeric), `name`, `bank`, `image`, `total_records`, `approved_count`, `rejected_count`, `tags`, etc.
+Returns all cards with approval stats. **Response:** Array of card objects with `card_id` (slug), `db_card_id` (numeric), `name`, `bank`, `image`, `total_records`, `approved_count`, `rejected_count`, `tags`, etc.
 
-#### `GET /card?card_name={name}` — Card Details
+#### `GET /card?card_name={name}`
 
-Detailed card info with median stats and referral links. Supports exact name match, slug match, or fuzzy "Card" suffix fallback.
-
-**Response:** Card object with `card_id` (numeric), approval/denial counts, `approved_median_credit_score`, `approved_median_income`, `approved_median_length_credit`, `referrals` array, etc.
-
-#### `GET /graphs?card_id={id}` — Card Graph Data
-
-Chart data for approval odds visualization (credit score distributions).
-
-#### `GET /leaderboard?limit={n}` — Top Contributors
-
-Leaderboard of top data contributors by submission count. Default limit: 25, max: 100.
-
-**Response:** `{ leaderboard: [...], stats: { total_records, total_contributors, ... } }`
-
-#### `GET /recent-records` — Recent Submissions
-
-Most recent approved records for the homepage ticker.
-
-#### `POST /referral-stats` — Track Referral Event
-
-Logs an impression or click on a referral link.
-
-**Body:** `{ "referral_id": 1, "event_type": "impression" | "click" }`
+Detailed card info with median stats and referral links. Supports exact name match, slug match, or fuzzy "Card" suffix fallback. **Response:** Card object with `card_id` (numeric), approval/denial counts, `approved_median_credit_score`, `approved_median_income`, `approved_median_length_credit`, `referrals` array, etc.
 
 ### Authenticated Endpoints
 
-#### `GET /records` — User's Records
+Require a valid Firebase auth token.
 
-Returns the authenticated user's submitted application records.
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/records` | The user's submitted application records |
+| `POST` | `/records` | Submit a credit card application result |
+| `PATCH` | `/records` | Edit one of the user's records |
+| `DELETE` | `/records?record_id={id}` | Soft-delete the user's own record |
+| `GET` | `/referrals` | The user's referral links with impression/click stats |
+| `POST` | `/referrals` | Submit a referral link (one per card per user) |
+| `PATCH` | `/referrals` | Edit the user's referral link |
+| `DELETE` | `/referrals?referral_id={id}` | Remove the user's referral link |
+| `GET` | `/wallet` | Cards in the user's wallet |
+| `POST` | `/wallet` | Add a card to the wallet |
+| `PUT` | `/wallet/{id}` | Update a wallet entry (e.g. acquisition date) |
+| `DELETE` | `/wallet/{id}` | Remove a wallet entry |
+| `PUT` | `/wallet/reorder` | Reorder wallet cards |
+| `GET` `PUT` `DELETE` | `/wallet/{id}/selections` | Manage selected categories for a wallet card |
+| `GET` | `/ratings/me?card_id={id}` | The user's rating for a card |
+| `POST` | `/ratings/me` | Submit or update a card rating |
+| `GET` `PUT` | `/user-settings` | Read or update the user's profile settings |
+| `POST` | `/plaid/link-token` | Create a Plaid Link token |
+| `POST` | `/plaid/exchange-token` | Exchange a Plaid public token |
+| `GET` | `/plaid/items` | The user's connected Plaid items |
+| `DELETE` | `/plaid/items/{id}` | Remove a Plaid connection |
+| `DELETE` | `/account` | Permanently delete the user's account and personal data |
 
-#### `POST /records` — Submit a Record
+#### `POST /records`
 
 Submit a credit card application result.
 
@@ -257,63 +305,38 @@ Submit a credit card application result.
 
 **Validation:** credit_score 300–850, income 0–1M, max 5 records per card per user, duplicate detection.
 
-#### `DELETE /records?record_id={id}` — Delete Record
-
-Soft-deletes the user's own record.
-
-#### `GET /referrals` — User's Referrals
-
-Returns the user's submitted referral links with impression/click stats.
-
-#### `POST /referrals` — Submit Referral Link
+#### `POST /referrals`
 
 **Body:** `{ "card_id": 42, "referral_link": "https://..." }`
 
 One referral per card per user. Link must be unique across all users.
 
-#### `DELETE /referrals?referral_id={id}` — Delete Referral
-
-Deletes the user's referral and its associated stats.
-
-#### `GET /wallet` — User's Wallet
-
-Returns cards the user owns with acquisition dates.
-
-#### `POST /wallet` — Add Card to Wallet
-
-**Body:** `{ "card_id": 42, "acquired_month": 5, "acquired_year": 2024 }`
-
-#### `DELETE /wallet` — Remove Card from Wallet
-
-**Body:** `{ "card_id": 42 }`
-
-#### `GET /profile` — User Profile
-
-Returns the authenticated user's profile information.
-
-#### `DELETE /account` — Delete Account
-
-Permanently deletes the user's account. Removes referrals and wallet entries; records are retained for data integrity.
-
 ### Admin Endpoints
 
-These require both Firebase auth and an `admin: 'true'` custom claim.
+Require Firebase auth plus an `admin: 'true'` custom claim. Mutations are recorded in `audit_log`.
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/admin/stats` | Dashboard overview (totals, pending referrals, top cards) |
-| `GET` | `/admin/records?limit=&offset=` | Browse all records (paginated) |
-| `DELETE` | `/admin/records?record_id={id}` | Hard-delete a record (audited) |
-| `GET` | `/admin/referrals?status=` | List referrals (filter: pending/approved) |
-| `PUT` | `/admin/referrals` | Approve/update a referral (audited) |
-| `DELETE` | `/admin/referrals?referral_id={id}` | Hard-delete a referral (audited) |
-| `GET` | `/admin/audit?limit=&offset=` | View audit log |
+| `GET` | `/admin/records` | Browse all records (paginated) |
+| `POST` `PUT` | `/admin/records` | Create or edit a record |
+| `DELETE` | `/admin/records?record_id={id}` | Hard-delete a record |
+| `GET` `PUT` `DELETE` | `/admin/referrals` | List, approve/update, or delete referrals |
+| `GET` | `/admin/graphs` | Aggregate graph data for the admin dashboard |
+| `GET` | `/admin/searches` | Recent check-odds searches |
+| `GET` | `/admin/user` | Look up a user |
+| `GET` | `/admin/audit` | View the audit log |
+| `POST` | `/admin/refresh-card-stats` | Manually trigger a `card_stats` refresh |
 
 ### Internal Endpoints
 
-#### `POST /sync-cards` — Sync CDN to Database
+#### `POST /sync-cards`
 
 Triggered by GitHub Actions when card YAML files change. Fetches `cards.json` from CloudFront and upserts into MySQL, matching by `card_name`.
+
+#### `POST /plaid/webhook`
+
+Receives Plaid webhook events for connected bank items.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ creditodds/
 ├── apps/
 │   ├── api/                 # AWS Lambda serverless API
 │   ├── functions/           # Firebase Cloud Functions
+│   ├── ios/                 # Native iOS app (SwiftUI)
 │   └── web-next/            # Next.js 16 frontend application
 ├── packages/
 │   └── shared/              # Shared utilities and validation schemas
@@ -20,7 +21,9 @@ creditodds/
 │   ├── cards/               # Credit card data (YAML files)
 │   │   └── images/          # Card images for PR submissions
 │   ├── news/                # News articles (Markdown)
-│   └── social-pages/        # Social page metadata (YAML)
+│   ├── social-pages/        # Social page metadata (YAML)
+│   ├── stores/              # Store / merchant data (YAML)
+│   └── valuations/          # Points & miles valuation history (YAML)
 ├── docs/                    # Project documentation
 ├── scripts/                 # Build and utility scripts
 └── .github/
@@ -111,6 +114,8 @@ npm run build:cards
 | `npm run build:news` | Build news.json from Markdown files |
 | `npm run build:articles` | Build articles.json from Markdown files |
 | `npm run build:best` | Build best.json from Markdown files |
+| `npm run build:stores` | Build stores.json from YAML files |
+| `npm run test:api` | Run the API (Lambda) test suite |
 | `npm run lint` | Run ESLint across all workspaces |
 
 ## Key Features
@@ -124,11 +129,11 @@ npm run build:cards
 - **Best Cards**: Ranked lists by category
 - **Check Odds**: Estimate your approval odds for a specific card
 - **Compare**: Side-by-side credit card comparisons
-- **Leaderboard**: Top contributors ranked by submissions
+- **Card Ratings**: User-submitted 1-5 star ratings on cards
 - **User Submissions**: Submit your credit card application results
-- **Wallet**: Track cards you own with acquisition dates
+- **Wallet**: Track cards you own, with best-card picks for stores and nearby places
 - **Referral Links**: Share and earn from referral links
-- **Rewards Tools**: 13 points/miles-to-USD converters (Chase UR, Amex MR, Capital One, airline & hotel programs)
+- **Rewards Tools**: 12 points/miles-to-USD converters (Chase UR, Amex MR, Capital One, airline & hotel programs)
 
 ## Contributing
 

--- a/data/cards/amazon-store-card.yaml
+++ b/data/cards/amazon-store-card.yaml
@@ -16,11 +16,11 @@ rewards:
     unit: "percent"
     note: "Amazon and Whole Foods Market (In-Store Code required) with an eligible Prime membership; no 5% without Prime"
 benefits:
-  - title: "0% APR Equal Monthly Payments"
+  - name: "0% APR Equal Monthly Payments"
     description: "6 months on Amazon purchases $50–$599.99, 12 months on $600+, 24 months on select purchases"
-  - title: "10%+ back limited-time offers"
+  - name: "10%+ back limited-time offers"
     description: "Rotating selection of items and categories on Amazon for eligible Prime cardmembers"
-  - title: "Amazon-only acceptance"
+  - name: "Amazon-only acceptance"
     description: "Closed-loop store card usable at Amazon.com, select physical Amazon stores, Whole Foods Market (via in-store code), and merchants accepting Amazon Pay"
 signup_bonus:
   value: 60

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -199,10 +199,65 @@
         "timeframe_months": {
           "type": "number",
           "description": "Months to meet spend requirement"
+        },
+        "note": {
+          "type": "string",
+          "description": "Optional caveat or context for the bonus, e.g. an elevated limited-time offer or a portal-valuation figure"
         }
       },
       "additionalProperties": false,
       "description": "Welcome/signup bonus details (optional)"
+    },
+    "benefits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "description"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Short name of the benefit"
+          },
+          "description": {
+            "type": "string",
+            "description": "Full description of the benefit"
+          },
+          "category": {
+            "type": "string",
+            "description": "Benefit grouping, e.g. travel, lounge, security, shopping, insurance"
+          },
+          "value": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Value of the benefit. Use 0 for non-monetary perks such as lounge access or elite status."
+          },
+          "value_unit": {
+            "type": "string",
+            "enum": ["dollars", "percent", "points", "miles"],
+            "description": "Unit of `value` when it is not a flat dollar amount. Defaults to dollars."
+          },
+          "value_per_cycle": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Value granted per frequency cycle when it differs from the headline `value`"
+          },
+          "frequency": {
+            "type": "string",
+            "enum": ["annual", "semi_annual", "quarterly", "monthly", "ongoing", "one_time", "multi_year", "every_4_years", "per_purchase", "per_flight", "per_trip", "per_stay", "per_visit", "per_rental", "per_claim", "per_redemption"],
+            "description": "How often the benefit applies"
+          },
+          "frequency_years": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Number of years between occurrences for multi_year benefits"
+          },
+          "enrollment_required": {
+            "type": "boolean",
+            "description": "Whether the cardholder must enroll or activate to receive the benefit"
+          }
+        }
+      },
+      "description": "Card perks, credits, and protections (optional)"
     },
     "apr": {
       "type": "object",

--- a/docs/adding-cards.md
+++ b/docs/adding-cards.md
@@ -202,6 +202,16 @@ apr:
     max: 28.49
 ```
 
+#### Editorial Take
+
+`our_take` is an optional editorial paragraph. When set, it renders in the "Our take" block on the card detail page; when omitted, that block is hidden.
+
+```yaml
+our_take: "A strong everyday card if you can use the travel credits, but the annual fee makes it a poor fit for occasional travelers."
+```
+
+Keep it to a sentence or two of honest, balanced assessment. Avoid em dashes in this copy.
+
 ### Step 5: Add a Card Image (Recommended)
 
 Adding an image helps users identify the card visually.

--- a/docs/adding-cards.md
+++ b/docs/adding-cards.md
@@ -94,13 +94,21 @@ signup_bonus:
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
 | `image` | string | Image filename | `"chase-sapphire-preferred.png"` |
-| `category` | string | Card category | `"travel"` |
+| `category` | string | Card category (see Valid Categories below) | `"travel"` |
 | `annual_fee` | number | Annual fee in USD | `95` |
+| `annual_fee_intro` | object | Promotional first-N-months fee: `{ value, months }` | `{ value: 0, months: 12 }` |
 | `foreign_transaction_fee` | boolean | `true` if the card charges a foreign transaction fee, `false` if not. Omit if unknown. | `false` |
+| `release_date` | string | Card release date in `YYYY-MM-DD` format | `"2025-03-01"` |
 | `tags` | array | Tags for filtering (see Valid Tags below) | `["travel", "dining"]` |
+| `apply_link` | string (URL) | Direct application URL | `"https://..."` |
+| `card_referral_link` | string (URL) | Base URL for the issuer's referral program | `"https://..."` |
+| `previous_names` | array | Prior names for rebranded cards (rendered on the card page) | `["Old Card Name"]` |
+| `our_take` | string | Editorial paragraph shown in the "Our take" block | `"..."` |
 | `reward_type` | string | Type of rewards: `cashback`, `points`, or `miles` | `"points"` |
 | `rewards` | array | Reward rates by spend category (see Rewards below) | See example |
 | `signup_bonus` | object | Welcome bonus details (see Signup Bonus below) | See example |
+| `benefits` | array | Card perks, credits, and protections (see Benefits below) | See example |
+| `apr` | object | Intro and regular APR details (see APR below) | See example |
 
 #### Valid Categories
 
@@ -110,13 +118,14 @@ signup_bonus:
 - `student` - Student credit cards
 - `secured` - Secured credit cards
 - `rewards` - General rewards cards
+- `balance_transfer` - Balance transfer cards
 - `other` - Other card types
 
 #### Valid Tags
 
 Tags allow a card to appear in multiple filter categories:
 
-`travel`, `cashback`, `hotel`, `shopping`, `student`, `secured`, `premium`, `business`, `rewards`, `airline`, `dining`
+`travel`, `cashback`, `hotel`, `shopping`, `student`, `secured`, `premium`, `business`, `rewards`, `airline`, `dining`, `entertainment`, `balance_transfer`, `credit_builder`
 
 #### Rewards
 
@@ -136,7 +145,20 @@ rewards:
     unit: points_per_dollar
 ```
 
+Each reward entry can also carry advanced fields for rotating, choose-your-own, or capped categories:
+
+- `note` - extra context shown alongside the rate
+- `mode` - `quarterly_rotating`, `user_choice`, or `auto_top_spend`
+- `eligible_categories` / `choices` - the category pool and pick count for `user_choice` cards
+- `current_categories` / `current_period` - the live categories for `quarterly_rotating` cards (e.g. `Q2 2026`)
+- `spend_cap` / `cap_period` / `rate_after_cap` - for categories that earn the headline rate only up to a spend limit
+- `merchant_specific` - `true` when the bonus is gated to specific merchants described in `note`
+
+See [`data/cards/schema.json`](../data/cards/schema.json) for the full field reference.
+
 #### Signup Bonus
+
+When `signup_bonus` is present, all four fields below are required. Add an optional `note` for offer caveats, such as an elevated limited-time offer or a portal-valuation figure.
 
 ```yaml
 signup_bonus:
@@ -144,6 +166,40 @@ signup_bonus:
   type: points        # cash, points, or miles
   spend_requirement: 4000
   timeframe_months: 3
+  note: "Plus a $100 statement credit"   # optional
+```
+
+#### Benefits
+
+Card perks, credits, and protections. Each entry needs a `name` and `description`; the other fields are optional:
+
+```yaml
+benefits:
+  - name: "Annual Travel Credit"
+    description: "Statement credit for travel booked through the issuer portal"
+    value: 300
+    frequency: "annual"      # annual, monthly, ongoing, one_time, per_trip, multi_year, ...
+    category: "travel"
+    enrollment_required: false
+```
+
+`value` is the dollar value of the perk. Use `0` for non-monetary perks like lounge access or elite status. For `multi_year` perks, add `frequency_years` (e.g. `5` for a Global Entry credit).
+
+#### APR
+
+Intro and ongoing interest rates. Every sub-object is optional:
+
+```yaml
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 19.49
+    max: 28.49
 ```
 
 ### Step 5: Add a Card Image (Recommended)
@@ -195,14 +251,14 @@ You should see output like:
 ```
 Building cards.json from YAML files...
 
-Found 77 card file(s)
+Found 166 card file(s)
 
 Processing: your-card-name.yaml
   OK: Your Card Full Name
 
 ---
 
-Successfully built 77 card(s) to data/cards.json
+Successfully built 166 card(s) to data/cards.json
 ```
 
 If there are errors, fix them before proceeding.


### PR DESCRIPTION
## Summary

The contributor docs and the card schema had drifted from the current monorepo. This brings them back in sync with the code.

### README.md
- Added the `apps/ios` app and the `data/stores` + `data/valuations` directories to the project tree
- Removed the **Leaderboard** key feature (the `/leaderboard` route was deleted)
- Corrected the rewards-tools converter count (13 → 12) and added a **Card Ratings** feature
- Added `build:stores` and `test:api` to the scripts table

### CONTRIBUTING.md
- Fixed dead npm commands: `start:web` → `start:web-next`, and `test:web` (the `@creditodds/web` workspace no longer exists)
- Corrected the project structure: `shared` lives in `packages/`, not `apps/`; added `apps/functions` and `apps/ios`
- Updated the DB schema: new columns on `records`, `referrals`, `referral_stats`, `user_cards`, plus a new **Supporting Tables** section
- Rewrote the API endpoint reference to match `apps/api/template.yml` (Plaid, ratings, wallet picks, card events, admin endpoints, etc.)

### docs/adding-cards.md
- Documented the full card schema: `annual_fee_intro`, `release_date`, `apply_link`, `card_referral_link`, `previous_names`, `our_take`, `benefits`, `apr`, and advanced reward fields (rotating / user-choice / caps)
- Added `balance_transfer` to valid categories and `entertainment`, `balance_transfer`, `credit_builder` to valid tags
- Documented the optional `signup_bonus.note` field
- Updated the example card count (77 → 166)

### data/cards/schema.json
- Added the **`benefits`** array (used by 90 cards but previously undefined) and **`signup_bonus.note`** (used by several cards). The build passed only because `build-cards.js` does not enforce the JSON Schema strictly.
- Fixed `amazon-store-card.yaml`, whose three benefit entries used a `title` key instead of the standard `name`.

## Test plan

- [x] `npm run build:cards` passes (166 cards)
- [ ] Verify rendered Markdown on GitHub