### PR TITLE
news + card: Citi Custom Cash confirmed closed to new applications

### DIFF
--- a/data/cards/citi-custom-cash.yaml
+++ b/data/cards/citi-custom-cash.yaml
@@ -2,7 +2,7 @@ name: "Citi Custom Cash"
 bank: "Citi"
 slug: "citi-custom-cash"
 image: "citi_custom_cash.png"
-accepting_applications: true
+accepting_applications: false
 annual_fee: 0
 reward_type: "cashback"
 tags:

--- a/data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
+++ b/data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
@@ -1,53 +1,59 @@
 id: "citi-custom-cash-discontinuation-rumor"
-title: "[RUMOR] Citi Custom Cash May Be Discontinued"
-summary: "An unconfirmed report on **r/CreditCards** from a user with a prior track record of accurately predicting Citi product changes claims the **Citi Custom Cash** will be closed to new applications by the end of the week. Citi has made no official announcement and the application page is still live. Cardholders are already rushing to **product-change existing Citi cards** (Double Cash, Strata, Rewards+ conversions) into Custom Cash before any change takes effect."
+title: "Citi Custom Cash Closed to New Applications (Confirmed)"
+summary: "**Confirmed May 28, 2026** — Citi has stopped accepting applications for the **Citi Custom Cash® Card**. The Citi product page now reads: *\"Not Available... Citi is no longer accepting applications for the Citi Custom Cash® Card product as of May 28, 2026.\"* Existing cardmembers are unaffected and can continue using their cards. Citi is directing new applicants to the **Citi Double Cash® Card**. The closure landed roughly 48 hours after r/CreditCards rumors first surfaced."
 tags:
-  - "rumor"
   - "discontinued"
   - "policy-change"
 bank: "Citi"
 card_slug: "citi-custom-cash"
 card_name: "Citi Custom Cash"
-source: "r/CreditCards"
-source_url: "https://www.reddit.com/r/CreditCards/comments/1tognri/the_end_of_the_custom_cash/"
-date: "2026-05-27"
+source: "Citi"
+source_url: "https://www.citi.com/credit-cards/citi-custom-cash-credit-card"
+date: "2026-05-28"
 body: |
-  **This is an unconfirmed rumor.** Citi has made no official announcement, and as of this writing the Citi Custom Cash application page is still accepting applications. Treat everything below as speculation pending confirmation from Citi.
+  ## Update — May 28, 2026 (Confirmed)
 
