### PR TITLE
Fix card structured data for Google

### DIFF
--- a/apps/web-next/public/llms.txt
+++ b/apps/web-next/public/llms.txt
@@ -24,7 +24,7 @@ The authoritative reference for any individual card. Each card page contains:
 - APR (purchase intro, balance transfer intro, regular range)
 - Median approved credit score, median approved income, median credit history length
 - Total approval/rejection counts from community data
-- Schema.org `CreditCard` JSON-LD with `aggregateRating`, offers, and structured properties
+- Google-compatible `Product` JSON-LD with `additionalType: CreditCard`, `aggregateRating`, offers, and structured properties
 - Related cards, related news, related articles
 
 Examples: [Chase Sapphire Preferred](https://creditodds.com/card/chase-sapphire-preferred), [American Express Gold](https://creditodds.com/card/american-express-gold), [Capital One Venture X](https://creditodds.com/card/capital-one-venture-x).

--- a/apps/web-next/src/components/seo/JsonLd.test.ts
+++ b/apps/web-next/src/components/seo/JsonLd.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildCreditCardSchema } from "./JsonLd";
+import { Card } from "@/lib/api";
+
+const baseCard: Card = {
+  card_id: "1",
+  card_name: "Citi Custom Cash",
+  slug: "citi-custom-cash",
+  bank: "Citi",
+  accepting_applications: true,
+  annual_fee: 0,
+  approved_median_credit_score: 751,
+  approved_median_income: 76500,
+  approved_median_length_credit: 7,
+};
+
+describe("buildCreditCardSchema", () => {
+  it("uses a Google-supported Product parent for review and offer markup", () => {
+    const schema = buildCreditCardSchema({
+      card: baseCard,
+      ratings: { count: 2, average: 5 },
+    });
+
+    expect(schema).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Product",
+      additionalType: "https://schema.org/CreditCard",
+      name: "Citi Custom Cash",
+      url: "https://creditodds.com/card/citi-custom-cash",
+      category: "Credit card",
+      aggregateRating: {
+        "@type": "AggregateRating",
+        ratingValue: "5.0",
+        ratingCount: 2,
+      },
+      offers: {
+        "@type": "Offer",
+        availability: "https://schema.org/InStock",
+        price: "0",
+        priceCurrency: "USD",
+      },
+    });
+  });
+
+  it("omits aggregateRating when there are no ratings", () => {
+    const schema = buildCreditCardSchema({
+      card: baseCard,
+      ratings: { count: 0, average: null },
+    });
+
+    expect(schema).not.toHaveProperty("aggregateRating");
+  });
+});

--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -73,11 +73,17 @@ interface CreditCardSchemaProps {
   ratings?: { count: number; average: number | null };
 }
 
-export function CreditCardSchema({ card, ratings }: CreditCardSchemaProps) {
+export function buildCreditCardSchema({ card, ratings }: CreditCardSchemaProps) {
   const schema = {
     '@context': 'https://schema.org',
-    '@type': 'CreditCard',
+    // Google review snippets require aggregateRating to be nested under a
+    // supported parent type. CreditCard is schema.org-valid, but not a Google
+    // review parent; Product + additionalType keeps both validators happy.
+    '@type': 'Product',
+    additionalType: 'https://schema.org/CreditCard',
     name: card.card_name,
+    url: card.slug ? `https://creditodds.com/card/${card.slug}` : undefined,
+    category: 'Credit card',
     brand: {
       '@type': 'Brand',
       name: card.bank,
@@ -142,7 +148,11 @@ export function CreditCardSchema({ card, ratings }: CreditCardSchemaProps) {
   };
 
   // Remove undefined values
-  const cleanSchema = JSON.parse(JSON.stringify(schema));
+  return JSON.parse(JSON.stringify(schema));
+}
+
+export function CreditCardSchema({ card, ratings }: CreditCardSchemaProps) {
+  const cleanSchema = buildCreditCardSchema({ card, ratings });
 
   return (
     <script


### PR DESCRIPTION
## Summary
- emit card JSON-LD as a Google-supported Product parent with additionalType CreditCard
- keep aggregateRating/offers on card pages while avoiding unsupported CreditCard review parent errors
- add focused regression coverage for the schema builder

## Verification
- npm run test -w @creditodds/web-next -- JsonLd.test.ts
- npm run check:seo -w @creditodds/web-next
- npm run build -w @creditodds/web-next
- inspected generated HTML for citi-custom-cash, blue-cash-everyday-card, and citi-double-cash