### PR TITLE
cards: normalize United Instacart category grocery→groceries

### DIFF
--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -77,7 +77,7 @@ benefits:
     value: 240
     description: "Two $10 Instacart credits each month through 12/31/27"
     frequency: "monthly"
-    category: "grocery"
+    category: "groceries"
   - name: "JSX Credit"
     value: 200
     description: "Up to $200 each anniversary year on flights purchased directly with JSX"

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -76,7 +76,7 @@ benefits:
     value: 120
     description: "$10 monthly Instacart credit through 12/31/27"
     frequency: "monthly"
-    category: "grocery"
+    category: "groceries"
   - name: "JSX Credit"
     value: 100
     description: "Up to $100 each anniversary year on flights purchased directly with JSX"

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -102,7 +102,7 @@ benefits:
     value: 180
     description: "Up to $180 in Instacart credits each calendar year ($10 + $5 monthly; benefits end 12/31/27)"
     frequency: "annual"
-    category: "grocery"
+    category: "groceries"
     enrollment_required: true
   - name: "JSX Flight Credit"
     value: 150


### PR DESCRIPTION
Normalizes the `category` on the Instacart Credit benefit for the three United co-brand cards (Club Infinite, Explorer, Quest) from singular `grocery` to `groceries`, the canonical spelling across the dataset.

Completes the grocery→groceries sweep started in #1466 (Southwest Plus). No singular `grocery` categories remain after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)