### PR TITLE
copy: update card count from 140+ to 150+

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -664,7 +664,7 @@ function FinalCTA() {
         <h2>
           Open the <em>file</em> on every card.
         </h2>
-        <p>140+ cards. Thousands of records. Free, forever, no email required to read.</p>
+        <p>150+ cards. Thousands of records. Free, forever, no email required to read.</p>
         <div className="ctas-row">
           <Link
             href="/explore"

--- a/apps/web-next/src/components/landing-v2/Chrome.tsx
+++ b/apps/web-next/src/components/landing-v2/Chrome.tsx
@@ -73,7 +73,7 @@ export function V2Footer() {
                 maxWidth: 320,
               }}
             >
-              Community-powered approval odds for 140+ credit cards. Independent, free,
+              Community-powered approval odds for 150+ credit cards. Independent, free,
               and built on real data.
             </p>
           </div>


### PR DESCRIPTION
Updates the two user-facing "140+ cards" references to "150+ cards" now that the catalog has over 150 cards.

- Landing closing CTA band (`LandingClient.tsx`)
- Footer brand blurb (`Chrome.tsx`)

The only other "140+" hits were in `docs/feature-audit/raw/landing-nav.json` (generated audit docs describing prior expected behavior), left untouched.

Verified live in the dev preview: both strings now render "150+".

🤖 Generated with [Claude Code](https://claude.com/claude-code)