### PR TITLE
Referrals: weekly validity check with auto-archive + replacement UX

### DIFF
--- a/.github/workflows/check-referrals.yml
+++ b/.github/workflows/check-referrals.yml
@@ -1,0 +1,99 @@
+name: Check Referrals
+
+# Weekly validator for referral links.
+#
+# Pulls the next batch of approved, non-archived referrals from the
+# ReferralValidationListFunction Lambda, fetches each URL (Playwright +
+# Haiku), and posts results back to ReferralValidationCompleteFunction.
+#
+# Conservative detection: HTTP 404/410/timeout + explicit "expired"
+# language only. After 2 consecutive failed checks per referral, the
+# Complete Lambda auto-archives with archived_reason='auto: <status>'.
+#
+# Off-peak schedule (Mon 12:00 UTC) so it doesn't collide with the daily
+# card-page check.
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'  # Mondays 12:00 UTC
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Max referrals to check this run (default 200, max 500)'
+        required: false
+        default: '200'
+
+# Don't overlap runs (a manual dispatch shouldn't race the cron).
+concurrency:
+  group: check-referrals
+  cancel-in-progress: false
+
+permissions:
+  id-token: write   # for OIDC into AWS
+  contents: read
+
+jobs:
+  check-referrals:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
+          aws-region: us-east-2
+
+      - name: Fetch batch from ReferralValidationListFunction
+        env:
+          LIMIT: ${{ github.event.inputs.limit || '200' }}
+        run: |
+          aws lambda invoke \
+            --region us-east-2 \
+            --function-name $(aws lambda list-functions \
+              --region us-east-2 \
+              --query "Functions[?contains(FunctionName, 'ReferralValidationListFunction')].FunctionName | [0]" \
+              --output text) \
+            --cli-binary-format raw-in-base64-out \
+            --payload "{\"limit\": ${LIMIT}}" \
+            --cli-read-timeout 70 \
+            batch.json
+          echo "Batch size: $(jq '.referrals | length' batch.json)"
+
+      - name: Run validation checks
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: node scripts/check-referrals.js
+
+      - name: Post results to ReferralValidationCompleteFunction
+        run: |
+          if [ ! -s results.json ]; then
+            echo "No results to post."
+            exit 0
+          fi
+          aws lambda invoke \
+            --region us-east-2 \
+            --function-name $(aws lambda list-functions \
+              --region us-east-2 \
+              --query "Functions[?contains(FunctionName, 'ReferralValidationCompleteFunction')].FunctionName | [0]" \
+              --output text) \
+            --cli-binary-format raw-in-base64-out \
+            --payload fileb://results.json \
+            --cli-read-timeout 310 \
+            complete-response.json
+          echo "Complete response:"
+          cat complete-response.json

--- a/apps/api/migrations/038_add_validation_to_referrals.sql
+++ b/apps/api/migrations/038_add_validation_to_referrals.sql
@@ -1,0 +1,5 @@
+ALTER TABLE referrals
+  ADD COLUMN last_validated_at TIMESTAMP NULL DEFAULT NULL,
+  ADD COLUMN validation_status VARCHAR(16) NULL DEFAULT NULL,
+  ADD COLUMN validation_consecutive_failures INT NOT NULL DEFAULT 0,
+  ADD INDEX idx_referrals_validation_due (admin_approved, archived_at, last_validated_at);

