### PR TITLE
docs: update Backend CI/CD section for deploy-api workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,30 +22,42 @@
   workflow after syncing JSON to S3.
 - Cards data: Run `npm run build-cards` in web-next to rebuild cards.json
 
-### Backend CI/CD: there is none — `sam deploy` is the only path
+### Backend CI/CD: GitHub Actions (`deploy-api.yml`)
 
-The `CreditCardOddsAPI` CodePipeline + `CreditCardOddsAPI-Builder` CodeBuild
-project were **deleted on 2026-05-08**. They had been pointing at the
-obsolete pre-monorepo `CreditCardOdds/creditcardodds-api` repo (different
-GitHub org from this monorepo). Triggering the pipeline pulled that stale
-template — missing 20+ Lambdas added since the migration — and CloudFormation
-deleted those functions from production. Recovery required a manual
+Backend deploys run through `.github/workflows/deploy-api.yml`: any push to
+`main` that touches `apps/api/**` runs `sam build && sam deploy` on a GitHub
+Actions runner — one deploy per merge, mirroring `deploy-frontend.yml`. It
+also exposes a `workflow_dispatch` button for manual runs.
+
+- **Auth**: GitHub OIDC (no stored keys), assuming the IAM role
+  `GitHubActions-CreditOdds-Deploy` — trust scoped to this repo's `main`
+  ref; currently carries `AdministratorAccess` (a SAM deploy that manages
+  IAM/Lambda/API Gateway needs broad rights; tighten later via a
+  CloudFormation service role if desired).
+- **Parameters**: `sam deploy` is invoked with explicit `--stack-name`,
+  `--s3-bucket`, etc. because `apps/api/samconfig.toml` is gitignored.
+  Those flags carry no secrets — the stack's existing NoEcho values
+  (DB creds, `IpHashPepper`, `GooglePlacesApiKey`) are reused automatically.
+
+GitHub Actions runs against the actual monorepo checkout, which structurally
+rules out the stale-repo failure described below. The leftover
+`apps/api/buildspec.yml` is dead (it was the old CodeBuild build spec).
+
+Manual deploy still works from a machine that has `samconfig.toml`:
+`cd apps/api && sam build && sam deploy`. On a brand-new machine the first
+manual deploy needs `--parameter-overrides` for the NoEcho params; the stack
+remembers them after that.
+
+**History — why not CodePipeline:** the `CreditCardOddsAPI` CodePipeline +
+`CreditCardOddsAPI-Builder` CodeBuild project were **deleted on 2026-05-08**.
+They had been pointing at the obsolete pre-monorepo
+`CreditCardOdds/creditcardodds-api` repo (different GitHub org from this
+monorepo). Triggering the pipeline pulled that stale template — missing 20+
+Lambdas added since the migration — and CloudFormation deleted those
+functions from production. Recovery required a manual
 `aws cloudformation deploy` with full param overrides + a freshly generated
-`IpHashPepper` (the previous value lived only on the deployer's machine
-and was wiped from the stack when the broken template was applied).
-
-If you want CI/CD back, build a new pipeline pointing at this monorepo:
-- New CodeStar connection authorized for the `CreditOdds` GitHub org
-- Source: `CreditOdds/creditodds` (branch `main`), with a path filter so
-  it only triggers on `apps/api/**` changes
-- CodeBuild project with `BuildSpec: apps/api/buildspec.yml`
-- Deploy stage's `ParameterOverrides` must wire in `IpHashPepper`,
-  `GooglePlacesApiKey`, and the DB creds (DB creds live in SSM at
-  `/creditodds/db/{endpoint,database,username,password}`)
-
-Until then: `cd apps/api && sam build && sam deploy`. The first time on a
-new machine you'll need `--parameter-overrides` for the NoEcho params; the
-stack remembers them after that.
+`IpHashPepper` (the previous value lived only on the deployer's machine and
+was wiped from the stack when the broken template was applied).
 
 ## Database
 


### PR DESCRIPTION
## Summary

The backend now has CI/CD (`.github/workflows/deploy-api.yml`, GitHub Actions + OIDC), so the CLAUDE.md "Backend CI/CD: there is none" section is out of date.

- Rewrites the section to describe the `deploy-api.yml` workflow, the `GitHubActions-CreditOdds-Deploy` OIDC role, and the explicit-parameters approach (`samconfig.toml` is gitignored).
- Keeps the deleted-CodePipeline incident as history — it explains *why* GitHub Actions was chosen over a new pipeline.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)