### PR TITLE
Split IHG Traveler 3x bonus into utilities / phone / streaming rows

### DIFF
--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -28,10 +28,18 @@ rewards:
   - category: gas
     value: 3
     unit: points_per_dollar
+  - category: utilities
+    value: 3
+    unit: points_per_dollar
+    note: "Utilities, internet, and cable services (combined 3x bucket with phone and select streaming)"
+  - category: phone
+    value: 3
+    unit: points_per_dollar
+    note: "Phone services (combined 3x bucket with utilities/internet/cable and select streaming)"
   - category: streaming
     value: 3
     unit: points_per_dollar
-    note: "Utilities, internet, cable, phone, and select streaming"
+    note: "Select streaming services (combined 3x bucket with utilities/internet/cable and phone)"
   - category: everything_else
     value: 2
     unit: points_per_dollar


### PR DESCRIPTION
## Summary
- IHG Rewards Club Traveler earns 3x across utilities, internet, cable, phone, and select streaming — but the YAML had it as a single \`streaming: 3x\` row with a free-text note, so the ranker only matched streaming searches.
- Split into three rows mapped to taxonomy categories: \`utilities\` (covers internet/cable/utilities), \`phone\`, and \`streaming\`. No cap on the 3x bucket.

Surfaced by the weekly check-card-rewards-and-benefits run (#1292).

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Spot-check IHG Traveler surfaces on utilities / phone / streaming searches after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)