### PR TITLE
best-card-for: fix 500 on on-demand store pages

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -20,6 +20,11 @@ interface PageProps {
 // cached by ISR (revalidate below). Stores with co-branded cards are
 // prioritized since they are the highest-intent SEO pages.
 const PRERENDER_LIMIT = 100;
+
+// ISR: on-demand-rendered long-tail pages (and the prerendered set) are
+// revalidated every 5 minutes, matching the rest of the site.
+export const revalidate = 300;
+
 export async function generateStaticParams() {
   const stores = await getAllStores();
   const sorted = [...stores].sort((a, b) => {

--- a/apps/web-next/src/lib/stores.ts
+++ b/apps/web-next/src/lib/stores.ts
@@ -1,6 +1,5 @@
 import 'server-only';
-import fs from 'fs/promises';
-import path from 'path';
+import storesData from '../../../../data/stores.json';
 
 export interface StoreAlsoEarns {
   card: string;
@@ -34,26 +33,24 @@ interface StoresFile {
   stores: Store[];
 }
 
-let cached: { stores: Store[]; generatedAt: string } | null = null;
-
-async function loadStores(): Promise<{ stores: Store[]; generatedAt: string }> {
-  if (cached) return cached;
-  const filePath = path.join(process.cwd(), '..', '..', 'data', 'stores.json');
-  const fileContent = await fs.readFile(filePath, 'utf8');
-  const data: StoresFile = JSON.parse(fileContent);
-  cached = { stores: data.stores || [], generatedAt: data.generated_at };
-  return cached;
-}
+// stores.json is imported statically so its contents are bundled straight
+// into the build output. The long-tail /best-card-for/[slug] pages render
+// on demand on Amplify's SSR runtime, which only ships files traced from
+// apps/web-next — a process.cwd()-relative fs.readFile of the repo-root
+// data/ dir there throws ENOENT and 500s the page. A static import
+// sidesteps file tracing entirely: the data lives in the JS bundle.
+const data = storesData as unknown as StoresFile;
+const stores: Store[] = data.stores || [];
+const generatedAt: string = data.generated_at ?? '';
 
 export async function getAllStores(): Promise<Store[]> {
-  return (await loadStores()).stores;
+  return stores;
 }
 
 export async function getStoresGeneratedAt(): Promise<string> {
-  return (await loadStores()).generatedAt;
+  return generatedAt;
 }
 
 export async function getStore(slug: string): Promise<Store | null> {
-  const { stores } = await loadStores();
   return stores.find(s => s.slug === slug) || null;
 }


### PR DESCRIPTION
## Summary

After [#1242](https://github.com/CreditOdds/creditodds/pull/1242) capped build-time prerendering at 100 stores, every non-prerendered store page returns **HTTP 500** — e.g. [/best-card-for/publix](https://www.creditodds.com/best-card-for/publix), `/target`, `/walmart`, `/starbucks` (all 58 long-tail stores, verified failing in production).

**Root cause:** the long-tail stores now render on demand (SSR). `getStore()` in `lib/stores.ts` loaded `data/stores.json` via a `process.cwd()`-relative `fs.readFile`. That file lives at the repo root, **outside `apps/web-next`**, so it is not bundled into Amplify's SSR runtime — the read throws `ENOENT` and 500s the page. Prerendered stores were unaffected because their HTML was baked at build time.

## Changes

- **`lib/stores.ts`** — import `stores.json` statically so its contents are compiled into the JS bundle, independent of Next.js file tracing or runtime `cwd`. Removes the runtime `fs`/`path` read.
- **`best-card-for/[slug]/page.tsx`** — add `export const revalidate = 300`. The #1242 comment already says results are "cached by ISR (revalidate below)" but the export was never declared, so long-tail pages re-rendered on every request.

## Test plan

- [ ] Amplify deploy succeeds (build size unaffected — change adds a ~115 KB JSON to the server bundle, nowhere near the 220 MB cap)
- [ ] `/best-card-for/publix`, `/target`, `/walmart` return 200
- [ ] Prerendered stores (`/costco`, `/amazon`) still return 200
- [ ] `/best-card-for` index still renders the full store list

🤖 Generated with [Claude Code](https://claude.com/claude-code)