### PR TITLE
api: stop logging bearer tokens and full payloads to CloudWatch

### DIFF
--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -32,7 +32,7 @@ const responseHeaders = {
 
 // ============ STATS HANDLER ============
 exports.AdminStatsHandler = async (event) => {
-  console.info("AdminStats received:", event);
+  console.info("AdminStats received:", event.httpMethod, event.path);
 
   // Handle OPTIONS preflight BEFORE auth check (no auth headers on preflight)
   if (event.httpMethod === "OPTIONS") {
@@ -104,7 +104,7 @@ exports.AdminStatsHandler = async (event) => {
 
 // ============ RECORDS HANDLER ============
 exports.AdminRecordsHandler = async (event) => {
-  console.info("AdminRecords received:", event);
+  console.info("AdminRecords received:", event.httpMethod, event.path);
 
   // Handle OPTIONS preflight BEFORE auth check
   if (event.httpMethod === "OPTIONS") {
@@ -408,7 +408,7 @@ exports.AdminRecordsHandler = async (event) => {
 
 // ============ REFERRALS HANDLER ============
 exports.AdminReferralsHandler = async (event) => {
-  console.info("AdminReferrals received:", event);
+  console.info("AdminReferrals received:", event.httpMethod, event.path);
 
   // Handle OPTIONS preflight BEFORE auth check
   if (event.httpMethod === "OPTIONS") {
@@ -615,7 +615,7 @@ exports.AdminReferralsHandler = async (event) => {
 
 // ============ SEARCHES HANDLER ============
 exports.AdminSearchesHandler = async (event) => {
-  console.info("AdminSearches received:", event);
+  console.info("AdminSearches received:", event.httpMethod, event.path);
 
   if (event.httpMethod === "OPTIONS") {
     return { statusCode: 200, headers: responseHeaders, body: JSON.stringify({ statusText: "OK" }) };
@@ -669,7 +669,7 @@ exports.AdminSearchesHandler = async (event) => {
 
 // ============ USER LOOKUP HANDLER ============
 exports.AdminUserLookupHandler = async (event) => {
-  console.info("AdminUserLookup received:", event);
+  console.info("AdminUserLookup received:", event.httpMethod, event.path);
 
   if (event.httpMethod === "OPTIONS") {
     return { statusCode: 200, headers: responseHeaders, body: JSON.stringify({ statusText: "OK" }) };
@@ -763,7 +763,7 @@ exports.AdminUserLookupHandler = async (event) => {
 
 // ============ GRAPHS HANDLER ============
 exports.AdminGraphsHandler = async (event) => {
-  console.info("AdminGraphs received:", event);
+  console.info("AdminGraphs received:", event.httpMethod, event.path);
 
   if (event.httpMethod === "OPTIONS") {
     return { statusCode: 200, headers: responseHeaders, body: JSON.stringify({ statusText: "OK" }) };
@@ -847,7 +847,7 @@ exports.AdminGraphsHandler = async (event) => {
 
 // ============ AUDIT LOG HANDLER ============
 exports.AdminAuditHandler = async (event) => {
-  console.info("AdminAudit received:", event);
+  console.info("AdminAudit received:", event.httpMethod, event.path);
 
   // Handle OPTIONS preflight BEFORE auth check
   if (event.httpMethod === "OPTIONS") {

--- a/apps/api/src/handlers/all-cards.js
+++ b/apps/api/src/handlers/all-cards.js
@@ -75,7 +75,7 @@ async function fetchCardStatsAndMetadata() {
 }
 
 exports.AllCardsHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 
@@ -129,7 +129,7 @@ exports.AllCardsHandler = async (event) => {
   }
 
   console.info(
-    `response from: ${event.path} statusCode: ${response.statusCode} body: ${response.body}`
+    `response from: ${event.path} statusCode: ${response.statusCode} bodyLength: ${response.body?.length ?? 0}`
   );
   return response;
 };

--- a/apps/api/src/handlers/best-card-here-report.js
+++ b/apps/api/src/handlers/best-card-here-report.js
@@ -78,7 +78,7 @@ function asNonNegativeInt(value) {
 }
 
 exports.BestCardHereReportHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 

--- a/apps/api/src/handlers/card-apply-click.js
+++ b/apps/api/src/handlers/card-apply-click.js
@@ -54,7 +54,7 @@ async function ensureNewClickTable() {
 }
 
 exports.CardApplyClickHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 

--- a/apps/api/src/handlers/card-by-id.js
+++ b/apps/api/src/handlers/card-by-id.js
@@ -90,7 +90,7 @@ async function fetchCardFromDB(cardName) {
 }
 
 exports.CardByIdHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 
@@ -173,7 +173,7 @@ exports.CardByIdHandler = async (event) => {
   }
 
   console.info(
-    `response from: ${event.path} statusCode: ${response.statusCode} body: ${response.body}`
+    `response from: ${event.path} statusCode: ${response.statusCode} bodyLength: ${response.body?.length ?? 0}`
   );
   return response;
 };

--- a/apps/api/src/handlers/card-compare-event.js
+++ b/apps/api/src/handlers/card-compare-event.js
@@ -32,7 +32,7 @@ function unorderedPairs(slugs) {
 }
 
 exports.CardCompareEventHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 

--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -19,7 +19,7 @@ async function resolveCardId(cardName) {
 
 // GET /ratings?card_name=Chase+Sapphire+Preferred — public, returns avg + count
 exports.CardRatingsHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 
@@ -96,7 +96,7 @@ exports.CardRatingsHandler = async (event) => {
 
 // Authenticated handler for user's own rating
 exports.CardRatingsUserHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
   const userId = event.requestContext?.authorizer?.sub;

--- a/apps/api/src/handlers/card-view.js
+++ b/apps/api/src/handlers/card-view.js
@@ -10,7 +10,7 @@ const responseHeaders = {
 };
 
 exports.CardViewHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 

--- a/apps/api/src/handlers/card-wire.js
+++ b/apps/api/src/handlers/card-wire.js
@@ -9,7 +9,7 @@ const responseHeaders = {
 };
 
 exports.CardWireHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   if (event.httpMethod === "OPTIONS") {
     return {

--- a/apps/api/src/handlers/check-odds.js
+++ b/apps/api/src/handlers/check-odds.js
@@ -166,7 +166,7 @@ function validateInput(body) {
 }
 
 exports.CheckOddsHandler = async (event) => {
-  console.info("CheckOdds received:", event);
+  console.info("CheckOdds received:", event.httpMethod, event.path);
 
   if (event.httpMethod === "OPTIONS") {
     return {

--- a/apps/api/src/handlers/delete-account.js
+++ b/apps/api/src/handlers/delete-account.js
@@ -18,7 +18,7 @@ const responseHeaders = {
 };
 
 exports.DeleteAccountHandler = async (event) => {
-  console.info("DeleteAccount received:", event);
+  console.info("DeleteAccount received:", event.httpMethod, event.path);
 
   if (event.httpMethod === "OPTIONS") {
     return {

--- a/apps/api/src/handlers/firebase-authorizer.js
+++ b/apps/api/src/handlers/firebase-authorizer.js
@@ -43,7 +43,7 @@ function generatePolicy(principalId, effect, resource, context = {}) {
  * Lambda authorizer handler
  */
 exports.firebaseAuthorizerHandler = async (event) => {
-  console.log('Authorizer event:', JSON.stringify(event, null, 2));
+  console.log('Authorizer request:', event.methodArn);
 
   // Get the authorization token from the header
   const authHeader = event.authorizationToken || event.headers?.Authorization || event.headers?.authorization;

--- a/apps/api/src/handlers/get-card-graphs.js
+++ b/apps/api/src/handlers/get-card-graphs.js
@@ -28,7 +28,7 @@ async function fetchCardsFromCDN() {
 
 exports.getCardGraphsHandler = async (event) => {
   // All log statements are written to CloudWatch
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response;
 
@@ -166,7 +166,7 @@ exports.getCardGraphsHandler = async (event) => {
 
   // All log statements are written to CloudWatch
   console.info(
-    `response from: ${event.path} statusCode: ${response.statusCode} body: ${response.body}`
+    `response from: ${event.path} statusCode: ${response.statusCode} bodyLength: ${response.body?.length ?? 0}`
   );
 
   return response;

--- a/apps/api/src/handlers/leaderboard.js
+++ b/apps/api/src/handlers/leaderboard.js
@@ -10,7 +10,7 @@ const responseHeaders = {
 };
 
 exports.LeaderboardHandler = async (event) => {
-  console.info("Leaderboard received:", event);
+  console.info("Leaderboard received:", event.httpMethod, event.path);
 
   if (event.httpMethod === "OPTIONS") {
     return {

--- a/apps/api/src/handlers/recent-records.js
+++ b/apps/api/src/handlers/recent-records.js
@@ -7,7 +7,7 @@ const responseHeaders = {
 };
 
 exports.RecentRecordsHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 

--- a/apps/api/src/handlers/referral-stats.js
+++ b/apps/api/src/handlers/referral-stats.js
@@ -11,7 +11,7 @@ const responseHeaders = {
 };
 
 exports.ReferralStatsHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 

--- a/apps/api/src/handlers/user-card-selections.js
+++ b/apps/api/src/handlers/user-card-selections.js
@@ -34,7 +34,7 @@ function ok(body, status = 200) {
 }
 
 exports.UserCardSelectionsHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   if (event.httpMethod === "OPTIONS") {
     return { statusCode: 200, headers: responseHeaders, body: "" };

--- a/apps/api/src/handlers/user-records.js
+++ b/apps/api/src/handlers/user-records.js
@@ -88,7 +88,7 @@ const responseHeaders = {
 
 exports.UserRecordsHandler = async (event) => {
   // All log statements are written to CloudWatch
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 
@@ -329,7 +329,7 @@ exports.UserRecordsHandler = async (event) => {
   }
   // All log statements are written to CloudWatch
   console.info(
-    `response from: ${event.path} statusCode: ${response.statusCode} body: ${response.body}`
+    `response from: ${event.path} statusCode: ${response.statusCode} bodyLength: ${response.body?.length ?? 0}`
   );
   return response;
 };

--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -11,7 +11,7 @@ const responseHeaders = {
 
 exports.UserReferralsHandler = async (event) => {
   // All log statements are written to CloudWatch
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   let response = {};
 
@@ -194,7 +194,7 @@ exports.UserReferralsHandler = async (event) => {
   }
   // All log statements are written to CloudWatch
   console.info(
-    `response from: ${event.path} statusCode: ${response.statusCode} body: ${response.body}`
+    `response from: ${event.path} statusCode: ${response.statusCode} bodyLength: ${response.body?.length ?? 0}`
   );
   return response;
 };

--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -37,7 +37,7 @@ function validateAcquiredDate(acquired_month, acquired_year) {
 }
 
 exports.UserWalletHandler = async (event) => {
-  console.info("received:", event);
+  console.info("received:", event.httpMethod, event.path);
 
   // Handle CORS preflight
   if (event.httpMethod === "OPTIONS") {


### PR DESCRIPTION
Fixes two findings from the stack review, both rooted in over-logging.

## Security (backend audit, Medium)
- `firebase-authorizer.js` logged the **full event including the raw bearer token** on every cold auth.
- ~20 API Gateway handlers logged the entire `event` (which carries the `Authorization` header) and, in 5 cases, the **full response body** (credit-profile data on `/records`).

Anyone with CloudWatch read access could replay live 1-hour Firebase sessions or read user PII.

## Cost (performance review, High)
`/cards` and friends wrote their full ~400KB response body to CloudWatch on **every** invocation. At $0.50/GB ingestion this was likely a top line item on the bill, plus it added serialization latency.

## Changes — 32 sites, 20 files
- **Authorizer:** `console.log('Authorizer request:', event.methodArn)` — never the token.
- **API Gateway handlers:** log `event.httpMethod` + `event.path` instead of the full event (drops the `Authorization` header from logs).
- **5 handlers:** log `response.body?.length` instead of the body.

### Intentionally left alone
- `referral-validation-list.js`, `update-cards-github.js` — IAM-invoked (no bearer token), run rarely.
- `plaid-webhook.js`, `referral-validation-complete.js` — already log only selected fields.
- `user-wallet.js:102` `body: JSON.stringify(events)` is an HTTP response, not a log.

## Testing
- `node --check` passes on all 20 files.
- Grep confirms no full-event/token/full-body log remains outside the excluded IAM handlers.
- No logic changes — logging statements only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)