### PR TITLE
Wallet: record product changes between same-issuer cards

### DIFF
--- a/apps/api/migrations/037_create_wallet_card_events.sql
+++ b/apps/api/migrations/037_create_wallet_card_events.sql
@@ -1,0 +1,15 @@
+CREATE TABLE wallet_card_events (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id VARCHAR(128) NOT NULL,
+  user_card_id INT NULL,
+  event_type VARCHAR(32) NOT NULL DEFAULT 'product_change',
+  old_card_id INT NOT NULL,
+  new_card_id INT NOT NULL,
+  change_date DATE NOT NULL,
+  reason VARCHAR(16) NULL,
+  note VARCHAR(500) NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_user_id (user_id),
+  INDEX idx_user_card_id (user_card_id),
+  INDEX idx_change_date (change_date)
+);

--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -1,14 +1,18 @@
 // User Wallet API - Manage cards in user's wallet
 //
 // Routes:
-//   GET    /wallet           — list every card instance in the user's wallet
-//   POST   /wallet           — add a new instance (duplicates of the same card_id are allowed)
-//   PUT    /wallet/reorder   — set sort_order for a list of wallet rows (drag-to-reorder)
-//   PUT    /wallet/{id}      — update acquired_month / acquired_year on a specific instance
-//   DELETE /wallet/{id}      — remove a specific instance
+//   GET    /wallet                          — list every card instance in the user's wallet
+//   POST   /wallet                          — add a new instance (duplicates of the same card_id are allowed)
+//   PUT    /wallet/reorder                  — set sort_order for a list of wallet rows (drag-to-reorder)
+//   GET    /wallet/events                   — list product-change events for the user
+//   PUT    /wallet/{id}                     — update acquired_month / acquired_year on a specific instance
+//   DELETE /wallet/{id}                     — remove a specific instance
+//   POST   /wallet/{id}/product-change      — convert a wallet row from one card to another (same issuer); logs the event
 //
 // Per-card identity is `user_cards.id` (auto-increment). Ratings live in `card_ratings`
 // keyed by (user_id, card_id) — one rating per card type, shared across duplicates.
