### PR TITLE
fix(card): US Bank Shield intro APR 24mo → 21mo

### DIFF
--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -16,19 +16,19 @@ rewards:
 apr:
   purchase_intro:
     rate: 0
-    months: 24
+    months: 21
   balance_transfer_intro:
     rate: 0
-    months: 24
+    months: 21
   regular:
     min: 16.99
     max: 27.99
 apply_link: https://www.usbank.com/credit-cards/pm/shield-visa-credit-card.html
 our_take: >
-  The Shield's 24-month 0% intro APR is one of the longest runways on the
+  The Shield's 21-month 0% intro APR is one of the longest runways on the
   market, and it covers both purchases and balance transfers with no annual
   fee. That makes it a strong pick if you're paying down existing debt or
-  financing a large purchase over the next two years. The catch is the rewards
+  financing a large purchase over the next year and a half. The catch is the rewards
   are thin: outside of 4% cash back on prepaid travel booked through the U.S.
   Bank Travel Center, there's no everyday earn rate, so once the intro period
   ends the card has little reason to stay in your wallet. Treat the $20 annual


### PR DESCRIPTION
## What

U.S. Bank shortened the **Shield Visa** 0% intro APR from **24 → 21 billing cycles** on both purchases and balance transfers (regular APR unchanged at 16.99–27.99%). Updated the `apr` block and the `our_take` copy.

Confirmed against the live apply page (`usbank.com/.../shield-visa-credit-card.html` reads "0% intro APR ... 21 billing cycles") and corroborated by CNBC/NerdWallet/WalletHub. U.S. Bank made the cut around March 2026.

## Why we didn't catch it automatically

Neither automated card check reads the `apr` block:
- `check-card-pages.js` extracts only `annual_fee` + `signup_bonus.*`
- `check-card-rewards-and-benefits.js` extracts only `rewards[]`, `benefits[]`, `foreign_transaction_fee` — and explicitly **excludes** "0% intro APR" entries

So intro-APR length is an automation blind spot. A follow-up could teach `check-card-pages.js` to extract `apr.purchase_intro.months` / `apr.balance_transfer_intro.months` / `apr.regular.{min,max}` and diff them, same pattern as the signup-bonus fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)