### PR TITLE
check-referrals: fix function-name lookup across paginated pages

### DIFF
--- a/.github/workflows/check-referrals.yml
+++ b/.github/workflows/check-referrals.yml
@@ -62,12 +62,18 @@ jobs:
         env:
           LIMIT: ${{ github.event.inputs.limit || '200' }}
         run: |
+          # NB: avoid `| [0]` JMESPath here. `aws lambda list-functions`
+          # paginates by default and `--query` is applied per page, so a
+          # JMESPath pipe to [0] emits one line per page (including `None`
+          # for pages where no match exists). `head -n 1` after `--output
+          # text` keeps the first non-empty line and is the same fix used
+          # in the deploy workflow.
           aws lambda invoke \
             --region us-east-2 \
             --function-name $(aws lambda list-functions \
               --region us-east-2 \
-              --query "Functions[?contains(FunctionName, 'ReferralValidationListFunction')].FunctionName | [0]" \
-              --output text) \
+              --query "Functions[?contains(FunctionName, 'ReferralValidationListFunction')].FunctionName" \
+              --output text | tr '\t' '\n' | grep -v '^$' | head -n 1) \
             --cli-binary-format raw-in-base64-out \
             --payload "{\"limit\": ${LIMIT}}" \
             --cli-read-timeout 70 \
@@ -89,8 +95,8 @@ jobs:
             --region us-east-2 \
             --function-name $(aws lambda list-functions \
               --region us-east-2 \
-              --query "Functions[?contains(FunctionName, 'ReferralValidationCompleteFunction')].FunctionName | [0]" \
-              --output text) \
+              --query "Functions[?contains(FunctionName, 'ReferralValidationCompleteFunction')].FunctionName" \
+              --output text | tr '\t' '\n' | grep -v '^$' | head -n 1) \
             --cli-binary-format raw-in-base64-out \
             --payload fileb://results.json \
             --cli-read-timeout 310 \


### PR DESCRIPTION
## Summary
Smoke run [26911049429](https://github.com/CreditOdds/creditodds/actions/runs/26911049429) failed with \`aws: [ERROR]: Unknown options: batch.json\`. Root cause: \`aws lambda list-functions --query \"... | [0]\"\` applies the JMESPath pipe per pagination page, so it emits the function name on one page and the literal \`None\` on the next. The two-token result broke \`--function-name\`.

## Fix
Drop the \`| [0]\` JMESPath pipe and pick the first non-empty token after \`--output text\`:

\`\`\`
$(aws lambda list-functions \\
   --query \"...FunctionName\" \\
   --output text | tr '\\t' '\\n' | grep -v '^$' | head -n 1)
\`\`\`

Verified locally — returns exactly \`CreditCardOddsAPI-ReferralValidationListFunction-g3xC79MmBaQQ\`.

## Test plan
- [x] Local command returns a single line
- [ ] Re-run \`workflow_dispatch\` with \`limit=10\` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)