### PR TITLE
Add Capital One Entertainment 5x to Venture X

### DIFF
--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -66,6 +66,11 @@ rewards:
   - category: flights_portal
     value: 5
     unit: points_per_dollar
+  - category: entertainment
+    value: 5
+    unit: points_per_dollar
+    note: "Capital One Entertainment ticketing platform only (excludes dining reservations and Capital One Dining)"
+    merchant_specific: true
   - category: everything_else
     value: 2
     unit: points_per_dollar


### PR DESCRIPTION
## Summary
- The Venture X apply page advertises 5x miles on Capital One Entertainment ticketing-platform purchases.
- Added as a new \`entertainment: 5x\` row with \`merchant_specific: true\` so the ranker doesn't surface Venture X for generic entertainment spend — only Capital One Entertainment qualifies. Note explicitly excludes dining reservations and Capital One Dining per the apply page.

Surfaced by the weekly check-card-rewards-and-benefits run (#1292).

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Spot-check Venture X doesn't get over-surfaced on generic entertainment searches (merchant_specific gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)