### PR TITLE
logrocket: update app id to 5sdtr5/creditodds

### DIFF
--- a/apps/web-next/src/components/ui/LogRocketInit.tsx
+++ b/apps/web-next/src/components/ui/LogRocketInit.tsx
@@ -11,7 +11,7 @@ export default function LogRocketInit() {
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production' && !initialized) {
-      LogRocket.init('jff9jn/co');
+      LogRocket.init('5sdtr5/creditodds');
       initialized = true;
     }
   }, []);


### PR DESCRIPTION
Updates the LogRocket init app ID from `jff9jn/co` to `5sdtr5/creditodds` so session capture points at the CreditOdds LogRocket project.

Single-line change in `apps/web-next/src/components/ui/LogRocketInit.tsx`. The CSP host allowlist in `next.config.mjs` references LogRocket's account-independent CDN/ingest hosts, so no CSP change is needed. Init is still gated to `NODE_ENV === 'production'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)