### PR TITLE
feat(card-wire): highest SUB ever on card page + log bonus unit

### DIFF
--- a/apps/api/migrations/040_add_unit_to_card_wire.sql
+++ b/apps/api/migrations/040_add_unit_to_card_wire.sql
@@ -1,0 +1,8 @@
+-- Add a `unit` column to card_wire so signup_bonus_value changes record the
+-- bonus type (cash / points / miles / free_nights) in effect at the time of the
+-- change. Without it, consumers can't tell that a card which switched its
+-- welcome bonus from free nights to points (e.g. Marriott Bonvoy Boundless)
+-- logged a meaningless "5 -> 125000" diff. New rows are stamped by
+-- update-cards-github; legacy rows stay NULL and fall back to a magnitude
+-- heuristic on the client.
+ALTER TABLE card_wire ADD COLUMN unit VARCHAR(20) DEFAULT NULL;

--- a/apps/api/src/handlers/card-wire.js
+++ b/apps/api/src/handlers/card-wire.js
@@ -47,7 +47,7 @@ exports.CardWireHandler = async (event) => {
     if (cardId) {
       rows = await mysql.query(
         `SELECT cw.id, cw.card_id, c.card_name, cw.field,
-                cw.old_value, cw.new_value, cw.changed_at
+                cw.old_value, cw.new_value, cw.unit, cw.changed_at
          FROM card_wire cw
          JOIN cards c ON c.card_id = cw.card_id
          WHERE cw.card_id = ?
@@ -59,7 +59,7 @@ exports.CardWireHandler = async (event) => {
     } else {
       rows = await mysql.query(
         `SELECT cw.id, cw.card_id, c.card_name, c.card_image_link,
-                cw.field, cw.old_value, cw.new_value, cw.changed_at
+                cw.field, cw.old_value, cw.new_value, cw.unit, cw.changed_at
          FROM card_wire cw
          JOIN cards c ON c.card_id = cw.card_id
          WHERE cw.field != 'reward_top_rate'

--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -65,14 +65,34 @@ async function detectAndRecordChanges(cardId, oldMetrics, newMetrics) {
     // Skip initial backfill (old is null = first time populating metrics)
     if (oldStr === null) continue;
 
-    changes.push({ field: t.field, old_value: oldStr, new_value: newStr });
+    // The signup bonus value is unit-bearing (cash / points / miles / free
+    // nights), so stamp each row with its unit and never compare across units.
+    // When the unit itself changes (e.g. Marriott Bonvoy Boundless switched
+    // from free nights to points), the old->new numbers aren't comparable, so
+    // skip the diff entirely — the next same-unit change records cleanly, and
+    // the new value still surfaces as that row's old_value.
+    let unit = null;
+    if (t.field === "signup_bonus_value") {
+      const oldType = oldMetrics.signup_bonus_type ?? null;
+      const newType = newMetrics.signup_bonus_type ?? null;
+      if (oldType !== null && newType !== null && oldType !== newType) continue;
+      unit = newType;
+    }
+
+    changes.push({ field: t.field, old_value: oldStr, new_value: newStr, unit });
   }
 
   if (changes.length > 0) {
-    const placeholders = changes.map(() => "(?, ?, ?, ?)").join(", ");
-    const flat = changes.flatMap((c) => [cardId, c.field, c.old_value, c.new_value]);
+    const placeholders = changes.map(() => "(?, ?, ?, ?, ?)").join(", ");
+    const flat = changes.flatMap((c) => [
+      cardId,
+      c.field,
+      c.old_value,
+      c.new_value,
+      c.unit,
+    ]);
     await mysql.query(
-      `INSERT INTO card_wire (card_id, field, old_value, new_value) VALUES ${placeholders}`,
+      `INSERT INTO card_wire (card_id, field, old_value, new_value, unit) VALUES ${placeholders}`,
       flat
     );
   }

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -156,6 +156,20 @@ function wireDirection(
   return wentUp ? "pos" : "neg";
 }
 
+// Formats a signup-bonus amount in its natural unit (mirrors the headline
+// `bonusDisplay` logic so the rail's "highest ever" reads the same way).
+function formatBonusValue(value: number, type: string): string {
+  if (type === "cash") return `$${value.toLocaleString()}`;
+  if (type === "free_nights")
+    return `${value} night${value !== 1 ? "s" : ""}`;
+  const compact =
+    value >= 1000
+      ? `${(value / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 })}K`
+      : value.toLocaleString();
+  const unit = type === "miles" ? "mi" : "pts";
+  return `${compact} ${unit}`;
+}
+
 function WireChip({
   entry,
   label,
@@ -527,6 +541,57 @@ export default function CardClient({
         .slice(0, 8),
     [wire],
   );
+
+  // Highest signup bonus ever seen — scans every wire diff's old/new value
+  // plus the current offer, so the rail can flag the all-time high (OP ask
+  // on Reddit: "what the best offer for a particular card has been").
+  const highestSub = useMemo(() => {
+    const sb = card.signup_bonus;
+    if (!sb || typeof sb.value !== "number" || sb.value <= 0) return null;
+
+    // Only compare bonuses in the current unit. New wire rows carry their unit;
+    // legacy rows (written before the column existed) don't, so fall back to a
+    // magnitude check — a past points offer on a now-free-nights card (e.g.
+    // Marriott Boundless: 125,000 pts vs 5 nights) is orders of magnitude off.
+    const inBand = (n: number) =>
+      n > 0 && n <= sb.value * 1000 && n >= sb.value / 1000;
+    const sameUnit = (w: CardWireEntry, n: number) =>
+      w.unit ? w.unit === sb.type : inBand(n);
+
+    let max = sb.value;
+    for (const w of wire) {
+      if (w.field !== "signup_bonus_value") continue;
+      for (const v of [w.old_value, w.new_value]) {
+        const n = v === null ? NaN : Number(v);
+        if (!Number.isNaN(n) && sameUnit(w, n) && n > max) max = n;
+      }
+    }
+
+    // Most recent date the bonus was observed at that high — either when it
+    // climbed to it (new_value) or last dropped away from it (old_value).
+    let asOfTs: number | null = null;
+    for (const w of wire) {
+      if (w.field !== "signup_bonus_value") continue;
+      const o = w.old_value === null ? NaN : Number(w.old_value);
+      const n = w.new_value === null ? NaN : Number(w.new_value);
+      if ((o === max && sameUnit(w, o)) || (n === max && sameUnit(w, n))) {
+        const ts = new Date(w.changed_at).getTime();
+        if (asOfTs === null || ts > asOfTs) asOfTs = ts;
+      }
+    }
+
+    return {
+      label: formatBonusValue(max, sb.type),
+      isCurrent: max <= sb.value,
+      asOf:
+        asOfTs === null
+          ? null
+          : new Date(asOfTs).toLocaleDateString("en-US", {
+              month: "short",
+              year: "numeric",
+            }),
+    };
+  }, [card.signup_bonus, wire]);
 
   const fieldLabel: Record<string, string> = {
     annual_fee: "Annual fee",
@@ -1619,6 +1684,23 @@ export default function CardClient({
           {wireEntries.length > 0 && (
             <div className="cj-rail-block cj-wire-rail">
               <div className="cj-rail-label">Card wire</div>
+              {highestSub && (
+                <div className="cj-wire-high">
+                  <span className="cj-wire-high-label">
+                    Highest bonus on record
+                  </span>
+                  <span className="cj-wire-high-val">{highestSub.label}</span>
+                  {highestSub.isCurrent ? (
+                    <span className="cj-wire-high-now">Live now</span>
+                  ) : (
+                    highestSub.asOf && (
+                      <span className="cj-wire-high-date">
+                        last offered {highestSub.asOf}
+                      </span>
+                    )
+                  )}
+                </div>
+              )}
               <ul className="cj-wire-rail-list">
                 {wireEntries.map((w) => {
                   const dir = wireDirection(w.field, w.old_value, w.new_value);

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7134,6 +7134,45 @@
   font-weight: 600;
 }
 
+/* "Highest bonus on record" callout pinned to the top of the Card wire rail. */
+.landing-v2 .cj-wire-high {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 10px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--line-2));
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--accent) 6%, var(--paper));
+}
+.landing-v2 .cj-wire-high-label {
+  flex: 1 1 100%;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.landing-v2 .cj-wire-high-val {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--accent);
+}
+.landing-v2 .cj-wire-high-now {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #0f8a5f;
+  background: color-mix(in oklab, #0f8a5f 12%, var(--paper));
+  border-radius: 999px;
+  padding: 2px 7px;
+}
+.landing-v2 .cj-wire-high-date {
+  font-size: 11px;
+  color: var(--muted);
+}
+
 .landing-v2 .cj-two-up {
   display: grid;
   grid-template-columns: minmax(0, 1fr);

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -973,6 +973,10 @@ export interface CardWireEntry {
   field: string;
   old_value: string | null;
   new_value: string | null;
+  // Bonus unit (cash / points / miles / free_nights) for signup_bonus_value
+  // rows, so values are never compared across units. Null on legacy rows
+  // written before the column existed.
+  unit?: string | null;
   changed_at: string;
 }
 


### PR DESCRIPTION
## What

Adds a **"Highest bonus on record"** callout to the Card wire rail on each card page, surfacing the all-time-high signup bonus from the SUB change history. This answers a [Reddit ask](https://www.reddit.com/r/creditodds): users want to see the best offer a card has had historically to time their application.

- Shows **`last offered <month year>`** for historical highs, so it's never mistaken for the current offer.
- Shows a green **`Live now`** badge when the current offer equals the all-time high.

## Why the unit change matters

`card_wire` stored `signup_bonus_value` as a raw number with **no unit**. A card that switched its welcome bonus from free nights to points (e.g. **Marriott Bonvoy Boundless**: `5 nights` → `125,000 points`) logged a meaningless `5 -> 125000` diff, and a naive "highest ever" rendered nonsense like *"125000 nights."*

This PR records the unit so values are never compared across units:

| Change | File |
|--------|------|
| `unit VARCHAR(20)` column on `card_wire` | `apps/api/migrations/040_add_unit_to_card_wire.sql` |
| Stamp each `signup_bonus_value` row with its bonus type; **skip the diff when the unit itself changes** | `update-cards-github.js` |
| Return `unit` from the API | `card-wire.js` |
| Compare only within the current bonus unit; legacy rows (no `unit`) fall back to a magnitude check | `CardClient.tsx`, `api.ts` |

## Migration

**Migration `040` has already been applied to production** (via `RunMigrationFunction`). It is included here so the repo/CI stay in sync; re-running is a no-op-or-error and not needed.

The column is additive and nullable — the updated `card-wire.js` `SELECT cw.unit` is safe because the column now exists in prod.

## Verification

- Backend: `node --check` passes both handlers.
- Frontend: `tsc --noEmit` clean; eslint adds no new issues over base.
- Verified locally against live data: World of Hyatt shows `60K pts · last offered Jun 2026` (current offer is 30K); Marriott Boundless correctly shows `5 nights` (not 125000) via the unit/magnitude guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)