### PR TITLE
fix(social): formal, informative tone for new-card announcement tweets

### DIFF
--- a/scripts/post-new-card.js
+++ b/scripts/post-new-card.js
@@ -130,15 +130,16 @@ Issuer: ${card.bank || 'unknown'}
 Details: ${summary || 'see card page for details'}
 
 Rules:
-- Lead with "NEW:" or "Just added:" to make it clear this is a new addition
+- Tone: formal and informative, like a brief from a financial publication. No clickbait, no hype, no sensational hooks
+- Open with a plain statement that the card is now listed, e.g. "Now on CreditOdds: ..." or "The ${card.name} has been added to CreditOdds"
 - Max 200 characters (shorter is better)
-- Highlight the single most compelling detail (sign-up bonus, top reward rate, or $0 annual fee — pick one)
-- Write like a human, not a corporate account — be direct, casual, punchy
+- State the most notable facts plainly (sign-up bonus, top reward rate, or annual fee) — facts only, no editorializing
+- No exclamation points, no all-caps words, no rhetorical questions
 - No filler words, no "excited to announce", no "stay tuned"
-- 1 hashtag max, only if it adds value. Skip hashtags if the tweet is strong without one
+- No hashtags
 - Do NOT include any URL
 - Do NOT use em dashes
-- Do NOT use emojis excessively — 0-1 emoji max`;
+- Do NOT use emojis`;
 
   const response = await fetchWithRetry('https://api.anthropic.com/v1/messages', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- New-card announcement tweets (scripts/post-new-card.js) were prompted to be "direct, casual, punchy" with hooks like "NEW:" — they read as clickbait.
- Rewrote the Claude Haiku prompt so posts read like a brief from a financial publication: plain opening ("Now on CreditOdds: ..."), facts only (SUB, top reward rate, annual fee), no exclamation points, no all-caps, no hashtags, no emojis.

## Test plan
- `node --check` passes.
- No local ANTHROPIC_API_KEY to dry-run generation; next real new-card addition (or a `--dry-run` invocation in CI) will exercise the new prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)