--- a/apps/api/src/handlers/referral-validation-complete.js
+++ b/apps/api/src/handlers/referral-validation-complete.js
@@ -1,0 +1,129 @@
+// Referral Validation — Complete handler
+//
+// Accepts per-referral results from the `check-referrals` GitHub Action
+// workflow and updates the DB. Called once per workflow run via
+// `aws lambda invoke`. NOT exposed via API Gateway.
+//
+// For each result:
+//   - `valid`        → reset consecutive failures to 0, mark valid, bump last_validated_at
+//   - `expired`      → increment consecutive failures, mark expired,
+//                      bump last_validated_at. Auto-archive once the
+//                      counter reaches ARCHIVE_THRESHOLD.
+//   - `unreachable`  → same as expired (network failures are treated as
+//                      soft signal; auto-archive only after the same N
+//                      consecutive misses).
+//
+// Invocation contract:
+//   Input  : { results: [{ referral_id, status, reason? }] }
+//   Output : { processed: number, archived: [referral_id, ...], skipped: [...] }
+
+const mysql = require("../db");
+
+const ARCHIVE_THRESHOLD = 2; // consecutive failures before auto-archive
+const VALID_STATUSES = new Set(["valid", "expired", "unreachable"]);
+
+exports.ReferralValidationCompleteHandler = async (event) => {
+  console.info("ReferralValidationComplete received:", {
+    count: (event && event.results && event.results.length) || 0,
+  });
+
+  const results = (event && Array.isArray(event.results)) ? event.results : [];
+  if (results.length === 0) {
+    return { processed: 0, archived: [], skipped: [] };
+  }
+
+  const archived = [];
+  const skipped = [];
+  let processed = 0;
+
+  try {
+    for (const r of results) {
+      const referralId = Number(r.referral_id);
+      const status = String(r.status || "").toLowerCase();
+
+      if (!Number.isFinite(referralId) || referralId <= 0 || !VALID_STATUSES.has(status)) {
+        skipped.push({ referral_id: r.referral_id, reason: "invalid input" });
+        continue;
+      }
+
+      // Look up the current row so we can decide whether to archive in
+      // the same statement (vs. relying on a second SELECT). Skip rows
+      // that were archived between list and complete — those are someone
+      // else's concern now.
+      const rows = await mysql.query(
+        "SELECT validation_consecutive_failures, archived_at FROM referrals WHERE referral_id = ?",
+        [referralId],
+      );
+
+      if (rows.length === 0) {
+        skipped.push({ referral_id: referralId, reason: "not found" });
+        continue;
+      }
+      if (rows[0].archived_at) {
+        skipped.push({ referral_id: referralId, reason: "already archived" });
+        continue;
+      }
+
+      if (status === "valid") {
+        await mysql.query(
+          `
+          UPDATE referrals
+          SET validation_status = 'valid',
+              validation_consecutive_failures = 0,
+              last_validated_at = NOW()
+          WHERE referral_id = ?
+          `,
+          [referralId],
+        );
+        processed += 1;
+        continue;
+      }
+
+      // expired or unreachable
+      const nextFailures = (rows[0].validation_consecutive_failures || 0) + 1;
+      const shouldArchive = nextFailures >= ARCHIVE_THRESHOLD;
+
+      if (shouldArchive) {
+        // Single UPDATE handles the archive + status bump together.
+        // archived_reason carries the prefix `auto:` so the user UI can
+        // distinguish "I archived this" from "the validator did".
+        await mysql.query(
+          `
+          UPDATE referrals
+          SET validation_status = ?,
+              validation_consecutive_failures = ?,
+              last_validated_at = NOW(),
+              archived_at = NOW(),
+              archived_reason = ?
+          WHERE referral_id = ?
+          `,
+          [status, nextFailures, `auto: ${status}`, referralId],
+        );
+        archived.push(referralId);
+      } else {
+        await mysql.query(
+          `
+          UPDATE referrals
+          SET validation_status = ?,
+              validation_consecutive_failures = ?,
+              last_validated_at = NOW()
+          WHERE referral_id = ?
+          `,
+          [status, nextFailures, referralId],
+        );
+      }
+      processed += 1;
+    }
+
+    await mysql.end();
+
+    console.info(
+      `ReferralValidationComplete: processed=${processed} archived=${archived.length} skipped=${skipped.length}`,
+    );
+    return { processed, archived, skipped };
+  } catch (error) {
+    console.error("ReferralValidationComplete error:", error);
+    await mysql.end();
+    throw error;
+  }
+};

