### PR TITLE
check-card-pages: gate note-only adds behind a value change

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -377,21 +377,23 @@ function detectChanges(card, extracted) {
         new_value: note,
       });
     } else if (sb.bonus_note) {
-      // Create note when missing.
-      if (!cur.note) {
+      // Only propose a note change when signup_bonus.value also changed in
+      // this run. Applies to both adding a new note and updating an existing
+      // one. Without this gate Haiku reliably manufactures boilerplate notes
+      // on cards whose SUB hasn't moved — "Welcome offers vary…", "$N cash
+      // redemption value", or text lifted from a benefit on the same page
+      // (e.g. Fidelity's Global Entry credit) — and each one becomes a
+      // recurring PR proposal even though the prompt forbids it. A missed
+      // legitimate note edit is cheap; the false-positive churn is not.
+      const valueChanged = changes.some(c => c.field === 'signup_bonus.value');
+
+      if (!cur.note && valueChanged) {
         changes.push({
           field: 'signup_bonus.note',
           old_value: null,
           new_value: sb.bonus_note,
         });
-      }
-      // Update an existing note only when value also changed — avoids noisy
-      // rewording proposals on cards whose bonus is unchanged but Haiku
-      // happens to phrase the note slightly differently each run.
-      else if (
-        cur.note !== sb.bonus_note &&
-        changes.some(c => c.field === 'signup_bonus.value')
-      ) {
+      } else if (cur.note && cur.note !== sb.bonus_note && valueChanged) {
         changes.push({
           field: 'signup_bonus.note',
           old_value: cur.note,


### PR DESCRIPTION
## Summary

The card-page-check note-add branch had no guard — any free-form note Haiku returned on a card that lacked one became a PR proposal, even when no SUB field had actually changed. Same boilerplate phrases and same misextractions kept resurfacing day after day (see #1257, #1263).

This mirrors the existing note-**update** gate onto the note-**add** path: only propose adding (or changing) `signup_bonus.note` when `signup_bonus.value` also changed in the same run.

### Concrete failures this would have blocked

- **Blue Cash Everyday** (#1257 & #1263): generic Amex disclaimer ("Welcome offers vary…") added to a card whose SUB value (200) did not change.
- **Wells Fargo Autograph** (#1263): "Bonus points have a \$200 cash redemption value" — pure restatement of the existing `value: 20000` `type: "points"`; SUB unchanged.
- The Fidelity Global Entry misextraction in #1257/#1263 also flipped `value`, so this gate alone wouldn't block it — that one needs a separate guard (suppress notes that match an existing benefit). Tracking separately.

### What this does NOT do
- Doesn't tighten the Haiku prompt itself (rules already exist at [scripts/check-card-pages.js:247–261](scripts/check-card-pages.js#L247-L261); the model is just ignoring them).
- Doesn't deduplicate against previously rejected proposals.
- Doesn't catch note adds where a real value change is in play but the note itself is wrong.

These are deliberate scope cuts — the simplest fix that kills the most-recurring class of noise. Other layers can follow if needed.

## Test plan
- [x] `node -c scripts/check-card-pages.js` — syntax OK
- [ ] Next scheduled card-page-check run produces a PR without Blue Cash / Wells Fargo–style note-only adds