### PR TITLE
Drop incorrect dining 3x row from Bilt Palladium

### DIFF
--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -43,20 +43,13 @@ tags:
   - premium
   - dining
 rewards:
-  - category: dining
-    value: 3
-    unit: points_per_dollar
-    note: "Choose dining or groceries as the 3x category"
-    spend_cap: 25000
-    cap_period: annual
-    rate_after_cap: 1
   - category: travel
     value: 2
     unit: points_per_dollar
   - category: everything_else
     value: 2
     unit: points_per_dollar
-    note: "Also earns 4% Bilt Cash on everyday purchases"
+    note: "Also earns 4% Bilt Cash on everyday purchases (separate currency). Bilt Cash can be redeemed as point accelerators that temporarily boost $5,000 of spend to 3x points (up to 5 accelerators per year)."
 signup_bonus:
   value: 50000
   type: "points"


### PR DESCRIPTION
## Summary
- Multiple third-party reviews (TPG, OMAAT, NerdWallet, Bankrate) indicate the Bilt Palladium earns 2x across travel and everyday spend; the 3x on dining/groceries with a \$25k cap is the **Bilt Obsidian's** structure, not Palladium's.
- The 3x effect on Palladium actually comes from redeeming Bilt Cash for *point accelerators* (\$200 Bilt Cash → boost \$5k of spend to 3x, up to 5/yr = \$25k boosted), which is a redemption mechanic, not a base earn rate. Encoding it as a base rate misrepresents the card.
- Conservative cleanup — drops the incorrect row, leaves travel/everyday at 2x, and notes the Bilt Cash mechanic. A deeper first-party verification pass (rent tiers, accelerator rules, full Bilt Cash flow) is still warranted as a follow-up.

Surfaced by the weekly check-card-rewards-and-benefits run (#1292).

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Deeper Palladium audit follow-up: encode rent tiers (0.5x–1.25x) and Bilt Cash accelerator mechanic accurately

🤖 Generated with [Claude Code](https://claude.com/claude-code)