### PR TITLE
cards: normalize Southwest Plus Instacart category grocery→groceries

### DIFF
--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -83,6 +83,6 @@ benefits:
     value: 120
     description: "Up to $120 in annual Instacart credits including $0 delivery fees with 3 months of complimentary Instacart+ and a $10 monthly Instacart credit."
     frequency: "annual"
-    category: "grocery"
+    category: "groceries"
     enrollment_required: true
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/plus


### PR DESCRIPTION
Normalizes the `category` on the Southwest Rapid Rewards Plus Instacart benefit from `grocery` (singular) to `groceries`, matching the canonical spelling used across the dataset (44 uses) and the sibling Premier/Priority Southwest cards.

Follow-up to the #1460 merge, which introduced the singular outlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)