### PR TITLE
landing: rank "Popular this week" by 30-day views, not record count

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -24,6 +24,7 @@ export type LandingCard = {
   slug: string;
   card_name: string;
   bank: string;
+  db_card_id?: number;
   card_image_link?: string;
   accepting_applications: boolean;
   approved_count?: number;
@@ -56,6 +57,7 @@ interface LandingClientProps {
   news: LandingNewsItem[];
   articles: LandingArticle[];
   bestPages: LandingBestPage[];
+  trendingViews: Record<number, number>;
 }
 
 const TOOL_LINKS: { name: string; value: string; href: string }[] = [
@@ -297,20 +299,41 @@ function Hero({ cards }: { cards: LandingCard[] }) {
   );
 }
 
-function PopularLane({ cards }: { cards: LandingCard[] }) {
+function PopularLane({
+  cards,
+  trendingViews,
+}: {
+  cards: LandingCard[];
+  trendingViews: Record<number, number>;
+}) {
   const popular = useMemo(() => {
     const active = cards.filter((c) => c.accepting_applications);
+    // Primary ranking: most-viewed in the last 30 days, matching the Explore
+    // page's "trending" sort (keyed by numeric db_card_id, tiebroken by records).
+    const viewsOf = (c: LandingCard) =>
+      c.db_card_id != null ? (trendingViews[c.db_card_id] ?? 0) : 0;
+    const hasViews = active.some((c) => viewsOf(c) > 0);
+    if (hasViews) {
+      return [...active]
+        .sort((a, b) => {
+          const dv = viewsOf(b) - viewsOf(a);
+          if (dv !== 0) return dv;
+          return totalRecords(b) - totalRecords(a);
+        })
+        .slice(0, 8);
+    }
+    // Fallback when view data is unavailable (endpoint failed/empty): record count.
     const hasRecords = active.some((c) => totalRecords(c) > 0);
     if (hasRecords) {
       return [...active].sort((a, b) => totalRecords(b) - totalRecords(a)).slice(0, 8);
     }
-    // Fallback for envs without record counts (local dev): curated set + first cards.
+    // Final fallback for envs without any stats (local dev): curated set + first cards.
     const bySlug = new Map(active.map((c) => [c.slug, c]));
     const curated = POPULAR_FALLBACK.map((s) => bySlug.get(s)).filter((c): c is LandingCard => !!c);
     const seen = new Set(curated.map((c) => c.slug));
     const rest = active.filter((c) => !seen.has(c.slug));
     return [...curated, ...rest].slice(0, 8);
-  }, [cards]);
+  }, [cards, trendingViews]);
 
   return (
     <div className="lane">
@@ -629,13 +652,14 @@ export default function LandingClient({
   news,
   articles,
   bestPages,
+  trendingViews,
 }: LandingClientProps) {
   return (
     <div className="landing-v2 landing-v3">
       <Hero cards={initialCards} />
       <section className="lanes">
         <div className="wrap">
-          <PopularLane cards={initialCards} />
+          <PopularLane cards={initialCards} trendingViews={trendingViews} />
           <BestForLane bestPages={bestPages} cards={initialCards} />
           <NewsLane news={news} articles={articles} />
         </div>

--- a/apps/web-next/src/app/page.tsx
+++ b/apps/web-next/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { getAllCards, Card } from "@/lib/api";
+import { getAllCards, getCardViewCounts, Card } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import { getBestPages } from "@/lib/best";
@@ -41,6 +41,7 @@ function slimCard(c: Card): LandingCard {
     slug: c.slug,
     card_name: c.card_name,
     bank: c.bank,
+    db_card_id: c.db_card_id,
     card_image_link: c.card_image_link,
     accepting_applications: c.accepting_applications,
     approved_count: c.approved_count,
@@ -105,11 +106,12 @@ function slimNews(news: NewsItem[], cardImageBySlug: Map<string, string | undefi
 }
 
 export default async function LandingPage() {
-  const [cards, news, articles, bestPages] = await Promise.all([
+  const [cards, news, articles, bestPages, trendingViews] = await Promise.all([
     getAllCards(),
     getNews(),
     getArticles(),
     getBestPages(),
+    getCardViewCounts('trending').catch(() => ({}) as Record<number, number>),
   ]);
 
   const slimmedCards: LandingCard[] = cards.map(slimCard);
@@ -135,6 +137,7 @@ export default async function LandingPage() {
       news={slimmedNews}
       articles={slimmedArticles}
       bestPages={slimmedBest}
+      trendingViews={trendingViews}
     />
   );
 }


### PR DESCRIPTION
## Problem

The **"Popular this week"** lane on the landing page sorted cards by total approval **records** (`approved_count + rejected_count`), not by views. The Explore page's "trending" sort uses **30-day page views**, so the landing lane was inconsistent with what "popular" implies.

## Fix

Rank the lane by 30-day views, matching Explore's trending sort.

- `page.tsx` now fetches `getCardViewCounts('trending')` (with a `.catch(() => ({}))` guard, same as Explore) and passes it to `LandingClient`. `slimCard` carries `db_card_id` — the numeric key the views map is keyed by.
- `PopularLane` sorts by views (tiebroken by record count), falling back to record count and then the curated list when view data is unavailable (e.g. local dev, where `getAllCards` omits DB-only fields).

## Verification

Against the production API, the lane now renders the view-ranked top 8 (US Bank Shield 466 views, Cap One Savor 178, Wells Fargo Reflect 137, …), which exactly matches the computed view ranking and differs from the old record-ranked order (Citi Double Cash, Chase Freedom Unlimited, …). `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)