### PR TITLE
tools: fix card list overflow on mobile

### DIFF
--- a/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/amex-membership-rewards-to-usd/page.tsx
@@ -66,7 +66,7 @@ export default async function AmexMRToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage

--- a/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/bilt-rewards-points-to-usd/page.tsx
@@ -63,7 +63,7 @@ export default async function BiltToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage

--- a/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/capital-one-miles-to-usd/page.tsx
@@ -63,7 +63,7 @@ export default async function CapitalOneMilesToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage

--- a/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/chase-ultimate-rewards-to-usd/page.tsx
@@ -64,7 +64,7 @@ export default async function ChaseURToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage

--- a/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/citi-thankyou-points-to-usd/page.tsx
@@ -63,7 +63,7 @@ export default async function CitiThankYouToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage

--- a/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/delta-skymiles-to-usd/page.tsx
@@ -68,7 +68,7 @@ export default async function DeltaSkyMilesToUsdPage() {
                     <Link
                       key={card.slug}
                       href={`/card/${card.slug}`}
-                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                     >
                       <div className="h-10 w-16 flex-shrink-0 relative">
                         <CardImage

--- a/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/hilton-honors-points-to-usd/page.tsx
@@ -63,7 +63,7 @@ export default async function HiltonHonorsToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage

--- a/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/ihg-one-rewards-points-to-usd/page.tsx
@@ -63,7 +63,7 @@ export default async function IHGToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage

--- a/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/marriott-bonvoy-points-to-usd/page.tsx
@@ -64,7 +64,7 @@ export default async function MarriottBonvoyToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage

--- a/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/southwest-rapid-rewards-to-usd/page.tsx
@@ -68,7 +68,7 @@ export default async function SouthwestRRToUsdPage() {
                     <Link
                       key={card.slug}
                       href={`/card/${card.slug}`}
-                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                     >
                       <div className="h-10 w-16 flex-shrink-0 relative">
                         <CardImage

--- a/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/united-miles-to-usd/page.tsx
@@ -68,7 +68,7 @@ export default async function UnitedMilesToUsdPage() {
                     <Link
                       key={card.slug}
                       href={`/card/${card.slug}`}
-                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                     >
                       <div className="h-10 w-16 flex-shrink-0 relative">
                         <CardImage

--- a/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
+++ b/apps/web-next/src/app/tools/world-of-hyatt-points-to-usd/page.tsx
@@ -63,7 +63,7 @@ export default async function HyattToUsdPage() {
                 <Link
                   key={card.slug}
                   href={`/card/${card.slug}`}
-                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group"
+                  className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow flex items-center gap-4 group min-w-0"
                 >
                   <div className="h-10 w-16 flex-shrink-0 relative">
                     <CardImage


### PR DESCRIPTION
## Summary
- Add \`min-w-0\` to the card \`<Link>\` in each converter tool page (12 files)
- Without it, the grid item's default \`min-width: auto\` lets long card names (e.g. "Delta SkyMiles Reserve American Express") expand the cell past the viewport, causing horizontal overflow on mobile
- The inner \`truncate\` now clamps correctly

## Test plan
- [x] Verified at 375px viewport on \`/tools/delta-skymiles-to-usd\`: card widths 343px (was overflowing), \`document.scrollWidth === window.innerWidth\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)