### PR TITLE
feat(explore): restore missing-card CTA in empty filter state

### DIFF
--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -570,7 +570,28 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
               fontSize: 13,
             }}
           >
-            No cards match these filters.
+            <p>No cards match these filters.</p>
+            <p style={{ marginTop: 12 }}>
+              Missing a card?{' '}
+              <a
+                href="https://github.com/CreditOdds/creditodds/issues/new?title=Add+card:+&labels=new+card"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="empty-cta-link"
+              >
+                Open an issue
+              </a>{' '}
+              or{' '}
+              <a
+                href="https://github.com/CreditOdds/creditodds/blob/main/CONTRIBUTING.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="empty-cta-link"
+              >
+                add it yourself
+              </a>{' '}
+              on GitHub.
+            </p>
           </div>
         ) : view === 'grid' ? (
           <div className="card-grid">

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1545,6 +1545,13 @@
 .landing-v2 .filter-clear-btn:hover {
   text-decoration: underline;
 }
+.landing-v2 .empty-cta-link {
+  font-weight: 500;
+  color: var(--accent);
+}
+.landing-v2 .empty-cta-link:hover {
+  text-decoration: underline;
+}
 .landing-v2 .ct-odds.odds-green,
 .landing-v2 .cc-odds .pct.odds-green { color: #15803d; }
 .landing-v2 .ct-odds.odds-amber,


### PR DESCRIPTION
## Summary
The pre-v2 /explore page had a bottom-of-page CTA (added in c1d158e4) prompting users to open a prefilled GitHub issue or add a missing card themselves via CONTRIBUTING.md. The v2 editorial redesign (#418) rebuilt the page and dropped it.

This restores it inside the zero-results empty state on /explore — "No cards match these filters." now follows with "Missing a card? Open an issue or add it yourself on GitHub." That placement targets exactly the moment someone searches for a card we don't have.

- Issue link prefills `title=Add card:` and the `new card` label, same as before
- Links use a new `.empty-cta-link` class in landing.css (accent color, underline on hover), matching the v2 `filter-clear-btn` idiom

## Verification
Ran the dev server, searched for a nonexistent card on /explore: empty state renders both links with correct hrefs (`issues/new?title=Add+card:+&labels=new+card` and `CONTRIBUTING.md`), accent color applied, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)