### PR TITLE
fix(api): require() stores.json so wallet picks survive esbuild bundling

### DIFF
--- a/apps/api/src/lib/ranker/data-loaders.js
+++ b/apps/api/src/lib/ranker/data-loaders.js
@@ -1,15 +1,16 @@
 // Data-loading helpers for the wallet-picks Lambda handlers.
 //
-// - stores.json is bundled in the Lambda zip (see scripts/build-stores.js,
-//   which mirrors data/stores.json into this directory).
+// - stores.json is require()'d so esbuild inlines it into each handler's
+//   bundle (see scripts/build-stores.js, which mirrors data/stores.json into
+//   this directory). It must NOT be read as a loose file via fs/__dirname:
+//   under `BuildMethod: esbuild` the data file isn't copied next to the
+//   bundle, so a runtime read throws ENOENT and 500s every wallet-picks call.
 // - cards.json is fetched from CloudFront per cold start. The existing
 //   nearby-recommendations / card-by-id / all-cards handlers do the same
 //   per request; we cache at module scope here with a short TTL to keep
 //   warm-container wallet picks fast without holding stale data forever.
 
 const https = require("https");
-const path = require("path");
-const fs = require("fs");
 const mysql = require("../../db");
 
 const CARDS_URL =
@@ -95,15 +96,11 @@ async function getAllCards() {
   return enriched;
 }
 
-// stores.json — bundled in CodeUri, loaded once at module init.
-const STORES_PATH = path.join(__dirname, "stores.json");
-let storesData = null;
+// stores.json — inlined into the bundle at build time via require() so the
+// data survives esbuild bundling (a loose-file read would not).
+const storesData = require("./stores.json");
 
 function getStoresData() {
-  if (!storesData) {
-    const raw = fs.readFileSync(STORES_PATH, "utf8");
-    storesData = JSON.parse(raw);
-  }
   return storesData;
 }
 


### PR DESCRIPTION
## The bug

Signed-in users see **"Couldn't load your wallet. View your wallet."** on every `/best-card-for/*` store page (e.g. `/best-card-for/vons`) and the BCH "near you" overlay. It is **not** an auth problem.

## Root cause

PR #1396 (deployed 2026-06-10) switched the wallet-picks Lambdas to `BuildMethod: esbuild`. esbuild bundles JS into a new output dir but does **not** copy loose data files that are read at runtime. `data-loaders.js` loads the store catalog with:

```js
fs.readFileSync(path.join(__dirname, "stores.json"))
```

After bundling, that file isn't next to the bundle, so the read throws `ENOENT`. And because `getStoreBySlug()` runs **before** the handler's `try/catch`, the exception is unhandled → the function 500s → the frontend throws → "Couldn't load your wallet." This hit **every** store for **every** user, site-wide, since the 6/10 deploy.

## Fix

Load the catalog via `require("./stores.json")` instead. esbuild's default JSON loader inlines the data straight into each handler bundle, so there's no runtime file read.

Fixes both `/wallet-picks/store` and `/wallet-picks/nearby` (they share `data-loaders.js`).

## Verification

Bundled `wallet-picks-store.js` with esbuild (node22, --bundle):
- store records are now inlined in the bundle (`Vons` present)
- `readFileSync` count in the bundle: **0**
- `getStoreBySlug('vons')` resolves to `vons / Vons`

🤖 Generated with [Claude Code](https://claude.com/claude-code)