### PR TITLE
card-wire: replace underline tabs with filter toolbar

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
 import { V2Footer } from '@/components/landing-v2/Chrome';
@@ -13,16 +13,18 @@ interface Props {
   entries: CardWireEntry[];
   slugMap: Record<string, string>;
   bonusTypeMap: Record<string, string>;
+  bankMap: Record<string, string>;
 }
 
 type FilterKey = 'all' | 'fee' | 'bonus' | 'apr' | 'apps';
+type DirKey = 'all' | 'pos' | 'neg';
 
-const FILTERS: { key: FilterKey; num: string; label: string }[] = [
-  { key: 'all', num: '01', label: 'All' },
-  { key: 'fee', num: '02', label: 'Annual fee' },
-  { key: 'bonus', num: '03', label: 'Sign-up bonus' },
-  { key: 'apr', num: '04', label: 'APR' },
-  { key: 'apps', num: '05', label: 'Applications' },
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'fee', label: 'Annual fee' },
+  { key: 'bonus', label: 'Sign-up bonus' },
+  { key: 'apr', label: 'APR' },
+  { key: 'apps', label: 'Applications' },
 ];
 
 const FIELD_LABELS: Record<string, string> = {
@@ -114,8 +116,10 @@ function formatDayShort(ts: string): string {
   });
 }
 
-export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Props) {
+export default function CardWireV2Client({ entries, slugMap, bonusTypeMap, bankMap }: Props) {
   const [filter, setFilter] = useState<FilterKey>('all');
+  const [issuer, setIssuer] = useState('all');
+  const [dir, setDir] = useState<DirKey>('all');
   const [page, setPage] = useState(1);
 
   const counts = useMemo(() => {
@@ -144,10 +148,26 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
     return superseded;
   }, [entries]);
 
+  const issuers = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const e of entries) {
+      const bank = bankMap[e.card_name];
+      if (!bank) continue;
+      tally.set(bank, (tally.get(bank) || 0) + 1);
+    }
+    return [...tally.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([name, count]) => ({ value: name, label: name, count }));
+  }, [entries, bankMap]);
+
   const filtered = useMemo(() => {
-    if (filter === 'all') return entries;
-    return entries.filter((e) => fieldGroup(e.field) === filter);
-  }, [entries, filter]);
+    return entries.filter((e) => {
+      if (filter !== 'all' && fieldGroup(e.field) !== filter) return false;
+      if (issuer !== 'all' && bankMap[e.card_name] !== issuer) return false;
+      if (dir !== 'all' && changeDirection(e.field, e.old_value, e.new_value) !== dir) return false;
+      return true;
+    });
+  }, [entries, filter, issuer, dir, bankMap]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages);
@@ -209,28 +229,77 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
           </p>
         </div>
 
