### PR TITLE
Wyndham Earner Business: $149 refresh + 100k tiered SUB

### DIFF
--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -5,7 +5,7 @@ accepting_applications: true
 apply_link: https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner-business-card/
 category: "business"
 image: "barclays-wyndham-earner-business.png"
-annual_fee: 95
+annual_fee: 149
 foreign_transaction_fee: false
 reward_type: "points"
 tags:
@@ -27,10 +27,11 @@ rewards:
     unit: points_per_dollar
     note: "5x on marketing, advertising, and utility purchases"
 signup_bonus:
-  value: 45000
+  value: 100000
   type: "points"
-  spend_requirement: 3000
-  timeframe_months: 3
+  spend_requirement: 3500
+  timeframe_months: 6
+  note: "Earn 45,000 bonus points after spending $3,000 on purchases in the first 90 days and also earn 55,000 bonus points after spending $500 at Hotels by Wyndham in the first 180 days."
 apr:
   regular:
     min: 19.49


### PR DESCRIPTION
Corrects an erroneous revert in #1426.

The live [Barclays business page](https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner-business-card/) confirms the card was refreshed:
- **Annual fee $95 → $149** (disclosure: "Annual Fee is $149")
- **Welcome bonus 45,000 → up to 100,000 points**: 45,000 after $3,000 in 90 days + 55,000 after $500 at Hotels by Wyndham in 180 days
- spend_requirement 3,000 → 3,500 (tiered total); timeframe stored as 6 months (the detector's `180` was days, not months); tier breakdown in note

Note: reward (gas 8x→5x) and benefit drift from the refresh are intentionally left out of this PR for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)