### PR TITLE
chore: re-queue 3 expired referrals for the validator

### DIFF
--- a/apps/api/migrations/039_reset_expired_referrals_for_archive.sql
+++ b/apps/api/migrations/039_reset_expired_referrals_for_archive.sql
@@ -1,0 +1,16 @@
+-- One-off: re-queue referrals 36, 38, 44 for the validator.
+--
+-- The smoke run on 2026-06-05 flagged these three as expired (Amex Gold,
+-- Chase Freedom Unlimited via HTTP 404, Hilton Honors) and set
+-- validation_consecutive_failures = 1 each. Owner confirmed all three
+-- truly dead. Auto-archive trips on the second consecutive failed check,
+-- but the List Lambda filters out anything validated in the last 7 days,
+-- so they would not surface again until Monday's cron.
+--
+-- Resetting last_validated_at to NULL puts them back at the front of the
+-- NULLs-first queue so the next workflow_dispatch can confirm + archive
+-- them now. Counter stays at 1 — the next failed check pushes it to 2
+-- and triggers archived_at = NOW(), archived_reason = 'auto: expired'.
+UPDATE referrals
+SET last_validated_at = NULL
+WHERE referral_id IN (36, 38, 44);


### PR DESCRIPTION
## Summary
One-off migration to re-queue referrals 36, 38, 44 for the weekly validator. Owner confirmed all three are truly expired from the 2026-06-05 smoke run; this resets their \`last_validated_at\` so the next \`workflow_dispatch\` confirms + auto-archives them now rather than next Monday.

## Why
- First smoke run validated refs 32, 36–46 → three flagged expired, counter at 1
- Auto-archive trips at counter ≥ 2
- List Lambda's 7-day staleness filter would defer the second check to Monday
- This NULL-resets just the three so the next run picks them up first (NULLs-first ordering)

## After merge
1. \`deploy-api.yml\` picks up the new file
2. Invoke \`RunMigrationFunction\` with \`039_reset_expired_referrals_for_archive.sql\`
3. \`workflow_dispatch\` \`check-referrals.yml\` with \`limit=10\`
4. Expect Complete response: \`{processed:3+, archived:[36,38,44], ...}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)