### PR TITLE
card-wire: only tweet when sign-up bonus increases

### DIFF
--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -2,7 +2,9 @@
 
 /**
  * CardWire Social Post — generates an image and queues a Twitter post
- * for each card metric change detected during a card sync.
+ * for cards whose sign-up bonus increased during a card sync. All changes
+ * (APR, SUB decreases, etc.) still populate the card wire table; only a
+ * SUB increase triggers a tweet.
  *
  * Usage:
  *   node scripts/post-card-wire.js --changes '<JSON>'
@@ -90,6 +92,15 @@ function getDirection(field, oldValue, newValue) {
   const increased = newNum > oldNum;
   if (higherIsBad.has(field)) return increased ? 'negative' : 'positive';
   return increased ? 'positive' : 'negative';
+}
+
+// A tweet only goes out when the sign-up bonus increased. APR changes and
+// SUB decreases still land in the card wire table but are never posted to X.
+function hasSubIncrease(changes) {
+  return changes.some(
+    c => c.field === 'signup_bonus_value' &&
+      getDirection(c.field, c.old_value, c.new_value) === 'positive'
+  );
 }
 
 // ── Card data lookup ──
@@ -561,6 +572,11 @@ async function main() {
     const cardChanges = entry.changes;
 
     console.log(`Processing: ${cardName} (${cardChanges.length} change(s))`);
+
+    if (!hasSubIncrease(cardChanges)) {
+      console.log(`  Skipped — no sign-up bonus increase; not posting to X\n`);
+      continue;
+    }
 
     // Look up card data for image + slug
     const card = await getCardByName(cardName);


### PR DESCRIPTION
## Summary
- Card wire updates now only queue an X/Twitter post when a card's sign-up bonus increases.
- APR changes and SUB decreases still populate the card wire table; they just no longer trigger a tweet.
- Gate added via `hasSubIncrease()` in `scripts/post-card-wire.js`, applied per-card in the main loop before image generation / queuing.

## Test plan
- [x] `node --check scripts/post-card-wire.js`
- [x] APR-only change → skipped, not posted
- [x] SUB decrease → skipped, not posted
- [ ] SUB increase → posts as before