### PR TITLE
Atmos cards: repoint to scrapeable Bank of America apply pages

### DIFF
--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -3,7 +3,7 @@ bank: "Bank of America"
 slug: "atmos-rewards-business"
 image: "atmos-rewards-business.png"
 accepting_applications: true
-apply_link: https://www.alaskaair.com/atmosrewards/content/credit-cards/visa-small-business
+apply_link: https://business.bankofamerica.com/en/credit-cards/atmos-rewards
 category: "business"
 annual_fee: 95
 foreign_transaction_fee: false

--- a/data/cards/atmos-rewards-summit.yaml
+++ b/data/cards/atmos-rewards-summit.yaml
@@ -3,7 +3,7 @@ bank: "Bank of America"
 slug: "atmos-rewards-summit"
 image: "atmos-rewards-summit.png"
 accepting_applications: true
-apply_link: https://www.alaskaair.com/atmosrewards/content/credit-cards/visa-summit
+apply_link: https://www.bankofamerica.com/credit-cards/products/alaska-airlines-infinite-credit-card/
 category: "travel"
 annual_fee: 395
 foreign_transaction_fee: false

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -22,6 +22,11 @@ const FETCH_DELAY_MS = 2000;
 const FETCH_TIMEOUT_MS = 15000;
 const PER_CARD_TIMEOUT_MS = 60000;   // 60s max per card (fetch + extraction)
 const SCRIPT_TIMEOUT_MS = 20 * 60 * 1000; // 20 min overall safety net
+// Max stripped page text handed to the extractor. Sized so nav-heavy issuer
+// pages still include the card terms — e.g. business.bankofamerica.com leads
+// with ~11k chars of menu chrome and the bonus/spend/timeframe land at ~12k–18k.
+// Most card pages strip to well under this, so the cap only bites on long pages.
+const MAX_CONTENT_CHARS = 18000;
 
 // ─── Timeout helpers ─────────────────────────────────────────────────────────
 
@@ -125,24 +130,24 @@ function stripHtml(html) {
     .replace(/&[a-z#0-9]+;/gi, ' ')
     .replace(/\s+/g, ' ')
     .trim()
-    .slice(0, 6000);
+    .slice(0, MAX_CONTENT_CHARS);
 }
 
-// Hosts/pages whose bot mitigation reliably defeats headless/CI fetches
-// (verified 2026-06-11). PNC (Akamai) resets the connection over HTTP/2 and
-// black-holes it over HTTP/1.1 — fails from CI and residential IPs alike.
-// alaskaair.com Atmos pages return 200 but are SPAs that render no card content
-// in headless Chromium (body innerText stays ~20 chars behind an Auth0 silent
-// frame). We short-circuit these so the run doesn't spend ~30s/card on
-// guaranteed timeouts; they still appear in the end-of-run skip summary so the
-// coverage gap stays visible. These cards are maintained manually for now —
-// remove an entry here to resume automated checks if a site's protection eases.
+// Hosts whose bot mitigation reliably defeats headless/CI fetches (verified
+// 2026-06-11). PNC (Akamai) resets the connection over HTTP/2 and black-holes
+// it over HTTP/1.1 — fails from CI and residential IPs alike, via browser and
+// curl. We short-circuit these so the run doesn't spend ~30s/card on guaranteed
+// timeouts; they still appear in the end-of-run skip summary so the coverage gap
+// stays visible. Maintained manually for now — remove an entry to resume
+// automated checks if a site's protection eases.
+//
+// (The Atmos cards previously listed here moved to scrapeable Bank of America
+// apply_links; the alaskaair.com SPA that rendered ~20 chars is no longer used.)
 function knownBlockedReason(url) {
   try {
     const u = new URL(url);
     const host = u.hostname.replace(/^www\./, '');
     if (host === 'pnc.com') return 'pnc.com bot mitigation blocks automated fetches (HTTP/2 reset + HTTP/1.1 black-hole)';
-    if (host === 'alaskaair.com' && /\/atmosrewards\//i.test(u.pathname)) return 'alaskaair.com Atmos page is an SPA that renders no content in headless';
   } catch { /* malformed URL — let the normal fetch path handle it */ }
   return null;
 }


### PR DESCRIPTION
## Summary

Follow-up to #1408. The two Atmos cards that the **Check Card Pages** run skips daily (`alaskaair.com` SPA → ~20 chars in headless) are **Bank of America–issued**, and BofA's pages render full static content. Repointing both `apply_link`s to BofA:

| Card | New apply_link |
|------|----------------|
| Atmos Rewards Summit | `https://www.bankofamerica.com/credit-cards/products/alaska-airlines-infinite-credit-card/` |
| Atmos Rewards Business | `https://business.bankofamerica.com/en/credit-cards/atmos-rewards` *(the `/smallbusiness/products/alaska-airlines-business-credit-card/` URL 301s here)* |

The business subdomain page leads with ~11k chars of nav chrome and the bonus/spend/fee land at ~12k–18k, so the extractor content cap is raised **6000 → 18000** (`MAX_CONTENT_CHARS`). Most card pages strip to far less, so the cap only bites on long pages. The now-unused alaskaair.com Atmos entry is dropped from `knownBlockedReason` (PNC stays blocked).

## Verified with live extraction (real Haiku run)
- **Summit**: fetched the BofA page and correctly read `spend_requirement 4000 → 6500` (matches the live $6,500/90d offer).
- **Business**: fetched the full 18k chars and read `annual_fee 95 → 70` from ~char 11k+ — content that was unreachable before. Bonus (80k/$5k/3mo) already matched, so no false positives.

Neither produced garbage, confirming the repoint + cap raise work end to end. Build validates (181 cards).

## Note
The two term corrections surfaced above are intentionally **not** in this PR (kept to repoint + script only). The daily run will surface them as normal review PRs now that the cards are scrapeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)