### PR TITLE
migration 045: remove misleading Wyndham stub accepting_applications wire rows

### DIFF
--- a/apps/api/migrations/045_remove_wyndham_stub_accepting_wire.sql
+++ b/apps/api/migrations/045_remove_wyndham_stub_accepting_wire.sql
@@ -1,0 +1,19 @@
+-- Remove two misleading card_wire entries. The Wyndham Rewards Earner Plus and
+-- the base Wyndham Rewards Earner existed in our data as bare stubs flagged
+-- accepting_applications=false. PR #1431 corrected them to true (the live
+-- Barclays pages show them as current, open products) and filled in real data.
+-- The sync diffed accepting_applications 0->1 and logged a wire row for each,
+-- which reads on the public feed as if Barclays reopened applications. That was
+-- a stale-data correction on our side, not a real-world reopening, so drop the
+-- two rows. Single statement; the subquery reads from `cards`, not `card_wire`,
+-- so the self-reference restriction does not apply. The date + value bounds keep
+-- it surgical (a genuine future reopen would not be touched).
+DELETE FROM card_wire
+WHERE field = 'accepting_applications'
+  AND old_value = '0'
+  AND new_value = '1'
+  AND changed_at >= '2026-06-18 00:00:00'
+  AND card_id IN (
+    SELECT card_id FROM cards
+    WHERE card_name IN ('Wyndham Rewards Earner Plus', 'Wyndham Rewards Earner')
+  );


### PR DESCRIPTION
Removes the two `Not accepting → Accepting` card-wire entries for **Wyndham Rewards Earner Plus** and **Wyndham Rewards Earner**.

Those cards weren't reopened by Barclays — they were stale stubs in our data flagged `accepting_applications: false`. #1431 corrected them to `true` and filled in real data, and the sync logged a `0 → 1` change for each, which reads on the public feed like a real-world reopening.

`045_remove_wyndham_stub_accepting_wire.sql` deletes exactly those two rows (bounded by field + `0→1` + today's date + the two card names, so a genuine future reopen is untouched). The card pages stay live and accepting; only the misleading wire entries go.

Rollout: merge → deploy-api ships the migration in the RunMigration bundle → I invoke it → verify the rows are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)