### PR TITLE
feat(card-wire): track intro APR length + detect it in card-page checks

### DIFF
--- a/apps/api/migrations/042_add_intro_apr_months_to_cards.sql
+++ b/apps/api/migrations/042_add_intro_apr_months_to_cards.sql
@@ -1,0 +1,9 @@
+-- Snapshot the 0% intro APR window length (in months / billing cycles) for both
+-- purchases and balance transfers, so update-cards-github can diff it on each
+-- sync and surface shortened or extended promo periods on /card-wire. Mirrors
+-- how apr_min / apr_max snapshot the regular APR. NULL for cards with no intro
+-- offer. Single ALTER (one statement) so the RunMigration Lambda — which runs
+-- each file without multipleStatements — applies it cleanly.
+ALTER TABLE cards
+  ADD COLUMN intro_apr_purchase_months INT DEFAULT NULL,
+  ADD COLUMN intro_apr_bt_months INT DEFAULT NULL;

--- a/apps/api/migrations/043_backfill_us_bank_shield_intro_apr_wire.sql
+++ b/apps/api/migrations/043_backfill_us_bank_shield_intro_apr_wire.sql
@@ -1,0 +1,26 @@
+-- Backfill the /card-wire feed with U.S. Bank Shield's intro-APR shortening:
+-- 0% for 24 -> 21 billing cycles on both purchases and balance transfers
+-- (U.S. Bank made the cut ~March 2026; corrected in YAML on 2026-06-16, PR #1423).
+--
+-- The sync handler only logs a card_wire row when it has a prior tracked value
+-- to diff against. Intro-APR tracking did not exist when this change merged, so
+-- the first post-deploy sync just sets the baseline (old=null, skipped) instead
+-- of recording the drop. This inserts the historical rows so the feed reflects
+-- it. Idempotent via NOT EXISTS, and a single INSERT statement so the
+-- RunMigration Lambda (no multipleStatements) applies it cleanly.
+INSERT INTO card_wire (card_id, field, old_value, new_value, unit)
+SELECT c.card_id, v.field, '24', '21', NULL
+FROM cards c
+JOIN (
+  SELECT 'intro_apr_purchase_months' AS field
+  UNION ALL
+  SELECT 'intro_apr_bt_months'
+) v
+WHERE c.card_name = 'US Bank Shield'
+  AND NOT EXISTS (
+    SELECT 1 FROM card_wire w
+    WHERE w.card_id = c.card_id
+      AND w.field = v.field
+      AND w.old_value = '24'
+      AND w.new_value = '21'
+  );

--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -34,6 +34,8 @@ function extractMetrics(cdnCard) {
     signup_bonus_type: cdnCard.signup_bonus?.type ?? null,
     apr_min: cdnCard.apr?.regular?.min ?? null,
     apr_max: cdnCard.apr?.regular?.max ?? null,
+    intro_apr_purchase_months: cdnCard.apr?.purchase_intro?.months ?? null,
+    intro_apr_bt_months: cdnCard.apr?.balance_transfer_intro?.months ?? null,
   };
 }
 
@@ -45,6 +47,8 @@ async function detectAndRecordChanges(cardId, oldMetrics, newMetrics) {
     { field: "signup_bonus_value", old: oldMetrics.signup_bonus_value, new: newMetrics.signup_bonus_value },
     { field: "apr_min", old: oldMetrics.apr_min, new: newMetrics.apr_min },
     { field: "apr_max", old: oldMetrics.apr_max, new: newMetrics.apr_max },
+    { field: "intro_apr_purchase_months", old: oldMetrics.intro_apr_purchase_months, new: newMetrics.intro_apr_purchase_months },
+    { field: "intro_apr_bt_months", old: oldMetrics.intro_apr_bt_months, new: newMetrics.intro_apr_bt_months },
   ];
 
   // Normalize values: parse through float so DECIMAL(5,2) "3.00" and integer 3 compare equal
