### PR TITLE
perf(check-odds): read card_stats instead of scanning records per request

### DIFF
--- a/apps/api/src/handlers/check-odds.js
+++ b/apps/api/src/handlers/check-odds.js
@@ -33,18 +33,23 @@ async function fetchCardsFromCDN() {
   });
 }
 
-// Fetch card stats and metadata from MySQL
-async function fetchCardStatsAndMetadata() {
+// Read precomputed per-card stats from card_stats (totals + medians) plus card
+// metadata. card_stats is refreshed every 5 min by RefreshCardStatsFunction and
+// is what /cards and /card already read, so check-odds no longer scans the full
+// records table (3 window-function CTEs + an aggregate) on every request — and
+// its numbers now stay consistent with the rest of the site. All card_stats
+// columns are INT, so values arrive as JS numbers.
+async function fetchStatsAndMetadata() {
   const [statsResults, cardResults] = await Promise.all([
     mysql.query(`
       SELECT
         card_id,
-        COUNT(*) as total_records,
-        SUM(CASE WHEN result = 1 THEN 1 ELSE 0 END) as approved_count,
-        SUM(CASE WHEN result = 0 THEN 1 ELSE 0 END) as rejected_count
-      FROM records
-      WHERE admin_review = 1 AND active = 1
-      GROUP BY card_id
+        total_records,
+        approved_count,
+        approved_median_credit_score,
+        approved_median_income,
+        approved_median_length_credit
+      FROM card_stats
     `),
     mysql.query(`
       SELECT card_id, card_name, card_image_link, accepting_applications, tags
@@ -72,76 +77,6 @@ async function fetchCardStatsAndMetadata() {
   }
 
   return { statsMap, cardMap };
-}
-
-// Compute medians for all cards using ROW_NUMBER() CTEs
-async function fetchApprovedMedians() {
-  const [creditScoreResults, incomeResults, lengthCreditResults] = await Promise.all([
-    mysql.query(`
-      WITH ranked AS (
-        SELECT card_id, credit_score,
-          ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY credit_score) AS rn,
-          COUNT(*) OVER (PARTITION BY card_id) AS cnt
-        FROM records
-        WHERE admin_review = 1 AND active = 1 AND result = 1
-      )
-      SELECT card_id,
-        AVG(credit_score) AS median_credit_score,
-        MAX(cnt) AS approved_count
-      FROM ranked
-      WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
-      GROUP BY card_id
-    `),
-    mysql.query(`
-      WITH ranked AS (
-        SELECT card_id, listed_income,
-          ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY listed_income) AS rn,
-          COUNT(*) OVER (PARTITION BY card_id) AS cnt
-        FROM records
-        WHERE admin_review = 1 AND active = 1 AND result = 1 AND listed_income IS NOT NULL
-      )
-      SELECT card_id,
-        AVG(listed_income) AS median_income
-      FROM ranked
-      WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
-      GROUP BY card_id
-    `),
-    mysql.query(`
-      WITH ranked AS (
-        SELECT card_id, length_credit,
-          ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY length_credit) AS rn,
-          COUNT(*) OVER (PARTITION BY card_id) AS cnt
-        FROM records
-        WHERE admin_review = 1 AND active = 1 AND result = 1
-      )
-      SELECT card_id,
-        AVG(length_credit) AS median_length_credit
-      FROM ranked
-      WHERE rn IN (FLOOR((cnt + 1) / 2), CEIL((cnt + 1) / 2))
-      GROUP BY card_id
-    `)
-  ]);
-
-  const medianMap = {};
-
-  for (const row of creditScoreResults) {
-    medianMap[row.card_id] = {
-      median_credit_score: Math.round(row.median_credit_score),
-      approved_count: row.approved_count,
-    };
-  }
-  for (const row of incomeResults) {
-    if (medianMap[row.card_id]) {
-      medianMap[row.card_id].median_income = Math.round(row.median_income);
-    }
-  }
-  for (const row of lengthCreditResults) {
-    if (medianMap[row.card_id]) {
-      medianMap[row.card_id].median_length_credit = Math.round(row.median_length_credit);
-    }
-  }
-
-  return medianMap;
 }
 
 // Validate input
@@ -212,10 +147,9 @@ exports.CheckOddsHandler = async (event) => {
         );
 
         // Fetch all data in parallel
-        const [cards, { statsMap, cardMap }, medianMap] = await Promise.all([
+        const [cards, { statsMap, cardMap }] = await Promise.all([
           fetchCardsFromCDN(),
-          fetchCardStatsAndMetadata(),
-          fetchApprovedMedians(),
+          fetchStatsAndMetadata(),
         ]);
 
         await mysql.end();
@@ -229,16 +163,19 @@ exports.CheckOddsHandler = async (event) => {
           .map(card => {
             const dbCard = cardMap[card.card_name] || cardMap[card.name] || {};
             const stats = statsMap[dbCard.db_card_id] || {};
-            const medians = medianMap[dbCard.db_card_id] || {};
 
-            const approvedCount = medians.approved_count || 0;
+            const approvedCount = stats.approved_count || 0;
             const hasEnoughData = approvedCount >= 5;
+
+            const medianCreditScore = stats.approved_median_credit_score;
+            const medianIncome = stats.approved_median_income;
+            const medianLengthCredit = stats.approved_median_length_credit;
 
             let matchScore = 0;
             if (hasEnoughData) {
-              if (credit_score >= medians.median_credit_score) matchScore++;
-              if (income >= medians.median_income) matchScore++;
-              if (length_credit >= medians.median_length_credit) matchScore++;
+              if (credit_score >= medianCreditScore) matchScore++;
+              if (income >= medianIncome) matchScore++;
+              if (length_credit >= medianLengthCredit) matchScore++;
             }
 
             return {
@@ -254,12 +191,12 @@ exports.CheckOddsHandler = async (event) => {
               total_records: stats.total_records || 0,
               approved_data_points: approvedCount,
               has_enough_data: hasEnoughData,
-              median_credit_score: hasEnoughData ? medians.median_credit_score : null,
-              median_income: hasEnoughData ? medians.median_income : null,
-              median_length_credit: hasEnoughData ? medians.median_length_credit : null,
-              above_credit_score: hasEnoughData ? credit_score >= medians.median_credit_score : null,
-              above_income: hasEnoughData ? income >= medians.median_income : null,
-              above_length_credit: hasEnoughData ? length_credit >= medians.median_length_credit : null,
+              median_credit_score: hasEnoughData ? medianCreditScore : null,
+              median_income: hasEnoughData ? medianIncome : null,
+              median_length_credit: hasEnoughData ? medianLengthCredit : null,
+              above_credit_score: hasEnoughData ? credit_score >= medianCreditScore : null,
+              above_income: hasEnoughData ? income >= medianIncome : null,
+              above_length_credit: hasEnoughData ? length_credit >= medianLengthCredit : null,
               match_score: matchScore,
             };
           });


### PR DESCRIPTION
Fixes optimization finding: `/check-odds` recomputed medians from `records` on every request.

## Before
Every `POST /check-odds` ran **four full-table operations** on `records`:
- 3 `ROW_NUMBER()` window-function CTEs (median credit score / income / length-of-credit)
- 1 `GROUP BY card_id` aggregate (totals)

…recomputing exactly what `card_stats` already stores and `RefreshCardStatsFunction` refreshes every 5 minutes — and what `/cards` and `/card` already read.

## After
A single `SELECT ... FROM card_stats` (keyed by `db_card_id`) replaces both `fetchCardStatsAndMetadata` and `fetchApprovedMedians`. The `cards` metadata query (name/image/tags) is unchanged.

- Removes 4 `records` scans from the hottest authenticated POST
- Deletes ~70 lines of duplicated median SQL (net −63 lines)
- Makes check-odds numbers **consistent** with the rest of the site (same source table)
- All `card_stats` columns are `INT` → values arrive as numbers, medians already rounded; output shape and the `approved_count >= 5` "enough data" gate are unchanged

## Behavior note
Medians now come from the 5-min precompute rather than a per-request live scan, so they can be up to ~5 min stale — same freshness as `/cards`/`/card` (and the frontend's `revalidate = 300`). This is a consistency improvement, not a regression.

## Testing
- `node --check` passes; no dangling refs to the removed functions; only stats source is now `card_stats` (no `records` window scans remain).
- Full runtime check needs the VPC DB — I'll direct-invoke `CheckOddsHandler` after deploy with a sample profile and cross-check a card's median against `/cards` (same `card_stats` source, so they must agree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)