### PR TITLE
perf: cache public GET responses + slim explore/compare payloads

### DIFF
--- a/apps/api/src/handlers/all-cards.js
+++ b/apps/api/src/handlers/all-cards.js
@@ -74,6 +74,15 @@ async function fetchCardStatsAndMetadata() {
   }
 }
 
+
+// Cacheable headers for public GET reads: lets CloudFront/browser cache
+// successful responses (s-maxage matches the 300s ISR/stats cadence). Applied
+// only to 200 reads, never to errors or authenticated/POST responses.
+const cacheableHeaders = {
+  ...responseHeaders,
+  "Cache-Control": "public, max-age=60, s-maxage=300",
+};
+
 exports.AllCardsHandler = async (event) => {
   console.info("received:", event.httpMethod, event.path);
 
@@ -106,7 +115,7 @@ exports.AllCardsHandler = async (event) => {
 
         response = {
           statusCode: 200,
-          headers: responseHeaders,
+          headers: cacheableHeaders,
           body: JSON.stringify(enrichedCards),
         };
         break;

--- a/apps/api/src/handlers/card-by-id.js
+++ b/apps/api/src/handlers/card-by-id.js
@@ -89,6 +89,15 @@ async function fetchCardFromDB(cardName) {
   }
 }
 
+
+// Cacheable headers for public GET reads: lets CloudFront/browser cache
+// successful responses (s-maxage matches the 300s ISR/stats cadence). Applied
+// only to 200 reads, never to errors or authenticated/POST responses.
+const cacheableHeaders = {
+  ...responseHeaders,
+  "Cache-Control": "public, max-age=60, s-maxage=300",
+};
+
 exports.CardByIdHandler = async (event) => {
   console.info("received:", event.httpMethod, event.path);
 
@@ -150,7 +159,7 @@ exports.CardByIdHandler = async (event) => {
 
         response = {
           statusCode: 200,
-          headers: responseHeaders,
+          headers: cacheableHeaders,
           body: JSON.stringify(enrichedCard),
         };
         break;

--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -18,6 +18,15 @@ async function resolveCardId(cardName) {
 }
 
 // GET /ratings?card_name=Chase+Sapphire+Preferred — public, returns avg + count
+
+// Cacheable headers for public GET reads: lets CloudFront/browser cache
+// successful responses (s-maxage matches the 300s ISR/stats cadence). Applied
+// only to 200 reads, never to errors or authenticated/POST responses.
+const cacheableHeaders = {
+  ...responseHeaders,
+  "Cache-Control": "public, max-age=60, s-maxage=300",
+};
+
 exports.CardRatingsHandler = async (event) => {
   console.info("received:", event.httpMethod, event.path);
 
@@ -49,7 +58,7 @@ exports.CardRatingsHandler = async (event) => {
           await mysql.end();
           response = {
             statusCode: 200,
-            headers: responseHeaders,
+            headers: cacheableHeaders,
             body: JSON.stringify({ count: 0, average: null }),
           };
           break;
@@ -64,7 +73,7 @@ exports.CardRatingsHandler = async (event) => {
 
         response = {
           statusCode: 200,
-          headers: responseHeaders,
+          headers: cacheableHeaders,
           body: JSON.stringify({
             count: results[0].count,
             average: results[0].average ? parseFloat(results[0].average.toFixed(2)) : null,

--- a/apps/api/src/handlers/card-records.js
+++ b/apps/api/src/handlers/card-records.js
@@ -30,6 +30,15 @@ function fetchCardsFromCDN() {
   });
 }
 
+
+// Cacheable headers for public GET reads: lets CloudFront/browser cache
+// successful responses (s-maxage matches the 300s ISR/stats cadence). Applied
+// only to 200 reads, never to errors or authenticated/POST responses.
+const cacheableHeaders = {
+  ...responseHeaders,
+  "Cache-Control": "public, max-age=60, s-maxage=300",
+};
+
 exports.CardRecordsHandler = async (event) => {
   if (event.httpMethod !== 'GET') {
     return {
@@ -107,7 +116,7 @@ exports.CardRecordsHandler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { ...responseHeaders, 'Content-Type': 'application/json' },
+      headers: { ...cacheableHeaders, 'Content-Type': 'application/json' },
       body: JSON.stringify(records),
     };
   } catch (error) {

--- a/apps/api/src/handlers/card-wire.js
+++ b/apps/api/src/handlers/card-wire.js
@@ -8,6 +8,15 @@ const responseHeaders = {
   "X-Requested-With": "*",
 };
 
+
+// Cacheable headers for public GET reads: lets CloudFront/browser cache
+// successful responses (s-maxage matches the 300s ISR/stats cadence). Applied
+// only to 200 reads, never to errors or authenticated/POST responses.
+const cacheableHeaders = {
+  ...responseHeaders,
+  "Cache-Control": "public, max-age=60, s-maxage=300",
+};
+
 exports.CardWireHandler = async (event) => {
   console.info("received:", event.httpMethod, event.path);
 
@@ -63,7 +72,7 @@ exports.CardWireHandler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: responseHeaders,
+      headers: cacheableHeaders,
       body: JSON.stringify({ changes: rows }),
     };
   } catch (error) {

--- a/apps/api/src/handlers/get-card-graphs.js
+++ b/apps/api/src/handlers/get-card-graphs.js
@@ -26,6 +26,15 @@ async function fetchCardsFromCDN() {
   });
 }
 
+
+// Cacheable headers for public GET reads: lets CloudFront/browser cache
+// successful responses (s-maxage matches the 300s ISR/stats cadence). Applied
+// only to 200 reads, never to errors or authenticated/POST responses.
+const cacheableHeaders = {
+  ...responseHeaders,
+  "Cache-Control": "public, max-age=60, s-maxage=300",
+};
+
 exports.getCardGraphsHandler = async (event) => {
   // All log statements are written to CloudWatch
   console.info("received:", event.httpMethod, event.path);
@@ -140,7 +149,7 @@ exports.getCardGraphsHandler = async (event) => {
 
           response = {
             statusCode: 200,
-            headers: responseHeaders,
+            headers: cacheableHeaders,
             body: JSON.stringify([chartOne, chartTwo, chartThree]),
           };
 

--- a/apps/api/src/handlers/recent-records.js
+++ b/apps/api/src/handlers/recent-records.js
@@ -6,6 +6,15 @@ const responseHeaders = {
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
+
+// Cacheable headers for public GET reads: lets CloudFront/browser cache
+// successful responses (s-maxage matches the 300s ISR/stats cadence). Applied
+// only to 200 reads, never to errors or authenticated/POST responses.
+const cacheableHeaders = {
+  ...responseHeaders,
+  "Cache-Control": "public, max-age=60, s-maxage=300",
+};
+
 exports.RecentRecordsHandler = async (event) => {
   console.info("received:", event.httpMethod, event.path);
 
@@ -35,7 +44,7 @@ exports.RecentRecordsHandler = async (event) => {
 
     response = {
       statusCode: 200,
-      headers: responseHeaders,
+      headers: cacheableHeaders,
       body: JSON.stringify(results),
     };
   } catch (error) {

--- a/apps/web-next/src/app/compare/page.tsx
+++ b/apps/web-next/src/app/compare/page.tsx
@@ -1,12 +1,36 @@
 import { Suspense } from 'react';
 import { Metadata } from 'next';
-import { getAllCards } from '@/lib/api';
+import { getAllCards, type Card } from '@/lib/api';
 import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import CompareClient from './CompareClient';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import '../landing.css';
 
 export const revalidate = 300;
+
+// CompareClient receives the full catalog (for the picker) and renders the
+// comparison table from whichever cards are selected, so rewards/benefits/apr/
+// medians must stay. We only drop fields the page never reads — referrals,
+// our_take, previous_names, apply links, tags, etc. Smaller cut than Explore
+// because the rich comparison data is genuinely needed here.
+function slimForCompare(c: Card): Card {
+  return {
+    card_id: c.card_id,
+    card_name: c.card_name,
+    slug: c.slug,
+    bank: c.bank,
+    card_image_link: c.card_image_link,
+    accepting_applications: c.accepting_applications,
+    annual_fee: c.annual_fee,
+    reward_type: c.reward_type,
+    approved_median_credit_score: c.approved_median_credit_score,
+    approved_median_income: c.approved_median_income,
+    signup_bonus: c.signup_bonus,
+    apr: c.apr,
+    rewards: c.rewards,
+    benefits: c.benefits,
+  };
+}
 
 export async function generateMetadata({
   searchParams,
@@ -120,7 +144,7 @@ export default async function ComparePage() {
             </div>
           }
         >
-          <CompareClient allCards={cards} />
+          <CompareClient allCards={cards.map(slimForCompare)} />
         </Suspense>
       </div>
       <V2Footer />

--- a/apps/web-next/src/app/explore/page.tsx
+++ b/apps/web-next/src/app/explore/page.tsx
@@ -1,10 +1,45 @@
 import { Metadata } from "next";
-import { getAllCards, getCardViewCounts } from "@/lib/api";
+import { getAllCards, getCardViewCounts, type Card } from "@/lib/api";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import ExploreV2Client from "./ExploreV2Client";
 
 // Revalidate every 5 minutes
 export const revalidate = 300;
+
+// Trim each card to only the fields ExploreV2Client actually reads before it
+// goes into the RSC/HTML payload. Drops benefits, apr, referrals, our_take,
+// medians, etc., and reduces rewards to {category,value,unit} — roughly a
+// two-thirds cut per card on a page that ships the full catalog.
+function slimForExplore(c: Card): Card {
+  return {
+    card_id: c.card_id,
+    db_card_id: c.db_card_id,
+    card_name: c.card_name,
+    slug: c.slug,
+    bank: c.bank,
+    card_image_link: c.card_image_link,
+    accepting_applications: c.accepting_applications,
+    approved_count: c.approved_count,
+    rejected_count: c.rejected_count,
+    annual_fee: c.annual_fee,
+    reward_type: c.reward_type,
+    category: c.category,
+    tags: c.tags,
+    signup_bonus: c.signup_bonus
+      ? {
+          value: c.signup_bonus.value,
+          type: c.signup_bonus.type,
+          spend_requirement: c.signup_bonus.spend_requirement,
+          timeframe_months: c.signup_bonus.timeframe_months,
+        }
+      : undefined,
+    rewards: c.rewards?.map((r) => ({
+      category: r.category,
+      value: r.value,
+      unit: r.unit,
+    })),
+  };
+}
 
 export const metadata: Metadata = {
   title: "Explore Credit Cards",
@@ -42,7 +77,7 @@ export default async function ExplorePage() {
           { name: 'Explore Cards', url: 'https://creditodds.com/explore' },
         ]}
       />
-      <ExploreV2Client cards={sortedCards} trendingViews={trendingViews} />
+      <ExploreV2Client cards={sortedCards.map(slimForExplore)} trendingViews={trendingViews} />
     </>
   );
 }


### PR DESCRIPTION
Fixes optimization findings #2 and #3 from the stack review.

## #2 — Cache-Control on public GET reads (backend)
No API response set `Cache-Control`, so CloudFront cached nothing and client-side `getAllCards()`/`getCard()` calls hit Lambda every time (the ~400KB `/cards` blob on every wallet-modal open).

Added `public, max-age=60, s-maxage=300` (matches the 300s ISR/stats cadence) to the **success** responses of the public GET read endpoints: `/cards`, `/card`, `/graphs`, `/card-records`, `/card-wire`, `/recent-records`, and the public `/ratings` GET.

Scoped via a `cacheableHeaders` const applied **only to 200 reads** — error responses keep plain headers (so CloudFront can't cache a transient 5xx), and the authenticated `/ratings/me` handler is untouched.

> ⚠️ **Depends on the CloudFront cache policy honoring origin headers.** If the distribution uses the AWS Managed-CachingOptimized policy, it ignores origin `Cache-Control` and uses its own TTLs — the header would still help browsers but not CloudFront. Worth confirming the cache policy is set to "use origin cache headers" (or has matching min/default TTLs).

## #3 — Slim card payload for /explore and /compare (frontend)
Both pages serialized the full ~320KB catalog into the RSC/HTML payload. Each card is now projected to the fields the client actually reads (inventoried against `ExploreV2Client`/`CompareClient` + children):

- **Explore:** drop `benefits`/`apr`/`referrals`/`our_take`/medians; reduce `rewards`→`{category,value,unit}` and `signup_bonus`→4 fields. ~2/3 cut per card.
- **Compare:** the table renders selected cards from this list, so `rewards`/`benefits`/`apr`/medians stay; only fields the page never reads are dropped (`referrals`, `our_take`, `previous_names`, apply links, tags). Smaller, architecture-bounded cut.

Kept as `Card[]` (heavy fields are optional) so no client prop-type change.

## Testing
- 7 handlers pass `node --check`; cache headers confirmed on 200 paths only.
- `tsc --noEmit` clean.
- Rendered both pages on the dev server: `/explore` (140 cards, name/bank/fee/reward/bonus all display) and `/compare?cards=...` (full table with rewards/benefits/APR/median score). No `undefined`/`NaN`, no console errors.

Note: merging triggers both `deploy-api.yml` (backend) and the Amplify frontend build. Two separate commits so either fix can be reverted independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)