### PR TITLE
profile: allow submitting records for any card (and multiple per card)

### DIFF
--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -1128,11 +1128,9 @@ function CardsTab(props: CardsTabProps) {
                         {c.selections && c.selections.length > 0 ? 'edit picks' : '+ pick categories'}
                       </button>
                     )}
-                    {!hasRecord && (
-                      <button type="button" className="cj-wd-cta" onClick={() => onSubmitRecord(c)}>
-                        + submit a record
-                      </button>
-                    )}
+                    <button type="button" className="cj-wd-cta" onClick={() => onSubmitRecord(c)}>
+                      {hasRecord ? '+ submit another record' : '+ submit a record'}
+                    </button>
                     {hasRecord && <span className="cj-wd-done">✓ record submitted</span>}
                     {!hasReferral && (
                       <button type="button" className="cj-wd-cta" onClick={onAddReferral}>

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -20,7 +20,6 @@ import { calculateApplicationRules, countCardsMissingDates } from "@/lib/applica
 import {
   createCardLookups,
   dedupeWalletByCardName,
-  getEligibleRecordCards,
   getEligibleReferralCards,
   getRelevantNews,
   getTotalAnnualFees,
@@ -140,7 +139,7 @@ export default function ProfileClient() {
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [editingCard, setEditingCard] = useState<WalletCard | null>(null);
-  const [submitRecordCard, setSubmitRecordCard] = useState<WalletCard | null>(null);
+  const [submitRecordCard, setSubmitRecordCard] = useState<{ card_id: number; card_name: string; card_image_link?: string; bank: string } | null>(null);
   const [showRecordCardPicker, setShowRecordCardPicker] = useState(false);
   const [editingRecord, setEditingRecord] = useState<RecordItem | null>(null);
   const [pickingCategoriesFor, setPickingCategoriesFor] = useState<WalletCard | null>(null);
@@ -208,11 +207,6 @@ export default function ProfileClient() {
   const cardsWithActiveReferrals = useMemo(
     () => new Set(referrals.filter(r => !r.archived_at).map(r => r.card_name)),
     [referrals]
-  );
-
-  const eligibleRecordCards = useMemo(
-    () => getEligibleRecordCards(walletCards, records),
-    [walletCards, records]
   );
 
   const applicationRules = useMemo(() => calculateApplicationRules(walletCards), [walletCards]);
@@ -517,7 +511,6 @@ export default function ProfileClient() {
                     type="button"
                     className="cj-mob-wallet-btn outline"
                     onClick={() => setShowRecordCardPicker(true)}
-                    disabled={eligibleRecordCards.length === 0}
                   >
                     submit a record
                   </button>
@@ -665,7 +658,6 @@ export default function ProfileClient() {
                 onDeleteRecord={handleDeleteRecord}
                 onEditRecord={handleEditRecord}
                 deletingRecordId={deletingRecordId}
-                eligibleRecordCards={eligibleRecordCards}
               />
             )}
 
@@ -717,7 +709,6 @@ export default function ProfileClient() {
                   onDeleteRecord={handleDeleteRecord}
                   onEditRecord={handleEditRecord}
                   deletingRecordId={deletingRecordId}
-                  eligibleRecordCards={eligibleRecordCards}
                 />
                 <div className="cj-mob-more-h">Referrals</div>
                 <ReferralsTab
@@ -751,15 +742,13 @@ export default function ProfileClient() {
             <button type="button" className="cj-apply-btn" onClick={() => setShowWalletModal(true)}>
               + add a card
             </button>
-            {eligibleRecordCards.length > 0 && (
-              <button
-                type="button"
-                className="cj-apply-btn-outline"
-                onClick={() => setShowRecordCardPicker(true)}
-              >
-                submit a record
-              </button>
-            )}
+            <button
+              type="button"
+              className="cj-apply-btn-outline"
+              onClick={() => setShowRecordCardPicker(true)}
+            >
+              submit a record
+            </button>
           </div>
 
           {reminders.length > 0 && (
@@ -873,19 +862,16 @@ export default function ProfileClient() {
       <SubmitRecordCardPicker
         show={showRecordCardPicker}
         onClose={() => setShowRecordCardPicker(false)}
-        cards={eligibleRecordCards}
+        cards={allCards}
+        recordedCardNames={cardsWithRecords}
+        walletCardNames={new Set(walletCards.map((w) => w.card_name))}
         onSelectCard={(card) => setSubmitRecordCard(card)}
       />
       {submitRecordCard && (
         <SubmitRecordModal
           show={!!submitRecordCard}
           handleClose={() => setSubmitRecordCard(null)}
-          card={{
-            card_id: submitRecordCard.card_id,
-            card_name: submitRecordCard.card_name,
-            card_image_link: submitRecordCard.card_image_link,
-            bank: submitRecordCard.bank,
-          }}
+          card={submitRecordCard}
           onSuccess={loadData}
         />
       )}
@@ -1185,11 +1171,10 @@ interface ApplicationsTabProps {
   onDeleteRecord: (id: number) => void;
   onEditRecord: (id: number) => void;
   deletingRecordId: number | null;
-  eligibleRecordCards: WalletCard[];
 }
 
 function ApplicationsTab(props: ApplicationsTabProps) {
-  const { recordsLoaded, walletLoaded, records, walletCards, applicationRules, cardsMissingDates, onPickCard, onDeleteRecord, onEditRecord, deletingRecordId, eligibleRecordCards } = props;
+  const { recordsLoaded, walletLoaded, records, walletCards, applicationRules, cardsMissingDates, onPickCard, onDeleteRecord, onEditRecord, deletingRecordId } = props;
   if (!recordsLoaded || !walletLoaded) return <LoadingPanel />;
 
   const approved = records.filter(r => r.result).length;
@@ -1283,20 +1268,15 @@ function ApplicationsTab(props: ApplicationsTabProps) {
           </div>
           <div className="cj-verdict">
             <b>{records.length} record{records.length === 1 ? '' : 's'}.</b> {approved} approved, {denied} denied.{' '}
-            {eligibleRecordCards.length > 0 ? (
-              <>Submit a new record from <button type="button" onClick={onPickCard} style={{ background: 'transparent', border: 0, padding: 0, color: 'var(--accent)', cursor: 'pointer', fontWeight: 600 }}>any card in your wallet</button>.</>
-            ) : 'You’ve submitted records for every card in your wallet.'}
+            <>Submit a new record for <button type="button" onClick={onPickCard} style={{ background: 'transparent', border: 0, padding: 0, color: 'var(--accent)', cursor: 'pointer', fontWeight: 600 }}>any card</button>, approved or denied.</>
           </div>
         </>
       ) : (
         <div className="cj-verdict">
-          {walletCards.length === 0
-            ? <><b>No records yet.</b> Add a card to your wallet to submit a data point.</>
-            : <><b>No records yet.</b>{' '}
-                <button type="button" onClick={onPickCard} style={{ background: 'transparent', border: 0, padding: 0, color: 'var(--accent)', cursor: 'pointer', fontWeight: 600 }}>
-                  Submit a record →
-                </button>
-              </>}
+          <b>No records yet.</b>{' '}
+          <button type="button" onClick={onPickCard} style={{ background: 'transparent', border: 0, padding: 0, color: 'var(--accent)', cursor: 'pointer', fontWeight: 600 }}>
+            Submit a record →
+          </button>
         </div>
       )}
     </section>

--- a/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
@@ -1,29 +1,68 @@
 'use client';
 
-import { Fragment } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { Dialog, DialogPanel, Transition, TransitionChild } from "@headlessui/react";
-import { XMarkIcon } from "@heroicons/react/24/solid";
+import { XMarkIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import CardImage from "@/components/ui/CardImage";
+import type { Card } from "@/lib/api";
 
-interface WalletCard {
-  id: number;
+export interface PickedCard {
   card_id: number;
   card_name: string;
   card_image_link?: string;
   bank: string;
-  acquired_month?: number;
-  acquired_year?: number;
-  created_at: string;
 }
 
 interface SubmitRecordCardPickerProps {
   show: boolean;
   onClose: () => void;
-  cards: WalletCard[];
-  onSelectCard: (card: WalletCard) => void;
+  // Full card catalog. The picker filters out cards the user already has a
+  // record for (since the modal blocks duplicate-card submissions) and any
+  // entry missing a numeric db_card_id.
+  cards: Card[];
+  recordedCardNames: Set<string>;
+  // Optional: card names already in the user's wallet are surfaced first so
+  // common picks stay near the top while denied/never-held cards remain
+  // selectable below.
+  walletCardNames?: Set<string>;
+  onSelectCard: (card: PickedCard) => void;
 }
 
-export default function SubmitRecordCardPicker({ show, onClose, cards, onSelectCard }: SubmitRecordCardPickerProps) {
+export default function SubmitRecordCardPicker({
+  show,
+  onClose,
+  cards,
+  recordedCardNames,
+  walletCardNames,
+  onSelectCard,
+}: SubmitRecordCardPickerProps) {
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    if (!show) setSearch("");
+  }, [show]);
+
+  const eligible = useMemo(() => {
+    const inWallet = walletCardNames ?? new Set<string>();
+    return cards
+      .filter((c) => c.db_card_id != null)
+      .filter((c) => !recordedCardNames.has(c.card_name))
+      .sort((a, b) => {
+        const aWallet = inWallet.has(a.card_name) ? 0 : 1;
+        const bWallet = inWallet.has(b.card_name) ? 0 : 1;
+        if (aWallet !== bWallet) return aWallet - bWallet;
+        return a.card_name.localeCompare(b.card_name);
+      });
+  }, [cards, recordedCardNames, walletCardNames]);
+
+  const filtered = useMemo(() => {
+    if (!search) return eligible;
+    const s = search.toLowerCase();
+    return eligible.filter(
+      (c) => c.card_name.toLowerCase().includes(s) || c.bank.toLowerCase().includes(s)
+    );
+  }, [eligible, search]);
+
   return (
     <Transition show={show} as={Fragment}>
       <Dialog as="div" className="relative z-50" onClose={onClose}>
@@ -63,42 +102,72 @@ export default function SubmitRecordCardPicker({ show, onClose, cards, onSelectC
                 </div>
 
                 <div className="p-6">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-4">
-                    Select a card to submit a data point
+                  <h3 className="text-lg font-semibold text-gray-900 mb-1">
+                    Submit a record
                   </h3>
+                  <p className="text-sm text-gray-500 mb-4">
+                    Pick any card you applied for, approved or denied.
+                  </p>
 
-                  {cards.length > 0 ? (
+                  <div className="relative mb-3">
+                    <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                    <input
+                      type="text"
+                      autoFocus
+                      placeholder="Search by card name or issuer…"
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      className="w-full rounded-md border border-gray-300 pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                    />
+                  </div>
+
+                  {filtered.length > 0 ? (
                     <div className="space-y-2 max-h-96 overflow-y-auto">
-                      {cards.map((card) => (
-                        <button
-                          key={card.id}
-                          onClick={() => {
-                            onSelectCard(card);
-                            onClose();
-                          }}
-                          className="w-full flex items-center gap-4 p-3 rounded-lg border border-gray-200 hover:border-indigo-300 hover:bg-indigo-50 transition-colors text-left"
-                        >
-                          <div className="flex-shrink-0 h-10 w-16 relative">
-                            <CardImage
-                              cardImageLink={card.card_image_link}
-                              alt={card.card_name}
-                              fill
-                              className="object-contain"
-                              sizes="64px"
-                            />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium text-gray-900 truncate">
-                              {card.card_name}
-                            </p>
-                            <p className="text-xs text-gray-500">{card.bank}</p>
-                          </div>
-                        </button>
-                      ))}
+                      {filtered.slice(0, 25).map((card) => {
+                        const inWallet = walletCardNames?.has(card.card_name);
+                        return (
+                          <button
+                            key={card.card_id}
+                            onClick={() => {
+                              onSelectCard({
+                                card_id: card.db_card_id as number,
+                                card_name: card.card_name,
+                                card_image_link: card.card_image_link,
+                                bank: card.bank,
+                              });
+                              onClose();
+                            }}
+                            className="w-full flex items-center gap-4 p-3 rounded-lg border border-gray-200 hover:border-indigo-300 hover:bg-indigo-50 transition-colors text-left"
+                          >
+                            <div className="flex-shrink-0 h-10 w-16 relative">
+                              <CardImage
+                                cardImageLink={card.card_image_link}
+                                alt={card.card_name}
+                                fill
+                                className="object-contain"
+                                sizes="64px"
+                              />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium text-gray-900 truncate">
+                                {card.card_name}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {card.bank}{inWallet ? ' · in your wallet' : ''}
+                              </p>
+                            </div>
+                          </button>
+                        );
+                      })}
+                      {filtered.length > 25 && (
+                        <p className="text-xs text-gray-400 text-center pt-2">
+                          showing first 25 — refine your search to see more
+                        </p>
+                      )}
                     </div>
                   ) : (
-                    <p className="text-gray-500 text-center py-4">
-                      No cards available for submission.
+                    <p className="text-gray-500 text-center py-4 text-sm">
+                      {search ? 'No cards match your search.' : 'No cards available.'}
                     </p>
                   )}
                 </div>

--- a/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
@@ -16,10 +16,11 @@ export interface PickedCard {
 interface SubmitRecordCardPickerProps {
   show: boolean;
   onClose: () => void;
-  // Full card catalog. The picker filters out cards the user already has a
-  // record for (since the modal blocks duplicate-card submissions) and any
-  // entry missing a numeric db_card_id.
+  // Full card catalog (entries missing a numeric db_card_id are skipped).
   cards: Card[];
+  // Cards the user already has a record for — shown with a hint, NOT filtered
+  // out. The backend allows up to 5 records per card so users can submit
+  // separate data points for a reapplication (e.g., denied then approved).
   recordedCardNames: Set<string>;
   // Optional: card names already in the user's wallet are surfaced first so
   // common picks stay near the top while denied/never-held cards remain
@@ -46,14 +47,13 @@ export default function SubmitRecordCardPicker({
     const inWallet = walletCardNames ?? new Set<string>();
     return cards
       .filter((c) => c.db_card_id != null)
-      .filter((c) => !recordedCardNames.has(c.card_name))
       .sort((a, b) => {
         const aWallet = inWallet.has(a.card_name) ? 0 : 1;
         const bWallet = inWallet.has(b.card_name) ? 0 : 1;
         if (aWallet !== bWallet) return aWallet - bWallet;
         return a.card_name.localeCompare(b.card_name);
       });
-  }, [cards, recordedCardNames, walletCardNames]);
+  }, [cards, walletCardNames]);
 
   const filtered = useMemo(() => {
     if (!search) return eligible;
@@ -125,6 +125,10 @@ export default function SubmitRecordCardPicker({
                     <div className="space-y-2 max-h-96 overflow-y-auto">
                       {filtered.slice(0, 25).map((card) => {
                         const inWallet = walletCardNames?.has(card.card_name);
+                        const hasRecord = recordedCardNames.has(card.card_name);
+                        const meta = [card.bank, inWallet && 'in your wallet', hasRecord && 'record submitted']
+                          .filter(Boolean)
+                          .join(' · ');
                         return (
                           <button
                             key={card.card_id}
@@ -152,9 +156,7 @@ export default function SubmitRecordCardPicker({
                               <p className="text-sm font-medium text-gray-900 truncate">
                                 {card.card_name}
                               </p>
-                              <p className="text-xs text-gray-500">
-                                {card.bank}{inWallet ? ' · in your wallet' : ''}
-                              </p>
+                              <p className="text-xs text-gray-500">{meta}</p>
                             </div>
                           </button>
                         );

--- a/apps/web-next/src/components/forms/SubmitRecordModal.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordModal.tsx
@@ -115,7 +115,9 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
   const { getToken } = useAuth();
   const isEditMode = !!editRecord;
   const [submitting, setSubmitting] = useState(false);
-  const [hasExistingRecord, setHasExistingRecord] = useState(false);
+  // Count of prior records for this card. Used to show a contextual hint
+  // ("you've submitted N records; add another if you reapplied"), not to block.
+  const [existingRecordCount, setExistingRecordCount] = useState(0);
   const [checkingRecords, setCheckingRecords] = useState(!isEditMode);
   const [lastRecord, setLastRecord] = useState<{ credit_score?: number; listed_income?: number; length_credit?: number } | null>(null);
   // Count of cards in the user's wallet — surfaced below the "Total open cards" input
@@ -194,12 +196,13 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
 
         setWalletCount(Array.isArray(wallet) ? wallet.length : 0);
 
-        // Check if user has already submitted for this card
-        const existingRecord = records.find((r: { card_name: string }) =>
+        // Count any prior records for this card so we can surface a hint —
+        // duplicate / max-per-card limits are enforced on the backend.
+        const priorRecords = records.filter((r: { card_name: string }) =>
           r.card_name === card.card_name ||
           r.card_name === card.card_name.replace(/ Card$/, '')
         );
-        setHasExistingRecord(!!existingRecord);
+        setExistingRecordCount(priorRecords.length);
 
         // Find most recent record to prepopulate fields
         if (records.length > 0) {
@@ -215,7 +218,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
         }
       } catch (error) {
         console.error("Error checking existing records:", error);
-        setHasExistingRecord(false);
+        setExistingRecordCount(0);
       } finally {
         setCheckingRecords(false);
       }
@@ -395,10 +398,10 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
 
   // Auto-save form data when values change (#7)
   useEffect(() => {
-    if (show && !hasExistingRecord && !isEditMode && formik.dirty) {
+    if (show && !isEditMode && formik.dirty) {
       saveFormData(formik.values);
     }
-  }, [show, hasExistingRecord, isEditMode, formik.values, formik.dirty, saveFormData]);
+  }, [show, isEditMode, formik.values, formik.dirty, saveFormData]);
 
   const handleModalClose = () => {
     formik.resetForm();
@@ -425,23 +428,6 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
               <div className="cj-modal-body">
                 <p style={{ textAlign: 'center', color: 'var(--muted)', fontSize: 12 }}>Checking submission status…</p>
               </div>
-            ) : hasExistingRecord && !isEditMode ? (
-              <div className="cj-modal-body">
-                <div className="cj-modal-error">
-                  You have already submitted a record for this card. You can only submit one record per card.
-                </div>
-                <div className="cj-modal-section">
-                  <div className="cj-modal-card-row">
-                    <span className="cj-modal-thumb">
-                      <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="56px" />
-                    </span>
-                    <div style={{ minWidth: 0 }}>
-                      <div className="cj-modal-card-name">{card.card_name}</div>
-                      {card.bank && <div className="cj-modal-card-meta">{card.bank}</div>}
-                    </div>
-                  </div>
-                </div>
-              </div>
             ) : (
               <form onSubmit={formik.handleSubmit}>
                 <div className="cj-modal-body">
@@ -456,9 +442,13 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
                         {card.bank && <div className="cj-modal-card-meta">{card.bank}</div>}
                       </div>
                     </div>
-                    {isEditMode && (
+                    {isEditMode ? (
                       <p style={{ fontSize: 11.5, color: 'var(--muted)', marginTop: 8 }}>Editing your existing record.</p>
-                    )}
+                    ) : existingRecordCount > 0 ? (
+                      <p style={{ fontSize: 11.5, color: 'var(--muted)', marginTop: 8 }}>
+                        You&apos;ve submitted {existingRecordCount} record{existingRecordCount === 1 ? '' : 's'} for this card. Add another if you reapplied or your situation changed.
+                      </p>
+                    ) : null}
                   </div>
 
                   {/* Credit Score + Source */}


### PR DESCRIPTION
## Summary
Two related fixes for the record-submission UX, both motivated by the reapply-after-denial scenario.

**Submit for any card, not just wallet cards.** The picker on the profile page was scoped to wallet cards only, which forced users who got denied (and therefore never added the card to their wallet) to hunt down the card's detail page. Rewrites \`SubmitRecordCardPicker\` as a search box over the full catalog and sorts wallet cards to the top with an "in your wallet" hint.

**Allow multiple records per card.** The frontend blocked subsequent submissions with "You can only submit one record per card," even though the backend allows up to 5 records per card. That made it impossible to record a denied-then-approved progression. Drops the modal-level hard block, drops the picker-level filter, and updates the wallet-row CTA to read "+ submit another record" when a record already exists. The backend's NULL-safe (card, score, income, result) duplicate check still prevents accidental identical resubmits.

## Changes
- \`apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx\` — search-based picker over all cards; wallet cards float to the top; cards with existing records show a "record submitted" hint and stay selectable.
- \`apps/web-next/src/components/forms/SubmitRecordModal.tsx\` — \`hasExistingRecord\` block removed; replaced with a soft contextual hint when prior records exist.
- \`apps/web-next/src/app/profile/ProfileClient.tsx\` — entry-point CTA no longer gated; verdict copy updated; wallet-row "+ submit a record" → "+ submit another record" when a record exists; removed unused \`eligibleRecordCards\` memo.

## Test plan
- [ ] Profile → "submit a record" → confirm search lists all cards (~140+) with wallet cards on top.
- [ ] Search by card name and by issuer.
- [ ] Pick a non-wallet card → submit a denied record → confirm save.
- [ ] On the same card, open the modal again → confirm the soft hint shows "You've submitted 1 record for this card" → submit an approved record (different outcome) → confirm save.
- [ ] Try to submit an exact-duplicate record → backend rejects with a clear toast.
- [ ] Submit 5 records for the same card → 6th attempt is rejected by the backend (max-per-card guard).
- [ ] Wallet card row shows "+ submit another record" alongside ✓ when a record exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)