### PR TITLE
Prime Visa: special apply link + $200 SUB

### DIFF
--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -28,16 +28,17 @@ rewards:
     value: 1
     unit: "percent"
 signup_bonus:
-  value: 150
+  value: 200
   type: "cash"
   spend_requirement: 0
   timeframe_months: 0
-  note: "$150 Amazon Gift Card instantly loaded upon approval"
+  note: "$200 Amazon Gift Card instantly loaded upon approval"
 apr:
   regular:
     min: 18.74
     max: 27.49
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/amazon-prime-rewards
+special_apply_link: https://www.amazon.com/dp/BT00LN946S
 foreign_transaction_fee: false
 benefits:
   - name: "Purchase Protection"


### PR DESCRIPTION
## Summary

The Amazon Prime Visa (Chase) has a higher headline welcome offer on its **Amazon-hosted application page** than on the generic Chase marketing page. Adopting the existing `special_apply_link` pattern (same as the Fidelity Rewards Visa) to capture it.

- `apply_link` — unchanged, the generic Chase page.
- `special_apply_link` — `https://www.amazon.com/dp/BT00LN946S`, the targeted offer.
- `signup_bonus` — bumped $150 → **$200** to reflect the special offer: "$200 Amazon Gift Card instantly loaded upon approval" (no spend requirement, Prime members).

## Verification

Amazon blocks automated fetches, so confirmed the live offer via:
- [Doctor of Credit](https://www.doctorofcredit.com/chase-amazon-prime-visa-200-signup-bonus-with-no-spend-required-june-11-july-9/) — "$200 signup bonus with no spend required, June 11 – July 9"
- [CNBC Select](https://www.cnbc.com/select/amazon-prime-visa-200-gift-card-before-prime-day-2026/)
- [Slickdeals](https://slickdeals.net/f/16733441-prime-visa-200-amazon-gift-card-instantly-upon-approval)

Build validates (181 cards); `cards.json` left for CI to rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)