### PR TITLE
best-card-for: rank related stores by category overlap

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -88,10 +88,20 @@ export default async function BestCardForStorePage({ params }: PageProps) {
   const usingFallback = picks.length > 0 && picks.every(p => p.source === 'flat_rate');
   const pageUrl = `https://creditodds.com/best-card-for/${store.slug}`;
 
+  // Rank related stores by category overlap so the most-similar stores win.
+  // A store sharing both [hotels, travel] with Best Western beats one that
+  // only shares [travel] — otherwise broad categories like `travel` flood the
+  // list with whichever stores happen to come first alphabetically.
   const relatedStores = allStores
     .filter(s => s.slug !== store.slug)
-    .filter(s => s.categories.some(c => store.categories.includes(c)))
-    .slice(0, 8);
+    .map(s => ({
+      store: s,
+      overlap: s.categories.filter(c => store.categories.includes(c)).length,
+    }))
+    .filter(x => x.overlap > 0)
+    .sort((a, b) => b.overlap - a.overlap || a.store.name.localeCompare(b.store.name))
+    .slice(0, 8)
+    .map(x => x.store);
 
   return (
     <div className="landing-v2 store-v2">


### PR DESCRIPTION
## Summary
- The Related Stores section on `/best-card-for/[slug]` filtered by category intersection but then sliced the first 8 in `stores.json` order (alphabetical by slug). On Best Western (categories `[hotels, travel]`), this surfaced Accor + 6 airlines + Avis instead of fellow hotels.
- Rank candidates by category-overlap count desc, then name asc. Other hotels share 2 categories with Best Western and now beat airlines that share only `travel`.
- Single-category stores (e.g., Shell `[gas]`, Home Depot `[home_improvement]`) are unaffected since every match ties at overlap=1.

## Test plan
- [x] Verified locally: `/best-card-for/best-western` now lists Accor, Choice Hotels, Drury Hotels, Extended Stay America, Hilton, Hotels.com, Hyatt, IHG.
- [x] No console or build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)