### PR TITLE
feat(web): editorial lane redesign + rank by top-viewed this week

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import CardImage from '@/components/ui/CardImage';
 import { categoryLabels, pickHeadlineReward } from '@/lib/cardDisplayUtils';
 import { cardMatchesSearch, expandSearchTerm } from '@/lib/searchAliases';
+import type { EditorialViewCounts } from '@/lib/api';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import CardRainCanvas from './CardRainCanvas';
 import './landing.css';
@@ -38,12 +39,14 @@ export type LandingArticle = {
   title: string;
   date: string;
   tag?: string;
+  summary: string;
   cardImages: { src?: string; alt: string }[];
 };
 export type LandingNewsItem = {
   id: string;
   title: string;
   date: string;
+  summary: string;
   cardImages: { src?: string; alt: string }[];
 };
 export type LandingBestPage = {
@@ -59,6 +62,7 @@ interface LandingClientProps {
   articles: LandingArticle[];
   bestPages: LandingBestPage[];
   trendingViews: Record<number, number>;
+  editorialViews: EditorialViewCounts;
 }
 
 const TOOL_LINKS: { name: string; value: string; href: string }[] = [
@@ -446,35 +450,58 @@ type EditorialItem = {
   tag: string;
   date: string;
   title: string;
+  summary: string;
   cardImages: { src?: string; alt: string }[];
+  ts: number;
+  views: number;
 };
 
 function NewsLane({
   news,
   articles,
+  editorialViews,
 }: {
   news: LandingNewsItem[];
   articles: LandingArticle[];
+  editorialViews: EditorialViewCounts;
 }) {
   const items = useMemo<EditorialItem[]>(() => {
+    const toTs = (d: string) => {
+      const t = new Date(d).getTime();
+      return isNaN(t) ? 0 : t;
+    };
     const fromArticles: EditorialItem[] = articles.map((a) => ({
       href: `/articles/${a.slug}`,
       tag: a.tag || 'Article',
       date: formatNewsDate(a.date),
       title: a.title,
+      summary: a.summary,
       cardImages: a.cardImages,
+      ts: toTs(a.date),
+      views: editorialViews.article[a.slug] ?? 0,
     }));
     const fromNews: EditorialItem[] = news.map((n) => ({
       href: `/news/${n.id}`,
       tag: 'News',
       date: formatNewsDate(n.date),
       title: n.title,
+      summary: n.summary,
       cardImages: n.cardImages,
+      ts: toTs(n.date),
+      views: editorialViews.news[n.id] ?? 0,
     }));
-    return [...fromArticles, ...fromNews].slice(0, 6);
-  }, [news, articles]);
+    // Rank by most-viewed this week; tiebreak (and cold-start fallback when
+    // there's no view data yet) by newest first. lead = items[0], digest = rest.
+    return [...fromArticles, ...fromNews]
+      .sort((a, b) => b.views - a.views || b.ts - a.ts)
+      .slice(0, 5);
+  }, [news, articles, editorialViews]);
 
   if (items.length === 0) return null;
+
+  const [lead, ...digest] = items;
+  const leadImages = lead.cardImages.filter((img) => !!img.src);
+  const hasLeadArt = leadImages.length > 0;
 
   return (
     <div className="lane">
@@ -489,50 +516,66 @@ function NewsLane({
           All news →
         </Link>
       </div>
-      <div className="lane-track">
-        {items.map((it, i) => (
-          <Link key={it.href + i} href={it.href} className="lna">
-            <div className="cv">
+      <div className="ed-grid">
+        <Link href={lead.href} className="ed-lead">
+          <div className="ed-cv">
+            {hasLeadArt ? (
               <div className="stack">
-                {(it.cardImages.length > 0
-                  ? it.cardImages
-                  : [{ src: undefined, alt: '' }]
-                )
-                  .slice(0, 3)
-                  .map((img, j, arr) => {
-                    const center = (arr.length - 1) / 2;
-                    const offset = j - center;
-                    return (
-                      <div
-                        key={j}
-                        className="stack-item"
-                        style={{
-                          transform: `rotate(${offset * 8}deg) translateY(${
-                            arr.length > 1 && j === Math.round(center) ? -8 : 0
-                          }px)`,
-                        }}
-                      >
-                        <CardImage
-                          cardImageLink={img.src}
-                          alt={img.alt || it.title}
-                          fill
-                          sizes="86px"
-                          style={{ objectFit: 'cover' }}
-                        />
-                      </div>
-                    );
-                  })}
+                {leadImages.slice(0, 3).map((img, j, arr) => {
+                  const center = (arr.length - 1) / 2;
+                  const offset = j - center;
+                  return (
+                    <div
+                      key={j}
+                      className="stack-item"
+                      style={{
+                        transform: `rotate(${offset * 8}deg) translateY(${
+                          arr.length > 1 && j === Math.round(center) ? -10 : 0
+                        }px)`,
+                      }}
+                    >
+                      <CardImage
+                        cardImageLink={img.src}
+                        alt={img.alt || lead.title}
+                        fill
+                        sizes="120px"
+                        style={{ objectFit: 'cover' }}
+                      />
+                    </div>
+                  );
+                })}
               </div>
+            ) : (
+              <div className="ed-plate">
+                <span className="ed-plate-kicker">— CreditOdds</span>
+                <span className="ed-plate-cat">{lead.tag}</span>
+              </div>
+            )}
+          </div>
+          <div className="ed-lead-bd">
+            <div className="meta">
+              <span className={`tag${lead.tag === 'News' ? ' is-news' : ''}`}>
+                {lead.tag}
+              </span>
+              <span>{lead.date}</span>
             </div>
-            <div className="bd">
+            <h4>{lead.title}</h4>
+            {lead.summary && <p className="dek">{lead.summary}</p>}
+          </div>
+        </Link>
+        <div className="ed-digest">
+          {digest.map((it, i) => (
+            <Link key={it.href + i} href={it.href} className="ed-row">
               <div className="meta">
-                <span className="tag">{it.tag}</span>
+                <span className={`tag${it.tag === 'News' ? ' is-news' : ''}`}>
+                  {it.tag}
+                </span>
                 <span>{it.date}</span>
               </div>
-              <h4>{it.title}</h4>
-            </div>
-          </Link>
-        ))}
+              <h5>{it.title}</h5>
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
   );
@@ -655,6 +698,7 @@ export default function LandingClient({
   articles,
   bestPages,
   trendingViews,
+  editorialViews,
 }: LandingClientProps) {
   return (
     <div className="landing-v2 landing-v3">
@@ -663,7 +707,7 @@ export default function LandingClient({
         <div className="wrap">
           <PopularLane cards={initialCards} trendingViews={trendingViews} />
           <BestForLane bestPages={bestPages} />
-          <NewsLane news={news} articles={articles} />
+          <NewsLane news={news} articles={articles} editorialViews={editorialViews} />
         </div>
       </section>
       <FooterBlocks cards={initialCards} />

--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { ShareButtons } from "@/components/articles/ShareButtons";
 import { RelatedArticles } from "@/components/articles/RelatedArticles";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import ViewTracker from "@/components/ViewTracker";
 import { truncateTitle } from "@/lib/seo";
 import "../../landing.css";
 
@@ -120,6 +121,7 @@ export default async function ArticlePage({ params }: Props) {
         ]}
       />
       <ReadingProgressBar />
+      <ViewTracker type="article" contentKey={article.slug} />
 
       <div className="landing-v2 articles-v2">
         <div className="cj-terminal">

--- a/apps/web-next/src/app/landing-v3.css
+++ b/apps/web-next/src/app/landing-v3.css
@@ -372,76 +372,172 @@
   line-height: 1.2;
 }
 
-/* Lane card — article/news */
-.landing-v3 .lna {
-  flex: 0 0 360px;
+/* Lane 03 — editorial: lead story + headline digest */
+.landing-v3 .ed-grid {
+  display: grid;
+  grid-template-columns: 1.18fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+.landing-v3 .ed-lead {
+  display: block;
   border: 1px solid var(--line-2);
   border-radius: 12px;
   background: var(--card);
   overflow: hidden;
-  cursor: pointer;
-  scroll-snap-align: start;
-  transition: border-color 0.15s ease;
   text-decoration: none;
   color: inherit;
-  display: block;
+  transition: border-color 0.15s ease;
 }
-.landing-v3 .lna:hover {
+.landing-v3 .ed-lead:hover {
   border-color: var(--ink);
 }
-.landing-v3 .lna .cv {
-  height: 140px;
+.landing-v3 .ed-cv {
+  height: 170px;
   background: linear-gradient(135deg, var(--accent-2), var(--paper-3));
   position: relative;
   overflow: hidden;
 }
-.landing-v3 .lna .cv::after {
+.landing-v3 .ed-cv::after {
   content: '';
   position: absolute;
   inset: 0;
   background: radial-gradient(ellipse at 30% 30%, color-mix(in oklab, var(--accent) 18%, transparent), transparent 60%);
   pointer-events: none;
 }
-.landing-v3 .lna .cv .stack {
+.landing-v3 .ed-cv .stack {
   position: absolute;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: 12px;
 }
-.landing-v3 .lna .cv .stack-item {
+.landing-v3 .ed-cv .stack-item {
   position: relative;
-  width: 86px;
-  height: 54px;
-  border-radius: 5px;
+  width: 104px;
+  height: 66px;
+  border-radius: 7px;
   overflow: hidden;
   background: var(--paper-2);
-  box-shadow: 0 4px 12px rgba(26, 19, 48, 0.18);
+  box-shadow: 0 5px 14px rgba(26, 19, 48, 0.19);
 }
-.landing-v3 .lna .bd {
-  padding: 14px 16px 16px;
-}
-.landing-v3 .lna .meta {
-  font-size: 10.5px;
-  color: var(--muted);
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+/* Cover fallback when the lead has no card art — editorial "plate" */
+.landing-v3 .ed-plate {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
   display: flex;
-  gap: 8px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 24px;
+  text-align: center;
 }
-.landing-v3 .lna .meta .tag {
+.landing-v3 .ed-plate-kicker {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
   color: var(--accent);
 }
-.landing-v3 .lna h4 {
+.landing-v3 .ed-plate-cat {
   font-family: 'Inter Tight', sans-serif;
   font-weight: 500;
-  letter-spacing: -0.012em;
-  font-size: 16px;
-  line-height: 1.25;
-  margin: 6px 0 0;
+  letter-spacing: -0.02em;
+  font-size: clamp(26px, 3.6vw, 36px);
+  line-height: 1;
+  color: var(--accent-deep);
+  text-transform: capitalize;
+  text-wrap: balance;
+}
+.landing-v3 .ed-lead-bd {
+  padding: 13px 18px 15px;
+}
+.landing-v3 .ed-lead-bd h4 {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  letter-spacing: -0.014em;
+  font-size: 18.5px;
+  line-height: 1.16;
+  margin: 7px 0 0;
   color: var(--ink);
+}
+.landing-v3 .ed-lead-bd .dek {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--ink-2);
+  margin: 6px 0 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+/* shared meta row + tag chip */
+.landing-v3 .ed-grid .meta {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.landing-v3 .ed-grid .meta .tag {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 5px;
+  letter-spacing: 0.06em;
+  background: var(--line);
+  color: var(--muted);
+}
+.landing-v3 .ed-grid .meta .tag.is-news {
+  background: var(--accent-2);
+  color: var(--accent-deep);
+}
+/* headline digest */
+.landing-v3 .ed-digest {
+  display: flex;
+  flex-direction: column;
+}
+.landing-v3 .ed-row {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  padding: 13px 2px 14px;
+  border-bottom: 1px solid var(--line);
+  transition: padding-left 0.12s ease, border-color 0.12s ease;
+}
+.landing-v3 .ed-row:first-child {
+  padding-top: 2px;
+}
+.landing-v3 .ed-row:last-child {
+  border-bottom: 0;
+}
+.landing-v3 .ed-row:hover {
+  padding-left: 8px;
+  border-color: var(--line-2);
+}
+.landing-v3 .ed-row .meta {
+  margin-bottom: 6px;
+}
+.landing-v3 .ed-row h5 {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  font-size: 15px;
+  line-height: 1.22;
+  margin: 0;
+  color: var(--ink);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.landing-v3 .ed-row:hover h5 {
+  color: var(--accent-deep);
 }
 
 /* Lane card — best-for ranking */
@@ -793,9 +889,12 @@
     flex-basis: 78%;
     min-width: 240px;
   }
-  .landing-v3 .lna {
-    flex-basis: 90%;
-    min-width: 280px;
+  .landing-v3 .ed-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  .landing-v3 .ed-cv {
+    height: 170px;
   }
   .landing-v3 .lnk {
     flex-basis: 70%;

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -9,6 +9,7 @@ import { RelatedCards } from "@/components/articles/RelatedCards";
 import { RelatedCardInfo } from "@/lib/articles";
 import CardImage from "@/components/ui/CardImage";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import ViewTracker from "@/components/ViewTracker";
 import { truncateTitle } from "@/lib/seo";
 import "../../landing.css";
 
@@ -92,6 +93,7 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
   return (
     <>
       <ReadingProgressBar />
+      <ViewTracker type="news" contentKey={item.id} />
       <div className="landing-v2">
         <script
           type="application/ld+json"

--- a/apps/web-next/src/app/page.tsx
+++ b/apps/web-next/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { getAllCards, getCardViewCounts, Card } from "@/lib/api";
+import { getAllCards, getCardViewCounts, getContentViewCounts, EditorialViewCounts, Card } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import { getBestPages } from "@/lib/best";
@@ -72,6 +72,7 @@ function slimArticles(articles: Article[], cardImageBySlug: Map<string, string |
       title: a.title,
       date: a.date,
       tag: a.tags?.[0]?.replace(/-/g, ' '),
+      summary: a.summary,
       cardImages: (a.related_cards_info || a.related_cards || [])
         .slice(0, 3)
         .map((rc) => {
@@ -101,17 +102,18 @@ function slimNews(news: NewsItem[], cardImageBySlug: Map<string, string | undefi
             alt: cardNameBySlug.get(slug) || names[i] || '',
           }))
         : links.slice(0, 3).map((src, i) => ({ src, alt: names[i] || '' }));
-      return { id: n.id, title: n.title, date: n.date, cardImages };
+      return { id: n.id, title: n.title, date: n.date, summary: n.summary, cardImages };
     });
 }
 
 export default async function LandingPage() {
-  const [cards, news, articles, bestPages, trendingViews] = await Promise.all([
+  const [cards, news, articles, bestPages, trendingViews, editorialViews] = await Promise.all([
     getAllCards(),
     getNews(),
     getArticles(),
     getBestPages(),
     getCardViewCounts('trending').catch(() => ({}) as Record<number, number>),
+    getContentViewCounts(7).catch(() => ({ article: {}, news: {} }) as EditorialViewCounts),
   ]);
 
   const slimmedCards: LandingCard[] = cards.map(slimCard);
@@ -142,6 +144,7 @@ export default async function LandingPage() {
       articles={slimmedArticles}
       bestPages={slimmedBest}
       trendingViews={trendingViews}
+      editorialViews={editorialViews}
     />
   );
 }

--- a/apps/web-next/src/components/ViewTracker.tsx
+++ b/apps/web-next/src/components/ViewTracker.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { trackContentView } from '@/lib/api';
+
+// Fires a single fire-and-forget view event on mount for an article or news
+// item. Renders nothing. Mirrors the card page's view tracking in CardClient.
+export default function ViewTracker({
+  type,
+  contentKey,
+}: {
+  type: 'article' | 'news';
+  contentKey: string;
+}) {
+  const tracked = useRef(false);
+
+  useEffect(() => {
+    if (!contentKey || tracked.current) return;
+    tracked.current = true;
+    trackContentView(type, contentKey).catch(() => {});
+  }, [type, contentKey]);
+
+  return null;
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -802,6 +802,40 @@ export async function getCardViewCounts(period: 'trending' | 'all-time' = 'trend
   return data.views || {};
 }
 
+// View counts for editorial content, keyed by slug (articles) / id (news).
+export type EditorialViewCounts = {
+  article: Record<string, number>;
+  news: Record<string, number>;
+};
+
+const EMPTY_EDITORIAL_VIEWS: EditorialViewCounts = { article: {}, news: {} };
+
+// Track an article/news page view (no auth required, fire-and-forget)
+export async function trackContentView(
+  contentType: 'article' | 'news',
+  contentKey: string,
+): Promise<void> {
+  await fetch(`${API_BASE}/content-view`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    keepalive: true,
+    body: JSON.stringify({ content_type: contentType, content_key: contentKey }),
+  });
+  // Fire and forget - don't throw on error
+}
+
+// Get article + news view counts over the trailing `periodDays` window.
+// Used to rank the landing page editorial lane by "top viewed this week".
+export async function getContentViewCounts(periodDays = 7): Promise<EditorialViewCounts> {
+  const res = await fetch(`${API_BASE}/content-view?period=${periodDays}`, {
+    next: { revalidate: 300 },
+  });
+  if (!res.ok) return EMPTY_EDITORIAL_VIEWS;
+  const data = await res.json();
+  const views = data.views || {};
+  return { article: views.article || {}, news: views.news || {} };
+}
+
 // Track a multi-card comparison so we can rank "frequently compared" partners
 // per card. Slugs are deduplicated and unordered server-side; fire-and-forget.
 export async function trackCardCompareEvent(slugs: string[]): Promise<void> {


### PR DESCRIPTION
## What

Redesigns landing **Lane 03 / Editorial** and ranks it by views.

- **Layout** — replaces the horizontal carousel with a **lead story + headline digest**. The lead shows the fanned card art (or a typographic "plate" fallback when an item has no related cards), a tag chip, date, headline, and one-line dek; the digest is a compact tag · date · title list with hairline dividers.
- **Ranking** — `NewsLane` now sorts by content views over the last 7 days, falling back to **newest-first** when there's no view data (cold start). So it degrades gracefully and works from day one.
- **Tracking** — a small `ViewTracker` client component fires a single fire-and-forget view event on the article and news detail pages; the landing page reads aggregated counts (`getContentViewCounts`).

Depends at runtime on the `/content-view` backend (#1443) only for the *ranking* — without it, `getContentViewCounts` no-ops and the lane stays newest-first.

## Verify

- `tsc --noEmit` clean; landing page renders with no console errors; lane falls back to newest-first locally (endpoint not deployed). Verified desktop + mobile layouts in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)