### PR TITLE
Tighten PayPal Cashback 3% note to clarify payment-method gate

### DIFF
--- a/data/cards/paypal-cashback-mastercard.yaml
+++ b/data/cards/paypal-cashback-mastercard.yaml
@@ -13,7 +13,7 @@ rewards:
   - category: online_shopping
     value: 3
     unit: percent
-    note: "Purchases made through PayPal checkout"
+    note: "Only when paying via PayPal checkout (online or in-store QR). Earns 1.5% anywhere PayPal is not used."
     merchant_specific: true
   - category: everything_else
     value: 1.5


### PR DESCRIPTION
## Summary
- The PayPal Cashback Mastercard's 3% is gated to checking out with PayPal — a payment-method condition rather than a merchant category. The previous note (\"Purchases made through PayPal checkout\") was technically right but easy to misread.
- Sharpened the note so users understand they only earn 3% when actively choosing PayPal at checkout (online or in-store QR); other purchases earn 1.5%.
- Encoding stays as \`online_shopping\` since PayPal is overwhelmingly used online, there's no \`payment_method\` category in our taxonomy, and \`merchant_specific: true\` already suppresses generic store-page matching.

Surfaced during the #1292 audit of merchant_specific rewards rows.

## Test plan
- [x] \`node scripts/build-cards.js\` passes validation
- [ ] Visual check of the note rendering on the card detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)