@@ -114,7 +118,8 @@ async function syncCardsToDatabase(cdnCards) {
     const existingCards = await mysql.query(
       `SELECT card_id, card_name, bank, accepting_applications, annual_fee,
               signup_bonus_value, signup_bonus_type,
-              apr_min, apr_max
+              apr_min, apr_max,
+              intro_apr_purchase_months, intro_apr_bt_months
        FROM cards`
     );
 
@@ -180,7 +185,9 @@ async function syncCardsToDatabase(cdnCards) {
               signup_bonus_value = ?,
               signup_bonus_type = ?,
               apr_min = ?,
-              apr_max = ?
+              apr_max = ?,
+              intro_apr_purchase_months = ?,
+              intro_apr_bt_months = ?
             WHERE card_id = ?`,
             [
               name, bank, acceptingApplications,
@@ -188,6 +195,7 @@ async function syncCardsToDatabase(cdnCards) {
               newMetrics.annual_fee, cdnCard.apply_link || null, cdnCard.card_referral_link || null,
               newMetrics.signup_bonus_value, newMetrics.signup_bonus_type,
               newMetrics.apr_min, newMetrics.apr_max,
+              newMetrics.intro_apr_purchase_months, newMetrics.intro_apr_bt_months,
               existingCard.card_id,
             ]
           );
@@ -201,14 +209,15 @@ async function syncCardsToDatabase(cdnCards) {
             `INSERT INTO cards (card_id, card_name, bank, accepting_applications, card_image_link,
               release_date, tags, annual_fee, apply_link, card_referral_link,
               signup_bonus_value, signup_bonus_type,
-              apr_min, apr_max, active)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+              apr_min, apr_max, intro_apr_purchase_months, intro_apr_bt_months, active)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
             [
               nextId, name, bank, acceptingApplications,
               cdnCard.image || null, cdnCard.release_date || null, tagsJson,
               newMetrics.annual_fee, cdnCard.apply_link || null, cdnCard.card_referral_link || null,
               newMetrics.signup_bonus_value, newMetrics.signup_bonus_type,
               newMetrics.apr_min, newMetrics.apr_max,
+              newMetrics.intro_apr_purchase_months, newMetrics.intro_apr_bt_months,
             ]
           );
           results.added.push(name);

--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -33,6 +33,8 @@ const FIELD_LABELS: Record<string, string> = {
   signup_bonus_value: 'Sign-up bonus',
   apr_min: 'APR min',
   apr_max: 'APR max',
+  intro_apr_purchase_months: 'Intro APR (purchases)',
+  intro_apr_bt_months: 'Intro APR (balance transfer)',
 };
 
 const HIGHER_IS_BAD = new Set(['annual_fee', 'apr_min', 'apr_max']);
@@ -41,6 +43,7 @@ function fieldGroup(field: string): FilterKey {
   if (field === 'annual_fee') return 'fee';
   if (field === 'signup_bonus_value') return 'bonus';
   if (field === 'apr_min' || field === 'apr_max') return 'apr';
+  if (field === 'intro_apr_purchase_months' || field === 'intro_apr_bt_months') return 'apr';
   if (field === 'accepting_applications') return 'apps';
   return 'all';
 }
@@ -70,6 +73,10 @@ function formatValue(
   }
   if (field === 'apr_min' || field === 'apr_max') {
     if (!Number.isNaN(num)) return `${num}%`;
+    return value;
+  }
+  if (field === 'intro_apr_purchase_months' || field === 'intro_apr_bt_months') {
+    if (!Number.isNaN(num)) return `${num} mo`;
     return value;
   }
   return value;

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -294,6 +294,10 @@ Extract the following fields and return ONLY valid JSON — no markdown fences, 
     "timeframe_months": <number or null>,
     "authorized_user_bonus": <number or null>,
     "bonus_note": <string or null>
+  },
+  "apr": {
+    "purchase_intro_months": <number or null>,
+    "balance_transfer_intro_months": <number or null>
   }
 }
 
@@ -327,6 +331,12 @@ Rules:
 - AUTHORIZED USER BONUSES: Do NOT include bonus miles/points earned for adding an authorized user in the "value" field. Only count the primary cardholder's signup bonus from spending. For example, if a card offers "90,000 miles after $4,000 spend + 10,000 miles for adding an authorized user", the value is 90000, NOT 100000. Instead, put the authorized user bonus amount in "authorized_user_bonus" (e.g. 10000). null if no AU bonus.
 - CASH vs POINTS: Do NOT combine cash/dollar bonuses with points/miles. If a card offers "50,000 points + $300 cash bonus", the signup_bonus value is 50000 (points only). Cash bonuses are separate from points/miles and must NOT be added to the value field. A $300 cash bonus is NOT 300 points.
 - POINTS REDEEMED AS CASH: Some cards earn points that convert to a fixed cash amount (e.g. "15,000 bonus points = $150 when deposited into your Fidelity account"). The points and the dollar amount describe the SAME offer in two different units — they are NOT two stackable bonuses. If the current YAML's signup_bonus.type is "cash" or "cashback", return the DOLLAR value (150), NOT the points count (15000). If the current type is "points" or "miles", return the points count. When unsure which unit the card is denominated in, prefer the value matching the existing type. NEVER return a 5-figure number as the value for a card whose current type is cash/cashback — that is the points figure, not the bonus value.
