### PR TITLE
seo: drop offers block from card JSON-LD to clear Merchant-listings warning

### DIFF
--- a/apps/web-next/src/components/seo/JsonLd.test.ts
+++ b/apps/web-next/src/components/seo/JsonLd.test.ts
@@ -15,7 +15,7 @@ const baseCard: Card = {
 };
 
 describe("buildCreditCardSchema", () => {
-  it("uses a Google-supported Product parent for review and offer markup", () => {
+  it("uses a Google-supported Product parent for review markup when rated", () => {
     const schema = buildCreditCardSchema({
       card: baseCard,
       ratings: { count: 2, average: 5 },
@@ -33,13 +33,34 @@ describe("buildCreditCardSchema", () => {
         ratingValue: "5.0",
         ratingCount: 2,
       },
-      offers: {
-        "@type": "Offer",
-        availability: "https://schema.org/InStock",
-        price: "0",
-        priceCurrency: "USD",
-      },
     });
+  });
+
+  it("does not emit an offers block so GSC doesn't flag Merchant listings", () => {
+    const rated = buildCreditCardSchema({
+      card: baseCard,
+      ratings: { count: 2, average: 5 },
+    });
+    const unrated = buildCreditCardSchema({
+      card: baseCard,
+      ratings: { count: 0, average: null },
+    });
+
+    expect(rated).not.toHaveProperty("offers");
+    expect(unrated).not.toHaveProperty("offers");
+  });
+
+  it("surfaces annual fee via additionalProperty instead of offers", () => {
+    const schema = buildCreditCardSchema({
+      card: { ...baseCard, annual_fee: 95 },
+      ratings: { count: 0, average: null },
+    });
+
+    expect(schema.additionalProperty).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Annual Fee", value: "$95" }),
+      ]),
+    );
   });
 
   it("omits aggregateRating when there are no ratings", () => {

--- a/apps/web-next/src/components/seo/JsonLd.tsx
+++ b/apps/web-next/src/components/seo/JsonLd.tsx
@@ -91,30 +91,23 @@ export function buildCreditCardSchema({ card, ratings }: CreditCardSchemaProps) 
     },
     description: `${card.card_name} by ${card.bank}. Average approved credit score: ${card.approved_median_credit_score || 'N/A'}, average approved income: $${card.approved_median_income?.toLocaleString() || 'N/A'}.`,
     image: card.slug ? `https://creditodds.com/card/${card.slug}/opengraph-image` : undefined,
-    offers: {
-      '@type': 'Offer',
-      availability: card.accepting_applications
-        ? 'https://schema.org/InStock'
-        : 'https://schema.org/Discontinued',
-      ...(card.annual_fee != null ? {
-        price: String(card.annual_fee),
-        priceCurrency: 'USD',
-        priceSpecification: {
-          '@type': 'UnitPriceSpecification',
-          price: String(card.annual_fee),
-          priceCurrency: 'USD',
-          unitText: 'ANNUAL',
-        },
-      } : {}),
-    },
-    aggregateRating: ratings && ratings.count > 0 && ratings.average !== null ? {
+    // No `offers` block: credit cards aren't shippable goods, so emitting an
+    // Offer triggers Google's Merchant-listings check for hasMerchantReturnPolicy
+    // and shippingDetails — fields that don't apply here. Annual fee is exposed
+    // via additionalProperty instead.
+    aggregateRating: hasRatings ? {
       '@type': 'AggregateRating',
-      ratingValue: ratings.average.toFixed(1),
-      ratingCount: ratings.count,
+      ratingValue: ratings!.average!.toFixed(1),
+      ratingCount: ratings!.count,
       bestRating: 5,
       worstRating: 0,
     } : undefined,
     additionalProperty: [
+      {
+        '@type': 'PropertyValue',
+        name: 'Annual Fee',
+        value: card.annual_fee != null ? `$${card.annual_fee}` : 'N/A',
+      },
       {
         '@type': 'PropertyValue',
         name: 'Median Approved Credit Score',


### PR DESCRIPTION
## Summary
- Google Search Console flagged card pages with "Missing hasMerchantReturnPolicy" and "Missing shippingDetails" in their `offers` block ([WNC-10030322]).
- Root cause: our card JSON-LD emits an `offers` block with annual-fee pricing, which Google treats as a merchant listing and expects shipping/return-policy fields. Credit cards aren't shippable or returnable, so faking those would be wrong.
- Fix: drop the `offers` block entirely. Rated cards still qualify for Product rich results via `aggregateRating`. Annual fee — the only useful data in `offers` — is now an `additionalProperty` PropertyValue next to APR fields.

## Test plan
- [x] `vitest run src/components/seo/JsonLd.test.ts` — 5 tests pass (existing + new assertions covering offers removal and annual-fee placement).
- [x] `tsc --noEmit` clean.
- [ ] After deploy, recrawl a few card URLs in GSC and confirm Merchant-listings warnings clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)