### PR TITLE
Wyndham cards: fix Business benefits + refresh Plus and base from live data

### DIFF
--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -71,14 +71,3 @@ benefits:
     frequency: "annual"
     category: "statement_credit"
     enrollment_required: false
-  - name: "Accounting Software Statement Credit"
-    value: 50
-    description: "Up to $50 in annual statement credits toward accounting software."
-    frequency: "annual"
-    category: "statement_credit"
-    enrollment_required: false
-  - name: "National Car Rental Emerald Club Executive Status"
-    description: "Complimentary Emerald Club Executive status with National Car Rental for as long as you're a cardmember."
-    frequency: "annual"
-    category: "travel"
-    enrollment_required: false

--- a/data/cards/wyndham-rewards-earner-card.yaml
+++ b/data/cards/wyndham-rewards-earner-card.yaml
@@ -1,8 +1,66 @@
 name: "Wyndham Rewards Earner"
 bank: "Barclays"
 slug: "wyndham-rewards-earner-card"
-accepting_applications: false
+accepting_applications: true
+apply_link: https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner-card/
 category: "travel"
 image: "barclays-wyndham-earner.png"
 annual_fee: 0
+foreign_transaction_fee: false
 reward_type: "points"
+tags:
+  - hotel
+  - travel
+  - rewards
+rewards:
+  - category: hotels
+    value: 5
+    unit: points_per_dollar
+    note: "At Hotels by Wyndham"
+    merchant_specific: true
+    merchant_gate: [wyndham]
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+  - category: gas
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 75000
+  type: "points"
+  spend_requirement: 1500
+  timeframe_months: 6
+  note: "Earn 30,000 bonus points after spending $1,000 on purchases in the first 90 days and also earn 45,000 bonus points after spending $500 at Hotels by Wyndham in the first 180 days."
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 19.24
+    max: 29.99
+benefits:
+  - name: "Wyndham Rewards Gold Status"
+    description: "Automatic Gold status with perks like preferred room selection and late checkout."
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false
+  - name: "Annual Spend Bonus"
+    value: 7500
+    value_unit: "points"
+    description: "7,500 bonus Wyndham Rewards points each anniversary year when you spend $15,000 on eligible purchases, enough for up to one free night."
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: false
+  - name: "Points Redemption Discount"
+    value: 10
+    value_unit: "percent"
+    description: "Redeem 10% fewer Wyndham Rewards points when you book free nights."
+    frequency: "per_purchase"
+    category: "rewards"
+    enrollment_required: false

--- a/data/cards/wyndham-rewards-earner-plus-card.yaml
+++ b/data/cards/wyndham-rewards-earner-plus-card.yaml
@@ -1,8 +1,73 @@
 name: "Wyndham Rewards Earner Plus"
 bank: "Barclays"
 slug: "wyndham-rewards-earner-plus-card"
-accepting_applications: false
+accepting_applications: true
+apply_link: https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner-plus-card/
 category: "travel"
 image: "barclays-wyndham-earner-plus.png"
-annual_fee: 75
+annual_fee: 95
+foreign_transaction_fee: false
 reward_type: "points"
+tags:
+  - hotel
+  - travel
+  - rewards
+rewards:
+  - category: hotels
+    value: 6
+    unit: points_per_dollar
+    note: "At Hotels by Wyndham"
+    merchant_specific: true
+    merchant_gate: [wyndham]
+  - category: dining
+    value: 4
+    unit: points_per_dollar
+  - category: groceries
+    value: 4
+    unit: points_per_dollar
+  - category: travel
+    value: 4
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 100000
+  type: "points"
+  spend_requirement: 1500
+  timeframe_months: 6
+  note: "Earn 45,000 bonus points after spending $1,000 on purchases in the first 90 days and also earn 55,000 bonus points after spending $500 at Hotels by Wyndham in the first 180 days."
+apr:
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 19.24
+    max: 29.99
+benefits:
+  - name: "Anniversary Points Bonus"
+    value: 15000
+    value_unit: "points"
+    description: "15,000 bonus Wyndham Rewards points each anniversary year, enough for up to two free award nights at participating Wyndham hotels."
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: false
+  - name: "Wyndham Rewards Status"
+    description: "Automatic Diamond status in your first year, then Platinum status, with perks like early check-in and late checkout."
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false
+  - name: "Annual Free Night"
+    value: 15000
+    value_unit: "points"
+    description: "A free night worth up to 15,000 Wyndham Rewards points after you stay five or more nights in a calendar year."
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false
+  - name: "Points Redemption Discount"
+    value: 10
+    value_unit: "percent"
+    description: "Redeem 10% fewer Wyndham Rewards points when you book free nights."
+    frequency: "per_purchase"
+    category: "rewards"
+    enrollment_required: false


### PR DESCRIPTION
All values verified against the **live Barclays pages** (curl with a browser UA gets through where the bot-blocked fetch returned 403).

## Business: remove two unverified benefits
The live page does **not** show the **$50 accounting software credit** or **National Emerald Club Executive status** that were merged in #1429 (`accounting`, `emerald`, `national car` appear zero times on the page). They were mis-attributed from the Premier in the source notes. Removed both.

Confirmed correct and kept: 8x Hotels by Wyndham, 5x (gas, EV charging, office supplies, shipping, marketing, advertising, Vacation Club), $65 wholesale credit, **20% award discount**, Diamond status, 15k anniversary points.

## Plus: full refresh (was a stub)
$95 fee · 6x Hotels by Wyndham · 4x dining/grocery/travel · up-to-100k tiered SUB · Diamond first year then Platinum · 10% discount · 15k anniversary · free night up to 15k after 5 nights · 0% intro BT for 15 cycles · no FTF · now accepting applications.

## Base Earner: full refresh (was a stub)
$0 fee · 5x Hotels by Wyndham · 2x dining/grocery/gas · up-to-75k tiered SUB · Gold status · 10% discount · 7,500 points for $15k annual spend (stored as a benefit, not a SUB, per the annual-spend-bonus convention) · 0% intro BT for 15 cycles · no FTF · now accepting applications.

## Notes
- The earn rates correct the source article's "all cards earn up to 8x at Wyndham" (only Premier and Business are 8x).
- `build:cards` passes; `cards.json` left for CI.
- Pairs with #1430 (the article → news move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)