### PR TITLE
card-page-check: convert days-as-months timeframe misreads

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -306,6 +306,7 @@ Rules:
 - signup_bonus.value: raw number only (e.g. 60000 for "60,000 points", or 3 for "3 free night awards"). null if absent.
 - signup_bonus.type: use "free_nights" when the bonus is free hotel night awards (e.g. Marriott free night certificates).
 - SIGNUP BONUS SCOPE: All signup_bonus fields refer ONLY to the one-time welcome/new-cardmember offer earned during the initial signup window. NEVER capture recurring/ongoing rewards in any signup_bonus field — including: anniversary bonuses, "each calendar year" bonuses, "every account year" bonuses, annual spend bonuses earned year after year, statement credits that reset annually, or cardmember-anniversary point awards. Those are ongoing benefits, not signup bonuses. If the offer is described with phrases like "each year", "every year", "annually", "each calendar year", "each anniversary", "every account anniversary" → it is NOT a signup bonus and must be excluded from value, spend_requirement, timeframe_months, AND bonus_note.
+- TIMEFRAME UNITS: signup_bonus.timeframe_months must be expressed in whole MONTHS, never raw days. Issuer pages often state the window in days (e.g. "within the first 90 days", "in the first 180 days") — convert to months: 90 days → 3, 120 days → 4, 150 days → 5, 180 days → 6, 270 days → 9, 365 days → 12. A welcome-offer window is essentially never longer than ~18 months, so NEVER return a value above 18 — if you computed one, you returned days by mistake and must convert it to months.
 - TIERED BONUSES: Many cards have one-time tiered signup bonuses (e.g., "earn 70,000 miles after $3,000 in 6 months, plus an additional 20,000 miles after an additional $2,000 in 6 months", or "3 free nights after $3,000 in 3 months, plus 1 more after $4,000 total in 4 months"). When the welcome offer is tiered, use the HEADLINE-MAX convention:
     - value = the **headline maximum** the issuer markets (e.g. 90000 for "up to 90,000 miles", or 4 for "up to 4 Free Night Awards")
     - spend_requirement = the **TOTAL** spend required to earn the maximum across all tiers (e.g. 5000 = $3,000 + $2,000)
@@ -389,6 +390,18 @@ function isExtractionEmpty(extracted) {
   return true;
 }
 
+// Haiku occasionally returns the signup-bonus timeframe as a raw DAY count instead
+// of months (e.g. "180 days" → 180 rather than 6), which surfaced a bogus
+// timeframe_months: 180 on Wyndham Earner Business (#1426). No real welcome offer
+// runs longer than ~18 months, so any extracted timeframe above 24 is a
+// days-as-months misread — convert it to whole months. Applied before the diff so
+// the change either disappears (YAML already stores the right month count) or
+// surfaces in the correct unit (e.g. a genuine 3 → 6 move) instead of as 180.
+function normalizeTimeframeMonths(v) {
+  if (typeof v === 'number' && v > 24) return Math.round(v / 30);
+  return v;
+}
+
 function detectChanges(card, extracted) {
   if (!extracted) return [];
 
@@ -433,6 +446,11 @@ function detectChanges(card, extracted) {
   if (extracted.signup_bonus && current.signup_bonus) {
     const sb = extracted.signup_bonus;
     const cur = current.signup_bonus;
+
+    // Convert a days-as-months misread before any comparison (see helper above).
+    if (sb.timeframe_months != null) {
+      sb.timeframe_months = normalizeTimeframeMonths(sb.timeframe_months);
+    }
 
     // Defensive: when Haiku reports both a value change and an authorized_user_bonus,
     // and the value delta is exactly the AU bonus, the page's headline is bundling

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -217,4 +217,48 @@ test('check_ignore suppresses annual_fee (Atmos split per-card fee)', () => {
   assert.deepEqual(fieldsChanged(changes), []);
 });
 
+// ─── signup_bonus.timeframe_months: days-as-months misread ──────────────────
+
+// Wyndham Earner Business pattern: the 100k offer's second tier runs 180 days.
+// Haiku returned timeframe_months: 180 (raw days) on #1426; the real value is 6.
+const TIERED_180_DAYS = {
+  data: {
+    name: 'Wyndham Rewards Earner Business',
+    signup_bonus: { value: 100000, type: 'points', spend_requirement: 3500, timeframe_months: 6, note: null },
+  },
+};
+
+console.log('\nsignup_bonus timeframe days-as-months misread:');
+
+test('extracted 180 (days) normalizes to 6 months — no change when YAML already 6', () => {
+  const changes = detectChanges(TIERED_180_DAYS, {
+    signup_bonus: { value: 100000, spend_requirement: 3500, timeframe_months: 180 },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('a real timeframe change stated in days (90→ proposes 6 months) surfaces with the converted value', () => {
+  const card = {
+    data: { name: 'Plain Card', signup_bonus: { value: 60000, type: 'points', spend_requirement: 3000, timeframe_months: 3, note: null } },
+  };
+  // Issuer moved the window to 180 days; Haiku returns 180, current is 3 months.
+  const changes = detectChanges(card, {
+    signup_bonus: { value: 60000, spend_requirement: 3000, timeframe_months: 180 },
+  });
+  assert.deepEqual(fieldsChanged(changes), ['signup_bonus.timeframe_months']);
+  const ch = changes.find(c => c.field === 'signup_bonus.timeframe_months');
+  assert.equal(ch.new_value, 6); // converted from 180 days, NOT 180
+});
+
+test('a normal months value (≤24) is left untouched', () => {
+  const card = {
+    data: { name: 'Plain Card', signup_bonus: { value: 60000, type: 'points', spend_requirement: 3000, timeframe_months: 3, note: null } },
+  };
+  const changes = detectChanges(card, {
+    signup_bonus: { value: 60000, spend_requirement: 3000, timeframe_months: 4 },
+  });
+  const ch = changes.find(c => c.field === 'signup_bonus.timeframe_months');
+  assert.equal(ch.new_value, 4);
+});
+
 console.log('');


### PR DESCRIPTION
Closes the last open item from the card-page-check extractor backlog.

## Problem
Haiku sometimes returns `signup_bonus.timeframe_months` as a raw **day** count instead of months. On Wyndham Earner Business (#1426) it emitted `timeframe_months: 180` for an offer whose second tier runs 180 days — i.e. 6 months.

## Fix
- **Detector guard** (`detectChanges`): no welcome offer runs longer than ~18 months, so any extracted `timeframe_months > 24` is a days-as-months misread. Convert to whole months (`Math.round(days/30)`) before diffing, so the change either disappears (YAML already correct in months) or surfaces in the right unit (e.g. a genuine 3 → 6 move) — never as 180.
- **Prompt rule**: explicit days→months conversion guidance (90→3, 120→4, 180→6, 365→12) and "never return a value above 18."

## Tests
+3 cases (20 total, all pass): 180 normalizes to 6 (no change when YAML already 6); a real day-stated change surfaces with the **converted** value (6, not 180); normal month values ≤24 untouched.

Script-only change — no card YAMLs touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)