### PR TITLE
us-bank-shield: add our_take editorial blurb

### DIFF
--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -18,6 +18,14 @@ apr:
     min: 16.99
     max: 27.99
 apply_link: https://www.usbank.com/credit-cards/pm/shield-visa-credit-card.html
+our_take: >
+  The Shield's 24-month 0% intro APR is one of the longest runways on the
+  market, and it covers both purchases and balance transfers with no annual
+  fee. That makes it a strong pick if you're paying down existing debt or
+  financing a large purchase over the next two years. The catch is there's no
+  rewards program, so once the intro period ends the card has little reason to
+  stay in your wallet. Treat the $20 annual statement credit and cell phone
+  protection as minor extras, not reasons to apply.
 benefits:
   - name: "Annual Statement Credit"
     value: 20


### PR DESCRIPTION
## Summary
- Add an `our_take` editorial blurb to the US Bank Shield card YAML, rendered in the "Our take" block on the card detail page.

## Test plan
- [ ] Verify the "Our take" block renders on the US Bank Shield card page

🤖 Generated with [Claude Code](https://claude.com/claude-code)