### PR TITLE
api: mark authenticated responses Cache-Control: no-store (CloudFront-safety prereq)

### DIFF
--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -21,6 +21,10 @@ function isAdmin(event) {
 }
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Headers":
     "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -1,6 +1,10 @@
 const mysql = require("../db");
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Headers":
     "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/handlers/check-odds.js
+++ b/apps/api/src/handlers/check-odds.js
@@ -4,6 +4,10 @@ const mysql = require("../db");
 const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Headers":
     "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/handlers/delete-account.js
+++ b/apps/api/src/handlers/delete-account.js
@@ -10,6 +10,10 @@ if (!admin.apps.length) {
 }
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Headers":
     "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/handlers/plaid-exchange-token.js
+++ b/apps/api/src/handlers/plaid-exchange-token.js
@@ -9,6 +9,10 @@ const { getPlaidClient, encryptToken } = require('../lib/plaid');
 const { isPlaidBetaEnabled } = require('../lib/plaid-gate');
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
   'Access-Control-Allow-Methods': 'POST,OPTIONS',

--- a/apps/api/src/handlers/plaid-items.js
+++ b/apps/api/src/handlers/plaid-items.js
@@ -6,6 +6,10 @@ const mysql = require('../db');
 const { isPlaidBetaEnabled } = require('../lib/plaid-gate');
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
   'Access-Control-Allow-Methods': 'GET,DELETE,OPTIONS',

--- a/apps/api/src/handlers/plaid-link-token.js
+++ b/apps/api/src/handlers/plaid-link-token.js
@@ -9,6 +9,10 @@ const { getPlaidClient } = require('../lib/plaid');
 const { isPlaidBetaEnabled } = require('../lib/plaid-gate');
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
   'Access-Control-Allow-Methods': 'POST,OPTIONS',

--- a/apps/api/src/handlers/user-card-selections.js
+++ b/apps/api/src/handlers/user-card-selections.js
@@ -12,6 +12,10 @@
 const mysql = require("../db");
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "Content-Type,Authorization",
   "Access-Control-Allow-Methods": "GET,PUT,DELETE,OPTIONS",

--- a/apps/api/src/handlers/user-records.js
+++ b/apps/api/src/handlers/user-records.js
@@ -79,6 +79,10 @@ const recordPatchSchema = yup.object().shape({
 const MAX_RECORDS_PER_CARD_PER_USER = 5;
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Headers":
     "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -2,6 +2,10 @@
 const mysql = require("../db");
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Headers":
     "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/handlers/user-settings.js
+++ b/apps/api/src/handlers/user-settings.js
@@ -5,6 +5,10 @@
 const mysql = require('../db');
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
   'Access-Control-Allow-Methods': 'GET,PUT,OPTIONS',

--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -16,6 +16,10 @@
 const mysql = require("../db");
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "Content-Type,Authorization",
   "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",

--- a/apps/api/src/handlers/wallet-picks-nearby.js
+++ b/apps/api/src/handlers/wallet-picks-nearby.js
@@ -25,6 +25,10 @@ const {
 } = require("../lib/ranker/walletPicksForPlace");
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "Content-Type,Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",

--- a/apps/api/src/handlers/wallet-picks-store.js
+++ b/apps/api/src/handlers/wallet-picks-store.js
@@ -14,6 +14,10 @@ const { getAllCards, getStoreBySlug } = require("../lib/ranker/data-loaders");
 const { loadUserWallet } = require("../lib/ranker/user-wallet-loader");
 
 const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  "Cache-Control": "no-store",
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "Content-Type,Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",


### PR DESCRIPTION
Step 1 of the #2 follow-up: make it safe to route the API through CloudFront.

## Why
The existing API CloudFront distro (`CreditOdds-API-CachePolicy`) caches GET/HEAD by URL with `DefaultTTL=300` and a cache key that does **not** include `Authorization` (the origin request policy forwards `Authorization` to origin, but it's not in the cache key). So any authenticated GET that doesn't send explicit cache headers would be cached and served **across users** — a cross-user data leak.

Today this is latent (the frontend calls API Gateway directly, confirmed via the Amplify env), but it blocks pointing `NEXT_PUBLIC_API_BASE_URL` at the CDN.

## Change
Add `"Cache-Control": "no-store"` to the module `responseHeaders` of every authenticated, user-specific handler:
`user-records`, `user-referrals`, `delete-account`, `user-wallet`, `user-card-selections`, `check-odds`, `admin` (all 7 handlers), `user-settings`, `wallet-picks-store`, `wallet-picks-nearby`, `plaid-link-token`, `plaid-exchange-token`, `plaid-items`, and `/ratings/me`.

`card-ratings` is a mixed file: the **public** `/ratings` GET keeps its cacheable header (`cacheableHeaders` spreads `responseHeaders` then overrides `Cache-Control` to `public`), while `/ratings/me` and error paths inherit `no-store`. Verified the composition resolves correctly.

## Testing
- `node --check` clean on all 14 files.
- Confirmed object-spread composition: public GET → `public, max-age=60, s-maxage=300`; everything else → `no-store`.
- Verified no authenticated handler builds inline headers that bypass the const.
- No behavior change today (these responses weren't being cached anyway).

## After this merges
The remaining step to actually realize the Lambda-offload is an **infra change you make** (not code): point the prod Amplify `NEXT_PUBLIC_API_BASE_URL` at the CloudFront API distro (`d2ojrhbh2dincr.cloudfront.net` or a custom `api.` alias). With this PR deployed, authenticated endpoints are safe from cross-user caching when you do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)