### PR TITLE
perf(api): esbuild-bundle 3 hottest public readers (canary)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -55,6 +55,13 @@ jobs:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
           aws-region: us-east-2
 
+      # SAM's esbuild BuildMethod (used by the bundled handlers) needs esbuild
+      # discoverable on PATH at build time. SAM's per-function npm install is
+      # production-only, so a global pinned install is the reliable way to
+      # provide it in CI.
+      - name: Install esbuild for SAM bundling
+        run: npm install -g esbuild@0.27.4
+
       - name: SAM build
         working-directory: apps/api
         run: sam build

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -101,6 +101,14 @@ Resources:
 
   AllCardsFunction:
     Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/all-cards.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
     Properties:
       Handler: src/handlers/all-cards.AllCardsHandler
       Runtime: nodejs22.x
@@ -127,6 +135,14 @@ Resources:
 
   CardByIdFunction:
     Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/card-by-id.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
     Properties:
       Handler: src/handlers/card-by-id.CardByIdHandler
       Runtime: nodejs22.x
@@ -153,6 +169,14 @@ Resources:
 
   getCardGraphsFunction:
     Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/get-card-graphs.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
     Properties:
       Handler: src/handlers/get-card-graphs.getCardGraphsHandler
       Runtime: nodejs22.x


### PR DESCRIPTION
First step toward esbuild-bundling the Lambda functions. Today every function ships **~98MB** (the whole `node_modules`, incl. `firebase-admin`) per artifact. esbuild tree-shakes each to its actual imports.

## This canary
Bundles the 3 hottest public DB readers — `/cards`, `/card`, `/graphs` — none of which import `firebase-admin`, so they bundle cleanly:

| Function | Before | After |
|---|---|---|
| AllCards / CardById / getCardGraphs | ~98MB each | **~0.5MB each** |

Verified locally via full `sam build`: all three bundle, load, and export their handlers; `mysql2` bundles without issue; SAM auto-rewrites the handler path in the built template (no source `Handler` change).

## CI change
SAM's esbuild BuildMethod needs `esbuild` on PATH, and SAM's per-function npm install is production-only — so `deploy-api.yml` gets a pinned `npm install -g esbuild@0.27.4` step before `sam build`.

## Deliberately NOT bundled
The 6 `firebase-admin` functions (authorizer, `delete-account`, and the 3 `click-identity` telemetry handlers) stay on the default build — `firebase-admin` bundles to 7MB *with warnings* and sits on the auth path.

## Why a canary
The bundles are clean locally, but a clean build ≠ proven runtime, and this is the first time the CI esbuild path runs. The 3 targets are **public GETs**, so I can `curl`-verify them in prod immediately after deploy with no auth. If the CI build fails, nothing deploys (build aborts before the CF update). Once verified, a follow-up PR bundles the remaining ~24 non-`firebase-admin` functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)