### PR TITLE
card-wire: point follow link to @creditodds

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -238,7 +238,7 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap, bankM
           </div>
           <a
             className="wire-follow"
-            href="https://x.com/card_wire"
+            href="https://x.com/creditodds"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -250,7 +250,7 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap, bankM
                     d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"
                   />
                 </svg>
-                @card_wire
+                @creditodds
               </span>
               <span className="wire-follow-sub">Every change, the moment it posts</span>
             </span>


### PR DESCRIPTION
Card-wire SUB updates are moving back to the main **@creditodds** X account (from @card_wire). This updates the `/card-wire` follow link accordingly.

- Follow link: `x.com/card_wire` → `x.com/creditodds`
- Displayed handle: `@card_wire` → `@creditodds`

The posting-logic side (so `twitter_cardwire` posts publish to @creditodds while keeping priority/immediate/blackout-bypass) is a separate change in the `social-posting-service` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)