### PR TITLE
US Bank Shopper: model the first-year annual-fee waiver

### DIFF
--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -4,6 +4,9 @@ slug: "us-bank-shopper"
 image: "us-bank-shopper.png"
 accepting_applications: true
 annual_fee: 95
+annual_fee_intro:
+  value: 0
+  months: 12
 tags:
   - cashback
   - shopping


### PR DESCRIPTION
The US Bank Shopper Cash Rewards card is **"$0 intro annual fee for the first year, then $95"** ([NerdWallet](https://www.nerdwallet.com/reviews/credit-cards/us-bank-shopper-cash-rewards), [FinanceBuzz](https://financebuzz.com/us-bank-shopper-cash-rewards-review)), but the YAML stored only `annual_fee: 95` with no `annual_fee_intro`.

Adds `annual_fee_intro: {value: 0, months: 12}`, which:
- **Corrects the card data** — the first-year waiver is a real feature and now surfaces on the card page.
- **Activates the #1435 waiver guard** for this card. The guard only fires when `annual_fee_intro` is present, which is why card-page-check kept proposing the bogus `95 → 0` (#1471, now closed). Future runs auto-suppress it.

`build:cards` clean (182 cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)