### PR TITLE
fix: accept blank optional fields when submitting records

### DIFF
--- a/apps/api/src/handlers/user-records.js
+++ b/apps/api/src/handlers/user-records.js
@@ -28,22 +28,31 @@ const REASON_DENIED_CODES = [
   "not_specified",
 ];
 
+// Coerce blank inputs ("", undefined, NaN) on optional numeric fields to null
+// so yup's number cast doesn't reject them. The client sometimes sends "" for
+// untouched optional fields and `JSON.stringify` keeps the empty string.
+const emptyToNull = (value, originalValue) => {
+  if (originalValue === "" || originalValue === undefined || originalValue === null) return null;
+  if (typeof value === "number" && Number.isNaN(value)) return null;
+  return value;
+};
+
 const recordSchema = yup.object().shape({
   card_id: yup.number().integer().required(),
   credit_score: yup.number().integer().min(300).max(850).required(),
   credit_score_source: yup.number().integer().min(0).max(4).required(),
   result: yup.boolean().required(),
-  listed_income: yup.number().integer().min(0).max(1000000).nullable(),
-  length_credit: yup.number().integer().min(0).max(100),
-  starting_credit_limit: yup.number().integer().min(0).max(1000000),
-  reason_denied: yup.string().max(254),
-  reason_denied_code: yup.string().oneOf(REASON_DENIED_CODES).nullable(),
-  total_open_cards: yup.number().integer().min(0).max(500).nullable(),
+  listed_income: yup.number().transform(emptyToNull).integer().min(0).max(1000000).nullable(),
+  length_credit: yup.number().transform(emptyToNull).integer().min(0).max(100).nullable(),
+  starting_credit_limit: yup.number().transform(emptyToNull).integer().min(0).max(1000000).nullable(),
+  reason_denied: yup.string().max(254).nullable(),
+  reason_denied_code: yup.string().oneOf([...REASON_DENIED_CODES, null]).nullable(),
+  total_open_cards: yup.number().transform(emptyToNull).integer().min(0).max(500).nullable(),
   date_applied: yup.date().max(endOfCurrentMonth(), "Application date cannot be in the future").required(),
   bank_customer: yup.boolean().required(),
-  inquiries_3: yup.number().integer().min(0).max(50),
-  inquiries_12: yup.number().integer().min(0).max(50),
-  inquiries_24: yup.number().integer().min(0).max(50),
+  inquiries_3: yup.number().transform(emptyToNull).integer().min(0).max(50).nullable(),
+  inquiries_12: yup.number().transform(emptyToNull).integer().min(0).max(50).nullable(),
+  inquiries_24: yup.number().transform(emptyToNull).integer().min(0).max(50).nullable(),
 });
 
 // PATCH only allows editing the user-correctable fields. card_id is fixed
@@ -53,17 +62,17 @@ const recordPatchSchema = yup.object().shape({
   credit_score: yup.number().integer().min(300).max(850).required(),
   credit_score_source: yup.number().integer().min(0).max(4).required(),
   result: yup.boolean().required(),
-  listed_income: yup.number().integer().min(0).max(1000000).nullable(),
-  length_credit: yup.number().integer().min(0).max(100).nullable(),
-  starting_credit_limit: yup.number().integer().min(0).max(1000000).nullable(),
+  listed_income: yup.number().transform(emptyToNull).integer().min(0).max(1000000).nullable(),
+  length_credit: yup.number().transform(emptyToNull).integer().min(0).max(100).nullable(),
+  starting_credit_limit: yup.number().transform(emptyToNull).integer().min(0).max(1000000).nullable(),
   reason_denied: yup.string().max(254).nullable(),
-  reason_denied_code: yup.string().oneOf(REASON_DENIED_CODES).nullable(),
-  total_open_cards: yup.number().integer().min(0).max(500).nullable(),
+  reason_denied_code: yup.string().oneOf([...REASON_DENIED_CODES, null]).nullable(),
+  total_open_cards: yup.number().transform(emptyToNull).integer().min(0).max(500).nullable(),
   date_applied: yup.date().max(endOfCurrentMonth(), "Application date cannot be in the future").required(),
   bank_customer: yup.boolean().required(),
-  inquiries_3: yup.number().integer().min(0).max(50).nullable(),
-  inquiries_12: yup.number().integer().min(0).max(50).nullable(),
-  inquiries_24: yup.number().integer().min(0).max(50).nullable(),
+  inquiries_3: yup.number().transform(emptyToNull).integer().min(0).max(50).nullable(),
+  inquiries_12: yup.number().transform(emptyToNull).integer().min(0).max(50).nullable(),
+  inquiries_24: yup.number().transform(emptyToNull).integer().min(0).max(50).nullable(),
 });
 
 // Constants for spam prevention

--- a/apps/web-next/src/components/forms/SubmitRecordModal.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordModal.tsx
@@ -314,9 +314,20 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
         }
 
         // Normalize empty strings to null so the API's yup .oneOf() / number coercion
-        // doesn't reject blank optional fields.
+        // doesn't reject blank optional fields. Optional numeric inputs hold "" while
+        // untouched; `JSON.stringify` would otherwise send those as empty strings and
+        // yup would cast them to NaN.
+        const blankToNull = (v: unknown) =>
+          v === "" || v === undefined || (typeof v === "number" && Number.isNaN(v)) ? null : v;
         const payload = {
           ...values,
+          listed_income: blankToNull(values.listed_income),
+          length_credit: blankToNull(values.length_credit),
+          starting_credit_limit: blankToNull(values.starting_credit_limit),
+          total_open_cards: blankToNull(values.total_open_cards),
+          inquiries_3: blankToNull(values.inquiries_3),
+          inquiries_12: blankToNull(values.inquiries_12),
+          inquiries_24: blankToNull(values.inquiries_24),
           reason_denied_code: values.reason_denied_code === "" ? null : values.reason_denied_code,
         };
 


### PR DESCRIPTION
## Summary
- Optional numeric inputs (inquiries_3/12/24, length_credit, starting_credit_limit, total_open_cards, listed_income) defaulted to `""` in the form. The POST yup schema lacked `.nullable()` on the inquiries fields and had no transform, so yup cast `""` → `NaN` and rejected the submission with `inquiries_24 must be a number type, but the final value was: NaN`.
- Added an `emptyToNull` transform on both POST and PATCH schemas in `user-records.js`, and normalized blanks to `null` on the client (`SubmitRecordModal.tsx`) before sending.
- Also widened `reason_denied_code.oneOf` to include `null` explicitly for safety — addresses the secondary "looking for a reason why you got rejected" symptom by ensuring approved submissions don't trip up on the unused denial field.

## Test plan
- [ ] Deploy API; submit a wallet record with **all optional fields blank** and result = approved → expect 200, no validation error.
- [ ] Submit a wallet record with some inquiries filled, some blank → blanks store as NULL, filled values store as integers.
- [ ] Edit an existing record (PATCH path) clearing previously filled inquiries → expect 200.
- [ ] Submit a denied record with a `reason_denied_code` → still validates and stores correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)