-  ## What's being reported
+  Citi has officially closed the **Citi Custom Cash® Card** to new applications. The [Citi Custom Cash product page](https://www.citi.com/credit-cards/citi-custom-cash-credit-card) now displays a "Not Available" notice in place of the application:
 
-  In a thread titled "[The end of the Custom Cash](https://www.reddit.com/r/CreditCards/comments/1tognri/the_end_of_the_custom_cash/)" on r/CreditCards, user *Karanel* claims the **Citi Custom Cash** will be gone "by the end of the week," citing an unnamed source they could not share publicly. The same poster previously, and accurately, predicted the discontinuation of the **Citi Rewards+** before it was publicly announced — a track record that has the community treating the claim more seriously than a typical anonymous rumor would warrant.
+  > **Not Available**
+  >
+  > Citi is no longer accepting applications for the Citi Custom Cash® Card product as of May 28, 2026. If you are interested in a cash back card, you are welcome to apply for the Citi Double Cash® Card. Existing Citi Custom Cash cardmembers are not impacted and can continue to use their card and enjoy its benefits.
 
-  A follow-up thread, "[Confirmation of Citi Custom Cash discontinued](https://www.reddit.com/r/CreditCards/comments/1toq86h/confirmation_of_citi_custom_cash_discontinued/)," and a [reportedly leaked internal screenshot on imgur](https://imgur.com/a/citi-custom-cash-discontinued-sJHozIK) have added fuel, though neither rises to the level of an official Citi communication.
+  **What this means:**
 
-  Per OP, the change as understood is **closure to new applications**, not a forced product change for existing cardholders. What happens to existing Custom Cash accounts is unknown.
+  - **New applications are closed.** The card cannot be applied for as of May 28, 2026.
+  - **Existing cardmembers are not affected.** Current Custom Cash holders keep their accounts, their 5% auto-top-spend category, and all other benefits with no announced changes.
+  - **Citi is steering new cash-back applicants to the Citi Double Cash®.**
+  - **The status of inbound product changes is not addressed** in Citi's notice. Cardholders who were attempting to PC older Citi cards (Double Cash, Strata, Rewards+ conversions) into a Custom Cash should expect that lane to close — or already have closed — though Citi has not explicitly said so.
 
-  ## Circumstantial signals the community is pointing to
+  The closure landed roughly 48 hours after the [first r/CreditCards rumor thread](https://www.reddit.com/r/CreditCards/comments/1tognri/the_end_of_the_custom_cash/) — well within the "by the end of the week" timeframe the original tipster claimed. Original rumor coverage below.
 
-  - **The Custom Cash is missing from at least one of Citi's own cash-back tabs** ([citicards.citi.com cash-back tab](https://citicards.citi.com/usc/Multi/Featured/default.htm?tab=cash-back)) where it was previously listed. It still appears in the [full all-cards view](https://www.citi.com/credit-cards/view-all-credit-cards) and the [savings and cash-back page](https://www.citi.com/credit-cards/savings-and-cash-back-credit-cards).
-  - Multiple users report the card is now sorted **after the secured card** when browsing Citi's card list.
-  - Citi has been **trimming its rewards portfolio** — Rewards+ was killed (and existing accounts were force-PC'd to the Strata), ShopYourWay was closed to applications, and the Kroger co-brand was [recently shuttered](/news/us-bank-kroger-cards-no-longer-accepting-applications).
+  ---
 
-  None of these signals are confirmation. Cards are reshuffled in marketing pages all the time. But the pattern of Citi consolidating its rewards lineup is real and makes the rumor structurally plausible.
+  ## Original report — May 27, 2026
+
+  In a thread titled "[The end of the Custom Cash](https://www.reddit.com/r/CreditCards/comments/1tognri/the_end_of_the_custom_cash/)" on r/CreditCards, user *Karanel* claimed the Citi Custom Cash would be gone "by the end of the week," citing an unnamed source. The same poster had previously, and accurately, predicted the discontinuation of the **Citi Rewards+** before it was publicly announced — a track record that had the community treating the claim more seriously than a typical anonymous rumor would warrant.
+
+  A follow-up thread, "[Confirmation of Citi Custom Cash discontinued](https://www.reddit.com/r/CreditCards/comments/1toq86h/confirmation_of_citi_custom_cash_discontinued/)," and a [reportedly leaked internal screenshot on imgur](https://imgur.com/a/citi-custom-cash-discontinued-sJHozIK) added weight — though neither rose to the level of an official Citi communication at the time. **Citi has now confirmed** with the May 28 application closure.
+
+  ## Circumstantial signals that turned out to be early indicators
+
+  - The Custom Cash had been **quietly removed from at least one of Citi's own cash-back tabs** ([citicards.citi.com cash-back tab](https://citicards.citi.com/usc/Multi/Featured/default.htm?tab=cash-back)) where it was previously listed.
+  - Multiple users reported the card had been **re-sorted after the secured card** on Citi's all-cards page.
+  - Citi has been **trimming its rewards portfolio** — Rewards+ was killed (existing accounts force-PC'd to the Strata), ShopYourWay was closed to applications, and the Kroger co-brand was [recently shuttered](/news/us-bank-kroger-cards-no-longer-accepting-applications).
+
+  In hindsight, the marketing-page reshuffles were a real signal, not noise.
 
   ## The product-change rush
 
-  The reaction in the community has been an immediate **product-change rush into the Custom Cash**, on the theory that an existing CCC account is far more valuable than one you can no longer get into:
+  In the 24–48 hours between the rumor breaking and the official closure, the community moved fast. Cardholders rushed to:
 
-  - Cardholders are calling Citi to **PC Double Cash → Custom Cash**, sometimes adding a second or third CCC.
-  - Users with the **Strata** (many of which were themselves PCs from the discontinued Rewards+) are PC'ing into Custom Cash to escape the Strata's worse cash-back redemption ratio.
-  - Several r/CreditCards users report YOLO applications going through in the last 24–48 hours.
-  - One user reported PC'ing their Double Cash to a third CCC the day before the rumor broke; another finished PC'ing into a fourth.
+  - **PC Double Cash → Custom Cash**, sometimes adding a second or third CCC.
+  - **PC Strata → Custom Cash** (the Strata, many of which were themselves PCs from the discontinued Rewards+, has a worse cash-back redemption ratio than the Custom Cash).
+  - **YOLO apply** for the card, with several r/CreditCards users reporting successful approvals in the final hours before closure.
 
-  If the rumor pans out and inbound product changes are closed alongside new applications, the window to lock in a Custom Cash account closes with it.
-
-  ## What we'd want to see before treating this as confirmed
-
-  - An official Citi statement, cardholder email, or press release.
-  - The application page going down or being marked "not currently accepting applications."
-  - Reporting from **Doctor of Credit**, Frequent Miler, or another credit card news outlet that independently verifies. (OP has been encouraged in the thread to forward their screenshot to Doctor of Credit.)
-  - A representative confirmation from Citi customer service, ideally more than one.
+  Whether inbound product changes are still being honored after the May 28 closure is unclear. Cardholders mid-PC or who applied late should keep an eye on their accounts.
 
   ## Bottom line
 
-  **Rumor only.** The source has been right before about Citi product changes, the circumstantial signals are consistent with a wind-down, and Citi has been actively consolidating its rewards lineup — but there is no official confirmation. If you have been on the fence about applying for a Custom Cash, or have an older Citi card you have been considering PC'ing into one, this is the kind of rumor where acting now and being wrong costs you very little, and waiting and being right costs you the card. We will update this post if and when Citi confirms.
+  The Citi Custom Cash, one of the strongest no-annual-fee 5% cash-back cards on the market for the last five years, is now closed to new applicants. Existing accounts are unaffected for now — but the playbook from Rewards+ suggests that "for now" deserves scrutiny: Citi force-PC'd Rewards+ holders to the Strata roughly a year after closing the card to new applications. Custom Cash holders should treat their current account as a finite asset and have a backup 5% category strategy in mind.


### PR DESCRIPTION
## Summary
Citi's [Custom Cash product page](https://www.citi.com/credit-cards/citi-custom-cash-credit-card) now shows a "Not Available" notice as of **May 28, 2026** — confirming the rumor from PR #1313. Existing cardmembers are unaffected; new cash-back applicants are directed to the Double Cash.

- \`data/cards/citi-custom-cash.yaml\`: \`accepting_applications: false\`
- \`data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml\`:
  - Retitled (drop [RUMOR], confirmed)
  - Date bumped to 2026-05-28 so the confirmation re-sorts to the top of /news
  - Body leads with the official Citi quote and May 28 closure detail; keeps the original rumor coverage below as historical context
  - Source switched to Citi (official); dropped \`rumor\` tag (kept \`discontinued\` + \`policy-change\`)

Filename intentionally unchanged so \`queue-social.js\` (which uses \`--diff-filter=A\`) does not re-trigger a social post on the same story.

## Test plan
- [x] \`npm run build:news\` passes
- [x] \`npm run build:cards\` passes
- [ ] Verify /news/citi-custom-cash-discontinuation-rumor shows the update banner after deploy
- [ ] Verify Citi Custom Cash card page shows the "no longer accepting applications" treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)