### PR TITLE
Recategorize Ink Business Cash 5% bonus to office_supplies / utilities / phone

### DIFF
--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -10,16 +10,27 @@ tags:
   - business
   - cashback
 rewards:
-  - category: online_shopping
+  - category: office_supplies
     value: 5
     unit: percent
-    note: "Office supply stores, internet, cable, and phone services"
+    note: "Office supply stores; combined $25,000/year cap with internet/cable and phone services; 1% thereafter"
     spend_cap: 25000
     cap_period: annual
     rate_after_cap: 1
-    # Bonus is gated to specific merchant types in note — exclude from
-    # generic store-page matching for arbitrary online retailers.
-    merchant_specific: true
+  - category: utilities
+    value: 5
+    unit: percent
+    note: "Internet and cable services; combined $25,000/year cap with office supplies and phone services; 1% thereafter"
+    spend_cap: 25000
+    cap_period: annual
+    rate_after_cap: 1
+  - category: phone
+    value: 5
+    unit: percent
+    note: "Phone services; combined $25,000/year cap with office supplies and internet/cable services; 1% thereafter"
+    spend_cap: 25000
+    cap_period: annual
+    rate_after_cap: 1
   - category: gas
     value: 2
     unit: percent


### PR DESCRIPTION
## Summary
- Ink Business Cash earns 5% on **office supply stores**, **internet/cable services**, and **phone services** (combined \$25,000 annual cap) — not on \"online shopping.\"
- Current YAML had it as \`online_shopping: 5%\` with \`merchant_specific: true\` to suppress generic store-page matching, which meant the card never surfaced on office-supply, internet/cable, or phone searches.
- Split into three properly-categorized rows. Each row carries the full \$25,000 cap with a note that the cap is shared (matches the AAA Daily Advantage / BoA Customized Cash pattern).

Surfaced by the weekly check-card-rewards-and-benefits run (#1292).

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Spot-check Ink Business Cash surfaces on office-supply / internet / phone searches after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)