### PR TITLE
ci: deploy frontend via webhook to stop double Amplify builds

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,39 @@
+name: Deploy Frontend
+
+# Fires the AWS Amplify build webhook for pushes to main that are NOT
+# data-only changes.
+#
+# Card / best / article / news data live in S3, not the repo build. Their
+# build-*.yml workflows rebuild the JSON, sync it to S3, and then fire the
+# same Amplify webhook themselves — so those four data directories are
+# excluded here to avoid building twice for one merge.
+#
+# Amplify's native auto-build on push is disabled (enableAutoBuild=false),
+# making this workflow the single build trigger for code changes. With
+# native auto-build on, every data PR would build twice (native + webhook).
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'data/cards/**'
+      - 'data/best/**'
+      - 'data/articles/**'
+      - 'data/news/**'
+  workflow_dispatch: {}
+
+jobs:
+  trigger-amplify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Amplify build
+        env:
+          AMPLIFY_WEBHOOK_URL: ${{ secrets.AMPLIFY_WEBHOOK_URL }}
+        run: |
+          if [ -z "$AMPLIFY_WEBHOOK_URL" ]; then
+            echo "::error::AMPLIFY_WEBHOOK_URL secret is not configured"
+            exit 1
+          fi
+          echo "Triggering Amplify build via webhook..."
+          curl -fsS -X POST "$AMPLIFY_WEBHOOK_URL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,11 @@
 ## Deployment
 
 - Backend: `cd apps/api && sam build && sam deploy`
-- Frontend: Deployed via AWS Amplify (automatic on push)
+- Frontend: AWS Amplify, triggered by webhook. Amplify native auto-build is
+  disabled (`enableAutoBuild=false`) so each merge builds exactly once.
+  Code pushes to `main` fire the webhook via `.github/workflows/deploy-frontend.yml`;
+  card/best/article/news data pushes fire it from their own `build-*.yml`
+  workflow after syncing JSON to S3.
 - Cards data: Run `npm run build-cards` in web-next to rebuild cards.json
 
 ### Backend CI/CD: there is none — `sam deploy` is the only path


### PR DESCRIPTION
## Summary

Every PR that touched `data/cards/**`, `data/best/**`, `data/articles/**`, or `data/news/**` was building Amplify **twice**:

1. Amplify's native GitHub auto-build fires on the merge push — and races ahead, deploying against the *stale* S3 data.
2. The matching `build-*.yml` workflow rebuilds the JSON, syncs it to S3, then fires the Amplify webhook — the correct build.

This implements **Option 1: webhook-only builds**.

- Adds `.github/workflows/deploy-frontend.yml` — fires the Amplify webhook for pushes to `main` that are *not* data-only changes (`paths-ignore` the four data dirs already covered by their own `build-*.yml`).
- After this merges, Amplify native auto-build will be disabled (`enableAutoBuild=false`) so each merge builds exactly once.

Result: code PR → one build via `deploy-frontend.yml`; data PR → one build via its `build-*.yml` webhook (correctly ordered, after the S3 sync).

## Notes

- The `AMPLIFY_WEBHOOK_URL` secret already exists (used by all four `build-*.yml` workflows).
- The auto-* workflows (`auto-news`, `check-card-pages`, `check-card-rewards-and-benefits`) create PRs, so they merge through the normal path. `reject-news` pushes `data/news-rejected.yaml` with `GITHUB_TOKEN` (does not trigger workflows, and that file does not affect the site).
- **Disabling native auto-build must happen only after this is on `main`**, otherwise there is a window where nothing deploys.

## Test plan

- [ ] Merge this PR, confirm `deploy-frontend.yml` runs once on the merge and Amplify builds once
- [ ] Disable Amplify native auto-build (`aws amplify update-branch --app-id d172gkg36enjcy --branch-name main --no-enable-auto-build`)
- [ ] Verify a later code PR triggers exactly one Amplify build
- [ ] Verify a later card-data PR triggers exactly one Amplify build (via `build-cards.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)