### PR TITLE
sync-cards: replace public POST route with direct Lambda invoke

### DIFF
--- a/.github/workflows/build-cards.yml
+++ b/.github/workflows/build-cards.yml
@@ -73,17 +73,23 @@ jobs:
       - name: Sync cards to database
         id: sync
         run: |
-          echo "Triggering card sync to MySQL database..."
-          response=$(curl -s -w "\n%{http_code}" -X POST "${{ secrets.API_BASE_URL }}/sync-cards" -H "Content-Type: application/json" -d '{"source": "github-action"}')
-          http_code=$(echo "$response" | tail -n1)
-          body=$(echo "$response" | sed '$d')
-          echo "Response: $body"
-          echo "HTTP Status: $http_code"
-          if [ "$http_code" -ne 200 ]; then
+          echo "Invoking sync-cards Lambda directly (no public endpoint)..."
+          aws lambda invoke \
+            --function-name creditodds-sync-cards \
+            --payload '{"source":"github-action"}' \
+            --cli-binary-format raw-in-base64-out \
+            response.json
+          echo "Lambda response envelope:"
+          cat response.json
+          # The handler returns an API-Gateway-style envelope {statusCode, body}
+          # where body is a JSON string, so parse both layers.
+          status=$(node -e "const fs=require('fs');const r=JSON.parse(fs.readFileSync('response.json','utf8'));console.log(r.statusCode||0)")
+          echo "Sync statusCode: $status"
+          if [ "$status" -ne 200 ]; then
             echo "Warning: Card sync returned non-200 status"
           fi
-          # Extract wire_changes for social posting
-          wire_changes=$(echo "$body" | node -e "const c=[];process.stdin.on('data',d=>c.push(d));process.stdin.on('end',()=>{try{const j=JSON.parse(Buffer.concat(c));const w=j.details?.wire_changes||[];console.log(JSON.stringify(w))}catch{console.log('[]')}})")
+          # Extract wire_changes for social posting (double-parse: envelope -> body)
+          wire_changes=$(node -e "const fs=require('fs');try{const r=JSON.parse(fs.readFileSync('response.json','utf8'));const b=JSON.parse(r.body||'{}');console.log(JSON.stringify(b.details?.wire_changes||[]))}catch{console.log('[]')}")
           echo "wire_changes=$wire_changes" >> "$GITHUB_OUTPUT"
 
       - name: Post CardWire updates to Twitter
@@ -91,9 +97,12 @@ jobs:
         env:
           SOCIAL_API_URL: ${{ secrets.SOCIAL_API_URL }}
           SOCIAL_API_KEY: ${{ secrets.SOCIAL_API_KEY }}
+          # Pass via env (not inline ${{ }}) so a card name with a quote can't
+          # break out of the shell argument or inject commands.
+          WIRE_CHANGES: ${{ steps.sync.outputs.wire_changes }}
         run: |
           echo "Posting CardWire changes..."
-          node scripts/post-card-wire.js --changes '${{ steps.sync.outputs.wire_changes }}'
+          node scripts/post-card-wire.js --changes "$WIRE_CHANGES"
 
       - name: Detect new card files
         id: new-cards

--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -238,10 +238,12 @@ exports.updateCardsGitHubHandler = async (event) => {
     triggerReason = `PR #${event.pull_request.number} merged: ${event.pull_request.title}`;
   }
 
-  // Handle manual trigger
-  if (event.source === "manual" || event.httpMethod === "POST") {
+  // Handle direct invoke (build-cards GitHub Action) or manual trigger.
+  // The CI workflow invokes this Lambda directly with {"source":"github-action"};
+  // "manual" is kept for ad-hoc `aws lambda invoke` runs.
+  if (event.source === "manual" || event.source === "github-action") {
     shouldSync = true;
-    triggerReason = "Manual trigger";
+    triggerReason = `Direct invoke (${event.source})`;
   }
 
   if (!shouldSync) {

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -342,11 +342,16 @@ Resources:
   updateCardsGitHub:
     Type: AWS::Serverless::Function
     Properties:
+      # Stable name so the build-cards.yml workflow can target it with
+      # `aws lambda invoke --function-name creditodds-sync-cards`.
+      FunctionName: creditodds-sync-cards
       Handler: src/handlers/update-cards-github.updateCardsGitHubHandler
       Runtime: nodejs22.x
       MemorySize: 128
       Timeout: 100
-      Description: Syncs cards from CDN to MySQL database when triggered by GitHub webhook or manual call
+      # Invoke-only: triggered by the build-cards GitHub Action via direct
+      # Lambda invoke (OIDC role), not a public API route. No API event.
+      Description: Syncs cards from CDN to MySQL database (direct-invoke from CI)
       Environment:
         Variables:
           ENDPOINT: !Ref ENDPOINT
@@ -354,16 +359,6 @@ Resources:
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
           CardsJsonUrl: !Ref CardsJsonUrl
-      Events:
-        SyncCardsAPI:
-          Type: Api
-          Properties:
-            Auth:
-              Authorizer: NONE
-            Path: /sync-cards
-            Method: POST
-            RestApiId:
-              Ref: CreditCardOddsAPI
 
   UserWalletFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## What

Removes the unauthenticated `POST /sync-cards` API route and has the `build-cards` workflow invoke the sync Lambda directly via its existing OIDC role instead.

Closes the top finding from the stack security review: `POST /sync-cards` was `Authorizer: NONE` with no shared secret, so anyone could trigger a full CDN→MySQL card sync (DB-load / write-amplification DoS). Also closes the related CI shell-injection finding by routing `wire_changes` through `env:` instead of inline `${{ }}`.

## Changes

- **template.yml** — drop the `SyncCardsAPI` API event (no more public route); add stable `FunctionName: creditodds-sync-cards`. Invoke-only now, matching the `ReferralValidation` pattern.
- **update-cards-github.js** — trigger on `event.source === "github-action"` (or `"manual"`); remove the dead `httpMethod === "POST"` branch.
- **build-cards.yml** — replace `curl POST /sync-cards` with `aws lambda invoke` (the job already assumes the AWS OIDC role for its S3 upload + CloudFront invalidation). Double-parse `wire_changes` from the invoke `{statusCode, body}` envelope. Pass `wire_changes` to the tweet step via `env:` (quote-injection safe).

## Testing

- `sam validate --lint` passes; workflow YAML parses.
- Workflow parse logic tested against a synthesized `aws lambda invoke` output: status + `wire_changes` extracted correctly; an apostrophe in a card name survives. Non-200 / malformed / no-change cases degrade safely.
- Handler routing tested with mocked DB + network: `github-action`/`manual` payloads trigger a sync; a bare event does not.

## Required before this is live (manual, infra)

1. **Deploy backend** — merging triggers `deploy-api.yml` (renames the function, removes the route). `FunctionName` forces a CloudFormation replacement (harmless; stateless, no other references).
2. **IAM grant** — add `lambda:InvokeFunction` on `arn:aws:lambda:us-east-2:953352003729:function:creditodds-sync-cards` to the `GitHubActions-CreditOdds` role.

**Ordering:** the workflow change only runs on a push touching `data/cards/**`, so it stays dormant until the next card change. Do both steps before that, or the next sync fails with AccessDenied/ResourceNotFound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)