### PR TITLE
cards: add special_apply_link for targeted-offer URLs

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -573,9 +573,9 @@ export default function CardClient({
       )}
       {card.accepting_applications ? (
         <>
-          {card.apply_link && (
+          {(card.special_apply_link || card.apply_link) && (
             <a
-              href={withApplySource(card.apply_link)}
+              href={withApplySource(card.special_apply_link || card.apply_link!)}
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => handleCardApplyClick("direct")}
@@ -602,7 +602,7 @@ export default function CardClient({
               )}
             </a>
           )}
-          {!card.apply_link && !randomReferralUrl && (
+          {!card.apply_link && !card.special_apply_link && !randomReferralUrl && (
             <div className="cj-apply-closed">
               Apply link not available yet
             </div>

--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -22,6 +22,7 @@ const TAG_FILTERS: { key: FilterKey; label: string }[] = [
   { key: 'policy-change', label: 'Policy' },
   { key: 'limited-time', label: 'Limited' },
   { key: 'discontinued', label: 'Discontinued' },
+  { key: 'rumor', label: 'Rumor' },
 ];
 
 const TAG_DISPLAY: Record<NewsTag, string> = {
@@ -32,6 +33,7 @@ const TAG_DISPLAY: Record<NewsTag, string> = {
   'policy-change': 'Policy',
   'limited-time': 'Limited time',
   'discontinued': 'Discontinued',
+  'rumor': 'Rumor',
   'general': 'News',
 };
 

--- a/apps/web-next/src/app/news/[id]/opengraph-image.tsx
+++ b/apps/web-next/src/app/news/[id]/opengraph-image.tsx
@@ -30,6 +30,7 @@ function toneForTag(tag: string): ToneKey {
     case 'discontinued':   return 'warn';
     case 'fee-change':     return 'gold';
     case 'limited-time':   return 'gold';
+    case 'rumor':          return 'gold';
     case 'bonus-change':
     case 'benefit-change':
     case 'policy-change':

--- a/apps/web-next/src/components/og/og-utils.tsx
+++ b/apps/web-next/src/components/og/og-utils.tsx
@@ -30,6 +30,7 @@ export const NEWS_TAG_COLORS: Record<string, { bg: string; text: string; accent:
   'benefit-change': { bg: '#f0e9ff', text: '#6d3fe8', accent: '#6d3fe8' }, // accent
   'limited-time':   { bg: '#faf0d9', text: '#a8792a', accent: '#a8792a' }, // gold
   'policy-change':  { bg: '#f7f5fc', text: '#3a2f55', accent: '#6b6384' }, // neutral
+  'rumor':          { bg: '#fef7d8', text: '#8a6a1e', accent: '#a8792a' }, // caution / unverified
   'general':        { bg: '#f7f5fc', text: '#3a2f55', accent: '#6b6384' }, // neutral
 };
 
@@ -49,6 +50,7 @@ export const NEWS_TAG_LABELS: Record<string, string> = {
   'benefit-change': 'Benefit Change',
   'limited-time': 'Limited Time',
   'policy-change': 'Policy Change',
+  'rumor': 'Rumor',
   'general': 'General',
 };
 

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -140,6 +140,7 @@ export interface Card {
   annual_fee_intro?: { value: number; months: number };
   foreign_transaction_fee?: boolean;
   apply_link?: string;
+  special_apply_link?: string;
   card_referral_link?: string;
   referral_bonus?: string;
   referrals?: CardReferral[];

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -8,6 +8,7 @@ export type NewsTag =
   | 'benefit-change'
   | 'limited-time'
   | 'policy-change'
+  | 'rumor'
   | 'general';
 
 export interface NewsItem {
@@ -42,6 +43,7 @@ export const tagLabels: Record<NewsTag, string> = {
   'benefit-change': '✨ Benefit Change',
   'limited-time': '⏰ Limited Time',
   'policy-change': '📋 Policy Change',
+  'rumor': '📡 Rumor',
   'general': '📰 General',
 };
 
@@ -53,6 +55,7 @@ export const tagColors: Record<NewsTag, string> = {
   'benefit-change': 'bg-violet-50 text-violet-700 ring-1 ring-inset ring-violet-600/20',
   'limited-time': 'bg-orange-50 text-orange-700 ring-1 ring-inset ring-orange-600/20',
   'policy-change': 'bg-slate-50 text-slate-700 ring-1 ring-inset ring-slate-600/20',
+  'rumor': 'bg-yellow-50 text-yellow-800 ring-1 ring-inset ring-yellow-600/20',
   'general': 'bg-indigo-50 text-indigo-700 ring-1 ring-inset ring-indigo-600/20',
 };
 

--- a/data/cards/fidelity-rewards-visa-signature.yaml
+++ b/data/cards/fidelity-rewards-visa-signature.yaml
@@ -31,6 +31,7 @@ apr:
     min: 16.49
     max: 26.49
 apply_link: https://www.fidelity.com/spend-save/visa-signature-card
+special_apply_link: https://www.fidelity.com/go/visa-signature-rewards-1502
 foreign_transaction_fee: false
 benefits:
   - name: "Global Entry or TSA PreCheck Credit"

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -83,6 +83,11 @@
       "format": "uri",
       "description": "Direct application URL for the card (optional)"
     },
+    "special_apply_link": {
+      "type": "string",
+      "format": "uri",
+      "description": "Targeted offer URL — used for the Apply button and for signup-bonus extraction by check-card-pages.js when set. Falls back to apply_link. Use when the card's headline SUB lives on a different page than the generic marketing page (e.g. Fidelity's /go/ offer pages)."
+    },
     "card_referral_link": {
       "type": "string",
       "format": "uri",

--- a/data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
+++ b/data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
@@ -2,6 +2,7 @@ id: "citi-custom-cash-discontinuation-rumor"
 title: "[RUMOR] Citi Custom Cash May Be Discontinued"
 summary: "An unconfirmed report on **r/CreditCards** from a user with a prior track record of accurately predicting Citi product changes claims the **Citi Custom Cash** will be closed to new applications by the end of the week. Citi has made no official announcement and the application page is still live. Cardholders are already rushing to **product-change existing Citi cards** (Double Cash, Strata, Rewards+ conversions) into Custom Cash before any change takes effect."
 tags:
+  - "rumor"
   - "discontinued"
   - "policy-change"
 bank: "Citi"

--- a/data/news/README.md
+++ b/data/news/README.md
@@ -111,6 +111,7 @@ card_names:
 | `benefit-change` | Card benefits added, removed, or modified |
 | `limited-time` | Temporary offer or promotion |
 | `policy-change` | Issuer policy update |
+| `rumor` | Unconfirmed report; not yet verified by the issuer or trusted outlet |
 | `general` | Other credit card news |
 
 ## Field Descriptions

--- a/data/news/schema.json
+++ b/data/news/schema.json
@@ -37,6 +37,7 @@
           "benefit-change",
           "limited-time",
           "policy-change",
+          "rumor",
           "general"
         ]
       },

--- a/scripts/auto-news-from-reddit.js
+++ b/scripts/auto-news-from-reddit.js
@@ -43,6 +43,7 @@ const VALID_TAGS = [
   'benefit-change',
   'limited-time',
   'policy-change',
+  'rumor',
   'general',
 ];
 

--- a/scripts/auto-news-update.js
+++ b/scripts/auto-news-update.js
@@ -28,6 +28,7 @@ const VALID_TAGS = [
   'benefit-change',
   'limited-time',
   'policy-change',
+  'rumor',
   'general'
 ];
 

--- a/scripts/build-news.js
+++ b/scripts/build-news.js
@@ -17,6 +17,7 @@ const VALID_TAGS = [
   'benefit-change',
   'limited-time',
   'policy-change',
+  'rumor',
   'general'
 ];
 

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -83,9 +83,18 @@ function loadAllCards() {
   return cards;
 }
 
+// Card-page-check fetches whichever URL hosts the headline signup bonus.
+// When `special_apply_link` is set in the YAML, the SUB lives there — not on
+// the generic apply_link — so we treat it as the source of truth for this
+// script. The rewards/benefits check (which reads structural earn rates and
+// perks) still uses apply_link; see check-card-rewards-and-benefits.js.
+function checkUrlFor(card) {
+  return card.data.special_apply_link || card.data.apply_link;
+}
+
 function filterCardsForCheck(allCards, slugFilter) {
   let cards = allCards.filter(
-    c => c.data.accepting_applications !== false && c.data.apply_link
+    c => c.data.accepting_applications !== false && checkUrlFor(c)
   );
   if (slugFilter) {
     cards = cards.filter(c => c.slug === slugFilter);
@@ -506,7 +515,7 @@ async function main() {
   }
 
   console.log(`Checking ${cardsToCheck.length} card(s):`);
-  cardsToCheck.forEach(c => console.log(`  - ${c.data.name} (${c.data.apply_link})`));
+  cardsToCheck.forEach(c => console.log(`  - ${c.data.name} (${checkUrlFor(c)})`));
   console.log('');
 
   const allChanges = [];
@@ -519,9 +528,10 @@ async function main() {
       break;
     }
 
-    const { name, bank, apply_link } = card.data;
+    const { name, bank } = card.data;
+    const apply_link = checkUrlFor(card);
     console.log(`Checking: ${name}`);
-    console.log(`  URL: ${apply_link}`);
+    console.log(`  URL: ${apply_link}${card.data.special_apply_link ? ' (special_apply_link)' : ''}`);
 
     try {
       await withTimeout((async () => {


### PR DESCRIPTION
## Summary
- Adds optional `special_apply_link` YAML field for cards whose headline SUB lives on a different URL than the generic apply page (e.g. Fidelity's `/go/visa-signature-rewards-1502` vs `/spend-save/visa-signature-card`).
- `check-card-pages.js` (SUB + annual fee extraction) fetches `special_apply_link` when present, falling back to `apply_link`. `check-card-rewards-and-benefits.js` keeps using `apply_link` since rewards/benefits structure lives on the main page.
- Site Apply button prefers `special_apply_link` so users hit the better offer URL.
- Sets it on the Fidelity Rewards Visa YAML — should stop the recurring "150 → 100" false positive (see #1315).

## Test plan
- [x] `node scripts/build-cards.js` — passes, field flows through cards.json
- [x] Local dev: `/card/fidelity-rewards-visa-signature` Apply button → `https://www.fidelity.com/go/visa-signature-rewards-1502?utm_source=creditodds&utm_medium=referral`
- [x] Local dev: `/card/chase-sapphire-preferred` (no special link) Apply button still uses normal `apply_link`
- [ ] Next card-page-check run no longer flags Fidelity SUB

🤖 Generated with [Claude Code](https://claude.com/claude-code)