### PR TITLE
Rewrite Marriott Bonvoy Bold rewards to match current apply page

### DIFF
--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -27,23 +27,30 @@ tags:
   - travel
 rewards:
   - category: hotels
-    value: 6
+    value: 3
     unit: points_per_dollar
-    note: "Marriott Bonvoy hotels"
+    note: "Marriott Bonvoy hotels (card portion; Bonvoy member rate and Silver Elite are program rates, not card rates)"
     merchant_specific: true
     merchant_gate: [marriott]
   - category: groceries
-    value: 3
-    unit: points_per_dollar
-    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
-  - category: gas
-    value: 3
-    unit: points_per_dollar
-    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
-  - category: dining
     value: 2
     unit: points_per_dollar
-    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+  - category: streaming
+    value: 2
+    unit: points_per_dollar
+    note: "Select streaming services"
+  - category: utilities
+    value: 2
+    unit: points_per_dollar
+    note: "Internet and cable services"
+  - category: phone
+    value: 2
+    unit: points_per_dollar
+    note: "Phone services"
+  - category: transit
+    value: 2
+    unit: points_per_dollar
+    note: "Rideshare; the same 2x bucket also covers select food delivery (no matching taxonomy category — food delivery shoppers may also see this rate)"
   - category: everything_else
     value: 1
     unit: points_per_dollar


### PR DESCRIPTION
## Summary
- The Marriott Bonvoy Bold YAML was materially out of date — overstated Marriott earn at 6x (actual: 3x, the card's portion of the advertised 14x total); listed a fake \$6,000/year cap; included earn categories (gas 3x, generic restaurant dining 2x) that no longer exist on the apply page; and was missing four new 2x buckets (streaming, internet/cable, phone, rideshare).
- Rewritten to match Chase's current apply page exactly: 3x Marriott hotels, 2x groceries, 2x streaming, 2x utilities (internet/cable), 2x phone, 2x transit (rideshare), 1x everything else.
- Food delivery shares the 2x rideshare bucket on Chase's page but doesn't map cleanly to our taxonomy (no \`food_delivery\` category); called out in the transit row's note.

Surfaced by the weekly check-card-rewards-and-benefits run (#1292).

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Spot-check the card surfaces correctly for streaming / phone / utilities / rideshare searches after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)