### PR TITLE
chore: remove dead @creditodds/web workspace scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,18 +7,14 @@
     "packages/*"
   ],
   "scripts": {
-    "build:web": "npm run build -w @creditodds/web",
     "build:web-next": "npm run build -w @creditodds/web-next",
     "build:cards": "node scripts/build-cards.js",
     "build:news": "node scripts/build-news.js",
     "build:articles": "node scripts/build-articles.js",
     "build:best": "node scripts/build-best.js",
     "build:stores": "node scripts/build-stores.js",
-    "start:web": "npm run start -w @creditodds/web",
     "start:web-next": "npm run dev -w @creditodds/web-next",
     "dev:web-next": "npm run dev -w @creditodds/web-next",
-    "test:web": "npm run test -w @creditodds/web",
-    "test:api": "npm run test -w @creditodds/api",
     "lint": "npm run lint --workspaces --if-present"
   },
   "dependencies": {


### PR DESCRIPTION
Follow-up to #1469. The root `package.json` had four dead scripts:

- `build:web`, `start:web`, `test:web` — point at the `@creditodds/web` workspace, which no longer exists (`apps/web` is gone).
- `test:api` — delegates to `npm run test -w @creditodds/api`, but `apps/api` has no `test` script, so the command fails.

None are referenced by any GitHub Actions workflow or other script. Removed all four. The remaining scripts (`build:web-next`, `start:web-next`, `dev:web-next`, the `build:*` data builders, `lint`) are unchanged and verified valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)