### PR TITLE
seo: switch unrated card JSON-LD to CreditCard type

### DIFF
--- a/apps/web-next/src/components/seo/JsonLd.test.ts
+++ b/apps/web-next/src/components/seo/JsonLd.test.ts
@@ -50,4 +50,14 @@ describe("buildCreditCardSchema", () => {
 
     expect(schema).not.toHaveProperty("aggregateRating");
   });
+
+  it("falls back to CreditCard type when there are no ratings so GSC doesn't flag Product snippets", () => {
+    const schema = buildCreditCardSchema({
+      card: baseCard,
+      ratings: { count: 0, average: null },
+    });
+
+    expect(schema["@type"]).toBe("CreditCard");
+    expect(schema).not.toHaveProperty("additionalType");
+  });
 });

--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -74,13 +74,14 @@ interface CreditCardSchemaProps {
 }
 
 export function buildCreditCardSchema({ card, ratings }: CreditCardSchemaProps) {
+  const hasRatings = !!ratings && ratings.count > 0 && ratings.average !== null;
   const schema = {
     '@context': 'https://schema.org',
-    // Google review snippets require aggregateRating to be nested under a
-    // supported parent type. CreditCard is schema.org-valid, but not a Google
-    // review parent; Product + additionalType keeps both validators happy.
-    '@type': 'Product',
-    additionalType: 'https://schema.org/CreditCard',
+    // Use Product only when we have an aggregateRating to attach — Product
+    // snippets require review or aggregateRating, and GSC flags cards with
+    // neither. Plain CreditCard avoids the Product-snippets check entirely.
+    '@type': hasRatings ? 'Product' : 'CreditCard',
+    ...(hasRatings ? { additionalType: 'https://schema.org/CreditCard' } : {}),
     name: card.card_name,
     url: card.slug ? `https://creditodds.com/card/${card.slug}` : undefined,
     category: 'Credit card',


### PR DESCRIPTION
## Summary
- Google Search Console flagged Product snippets on card pages for missing `aggregateRating` and `review` fields ([WNC-10030322]).
- Root cause: every card page emits `@type: Product` in JSON-LD, but only cards with ratings include `aggregateRating`. Cards without ratings have a Product schema with neither `review` nor `aggregateRating`, so GSC flags them.
- Fix: only use `@type: Product` when we have an `aggregateRating` to attach. Cards without ratings fall back to `@type: CreditCard` — schema.org-valid but not a Google Product-snippets target, so GSC stops flagging. Cards with ratings keep the Product wrapper so review snippet eligibility is preserved.

## Test plan
- [x] `vitest run src/components/seo/JsonLd.test.ts` — 3 tests pass (existing + new fallback assertion).
- [ ] After deploy, recrawl a few unrated card URLs in GSC and confirm Product-snippets warnings clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)