### PR TITLE
Recategorize CSP 3x online groceries: online_shopping -> groceries

### DIFF
--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -36,12 +36,13 @@ rewards:
   - category: "streaming"
     value: 3
     unit: "points_per_dollar"
-  - category: "online_shopping"
+  - category: "groceries"
     value: 3
     unit: "points_per_dollar"
-    note: "Online grocery purchases (excluding Target, Walmart, wholesale clubs)"
-    # Bonus is online grocery only, not generic online retail —
-    # exclude from store-page category matching.
+    note: "Online grocery purchases only (excluding Target, Walmart, and wholesale clubs)"
+    # Bonus applies to online grocery delivery only (Instacart, Whole Foods
+    # online, etc.) — keep merchant_specific to suppress in-store grocery
+    # store-page matching (Kroger, Safeway, in-person Whole Foods).
     merchant_specific: true
   - category: "travel"
     value: 2


### PR DESCRIPTION
## Summary
- The Chase Sapphire Preferred 3x bonus is on online grocery delivery (Instacart, Whole Foods Market online, etc.) — not on general online shopping.
- Encoded as \`online_shopping\`, it would surface CSP on /best-for/online-shopping and on generic online retail searches where the bonus doesn't actually apply.
- Recategorized to \`groceries\` with an explicit 'online only' note. \`merchant_specific: true\` retained to suppress in-store grocery store-page matching (Kroger, Safeway, in-person Whole Foods) since the bonus only earns online.

Surfaced during the #1292 audit of merchant_specific rewards rows.

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Confirm CSP no longer appears on /best-for/online-shopping after deploy
- [ ] Confirm CSP surfaces on /best-for/groceries (or equivalent online-grocery search) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)