### PR TITLE
Encode Marriott Bonvoy Boundless 3x cap and missing travel 2x row

### DIFF
--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -41,21 +41,34 @@ rewards:
   - category: hotels
     value: 6
     unit: points_per_dollar
-    note: "Marriott Bonvoy hotels"
+    note: "Marriott Bonvoy hotels (card portion; Bonvoy member rate and Silver Elite are program rates, not card rates)"
     merchant_specific: true
     merchant_gate: [marriott]
   - category: groceries
     value: 3
     unit: points_per_dollar
-    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+    note: "Combined $6,000/year cap with gas stations and dining; 2x thereafter"
+    spend_cap: 6000
+    cap_period: annual
+    rate_after_cap: 2
   - category: gas
     value: 3
     unit: points_per_dollar
-    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+    note: "Combined $6,000/year cap with grocery stores and dining; 2x thereafter"
+    spend_cap: 6000
+    cap_period: annual
+    rate_after_cap: 2
   - category: dining
     value: 3
     unit: points_per_dollar
-    note: "Grocery stores, gas stations, and dining (first $6,000/year)"
+    note: "Combined $6,000/year cap with grocery stores and gas stations; 2x thereafter"
+    spend_cap: 6000
+    cap_period: annual
+    rate_after_cap: 2
+  - category: travel
+    value: 2
+    unit: points_per_dollar
+    note: "Other travel purchases (non-Marriott)"
   - category: everything_else
     value: 2
     unit: points_per_dollar


### PR DESCRIPTION
## Summary
- The Boundless 3x bucket (gas + groceries + dining) has a \$6,000/year combined cap that wasn't encoded as a real spend_cap — only mentioned in the note. Added \`spend_cap: 6000\` / \`cap_period: annual\` / \`rate_after_cap: 2\` to all three rows so the ranker accurately models the post-cap drop.
- Added the missing \`travel: 2x\` row (other non-Marriott travel purchases) that the apply page advertises separately from the everything_else 2x.
- Tightened the hotels-row note to clarify that the 6x is the card portion of the advertised 17x total at Marriott properties (Bonvoy member and Silver Elite are program rates).

Surfaced by the weekly check-card-rewards-and-benefits run (#1292).

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Spot-check the card surfaces for travel searches and that the 3x rate correctly caps at \$6k after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)