### PR TITLE
landing: redesign "Best for" lane as fanned card-art stack

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -49,7 +49,8 @@ export type LandingNewsItem = {
 export type LandingBestPage = {
   slug: string;
   title: string;
-  cardSlugs: string[];
+  cardCount: number;
+  cardImages: { src?: string; alt: string }[];
 };
 
 interface LandingClientProps {
@@ -391,19 +392,7 @@ function PopularLane({
   );
 }
 
-function BestForLane({
-  bestPages,
-  cards,
-}: {
-  bestPages: LandingBestPage[];
-  cards: LandingCard[];
-}) {
-  const nameBySlug = useMemo(() => {
-    const m = new Map<string, string>();
-    cards.forEach((c) => m.set(c.slug, shortName(c)));
-    return m;
-  }, [cards]);
-
+function BestForLane({ bestPages }: { bestPages: LandingBestPage[] }) {
   if (bestPages.length === 0) return null;
 
   return (
@@ -424,14 +413,27 @@ function BestForLane({
           <Link key={page.slug} href={`/best/${page.slug}`} className="lnk">
             <div className="cat">Best for</div>
             <h4>{shortenBestTitle(page.title)}</h4>
-            <div className="top3">
-              {page.cardSlugs.map((slug, i) => (
-                <div className="row" key={slug}>
-                  <span className="r">{i + 1}</span>
-                  <span>{nameBySlug.get(slug) ?? slug}</span>
+            <div className="bf-stack">
+              {page.cardImages.map((img, i) => (
+                <div className="bf-mini" key={i}>
+                  <CardImage
+                    cardImageLink={img.src}
+                    alt={img.alt}
+                    fill
+                    sizes="64px"
+                    style={{ objectFit: 'cover', borderRadius: 4 }}
+                  />
+                  {i === 0 && (
+                    <span className="bf-crown" aria-hidden="true">
+                      <svg viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M4 18h16l1-9-5 3.5L12 6l-4 6.5L3 9z" />
+                      </svg>
+                    </span>
+                  )}
                 </div>
               ))}
             </div>
+            <div className="bf-cta">{page.cardCount} cards ranked →</div>
           </Link>
         ))}
       </div>
@@ -660,7 +662,7 @@ export default function LandingClient({
       <section className="lanes">
         <div className="wrap">
           <PopularLane cards={initialCards} trendingViews={trendingViews} />
-          <BestForLane bestPages={bestPages} cards={initialCards} />
+          <BestForLane bestPages={bestPages} />
           <NewsLane news={news} articles={articles} />
         </div>
       </section>

--- a/apps/web-next/src/app/landing-v3.css
+++ b/apps/web-next/src/app/landing-v3.css
@@ -456,10 +456,12 @@
   text-decoration: none;
   color: inherit;
   display: block;
-  transition: border-color 0.15s ease;
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 }
 .landing-v3 .lnk:hover {
   border-color: var(--ink);
+  transform: translateY(-3px);
+  box-shadow: 0 14px 28px -18px rgba(109, 63, 232, 0.4);
 }
 .landing-v3 .lnk .cat {
   font-size: 11px;
@@ -476,18 +478,57 @@
   margin: 6px 0 10px;
   color: var(--ink);
 }
-.landing-v3 .lnk .top3 {
-  display: grid;
-  gap: 6px;
+/* Best-for card — fanned card-art stack */
+.landing-v3 .lnk .bf-stack {
+  display: flex;
+  align-items: center;
+  margin: 4px 0 12px;
+  padding: 4px 0 4px 3px;
+}
+.landing-v3 .lnk .bf-mini {
+  position: relative;
+  flex: 0 0 auto;
+  width: 60px;
+  height: 38px;
+  border-radius: 6px;
+  border: 2px solid var(--card);
+  background: var(--paper-2);
+}
+.landing-v3 .lnk .bf-mini + .bf-mini {
+  margin-left: -18px;
+}
+.landing-v3 .lnk .bf-mini:nth-child(1) {
+  z-index: 3;
+}
+.landing-v3 .lnk .bf-mini:nth-child(2) {
+  z-index: 2;
+}
+.landing-v3 .lnk .bf-mini:nth-child(3) {
+  z-index: 1;
+}
+.landing-v3 .lnk .bf-crown {
+  position: absolute;
+  top: -9px;
+  left: -8px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  border: 2px solid var(--card);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 4;
+}
+.landing-v3 .lnk .bf-crown svg {
+  width: 11px;
+  height: 11px;
+}
+.landing-v3 .lnk .bf-cta {
   font-size: 12px;
-}
-.landing-v3 .lnk .top3 .row {
-  display: grid;
-  grid-template-columns: 16px 1fr;
-  color: var(--ink-2);
-}
-.landing-v3 .lnk .top3 .row .r {
-  color: var(--muted);
+  font-weight: 600;
+  color: var(--accent);
 }
 
 /* ---------- Wallet + Tools split ---------- */

--- a/apps/web-next/src/app/page.tsx
+++ b/apps/web-next/src/app/page.tsx
@@ -128,7 +128,11 @@ export default async function LandingPage() {
   const slimmedBest: LandingBestPage[] = bestPages.slice(0, 8).map((p) => ({
     slug: p.slug,
     title: p.title,
-    cardSlugs: p.cards.slice(0, 3).map((c) => c.slug),
+    cardCount: p.cards.length,
+    cardImages: p.cards.slice(0, 3).map((c) => ({
+      src: cardImageBySlug.get(c.slug),
+      alt: cardNameBySlug.get(c.slug) || c.slug,
+    })),
   }));
 
   return (


### PR DESCRIPTION
## What

Redesigns the **Lane 02 / Best for — "Editorial rankings"** row on the landing page to be more visual and clickable. The cards were flat, text-only numbered lists that read as inert next to the image-rich "Popular this week" lane directly above them.

Each "Best for" card now shows:
- the **top-3 cards' real artwork**, fanned in an overlapping stack
- a **crown badge** on the #1 pick
- an **"N cards ranked →"** CTA (real per-category count)
- a subtle **hover lift** so the card reads as clickable

This was concept B of three explored (icon medallion / card-art stack / winner spotlight); the card-art stack was chosen as the most visual option.

## How

- `LandingBestPage` now carries `cardImages` (top 3) + `cardCount` instead of `cardSlugs`; `page.tsx` populates them from the existing `cardImageBySlug` / `cardNameBySlug` maps (no extra fetch).
- `BestForLane` renders the stack via the shared `CardImage` component (its own CDN + `generic-card.svg` fallback); the `cards` prop is no longer needed.
- `landing-v3.css`: new `.bf-stack` / `.bf-mini` / `.bf-crown` / `.bf-cta` rules + a `.lnk` hover lift.

## Verification

Ran against local dev (production data). All 7 categories render the fan with correct per-category card images and counts (e.g. "0% APR — 6 cards ranked", "Airline — 19 cards ranked"), crown on #1, no console errors. Verified on desktop and mobile (375px); `tsc --noEmit` passes. Card names are preserved as image `alt` text for accessibility/SEO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)