### PR TITLE
ci: fix deploy-api — pass sam deploy params explicitly

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -61,4 +61,16 @@ jobs:
 
       - name: SAM deploy
         working-directory: apps/api
-        run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset
+        # apps/api/samconfig.toml is gitignored, so the runner has no saved
+        # deploy config — the parameters are passed explicitly here. They
+        # carry no secrets; `sam deploy` reuses the stack's existing NoEcho
+        # parameter values (DB creds, IpHashPepper, GooglePlacesApiKey).
+        run: |
+          sam deploy \
+            --stack-name CreditCardOddsAPI \
+            --s3-bucket codepipeline-us-east-2-534542813767 \
+            --s3-prefix CreditCardOddsAPI \
+            --region us-east-2 \
+            --capabilities CAPABILITY_IAM \
+            --no-confirm-changeset \
+            --no-fail-on-empty-changeset


### PR DESCRIPTION
## Why

The first run of `deploy-api.yml` failed at **SAM deploy** with:

```
Error: Missing option '--stack-name'
```

`apps/api/samconfig.toml` is gitignored (only `samconfig.toml.example` is tracked), so the CI runner has no saved deploy config.

OIDC auth, checkout, Node, SAM CLI, and `sam build` all succeeded — this is the only remaining gap.

## Fix

Pass the deploy parameters explicitly on the `sam deploy` command line (stack name, S3 bucket/prefix, region, capabilities). These carry no secrets; `sam deploy` reuses the stack's existing NoEcho parameter values.

## Test plan

- [ ] `workflow_dispatch` run completes green (empty changeset is expected — the backend is already current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)