### PR TITLE
check-referrals: match shorter substring to survive 64-char name cap

### DIFF
--- a/.github/workflows/check-referrals.yml
+++ b/.github/workflows/check-referrals.yml
@@ -62,6 +62,13 @@ jobs:
         env:
           LIMIT: ${{ github.event.inputs.limit || '200' }}
         run: |
+          # NB: match on the shorter `ReferralValidationList`/`...Complete`
+          # substring, NOT the full handler name. CloudFormation caps Lambda
+          # function names at 64 chars and silently truncates the middle
+          # piece — `ReferralValidationCompleteFunction` becomes
+          # `ReferralValidationCompleteFuncti` in the deployed name, so a
+          # contains() on the trailing `Function` matches zero rows.
+          #
           # NB: avoid `| [0]` JMESPath here. `aws lambda list-functions`
           # paginates by default and `--query` is applied per page, so a
           # JMESPath pipe to [0] emits one line per page (including `None`
@@ -72,7 +79,7 @@ jobs:
             --region us-east-2 \
             --function-name $(aws lambda list-functions \
               --region us-east-2 \
-              --query "Functions[?contains(FunctionName, 'ReferralValidationListFunction')].FunctionName" \
+              --query "Functions[?contains(FunctionName, 'ReferralValidationList')].FunctionName" \
               --output text | tr '\t' '\n' | grep -v '^$' | head -n 1) \
             --cli-binary-format raw-in-base64-out \
             --payload "{\"limit\": ${LIMIT}}" \
@@ -95,7 +102,7 @@ jobs:
             --region us-east-2 \
             --function-name $(aws lambda list-functions \
               --region us-east-2 \
-              --query "Functions[?contains(FunctionName, 'ReferralValidationCompleteFunction')].FunctionName" \
+              --query "Functions[?contains(FunctionName, 'ReferralValidationComplete')].FunctionName" \
               --output text | tr '\t' '\n' | grep -v '^$' | head -n 1) \
             --cli-binary-format raw-in-base64-out \
             --payload fileb://results.json \


### PR DESCRIPTION
## Summary
Smoke run [26988720012](https://github.com/CreditOdds/creditodds/actions/runs/26988720012) got past the List step (10 referrals checked, 3 expired detected) but failed at Complete with \`argument --function-name: expected one argument\`.

Root cause: CloudFormation caps Lambda physical names at 64 chars. The List function fits as \`...ReferralValidationListFunction-<suffix>\` but Complete becomes \`...ReferralValidationCompleteFuncti-6tT7Mg3Xuk2i\` (note the truncated \`Functi\`). The workflow's \`contains(FunctionName, 'ReferralValidationCompleteFunction')\` matched zero rows, so \`--function-name\` got an empty string.

## Fix
Match on \`ReferralValidationList\` / \`ReferralValidationComplete\` (the prefix is always intact) instead of the full handler name. Added a comment so the trap stays visible.

Verified locally:
\`\`\`
$ aws lambda list-functions --query "Functions[?contains(FunctionName, 'ReferralValidationComplete')].FunctionName" --output text | tr '\\t' '\\n' | grep -v '^$' | head -n 1
CreditCardOddsAPI-ReferralValidationCompleteFuncti-6tT7Mg3Xuk2i
\`\`\`

## Validation run results so far
The first half of the workflow already worked end-to-end on the smoke run:
- Batch fetch: 10 referrals
- Detected: 7 valid, 3 expired (1 via HTTP 404 short-circuit, 2 via Haiku)
- Detected-expired referrals haven't been written to DB yet (this PR's bug stopped the Complete step). Once merged + re-run, the counter increments will land; second consecutive failure → auto-archive.

## Test plan
- [ ] Re-run \`workflow_dispatch\` with \`limit=10\` post-merge; expect both Lambdas to invoke and the Complete response to show \`processed=10\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)