### PR TITLE
web: fix breadcrumb bar capitalization and alignment

### DIFF
--- a/apps/web-next/src/app/about/page.tsx
+++ b/apps/web-next/src/app/about/page.tsx
@@ -24,7 +24,7 @@ export default function AboutPage() {
     <div className="landing-v2 static-v2">
       <div className="cj-terminal">
         <nav className="cj-crumbs" aria-label="Breadcrumb">
-          <span className="cj-crumb cj-crumb-current">about</span>
+          <span className="cj-crumb cj-crumb-current">About</span>
         </nav>
         <span className="cj-spacer" />
         <div className="cj-term-actions">

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -293,8 +293,6 @@ export default function AdminPage() {
       <div className="av-terminal">
         <nav className="av-crumbs" aria-label="Breadcrumb">
           <span className="av-crumb-current">Admin</span>
-          <span className="av-crumb-sep">/</span>
-          <span>{tabs.find(t => t.id === activeTab)?.name.toLowerCase()}</span>
         </nav>
         <span className="av-spacer" />
         <span className="av-term-status">

--- a/apps/web-next/src/app/articles/author/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/author/[slug]/page.tsx
@@ -86,7 +86,7 @@ export default async function AuthorPage({ params }: Props) {
         <nav className="cj-crumbs" aria-label="Breadcrumb">
           <Link href="/articles" className="cj-crumb">Articles</Link>
           <span className="cj-sep">/</span>
-          <span className="cj-crumb cj-crumb-current" aria-current="page">by {author.name}</span>
+          <span className="cj-crumb cj-crumb-current" aria-current="page">By {author.name}</span>
         </nav>
         <span className="cj-spacer" />
         <div className="cj-term-actions">

--- a/apps/web-next/src/app/best/BestV2Client.tsx
+++ b/apps/web-next/src/app/best/BestV2Client.tsx
@@ -56,7 +56,7 @@ export default function BestV2Client({
     <div className="landing-v2">
       <div className="cj-terminal">
         <nav className="cj-crumbs" aria-label="Breadcrumb">
-          <span className="cj-crumb cj-crumb-current" aria-current="page">Best cards</span>
+          <span className="cj-crumb cj-crumb-current" aria-current="page">Best Cards</span>
         </nav>
         <span className="cj-spacer" />
         <div className="cj-term-actions">

--- a/apps/web-next/src/app/check-odds/page.tsx
+++ b/apps/web-next/src/app/check-odds/page.tsx
@@ -30,7 +30,7 @@ export default function CheckOddsPage() {
       />
       <div className="cj-terminal">
         <nav className="cj-crumbs" aria-label="Breadcrumb">
-          <span className="cj-crumb cj-crumb-current" aria-current="page">Check odds</span>
+          <span className="cj-crumb cj-crumb-current" aria-current="page">Check Odds</span>
         </nav>
         <span className="cj-spacer" />
         <div className="cj-term-actions">

--- a/apps/web-next/src/app/how/page.tsx
+++ b/apps/web-next/src/app/how/page.tsx
@@ -120,7 +120,7 @@ export default function HowPage() {
 
       <div className="cj-terminal">
         <nav className="cj-crumbs" aria-label="Breadcrumb">
-          <span className="cj-crumb cj-crumb-current">how it works</span>
+          <span className="cj-crumb cj-crumb-current">How It Works</span>
         </nav>
         <span className="cj-spacer" />
         <div className="cj-term-actions">

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3380,7 +3380,7 @@
 .landing-v2.profile-v2 .cj-terminal {
   background: var(--ink);
   color: #fff;
-  padding: 10px 18px;
+  padding: 10px max(16px, calc((100% - 1280px) / 2 + 16px));
   display: flex;
   align-items: center;
   gap: 14px;
@@ -3388,8 +3388,15 @@
   font-size: 11.5px;
   flex-wrap: wrap;
 }
-@media (min-width: 768px) {
-  .landing-v2.profile-v2 .cj-terminal { padding: 10px 24px; }
+@media (min-width: 640px) {
+  .landing-v2.profile-v2 .cj-terminal {
+    padding-inline: max(24px, calc((100% - 1280px) / 2 + 24px));
+  }
+}
+@media (min-width: 1024px) {
+  .landing-v2.profile-v2 .cj-terminal {
+    padding-inline: max(32px, calc((100% - 1280px) / 2 + 32px));
+  }
 }
 .landing-v2.profile-v2 .cj-terminal .cj-spacer { flex: 1; }
 .landing-v2.profile-v2 .cj-terminal .cj-crumbs {
@@ -6481,13 +6488,25 @@
 .landing-v2 .cj-terminal {
   background: var(--ink);
   color: #fff;
-  padding: 10px 24px;
+  /* Full-bleed bar, but align inner content to the centered 1280px container
+     so breadcrumb text lines up with the navbar and page content. */
+  padding: 10px max(16px, calc((100% - 1280px) / 2 + 16px));
   display: flex;
   align-items: center;
   gap: 14px;
   font-family: 'Inter', sans-serif;
   font-size: 11.5px;
   flex-wrap: wrap;
+}
+@media (min-width: 640px) {
+  .landing-v2 .cj-terminal {
+    padding-inline: max(24px, calc((100% - 1280px) / 2 + 24px));
+  }
+}
+@media (min-width: 1024px) {
+  .landing-v2 .cj-terminal {
+    padding-inline: max(32px, calc((100% - 1280px) / 2 + 32px));
+  }
 }
 .landing-v2 .cj-terminal a { color: inherit; text-decoration: none; }
 .landing-v2 .cj-terminal .cj-dim { color: var(--muted-2); }

--- a/apps/web-next/src/app/privacy/page.tsx
+++ b/apps/web-next/src/app/privacy/page.tsx
@@ -23,7 +23,7 @@ export default function PrivacyPage() {
     <div className="landing-v2 static-v2">
       <div className="cj-terminal">
         <nav className="cj-crumbs" aria-label="Breadcrumb">
-          <span className="cj-crumb cj-crumb-current">privacy</span>
+          <span className="cj-crumb cj-crumb-current">Privacy</span>
         </nav>
         <span className="cj-spacer" />
         <div className="cj-term-actions">

--- a/apps/web-next/src/app/terms/page.tsx
+++ b/apps/web-next/src/app/terms/page.tsx
@@ -22,7 +22,7 @@ export default function TermsPage() {
     <div className="landing-v2 static-v2">
       <div className="cj-terminal">
         <nav className="cj-crumbs" aria-label="Breadcrumb">
-          <span className="cj-crumb cj-crumb-current">terms</span>
+          <span className="cj-crumb cj-crumb-current">Terms</span>
         </nav>
         <span className="cj-spacer" />
         <div className="cj-term-actions">


### PR DESCRIPTION
## Summary
Cleans up the v2 breadcrumb bar across the site:

- **Capitalization** — breadcrumb labels now start capitalized: `Check Odds`, `Privacy`, `Terms`, `About`, `How It Works`, `By {author}`, and `Best Cards` (previously several rendered lowercase).
- **/admin** — the breadcrumb now shows just `Admin` instead of `Admin / <tab>`, so it no longer changes as you switch tabs.
- **Alignment** — the full-bleed breadcrumb bar keeps its edge-to-edge dark background, but its inner content is now pulled in to match the centered 1280px container, using the same 16/24/32px responsive padding as the navbar and `.wrap`. Breadcrumb text now lines up with the logo, page heading, and footer at every breakpoint (previously it sat ~88px to the left on a 1440px viewport).

## Verification
Checked rendered breadcrumb text and left-edge alignment in the dev server at 375 / 768 / 1440px — breadcrumb text matches nav/content offset (16 / 24 / 112px respectively) and the bar remains full-bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)