### PR TITLE
Chase Sapphire Preferred: restore 100,000 limited-time SUB

### DIFF
--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -51,7 +51,7 @@ rewards:
     value: 1
     unit: "points_per_dollar"
 signup_bonus:
-  value: 75000
+  value: 100000
   type: "points"
   spend_requirement: 5000
   timeframe_months: 3


### PR DESCRIPTION
Corrects an erroneous revert in #1416.

The live [apply page](https://creditcards.chase.com/rewards-credit-cards/sapphire/preferred) shows the standard 75,000 struck through with the **limited-time 100,000-point** offer as the current bonus ($5,000 spend / 3 months unchanged). The earlier review misread which number was struck through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)