+// Product changes preserve the wallet row id and acquired_month/year (same account,
+// different product) and append a row to `wallet_card_events`.
 const mysql = require("../db");
 
 const responseHeaders = {
@@ -55,12 +59,51 @@ exports.UserWalletHandler = async (event) => {
   }
 
   const walletRowId = event.pathParameters?.id ? Number(event.pathParameters.id) : null;
-  const isReorderRoute = (event.resource || event.path || "").endsWith("/wallet/reorder");
+  const routeKey = event.resource || event.path || "";
+  const isReorderRoute = routeKey.endsWith("/wallet/reorder");
+  const isEventsRoute = routeKey.endsWith("/wallet/events");
+  const isProductChangeRoute = routeKey.endsWith("/wallet/{id}/product-change") || routeKey.endsWith("/product-change");
   let response = {};
 
   try {
     switch (event.httpMethod) {
       case "GET": {
+        if (isEventsRoute) {
+          // Product-change history for the user. Joins both old and new card
+          // names so the frontend can render "Sapphire Preferred → Sapphire
+          // Reserve" without a second lookup. Newest event first.
+          const events = await mysql.query(`
+            SELECT
+              e.id,
+              e.user_card_id,
+              e.event_type,
+              e.old_card_id,
+              e.new_card_id,
+              e.change_date,
+              e.reason,
+              e.note,
+              e.created_at,
+              co.card_name AS old_card_name,
+              co.card_image_link AS old_card_image_link,
+              cn.card_name AS new_card_name,
+              cn.card_image_link AS new_card_image_link,
+              cn.bank AS bank
+            FROM wallet_card_events e
+            LEFT JOIN cards co ON e.old_card_id = co.card_id
+            LEFT JOIN cards cn ON e.new_card_id = cn.card_id
+            WHERE e.user_id = ?
+            ORDER BY e.change_date DESC, e.id DESC
+          `, [userId]);
+          await mysql.end();
+
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify(events),
+          };
+          break;
+        }
+
         // Get all card instances in the user's wallet, with the shared
         // (per-card-type) rating preloaded so the edit modal doesn't flash empty stars.
         // Rows the user has explicitly reordered (sort_order set) come first; the rest
@@ -132,6 +175,153 @@ exports.UserWalletHandler = async (event) => {
       }
 
       case "POST": {
+        if (isProductChangeRoute) {
+          // Product change: same account, different card. Preserve the wallet
+          // row id, user_id, acquired_month, acquired_year, sort_order — only
+          // the linked card_id changes. Issuer (cards.bank) must match.
+          if (!walletRowId || !Number.isFinite(walletRowId)) {
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "wallet row id is required in path" }),
+            };
+            break;
+          }
+
+          const body = JSON.parse(event.body || "{}");
+          const { new_card_id, change_date, reason, note } = body;
+
+          if (!new_card_id || !Number.isFinite(Number(new_card_id))) {
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "new_card_id is required" }),
+            };
+            break;
+          }
+
+          if (reason && reason !== "voluntary" && reason !== "forced") {
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "reason must be 'voluntary' or 'forced'" }),
+            };
+            break;
+          }
+
+          if (note && typeof note === "string" && note.length > 500) {
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "note must be 500 characters or fewer" }),
+            };
+            break;
+          }
+
+          // Default change_date to today; validate YYYY-MM-DD when provided.
+          let effectiveDate = change_date;
+          if (effectiveDate) {
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(effectiveDate)) {
+              response = {
+                statusCode: 400,
+                headers: responseHeaders,
+                body: JSON.stringify({ error: "change_date must be YYYY-MM-DD" }),
+              };
+              break;
+            }
+          } else {
+            effectiveDate = new Date().toISOString().slice(0, 10);
+          }
+
+          // Load the wallet row + its current card's bank in one query so we
+          // can validate ownership and issuer match together.
+          const walletRow = await mysql.query(`
+            SELECT uc.id, uc.card_id, c.bank
+            FROM user_cards uc
+            JOIN cards c ON uc.card_id = c.card_id
+            WHERE uc.id = ? AND uc.user_id = ?
+          `, [walletRowId, userId]);
+
+          if (walletRow.length === 0) {
+            await mysql.end();
+            response = {
+              statusCode: 404,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "Wallet card not found" }),
+            };
+            break;
+          }
+
+          const oldCardId = walletRow[0].card_id;
+          const oldBank = walletRow[0].bank;
+
+          if (Number(new_card_id) === Number(oldCardId)) {
+            await mysql.end();
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "new_card_id must differ from the current card" }),
+            };
+            break;
+          }
+
+          const newCard = await mysql.query(
+            "SELECT card_id, bank FROM cards WHERE card_id = ?",
+            [new_card_id]
+          );
+          if (newCard.length === 0) {
+            await mysql.end();
+            response = {
+              statusCode: 404,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "Target card not found" }),
+            };
+            break;
+          }
+
+          if (newCard[0].bank !== oldBank) {
+            await mysql.end();
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({
+                error: `Product changes are only allowed between cards from the same issuer (current: ${oldBank}, target: ${newCard[0].bank})`,
+              }),
+            };
+            break;
+          }
+
+          // Update the wallet row's card_id, then log the event. Two statements
+          // (no transactions in the serverless-mysql wrapper); the event log is
+          // a record-keeping concern, so order matters less than atomicity.
+          await mysql.query(
+            "UPDATE user_cards SET card_id = ? WHERE id = ? AND user_id = ?",
+            [new_card_id, walletRowId, userId]
+          );
+
+          const insertResult = await mysql.query(`
+            INSERT INTO wallet_card_events
+              (user_id, user_card_id, event_type, old_card_id, new_card_id, change_date, reason, note)
+            VALUES (?, ?, 'product_change', ?, ?, ?, ?, ?)
+          `, [userId, walletRowId, oldCardId, new_card_id, effectiveDate, reason || null, note || null]);
+
+          await mysql.end();
+
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({
+              message: "Product change recorded",
+              event_id: insertResult.insertId,
+              wallet_card_id: walletRowId,
+              old_card_id: oldCardId,
+              new_card_id: Number(new_card_id),
+              change_date: effectiveDate,
+            }),
+          };
+          break;
+        }
+
         // Add a new card instance to the wallet. Duplicates of the same card_id are allowed —
         // each row has its own auto-increment `id`.
         const addBody = JSON.parse(event.body || "{}");

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -442,6 +442,38 @@ Resources:
               Ref: CreditCardOddsAPI
             Auth:
               Authorizer: NONE
