### PR TITLE
feat(api): track article + news page views

### DIFF
--- a/apps/api/migrations/046_create_content_view_counts.sql
+++ b/apps/api/migrations/046_create_content_view_counts.sql
@@ -1,0 +1,11 @@
+-- Track daily page views for editorial content (articles + news).
+-- Articles/news are file-based (no cards-style numeric id), so rows are keyed
+-- by content_type ('article' | 'news') + content_key (slug / news id).
+CREATE TABLE IF NOT EXISTS content_view_counts (
+  content_type VARCHAR(16) NOT NULL,
+  content_key VARCHAR(191) NOT NULL,
+  view_date DATE NOT NULL,
+  view_count INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (content_type, content_key, view_date),
+  INDEX idx_content_view_date (view_date)
+);

--- a/apps/api/src/handlers/content-view.js
+++ b/apps/api/src/handlers/content-view.js
@@ -1,0 +1,146 @@
+// Track editorial (article + news) page views and return view counts.
+// Mirrors card-view.js, but keys rows by content_type + content_key (string)
+// since articles/news live in JSON, not the cards table.
+const mysql = require("../db");
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+const VALID_TYPES = ["article", "news"];
+
+exports.ContentViewHandler = async (event) => {
+  console.info("received:", event.httpMethod, event.path);
+
+  let response = {};
+
+  switch (event.httpMethod) {
+    case "OPTIONS":
+      response = {
+        statusCode: 200,
+        headers: responseHeaders,
+        body: JSON.stringify({ statusText: "OK" }),
+      };
+      break;
+
+    case "POST":
+      try {
+        const body = JSON.parse(event.body);
+        const { content_type, content_key } = body;
+
+        if (!VALID_TYPES.includes(content_type)) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "content_type must be 'article' or 'news'" }),
+          };
+          break;
+        }
+        if (typeof content_key !== "string" || !content_key || content_key.length > 191) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "content_key must be a non-empty string (<=191 chars)" }),
+          };
+          break;
+        }
+
+        // Filter out obvious bots
+        const userAgent = event.headers?.['User-Agent'] || event.headers?.['user-agent'] || '';
+        if (/bot|crawler|spider|scraper/i.test(userAgent)) {
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({ success: true }),
+          };
+          break;
+        }
+
+        await mysql.query(
+          `INSERT INTO content_view_counts (content_type, content_key, view_date, view_count)
+           VALUES (?, ?, CURDATE(), 1)
+           ON DUPLICATE KEY UPDATE view_count = view_count + 1`,
+          [content_type, content_key]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ success: true }),
+        };
+      } catch (error) {
+        console.error("Error tracking content view:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to track view" }),
+        };
+      }
+      break;
+
+    case "GET":
+      try {
+        const period = event.queryStringParameters?.period;
+        const typeFilter = event.queryStringParameters?.type;
+
+        const where = [];
+        const params = [];
+        if (period && period !== '0') {
+          const days = Math.min(Math.max(parseInt(period, 10) || 7, 1), 365);
+          where.push(`view_date >= CURDATE() - INTERVAL ? DAY`);
+          params.push(days);
+        }
+        if (VALID_TYPES.includes(typeFilter)) {
+          where.push(`content_type = ?`);
+          params.push(typeFilter);
+        }
+        const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+        const rows = await mysql.query(
+          `SELECT content_type, content_key, SUM(view_count) AS views
+           FROM content_view_counts
+           ${whereSql}
+           GROUP BY content_type, content_key`,
+          params
+        );
+        await mysql.end();
+
+        // Nested map: { article: { slug: count }, news: { id: count } }
+        const views = { article: {}, news: {} };
+        for (const row of rows) {
+          if (!views[row.content_type]) views[row.content_type] = {};
+          views[row.content_type][row.content_key] = Number(row.views);
+        }
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ views }),
+        };
+      } catch (error) {
+        console.error("Error fetching content view counts:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to fetch view counts" }),
+        };
+      }
+      break;
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: `ContentView only accepts GET and POST methods, you tried: ${event.httpMethod}`,
+      };
+      break;
+  }
+
+  console.info(`response from: ${event.path} statusCode: ${response.statusCode}`);
+  return response;
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -667,6 +667,57 @@ Resources:
             RestApiId:
               Ref: CreditCardOddsAPI
 
+  ContentViewFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/content-view.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
+    Properties:
+      Handler: src/handlers/content-view.ContentViewHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 100
+      Description: Track article/news page views and return view counts
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        TrackContentView:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /content-view
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        GetContentViews:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /content-view
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        ContentViewOptions:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /content-view
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+
   CardCompareEventFunction:
     Type: AWS::Serverless::Function
     Metadata:


### PR DESCRIPTION
## What

Adds view tracking for editorial content (articles + news), mirroring the existing card-view mechanism (#1440).

- **Migration** `046_create_content_view_counts.sql` — new `content_view_counts` table keyed by `content_type` ('article'|'news') + `content_key` (slug / news id) + `view_date`, with a daily `view_count`. Single-statement; no FK (articles/news are file-based JSON, not in the `cards` table).
- **Handler** `content-view.js` — `POST /content-view` increments today's count (validates type, bot-filtered, `ON DUPLICATE KEY UPDATE`); `GET /content-view?period=7` returns `{views: {article:{slug:n}, news:{id:n}}}` over a trailing window.
- **Template** — new `ContentViewFunction` (POST/GET/OPTIONS), cloned from `CardViewFunction`.

Kept separate from `card_view_counts` on purpose: cards are numeric DB rows with an FK; articles/news are string-keyed file content with no DB presence.

## Deploy notes

- Deploys via `deploy-api.yml` on merge (creates the Lambda + `/content-view`).
- **Requires running migration 046** to create the table (private-VPC DB → `RunMigration` handler dance). Until the table exists, writes 500 harmlessly (caught client-side) and reads return empty.

## Verify

- `sam validate` → valid template; `node --check` on the handler passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)