+- INTRO APR: The introductory (promotional) APR is the temporary 0% (or low) APR a card extends to new cardholders. Issuer pages state its length in "months" or "billing cycles" — treat one billing cycle as one month. Extract the LENGTH in months only:
+    - apr.purchase_intro_months = the intro APR period for PURCHASES (e.g. "0% intro APR for 21 billing cycles on purchases" → 21).
+    - apr.balance_transfer_intro_months = the intro APR period for BALANCE TRANSFERS (e.g. "0% intro APR for 21 billing cycles on balance transfers" → 21).
+    - When a single 0% intro period is described as applying to both purchases and balance transfers, use that same value for both fields.
+    - These are the INTRO/promotional period ONLY. NEVER put the ongoing/regular APR here — e.g. "16.99%–27.99% variable APR" after the intro ends is the regular APR, not an intro length.
+    - Return null (NOT 0) when the card has no intro APR offer or the page doesn't state one. Ignore any intro APR length found inside [STRIKETHROUGH: ...] (expired offer) and use the live value.
 - STRIKETHROUGH TEXT: Text wrapped in [STRIKETHROUGH: ...] is struck through on the page and represents old/expired values. Always ignore strikethrough values and use the non-strikethrough value instead.
 - Return null for any field you cannot determine with confidence.`;
 
@@ -548,6 +558,31 @@ function detectChanges(card, extracted) {
     }
   }
 
+  // Intro APR period length (months). Only diff a card that ALREADY stores an
+  // intro months value for that line — so we never invent an intro offer for a
+  // card without one, and never overwrite a real number with a null Haiku
+  // returns when the page wording it can't parse. The regular APR
+  // (apr.regular.min/max) is intentionally not compared here: it drifts with
+  // the prime rate and would generate constant false-positive PRs.
+  if (extracted.apr && current.apr) {
+    const introFields = [
+      { group: 'purchase_intro', extracted: extracted.apr.purchase_intro_months },
+      { group: 'balance_transfer_intro', extracted: extracted.apr.balance_transfer_intro_months },
+    ];
+    for (const f of introFields) {
+      const field = `apr.${f.group}.months`;
+      const curVal = current.apr[f.group]?.months;
+      if (
+        f.extracted !== null && f.extracted !== undefined &&
+        curVal !== null && curVal !== undefined &&
+        f.extracted !== curVal &&
+        !ignoreFields.has(field)
+      ) {
+        changes.push({ field, old_value: curVal, new_value: f.extracted });
+      }
+    }
+  }
+
   return changes;
 }
 
@@ -580,6 +615,15 @@ function applyChanges(allChanges, allCards) {
         if (!parsedData.signup_bonus) parsedData.signup_bonus = {};
         parsedData.signup_bonus[subfield] = new_value;
         yamlText = replaceYamlBlock(yamlText, 'signup_bonus', parsedData.signup_bonus);
+        modified = true;
+      } else if (field.startsWith('apr.')) {
+        // apr.<group>.<key>, e.g. apr.purchase_intro.months — re-dump the whole
+        // apr block so the untouched lines (rate, regular range) are preserved.
+        const [, group, key] = field.split('.');
+        if (!parsedData.apr) parsedData.apr = {};
+        if (!parsedData.apr[group]) parsedData.apr[group] = {};
+        parsedData.apr[group][key] = new_value;
+        yamlText = replaceYamlBlock(yamlText, 'apr', parsedData.apr);
         modified = true;
       }
 

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -116,4 +116,67 @@ test('tiered card: a genuine value INCREASE (offer got richer) still surfaces', 
   assert.deepEqual(fieldsChanged(changes), ['signup_bonus.value']);
 });
 
+// ─── Intro APR detection ────────────────────────────────────────────────────
+
+const SHIELD = {
+  data: {
+    name: 'US Bank Shield',
+    apr: {
+      purchase_intro: { rate: 0, months: 24 },
+      balance_transfer_intro: { rate: 0, months: 24 },
+      regular: { min: 16.99, max: 27.99 },
+    },
+  },
+};
+
+console.log('\nIntro APR detection:');
+
+test('a shortened intro APR (24 → 21) surfaces on both purchase and BT', () => {
+  const changes = detectChanges(SHIELD, {
+    apr: { purchase_intro_months: 21, balance_transfer_intro_months: 21 },
+  });
+  assert.deepEqual(fieldsChanged(changes), [
+    'apr.balance_transfer_intro.months',
+    'apr.purchase_intro.months',
+  ]);
+  const purchase = changes.find(c => c.field === 'apr.purchase_intro.months');
+  assert.equal(purchase.old_value, 24);
+  assert.equal(purchase.new_value, 21);
+});
+
+test('an unchanged intro APR produces no change', () => {
+  const changes = detectChanges(SHIELD, {
+    apr: { purchase_intro_months: 24, balance_transfer_intro_months: 24 },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('a null intro months (page wording Haiku could not parse) never erases a real value', () => {
+  const changes = detectChanges(SHIELD, {
+    apr: { purchase_intro_months: null, balance_transfer_intro_months: null },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('a card with no apr block is never given an invented intro offer', () => {
+  const noApr = { data: { name: 'No APR Card' } };
+  const changes = detectChanges(noApr, {
+    apr: { purchase_intro_months: 18, balance_transfer_intro_months: 18 },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('check_ignore suppresses an intro APR field', () => {
+  const ignored = {
+    data: {
+      ...SHIELD.data,
+      check_ignore: ['apr.purchase_intro.months'],
+    },
+  };
+  const changes = detectChanges(ignored, {
+    apr: { purchase_intro_months: 21, balance_transfer_intro_months: 21 },
+  });
+  assert.deepEqual(fieldsChanged(changes), ['apr.balance_transfer_intro.months']);
+});
+
 console.log('');

--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -60,6 +60,8 @@ const fieldLabels = {
   signup_bonus_value: 'Sign-up Bonus',
   apr_min: 'APR Min',
   apr_max: 'APR Max',
+  intro_apr_purchase_months: 'Intro APR (Purchases)',
+  intro_apr_bt_months: 'Intro APR (Balance Transfer)',
 };
 
 const higherIsBad = new Set(['annual_fee', 'apr_min', 'apr_max']);
@@ -87,6 +89,9 @@ function formatValue(field, value, bonusType) {
   }
   if (field === 'apr_min' || field === 'apr_max') {
     return !isNaN(num) ? `${num}%` : value;
+  }
+  if (field === 'intro_apr_purchase_months' || field === 'intro_apr_bt_months') {
+    return !isNaN(num) ? `${num} mo` : value;
   }
   return value;
 }


### PR DESCRIPTION
## Why

Intro-APR period length was a blind spot. Neither automated check read it, and the sync handler / `card_wire` feed only tracked the **regular** APR (`apr_min`/`apr_max`). That's why U.S. Bank shortening the **Shield's** 0% window from **24 → 21 billing cycles** went unnoticed ([#1423](https://github.com/CreditOdds/creditodds/pull/1423) fixed the card page; this closes the automation gap).

## What

Wires intro APR (length in months) through the whole pipeline so future changes are caught automatically and surface on `/card-wire`:

| Layer | Change |
|---|---|
| **DB** | `042` — add `intro_apr_purchase_months` + `intro_apr_bt_months` to `cards` |
| **Sync** | `update-cards-github.js` snapshots + diffs both fields, emits `card_wire` rows. Longer window = positive; a shortening reads as a downgrade |
| **Frontend** | `CardWireV2Client.tsx` labels "Intro APR (purchases)" / "(balance transfer)", formats `21 mo`, groups under the existing APR filter |
| **Social** | `post-card-wire.js` mirrors the label/format (image + text) |
| **Detection** | `check-card-pages.js` extracts intro-APR length from the issuer page and opens a review PR when it changes. Regular APR is intentionally **not** detected by the script — prime-rate drift would cause constant false positives. + unit tests |
| **Backfill** | `043` — idempotent insert of the Shield `24 → 21` rows, since the change predates tracking and the first sync only sets the baseline |

## Rollout (important ordering)

`creditodds-sync-cards` is **invoke-only** (fired by `build-cards.yml` on `data/cards/**` pushes), so merging this API/scripts PR deploys the new handler with **no sync firing**.

1. Merge → `deploy-api.yml` deploys backend (handler idle), Amplify deploys frontend
2. Run migration **042** (adds columns) — **before any card-data push**, or a sync would hit an unknown column
3. Run migration **043** (Shield backfill rows)
4. Verify `/card-wire` shows the Shield intro-APR change

## Tests

`node scripts/check-card-pages.test.js` — added 5 intro-APR cases (shortening surfaces on both lines, no-op when unchanged, null never erases a real value, no invented offer for cards without an `apr` block, `check_ignore` honored). YAML round-trip verified to preserve `rate`/regular/`our_take`/benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)