### PR TITLE
api: remove public /admin/refresh-card-stats route (invoke-only)

### DIFF
--- a/apps/api/src/handlers/refresh-card-stats.js
+++ b/apps/api/src/handlers/refresh-card-stats.js
@@ -1,5 +1,7 @@
 // Recomputes per-card stats and upserts them into the card_stats table.
-// Triggered by EventBridge on a schedule; also callable via HTTP for ops use.
+// Triggered by EventBridge on a schedule. Invoke-only — there is no public
+// HTTP route (a manual recompute is `aws lambda invoke`). The httpMethod
+// branches below are inert defensive handling, kept in case of direct invoke.
 
 const mysql = require("../db");
 

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -1207,7 +1207,7 @@ Resources:
       Runtime: nodejs22.x
       MemorySize: 256
       Timeout: 300
-      Description: Recomputes per-card stats (totals + medians) into card_stats every 5 minutes; also callable via admin HTTP endpoint
+      Description: Recomputes per-card stats (totals + medians) into card_stats every 5 minutes (EventBridge schedule). Invoke-only — no public HTTP route.
       Environment:
         Variables:
           ENDPOINT: !Ref ENDPOINT
@@ -1221,22 +1221,6 @@ Resources:
             Schedule: rate(5 minutes)
             Description: Refresh precomputed card stats
             Enabled: true
-        ManualRefresh:
-          Type: Api
-          Properties:
-            Path: /admin/refresh-card-stats
-            Method: POST
-            RestApiId:
-              Ref: CreditCardOddsAPI
-        ManualRefreshOptions:
-          Type: Api
-          Properties:
-            Auth:
-              Authorizer: NONE
-            Path: /admin/refresh-card-stats
-            Method: OPTIONS
-            RestApiId:
-              Ref: CreditCardOddsAPI
 
   WalletPicksStoreFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Removes the unauthenticated-by-any-signed-in-user `/admin/refresh-card-stats` route.

## Why
The route was behind the Firebase authorizer but the handler never checked the admin claim, so **any signed-in user** (not just admins) could trigger the 300s full-table `card_stats` recompute — a DB-load/cost lever. It's idempotent (same query the cron runs), so no data risk.

Grep confirms **nothing** in the frontend, `scripts/`, or `apps/api/scripts/` calls it. The EventBridge 5-minute schedule is what actually keeps `card_stats` fresh.

## Change
Mirrors the `/sync-cards` decision — remove the surface instead of guarding it:
- Drop the `ManualRefresh` (POST) and `ManualRefreshOptions` (OPTIONS) `Api` events from `RefreshCardStatsFunction`.
- **Keep** `ScheduledRefresh` (`rate(5 minutes)`) — stats refresh is unchanged.
- Updated the function description + handler comment; left the handler's `httpMethod` branches as inert defensive code.

Manual recompute is still possible via `aws lambda invoke` (requires AWS creds), not a public URL.

## Testing
- `sam validate --lint` passes.
- `node --check` on the handler passes.
- Confirmed `/admin/refresh-card-stats` no longer appears in the template; `ScheduledRefresh` / `rate(5 minutes)` retained.

On deploy, CloudFormation removes the POST+OPTIONS methods from that API Gateway path; the function and its schedule are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)