### PR TITLE
web: block open redirect on /login

### DIFF
--- a/apps/web-next/src/app/(auth)/login/page.tsx
+++ b/apps/web-next/src/app/(auth)/login/page.tsx
@@ -26,7 +26,18 @@ function LoginPageInner() {
   // Build redirect URL from query params
   const getRedirectUrl = () => {
     const redirect = searchParams.get('redirect');
-    if (!redirect) return '/profile';
+    // Only allow same-origin relative paths. Reject absolute and
+    // protocol-relative URLs (https://evil.com, //evil.com, /\evil.com) so a
+    // crafted ?redirect= can't bounce an authenticated user off-site (open
+    // redirect / phishing vector).
+    if (
+      !redirect ||
+      !redirect.startsWith('/') ||
+      redirect.startsWith('//') ||
+      redirect.startsWith('/\\')
+    ) {
+      return '/profile';
+    }
     // Preserve other query params for the redirect target
     const params = new URLSearchParams();
     searchParams.forEach((value, key) => {


### PR DESCRIPTION
Fixes the open-redirect finding on `/login`.

## Issue
`getRedirectUrl()` ([login/page.tsx](apps/web-next/src/app/(auth)/login/page.tsx)) read the `?redirect=` query param and passed it straight to `router.push()` with no validation. `https://creditodds.com/login?redirect=https://evil.com` (or `//evil.com`) bounced the user off-site — immediately if already authenticated, or right after sign-in.

**Risk:** phishing that borrows the real `creditodds.com` domain's credibility (legit-looking link → real login → silent forward to a look-alike). **Not** a token leak — Firebase tokens live in IndexedDB and never touch the URL, and the redirect fires post-auth. So it's the credibility/phishing class of open redirect, not an auth bypass.

## Fix
Allow only same-origin relative paths; reject empty, non-`/`-prefixed, protocol-relative (`//`), and backslash (`/\`) values, falling back to `/profile`.

## Testing
- `tsc --noEmit` clean.
- Guard unit-tested against 11 inputs: `/profile`, `/wallet`, `/explore?x=1` pass; `https://`, `http://`, `//evil.com`, `/\evil.com`, `/\/evil.com`, `javascript:`, null, empty all fall back to `/profile`.
- Rendered `/login?redirect=https://evil.com` on the dev server: stays on-site, login UI renders, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)