### PR TITLE
cards: drop non-enum tags and validate tags in build

### DIFF
--- a/data/cards/amazon-store-card.yaml
+++ b/data/cards/amazon-store-card.yaml
@@ -8,7 +8,6 @@ tags:
   - shopping
   - cashback
   - rewards
-  - no_annual_fee
 reward_type: "cashback"
 rewards:
   - category: "amazon"

--- a/data/cards/atlas-card.yaml
+++ b/data/cards/atlas-card.yaml
@@ -108,5 +108,3 @@ tags:
   - premium
   - travel
   - dining
-  - lifestyle
-  - invite-only

--- a/data/cards/att-points-plus-from-citi.yaml
+++ b/data/cards/att-points-plus-from-citi.yaml
@@ -9,7 +9,6 @@ annual_fee: 0
 reward_type: "points"
 tags:
   - rewards
-  - co-branded
 rewards:
   - category: gas
     value: 3

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -42,6 +42,15 @@ function validateCard(card, schema, categoryIds) {
     }
   }
 
+  // Validate tags enum
+  if (card.tags && schema.properties.tags.items.enum) {
+    for (const tag of card.tags) {
+      if (!schema.properties.tags.items.enum.includes(tag)) {
+        errors.push(`Invalid tag: ${tag}`);
+      }
+    }
+  }
+
   // Validate annual_fee
   if (card.annual_fee !== undefined && (typeof card.annual_fee !== 'number' || card.annual_fee < 0)) {
     errors.push(`Invalid annual_fee: ${card.annual_fee}`);


### PR DESCRIPTION
## Summary
- Four card YAMLs used `tags` values absent from `data/cards/schema.json`'s `tags` enum. Removed each:
  - `no_annual_fee` (amazon-store-card) — redundant with `annual_fee: 0`
  - `lifestyle`, `invite-only` (atlas-card) — no enum equivalent; `invite-only` is an availability trait, not a filter tag
  - `co-branded` (att-points-plus-from-citi) — a card type, not a filter category
- Added a `tags` enum check in `validateCard` (`scripts/build-cards.js`), next to the existing `category` check, so future invalid tags fail the build instead of slipping through.

## Test plan
- [x] `npm run build:cards` passes (166 cards built)
- [x] Verified the new check rejects an unknown tag

Note: the regenerated `data/cards.json` is intentionally not included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)