### PR TITLE
news: add 'rumor' tag and apply to Citi Custom Cash post

### DIFF
--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -22,6 +22,7 @@ const TAG_FILTERS: { key: FilterKey; label: string }[] = [
   { key: 'policy-change', label: 'Policy' },
   { key: 'limited-time', label: 'Limited' },
   { key: 'discontinued', label: 'Discontinued' },
+  { key: 'rumor', label: 'Rumor' },
 ];
 
 const TAG_DISPLAY: Record<NewsTag, string> = {
@@ -32,6 +33,7 @@ const TAG_DISPLAY: Record<NewsTag, string> = {
   'policy-change': 'Policy',
   'limited-time': 'Limited time',
   'discontinued': 'Discontinued',
+  'rumor': 'Rumor',
   'general': 'News',
 };
 

--- a/apps/web-next/src/app/news/[id]/opengraph-image.tsx
+++ b/apps/web-next/src/app/news/[id]/opengraph-image.tsx
@@ -30,6 +30,7 @@ function toneForTag(tag: string): ToneKey {
     case 'discontinued':   return 'warn';
     case 'fee-change':     return 'gold';
     case 'limited-time':   return 'gold';
+    case 'rumor':          return 'gold';
     case 'bonus-change':
     case 'benefit-change':
     case 'policy-change':

--- a/apps/web-next/src/components/og/og-utils.tsx
+++ b/apps/web-next/src/components/og/og-utils.tsx
@@ -30,6 +30,7 @@ export const NEWS_TAG_COLORS: Record<string, { bg: string; text: string; accent:
   'benefit-change': { bg: '#f0e9ff', text: '#6d3fe8', accent: '#6d3fe8' }, // accent
   'limited-time':   { bg: '#faf0d9', text: '#a8792a', accent: '#a8792a' }, // gold
   'policy-change':  { bg: '#f7f5fc', text: '#3a2f55', accent: '#6b6384' }, // neutral
+  'rumor':          { bg: '#fef7d8', text: '#8a6a1e', accent: '#a8792a' }, // caution / unverified
   'general':        { bg: '#f7f5fc', text: '#3a2f55', accent: '#6b6384' }, // neutral
 };
 
@@ -49,6 +50,7 @@ export const NEWS_TAG_LABELS: Record<string, string> = {
   'benefit-change': 'Benefit Change',
   'limited-time': 'Limited Time',
   'policy-change': 'Policy Change',
+  'rumor': 'Rumor',
   'general': 'General',
 };
 

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -8,6 +8,7 @@ export type NewsTag =
   | 'benefit-change'
   | 'limited-time'
   | 'policy-change'
+  | 'rumor'
   | 'general';
 
 export interface NewsItem {
@@ -42,6 +43,7 @@ export const tagLabels: Record<NewsTag, string> = {
   'benefit-change': '✨ Benefit Change',
   'limited-time': '⏰ Limited Time',
   'policy-change': '📋 Policy Change',
+  'rumor': '📡 Rumor',
   'general': '📰 General',
 };
 
@@ -53,6 +55,7 @@ export const tagColors: Record<NewsTag, string> = {
   'benefit-change': 'bg-violet-50 text-violet-700 ring-1 ring-inset ring-violet-600/20',
   'limited-time': 'bg-orange-50 text-orange-700 ring-1 ring-inset ring-orange-600/20',
   'policy-change': 'bg-slate-50 text-slate-700 ring-1 ring-inset ring-slate-600/20',
+  'rumor': 'bg-yellow-50 text-yellow-800 ring-1 ring-inset ring-yellow-600/20',
   'general': 'bg-indigo-50 text-indigo-700 ring-1 ring-inset ring-indigo-600/20',
 };
 

--- a/data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
+++ b/data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
@@ -2,6 +2,7 @@ id: "citi-custom-cash-discontinuation-rumor"
 title: "[RUMOR] Citi Custom Cash May Be Discontinued"
 summary: "An unconfirmed report on **r/CreditCards** from a user with a prior track record of accurately predicting Citi product changes claims the **Citi Custom Cash** will be closed to new applications by the end of the week. Citi has made no official announcement and the application page is still live. Cardholders are already rushing to **product-change existing Citi cards** (Double Cash, Strata, Rewards+ conversions) into Custom Cash before any change takes effect."
 tags:
+  - "rumor"
   - "discontinued"
   - "policy-change"
 bank: "Citi"

--- a/data/news/README.md
+++ b/data/news/README.md
@@ -111,6 +111,7 @@ card_names:
 | `benefit-change` | Card benefits added, removed, or modified |
 | `limited-time` | Temporary offer or promotion |
 | `policy-change` | Issuer policy update |
+| `rumor` | Unconfirmed report; not yet verified by the issuer or trusted outlet |
 | `general` | Other credit card news |
 
 ## Field Descriptions

--- a/data/news/schema.json
+++ b/data/news/schema.json
@@ -37,6 +37,7 @@
           "benefit-change",
           "limited-time",
           "policy-change",
+          "rumor",
           "general"
         ]
       },

--- a/scripts/auto-news-from-reddit.js
+++ b/scripts/auto-news-from-reddit.js
@@ -43,6 +43,7 @@ const VALID_TAGS = [
   'benefit-change',
   'limited-time',
   'policy-change',
+  'rumor',
   'general',
 ];
 

--- a/scripts/auto-news-update.js
+++ b/scripts/auto-news-update.js
@@ -28,6 +28,7 @@ const VALID_TAGS = [
   'benefit-change',
   'limited-time',
   'policy-change',
+  'rumor',
   'general'
 ];
 

--- a/scripts/build-news.js
+++ b/scripts/build-news.js
@@ -17,6 +17,7 @@ const VALID_TAGS = [
   'benefit-change',
   'limited-time',
   'policy-change',
+  'rumor',
   'general'
 ];
 


### PR DESCRIPTION
## Summary
- Adds a new \`rumor\` news tag for unverified reports — distinct from confirmed \`discontinued\` / \`policy-change\` items so readers can immediately spot unconfirmed stories
- Wired through schema, build validation, AI auto-news prompts, frontend types/labels/colors/chip filter, and OG image palettes
- Applied to the existing Citi Custom Cash discontinuation post (#1313)

## Files touched
- \`data/news/schema.json\`, \`data/news/README.md\`
- \`scripts/build-news.js\`, \`scripts/auto-news-update.js\`, \`scripts/auto-news-from-reddit.js\` — VALID_TAGS
- \`apps/web-next/src/lib/news.ts\` — NewsTag union, tagLabels (📡 Rumor), tagColors (yellow ring)
- \`apps/web-next/src/app/news/NewsV2Client.tsx\` — TAG_FILTERS chip + TAG_DISPLAY
- \`apps/web-next/src/components/og/og-utils.tsx\` — NEWS_TAG_COLORS + NEWS_TAG_LABELS (caution palette)
- \`apps/web-next/src/app/news/[id]/opengraph-image.tsx\` — toneForTag → gold
- \`data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml\` — adds \`rumor\` to tags

## Test plan
- [x] \`npm run build:news\` passes; Citi Custom Cash post validates with new tag
- [x] \`tsc --noEmit\` clean on edited web-next files
- [ ] After deploy, verify \`Rumor\` chip appears on /news and filters correctly
- [ ] Verify rumor tag chip renders on the Citi Custom Cash article and on its OG image

🤖 Generated with [Claude Code](https://claude.com/claude-code)