### PR TITLE
docs: refresh README, CONTRIBUTING, and agent md to match project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
   Code pushes to `main` fire the webhook via `.github/workflows/deploy-frontend.yml`;
   card/best/article/news data pushes fire it from their own `build-*.yml`
   workflow after syncing JSON to S3.
-- Cards data: Run `npm run build-cards` in web-next to rebuild cards.json
+- Cards data: Run `npm run build:cards` from the repo root to rebuild cards.json
 
 ### Backend CI/CD: GitHub Actions (`deploy-api.yml`)
 
@@ -61,6 +61,10 @@ was wiped from the stack when the broken template was applied).
 
 ## Database
 
-- MySQL database hosted on AWS
-- Migrations in `apps/api/migrations/`
-- Run migrations with `node scripts/run-migration.js <migration-file>`
+- MySQL database hosted on AWS (RDS), inside a **private VPC** — not reachable
+  from a local machine.
+- Migrations in `apps/api/migrations/`, numbered sequentially and
+  **single-statement only** (split multi-step changes into `NNNa_*`, `NNNb_*`).
+- To run a migration: wire `RunMigrationHandler` into `template.yml`, deploy,
+  invoke it, then unwire it. The `apps/api/scripts/run-migration.js` helper only
+  works from inside the VPC.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ For code changes:
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/your-feature`
 3. Make your changes
-4. Run tests for the workspace you touched (`cd apps/web-next && npm test`, or `npm run test:api`)
+4. Run tests for the workspace you touched (web: `cd apps/web-next && npm test`; API: `cd apps/api && npm run test-*`, e.g. `npm run test-get-all-cards`)
 5. Submit a Pull Request
 
 ## Development Setup

--- a/README.md
+++ b/README.md
@@ -115,8 +115,11 @@ npm run build:cards
 | `npm run build:articles` | Build articles.json from Markdown files |
 | `npm run build:best` | Build best.json from Markdown files |
 | `npm run build:stores` | Build stores.json from YAML files |
-| `npm run test:api` | Run the API (Lambda) test suite |
 | `npm run lint` | Run ESLint across all workspaces |
+
+> **Tests:** the web app uses Vitest (`cd apps/web-next && npm test`). The API
+> has per-handler smoke tests run with SAM (`cd apps/api && npm run test-*`,
+> e.g. `npm run test-get-all-cards`).
 
 ## Key Features
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,156 +1,67 @@
-# CreditCardOddsAPI
+# CreditOdds API
 
-This project contains source code and supporting files for a serverless application that you can deploy with the AWS Serverless Application Model (AWS SAM) command line interface (CLI). It includes the following files and folders:
+The serverless backend for CreditOdds, built with the [AWS Serverless
+Application Model (SAM)](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+It runs on AWS Lambda (Node.js 22) behind API Gateway, with a Firebase token
+authorizer for authenticated and admin routes and MySQL (AWS RDS) for user data.
 
-- `src` - Code for the application's Lambda function.
-- `events` - Invocation events that you can use to invoke the function.
-- `template.yml` - A template that defines the application's AWS resources.
+For the full endpoint reference and database schema, see the
+[root CONTRIBUTING.md](../../CONTRIBUTING.md#api-endpoints).
 
-The application uses several AWS resources, including Lambda functions, an API Gateway API. These resources are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code.
+## Layout
 
-If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.  
-The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code. 
+- `src/handlers/` — Lambda handlers, one file per route (≈34 handlers)
+- `src/lib/` — shared helpers (DB access via `serverless-mysql`, the wallet
+  `ranker/`, auth, etc.)
+- `template.yml` — SAM/CloudFormation template defining every function, the
+  API, schedules, and IAM
+- `migrations/` — numbered, single-statement SQL migrations
+- `events/` — sample invocation events for `sam local invoke`
 
-To get started, see the following:
+## Prerequisites
 
-* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
-* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
-* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
-* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+- [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
+- Node.js 22+
+- Docker (only needed for `sam local`)
 
-## Deploy the sample application
+## Build & deploy
 
-The AWS SAM CLI is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+Deploys normally run through GitHub Actions (`.github/workflows/deploy-api.yml`):
+any push to `main` touching `apps/api/**` runs `sam build && sam deploy` via
+GitHub OIDC. There's also a `workflow_dispatch` button for manual runs.
 
-To use the AWS SAM CLI, you need the following tools:
-
-* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
-* Node.js - [Install Node.js 12](https://nodejs.org/en/), including the npm package management tool.
-* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
-
-To build and deploy your application for the first time, run the following in your shell:
+To deploy by hand from a machine that already has `samconfig.toml`
+(gitignored — holds the stack name, bucket, and params):
 
 ```bash
 sam build
-sam deploy --guided
+sam deploy
 ```
 
-The first command will build the source of your application. The second command will package and deploy your application to AWS, with a series of prompts:
+The stack reuses its existing `NoEcho` parameters (DB credentials,
+`IpHashPepper`, `GooglePlacesApiKey`) automatically. A brand-new machine's
+first deploy needs them passed via `--parameter-overrides`; the stack
+remembers them afterward.
 
-* **Stack Name**: The name of the stack to deploy to CloudFormation. This should be unique to your account and region, and a good starting point would be something matching your project name.
-* **AWS Region**: The AWS region you want to deploy your app to.
-* **Confirm changes before deploy**: If set to yes, any change sets will be shown to you before execution for manual review. If set to no, the AWS SAM CLI will automatically deploy application changes.
-* **Allow SAM CLI IAM role creation**: Many AWS SAM templates, including this example, create AWS IAM roles required for the AWS Lambda function(s) included to access AWS services. By default, these are scoped down to minimum required permissions. To deploy an AWS CloudFormation stack which creates or modified IAM roles, the `CAPABILITY_IAM` value for `capabilities` must be provided. If permission isn't provided through this prompt, to deploy this example you must explicitly pass `--capabilities CAPABILITY_IAM` to the `sam deploy` command.
-* **Save arguments to samconfig.toml**: If set to yes, your choices will be saved to a configuration file inside the project, so that in the future you can just re-run `sam deploy` without parameters to deploy changes to your application.
+## Local testing
 
-The API Gateway endpoint API will be displayed in the outputs when the deployment is complete.
-
-## Use the AWS SAM CLI to build and test locally
-
-Build your application by using the `sam build` command.
+Each `test-*` script in `package.json` invokes one handler against a sample
+event with `sam local invoke` (requires Docker):
 
 ```bash
-my-application$ sam build
+npm run test-get-all-cards
+npm run test-get-card-by-id
+npm run test-post-record
+# ...see package.json for the full list
 ```
 
-The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves it in the `.aws-sam/build` folder.
+Add new sample events under `events/` and a matching `test-*` script to cover
+more handlers.
 
-Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+## Migrations
 
-Run functions locally and invoke them with the `sam local invoke` command.
-
-```bash
-my-application$ sam local invoke putItemFunction --event events/event-post-item.json
-my-application$ sam local invoke getAllItemsFunction --event events/event-get-all-items.json
-```
-
-The AWS SAM CLI can also emulate your application's API. Use the `sam local start-api` command to run the API locally on port 3000.
-
-```bash
-my-application$ sam local start-api
-my-application$ curl http://localhost:3000/
-```
-
-The AWS SAM CLI reads the application template to determine the API's routes and the functions that they invoke. The `Events` property on each function's definition includes the route and method for each path.
-
-```yaml
-      Events:
-        Api:
-          Type: Api
-          Properties:
-            Path: /
-            Method: GET
-```
-
-## Add a resource to your application
-The application template uses AWS SAM to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
-
-Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**. Then add a property to the **AWS::Serverless::Function** resource named **DeadLetterQueue** that targets the queue's Amazon Resource Name (ARN), and a policy that grants the function permission to access the queue.
-
-```
-Resources:
-  MyQueue:
-    Type: AWS::SQS::Queue
-  getAllItemsFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: src/handlers/get-all-items.getAllItemsHandler
-      Runtime: nodejs12.x
-      DeadLetterQueue:
-        Type: SQS 
-        TargetArn: !GetAtt MyQueue.Arn
-      Policies:
-        - SQSSendMessagePolicy:
-            QueueName: !GetAtt MyQueue.QueueName
-```
-
-The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
-
-Deploy the updated application.
-
-```bash
-my-application$ sam deploy
-```
-
-Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page of the Lambda console, and choose your application. When the deployment completes, view the application resources on the **Overview** tab to see the new resource. Then, choose the function to see the updated configuration that specifies the dead-letter queue.
-
-## Fetch, tail, and filter Lambda function logs
-
-To simplify troubleshooting, the AWS SAM CLI has a command called `sam logs`. `sam logs` lets you fetch logs that are generated by your Lambda function from the command line. In addition to printing the logs on the terminal, this command has several nifty features to help you quickly find the bug.
-
-**NOTE:** This command works for all Lambda functions, not just the ones you deploy using AWS SAM.
-
-```bash
-my-application$ sam logs -n putItemFunction --stack-name sam-app --tail
-```
-
-**NOTE:** This uses the logical name of the function within the stack. This is the correct name to use when searching logs inside an AWS Lambda function within a CloudFormation stack, even if the deployed function name varies due to CloudFormation's unique resource name generation.
-
-You can find more information and examples about filtering Lambda function logs in the [AWS SAM CLI documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
-
-## Tests
-
-Tests are defined in the `__tests__` folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run tests.
-
-```bash
-my-application$ npm install
-# Unit test
-my-application$ npm run test
-# Integration test, requiring deploying the stack first.
-# Create the env variable AWS_SAM_STACK_NAME with the name of the stack we are testing
-my-application$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
-```
-
-## Cleanup
-
-To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
-
-```bash
-aws cloudformation delete-stack --stack-name CreditCardOddsAPI
-```
-
-## Resources
-
-For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
-
-Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).
+The database lives in a private VPC and can't be reached from a local machine.
+To run a migration, wire `RunMigrationHandler` into `template.yml`, deploy,
+invoke it, then unwire it again. Migration files must be **single-statement**;
+split multi-step changes into `NNNa_*`, `NNNb_*`. See
+[apps/api/migrations/](./migrations/) for the numbered history.

--- a/apps/web-next/README.md
+++ b/apps/web-next/README.md
@@ -1,36 +1,56 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# CreditOdds Web (Next.js)
 
-## Getting Started
+The CreditOdds frontend: a [Next.js 16](https://nextjs.org) App Router app in
+TypeScript, styled with Tailwind CSS and the editorial "v2" design system
+(Inter Tight headlines, Inter body). It uses SSR/SSG with ISR for SEO, Firebase
+Authentication (Google sign-in + email magic links), and Highcharts for the
+approval-odds visualizations. It's deployed on AWS Amplify.
 
-First, run the development server:
+## Getting started
+
+From the repo root, `npm install` once (it installs every workspace), then:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm run dev          # from apps/web-next
+# or, from the repo root:
+npm run start:web-next
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Environment
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Create `.env.local` in this directory (see the
+[root README](../../README.md#environment-setup) for the full list):
 
-## Learn More
+```bash
+NEXT_PUBLIC_API_BASE_URL=...
+NEXT_PUBLIC_CDN_URL=...
+NEXT_PUBLIC_FIREBASE_API_KEY=...
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=...
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=...
+NEXT_PUBLIC_FIREBASE_APP_ID=...
+```
 
-To learn more about Next.js, take a look at the following resources:
+## Scripts
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+| Script | Description |
+|--------|-------------|
+| `npm run dev` | Start the dev server |
+| `npm run build` | Production build (runs the SEO check first via `prebuild`) |
+| `npm start` | Serve the production build |
+| `npm test` | Run the Vitest suite |
+| `npm run lint` | ESLint (`--max-warnings=0`) |
+| `npm run check:seo` | Run the SEO check (`scripts/check-seo.mjs`) on its own |
+| `npm run analyze` | Build with the bundle analyzer |
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+> The `prebuild` SEO check fails the build on issues like an empty `alt`
+> attribute, so always give images a real `alt`.
 
-## Deploy on Vercel
+## Deployment
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Pushed to `main` and deployed via AWS Amplify. Native auto-build is disabled
+(`enableAutoBuild=false`); each merge fires the build webhook exactly once
+through `.github/workflows/deploy-frontend.yml` (code) or the relevant
+`build-*.yml` workflow (data). See the
+[root README](../../README.md#deployment) for details.


### PR DESCRIPTION
Reviewed every README, CONTRIBUTING, and agent md against the actual project state and fixed the stale ones. Docs only — no code or behavior changes.

## Fixed
- **apps/api/README.md** — was 100% generic SAM boilerplate (`CreditCardOddsAPI`, `putItemFunction`, **Node.js 12**, `sam deploy --guided`, `delete-stack`). Rewrote for the real project: Node 22, GitHub Actions OIDC deploy, actual `src/handlers`/`migrations` layout, the `test-*` SAM smoke tests, and the VPC migration process.
- **apps/web-next/README.md** — was generic `create-next-app` boilerplate (Geist font, "Deploy on Vercel"). Rewrote for the real stack: Inter/Inter Tight, Firebase auth, Highcharts, AWS Amplify, the actual script table (Vitest, `prebuild` SEO check, `analyze`).
- **README.md** — `npm run test:api` was listed as the API test suite, but `apps/api` has no `test` script (command is broken). Replaced with an accurate tests note (web = Vitest, API = per-handler SAM smoke tests).
- **CONTRIBUTING.md** — same broken `npm run test:api` reference corrected.
- **CLAUDE.md** — `npm run build-cards` in web-next → `npm run build:cards` from root; corrected the Database/migration section (right path + VPC `RunMigrationHandler` process).

## Verified already-current (no change)
Root README structure/stack, CONTRIBUTING DB schema + API endpoint reference, AGENTS.md, docs/adding-cards.md, and the data/ READMEs (news, valuations, article drafts).

All claims checked against `package.json` scripts, `template.yml` (Node 22, 40 functions), the handler/tools/migrations directories, and the git remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)