### PR TITLE
feat(social): route SUB-increase tweets to @card_wire

### DIFF
--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -479,7 +479,7 @@ function buildPostText(cardName, changes, bank) {
 
 function buildLinkUrl(slug) {
   const url = new URL(`https://creditodds.com/card/${slug}`);
-  url.searchParams.set('utm_source', 'twitter');
+  url.searchParams.set('utm_source', 'twitter_cardwire');
   url.searchParams.set('utm_medium', 'social');
   url.searchParams.set('utm_campaign', 'card-wire');
   return url.toString();
@@ -497,7 +497,9 @@ async function queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffe
     link_url: linkUrl,
     source_type: 'card-wire',
     source_id: sourceId,
-    platforms: ['twitter'],
+    // SUB-increase tweets route only to the dedicated @card_wire X account.
+    // (Omitting platforms would fan out to every connected account.)
+    platforms: ['twitter_cardwire'],
   };
   if (twitterText && twitterText !== textContent) {
     body.twitter_text = twitterText;


### PR DESCRIPTION
## What

Routes sign-up-bonus-increase tweets (the CardWire posts) to the new dedicated **@card_wire** X account instead of @creditodds.

The social posting service (`CreditOddsSocialPostingService`) already supports the new account via the platform key `twitter_cardwire`. The only change needed here is the queue payload `post-card-wire.js` sends.

## Changes

- `platforms: ['twitter']` → `platforms: ['twitter_cardwire']` so SUB-increase posts route **only** to @card_wire. (Omitting `platforms` would fan out to every connected account, so it's set explicitly.)
- Card-wire link `utm_source` → `twitter_cardwire` for per-account attribution.

## Scope / safety

- Only `source_type: 'card-wire'` (SUB increases) is affected. News, articles, new-card announcements, and rankings are untouched and still post to @creditodds.
- No secrets, workflow, or infra changes — the posting service handles credentials and publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)