### PR TITLE
card-page-check: stop recurring annual_fee false positives

### DIFF
--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -6,6 +6,11 @@ accepting_applications: true
 apply_link: https://business.bankofamerica.com/en/credit-cards/atmos-rewards
 category: "business"
 annual_fee: 95
+# $70 per company + $25 per card = $95 effective. The apply page only exposes the
+# $70 per-company figure, so card-page-check (a single-number extractor) keeps
+# proposing 95 -> 70. Ignore annual_fee for this card. (#1413/#1421/#1426/#1434)
+check_ignore:
+  - annual_fee
 foreign_transaction_fee: false
 tags:
   - travel

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -3,6 +3,11 @@ bank: "Citi"
 slug: "citi-aadvantage-platinum-select-world-elite-m"
 accepting_applications: true
 annual_fee: 99
+# Ongoing fee is $99, waived the first 12 months (annual_fee_intro below). The fee
+# is JS-rendered, so card-page-check's extractor reads the waiver and proposes
+# phantom drops to 0 or 95. Ignore annual_fee for this card. (#1413/#1416/#1426/#1434)
+check_ignore:
+  - annual_fee
 annual_fee_intro:
   value: 0
   months: 12

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -6,6 +6,11 @@ previous_names:
 accepting_applications: true
 image: "citi-business-aadvantage-platinum-select.png"
 annual_fee: 99
+# Ongoing fee is $99, waived the first 12 months (annual_fee_intro below). Same
+# JS-rendered-fee misread as the consumer Citi AAdvantage card; preempt it here so
+# the business variant doesn't generate the same false-positive PRs.
+check_ignore:
+  - annual_fee
 annual_fee_intro:
   value: 0
   months: 12

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -297,6 +297,11 @@
       },
       "additionalProperties": false,
       "description": "APR details including intro offers and regular rate (optional)"
+    },
+    "check_ignore": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Field paths the automated check scripts (check-card-pages, check-card-rewards-and-benefits) skip when proposing updates, e.g. \"annual_fee\" or \"apr.purchase_intro.months\". Build-time only — stripped from cards.json output."
     }
   },
   "additionalProperties": false

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -399,7 +399,32 @@ function detectChanges(card, extracted) {
   // annual_fee
   if (extracted.annual_fee !== null && extracted.annual_fee !== undefined) {
     const cur = current.annual_fee ?? null;
-    if (cur !== null && extracted.annual_fee !== cur && !ignoreFields.has('annual_fee')) {
+
+    // Defensive: cards with a first-year fee waiver (annual_fee_intro) render the
+    // ongoing fee client-side, so the stripped page text frequently shows only the
+    // waived "$0 first year" figure. Haiku then returns that waiver value as the
+    // annual fee, proposing a phantom drop from the ongoing fee to the intro value
+    // (Citi AAdvantage: ongoing $99, extracted 0 = the 12-month waiver — rejected
+    // on #1413/#1416/#1426/#1434). When the extracted value equals the card's known
+    // annual_fee_intro waiver value and differs from the ongoing fee, it's the
+    // waiver misread, not a real fee change — skip it.
+    const introWaiver = current.annual_fee_intro?.value;
+    const isIntroWaiverMisread =
+      introWaiver !== null && introWaiver !== undefined &&
+      extracted.annual_fee === introWaiver &&
+      cur !== introWaiver;
+    if (isIntroWaiverMisread) {
+      console.log(
+        `  Ignoring annual_fee change ${cur} → ${extracted.annual_fee}: matches the first-year annual_fee_intro waiver ($${introWaiver}), not the ongoing fee`
+      );
+    }
+
+    if (
+      cur !== null &&
+      extracted.annual_fee !== cur &&
+      !isIntroWaiverMisread &&
+      !ignoreFields.has('annual_fee')
+    ) {
       changes.push({ field: 'annual_fee', old_value: cur, new_value: extracted.annual_fee });
     }
   }

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -179,4 +179,42 @@ test('check_ignore suppresses an intro APR field', () => {
   assert.deepEqual(fieldsChanged(changes), ['apr.balance_transfer_intro.months']);
 });
 
+// ─── annual_fee: first-year-waiver misread + check_ignore ───────────────────
+
+// Citi AAdvantage pattern: ongoing $99, waived the first 12 months. The fee is
+// JS-rendered, so Haiku reads the waiver and returns 0 (#1413/#1434).
+const CITI_AADVANTAGE = {
+  data: {
+    name: 'Citi AAdvantage Platinum Select',
+    annual_fee: 99,
+    annual_fee_intro: { value: 0, months: 12 },
+  },
+};
+
+console.log('\nannual_fee first-year-waiver misread:');
+
+test('extracted annual_fee matching the intro waiver (99 → 0) is suppressed', () => {
+  const changes = detectChanges(CITI_AADVANTAGE, { annual_fee: 0 });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('a real ongoing-fee change on a waiver card (99 → 149) still surfaces', () => {
+  const changes = detectChanges(CITI_AADVANTAGE, { annual_fee: 149 });
+  assert.deepEqual(fieldsChanged(changes), ['annual_fee']);
+});
+
+test('a normal card (no waiver) still surfaces a genuine annual_fee change', () => {
+  const plain = { data: { name: 'Plain Card', annual_fee: 95 } };
+  const changes = detectChanges(plain, { annual_fee: 99 });
+  assert.deepEqual(fieldsChanged(changes), ['annual_fee']);
+});
+
+test('check_ignore suppresses annual_fee (Atmos split per-card fee)', () => {
+  const atmos = {
+    data: { name: 'Atmos Rewards Business', annual_fee: 95, check_ignore: ['annual_fee'] },
+  };
+  const changes = detectChanges(atmos, { annual_fee: 70 });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
 console.log('');


### PR DESCRIPTION
Stops the near-weekly false-positive PRs from the card-page-check on Atmos Rewards Business and Citi AAdvantage (rejected on #1413, #1416, #1421, #1426, #1434).

## Two root causes, two fixes

**1. First-year-waiver misread (general fix).** Cards with `annual_fee_intro` render the ongoing fee client-side, so Haiku reads the waived "$0 first year" and proposes a phantom drop to the intro value (Citi AAdvantage: ongoing $99, extracted 0). `detectChanges` now skips an `annual_fee` change whose extracted value equals the card's known `annual_fee_intro` waiver value. This protects any first-year-waiver card, current or future — not just Citi.

**2. Unscrapeable single-number fee (targeted fix).** Some fees can't be read as one number, so the extractor is wrong no matter what. Wired up the existing `check_ignore` mechanism for:
- **Atmos Rewards Business** — "$70 per company + $25 per card" = $95 effective; page only exposes the $70.
- **Citi AAdvantage Platinum Select** + **CitiBusiness AAdvantage** — JS-rendered fee; Haiku returns 0 or 95 unpredictably. (Business variant added preemptively — identical pattern.)

## Also
- Made `check_ignore` a first-class `schema.json` field (already read by the check scripts and stripped by `build-cards.js`; this is its first real use).
- Added 4 unit tests: waiver misread suppressed, real fee change on a waiver card still surfaces, normal card change still surfaces, `check_ignore` suppresses `annual_fee`. All 17 tests pass; `build:cards` clean (182 cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)