### PR TITLE
cards: update Our Take for US Bank Shield (24→21mo) and add Wells Fargo Reflect

### DIFF
--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -25,13 +25,14 @@ apr:
     max: 27.99
 apply_link: https://www.usbank.com/credit-cards/pm/shield-visa-credit-card.html
 our_take: >
-  The Shield's 21-month 0% intro APR is one of the longest runways on the
-  market, and it covers both purchases and balance transfers with no annual
-  fee. That makes it a strong pick if you're paying down existing debt or
-  financing a large purchase over the next year and a half. The catch is the rewards
-  are thin: outside of 4% cash back on prepaid travel booked through the U.S.
-  Bank Travel Center, there's no everyday earn rate, so once the intro period
-  ends the card has little reason to stay in your wallet. Treat the $20 annual
+  U.S. Bank recently trimmed the Shield's 0% intro APR from 24 months to 21,
+  but even after the cut it remains one of the longest runways on the market,
+  covering both purchases and balance transfers with no annual fee. That still
+  makes it a strong pick if you're paying down existing debt or financing a
+  large purchase over the next year and a half. The catch is the rewards are
+  thin: outside of 4% cash back on prepaid travel booked through the U.S. Bank
+  Travel Center, there's no everyday earn rate, so once the intro period ends
+  the card has little reason to stay in your wallet. Treat the $20 annual
   statement credit and cell phone protection as minor extras.
 benefits:
   - name: "Annual Statement Credit"

--- a/data/cards/wells-fargo-reflect.yaml
+++ b/data/cards/wells-fargo-reflect.yaml
@@ -19,6 +19,16 @@ apr:
     max: 28.24
 apply_link: https://creditcards.wellsfargo.com/reflect-visa-credit-card
 foreign_transaction_fee: true
+our_take: >
+  The Reflect is a pure balance-transfer play: 21 months of 0% intro APR on
+  purchases and qualifying balance transfers, with no annual fee. That long
+  runway makes it a solid choice if your only goal is to pay down existing debt
+  or float a big purchase interest-free for nearly two years. Just be clear-eyed
+  about the tradeoff: this card earns no rewards at all, so there's no cash back
+  or points to keep it relevant once the intro period ends. Cell phone
+  protection when you pay your bill with the card is the lone ongoing perk. Open
+  it for the 0% window, run your payoff plan, and don't expect a reason to keep
+  using it after that.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 600


### PR DESCRIPTION
## Summary
Updates the **Our Take** editorial copy for two balance-transfer cards.

- **US Bank Shield** — rewrites Our Take to note that U.S. Bank trimmed the 0% intro APR from **24 months to 21**, while still framing 21 months as one of the longest runways on the market. (The `apr` data was already at 21 months; only the prose mentioned the old framing.)
- **Wells Fargo Reflect** — adds a new Our Take covering the 21-month 0% intro APR, no annual fee, and the absence of any rewards program (the angle is even stronger here than the Shield, which at least earns 4% on travel-center bookings).

## Notes
- No em dashes (house style).
- Validated with `npm run build:cards` (all 182 cards build clean); regenerated `data/cards.json` intentionally **not** committed — CI rebuilds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)