### PR TITLE
us-bank-shield: trim closing line from our_take

### DIFF
--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -25,7 +25,7 @@ our_take: >
   financing a large purchase over the next two years. The catch is there's no
   rewards program, so once the intro period ends the card has little reason to
   stay in your wallet. Treat the $20 annual statement credit and cell phone
-  protection as minor extras, not reasons to apply.
+  protection as minor extras.
 benefits:
   - name: "Annual Statement Credit"
     value: 20


### PR DESCRIPTION
## Summary
- Remove the trailing "not reasons to apply." clause from the US Bank Shield `our_take` blurb.

## Test plan
- [ ] Verify the "Our take" block on the US Bank Shield card page ends with "...as minor extras."

🤖 Generated with [Claude Code](https://claude.com/claude-code)