--- a/apps/api/src/handlers/referral-validation-list.js
+++ b/apps/api/src/handlers/referral-validation-list.js
@@ -1,0 +1,57 @@
+// Referral Validation — List handler
+//
+// Returns the next batch of referrals due for validation. Called by the
+// `check-referrals` GitHub Action once per week via `aws lambda invoke`.
+//
+// Eligible rows: admin-approved, not archived, and either never validated
+// or last validated > 7 days ago. Ordered oldest-first (NULLs first) so
+// the cap is fair across batches when the active set grows beyond it.
+//
+// Invocation contract:
+//   Input  : { limit?: number }                        (optional, default 200, max 500)
+//   Output : { referrals: [{ referral_id, card_id, card_name, referral_link }] }
+
+const mysql = require("../db");
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 500;
+const STALE_DAYS = 7;
+
+exports.ReferralValidationListHandler = async (event) => {
+  console.info("ReferralValidationList received:", event);
+
+  let limit = Number((event && event.limit) || DEFAULT_LIMIT);
+  if (!Number.isFinite(limit) || limit <= 0) limit = DEFAULT_LIMIT;
+  if (limit > MAX_LIMIT) limit = MAX_LIMIT;
+
+  try {
+    // ORDER BY (last_validated_at IS NULL) DESC puts NULLs first (the
+    // never-checked) which is the correct fairness behaviour. After NULLs,
+    // oldest-validated wins, then referral_id as a stable tiebreaker.
+    const rows = await mysql.query(
+      `
+      SELECT r.referral_id, r.card_id, r.referral_link, c.card_name
+      FROM referrals r
+      JOIN cards c ON c.card_id = r.card_id
+      WHERE r.admin_approved = 1
+        AND r.archived_at IS NULL
+        AND (
+          r.last_validated_at IS NULL
+          OR r.last_validated_at < (NOW() - INTERVAL ? DAY)
+        )
+      ORDER BY (r.last_validated_at IS NULL) DESC, r.last_validated_at ASC, r.referral_id ASC
+      LIMIT ?
+      `,
+      [STALE_DAYS, limit],
+    );
+
+    await mysql.end();
+
+    console.info(`ReferralValidationList returning ${rows.length} referral(s)`);
+    return { referrals: rows };
+  } catch (error) {
+    console.error("ReferralValidationList error:", error);
+    await mysql.end();
+    throw error;
+  }
+};

