### PR TITLE
card: fix United Explorer sign-up bonus to 50k base miles

### DIFF
--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -21,7 +21,7 @@ rewards:
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 60000
+  value: 50000
   type: "miles"
   spend_requirement: 3000
   timeframe_months: 3


### PR DESCRIPTION
## Summary
- Corrects `United Explorer` `signup_bonus.value` from `60000` to `50000`.
- The Chase apply page advertises "up to 60,000 bonus miles" — that headline total is **50,000** after $3,000 spend in 3 months **plus** a separate **10,000** for adding an authorized user.
- `signup_bonus.value` should be the spend-based bonus only; the AU bonus is already captured in `signup_bonus.note`.
- Follow-up to #1257, where the card-page-check automation conflated the "up to" total into `value`.

Verified the sibling United cards are correct: United Quest (60k spend-based) and United Club Infinite (80k spend-based) each list their AU bonus separately on the issuer page.

## Test plan
- [x] `npm run build:cards` passes (166 cards)