+        GetWalletEvents:
+          Type: Api
+          Properties:
+            Path: /wallet/events
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        WalletEventsOptions:
+          Type: Api
+          Properties:
+            Path: /wallet/events
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+        WalletProductChange:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}/product-change
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        WalletProductChangeOptions:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}/product-change
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
 
   UserCardSelectionsFunction:
     Type: AWS::Serverless::Function

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -9,7 +9,7 @@ import { useAuth } from "@/auth/AuthProvider";
 import { useUserSettings } from "@/user-settings/UserSettingsProvider";
 import UserAvatar from "@/components/user/UserAvatar";
 import { V2Footer } from "@/components/landing-v2/Chrome";
-import { getAllCards, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, deleteAccount, reorderWallet, WalletCard, Card } from "@/lib/api";
+import { getAllCards, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, getWalletEvents, deleteAccount, reorderWallet, WalletCard, WalletCardEvent, Card } from "@/lib/api";
 import "../landing.css";
 import { getNews, NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
@@ -31,6 +31,7 @@ import {
 const ReferralModal = dynamic(() => import("@/components/forms/ReferralModal"), { ssr: false, loading: () => null });
 const AddToWalletModal = dynamic(() => import("@/components/wallet/AddToWalletModal"), { ssr: false, loading: () => null });
 const EditWalletCardModal = dynamic(() => import("@/components/wallet/EditWalletCardModal"), { ssr: false, loading: () => null });
+const ProductChangeModal = dynamic(() => import("@/components/wallet/ProductChangeModal"), { ssr: false, loading: () => null });
 const SelectCategoriesModal = dynamic(() => import("@/components/wallet/SelectCategoriesModal"), { ssr: false, loading: () => null });
 const BestCardByCategory = dynamic(() => import("@/components/wallet/BestCardByCategory"), { ssr: false, loading: () => null });
 const BestCardHere = dynamic(() => import("@/components/wallet/BestCardHere"), { ssr: false, loading: () => null });
@@ -139,6 +140,8 @@ export default function ProfileClient() {
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [editingCard, setEditingCard] = useState<WalletCard | null>(null);
+  const [productChangingCard, setProductChangingCard] = useState<WalletCard | null>(null);
+  const [walletEvents, setWalletEvents] = useState<WalletCardEvent[]>([]);
   const [submitRecordCard, setSubmitRecordCard] = useState<{ card_id: number; card_name: string; card_image_link?: string; bank: string } | null>(null);
   const [showRecordCardPicker, setShowRecordCardPicker] = useState(false);
   const [editingRecord, setEditingRecord] = useState<RecordItem | null>(null);
@@ -332,6 +335,9 @@ export default function ProfileClient() {
       try { setWalletCards(await getWallet(token) || []); } catch (e) { console.error("Wallet error:", e); setWalletCards([]); }
       setWalletLoaded(true);
     };
+    const loadWalletEvents = async () => {
+      try { setWalletEvents(await getWalletEvents(token) || []); } catch (e) { console.error("Wallet events error:", e); setWalletEvents([]); }
+    };
     const loadRecords = async () => {
       try { setRecords(await getRecords(token) || []); } catch (e) { console.error("Records error:", e); setRecords([]); }
       setRecordsLoaded(true);
@@ -344,7 +350,7 @@ export default function ProfileClient() {
       setReferralsLoaded(true);
     };
 
-    loadWallet(); loadRecords(); loadReferrals();
+    loadWallet(); loadWalletEvents(); loadRecords(); loadReferrals();
   };
 
   const handleEditRecord = (recordId: number) => {
@@ -849,7 +855,19 @@ export default function ProfileClient() {
         cardSlug={editingCard ? allCards.find(c => c.card_name === editingCard.card_name)?.slug : undefined}
         annualFee={editingCard ? (cardLookups.byName.get(editingCard.card_name)?.annual_fee ?? 0) : 0}
         displayName={editingCard ? walletDisplayNames.get(editingCard.id) : undefined}
+        lastProductChange={editingCard ? (walletEvents.find(e => e.user_card_id === editingCard.id) ?? null) : null}
         onClose={() => setEditingCard(null)}
+        onSuccess={loadData}
+        onRequestProductChange={editingCard ? () => {
+          const current = editingCard;
+          setEditingCard(null);
+          setProductChangingCard(current);
+        } : undefined}
+      />
+      <ProductChangeModal
+        show={!!productChangingCard}
+        card={productChangingCard}
+        onClose={() => setProductChangingCard(null)}
         onSuccess={loadData}
       />
       <SelectCategoriesModal
@@ -970,6 +988,9 @@ function CardsTab(props: CardsTabProps) {
             {showArchived ? 'hide archived' : `show ${inactiveCount} archived`}
           </button>
         )}
+        <Link href="/profile/history" className="cj-archived-toggle" style={{ textDecoration: 'none' }}>
+          history
+        </Link>
         <button type="button" className="cj-inline-cta" onClick={onAdd}>+ add a card</button>
       </div>
 

--- a/apps/web-next/src/app/profile/history/WalletHistoryClient.tsx
+++ b/apps/web-next/src/app/profile/history/WalletHistoryClient.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import CardImage from '@/components/ui/CardImage';
+import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+import { useAuth } from '@/auth/AuthProvider';
+import { V2Footer } from '@/components/landing-v2/Chrome';
+import { getWalletEvents, WalletCardEvent } from '@/lib/api';
+import '../../landing.css';
+
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso.slice(0, 10);
+  return `${MONTHS_SHORT[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
+}
+
+function reasonLabel(reason: WalletCardEvent['reason']): string | null {
+  if (reason === 'voluntary') return 'You requested it';
+  if (reason === 'forced') return 'Bank initiated';
+  return null;
+}
+
+export default function WalletHistoryClient() {
+  const { authState, getToken } = useAuth();
+  const router = useRouter();
+  const [events, setEvents] = useState<WalletCardEvent[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (authState.isLoading) return;
+    if (!authState.isAuthenticated) {
+      router.replace('/login?next=/profile/history');
+      return;
+    }
+    (async () => {
+      try {
+        const token = await getToken();
+        if (!token) throw new Error('Authentication required');
+        const rows = await getWalletEvents(token);
+        setEvents(rows);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load wallet history');
+      } finally {
+        setLoaded(true);
+      }
+    })();
+  }, [authState.isAuthenticated, authState.isLoading, getToken, router]);
+
+  return (
+    <div className="landing-v2 profile-v2">
+      <main className="cj-main" style={{ paddingTop: 24, paddingBottom: 48 }}>
+        <div className="wrap">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+            <Link href="/profile" className="cj-modal-link" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+              <ArrowLeftIcon style={{ width: 12, height: 12 }} /> back to profile
+            </Link>
+          </div>
+
+          <h1 style={{ fontSize: 28, fontWeight: 600, margin: '0 0 4px' }}>Wallet history</h1>
+          <p style={{ fontSize: 14, color: 'var(--muted)', margin: '0 0 24px' }}>
+            Every product change recorded on your wallet cards, newest first.
+          </p>
+
+          {error && <div className="cj-modal-error" style={{ marginBottom: 16 }}>{error}</div>}
+
+          {!loaded && (
+            <div style={{ padding: '32px 0', color: 'var(--muted)', fontSize: 14 }}>Loading…</div>
+          )}
+
+          {loaded && events.length === 0 && !error && (
+            <div style={{ border: '1px solid var(--border)', borderRadius: 12, padding: 24, color: 'var(--muted)', fontSize: 14 }}>
+              No product changes recorded yet. When you convert a wallet card to another product from the same issuer, the change shows up here.
+            </div>
+          )}
+
+          {loaded && events.length > 0 && (
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {events.map((e) => {
+                const reason = reasonLabel(e.reason);
+                return (
+                  <li
+                    key={e.id}
+                    style={{
+                      border: '1px solid var(--border)',
+                      borderRadius: 12,
+                      padding: 16,
+                      background: 'var(--surface)',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                        <span className="cj-modal-thumb" style={{ flexShrink: 0 }}>
+                          <CardImage
+                            cardImageLink={e.old_card_image_link || undefined}
+                            alt={e.old_card_name || 'Old card'}
+                            fill
+                            className="object-contain"
+                            sizes="56px"
+                          />
+                        </span>
+                        <span style={{ fontSize: 13, color: 'var(--text)', minWidth: 0 }}>
+                          {e.old_card_name || `Card #${e.old_card_id}`}
+                        </span>
+                      </div>
+
+                      <ArrowRightIcon style={{ width: 14, height: 14, color: 'var(--muted)', flexShrink: 0 }} />
+
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                        <span className="cj-modal-thumb" style={{ flexShrink: 0 }}>
+                          <CardImage
+                            cardImageLink={e.new_card_image_link || undefined}
+                            alt={e.new_card_name || 'New card'}
+                            fill
+                            className="object-contain"
+                            sizes="56px"
+                          />
+                        </span>
+                        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text)', minWidth: 0 }}>
+                          {e.new_card_name || `Card #${e.new_card_id}`}
+                        </span>
+                      </div>
+
+                      <div style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--muted)', textAlign: 'right' }}>
+                        <div>{formatDate(e.change_date)}</div>
+                        {e.bank && <div style={{ fontSize: 11 }}>{e.bank}</div>}
+                      </div>
+                    </div>
+
+                    {(reason || e.note) && (
+                      <div style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--border)', fontSize: 12, color: 'var(--muted)' }}>
+                        {reason && <div>{reason}</div>}
+                        {e.note && <div style={{ marginTop: 4, fontStyle: 'italic' }}>“{e.note}”</div>}
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </main>
+      <V2Footer />
+    </div>
+  );
+}

--- a/apps/web-next/src/app/profile/history/page.tsx
+++ b/apps/web-next/src/app/profile/history/page.tsx
@@ -1,0 +1,10 @@
+import WalletHistoryClient from "./WalletHistoryClient";
+
+export const metadata = {
+  title: "Wallet history",
+  robots: { index: false, follow: false },
+};
+
+export default function WalletHistoryPage() {
+  return <WalletHistoryClient />;
+}

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -4,8 +4,8 @@ import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
-import { XMarkIcon, TrashIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
-import { updateWalletCard, removeFromWallet, WalletCard, getUserCardRating, submitCardRating } from '@/lib/api';
+import { XMarkIcon, TrashIcon, ArrowTopRightOnSquareIcon, ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
+import { updateWalletCard, removeFromWallet, WalletCard, WalletCardEvent, getUserCardRating, submitCardRating } from '@/lib/api';
 import { useAuth } from '@/auth/AuthProvider';
 
 interface EditWalletCardModalProps {
@@ -16,8 +16,14 @@ interface EditWalletCardModalProps {
   // Optional override for the display name when the user holds multiple of the same card
   // (e.g. "Citi Custom Cash A" vs "Citi Custom Cash B"). Falls back to card.card_name.
   displayName?: string;
+  // Most recent product-change event for this wallet row, when one exists.
+  // Used to render the "Previously: <old card>" subtitle.
+  lastProductChange?: WalletCardEvent | null;
   onClose: () => void;
   onSuccess: () => void;
+  // Opens the product-change picker. The host is expected to close this modal
+  // and show the ProductChangeModal in its place.
+  onRequestProductChange?: () => void;
 }
 
 const RATING_LABELS: Record<number, string> = {
@@ -43,7 +49,7 @@ const months = [
   { value: 10, label: 'October' }, { value: 11, label: 'November' }, { value: 12, label: 'December' },
 ];
 
-export default function EditWalletCardModal({ show, card, cardSlug, annualFee, displayName, onClose, onSuccess }: EditWalletCardModalProps) {
+export default function EditWalletCardModal({ show, card, cardSlug, annualFee, displayName, lastProductChange, onClose, onSuccess, onRequestProductChange }: EditWalletCardModalProps) {
   const { getToken } = useAuth();
   const [acquiredMonth, setAcquiredMonth] = useState<number | undefined>();
   const [acquiredYear, setAcquiredYear] = useState<number | undefined>();
@@ -188,12 +194,28 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, d
                   <div className="cj-modal-card-meta">
                     {card.bank}{acquiredLabel ? ` · ${acquiredLabel}` : ''}
                   </div>
+                  {lastProductChange?.old_card_name && (
+                    <div style={{ fontStyle: 'italic', fontSize: 12, color: 'var(--muted)', marginTop: 2 }}>
+                      Previously: {lastProductChange.old_card_name}
+                      {lastProductChange.change_date ? ` on ${lastProductChange.change_date.slice(0, 10)}` : ''}
+                    </div>
+                  )}
                 </div>
               </div>
               {cardSlug && (
                 <Link href={`/card/${cardSlug}`} className="cj-modal-link">
                   view card details <ArrowTopRightOnSquareIcon style={{ width: 11, height: 11 }} />
                 </Link>
+              )}
+              {onRequestProductChange && (
+                <button
+                  type="button"
+                  className="cj-modal-link"
+                  onClick={onRequestProductChange}
+                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4, marginLeft: cardSlug ? 12 : 0 }}
+                >
+                  <ArrowsRightLeftIcon style={{ width: 11, height: 11 }} /> product change
+                </button>
               )}
             </div>
 

--- a/apps/web-next/src/components/wallet/ProductChangeModal.tsx
+++ b/apps/web-next/src/components/wallet/ProductChangeModal.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { XMarkIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import CardImage from '@/components/ui/CardImage';
+import {
+  Card,
+  WalletCard,
+  getAllCards,
+  productChangeWalletCard,
+} from '@/lib/api';
+import { useAuth } from '@/auth/AuthProvider';
+
+interface ProductChangeModalProps {
+  show: boolean;
+  card: WalletCard | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function ProductChangeModal({ show, card, onClose, onSuccess }: ProductChangeModalProps) {
+  const { getToken } = useAuth();
+  const [cards, setCards] = useState<Card[]>([]);
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<Card | null>(null);
+  const [reason, setReason] = useState<'voluntary' | 'forced' | ''>('');
+  const [changeDate, setChangeDate] = useState<string>(() => new Date().toISOString().slice(0, 10));
+  const [note, setNote] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => { setMounted(true); }, []);
+
+  useEffect(() => {
+    if (!show) return;
+    (async () => {
+      try {
+        setCards(await getAllCards());
+      } catch (err) {
+        console.error('Failed to load cards for product change:', err);
+      }
+    })();
+  }, [show]);
+
+  useEffect(() => {
+    if (!show) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, [show]);
+
+  const sameIssuerCards = useMemo(() => {
+    if (!card) return [];
+    return cards.filter((c) => {
+      if (!c.db_card_id) return false;
+      if (c.db_card_id === card.card_id) return false;
+      return c.bank?.toLowerCase() === card.bank?.toLowerCase();
+    });
+  }, [cards, card]);
+
+  const filteredCards = useMemo(() => {
+    if (!search) return sameIssuerCards;
+    const s = search.toLowerCase();
+    return sameIssuerCards.filter((c) => c.card_name.toLowerCase().includes(s));
+  }, [sameIssuerCards, search]);
+
+  const resetState = () => {
+    setSearch('');
+    setSelected(null);
+    setReason('');
+    setChangeDate(new Date().toISOString().slice(0, 10));
+    setNote('');
+    setError(null);
+  };
+
+  const handleClose = () => {
+    resetState();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!card || !selected?.db_card_id) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error('Authentication required');
+      await productChangeWalletCard(
+        card.id,
+        {
+          new_card_id: selected.db_card_id,
+          change_date: changeDate || undefined,
+          reason: reason || undefined,
+          note: note.trim() || undefined,
+        },
+        token,
+      );
+      onSuccess();
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to record product change');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!show || !card || !mounted) return null;
+
+  return createPortal(
+    <div className="landing-v2 profile-v2">
+      <div className="cj-modal-root" role="dialog" aria-modal="true">
+        <div className="cj-modal-backdrop" onClick={handleClose} />
+        <div className="cj-modal-shell">
+          <div className="cj-modal-card cj-modal-card-bounded" style={{ maxWidth: 560 }}>
+            <div className="cj-modal-head">
+              <span className="cj-status-dot" />
+              <span className="cj-modal-title">product change</span>
+              <button type="button" className="cj-modal-close" onClick={handleClose} aria-label="Close">
+                <XMarkIcon style={{ width: 16, height: 16 }} />
+              </button>
+            </div>
+
+            <div className="cj-modal-body">
+              {error && <div className="cj-modal-error">{error}</div>}
+
+              <div className="cj-modal-section">
+                <div className="cj-modal-card-row">
+                  <span className="cj-modal-thumb">
+                    <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="56px" />
+                  </span>
+                  <div style={{ minWidth: 0 }}>
+                    <div className="cj-modal-card-name">{card.card_name}</div>
+                    <div className="cj-modal-card-meta">
+                      {card.bank} · current card
+                    </div>
+                  </div>
+                </div>
+                <p style={{ fontSize: 12, color: 'var(--muted)', margin: '8px 0 0' }}>
+                  Pick the new {card.bank} card this account was converted to. We keep the open date and the wallet slot, and record the change in your history.
+                </p>
+              </div>
+
+              {!selected ? (
+                <>
+                  <div className="cj-modal-section">
+                    <label className="cj-modal-label">Search {card.bank} cards</label>
+                    <div className="cj-modal-search">
+                      <MagnifyingGlassIcon className="cj-modal-search-icon" />
+                      <input
+                        type="text"
+                        placeholder={`${card.bank} card name…`}
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        className="cj-modal-search-input"
+                        autoFocus
+                      />
+                    </div>
+                  </div>
+
+                  <div className="cj-modal-section">
+                    <div className="cj-modal-list">
+                      {filteredCards.slice(0, 20).map((c) => (
+                        <button
+                          key={c.card_id}
+                          type="button"
+                          onClick={() => setSelected(c)}
+                          className="cj-modal-list-row"
+                        >
+                          <span className="cj-modal-thumb">
+                            <CardImage cardImageLink={c.card_image_link} alt={c.card_name} fill className="object-contain" sizes="56px" />
+                          </span>
+                          <div style={{ minWidth: 0 }}>
+                            <div className="cj-modal-list-name">{c.card_name}</div>
+                            <div className="cj-modal-list-meta">{c.bank}</div>
+                          </div>
+                        </button>
+                      ))}
+                      {filteredCards.length === 0 && (
+                        <div className="cj-modal-list-empty">
+                          {sameIssuerCards.length === 0
+                            ? `No other ${card.bank} cards available`
+                            : 'No cards match'}
+                        </div>
+                      )}
+                      {filteredCards.length > 20 && (
+                        <div className="cj-modal-list-foot">
+                          showing first 20, refine your search to see more
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="cj-modal-section">
+                    <div className="cj-modal-card-row">
+                      <span className="cj-modal-thumb">
+                        <CardImage cardImageLink={selected.card_image_link} alt={selected.card_name} fill className="object-contain" sizes="56px" />
+                      </span>
+                      <div style={{ minWidth: 0 }}>
+                        <div className="cj-modal-card-name">{selected.card_name}</div>
+                        <div className="cj-modal-card-meta">{selected.bank} · new card</div>
+                      </div>
+                    </div>
+                    <button type="button" className="cj-modal-back" onClick={() => setSelected(null)}>
+                      ← choose a different card
+                    </button>
+                  </div>
+
+                  <div className="cj-modal-section">
+                    <label className="cj-modal-label">Change date</label>
+                    <input
+                      type="date"
+                      value={changeDate}
+                      onChange={(e) => setChangeDate(e.target.value)}
+                      className="cj-modal-select"
+                      max={new Date().toISOString().slice(0, 10)}
+                    />
+                  </div>
+
+                  <div className="cj-modal-section">
+                    <label className="cj-modal-label">Reason <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional)</span></label>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                      {([
+                        { value: 'voluntary', label: 'I requested it' },
+                        { value: 'forced', label: 'Bank initiated' },
+                      ] as const).map((opt) => (
+                        <button
+                          key={opt.value}
+                          type="button"
+                          onClick={() => setReason(reason === opt.value ? '' : opt.value)}
+                          className={'cj-modal-btn' + (reason === opt.value ? ' cj-modal-btn-primary' : '')}
+                          style={{ flex: 1 }}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="cj-modal-section">
+                    <label className="cj-modal-label">Note <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional)</span></label>
+                    <textarea
+                      value={note}
+                      onChange={(e) => setNote(e.target.value.slice(0, 500))}
+                      className="cj-modal-select"
+                      rows={2}
+                      placeholder="Anything to remember about this change…"
+                      style={{ resize: 'vertical', minHeight: 56 }}
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+
+            {selected && (
+              <div className="cj-modal-footer">
+                <span style={{ fontSize: 11, color: 'var(--muted)' }} />
+                <div className="cj-modal-actions">
+                  <button type="button" className="cj-modal-btn" onClick={handleClose}>cancel</button>
+                  <button
+                    type="button"
+                    className="cj-modal-btn cj-modal-btn-primary"
+                    onClick={handleSubmit}
+                    disabled={saving}
+                  >
+                    {saving ? 'saving…' : 'record product change'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -533,6 +533,71 @@ export async function removeFromWallet(walletRowId: number, token: string): Prom
   return res.json();
 }
 
+// Product-change history: one row per recorded conversion of a wallet card
+// from one product to another (same issuer). Sorted newest-first by the API.
+export interface WalletCardEvent {
+  id: number;
+  user_card_id: number | null;
+  event_type: 'product_change';
+  old_card_id: number;
+  new_card_id: number;
+  change_date: string;
+  reason: 'voluntary' | 'forced' | null;
+  note: string | null;
+  created_at: string;
+  old_card_name: string | null;
+  old_card_image_link: string | null;
+  new_card_name: string | null;
+  new_card_image_link: string | null;
+  bank: string | null;
+}
+
+export async function getWalletEvents(token: string): Promise<WalletCardEvent[]> {
+  const res = await fetch(`${API_BASE}/wallet/events`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to fetch wallet events: ${errorText}`);
+  }
+  return res.json();
+}
+
+export interface ProductChangeBody {
+  new_card_id: number;
+  change_date?: string;
+  reason?: 'voluntary' | 'forced';
+  note?: string;
+}
+
+export async function productChangeWalletCard(
+  walletRowId: number,
+  body: ProductChangeBody,
+  token: string,
+): Promise<{
+  message: string;
+  event_id: number;
+  wallet_card_id: number;
+  old_card_id: number;
+  new_card_id: number;
+  change_date: string;
+}> {
+  const res = await fetch(`${API_BASE}/wallet/${walletRowId}/product-change`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(errorText || `Failed to record product change: ${res.status}`);
+  }
+  return res.json();
+}
+
 // User category selections per wallet card (Cash+, Custom Cash, etc).
 // PUT replaces the active set wholesale — partial updates aren't supported.
 export interface UpdateSelectionsBody {


### PR DESCRIPTION
## Summary
- Lets a user convert a wallet card to another product from the same issuer (voluntary or bank-initiated). Preserves the wallet row id, open date, and sort order (same account, different product) and logs the event for a changelog.
- New `wallet_card_events` table, `POST /wallet/{id}/product-change`, `GET /wallet/events`, plus a `ProductChangeModal`, inline "Previously: …" subtitle in the edit modal, and a `/profile/history` route.

## Data model
- Migration: `apps/api/migrations/037_create_wallet_card_events.sql` (single-statement CREATE TABLE; runs via the `RunMigrationHandler` pattern).
- Columns: `user_id`, `user_card_id`, `event_type` (default `product_change`), `old_card_id`, `new_card_id`, `change_date`, `reason` (`voluntary`/`forced`, nullable), `note` (≤500 chars), `created_at`. Indexed on `user_id`, `user_card_id`, `change_date`.
- `user_card_id` is nullable on purpose: a future delete of the wallet row should not cascade away the user's history.

## Backend
- `POST /wallet/{id}/product-change` validates row ownership, target card existence, **same-issuer match (`cards.bank`)**, and `new_card_id != old`. Updates `user_cards.card_id` and inserts the event.
- `GET /wallet/events` joins old/new card names + images so the changelog renders without a second round-trip.
- Both wired in `apps/api/template.yml` with OPTIONS routes for CORS.

## Frontend
- **`ProductChangeModal.tsx`** — Same-issuer-only card picker (filtered by `card.bank`), change date input (defaults to today, max=today), optional reason buttons (`I requested it` / `Bank initiated`), optional ≤500-char note.
- **`EditWalletCardModal.tsx`** — adds a `product change` link in the same row as `view card details`, and renders a small `Previously: <old card> on <date>` line under the card header when the row has a prior event.
- **`/profile/history`** — new authenticated route with a list of every event, newest first, showing old → new card images, change date, issuer, reason, and note.
- Profile cards toolbar gets a `history` link next to `+ add a card`.

## Deploy order
1. Merge → `sam build && sam deploy` (picks up the new routes + handler change).
2. Run migration 037 via the `RunMigrationHandler` pattern.
3. Frontend deploys via Amplify webhook on merge as usual.

## Test plan
- [x] `tsc --noEmit` on `apps/web-next` passes
- [x] `node -c apps/api/src/handlers/user-wallet.js` passes
- [x] `/profile/history` compiles and serves 200 in dev; redirects unauthenticated users to `/login?next=…`
- [ ] Smoke test signed-in: open a wallet card → product change → pick same-issuer target → confirm Previously subtitle appears + entry shows in `/profile/history`
- [ ] Cross-issuer attempt rejected with 400 (verify via DevTools)
- [ ] Wallet ranker / BCH unaffected (same `user_cards` shape, just a new card_id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)