### PR TITLE
fix(web): wire 'tracked since' note, admin breadcrumb alignment, drop stale footer version

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1732,6 +1732,7 @@ export default function CardClient({
                   );
                 })}
               </ul>
+              <p className="cj-wire-rail-note">Tracked since April 2026</p>
             </div>
           )}
 

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7088,6 +7088,12 @@
   margin: 0;
   padding: 0;
 }
+.landing-v2 .cj-wire-rail-note {
+  margin: 8px 0 0;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--muted);
+}
 .landing-v2 .cj-wire-rail-row {
   display: flex;
   flex-direction: column;
@@ -8729,7 +8735,9 @@
 .landing-v2.admin-v2 .av-terminal {
   background: var(--ink);
   color: #fff;
-  padding: 10px 18px;
+  /* Full-bleed bar, but align inner content to the centered 1280px av-wrap
+     so the breadcrumb lines up with the navbar and page content. */
+  padding: 10px max(18px, calc((100% - 1280px) / 2 + 18px));
   display: flex;
   align-items: center;
   gap: 14px;
@@ -8738,10 +8746,14 @@
   flex-wrap: wrap;
 }
 @media (min-width: 768px) {
-  .landing-v2.admin-v2 .av-terminal { padding: 10px 24px; }
+  .landing-v2.admin-v2 .av-terminal {
+    padding-inline: max(24px, calc((100% - 1280px) / 2 + 24px));
+  }
 }
 @media (min-width: 1024px) {
-  .landing-v2.admin-v2 .av-terminal { padding: 10px 32px; }
+  .landing-v2.admin-v2 .av-terminal {
+    padding-inline: max(32px, calc((100% - 1280px) / 2 + 32px));
+  }
 }
 .landing-v2.admin-v2 .av-terminal .av-spacer { flex: 1; }
 .landing-v2.admin-v2 .av-crumbs {

--- a/apps/web-next/src/components/landing-v2/Chrome.tsx
+++ b/apps/web-next/src/components/landing-v2/Chrome.tsx
@@ -116,7 +116,6 @@ export function V2Footer() {
         </div>
         <div className="foot-bottom">
           <span>© {new Date().getFullYear()} CreditOdds. Built by the community.</span>
-          <span>v2.6 · Last updated May 2026</span>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Three small front-end fixes (all in the shared v2 UI):

- **Card wire disclaimer** — added an italic `Tracked since April 2026` note under the Card wire rail on card pages, so the "Highest bonus on record" figure isn't mistaken for an all-time high (better offers existed earlier in 2026). Prompted by community feedback.
- **/admin breadcrumb alignment** — the admin terminal bar was full-bleed with a flat gutter, leaving the "Admin" crumb flush-left while the centered 1280px content drifted inward on wide screens. Now uses the same full-bleed-but-aligned padding pattern as `cj-terminal`. Verified at 1600px: crumb and content both start at x=192.
- **Footer version stamp** — removed the inaccurate `v2.6 · Last updated May 2026` line from `V2Footer` (shared across all v2 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)