### PR TITLE
Move AAA Daily Advantage 3% AAA-purchases bonus from rewards to benefits

### DIFF
--- a/data/cards/aaa-daily-advantage-visa-signature.yaml
+++ b/data/cards/aaa-daily-advantage-visa-signature.yaml
@@ -45,11 +45,6 @@ rewards:
     value: 3
     unit: percent
     note: "Pharmacy purchases"
-  - category: travel
-    value: 3
-    unit: percent
-    note: "AAA purchases"
-    merchant_specific: true
   - category: everything_else
     value: 1
     unit: percent
@@ -65,4 +60,8 @@ apr:
 benefits:
   - name: "AAA Redemption Bonus"
     description: "5% more cash back when redeeming with AAA Northeast Counselors and Advisors"
+    category: "rewards"
+  - name: "3% on AAA Purchases"
+    description: "3% cash back on AAA memberships and AAA Travel agency bookings"
+    frequency: "ongoing"
     category: "rewards"


### PR DESCRIPTION
## Summary
- The 3% on \"AAA purchases\" applies to AAA memberships and AAA Travel agency bookings — not general travel. Encoded as \`travel: 3%\` it would surface this card on /best-for/travel and similar pages where the bonus wouldn't actually apply to a user's flights, hotels, rideshare, or gas.
- \`merchant_specific: true\` only suppresses store-page matching; it doesn't stop category-level surfacing.
- Moved to a benefit entry instead, since it's a partner-specific perk rather than a category bonus.

Surfaced during the #1292 audit of merchant_specific rewards rows.

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Confirm /best-for/travel no longer surfaces AAA Daily Advantage after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)