### PR TITLE
Review #1341: weekly card benefits triage

### DIFF
--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -54,4 +54,16 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: true
+  - name: "Baggage Delay Insurance"
+    description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
+    category: "travel"
+    enrollment_required: false
+  - name: "Lost Luggage Reimbursement"
+    description: "Reimbursement up to $3,000 per covered traveler for lost, damaged, or stolen checked or carry-on baggage during a covered trip"
+    category: "travel"
+    enrollment_required: false
+  - name: "Purchase Protection"
+    description: "Covers eligible new purchases for 120 days from purchase date against damage or theft, up to $500 per item"
+    category: "protection"
+    enrollment_required: false
 apply_link: https://creditcards.chase.com/travel-credit-cards/aer-lingus

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -39,3 +39,20 @@ apr:
     max: 27.49
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/amazon-prime-rewards
 foreign_transaction_fee: false
+benefits:
+  - name: "Purchase Protection"
+    description: "Covers eligible new purchases for 120 days from purchase date against damage or theft up to $500 per item"
+    category: "protection"
+    enrollment_required: false
+  - name: "Baggage Delay Insurance"
+    description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
+    category: "travel"
+    enrollment_required: false
+  - name: "Travel Accident Insurance"
+    description: "Provides up to $500,000 in accidental death or dismemberment coverage when you pay for air, bus, train or cruise transportation with your card"
+    category: "travel"
+    enrollment_required: false
+  - name: "Lost Luggage Reimbursement"
+    description: "Provides reimbursement up to $3,000 per covered traveler for lost, damaged or stolen checked or carry-on baggage during a covered trip"
+    category: "travel"
+    enrollment_required: false

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -53,3 +53,7 @@ benefits:
     frequency: "annual"
     category: "streaming"
     enrollment_required: true
+  - name: "Purchase Protection"
+    description: "Coverage up to $50,000 per calendar year (maximum $1,000 per purchase) for stolen or accidentally damaged covered purchases within 90 days"
+    category: "protection"
+    enrollment_required: false

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -49,6 +49,18 @@ benefits:
     frequency: "monthly"
     category: "streaming"
     enrollment_required: true
+  - name: "Purchase Protection"
+    description: "Coverage up to $1,000 per covered purchase and $50,000 per account per calendar year if a charged item is stolen or accidentally damaged within 90 days"
+    category: "protection"
+    enrollment_required: false
+  - name: "Return Protection"
+    description: "Return eligible purchases to American Express for refund if the seller won't accept returns, up to $300 per item and $1,000 per calendar year"
+    category: "protection"
+    enrollment_required: false
+  - name: "Extended Warranty"
+    description: "Up to one extra year added to the original manufacturer's warranty on covered purchases (up to $10,000 per item, $50,000 per account per calendar year)"
+    category: "protection"
+    enrollment_required: false
 tags:
   - cashback
   - shopping

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -52,4 +52,16 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: true
+  - name: "Baggage Delay Insurance"
+    description: "Reimbursement up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
+    category: "travel"
+    enrollment_required: false
+  - name: "Lost Luggage Reimbursement"
+    description: "Reimbursement up to $3,000 per covered traveler for repair or replacement of lost, damaged, or stolen baggage during a covered trip"
+    category: "travel"
+    enrollment_required: false
+  - name: "Purchase Protection"
+    description: "Coverage for eligible new purchases against damage or theft up to $500 per item for 120 days from purchase date"
+    category: "protection"
+    enrollment_required: false
 apply_link: https://creditcards.chase.com/travel-credit-cards/british-airways

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -12,6 +12,14 @@ benefits:
     description: "Annual statement credit for Disney purchases"
     frequency: "annual"
     category: "entertainment"
+  - name: "Purchase Protection"
+    description: "Covers eligible new purchases for 120 days from date of purchase against damage or theft, up to $500 per item"
+    category: "protection"
+    enrollment_required: false
+  - name: "Baggage Delay Insurance"
+    description: "Reimburses up to $100 a day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
+    category: "travel"
+    enrollment_required: false
 tags:
   - rewards
   - shopping

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -20,6 +20,9 @@ rewards:
   - category: groceries
     value: 2
     unit: percent
+  - category: dining
+    value: 2
+    unit: percent
   - category: everything_else
     value: 1
     unit: percent
@@ -58,6 +61,14 @@ benefits:
     description: "10% savings on select purchases at shopDisney.com"
     frequency: "per_purchase"
     category: "shopping"
+    enrollment_required: false
+  - name: "Purchase Protection"
+    description: "Covers eligible new purchases for 120 days from purchase date against damage or theft up to $500 per item"
+    category: "protection"
+    enrollment_required: false
+  - name: "Baggage Delay Insurance"
+    description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
+    category: "travel"
     enrollment_required: false
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/premier
 

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -29,3 +29,11 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+  - name: "Purchase Protection"
+    description: "Covers eligible new purchases against damage or theft for 120 days from date of purchase up to $500 per item"
+    category: "protection"
+    enrollment_required: false
+  - name: "Baggage Delay Insurance"
+    description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
+    category: "travel"
+    enrollment_required: false

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -25,10 +25,6 @@ rewards:
     value: 6
     unit: points_per_dollar
     note: "U.S. gas stations"
