### PR TITLE
ci: deploy the SAM backend on push to main

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,64 @@
+name: Deploy API
+
+# Deploys the AWS SAM backend (apps/api) on every push to main that
+# touches apps/api/**. This is the backend's only CI/CD path.
+#
+# Why it exists: the Lambdas bundle their own data — e.g. the wallet
+# ranker's apps/api/src/lib/ranker/stores.json. When a PR changes
+# apps/api/** but no one runs `sam deploy`, the deployed Lambdas keep
+# serving stale code/data. That is exactly how ~200 store pages ended up
+# 404ing the /wallet-picks/store endpoint after 200 merchants were added.
+#
+# Mirrors deploy-frontend.yml: one deploy per merge, path-filtered.
+# Auth is GitHub OIDC (no stored AWS keys). `sam deploy` reuses the
+# stack's existing parameter values, so the NoEcho params (DB creds,
+# IpHashPepper, GooglePlacesApiKey) never need to be exposed to CI.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/api/**'
+  workflow_dispatch: {}
+
+# Serialize deploys; let an in-flight deploy finish rather than cancel it
+# mid-CloudFormation-update.
+concurrency:
+  group: deploy-api
+  cancel-in-progress: false
+
+permissions:
+  id-token: write   # required to request the OIDC token
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup AWS SAM CLI
+        uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
+          aws-region: us-east-2
+
+      - name: SAM build
+        working-directory: apps/api
+        run: sam build
+
+      - name: SAM deploy
+        working-directory: apps/api
+        run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
   workflow after syncing JSON to S3.
 - Cards data: Run `npm run build-cards` in web-next to rebuild cards.json
 
-### Backend CI/CD: GitHub Actions (`deploy-api.yml`)
+### Backend CI/CD: there is none — `sam deploy` is the only path
 
 The `CreditCardOddsAPI` CodePipeline + `CreditCardOddsAPI-Builder` CodeBuild
 project were **deleted on 2026-05-08**. They had been pointing at the
@@ -34,22 +34,18 @@ deleted those functions from production. Recovery required a manual
 `IpHashPepper` (the previous value lived only on the deployer's machine
 and was wiped from the stack when the broken template was applied).
 
-Backend deploys now run through `.github/workflows/deploy-api.yml`: any push
-to `main` that touches `apps/api/**` runs `sam build && sam deploy` on a
-GitHub Actions runner — one deploy per merge, mirroring `deploy-frontend.yml`.
-It authenticates with AWS via GitHub OIDC (no stored keys) using the
-`GitHubActions-CreditOdds-Deploy` IAM role, and reuses the stack's existing
-parameter values, so the NoEcho params (DB creds, `IpHashPepper`,
-`GooglePlacesApiKey`) never touch CI.
+If you want CI/CD back, build a new pipeline pointing at this monorepo:
+- New CodeStar connection authorized for the `CreditOdds` GitHub org
+- Source: `CreditOdds/creditodds` (branch `main`), with a path filter so
+  it only triggers on `apps/api/**` changes
+- CodeBuild project with `BuildSpec: apps/api/buildspec.yml`
+- Deploy stage's `ParameterOverrides` must wire in `IpHashPepper`,
+  `GooglePlacesApiKey`, and the DB creds (DB creds live in SSM at
+  `/creditodds/db/{endpoint,database,username,password}`)
 
-GitHub Actions runs against the actual monorepo checkout, which structurally
-rules out the stale-repo failure that took down the old CodePipeline. The
-leftover `apps/api/buildspec.yml` is dead (it was the CodeBuild build spec).
-
-Manual deploy still works: `cd apps/api && sam build && sam deploy`, or the
-workflow's `workflow_dispatch` button. On a brand-new machine the first
-manual deploy needs `--parameter-overrides` for the NoEcho params; the stack
-remembers them after that.
+Until then: `cd apps/api && sam build && sam deploy`. The first time on a
+new machine you'll need `--parameter-overrides` for the NoEcho params; the
+stack remembers them after that.
 
 ## Database
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
   workflow after syncing JSON to S3.
 - Cards data: Run `npm run build-cards` in web-next to rebuild cards.json
 
-### Backend CI/CD: there is none — `sam deploy` is the only path
+### Backend CI/CD: GitHub Actions (`deploy-api.yml`)
 
 The `CreditCardOddsAPI` CodePipeline + `CreditCardOddsAPI-Builder` CodeBuild
 project were **deleted on 2026-05-08**. They had been pointing at the
@@ -34,18 +34,22 @@ deleted those functions from production. Recovery required a manual
 `IpHashPepper` (the previous value lived only on the deployer's machine
 and was wiped from the stack when the broken template was applied).
 
