### PR TITLE
Wyndham: publish Earner Premier article + refresh Business card data

### DIFF
--- a/data/articles/wyndham-rewards-earner-premier.yaml
+++ b/data/articles/wyndham-rewards-earner-premier.yaml
@@ -1,0 +1,75 @@
+id: "wyndham-rewards-earner-premier"
+slug: "wyndham-rewards-earner-premier"
+title: "Wyndham's New $395 Earner Premier Card: Is It Worth It, and What Changed Across the Lineup"
+date: "2026-06-17"
+author: "CreditOdds"
+summary: "Barclays and Wyndham launched the $395 Earner Premier, the new top of a refreshed four-card lineup. Here is what it earns, the credits that offset the fee, and who it is for."
+tags:
+  - news-analysis
+  - analysis
+related_cards:
+  - wyndham-rewards-earner-business-card
+  - wyndham-rewards-earner-plus-card
+  - wyndham-rewards-earner-card
+seo_title: "Wyndham Earner Premier: Is the $395 Card Worth It? (2026)"
+seo_description: "Wyndham's new $395 Earner Premier: earning rates, the 120,000-point welcome offer, annual credits, Diamond status, and how it compares to the rest of the lineup."
+social_title: "Wyndham's New $395 Premier Card"
+image_alt: "The Wyndham Rewards Earner Premier credit card from Barclays"
+content: |
+  Barclays and Wyndham have added a premium tier to the Wyndham Rewards Earner family: the Earner Premier, a $395 card aimed at travelers who stay with Wyndham often enough to lean on its credits and elite perks. The launch arrived alongside a refresh of the rest of the lineup, so it is worth looking at the whole picture before deciding where you fit.
+
+  Here is what the Premier offers, how the fee can be offset, and how the four cards now stack up.
+
+  ## What the Earner Premier earns
+
+  The card keeps Wyndham's signature high hotel rate and adds a broad everyday tier:
+
+  - 8 points per dollar at Hotels by Wyndham
+  - 4 points per dollar on dining, groceries, and eligible travel
+  - 1 point per dollar everywhere else
+
+  The welcome offer is tiered. You can earn 90,000 points after spending $6,000 in the first 120 days, plus another 30,000 points after spending $750 at Wyndham properties within the first 180 days, for up to 120,000 points total.
+
+  ## The credits and perks that justify the fee
+
+  The $395 annual fee is steep for a hotel card, but Wyndham packed in enough recurring value that frequent guests can come out ahead:
+
+  - 30,000 anniversary points every year after you pay the annual fee
+  - A free-night award worth up to 30,000 points after five qualifying nights each year
+  - Wyndham Rewards Diamond status, the program's top tier
+  - A 25% discount on free-night redemptions
+  - Complimentary Wyndham Rewards Insider membership (a $95 value)
+  - Up to $100 in Wyndham hotel credits
+  - Up to $120 in meal delivery credits
+  - Up to $100 in streaming credits
+  - A $65 warehouse club membership credit
+  - Up to $125 toward TSA PreCheck or Global Entry every four years
+  - Emerald Club Executive status with National Car Rental
+  - Points that never expire while the account is open
+
+  ## Is the $395 worth it?
+
+  It comes down to how you travel. Stack the 30,000 anniversary points and the yearly free night against the fee and a regular Wyndham guest is already most of the way there, before counting the hotel, meal delivery, and streaming credits. The 25% redemption discount and Diamond status add ongoing value on top.
+
+  The catch is that several of those credits only pay off if you actually use them. Meal delivery and streaming credits are easy value for some households and dead weight for others. If you would not use them, discount them when you run the numbers, and one of the lower-fee cards may serve you better.
+
+  ## How the whole lineup compares
+
+  The refresh repositioned all four cards. Every card now earns up to 8 points per dollar on Wyndham stays, and the differences come down to fee, status, and perks:
+
+  | Card | Annual Fee | Wyndham Status | Anniversary Points | Free-Night Discount |
+  |------|-----------|----------------|--------------------|---------------------|
+  | Earner Premier | $395 | Diamond | 30,000 | 25% |
+  | Earner Business | $149 | Diamond | 15,000 | 20% |
+  | Earner Plus | $95 | Diamond first year, then Platinum | 15,000 | 10% |
+  | Earner | $0 | Gold | None | 10% |
+
+  A few notes:
+
+  - The Earner Business now earns 8x at Wyndham and 5x across a business-spend tier that includes gas, EV charging, office supplies, shipping, marketing, advertising, and Wyndham Vacation Club. It also added a $65 warehouse club credit and a $50 accounting software credit, on top of Diamond status and Emerald Club Executive status with National.
+  - The Earner Plus gives you Diamond status in the first year and Platinum after, plus a free night worth up to 15,000 points, for a modest $95.
+  - The no-fee Earner is the entry point: Gold status, a 10% redemption discount, and 7,500 points after $15,000 in annual spend.
+
+  ## Bottom line
+
+  The Earner Premier is built for the committed Wyndham guest who will use the credits and values Diamond status and a yearly free night. If your Wyndham stays are occasional, the $149 Business card or the $95 Plus deliver most of the elite benefits for a fraction of the fee, and the no-fee Earner still earns 8x on stays. Match the card to how often you actually book Wyndham, not to the size of the welcome offer.

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -20,12 +20,21 @@ rewards:
     merchant_specific: true
     merchant_gate: [wyndham]
   - category: gas
