### PR TITLE
Split Wells Fargo Attune 4% bonus into per-category rows

### DIFF
--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -10,13 +10,26 @@ tags:
   - cashback
   - rewards
 rewards:
+  - category: gyms_fitness
+    value: 4
+    unit: percent
+    note: "Self-Care: fitness, wellness, spa, gym"
   - category: entertainment
     value: 4
     unit: percent
-    note: "Fitness, wellness, sports, recreation, live events, gardening, pet supplies, transit, EV charging, thrift stores"
+    note: "Sports, recreation, live events, movies"
+  - category: transit
+    value: 4
+    unit: percent
+    note: "Impactful Purchases: public transportation"
+  - category: ev_charging
+    value: 4
+    unit: percent
+    note: "Impactful Purchases: EV charging"
   - category: everything_else
     value: 1
     unit: percent
+    note: "Also includes 4% on pet supplies, gardening, and select thrift stores (no matching taxonomy category)"
 signup_bonus:
   value: 100
   type: cash


### PR DESCRIPTION
## Summary
- The Wells Fargo Attune card earns 4% on three broad buckets: Self-Care, Sports/Rec/Entertainment, and Impactful Purchases (per Wells Fargo's marketing page).
- Current YAML lumped everything into a single \`entertainment: 4%\` row with a free-text note, so the ranker only surfaced Attune for entertainment searches — transit, gym, and EV-charging purchases never matched.
- Split into individual taxonomy categories: \`gyms_fitness\`, \`entertainment\`, \`transit\`, \`ev_charging\`. Thrift stores, pet supplies, and gardening have no matching taxonomy entry, so they're noted on the \`everything_else\` row for transparency.

Surfaced by the weekly check-card-rewards-and-benefits run (#1292).

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Spot-check Attune surfaces on transit / gym / EV-charging searches after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)