-        {/* Sticky filter tabs — same shell as profile cj-main-tabs */}
-        <div className="cj-main-tabs wire-tabs">
-          {FILTERS.map((f) => {
-            const count = counts[f.key];
-            return (
+        {/* Sticky filter toolbar — segmented control + issuer select + direction */}
+        <div className="wire-bar-wrap">
+          <div className="wire-bar">
+            <div className="wire-bar-seg" role="group" aria-label="Change type">
+              {FILTERS.map((f) => (
+                <button
+                  key={f.key}
+                  type="button"
+                  className={'wire-bar-seg-btn' + (filter === f.key ? ' active' : '')}
+                  aria-pressed={filter === f.key}
+                  onClick={() => {
+                    setFilter(f.key);
+                    setPage(1);
+                  }}
+                >
+                  {f.label}
+                  <span className="wire-bar-seg-count">{counts[f.key]}</span>
+                </button>
+              ))}
+            </div>
+            <span className="wire-bar-divider" aria-hidden="true" />
+            <IssuerSelect
+              issuers={issuers}
+              total={entries.length}
+              value={issuer}
+              onChange={(v) => {
+                setIssuer(v);
+                setPage(1);
+              }}
+            />
+            <span className="wire-bar-divider" aria-hidden="true" />
+            <div className="wire-bar-dir" role="group" aria-label="Change direction">
               <button
-                key={f.key}
                 type="button"
-                className={'cj-main-tab' + (filter === f.key ? ' active' : '')}
+                className={'wire-bar-dir-btn both' + (dir === 'all' ? ' active' : '')}
+                aria-pressed={dir === 'all'}
                 onClick={() => {
-                  setFilter(f.key);
+                  setDir('all');
                   setPage(1);
                 }}
               >
-                <span className="cj-main-tab-num">{f.num}</span>
-                {f.label}
-                {count > 0 && (
-                  <span className="cj-main-tab-count">· {count}</span>
-                )}
+                Both
               </button>
-            );
-          })}
+              <button
+                type="button"
+                className={'wire-bar-dir-btn up' + (dir === 'pos' ? ' active' : '')}
+                aria-pressed={dir === 'pos'}
+                onClick={() => {
+                  setDir('pos');
+                  setPage(1);
+                }}
+              >
+                ↑ Better
+              </button>
+              <button
+                type="button"
+                className={'wire-bar-dir-btn down' + (dir === 'neg' ? ' active' : '')}
+                aria-pressed={dir === 'neg'}
+                onClick={() => {
+                  setDir('neg');
+                  setPage(1);
+                }}
+              >
+                ↓ Worse
+              </button>
+            </div>
+            <span className="wire-bar-right">
+              <span className="wire-bar-dot" aria-hidden="true" />
+              {filtered.length} change{filtered.length === 1 ? '' : 's'}
+            </span>
+          </div>
         </div>
 
         <div className="cj-main-content">
@@ -281,6 +350,80 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap }: Pro
       </main>
       <V2Footer />
     </div>
