### PR TITLE
Remove unverifiable car_rentals 3x row from Atlas Card

### DIFF
--- a/data/cards/atlas-card.yaml
+++ b/data/cards/atlas-card.yaml
@@ -11,12 +11,7 @@ rewards:
   - category: hotels
     value: 3
     unit: points_per_dollar
-    note: "Hotels (also earns on private charters and luxury car rentals)"
-  - category: car_rentals
-    value: 3
-    unit: points_per_dollar
-    note: "Luxury car rentals only"
-    merchant_specific: true
+    note: "Hotels (also earns 3x on private charters and luxury car rentals — luxury rentals are merchant-gated, see Atlas terms)"
   - category: dining
     value: 2
     unit: points_per_dollar


### PR DESCRIPTION
## Summary
- The Atlas Card's \`car_rentals: 3x\` row was gated to \"luxury car rentals only\" with no published MCC list or merchant definition. Encoded as a standalone car_rentals row, it would surface the card on /best-for/car-rentals where a user's typical Enterprise/Budget/Hertz economy booking would earn only 1x.
- \`merchant_specific: true\` only suppresses store-page matching, not category-level surfacing on best-for pages.
- Removed the row; tightened the existing hotels-row note to retain disclosure of the luxury-rentals perk on the card detail page.

Surfaced during the #1292 audit of merchant_specific rewards rows.

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Confirm /best-for/car-rentals no longer surfaces Atlas after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)