-If you want CI/CD back, build a new pipeline pointing at this monorepo:
-- New CodeStar connection authorized for the `CreditOdds` GitHub org
-- Source: `CreditOdds/creditodds` (branch `main`), with a path filter so
-  it only triggers on `apps/api/**` changes
-- CodeBuild project with `BuildSpec: apps/api/buildspec.yml`
-- Deploy stage's `ParameterOverrides` must wire in `IpHashPepper`,
-  `GooglePlacesApiKey`, and the DB creds (DB creds live in SSM at
-  `/creditodds/db/{endpoint,database,username,password}`)
+Backend deploys now run through `.github/workflows/deploy-api.yml`: any push
+to `main` that touches `apps/api/**` runs `sam build && sam deploy` on a
+GitHub Actions runner — one deploy per merge, mirroring `deploy-frontend.yml`.
+It authenticates with AWS via GitHub OIDC (no stored keys) using the
+`GitHubActions-CreditOdds-Deploy` IAM role, and reuses the stack's existing
+parameter values, so the NoEcho params (DB creds, `IpHashPepper`,
+`GooglePlacesApiKey`) never touch CI.
 
-Until then: `cd apps/api && sam build && sam deploy`. The first time on a
-new machine you'll need `--parameter-overrides` for the NoEcho params; the
-stack remembers them after that.
+GitHub Actions runs against the actual monorepo checkout, which structurally
+rules out the stale-repo failure that took down the old CodePipeline. The
+leftover `apps/api/buildspec.yml` is dead (it was the CodeBuild build spec).
+
+Manual deploy still works: `cd apps/api && sam build && sam deploy`, or the
+workflow's `workflow_dispatch` button. On a brand-new machine the first
+manual deploy needs `--parameter-overrides` for the NoEcho params; the stack
+remembers them after that.
 
 ## Database
 


### PR DESCRIPTION
## Why

The backend (`apps/api`) has had **no CI/CD** since the CodePipeline was deleted on 2026-05-08. It only reached production when someone ran `sam deploy` by hand — and that is exactly the gap that caused today's incident: PR #1235 added 200 stores to the wallet ranker's bundled `stores.json`, the backend was never redeployed, and `POST /wallet-picks/store` returned **404 for all 200 new merchants** ("Couldn't load your wallet") until a manual deploy.

## What this does

Adds `.github/workflows/deploy-api.yml`:

- Triggers on `push` to `main` touching `apps/api/**` (one deploy per merge, mirroring `deploy-frontend.yml`), plus `workflow_dispatch`.
- Runs `sam build && sam deploy --no-confirm-changeset --no-fail-on-empty-changeset` on an `ubuntu-latest` runner.
- Authenticates via **GitHub OIDC** — no stored AWS keys.
- `sam deploy` reuses the stack's existing parameter values, so the NoEcho params (DB creds, `IpHashPepper`, `GooglePlacesApiKey`) **never touch CI**.
- `concurrency` group serializes deploys.

Also updates the CLAUDE.md "Backend CI/CD" section.

### Why GitHub Actions, not a new CodePipeline

- Consistent with the rest of the repo (`deploy-frontend.yml`, all `build-*.yml` already use Actions + OIDC).
- Runs against the **actual monorepo checkout**, which structurally eliminates the stale-repo failure mode that took down the old pipeline.
- `sam deploy` reuses stack params, so — unlike a CodePipeline CFN deploy action — no DB creds / secrets need to be wired into CI.

## ⚠️ Required before this works: IAM role

The workflow assumes `arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy`, which **does not exist yet**. Until it's created, runs of this workflow will fail at the "Configure AWS credentials" step.

Create it with:

- **Trust policy** — federated to the existing GitHub OIDC provider, scoped to this repo's `main`:
  - `Principal.Federated`: `arn:aws:iam::953352003729:oidc-provider/token.actions.githubusercontent.com`
  - `Action`: `sts:AssumeRoleWithWebIdentity`
  - Condition: `token.actions.githubusercontent.com:aud` = `sts.amazonaws.com` and `token.actions.githubusercontent.com:sub` = `repo:CreditOdds/creditodds:ref:refs/heads/main`
- **Permissions** — equivalent to what a manual `sam deploy` needs: CloudFormation on the `CreditCardOddsAPI` stack, read/write on the SAM artifact bucket (`codepipeline-us-east-2-534542813767`), `iam:PassRole`, and the service types in `template.yml` (Lambda, API Gateway, IAM, Logs, EventBridge). Mirroring the current manual deployer's policy is the simplest accurate option. For tighter least-privilege, give CloudFormation its own service role and limit this role to `cloudformation:*` + S3 + `iam:PassRole`.

I can script the role creation in a follow-up if you'd like — it's left out here because IAM changes warrant their own review.

## Test plan

- [ ] Create the `GitHubActions-CreditOdds-Deploy` role
- [ ] Merge, then trigger via `workflow_dispatch` and confirm a clean `sam deploy` (empty changeset is fine — exits 0)
- [ ] Next `apps/api/**` merge auto-deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)