+  );
+}
+
+function IssuerSelect({
+  issuers,
+  total,
+  value,
+  onChange,
+}: {
+  issuers: { value: string; label: string; count: number }[];
+  total: number;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDown(ev: MouseEvent) {
+      if (ref.current && !ref.current.contains(ev.target as Node)) setOpen(false);
+    }
+    function onKey(ev: KeyboardEvent) {
+      if (ev.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const options = [{ value: 'all', label: 'Every issuer', count: total }, ...issuers];
+  const current = options.find((o) => o.value === value) ?? options[0];
+
+  return (
+    <span className="wire-bar-select" ref={ref}>
+      <button
+        type="button"
+        className={
+          'wire-bar-select-btn' + (open ? ' open' : '') + (value !== 'all' ? ' set' : '')
+        }
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className="k">Issuer</span>
+        {current.label}
+        <span className="caret" aria-hidden="true">
+          ▼
+        </span>
+      </button>
+      {open && (
+        <span className="wire-bar-menu" role="listbox" aria-label="Issuer">
+          {options.map((o) => (
+            <button
+              key={o.value}
+              type="button"
+              role="option"
+              aria-selected={o.value === value}
+              className={'wire-bar-mi' + (o.value === value ? ' sel' : '')}
+              onClick={() => {
+                onChange(o.value);
+                setOpen(false);
+              }}
+            >
+              <span>{o.label}</span>
+              <span className="n">{o.count}</span>
+            </button>
+          ))}
+        </span>
+      )}
+    </span>
   );
 }
 

--- a/apps/web-next/src/app/card-wire/page.tsx
+++ b/apps/web-next/src/app/card-wire/page.tsx
@@ -28,8 +28,10 @@ export default async function CardWirePage() {
   // Build card_name → slug map for linking
   const slugMap: Record<string, string> = {};
   const bonusTypeMap: Record<string, string> = {};
+  const bankMap: Record<string, string> = {};
   for (const card of cards) {
     slugMap[card.card_name] = String(card.slug ?? card.card_id);
+    if (card.bank) bankMap[card.card_name] = card.bank;
     if (card.signup_bonus?.type) {
       const typeLabels: Record<string, string> = {
         points: 'pts',
@@ -50,7 +52,12 @@ export default async function CardWirePage() {
           { name: 'Card Wire', url: 'https://creditodds.com/card-wire' },
         ]}
       />
-      <CardWireV2Client entries={entries} slugMap={slugMap} bonusTypeMap={bonusTypeMap} />
+      <CardWireV2Client
+        entries={entries}
+        slugMap={slugMap}
+        bonusTypeMap={bonusTypeMap}
+        bankMap={bankMap}
+      />
     </>
   );
 }

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2763,57 +2763,187 @@
   }
 }
 
-/* Sticky tab row — sits below the global navbar (h-14 mobile / h-16 desktop) */
-.landing-v2.wire-v2 .wire-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0;
-  border-bottom: 1px solid var(--line);
-  margin: 8px 0 20px;
+/* Sticky filter toolbar — segmented control + issuer select + direction.
+   Wrapper stays sticky below the global navbar (h-14 mobile / h-16 desktop). */
+.landing-v2.wire-v2 .wire-bar-wrap {
   position: sticky;
   top: 56px;
   z-index: 20;
   background: var(--paper);
-  box-shadow: 0 1px 0 var(--line);
+  padding: 8px 0 12px;
+  margin: 4px 0 8px;
 }
 @media (min-width: 640px) {
-  .landing-v2.wire-v2 .wire-tabs { top: 64px; }
+  .landing-v2.wire-v2 .wire-bar-wrap { top: 64px; }
 }
-.landing-v2.wire-v2 .wire-tabs .cj-main-tab {
-  padding: 10px 18px 10px 0;
-  margin-right: 22px;
-  background: transparent;
+.landing-v2.wire-v2 .wire-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  padding: 8px 12px 8px 8px;
+  border: 1px solid var(--line-2);
+  background: var(--paper-2);
+  border-radius: 8px;
+}
+.landing-v2.wire-v2 .wire-bar-seg {
+  display: flex;
+  gap: 2px;
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 2px;
+  max-width: 100%;
+  overflow-x: auto;
+}
+.landing-v2.wire-v2 .wire-bar-seg-btn {
   border: 0;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
+  background: transparent;
+  padding: 5px 12px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  border-radius: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 5px;
+  align-items: baseline;
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s;
+}
+.landing-v2.wire-v2 .wire-bar-seg-btn:hover { color: var(--ink); }
+.landing-v2.wire-v2 .wire-bar-seg-btn.active { background: var(--ink); color: #fff; }
+.landing-v2.wire-v2 .wire-bar-seg-count {
+  font-size: 10px;
+  font-weight: 500;
+  opacity: 0.55;
+}
+.landing-v2.wire-v2 .wire-bar-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--line-2);
+  flex: 0 0 auto;
+}
+.landing-v2.wire-v2 .wire-bar-select {
+  position: relative;
+  display: inline-block;
+}
+.landing-v2.wire-v2 .wire-bar-select-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--line-2);
+  background: var(--paper);
+  border-radius: 6px;
+  padding: 6px 11px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink-2);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.12s;
+}
+.landing-v2.wire-v2 .wire-bar-select-btn:hover,
+.landing-v2.wire-v2 .wire-bar-select-btn.open { border-color: var(--muted-2); }
+.landing-v2.wire-v2 .wire-bar-select-btn .k { color: var(--muted-2); font-weight: 500; }
+.landing-v2.wire-v2 .wire-bar-select-btn .caret { font-size: 8.5px; color: var(--muted-2); }
+.landing-v2.wire-v2 .wire-bar-select-btn.set {
+  border-color: var(--accent);
+  color: var(--accent-deep);
+  background: var(--accent-2);
+}
+.landing-v2.wire-v2 .wire-bar-select-btn.set .k,
+.landing-v2.wire-v2 .wire-bar-select-btn.set .caret {
+  color: color-mix(in oklab, var(--accent-deep) 60%, transparent);
+}
+.landing-v2.wire-v2 .wire-bar-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 5px;
+  min-width: 200px;
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 40;
+  box-shadow: var(--shadow);
+}
+.landing-v2.wire-v2 .wire-bar-mi {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  width: 100%;
+  padding: 7px 10px;
   font-family: inherit;
   font-size: 13px;
   font-weight: 500;
+  color: var(--ink-2);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  border-radius: 4px;
+  text-align: left;
+  white-space: nowrap;
+}
+.landing-v2.wire-v2 .wire-bar-mi:hover { background: var(--paper-2); }
+.landing-v2.wire-v2 .wire-bar-mi.sel { color: var(--accent-deep); background: var(--accent-2); }
+.landing-v2.wire-v2 .wire-bar-mi .n { font-size: 10px; color: var(--muted-2); }
+.landing-v2.wire-v2 .wire-bar-dir {
+  display: flex;
+  gap: 2px;
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 2px;
+}
+.landing-v2.wire-v2 .wire-bar-dir-btn {
+  border: 0;
+  background: transparent;
+  padding: 5px 10px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
   color: var(--muted);
+  border-radius: 4px;
   cursor: pointer;
   white-space: nowrap;
-  letter-spacing: 0.01em;
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
 }
