### PR TITLE
chore: gitignore + remove stale apps/api/packaged.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 build/
 .build/
 .aws-sam/
+apps/api/packaged.yaml
 data/news.json
 
 # Environment files


### PR DESCRIPTION
Removes the last loose artifact from the repo review.

`apps/api/packaged.yaml` is a leftover `sam package` output — it predates the current template and references the **deleted** CodePipeline's S3 bucket. It holds **no resolved secrets** (parameters stay `NoEcho`), but it was untracked and one `git add -A` from being committed.

- Delete the file
- Add `apps/api/packaged.yaml` to `.gitignore` so a future `sam package` can't re-introduce it

🤖 Generated with [Claude Code](https://claude.com/claude-code)