### PR TITLE
Add Capital One Entertainment 5x as a partner benefit on Venture X

### DIFF
--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -54,6 +54,11 @@ benefits:
     frequency: "annual"
     category: "travel"
     enrollment_required: false
+  - name: "Capital One Entertainment 5x"
+    description: "5x miles on ticket purchases through the Capital One Entertainment platform (concerts, sports, dining experiences). Excludes dining reservations and Capital One Dining."
+    frequency: "per_purchase"
+    category: "entertainment"
+    enrollment_required: false
 tags:
   - travel
   - premium


### PR DESCRIPTION
## Summary
- Venture X advertises 5x miles on tickets purchased through the Capital One Entertainment platform.
- Encoded as a **benefit** (not a rewards row) since the bonus is gated to a single partner platform — same pattern as the Bilt Travel Portal hotel credit on Bilt Obsidian / Palladium. Surfacing it as \`entertainment: 5x\` in rewards would risk the ranker recommending Venture X for generic entertainment searches where the bonus wouldn't actually apply.
- Supersedes the now-closed PR #1302.

Surfaced by the weekly check-card-rewards-and-benefits run (#1292).

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Confirm benefit renders correctly on the Venture X card page

🤖 Generated with [Claude Code](https://claude.com/claude-code)