-.landing-v2.wire-v2 .wire-tabs .cj-main-tab:hover { color: var(--ink); }
-.landing-v2.wire-v2 .wire-tabs .cj-main-tab.active {
-  color: var(--ink);
-  border-bottom-color: var(--accent);
+.landing-v2.wire-v2 .wire-bar-dir-btn:hover { color: var(--ink); }
+.landing-v2.wire-v2 .wire-bar-dir-btn.active.up {
+  background: color-mix(in oklab, #0c8450 12%, var(--paper));
+  color: #0c8450;
+}
+.landing-v2.wire-v2 .wire-bar-dir-btn.active.down { background: var(--warn-2); color: var(--warn); }
+.landing-v2.wire-v2 .wire-bar-dir-btn.active.both { background: var(--ink); color: #fff; }
+.landing-v2.wire-v2 .wire-bar-right {
+  margin-left: auto;
+  font-size: 10.5px;
   font-weight: 600;
-}
-.landing-v2.wire-v2 .wire-tabs .cj-main-tab-num {
-  font-size: 10px;
-  color: var(--muted-2);
-  font-weight: 500;
-}
-.landing-v2.wire-v2 .wire-tabs .cj-main-tab.active .cj-main-tab-num { color: var(--accent); }
-.landing-v2.wire-v2 .wire-tabs .cj-main-tab-count {
-  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
   color: var(--muted);
-  font-weight: 500;
-  margin-left: 2px;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+.landing-v2.wire-v2 .wire-bar-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #2fd08c;
+  box-shadow: 0 0 0 3px rgba(47, 208, 140, 0.18);
+  margin-right: 8px;
+}
+@media (max-width: 767px) {
+  .landing-v2.wire-v2 .wire-bar { gap: 8px 10px; }
+  .landing-v2.wire-v2 .wire-bar-divider { display: none; }
 }
 
 /* Empty state */


### PR DESCRIPTION
## Summary
- Replaces the sticky underline tabs on /card-wire with the toolbar from the Claude Design exploration (concept E of "Card Wire Filters")
- Segmented change-type control (All / Annual fee / Sign-up bonus / APR / Applications) with per-type counts
- New issuer dropdown, populated from the cards feed via a card-name-to-bank map, sorted by change count; selected state gets the purple accent treatment
- New direction toggle (Both / Better / Worse) using the existing changeDirection logic; Better gets the green active state, Worse the pink one
- Live filtered result count with status dot on the right of the bar
- All three filters compose, and any filter change resets pagination to page 1

## Notes
- Toolbar stays sticky below the navbar like the old tabs did, via a thin wrapper so the rounded bar has a solid backdrop while scrolling
- Counts use Inter (no JetBrains Mono), per design-system preference
- Mobile: bar wraps, segmented control scrolls horizontally, dividers hidden

## Testing
- Verified in local preview: filter combinations (issuer + type + direction) produce correct counts and rows, dropdown closes on outside click and Escape, no console errors
- Checked mobile (375px) and desktop layouts
- `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)