### PR TITLE
check-odds: remove em dash from hero subtitle

### DIFF
--- a/apps/web-next/src/app/check-odds/page.tsx
+++ b/apps/web-next/src/app/check-odds/page.tsx
@@ -43,7 +43,7 @@ export default function CheckOddsPage() {
         </h1>
         <p className="page-sub">
           Enter your credit profile and see how you stack up against real approved
-          applicants — before you take the hard pull.
+          applicants, before you take the hard pull.
         </p>
       </section>
       <div className="wrap" style={{ paddingTop: 8, paddingBottom: 64 }}>


### PR DESCRIPTION
Removes the em dash from the check-odds hero subtitle, replacing it with a comma. Em dashes read as AI-generated in user-facing copy, which violates the project's writing-style rule.

Before: "...against real approved applicants — before you take the hard pull."
After: "...against real approved applicants, before you take the hard pull."

This was the only em dash in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)