### PR TITLE
Referral validator: audit log + admin monitoring

### DIFF
--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -1,6 +1,7 @@
 // Comprehensive admin handler
 const yup = require("yup");
 const mysql = require("../db");
+const { logAuditAction } = require("../lib/audit-log");
 
 // Fallback admin user IDs (Firebase UIDs) - used if custom claims not set
 const FALLBACK_ADMIN_IDS = ['zXOyHmGl7HStyAqEdLsgXLA5inS2'];
@@ -27,18 +28,7 @@ const responseHeaders = {
   "X-Requested-With": "*",
 };
 
-// Helper to log admin actions
-async function logAuditAction(adminId, action, entityType, entityId, details = null) {
-  try {
-    await mysql.query(
-      "INSERT INTO audit_log (admin_id, action, entity_type, entity_id, details) VALUES (?, ?, ?, ?, ?)",
-      [adminId, action, entityType, entityId, details ? JSON.stringify(details) : null]
-    );
-  } catch (error) {
-    console.error("Failed to log audit action:", error);
-    // Don't throw - audit logging shouldn't break the main operation
-  }
-}
+// Admin action logging uses the shared `logAuditAction` helper (imported above).
 
 // ============ STATS HANDLER ============
 exports.AdminStatsHandler = async (event) => {
@@ -453,6 +443,10 @@ exports.AdminReferralsHandler = async (event) => {
             r.submit_datetime,
             r.admin_approved,
             r.archived_at,
+            r.archived_reason,
+            r.last_validated_at,
+            r.validation_status,
+            r.validation_consecutive_failures,
             c.card_name,
             c.card_image_link,
             c.bank,

--- a/apps/api/src/handlers/referral-validation-complete.js
+++ b/apps/api/src/handlers/referral-validation-complete.js
@@ -16,11 +16,22 @@
 // Invocation contract:
 //   Input  : { results: [{ referral_id, status, reason? }] }
 //   Output : { processed: number, archived: [referral_id, ...], skipped: [...] }
+//
+// Audit log: every consequential outcome is recorded in `audit_log` under the
+// actor `system:referral-validation` so the admin Activity tab can monitor the
+// automation — `VALIDATION_FAIL` for each expired/unreachable hit (with the
+// running consecutive-failure count) and `AUTO_ARCHIVE` when a link is killed.
+// `valid` results are intentionally not logged to keep the audit trail signal.
 
 const mysql = require("../db");
+const { logAuditAction } = require("../lib/audit-log");
 
 const ARCHIVE_THRESHOLD = 2; // consecutive failures before auto-archive
 const VALID_STATUSES = new Set(["valid", "expired", "unreachable"]);
+
+// Actor recorded in audit_log for entries written by this automation, so the
+// admin Activity tab can tell the validator's actions apart from a human admin.
+const AUDIT_ACTOR = "system:referral-validation";
 
 exports.ReferralValidationCompleteHandler = async (event) => {
   console.info("ReferralValidationComplete received:", {
@@ -100,6 +111,12 @@ exports.ReferralValidationCompleteHandler = async (event) => {
           [status, nextFailures, `auto: ${status}`, referralId],
         );
         archived.push(referralId);
+        await logAuditAction(AUDIT_ACTOR, "AUTO_ARCHIVE", "referral", referralId, {
+          status,
+          consecutive_failures: nextFailures,
+          reason: r.reason || null,
+          archived_reason: `auto: ${status}`,
+        });
       } else {
         await mysql.query(
           `
@@ -111,6 +128,11 @@ exports.ReferralValidationCompleteHandler = async (event) => {
           `,
           [status, nextFailures, referralId],
         );
+        await logAuditAction(AUDIT_ACTOR, "VALIDATION_FAIL", "referral", referralId, {
+          status,
+          consecutive_failures: nextFailures,
+          reason: r.reason || null,
+        });
       }
       processed += 1;
     }

--- a/apps/api/src/lib/audit-log.js
+++ b/apps/api/src/lib/audit-log.js
@@ -1,0 +1,25 @@
+// Shared audit-log writer.
+//
+// Records an entry in the `audit_log` table. Used by the admin handlers
+// (human actions) and by automation such as the referral validator
+// (actor = a `system:*` pseudo-id). Best-effort: a logging failure must
+// never break the operation being audited, so errors are swallowed.
+//
+// Uses the same shared serverless-mysql singleton as every handler, so the
+// INSERT runs on the caller's existing connection — call before `mysql.end()`.
+
+const mysql = require("../db");
+
+async function logAuditAction(adminId, action, entityType, entityId, details = null) {
+  try {
+    await mysql.query(
+      "INSERT INTO audit_log (admin_id, action, entity_type, entity_id, details) VALUES (?, ?, ?, ?, ?)",
+      [adminId, action, entityType, entityId, details ? JSON.stringify(details) : null],
+    );
+  } catch (error) {
+    console.error("Failed to log audit action:", error);
+    // Don't throw - audit logging shouldn't break the main operation
+  }
+}
+
+module.exports = { logAuditAction };

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -876,10 +876,11 @@ function ReferralsTab({
       </div>
       <div className="av-tape">
         <div className="av-tape-scroll">
-          <div className="av-tape-head" style={{ gridTemplateColumns: 'minmax(180px, 1.2fr) minmax(200px, 1.6fr) 100px 110px 140px 90px 70px' }}>
+          <div className="av-tape-head" style={{ gridTemplateColumns: 'minmax(180px, 1.2fr) minmax(200px, 1.6fr) 100px 120px 110px 140px 90px 70px' }}>
             <span>Card</span>
             <span>Referral link</span>
             <span>Status</span>
+            <span>Validation</span>
             <span>Stats</span>
             <span>Submitter</span>
             <span>Date</span>
@@ -891,7 +892,7 @@ function ReferralsTab({
             <div
               key={referral.referral_id}
               className={'av-tape-row' + (!referral.admin_approved ? ' av-tape-pending' : '')}
-              style={{ gridTemplateColumns: 'minmax(180px, 1.2fr) minmax(200px, 1.6fr) 100px 110px 140px 90px 70px' }}
+              style={{ gridTemplateColumns: 'minmax(180px, 1.2fr) minmax(200px, 1.6fr) 100px 120px 110px 140px 90px 70px' }}
             >
               <div className="av-card-cell">
                 <div className="av-thumb">
@@ -971,7 +972,28 @@ function ReferralsTab({
                   {referral.admin_approved ? 'Approved' : 'Pending'}
                 </span>
                 {referral.archived_at && (
-                  <span className="av-pill av-pill-arch">Archived</span>
+                  <span className="av-pill av-pill-arch">
+                    {referral.archived_reason?.startsWith('auto:') ? 'Auto-archived' : 'Archived'}
+                  </span>
+                )}
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {referral.validation_status ? (
+                  <span className={'av-pill ' + (referral.validation_status === 'valid' ? 'av-pill-app' : 'av-pill-den')}>
+                    {referral.validation_status}
+                  </span>
+                ) : (
+                  <span className="av-mono" style={{ color: 'var(--ink-2)', fontSize: 11 }}>not checked</span>
+                )}
+                {(referral.validation_consecutive_failures ?? 0) > 0 && (
+                  <span className="av-mono" style={{ color: '#b91c1c', fontSize: 11 }}>
+                    {referral.validation_consecutive_failures} fail{referral.validation_consecutive_failures === 1 ? '' : 's'}
+                  </span>
+                )}
+                {referral.last_validated_at && (
+                  <span className="av-mono" style={{ color: 'var(--ink-2)', fontSize: 11 }}>
+                    {new Date(referral.last_validated_at).toLocaleDateString()}
+                  </span>
                 )}
               </div>
               <div className="av-mono" style={{ color: 'var(--ink-2)' }}>

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1344,6 +1344,10 @@ export interface AdminReferral {
   submit_datetime: string;
   admin_approved: number;
   archived_at: string | null;
+  archived_reason?: string | null;
+  last_validated_at?: string | null;
+  validation_status?: 'valid' | 'expired' | 'unreachable' | null;
+  validation_consecutive_failures?: number;
   impressions: number;
   clicks: number;
   unique_clicks?: number;


### PR DESCRIPTION
## Summary

The weekly referral-validity automation (`check-referrals.yml` → `ReferralValidationCompleteFunction`) previously left no trace beyond CloudWatch. This wires it into the existing audit log and surfaces its results in `/_admin`, so the automation can be monitored — including how many times each link has failed.

## Backend
- **Shared audit helper**: extracted `logAuditAction` into [`apps/api/src/lib/audit-log.js`](apps/api/src/lib/audit-log.js); `admin.js` now imports it rather than keeping a private copy (single source of truth, same `audit_log` table).
- **Validator writes audit entries** in [`referral-validation-complete.js`](apps/api/src/handlers/referral-validation-complete.js):
  - `VALIDATION_FAIL` for each expired/unreachable hit, with the running `consecutive_failures` count and the detector's reason.
  - `AUTO_ARCHIVE` when a link crosses the 2-failure threshold and gets killed.
  - Actor is `system:referral-validation` so these are clearly distinguishable from human admin actions in the Activity tab.
  - `valid` results are intentionally **not** logged, to keep the trail high-signal.
- **`GET /admin/referrals`** now also selects `archived_reason`, `last_validated_at`, `validation_status`, `validation_consecutive_failures`.

## Frontend
- `AdminReferral` type extended with the validation fields.
- Referrals tab gains a **Validation** column: status pill (`valid` green / `expired`·`unreachable` red), **fail count** (e.g. "1 fail"), and last-checked date. Auto-archived rows are now labelled "Auto-archived" vs a manual "Archived".

## Monitoring surfaces
1. **Activity → Audit Log tab** — every `VALIDATION_FAIL` / `AUTO_ARCHIVE` event, newest first, with the fail count in the details JSON.
2. **Referrals tab** — per-link current validation status + consecutive fail count at a glance.

## Verification
- `node -c` on all three changed backend files — OK.
- `tsc --noEmit` on web-next — clean.
- No new eslint findings (the 2 pre-existing warnings/1 error in `admin.js` are outside this change).
- Browser preview not applicable: the admin tab requires Firebase admin auth and the deployed backend (DB is in a private VPC; validation columns are only populated by the weekly job).

## Deploy notes
- Backend auto-deploys via `deploy-api.yml` on merge (touches `apps/api/**`); frontend via the Amplify webhook.
- No schema migration needed — the validation columns already exist (migration 038).

🤖 Generated with [Claude Code](https://claude.com/claude-code)