-  - category: online_shopping
-    value: 4
-    unit: points_per_dollar
-    note: "U.S. online retail purchases"
   - category: everything_else
     value: 3
     unit: points_per_dollar

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -47,4 +47,16 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: true
+  - name: "Baggage Delay Insurance"
+    description: "Reimbursement up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
+    category: "travel"
+    enrollment_required: false
+  - name: "Lost Luggage Reimbursement"
+    description: "Reimbursement up to $3,000 per covered traveler for lost, damaged, or stolen checked or carry-on baggage during a covered trip"
+    category: "travel"
+    enrollment_required: false
+  - name: "Purchase Protection"
+    description: "Coverage for eligible new purchases for 120 days from purchase against damage or theft up to $500 per item"
+    category: "protection"
+    enrollment_required: false
 apply_link: https://creditcards.chase.com/travel-credit-cards/avios/iberia

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -113,6 +113,18 @@ benefits:
     frequency: "ongoing"
     category: "car_rental"
     enrollment_required: true
+  - name: "Trip Delay Insurance"
+    description: "Reimbursement for additional expenses up to $500 per trip when a covered trip is delayed more than 6 hours (maximum 2 claims per 12 months)"
+    category: "travel"
+    enrollment_required: false
+  - name: "Trip Cancellation and Interruption Insurance"
+    description: "Reimbursement for non-refundable trip expenses up to $10,000 per trip and $20,000 per card per 12 months if covered reason cancels or interrupts trip"
+    category: "travel"
+    enrollment_required: false
+  - name: "Baggage Insurance"
+    description: "Coverage for lost, damaged, or stolen baggage up to $3,000 aggregate per trip when entire fare purchased on card"
+    category: "travel"
+    enrollment_required: false
 tags:
   - business
   - travel

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -28,7 +28,13 @@ rewards:
   - category: travel
     value: 4
     unit: points_per_dollar
-    note: "Also gas stations and EV charging, up to $1,000/quarter"
+  - category: gas
+    value: 4
+    unit: points_per_dollar
+    note: "Includes EV charging stations"
+    spend_cap: 1000
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: groceries
     value: 2
     unit: points_per_dollar

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -17,6 +17,18 @@ benefits:
     description: "Up to $800 per claim for cell phone damage or theft when you pay your bill with the card"
     frequency: "ongoing"
     category: "other"
+  - name: "Travel Accident Insurance"
+    description: "Up to $1,000,000 in travel accident insurance when purchasing airline or common carrier tickets"
+    category: "travel"
+    enrollment_required: false
+  - name: "Lost Baggage Reimbursement"
+    description: "Up to $3,000 in luggage reimbursement per trip if bags are lost due to theft or misdirection"
+    category: "travel"
+    enrollment_required: false
+  - name: "Trip Cancellation and Interruption Protection"
+    description: "Up to $15,000 reimbursement for lodging, flights, and activities if trip is canceled for a covered reason"
+    category: "travel"
+    enrollment_required: false
 tags:
   - travel
   - rewards

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -24,3 +24,8 @@ apr:
   regular:
     min: 18.49
     max: 26.49
+benefits:
+  - name: "Travel Accident Insurance"
+    description: "Up to $250,000 in travel accident insurance coverage when airline or common carrier tickets are purchased with the card"
+    category: "travel"
+    enrollment_required: false


### PR DESCRIPTION
## Summary

Triaged the 2026-05-31 weekly review queue from `check-card-rewards-and-benefits` (issue #1341). Most "verify before removing" flags were false positives from truncated apply pages.

**Benefits added** (confirmed on live apply pages):
- **Chase Visa Signature set** (Baggage Delay, Lost Luggage, Purchase Protection): Aer Lingus, British Airways, Iberia, Amazon Prime Visa, Disney Inspire/Premier/Visa
- **Amex protections**: Blue Cash Everyday (Purchase Protection); Blue Cash Preferred (Purchase Protection, Return Protection, Extended Warranty); Business Platinum (Trip Delay, Trip Cancellation, Baggage Insurance)
- **Wells Fargo**: Autograph Journey (Travel Accident, Lost Baggage, Trip Cancellation/Interruption); Signify Business Cash (Travel Accident)
- **Skipped Global Assist Hotline** across all Amex cards (advisory service, no payout — per user rule)

**Rate / category updates**:
- Disney Premier: added `dining: 2%` (confirmed on live page, missing from YAML)
- Hilton Surpass: removed `online_shopping: 4x` (limited-time promo ended)
- US Bank Altitude Connect: split `gas: 4x` into its own row with the $1,000/quarter cap

**Skipped**: Robinhood Gold `travel_portal: 5%` — pending in-app verification.

Closes #1341

## Test plan
- [ ] CI runs `build:cards` and `cards.json` is regenerated automatically
- [ ] Spot-check Aer Lingus, Disney Premier, Hilton Surpass, US Bank Altitude Connect on the deployed site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)