--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -38,6 +38,7 @@ exports.UserReferralsHandler = async (event) => {
           `SELECT
              r.referral_id, r.card_id, r.referral_link, r.admin_approved,
              r.submit_datetime, r.archived_at, r.archived_reason,
+             r.validation_status, r.last_validated_at,
              c.card_name, c.card_image_link, c.card_referral_link
            FROM referrals r
            JOIN cards c ON r.card_id = c.card_id

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -1172,6 +1172,39 @@ Resources:
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
 
+  # Referral validity check: paired Lambdas invoked by the
+  # `check-referrals.yml` GitHub Action. List returns the due batch;
+  # Complete writes back per-referral results. Not exposed via API Gateway.
+  ReferralValidationListFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/referral-validation-list.ReferralValidationListHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 60
+      Description: Returns the next batch of referrals due for validity check
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+
+  ReferralValidationCompleteFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/referral-validation-complete.ReferralValidationCompleteHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 300
+      Description: Records referral validation results; auto-archives after consecutive failures
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+
   RefreshCardStatsFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -73,9 +73,18 @@ interface Referral {
   admin_approved: boolean;
   archived_at?: string | null;
   archived_reason?: string | null;
+  validation_status?: 'valid' | 'expired' | 'unreachable' | null;
+  last_validated_at?: string | null;
   impressions?: number;
   clicks?: number;
   unique_clicks?: number;
+}
+
+// A referral was auto-archived by the weekly validity check when
+// archived_reason starts with "auto:". Used in the profile referrals tab
+// to surface a "this link expired" banner + "add replacement" CTA.
+function isAutoArchivedReferral(r: Pick<Referral, 'archived_at' | 'archived_reason'>): boolean {
+  return !!r.archived_at && typeof r.archived_reason === 'string' && r.archived_reason.startsWith('auto:');
 }
 
 type TabKey = 'cards' | 'rewards' | 'benefits' | 'applications' | 'referrals' | 'settings' | 'news' | 'more';
@@ -130,6 +139,10 @@ export default function ProfileClient() {
   const [recordsLoaded, setRecordsLoaded] = useState(false);
   const [referralsLoaded, setReferralsLoaded] = useState(false);
   const [showReferralModal, setShowReferralModal] = useState(false);
+  // When the user clicks "add replacement" on an auto-archived referral
+  // row, we open the ReferralModal pre-selected to that card_id so they
+  // can skip the picker. Cleared on modal close.
+  const [replacementForCardId, setReplacementForCardId] = useState<string | null>(null);
   const [showWalletModal, setShowWalletModal] = useState(false);
   const [deletingRecordId, setDeletingRecordId] = useState<number | null>(null);
   const [archivingReferralId, setArchivingReferralId] = useState<number | null>(null);
@@ -412,6 +425,10 @@ export default function ProfileClient() {
   const displayName = authState.user?.displayName || authState.user?.email?.split('@')[0] || 'there';
   const handle = authState.user?.email?.split('@')[0] || '';
   const activeReferralsCount = referrals.filter(r => !r.archived_at).length;
+  // Referrals that the weekly validator auto-archived. We want the
+  // referrals tab to surface a "needs attention" cue in its label so
+  // users notice without having to click in.
+  const expiredReferralsCount = referrals.filter(isAutoArchivedReferral).length;
   const visibleWalletCards = activeWalletCards;
 
   const tabs: { key: TabKey; num: string; label: string; count: string }[] = [
@@ -419,7 +436,9 @@ export default function ProfileClient() {
     { key: 'rewards', num: '02', label: 'Earn', count: '' },
     { key: 'benefits', num: '03', label: 'Benefits', count: '' },
     { key: 'applications', num: '04', label: 'Applications', count: records.length ? `${records.length} records` : '' },
-    { key: 'referrals', num: '05', label: 'Referrals', count: activeReferralsCount ? `${activeReferralsCount} links` : '' },
+    { key: 'referrals', num: '05', label: 'Referrals', count: expiredReferralsCount
+        ? `${expiredReferralsCount} needs attention`
+        : (activeReferralsCount ? `${activeReferralsCount} links` : '') },
     { key: 'settings', num: '06', label: 'Settings', count: '' },
   ];
 
@@ -673,7 +692,8 @@ export default function ProfileClient() {
                 referralsLoaded={referralsLoaded}
                 referrals={referrals}
                 eligibleReferralCards={eligibleReferralCards}
-                onAddReferral={() => setShowReferralModal(true)}
+                onAddReferral={() => { setReplacementForCardId(null); setShowReferralModal(true); }}
+                onReplace={(cardId) => { setReplacementForCardId(cardId); setShowReferralModal(true); }}
                 onArchive={handleArchiveReferral}
                 archivingReferralId={archivingReferralId}
               />
@@ -722,7 +742,8 @@ export default function ProfileClient() {
                   referralsLoaded={referralsLoaded}
                   referrals={referrals}
                   eligibleReferralCards={eligibleReferralCards}
-                  onAddReferral={() => setShowReferralModal(true)}
+                  onAddReferral={() => { setReplacementForCardId(null); setShowReferralModal(true); }}
+                  onReplace={(cardId) => { setReplacementForCardId(cardId); setShowReferralModal(true); }}
                   onArchive={handleArchiveReferral}
                   archivingReferralId={archivingReferralId}
                 />
@@ -840,8 +861,9 @@ export default function ProfileClient() {
       {/* Modals */}
       <ReferralModal
         show={showReferralModal}
-        handleClose={() => setShowReferralModal(false)}
+        handleClose={() => { setShowReferralModal(false); setReplacementForCardId(null); }}
         openReferrals={eligibleReferralCards}
+        preselectCardId={replacementForCardId}
         onSuccess={loadData}
       />
       <AddToWalletModal
@@ -1372,16 +1394,22 @@ interface ReferralsTabProps {
   referrals: Referral[];
   eligibleReferralCards: ReturnType<typeof getEligibleReferralCards>;
   onAddReferral: () => void;
+  onReplace: (cardId: string) => void;
   onArchive: (id: number) => void;
   archivingReferralId: number | null;
 }
 
 function ReferralsTab(props: ReferralsTabProps) {
-  const { referralsLoaded, referrals, eligibleReferralCards, onAddReferral, onArchive, archivingReferralId } = props;
+  const { referralsLoaded, referrals, eligibleReferralCards, onAddReferral, onReplace, onArchive, archivingReferralId } = props;
   if (!referralsLoaded) return <LoadingPanel />;
 
   const active = referrals.filter(r => !r.archived_at);
-  const adminArchived = referrals.filter(r => r.archived_at && r.archived_reason);
+  // Split archived referrals: auto = expired/unreachable detection by the
+  // weekly validator (need a replacement), manual = admin or user
+  // archived (already shown as the existing yellow notice).
+  const autoArchived = referrals.filter(isAutoArchivedReferral);
+  const adminArchived = referrals.filter(r => r.archived_at && r.archived_reason && !isAutoArchivedReferral(r));
+  const eligibleCardIds = new Set(eligibleReferralCards.map(c => c.card_id));
   const totalImpressions = active.reduce((s, r) => s + (r.impressions ?? 0), 0);
   const totalClicks = active.reduce((s, r) => s + (r.clicks ?? 0), 0);
   const ctr = totalImpressions > 0 ? ((totalClicks / totalImpressions) * 100).toFixed(1) : '0.0';
@@ -1407,6 +1435,48 @@ function ReferralsTab(props: ReferralsTabProps) {
           <div className="cj-readoff-foot">{ctr}% CTR</div>
         </div>
       </div>
+
+      {autoArchived.length > 0 && (
+        <div style={{ marginTop: 16, border: '1px solid var(--line-2)', borderLeft: '3px solid #a8792a', background: '#fef9e8', borderRadius: 6, padding: '12px 14px' }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#5c4318', marginBottom: 8 }}>
+            {autoArchived.length === 1
+              ? '1 referral link looks like it expired'
+              : `${autoArchived.length} referral links look like they expired`}
+          </div>
+          <div style={{ fontSize: 12, color: '#5c4318', marginBottom: 10 }}>
+            Our weekly check stopped serving {autoArchived.length === 1 ? 'this one' : 'these'} on card pages. Add a replacement to start collecting clicks again. The old stats below stay yours.
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {autoArchived.map((r) => {
+              const cardIdStr = String(r.card_id);
+              const eligible = eligibleCardIds.has(cardIdStr);
+              const validatedDate = r.last_validated_at ? r.last_validated_at.slice(0, 10) : null;
+              return (
+                <div key={r.referral_id} style={{ display: 'flex', alignItems: 'center', gap: 10, paddingTop: 8, borderTop: '1px solid rgba(168, 121, 42, 0.18)' }}>
+                  <span className="cj-tape-thumb" style={{ flexShrink: 0 }}>
+                    <CardImage cardImageLink={r.card_image_link} alt={r.card_name} fill sizes="36px" className="object-contain" />
+                  </span>
+                  <div style={{ minWidth: 0, flex: 1 }}>
+                    <div style={{ fontSize: 13, fontWeight: 500, color: '#2a2a2a' }}>{r.card_name}</div>
+                    <div style={{ fontSize: 11, color: '#7a6035' }}>
+                      flagged {validatedDate || 'recently'} · {(r.impressions ?? 0).toLocaleString()} impr · {r.clicks ?? 0} click{(r.clicks ?? 0) === 1 ? '' : 's'} on the old link
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    className="cj-inline-cta"
+                    onClick={() => onReplace(cardIdStr)}
+                    disabled={!eligible}
+                    title={eligible ? '' : 'You no longer hold this card in your wallet or records, so a new referral cannot be submitted.'}
+                  >
+                    {eligible ? 'add replacement' : 'card not held'}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <div className="cj-wallet-toolbar" style={{ marginTop: 16 }}>
         <div className="cj-table-label">Your referral links</div>

--- a/apps/web-next/src/components/forms/ReferralModal.tsx
+++ b/apps/web-next/src/components/forms/ReferralModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { XMarkIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import CardImage from '@/components/ui/CardImage';
 import { useAuth } from '@/auth/AuthProvider';
@@ -18,6 +18,10 @@ interface ReferralModalProps {
   handleClose: () => void;
   openReferrals: OpenReferral[];
   onSuccess: () => void;
+  // When set, the modal opens directly on the URL-entry step for this
+  // card_id (skipping the picker). Used by the referrals tab's
+  // "add replacement" flow after a referral is auto-archived.
+  preselectCardId?: string | null;
 }
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
@@ -30,7 +34,7 @@ function validateUrl(value: string): string | null {
   return null;
 }
 
-export default function ReferralModal({ show, handleClose, openReferrals, onSuccess }: ReferralModalProps) {
+export default function ReferralModal({ show, handleClose, openReferrals, onSuccess, preselectCardId }: ReferralModalProps) {
   const { getToken } = useAuth();
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<OpenReferral | null>(null);
@@ -38,6 +42,17 @@ export default function ReferralModal({ show, handleClose, openReferrals, onSucc
   const [touched, setTouched] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Replacement flow: when preselectCardId points at a card in
+  // openReferrals, jump straight to the URL-entry step. Re-runs when
+  // openReferrals lands asynchronously after open.
+  useEffect(() => {
+    if (!show || !preselectCardId) return;
+    const match = openReferrals.find((c) => c.card_id === preselectCardId);
+    if (match && (!selected || selected.card_id !== match.card_id)) {
+      setSelected(match);
+    }
+  }, [show, preselectCardId, openReferrals, selected]);
 
   const validationError = validateUrl(referralLink);
 

--- a/scripts/check-referrals.js
+++ b/scripts/check-referrals.js
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+
+/**
+ * Check Referrals Script
+ *
+ * Reads a list of referrals due for validation from `batch.json`, fetches
+ * each referral URL with Playwright (falling back from a simple fetch),
+ * and asks Claude Haiku whether the link still serves a working referral.
+ * Writes per-referral results to `results.json`.
+ *
+ * Conservative detection only (per project_referral_validation_roadmap.md):
+ *   - HTTP 4xx/410/timeout/DNS-fail short-circuit to expired/unreachable
+ *     (no Haiku call needed).
+ *   - HTTP 200 → Haiku looks for explicit dead signals (e.g. "this referral
+ *     has expired", "no longer available", "this offer has ended"). Anything
+ *     else returns "valid".
+ *
+ * Inputs (env / files):
+ *   BATCH_FILE      : path to batch JSON                (default ./batch.json)
+ *   RESULTS_FILE    : path to results JSON              (default ./results.json)
+ *   ANTHROPIC_API_KEY : required for Haiku
+ *
+ * batch.json shape : { referrals: [{ referral_id, card_id, card_name, referral_link }] }
+ * results.json shape : { results: [{ referral_id, status, reason }] }
+ *   status ∈ "valid" | "expired" | "unreachable"
+ */
+
+const fs = require('fs');
+
+const BATCH_FILE = process.env.BATCH_FILE || './batch.json';
+const RESULTS_FILE = process.env.RESULTS_FILE || './results.json';
+
+const FETCH_DELAY_MS = 1500;
+const FETCH_TIMEOUT_MS = 15000;
+const PER_REFERRAL_TIMEOUT_MS = 60000;
+const SCRIPT_TIMEOUT_MS = 25 * 60 * 1000;
+
+// ─── Timeout helper ──────────────────────────────────────────────────────────
+
+function withTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`Timed out after ${ms}ms: ${label}`)), ms)
+    ),
+  ]);
+}
+
+// ─── Page fetch (mirrors check-card-pages.js patterns) ───────────────────────
+
+function stripHtml(html) {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+    .replace(/<nav\b[^<]*(?:(?!<\/nav>)<[^<]*)*<\/nav>/gi, '')
+    .replace(/<header\b[^<]*(?:(?!<\/header>)<[^<]*)*<\/header>/gi, '')
+    .replace(/<footer\b[^<]*(?:(?!<\/footer>)<[^<]*)*<\/footer>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z#0-9]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 6000);
+}
+
+let _browser = null;
+async function getBrowser() {
+  if (!_browser) {
+    try {
+      const { chromium } = require('playwright');
+      _browser = await chromium.launch({ headless: true });
+    } catch (err) {
+      console.warn(`  Playwright not available: ${err.message}`);
+      return null;
+    }
+  }
+  return _browser;
+}
+
+async function closeBrowser() {
+  if (_browser) {
+    await _browser.close();
+    _browser = null;
+  }
+}
+
+// Returns one of:
+//   { kind: 'ok', content: string, finalUrl: string }
+//   { kind: 'expired-by-status', status: number }   (404, 410, 451)
+//   { kind: 'unreachable', reason: string }
+async function fetchReferralPage(url) {
+  // Try simple fetch first.
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    // Conservative dead-by-status signals.
+    if (response.status === 404 || response.status === 410 || response.status === 451) {
+      return { kind: 'expired-by-status', status: response.status };
+    }
+
+    if (response.ok) {
+      const ct = response.headers.get('content-type') || '';
+      if (ct.includes('text/html')) {
+        const html = await response.text();
+        const stripped = stripHtml(html);
+        if (stripped.length >= 100) {
+          return { kind: 'ok', content: stripped, finalUrl: response.url };
+        }
+        console.warn(`  Simple fetch too short (${stripped.length}); trying browser`);
+      }
+    }
+  } catch (err) {
+    console.warn(`  Simple fetch failed: ${err.message}; trying browser`);
+  }
+
+  // Fall back to Playwright for JS-rendered pages.
+  const browser = await getBrowser();
+  if (!browser) return { kind: 'unreachable', reason: 'browser unavailable' };
+
+  let page;
+  try {
+    const context = await browser.newContext({
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
+    page = await context.newPage();
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    const status = response ? response.status() : 0;
+    if (status === 404 || status === 410 || status === 451) {
+      await context.close();
+      return { kind: 'expired-by-status', status };
+    }
+    await page.waitForTimeout(2500);
+    const html = await page.content();
+    const finalUrl = page.url();
+    await context.close();
+    const stripped = stripHtml(html);
+    if (stripped.length < 100) {
+      return { kind: 'unreachable', reason: `browser content too short (${stripped.length})` };
+    }
+    return { kind: 'ok', content: stripped, finalUrl };
+  } catch (err) {
+    if (page) await page.context().close().catch(() => {});
+    return { kind: 'unreachable', reason: err.message };
+  }
+}
+
+// ─── Claude Haiku classification ─────────────────────────────────────────────
+
+async function classifyWithHaiku(cardName, referralUrl, finalUrl, pageContent) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY required');
+
+  const prompt = `You are classifying a credit-card referral landing page.
+
+Card: ${cardName}
+Referral URL: ${referralUrl}
+Final URL after redirects: ${finalUrl}
+
+Page content (HTML stripped to plain text, truncated to 6000 chars):
+${pageContent}
+
+Decide whether this referral link is still WORKING (referrer will be credited if a new applicant signs up via this link) or DEAD (the page no longer accepts a referral signup).
+
+Return ONLY valid JSON, no markdown fences, no explanation:
+
+{
+  "status": "valid" | "expired",
+  "reason": "<short phrase quoting the signal you saw>"
+}
+
+Rules:
+- "expired" ONLY when the page contains an EXPLICIT dead-signal phrase such as:
+    "this referral link has expired"
+    "no longer accepting referrals"
+    "this offer is no longer available"
+    "this offer has ended"
+    "referral program has ended"
+    "this link is no longer valid"
+  Or visually equivalent variants from the issuer (Chase, Amex, Citi, Capital One, Discover, US Bank, Wells Fargo, etc.). Quote the phrase you saw in "reason".
+- If the page is the issuer's normal apply form / card landing page with no expiration notice, return "valid".
+- Do NOT mark "expired" just because the page is a generic apply page or doesn't show the referrer's name.
+- Do NOT mark "expired" because the signup bonus differs from what the user advertised.
+- When unsure, return "valid". A missed expiry is cheap; a wrong "expired" auto-archives a working link after two runs.`;
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`Claude API error: ${response.status} — ${errText}`);
+  }
+
+  const data = await response.json();
+  const text = (data.content[0]?.text || '{}')
+    .replace(/^```json?\n?/, '')
+    .replace(/\n?```$/, '')
+    .trim();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    console.warn(`  Could not parse Claude response: ${err.message}`);
+    return { status: 'valid', reason: 'unparseable Haiku response; defaulting to valid' };
+  }
+  // Defensive: clamp to the two values we trust here. unreachable is
+  // produced by the network layer above; Haiku never emits it.
+  const status = parsed.status === 'expired' ? 'expired' : 'valid';
+  return { status, reason: String(parsed.reason || '').slice(0, 200) };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('=== Check Referrals ===\n');
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('Error: ANTHROPIC_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(BATCH_FILE)) {
+    console.error(`Error: batch file not found at ${BATCH_FILE}`);
+    process.exit(1);
+  }
+
+  const batch = JSON.parse(fs.readFileSync(BATCH_FILE, 'utf8'));
+  const referrals = Array.isArray(batch.referrals) ? batch.referrals : [];
+  console.log(`Loaded ${referrals.length} referral(s) from ${BATCH_FILE}\n`);
+
+  if (referrals.length === 0) {
+    fs.writeFileSync(RESULTS_FILE, JSON.stringify({ results: [] }, null, 2));
+    console.log('No referrals to check. Wrote empty results.');
+    return;
+  }
+
+  const results = [];
+  const scriptDeadline = Date.now() + SCRIPT_TIMEOUT_MS;
+
+  for (const ref of referrals) {
+    if (Date.now() > scriptDeadline) {
+      console.warn(`\nScript timeout reached (${SCRIPT_TIMEOUT_MS / 60000} min) — stopping early.`);
+      break;
+    }
+
+    console.log(`Checking: ${ref.card_name} (#${ref.referral_id})`);
+    console.log(`  URL: ${ref.referral_link}`);
+
+    try {
+      await withTimeout(
+        (async () => {
+          const fetched = await fetchReferralPage(ref.referral_link);
+
+          if (fetched.kind === 'expired-by-status') {
+            console.log(`  → expired (HTTP ${fetched.status})`);
+            results.push({
+              referral_id: ref.referral_id,
+              status: 'expired',
+              reason: `HTTP ${fetched.status}`,
+            });
+            return;
+          }
+
+          if (fetched.kind === 'unreachable') {
+            console.log(`  → unreachable (${fetched.reason})`);
+            results.push({
+              referral_id: ref.referral_id,
+              status: 'unreachable',
+              reason: fetched.reason,
+            });
+            return;
+          }
+
+          // HTTP 200 with content → ask Haiku.
+          try {
+            const verdict = await classifyWithHaiku(
+              ref.card_name,
+              ref.referral_link,
+              fetched.finalUrl,
+              fetched.content,
+            );
+            console.log(`  → ${verdict.status} (${verdict.reason})`);
+            results.push({
+              referral_id: ref.referral_id,
+              status: verdict.status,
+              reason: verdict.reason,
+            });
+          } catch (err) {
+            console.warn(`  Haiku error: ${err.message} — recording unreachable`);
+            results.push({
+              referral_id: ref.referral_id,
+              status: 'unreachable',
+              reason: `haiku error: ${err.message}`,
+            });
+          }
+        })(),
+        PER_REFERRAL_TIMEOUT_MS,
+        `referral #${ref.referral_id}`,
+      );
+    } catch (err) {
+      console.warn(`  ${err.message} — recording unreachable`);
+      results.push({
+        referral_id: ref.referral_id,
+        status: 'unreachable',
+        reason: err.message,
+      });
+    }
+
+    console.log('');
+    await new Promise((r) => setTimeout(r, FETCH_DELAY_MS));
+  }
+
+  fs.writeFileSync(RESULTS_FILE, JSON.stringify({ results }, null, 2));
+  console.log(`\nWrote ${results.length} result(s) to ${RESULTS_FILE}`);
+  await closeBrowser();
+  console.log('\n=== Complete ===');
+}
+
+main().catch(async (err) => {
+  console.error('Fatal error:', err);
+  await closeBrowser();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Weekly GitHub Action validates each approved referral, auto-archives after 2 consecutive failed checks, surfaces "needs attention" + add-replacement UX in the profile referrals tab.
- Conservative detection only: HTTP 404/410/timeout short-circuit; otherwise Haiku looks for explicit dead-language ("this offer has expired", "no longer accepting referrals", etc.) and defaults to valid when unsure.

## Data model (migration 038)
Single ALTER on `referrals`:
- `last_validated_at TIMESTAMP NULL`
- `validation_status VARCHAR(16) NULL` (`valid` | `expired` | `unreachable`)
- `validation_consecutive_failures INT NOT NULL DEFAULT 0`
- `INDEX (admin_approved, archived_at, last_validated_at)` for the due-batch query

## Backend
Two new Lambdas, no API Gateway, invoked only by the workflow:
- `ReferralValidationListFunction` — returns up to 200 referrals where `admin_approved=1 AND archived_at IS NULL AND (last_validated_at IS NULL OR last_validated_at < NOW() - INTERVAL 7 DAY)`, oldest-first.
- `ReferralValidationCompleteFunction` — for each result:
  - `valid` → reset consecutive failures to 0
  - `expired`/`unreachable` → bump counter; once ≥ 2, set `archived_at=NOW()` + `archived_reason='auto: <status>'`
- One-bad-day grace: a transient outage can't kill a working link.

## Workflow (`.github/workflows/check-referrals.yml`)
- Cron: Mondays 12:00 UTC + `workflow_dispatch`
- Auth: existing OIDC deploy role (already has `lambda:InvokeFunction`)
- `aws lambda invoke` (List) → `node scripts/check-referrals.js` (Playwright + Haiku) → `aws lambda invoke` (Complete)
- Script mirrors `check-card-pages.js` stripper, timeouts, and per-item caps

## Frontend
- `GET /referrals` now returns `validation_status` + `last_validated_at`
- Profile tab label switches from `N links` to `N needs attention` when any of your referrals were auto-archived
- New banner above the active list shows each auto-archived row with the validation date, old stats ("412 impr, 18 clicks on the old link"), and an "add replacement" button (disabled with tooltip if the user no longer holds the card)
- `ReferralModal` gets `preselectCardId` so the replacement flow skips the picker
- Old `referral_stats` rows untouched: historical numbers stay visible

## Public card page
No changes needed. The existing query in `card-by-id.js` already filters `archived_at IS NULL`, so auto-archived links drop out of the rotator immediately.

## Deploy order
1. Merge → `deploy-api.yml` builds + deploys (new Lambdas + new migration file in the bundle)
2. Invoke `RunMigrationFunction` with `038_add_validation_to_referrals.sql`
3. Frontend redeploys via Amplify webhook
4. First workflow run: Mon 12:00 UTC (or trigger manually via `workflow_dispatch`)

## Test plan
- [x] `tsc --noEmit` passes on apps/web-next
- [x] `node -c` clean on all three new handler/script files
- [x] Dev server `/profile` serves 200
- [ ] Post-deploy: workflow_dispatch to confirm both Lambdas wire correctly
- [ ] Spot-check the badge + banner after one referral has been auto-archived

Roadmap memory: [project_referral_validation_roadmap](memory/project_referral_validation_roadmap.md). Closes the planning items #8–#11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)