### PR TITLE
fix(card-wire): keep long intro-APR field chips inside their column

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -34,7 +34,7 @@ const FIELD_LABELS: Record<string, string> = {
   apr_min: 'APR min',
   apr_max: 'APR max',
   intro_apr_purchase_months: 'Intro APR (purchases)',
-  intro_apr_bt_months: 'Intro APR (balance transfer)',
+  intro_apr_bt_months: 'Intro APR (transfers)',
 };
 
 const HIGHER_IS_BAD = new Set(['annual_fee', 'apr_min', 'apr_max']);

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3183,6 +3183,17 @@
   white-space: nowrap;
   text-transform: uppercase;
 }
+/* Long field labels (e.g. "Intro APR (balance transfer)") overflow the fixed
+   130px FIELD column with nowrap and collide with the CHANGE column. In the
+   desktop grid cell, let the chip wrap within the column instead. The mobile
+   row uses its own single-column layout (.wire-row-mobile) and is unaffected. */
+.landing-v2.wire-v2 .wire-row-field .wire-field-chip {
+  display: inline-block;
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  line-height: 1.3;
+}
 .landing-v2.wire-v2 .wire-field-chip.fee {
   background: color-mix(in oklab, var(--gold) 15%, var(--paper));
   color: var(--gold);


### PR DESCRIPTION
Follow-up to [#1424](https://github.com/CreditOdds/creditodds/pull/1424). The new `Intro APR (...)` field chips are much longer than existing wire labels and, with `white-space: nowrap` in the fixed 130px FIELD column, overflowed into the CHANGE column on the US Bank Shield rows.

- Let the **desktop** field chip wrap within its grid cell (`.wire-row-field .wire-field-chip`)
- Shorten the balance-transfer label to **"Intro APR (transfers)"** so it wraps to a tidy two lines

Mobile uses its own single-column `.wire-row-mobile` layout and is unaffected.

Verified locally at desktop (800px) and mobile (375px): chips stay inside their column, `24 mo → 21 mo` renders as a downgrade, the APR filter isolates the 4 APR rows, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)