-    value: 8
+    value: 5
+    unit: points_per_dollar
+  - category: ev_charging
+    value: 5
+    unit: points_per_dollar
+  - category: office_supplies
+    value: 5
+    unit: points_per_dollar
+  - category: shipping
+    value: 5
     unit: points_per_dollar
   - category: everything_else
     value: 1
     unit: points_per_dollar
-    note: "5x on marketing, advertising, and utility purchases"
+    note: "Also earns 5x on marketing, advertising, and Wyndham Vacation Club purchases"
 signup_bonus:
   value: 100000
   type: "points"
@@ -50,9 +59,26 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Points Redemption Discount"
-    value: 10
+    value: 20
     value_unit: "percent"
-    description: "Redeem 10% fewer Wyndham Rewards points when you book free nights."
+    description: "Redeem 20% fewer Wyndham Rewards points when you book free nights."
     frequency: "per_purchase"
     category: "rewards"
+    enrollment_required: false
+  - name: "Warehouse Club Statement Credit"
+    value: 65
+    description: "Up to $65 in annual statement credits toward a warehouse club membership."
+    frequency: "annual"
+    category: "statement_credit"
+    enrollment_required: false
+  - name: "Accounting Software Statement Credit"
+    value: 50
+    description: "Up to $50 in annual statement credits toward accounting software."
+    frequency: "annual"
+    category: "statement_credit"
+    enrollment_required: false
+  - name: "National Car Rental Emerald Club Executive Status"
+    description: "Complimentary Emerald Club Executive status with National Car Rental for as long as you're a cardmember."
+    frequency: "annual"
+    category: "travel"
     enrollment_required: false


### PR DESCRIPTION
Prompted by the 2026-06-17 launch coverage of the new Wyndham Rewards Earner Premier.

## 1. New article

`data/articles/wyndham-rewards-earner-premier.yaml` — an original CreditOdds breakdown of the new **$395 Earner Premier** and the lineup-wide refresh: earning rates, the up-to-120,000-point welcome offer, the credit stack, Diamond status, an "is the $395 worth it" analysis, and a four-card comparison table. Tags `news-analysis` + `analysis`. Hero/social images auto-generate on the build-articles workflow.

## 2. Wyndham Earner Business data refresh

Applies the rewards/benefits drift flagged after the $149 refresh (#1427) finally:

**Rewards**
- gas **8x → 5x** (it moved out of the hotel tier)
- added the rest of the 5x business tier as explicit categories: `ev_charging`, `office_supplies`, `shipping`
- `everything_else` note corrected to "marketing, advertising, and Wyndham Vacation Club" (dropped the stale "utility")

**Benefits**
- new: **$65 warehouse club** credit, **$50 accounting software** credit, **National Emerald Club Executive** status
- redemption discount **10% → 20%**

## ⚠️ One value to double-check

The **redemption discount 10% → 20%** comes from the launch coverage. The live Barclays page returned 403 (bot mitigation), so I could not verify it directly, and our live-page-derived notes from earlier today did not flag a discount change. 20% matches the Business card's historical "Go Free" discount and the article, so I went with it, but flagging for a second look.

## Not included (happy to do as follow-ups)
- Adding the new **Earner Premier** as its own card page (needs image + apply link + full data)
- Refreshing the **Earner Plus** ($95) and base **Earner** cards, which the article says also changed (our Plus YAML is currently a stub)

## Validation
`build:cards` and `build:articles` both pass; `cards.json`/`articles.json` left for CI to rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)