### PR TITLE
content: add our_take editorial blurbs to 180 cards

### DIFF
--- a/data/cards/aaa-daily-advantage-visa-signature.yaml
+++ b/data/cards/aaa-daily-advantage-visa-signature.yaml
@@ -57,6 +57,12 @@ apr:
   regular:
     min: 17.49
     max: 31.49
+our_take: >
+  A no-fee everyday-spend card built around the AAA membership: 5% on groceries and 3% on
+  gas, EV charging, and wholesale clubs, plus 3% on streaming and drugstores. The real
+  catch is the cap, only $500 in cash back per year shared across the grocery, gas, and
+  wholesale-club rows, so those headline rates dry up fast for a heavy spender. Treat it as
+  a supplementary card for AAA members and pair it with a flat-rate 2% card once you cap out.
 benefits:
   - name: "AAA Redemption Bonus"
     description: "5% more cash back when redeeming with AAA Northeast Counselors and Advisors"

--- a/data/cards/aaa-travel-advantage-visa-signature.yaml
+++ b/data/cards/aaa-travel-advantage-visa-signature.yaml
@@ -47,6 +47,11 @@ apr:
   regular:
     min: 17.49
     max: 31.49
+our_take: >
+  A no-fee card built around driving: 5% back on gas and EV charging (capped at $350 in
+  cash back a year), plus 3% on groceries, dining, and travel. The 5% rate is strong for
+  no annual fee, but the low cap means heavy spenders top out fast, and you do not need a
+  AAA membership to apply. Fine as a gas card if you keep an eye on that cap.
 benefits:
   - name: "AAA Redemption Bonus"
     description: "5% more cash back when redeeming with AAA Northeast Counselors and Advisors"

--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -67,3 +67,10 @@ benefits:
     category: "protection"
     enrollment_required: false
 apply_link: https://creditcards.chase.com/travel-credit-cards/aer-lingus
+our_take: >
+  This is a niche co-brand for people who fly Aer Lingus, British Airways, or
+  Iberia, earning 3x on those airlines plus a 75,000-mile signup bonus for the
+  $95 fee. The real draw is the companion ticket, but it takes $30,000 of annual
+  spend to earn, so it only pays off if you put heavy spend on the card or fly
+  the Avios partners often. No foreign transaction fees help abroad, but for
+  general travel a flexible-points card will serve most people better.

--- a/data/cards/amazon-business-prime-american-express-card.yaml
+++ b/data/cards/amazon-business-prime-american-express-card.yaml
@@ -39,3 +39,9 @@ tags:
   - cashback
   - shopping
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/amazon-business-prime-card/
+our_take: >
+  Built for businesses that live on Amazon: 5% back on Amazon, Amazon Business, AWS,
+  and Whole Foods up to $120,000 a year, with 2% on dining and gas, all for no annual
+  fee. The catch is the 5% requires an eligible Prime membership, and outside the
+  Amazon ecosystem the 1% base rate is weak, so a flat-rate card like Wells Fargo
+  Active Cash earns more on general spend.

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -40,6 +40,13 @@ apr:
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/amazon-prime-rewards
 special_apply_link: https://www.amazon.com/dp/BT00LN946S
 foreign_transaction_fee: false
+our_take: >
+  If you have a Prime membership and shop Amazon and Whole Foods regularly, this
+  is the no-fee card to do it with: 5% back on Amazon and Whole Foods, plus 2% on
+  dining, gas, and transit and no foreign transaction fees. The catch is the 5%
+  is tied to keeping Prime (it drops to 3% without it), and 1% on everything else
+  means this is a supplement to a flat-rate card, not your only one. The $200
+  instant gift card at approval is a nice no-spend bonus.
 benefits:
   - name: "Purchase Protection"
     description: "Covers eligible new purchases for 120 days from purchase date against damage or theft up to $500 per item"

--- a/data/cards/amazon-store-card.yaml
+++ b/data/cards/amazon-store-card.yaml
@@ -33,3 +33,11 @@ apr:
     max: 29.49
 apply_link: https://www.amazon.com/Synchrony-Bank-Amazon-com-Store-Card/dp/B008A0GNA8
 foreign_transaction_fee: false
+our_take: >
+  This is a closed-loop store card that only earns its 5% at Amazon and Whole
+  Foods, and only with an active Prime membership, so it suits committed Amazon
+  shoppers and not much else. The Amazon Prime Visa earns the same 5% on Amazon
+  but works everywhere and adds 2% on dining and gas, so unless you can't
+  qualify for that Visa there is little reason to pick the store card. Mind the
+  29.49% APR: the equal-monthly-payment financing only helps if you clear it
+  before each promo window closes.

--- a/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
+++ b/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
@@ -29,6 +29,12 @@ apr:
     min: 19.49
     max: 29.49
 apply_link: https://www.citi.com/credit-cards/aadvantage-mile-up-credit-card
+our_take: >
+  A no-fee way to start earning AAdvantage miles, with 2x on groceries and on
+  American purchases plus a modest 15,000-mile bonus after $1,000 in spend. It
+  is the right pick only if you fly American occasionally and want miles without
+  a fee, since it skips the checked-bag and priority-boarding perks that make
+  the paid AAdvantage cards worth their cost.
 benefits:
   - name: "Inflight Food & Beverage Discount"
     value: 25

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -66,3 +66,11 @@ tags:
   - premium
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/american-express-business-gold-card-amex/
 foreign_transaction_fee: false
+our_take: >
+  Built for businesses with lumpy, varied spend: 4x auto-applies to your top
+  two categories each cycle (airfare, U.S. gas, dining, advertising, cloud,
+  transit) up to $150k a year, which beats fixed-category business cards if your
+  spending moves around. The catch is a $375 fee that you mostly justify through
+  the statement credits (FedEx/Grubhub/office supply, Walmart+, Squarespace),
+  so it pays off only if you actually use those. If you want simpler flat-rate
+  earning, the no-fee Blue Business Plus is the easier hold.

--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -5,7 +5,14 @@ image: "amex_gold_card.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/gold-card/
 foreign_transaction_fee: false
-card_referral_link: "https://www.americanexpress.com/en-us/referral/personal/gold-card?ref=" 
+card_referral_link: "https://www.americanexpress.com/en-us/referral/personal/gold-card?ref="
+our_take: >
+  The Gold is built for people who spend heavily on food: 4x at restaurants and 4x at U.S.
+  supermarkets is among the best dining and grocery earning you can get, and it pairs with a
+  large 100,000-point signup bonus. The $325 fee only works out if you actually use the
+  monthly Uber, dining, Dunkin, and Resy credits, so this is a card to use, not to set and
+  forget. Approvals here lean toward solid credit, so it is more realistic once you are past
+  the credit-building stage.
 annual_fee: 325
 benefits:
   - name: "Uber Cash"

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -5,6 +5,13 @@ image: "amex_green_card.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/green/
 foreign_transaction_fee: false
+our_take: >
+  The Green earns a flat 3x on travel, transit, and dining with no foreign
+  transaction fee, a clean setup for frequent travelers who spread spending
+  across all three. The catch is its own family: for $175 more the Amex Gold
+  pays 4x on dining and groceries, so the Green only makes sense if your
+  spending leans toward transit and broad travel rather than restaurants. The
+  CLEAR Plus credit can nearly cover the $150 fee if you fly enough to use it.
 annual_fee: 150
 reward_type: "points"
 rewards:

--- a/data/cards/amex-everyday-credit-card.yaml
+++ b/data/cards/amex-everyday-credit-card.yaml
@@ -6,3 +6,8 @@ accepting_applications: false
 annual_fee: 0
 reward_type: "points"
 apply_link: https://www.americanexpress.com/us/credit-cards/card/amex-everyday/
+our_take: >
+  The Amex EveryDay was a no-annual-fee entry point into Membership Rewards, but
+  it is no longer accepting applications, so it is closed to new cardholders. If
+  you want a no-fee Amex points card today, look to a current Membership Rewards
+  product instead.

--- a/data/cards/amex-everyday-preferred-credit-card.yaml
+++ b/data/cards/amex-everyday-preferred-credit-card.yaml
@@ -6,3 +6,9 @@ image: "everyday-preferred.png"
 annual_fee: 95
 reward_type: "points"
 apply_link: https://www.americanexpress.com/us/credit-cards/card/amex-everyday-preferred/
+our_take: >
+  This is the fee-paying step up in Amex's Everyday line, earning Membership Rewards
+  points for a $95 annual fee versus the no-fee Everyday card. It is no longer open to
+  new applicants, so treat it as a card to keep rather than chase. If you want a current
+  Amex points card, the Gold covers dining and groceries far more heavily, though at a
+  much higher fee.

--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -37,6 +37,12 @@ apr:
     max: 27.74
 apply_link: https://www.apple.com/apple-card/
 foreign_transaction_fee: false
+our_take: >
+  The Apple Card makes sense mainly if you live in the Apple ecosystem: 3% on Apple and a
+  few partner merchants, 2% on anything else through Apple Pay, but only 1% on the physical
+  titanium card. With no annual fee and no signup bonus, a flat 2% card like Wells Fargo
+  Active Cash beats it on most everyday spend that is not tapped through Apple Pay. The draw
+  is the daily cash, clean app, and no fees, not the earn rate.
 benefits:
   - name: "Booking.com Travel Credits"
     value: 2

--- a/data/cards/at-t-access-card-from-citi.yaml
+++ b/data/cards/at-t-access-card-from-citi.yaml
@@ -5,3 +5,9 @@ accepting_applications: false
 image: "citi-att-access.png"
 annual_fee: 0
 reward_type: "points"
+our_take: >
+  The AT&T Access from Citi is no longer open to new applicants, so it is here mainly for
+  reference and existing cardholders. If you already carry it, fine, but there is nothing
+  to chase here: look to a current Citi rewards card if you want a points earner you can
+  actually apply for.
+

--- a/data/cards/atlas-card.yaml
+++ b/data/cards/atlas-card.yaml
@@ -4,6 +4,14 @@ slug: "atlas-card"
 accepting_applications: true
 image: "atlas.png"
 apply_link: https://atlascard.com/
+our_take: >
+  At a $3,000 annual fee, the Atlas is an ultra-premium lifestyle card aimed at
+  high spenders who will actually use the concierge, private-aviation rates, and
+  curated dining and wellness perks. Earn rates are modest for the price (3x
+  hotels, 2x dining, 1x everything else), so the math only works if the
+  experiential benefits and member access matter more to you than raw points.
+  For most travelers a card like the Amex Platinum at a fraction of the fee
+  covers the practical perks.
 annual_fee: 3000
 category: "travel"
 reward_type: "points"

--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -39,3 +39,9 @@ benefits:
     frequency: "annual"
     category: "travel"
 apply_link: https://www.bankofamerica.com/credit-cards/products/alaska-airlines-credit-card/
+our_take: >
+  The real draw here is the companion fare, both the buy-one-get-one at signup and the
+  $99 version each anniversary after $6,000 in spend, which can cover the $95 fee on a
+  single trip. Earning is middling at 3x on airfare and 2x on gas, streaming, and
+  transit, so this is a card for people flying Alaska/Atmos routes who will actually use
+  the companion certificate, not a general travel earner.

--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -12,6 +12,14 @@ annual_fee: 95
 check_ignore:
   - annual_fee
 foreign_transaction_fee: false
+our_take: >
+  A business card built for Alaska and Atmos Rewards loyalists: 3x on airfare,
+  free first checked bag, an annual coach companion fare, and an 80,000-point
+  signup bonus after $5,000 in spend, with no foreign transaction fees. The
+  effective $95 fee (a $70 company fee plus $25 per card) is reasonable for the
+  perks, and the fact that activity does not hit your personal credit is a real
+  plus for keeping personal utilization clean. Worth it only if you actually fly
+  Alaska, since the 2x non-airline categories are nothing special.
 tags:
   - travel
   - airline

--- a/data/cards/atmos-rewards-summit.yaml
+++ b/data/cards/atmos-rewards-summit.yaml
@@ -7,6 +7,14 @@ apply_link: https://www.bankofamerica.com/credit-cards/products/alaska-airlines-
 category: "travel"
 annual_fee: 395
 foreign_transaction_fee: false
+our_take: >
+  The Summit is the top Alaska/Atmos card, and the value is in the perks, not
+  the 3x earn: a 25,000-point companion award every year, free checked bags,
+  Alaska Lounge passes, and a Global Entry credit. At $395 it justifies its fee
+  for frequent Alaska or Hawaiian flyers, but light flyers are better served by
+  the $95 Ascent, which keeps the same 3x on airfare without the lounge-heavy
+  benefits. The six-figure intro bonus is one of the larger airline offers, but
+  the perks only pay off if you fly the network regularly.
 tags:
   - travel
   - airline

--- a/data/cards/att-points-plus-from-citi.yaml
+++ b/data/cards/att-points-plus-from-citi.yaml
@@ -5,6 +5,12 @@ image: "citi-att-points-plus.png"
 accepting_applications: true
 apply_link: https://www.citi.com/credit-cards/citi-att-pointsplus-credit-card
 foreign_transaction_fee: false
+our_take: >
+  This card really only makes sense if you are an AT&T customer: the $10/line
+  wireless and $10 internet credits plus 2x on AT&T bills are where the value
+  lives, alongside 3x on gas and 2x on groceries with no annual fee or foreign
+  transaction fees. Cut the cord from AT&T and a flat 2% card earns more
+  everywhere, so the whole pitch hinges on keeping those telecom bills.
 annual_fee: 0
 reward_type: "points"
 tags:

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -33,3 +33,10 @@ apr:
     min: 27.49
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/secured-credit-card/
+our_take: >
+  A rare secured card that actually earns: 3% in a category you choose plus 2%
+  at groceries and wholesale clubs, with no annual fee, which makes it one of
+  the stronger no-fee secured options for building credit. The combined 3%/2%
+  cap is only $2,500 per quarter, so it is a starter card, not a long-term
+  earner. Carry no balance, since the 27.49% APR is steep, and aim to graduate
+  to an unsecured Bank of America card once your credit is established.

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -44,3 +44,10 @@ apr:
     min: 17.49
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/cash-back-credit-card/
+our_take: >
+  This is a flexible no-fee category card: 3% in one category you pick (gas, online shopping,
+  dining, travel, drugstores, or home improvement) plus 2% at groceries and warehouse clubs,
+  though both share a $2,500 quarterly cap before dropping to 1%. The real upside is for Bank
+  of America customers, since Preferred Rewards members can boost those rates by 25% to 75%.
+  Without that relationship, a flat 2% card like Citi Double Cash or an automatic 5% card like
+  Citi Custom Cash is often simpler.

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -54,3 +54,10 @@ apr:
     min: 19.49
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/premium-rewards-elite-credit-card/
+our_take: >
+  The Premium Rewards Elite leans on credits rather than earn rates: a $300
+  airline incidental credit plus a $150 lifestyle credit roughly cancel the $550
+  fee before you count Priority Pass and the Global Entry credit. The catch is the
+  flat 2x travel/dining and 1.5x everything-else rates are modest for the price, so
+  it mostly pays off if you reliably use the credits; otherwise the Venture X earns
+  comparable rates for $395.

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -41,3 +41,11 @@ apr:
     min: 19.49
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/premium-rewards-credit-card/
+our_take: >
+  A solid flat-rate travel card: 2x on travel and dining, 1.5x everywhere else,
+  plus $100 in airline incidentals and a Global Entry credit against a $95 fee.
+  Its real edge shows for Bank of America customers, where Preferred Rewards
+  status can lift earn rates by 25 to 75 percent and turn the base 1.5x into a
+  genuinely strong everyday rate. Without that relationship, the Citi Strata
+  Premier earns 3x across more categories for the same fee, so non-BofA
+  customers should compare carefully.

--- a/data/cards/bank-of-america-travel-rewards.yaml
+++ b/data/cards/bank-of-america-travel-rewards.yaml
@@ -27,3 +27,9 @@ apr:
     min: 17.49
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/travel-rewards-credit-card/
+our_take: >
+  A simple no-annual-fee travel card: a flat 1.5x on everything, no foreign transaction
+  fees, and a 25,000-point bonus worth $250 toward travel after $1,000 of spend. It earns
+  its keep for Bank of America Preferred Rewards members, whose relationship bonus can push
+  that 1.5x meaningfully higher. Outside that, flat 2% cards like Wells Fargo Active Cash
+  return more on everyday spend, so this one makes the most sense if you already bank with BofA.

--- a/data/cards/bank-of-america-unlimited-cash-rewards.yaml
+++ b/data/cards/bank-of-america-unlimited-cash-rewards.yaml
@@ -29,3 +29,9 @@ apr:
     min: 17.49
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/unlimited-cash-back-credit-card/
+our_take: >
+  A simple no-fee flat-rate card: 1.5% on everything, a $200 bonus after $1,000 of spend,
+  and 0% intro APR for 15 months on purchases and balance transfers. The 1.5% base lags
+  true 2% cards like Wells Fargo Active Cash, so this only pulls ahead if you are a Bank of
+  America customer who qualifies for Preferred Rewards, which can lift the rate to 1.87% or
+  more. Outside that relationship, a 2% card earns you more for the same zero fee.

--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -18,3 +18,9 @@ apr:
     min: 14.49
     max: 24.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/bankamericard-credit-card/
+our_take: >
+  A straight 0% intro APR play: 21 months on both purchases and balance transfers with no
+  annual fee, one of the longer runways out there and among the stronger no-fee options for
+  carrying a balance. It earns no rewards, so treat it as a payoff tool, open it for the 0%
+  window, clear your balance, and don't expect a reason to keep using it afterward.
+

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -8,6 +8,13 @@ foreign_transaction_fee: false
 annual_fee: 0
 reward_type: "points"
 release_date: "2025-01-15"
+our_take: >
+  Bilt Blue is the no-fee entry point to the Bilt ecosystem: its draw is paying
+  rent by card with no transaction fee, plus 4% Bilt Cash on everyday purchases.
+  Outside of rent and the limited Bilt Dining network the base earn is only 1x,
+  so it makes the most sense for renters who want rewards on their biggest
+  monthly bill. If you spend heavily elsewhere, pair it with a stronger everyday
+  card.
 benefits:
   - name: "Rent Payment Without Fees"
     value: 0

--- a/data/cards/bilt-mastercard.yaml
+++ b/data/cards/bilt-mastercard.yaml
@@ -8,3 +8,8 @@ category: "rewards"
 annual_fee: 0
 reward_type: "points"
 release_date: "2022-06-01"
+our_take: >
+  This original Wells Fargo version of the Bilt Mastercard is no longer open to new
+  applicants and has been succeeded by a newer lineup. If you are looking at Bilt for
+  earning points on rent with no annual fee, check the current card rather than this
+  retired version.

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -8,6 +8,13 @@ foreign_transaction_fee: false
 annual_fee: 95
 reward_type: "points"
 release_date: "2025-01-15"
+our_take: >
+  This is the paid Bilt tier, justified mainly if you pay rent by card and value
+  flexible Bilt points: you get fee-free rent payments, a choice of 3x dining or
+  groceries, 2x travel, and a $100 annual hotel credit that nearly covers the $95
+  fee. The free Bilt Mastercard already does fee-free rent, so the upgrade only
+  pays off if you actually spend in the bonus categories and use the hotel credit.
+  Outside of rent and the chosen 3x category, the earn rates are average.
 benefits:
   - name: "Rent Payment Without Fees"
     value: 0

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -5,6 +5,14 @@ image: "bilt_palladium.png"
 accepting_applications: true
 apply_link: https://www.biltrewards.com/card/apply
 foreign_transaction_fee: false
+our_take: >
+  Bilt's premium card exists for one reason: paying rent with no transaction fee
+  while still earning points, which no mainstream card does. At $495 it leans on
+  the $400 hotel credit, $200 Bilt Cash, and Priority Pass to offset the fee,
+  and the 4% Bilt Cash on everyday spend (separate from the 2x base points) is a
+  quirky extra. It is built for renters who pay a lot and will actually use the
+  travel credits and lounge access; if rent isn't a major expense, the $495 fee
+  is hard to justify.
 annual_fee: 495
 reward_type: "points"
 release_date: "2025-01-15"

--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -29,3 +29,9 @@ tags:
   - business
   - cashback
 apply_link: https://www.americanexpress.com/en-us/business/credit-cards/blue-business-cash
+our_take: >
+  A simple flat-rate business card: 2% back on everything up to $50,000 a year,
+  then 1%, with no annual fee and a 12-month 0% intro APR for early purchases.
+  It is a clean no-fuss option for a small business, but the cash-back cap and
+  drop to 1% afterward mean heavy spenders or anyone with concentrated
+  categories will earn more from Chase's Ink lineup.

--- a/data/cards/blue-business-plus-credit-card-from-american-express.yaml
+++ b/data/cards/blue-business-plus-credit-card-from-american-express.yaml
@@ -29,3 +29,10 @@ tags:
   - business
   - rewards
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/american-express-blue-business-plus-credit-card-amex/
+our_take: >
+  The simplest business card worth holding: 2x Membership Rewards on everything
+  up to $50k a year, no annual fee, plus 12 months of 0% intro purchase APR.
+  That flat 2x with transferable points beats most no-fee business cards for
+  everyday and uncategorized spend. If your spending clusters in specific
+  categories or you can use the credits, the Business Gold earns more, but it
+  carries a $375 fee this card avoids entirely.

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -6,6 +6,11 @@ accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/blue-cash-everyday/
 foreign_transaction_fee: true
 card_referral_link: "https://americanexpress.com/en-us/referral/blue-cash-everyday-credit-card?ref="
+our_take: >
+  A solid no-fee everyday card earning 3% at U.S. supermarkets, gas, and online retail, each
+  capped at $6,000 a year. If your grocery spend is high, the $95 Blue Cash Preferred earns 6%
+  and usually pays for itself, so run the math before defaulting to this one. Note the foreign
+  transaction fee, which makes it a poor pick for travel abroad.
 annual_fee: 0
 reward_type: "cashback"
 tags:

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -5,6 +5,13 @@ image: "amex_blue_cash_preferred.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/blue-cash-preferred/
 foreign_transaction_fee: true
+our_take: >
+  One of the strongest grocery cards going: 6% back at U.S. supermarkets on the
+  first $6,000 a year, plus 6% on select streaming and 3% on gas and transit.
+  If you spend the full grocery cap that is $360 back, easily clearing the $95
+  fee, and a Disney Bundle credit can offset the rest. The tradeoff is the
+  annual fee and a foreign transaction fee, so budget shoppers who stay under
+  the cap or travel abroad may prefer the no-fee Blue Cash Everyday at 3%.
 annual_fee: 95
 reward_type: "cashback"
 rewards:

--- a/data/cards/blue-from-american-express.yaml
+++ b/data/cards/blue-from-american-express.yaml
@@ -4,3 +4,7 @@ slug: "blue-from-american-express"
 accepting_applications: false
 annual_fee: 0
 reward_type: "points"
+our_take: >
+  Blue from American Express is a legacy no-annual-fee card that is no longer
+  open to new applicants. There is nothing to apply for here; if you want a
+  current no-fee Amex, shop the active Membership Rewards or cash-back lineup.

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -64,4 +64,11 @@ benefits:
     description: "Coverage for eligible new purchases against damage or theft up to $500 per item for 120 days from purchase date"
     category: "protection"
     enrollment_required: false
+our_take: >
+  This is a card for people who actually fly British Airways and its partners, earning 3x
+  Avios on those tickets plus a 75,000-mile bonus for a $95 annual fee with no foreign
+  transaction fees. The standout perk is the Travel Together Ticket after $30,000 of annual
+  spend, which is only worthwhile if you can hit that and have a partner to fly with. It is
+  effectively the same card as the Aer Lingus and Iberia Visas, so pick whichever loyalty
+  program you actually use, and skip it if you do not regularly fly the British Airways group.
 apply_link: https://creditcards.chase.com/travel-credit-cards/british-airways

--- a/data/cards/capital-one-platinum-secured.yaml
+++ b/data/cards/capital-one-platinum-secured.yaml
@@ -13,3 +13,9 @@ apr:
     min: 28.99
     max: 28.99
 apply_link: https://www.capitalone.com/credit-cards/platinum-secured/
+our_take: >
+  A solid no-frills credit builder: no annual fee, reports to all three bureaus, and one of
+  the more accessible secured cards for fair or thin credit. The tradeoffs are no rewards
+  and a high 28.99% APR, so pay in full every month and use it purely to build history. Once
+  your score firms up, graduate to a card that actually earns.
+

--- a/data/cards/capital-one-platinum.yaml
+++ b/data/cards/capital-one-platinum.yaml
@@ -12,3 +12,9 @@ apr:
     min: 28.99
     max: 28.99
 apply_link: https://www.capitalone.com/credit-cards/platinum/
+our_take: >
+  A bare-bones credit builder: no annual fee, no rewards, and a flat 28.99% APR, aimed at
+  people with fair or limited credit who want a path to a real Capital One card. It does the
+  job of establishing history with no cost to carry, but if you can swing a small deposit,
+  Capital One's secured Quicksilver earns 1.5% cash back for the same $0 fee. Use this to
+  build, then graduate as soon as you qualify for something that pays you back.

--- a/data/cards/capital-one-quicksilver-secured.yaml
+++ b/data/cards/capital-one-quicksilver-secured.yaml
@@ -24,3 +24,10 @@ apr:
     min: 26.49
     max: 26.49
 apply_link: https://www.capitalone.com/credit-cards/quicksilver-secured/
+our_take: >
+  One of the stronger secured cards because it actually earns: a flat 1.5% on
+  everything plus 5% on hotels and rental cars booked through Capital One Travel, with
+  no annual fee and a path to graduate to an unsecured card. Most secured cards earn
+  nothing, so if you can fund the deposit this is a better credit-builder than a
+  rewardless option like the Citi or U.S. Bank secured cards. The 26.49% APR means you
+  still want to pay in full each month.

--- a/data/cards/capital-one-quicksilver.yaml
+++ b/data/cards/capital-one-quicksilver.yaml
@@ -32,6 +32,13 @@ apr:
     min: 18.49
     max: 28.49
 apply_link: https://www.capitalone.com/credit-cards/quicksilver/
+our_take: >
+  The Quicksilver is a simple no-fee flat-rate card: 1.5% on everything, a $200
+  bonus after $500 of spend, and 15 months of 0% intro APR on purchases and
+  balance transfers. It is solid for hands-off spenders, but for the same $0 fee
+  the Wells Fargo Active Cash and Citi Double Cash both earn a flat 2%, so the
+  main reasons to pick this one are the long 0% window or wanting to stay in the
+  Capital One ecosystem.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-quicksilverone.yaml
+++ b/data/cards/capital-one-quicksilverone.yaml
@@ -19,3 +19,10 @@ apr:
     min: 28.99
     max: 28.99
 apply_link: https://www.capitalone.com/credit-cards/quicksilverone/
+our_take: >
+  This is the credit-building version of the Quicksilver, aimed at fair credit:
+  flat 1.5% back on everything, with a $39 annual fee and a steep 28.99% APR. If
+  your credit qualifies for the regular Quicksilver, take that instead, since it
+  earns the same 1.5% with no annual fee. Use this to establish history and pay in
+  full every month, because that APR makes carrying a balance expensive, then
+  graduate to a no-fee card once your score improves.

--- a/data/cards/capital-one-savor-student.yaml
+++ b/data/cards/capital-one-savor-student.yaml
@@ -41,6 +41,12 @@ apr:
     max: 28.49
 apply_link: https://www.capitalone.com/credit-cards/savor-student/
 foreign_transaction_fee: false
+our_take: >
+  One of the stronger student cards: 3% on dining, groceries, entertainment, and
+  streaming with no annual fee and no foreign transaction fees, matching the
+  regular Savor's earn rates while you build credit. The catch is the high APR,
+  so treat it as a rewards card you pay off in full, not one to carry a balance
+  on.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -48,6 +48,14 @@ apr:
     max: 28.49
 apply_link: https://www.capitalone.com/credit-cards/savor/
 foreign_transaction_fee: false
+our_take: >
+  The Savor is a strong no-fee dining and entertainment card: 3% on dining,
+  groceries, entertainment, and streaming, plus 8% on Capital One Entertainment
+  bookings, with a $250 bonus after just $500 of spend. It covers more 3%
+  categories than most no-annual-fee cards and skips the foreign transaction
+  fee, which the older SavorOne (now carrying a small fee) doesn't beat. The
+  catch is the flat 1% outside those categories, so pair it with a 2% flat-rate
+  card for everything else.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-savorone.yaml
+++ b/data/cards/capital-one-savorone.yaml
@@ -39,3 +39,10 @@ apr:
     min: 18.49
     max: 28.49
 apply_link: https://www.capitalone.com/credit-cards/savorone/
+our_take: >
+  A solid dining-and-everyday earner: 3% on dining, entertainment, streaming,
+  and groceries with no caps, and it ranks among the better dining and grocery
+  cards. The problem is the $39 annual fee, because the newer no-fee Savor earns
+  the same 3% in those categories (and 8% on Capital One Entertainment), so
+  there is little reason to pay for this version. Pick the no-fee Savor instead
+  unless you specifically already hold this one.

--- a/data/cards/capital-one-venture-business.yaml
+++ b/data/cards/capital-one-venture-business.yaml
@@ -55,3 +55,9 @@ benefits:
     enrollment_required: false
 apply_link: https://www.capitalone.com/small-business/credit-cards/venture-business/
 foreign_transaction_fee: false
+our_take: >
+  A simple business travel card: a flat 2x miles on everything, 5x on hotels and cars booked
+  through Capital One Business Travel, no foreign transaction fee, and free employee cards for
+  a modest $95. The headline 150,000-mile bonus is large but tiered and demands $37,500 of
+  spend over six months, so it is aimed at higher-volume businesses. If you want richer travel
+  perks and lounge access, Capital One's own Venture X is worth comparing.

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -46,3 +46,11 @@ apr:
     max: 28.49
 apply_link: https://www.capitalone.com/credit-cards/venture/
 foreign_transaction_fee: false
+our_take: >
+  The Venture's pitch is simplicity: a flat 2x miles on everything, no foreign
+  transaction fee, and miles you can transfer to airline and hotel partners or
+  wipe against any travel purchase. The 75,000-mile bonus plus a $250 travel
+  credit makes the first year easy to justify against the $95 fee. The honest
+  comparison is one tier up: for $300 more the Venture X adds lounge access and
+  a $300 travel credit that more than covers its fee, so heavier travelers
+  often find it the better value.

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -85,3 +85,10 @@ apr:
     max: 28.49
 apply_link: https://www.capitalone.com/credit-cards/venture-x/
 foreign_transaction_fee: false
+our_take: >
+  The Venture X is the value pick among premium travel cards: the $300 annual
+  travel credit plus 10,000 anniversary miles effectively erase the $395 fee, and
+  you still get Priority Pass and Capital One Lounge access. The flat 2x on
+  everything (10x and 5x in the portal) keeps it simple, and it stands among the
+  stronger premium travel options without the $795 Sapphire Reserve sticker. The
+  main tradeoff is that the best rates require booking through Capital One Travel.

--- a/data/cards/capital-one-ventureone-rewards.yaml
+++ b/data/cards/capital-one-ventureone-rewards.yaml
@@ -30,6 +30,12 @@ apr:
     max: 28.49
 apply_link: https://www.capitalone.com/credit-cards/ventureone/
 foreign_transaction_fee: false
+our_take: >
+  The VentureOne is the no-fee, lighter version of Capital One's travel lineup: 1.25x miles
+  on everything, 5x through Capital One Travel, no foreign transaction fees, and a small
+  20,000-mile bonus after just $500 of spend. It is a reasonable entry point into
+  transferable Capital One miles, but the earn rate is thin. If you spend enough to justify
+  $95, the regular Venture's flat 2x and larger bonus pull well ahead.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/cash-magnet-card.yaml
+++ b/data/cards/cash-magnet-card.yaml
@@ -11,3 +11,8 @@ rewards:
     unit: "percent"
     note: "1.5% unlimited cash back on all eligible purchases"
 apply_link: https://www.americanexpress.com/us/credit-cards/card/cash-magnet/
+our_take: >
+  Amex's plain flat-rate cash-back card, 1.5% on everything with no annual fee, but it is no
+  longer open to new applicants. Even when it was, the 1.5% rate trailed true 2% cards like
+  Wells Fargo Active Cash, leaving little reason to choose it. If you hold one, it is a fine
+  Membership Rewards-adjacent backup, but new shoppers should look at a 2% flat card instead.

--- a/data/cards/chase-aeroplan.yaml
+++ b/data/cards/chase-aeroplan.yaml
@@ -71,3 +71,11 @@ tags:
   - rewards
 apply_link: https://creditcards.chase.com/travel-credit-cards/aircanada/aeroplan
 foreign_transaction_fee: false
+our_take: >
+  The best fit if you fly Air Canada or value Aeroplan as a flexible award currency: $95 a
+  year buys a free first checked bag, two years of Aeroplan 25K status, no foreign
+  transaction fees, and 3x on dining, groceries, and Air Canada. Because Chase Ultimate
+  Rewards transfer in (with a 10% bonus on large transfers), existing Chase points holders
+  get more from it than from a typical single-airline card. Skip it if you never touch
+  Aeroplan.
+

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -53,6 +53,14 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/flex
 foreign_transaction_fee: true
+our_take: >
+  The Freedom Flex is one of the strongest no-fee cash-back cards going: 5% on
+  rotating quarterly categories (up to $1,500/quarter), a permanent 5% on Chase
+  Travel, 3% on dining and drugstores, plus a $200 bonus and 15 months of 0%
+  intro APR. The catches are activating the rotating categories each quarter and
+  a foreign transaction fee that makes it a poor choice abroad. It shines most
+  when paired with a Chase Sapphire so the points convert to transferable Ultimate
+  Rewards; approvals here skew toward solid credit.
 benefits:
   - name: "Cell Phone Protection"
     value: 1000

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -15,6 +15,12 @@ apr:
     min: 25.24
     max: 25.24
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/rise
+our_take: >
+  An entry-level card for people new to credit: a flat 1.5% back, no annual fee, and a
+  $25 credit for setting up autopay. Approvals here skew young and approachable (low
+  income and short credit history get in), so it works well as a first Chase card and a
+  foot in the door to better Freedom and Sapphire products later. Once your credit is
+  established, a 2% flat card like Wells Fargo Active Cash earns more.
 benefits:
   - name: "DashPass Complimentary Membership"
     value: 0

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -38,6 +38,13 @@ apr:
     min: 18.24
     max: 27.74
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/unlimited
+our_take: >
+  One of the strongest no-fee cash-back cards going: a flat 1.5% floor plus 3% on
+  dining and drugstores and 5% on Chase travel, with a 15-month 0% intro APR on
+  purchases and balance transfers. It really shines paired with a Chase Sapphire
+  card, since the cash back converts to transferable Ultimate Rewards points.
+  Approvals here skew toward solid credit (median score in the mid-740s), so it
+  is better suited to established borrowers than thin files.
 benefits:
   - name: "DashPass Complimentary Membership"
     description: "6 months of complimentary DashPass membership with $0 delivery fees on eligible orders."

--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -62,3 +62,11 @@ apr:
     max: 29.99
 apply_link: https://creditcards.chase.com/business-credit-cards/IHG/business-premier
 foreign_transaction_fee: false
+our_take: >
+  At $99 this business card punches above its fee: an anniversary free night
+  (up to 40,000 points, toppable), automatic Platinum Elite status, the 4th
+  reward night free, and up to 26x at IHG hotels. It mirrors the personal IHG
+  Premier closely, so choose it mainly if you want the spend on a business
+  account, and the free night alone usually covers the fee for anyone who stays
+  at IHG even occasionally. The large tiered intro bonus is generous but needs
+  $9,000 of spend over six months, so size it to your real business volume.

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -61,3 +61,9 @@ apr:
     min: 16.74
     max: 24.74
 apply_link: https://creditcards.chase.com/business-credit-cards/ink/cash
+our_take: >
+  A no-fee business card with a standout 5% back on office supplies, internet,
+  cable, and phone services up to $25,000 a year, plus a large $1,000 bonus
+  after $8,000 in spend. It shines for businesses with real spend in those bonus
+  categories, but the combined caps and plain 1% on everything else mean you
+  will want a flat-rate card to pair with it for general purchases.

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -35,6 +35,14 @@ apr:
   regular:
     min: 19.49
     max: 29.99
+our_take: >
+  One of the best business cards for the money: a 100k-point signup bonus (among
+  the strongest on the market) plus 3x on travel, shipping, internet/phone, and
+  digital advertising up to $150k a year, all for a $95 fee with no foreign
+  transaction fees. The cell phone protection (up to $1,000 per claim) and
+  primary rental coverage are real perks for a card this cheap. The 3x bonus
+  categories are capped, but they line up well with how most small businesses
+  actually spend.
 benefits:
   - name: "Cell Phone Protection"
     value: 0

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -29,4 +29,10 @@ apr:
   regular:
     min: 16.74
     max: 24.74
+our_take: >
+  The no-fee workhorse of Chase's business lineup: a flat 1.5% on everything, a strong $1,000
+  bonus after $8,000 of spend, and 12 months of 0% intro APR. Its real value shows when paired
+  with a points-earning Chase card like Ink Business Preferred, since you can convert the
+  cash back into transferable Ultimate Rewards. On its own it is a flat-rate card, so a
+  category-heavy spender may earn more with Ink Business Cash.
 apply_link: https://creditcards.chase.com/business-credit-cards/ink/unlimited

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -61,3 +61,11 @@ apr:
     max: 27.49
 apply_link: https://creditcards.chase.com/rewards-credit-cards/sapphire/preferred
 foreign_transaction_fee: false
+our_take: >
+  Still the default first travel card for good reason: 3x on dining, 5x on
+  travel booked through Chase, no foreign transaction fee, and access to
+  transfer partners that can stretch points well past their cash value, all for
+  a $95 fee. The 100,000-point sign-up bonus is among the more generous on the
+  market right now. Approvals tend to want solid credit, so it suits people
+  with established history; if you want lounge access and a bigger travel
+  credit, the Reserve is the step up.

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -119,3 +119,11 @@ apr:
     max: 27.99
 apply_link: https://creditcards.chase.com/rewards-credit-cards/sapphire/reserve
 foreign_transaction_fee: false
+our_take: >
+  Chase pushed the Reserve to a $795 fee and rebuilt it around a stack of credits
+  (travel, The Edit, dining, DoorDash, Lyft, Apple, Peloton) plus 8x in the Chase
+  travel portal and 4x on direct flights and hotels. The math works only if you
+  actually use those enrollment-gated credits and value Ultimate Rewards transfers,
+  and approvals skew toward strong credit. If you want premium travel perks without
+  the chore of activating credits, the Venture X delivers most of the value for
+  $395.

--- a/data/cards/chase-slate-edge.yaml
+++ b/data/cards/chase-slate-edge.yaml
@@ -15,6 +15,12 @@ apr:
     min: 22.49
     max: 31.24
 apply_link: https://creditcards.chase.com/credit-building-credit-cards/edge
+our_take: >
+  The Slate Edge is a balance-transfer card first: 21 months of 0% intro APR with no annual
+  fee, and a built-in incentive to lower your rate over time if you pay on time and spend a
+  set amount each year. It earns no rewards, so open it to pay down a balance and don't
+  expect a reason to keep using it after. It is one of the stronger no-fee 0% options, though
+  cards like the Wells Fargo Reflect match the long intro window.
 benefits:
   - name: "Complimentary DashPass"
     value: 0

--- a/data/cards/chase-united-presidential-plus.yaml
+++ b/data/cards/chase-united-presidential-plus.yaml
@@ -9,3 +9,9 @@ reward_type: "miles"
 tags:
   - airline
   - travel
+our_take: >
+  A legacy United co-brand that is no longer open to new applicants, carrying a steep $495
+  annual fee from an era before today's tiered United lineup. If you still hold it, compare
+  the perks you actually use against the current cards: the United Quest ($350) and Club
+  Infinite ($695) cover most of the same ground with clearer, published benefits. There is
+  no way to apply now, so this is a hold-or-product-change decision, not a new-card pick.

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -80,3 +80,10 @@ apr:
     max: 29.49
 apply_link: https://www.citi.com/usc/lpaca/aa/aadvantage/exec/ps/index0.html
 foreign_transaction_fee: false
+our_take: >
+  A frequent American Airlines flyer's card whose math only works if you use Admirals Club
+  lounges, since full membership for you and authorized users is the perk that justifies the
+  $595 fee. You also get a free first checked bag, 4x on AA purchases, and Lyft, Grubhub, and
+  car-rental credits that offset part of the cost. Rarely fly American or won't use the
+  lounges? A cheaper AA card makes more sense.
+

--- a/data/cards/citi-aadvantage-globe.yaml
+++ b/data/cards/citi-aadvantage-globe.yaml
@@ -93,3 +93,12 @@ apr:
     max: 29.49
 apply_link: https://www.citi.com/credit-cards/citi-aadvantage-globe-mastercard
 foreign_transaction_fee: false
+our_take: >
+  The Globe sits above the $99 Platinum Select in Citi's AAdvantage lineup,
+  justifying its $350 fee with Admirals Club Globe passes, a stack of annual
+  credits (Turo, inflight, splurge, Global Entry), and a 90,000-mile signup
+  bonus. It is a credible mid-tier option for frequent American flyers who will
+  use the lounge passes and credits, but if you want full Admirals Club access
+  the $595 Executive is the better fit, and lighter flyers are better served by
+  the cheaper Platinum Select. The credits require enrollment and effort, so the
+  value is real only if you actually redeem them.

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -60,3 +60,9 @@ apr:
     max: 29.49
 apply_link: https://www.citi.com/credit-cards/citi-aadvantage-platinum-select-world-elite-mastercard
 foreign_transaction_fee: false
+our_take: >
+  The workhorse American Airlines card: a free first checked bag and preferred boarding
+  that pay for the $99 fee (waived the first year) if even one person on your reservation
+  flies AA, plus a sizable 80,000-mile signup bonus. Earning is just 2x on AA, dining,
+  and gas, so it is a perks-and-bag card more than a spending card. Approvals lean toward
+  strong credit, so it suits established applicants who fly American a few times a year.

--- a/data/cards/citi-custom-cash.yaml
+++ b/data/cards/citi-custom-cash.yaml
@@ -50,3 +50,11 @@ apr:
     min: 17.49
     max: 27.49
 apply_link: https://www.citi.com/credit-cards/citi-custom-cash-credit-card
+our_take: >
+  A set-it-and-forget-it 5% card: it automatically pays 5% on your top eligible
+  category each cycle (dining, groceries, gas, and more) with no fee, which makes
+  it one of the better no-annual-fee cash-back picks for people with one dominant
+  spending category. The catch is the $500 monthly cap on that 5%, and everything
+  outside the top category earns just 1%, so pair it with a flat 2% card like the
+  Double Cash. Approvals lean toward good-to-strong credit (median score around
+  750), and note it is not currently accepting new applications.

--- a/data/cards/citi-diamond-preferred.yaml
+++ b/data/cards/citi-diamond-preferred.yaml
@@ -19,3 +19,10 @@ apr:
     max: 27.24
 apply_link: https://www.citi.com/credit-cards/citi-diamond-preferred-credit-card
 foreign_transaction_fee: true
+our_take: >
+  The Diamond Preferred is a pure debt-payoff card: 21 months of 0% intro APR on
+  balance transfers (12 on purchases) with no annual fee, and it sits among the
+  longer 0% runways available. It earns no rewards at all, so open it to clear a
+  balance, run your payoff plan, and don't expect a reason to keep using it
+  after the intro window closes. Note the foreign transaction fee, which makes
+  it a poor travel companion.

--- a/data/cards/citi-double-cash.yaml
+++ b/data/cards/citi-double-cash.yaml
@@ -30,3 +30,10 @@ apr:
     min: 17.49
     max: 27.49
 apply_link: https://www.citi.com/credit-cards/citi-double-cash-credit-card
+our_take: >
+  A longtime flat-rate favorite: effectively 2% on everything (1% when you buy,
+  1% when you pay) with no annual fee, and an 18-month 0% balance transfer
+  offer that makes it double as a payoff tool. It remains one of the stronger
+  no-fee cash-back picks, though approvals skew toward solid credit (median
+  score around 748), and pairing it with a Citi card that has bonus categories
+  unlocks more value via ThankYou point transfers.

--- a/data/cards/citi-prestige.yaml
+++ b/data/cards/citi-prestige.yaml
@@ -5,3 +5,9 @@ accepting_applications: false
 image: "citi-prestige.png"
 annual_fee: 495
 reward_type: "points"
+our_take: >
+  The Prestige is closed to new applicants, so this is mostly a record for
+  existing cardholders. It was Citi's $495 premium travel card, best known for
+  its 4th-night-free hotel benefit, but Citi has shifted its premium travel
+  focus to the Strata Premier and related lineup. If you do not already hold it,
+  there is nothing to apply for here.

--- a/data/cards/citi-rewards.yaml
+++ b/data/cards/citi-rewards.yaml
@@ -5,3 +5,7 @@ accepting_applications: false
 annual_fee: 0
 reward_type: "points"
 image: "citi-rewards-plus.png"
+our_take: >
+  Citi has closed the Rewards+ to new applicants, so this is reference only for existing
+  cardholders. It carried no annual fee and earned Citi ThankYou points. If you want a current
+  no-fee ThankYou earner, look at the Citi Custom Cash or Double Cash instead.

--- a/data/cards/citi-secured-mastercard.yaml
+++ b/data/cards/citi-secured-mastercard.yaml
@@ -12,3 +12,10 @@ apr:
     min: 26.74
     max: 26.74
 apply_link: https://www.citi.com/credit-cards/citi-secured-credit-card
+our_take: >
+  A no-frills credit builder: no annual fee, reports to all three bureaus, and a
+  clear path to establishing history from a refundable deposit. It earns no
+  rewards, so its only job is getting you approved and building score, and on
+  that it does the job. If you can qualify, the Discover it Secured covers the
+  same ground but adds 2% back on gas and dining, which makes it the better
+  starter card for most people.

--- a/data/cards/citi-simplicity-card.yaml
+++ b/data/cards/citi-simplicity-card.yaml
@@ -19,3 +19,9 @@ apr:
     max: 28.24
 apply_link: https://www.citi.com/credit-cards/citi-simplicity-credit-card
 foreign_transaction_fee: true
+our_take: >
+  The Simplicity is a debt-payoff card: 21 months of 0% intro APR on balance
+  transfers (12 on purchases) with no annual fee, and it is one of the stronger
+  picks for a long 0% runway. It earns no rewards and charges a foreign
+  transaction fee, so open it to clear a balance on a fixed plan, not to keep
+  spending on after the intro period ends.

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -83,3 +83,10 @@ apr:
     max: 29.24
 apply_link: https://www.citi.com/credit-cards/citi-strata-elite-credit-card
 foreign_transaction_fee: false
+our_take: >
+  Citi's run at the premium-travel tier, a $595 card stacked with credits (hotel, dining,
+  splurge, Blacklane), Priority Pass, and a strong 75,000-point bonus, and it ranks among
+  the better travel cards on our lists. The 1.5x base earn is soft for the price, so the math
+  only works if you reliably use the credits and value ThankYou transfer partners. Against
+  the $795 Sapphire Reserve and $395 Venture X, it lands in between: cheaper than Chase, more
+  credit-juggling than Capital One.

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -51,3 +51,10 @@ apr:
     max: 28.24
 apply_link: https://www.citi.com/credit-cards/citi-strata-premier-credit-card
 foreign_transaction_fee: false
+our_take: >
+  One of the better-value $95 travel cards thanks to unusually broad 3x earning: air, hotels,
+  dining, groceries, and gas all qualify, where rivals like the Sapphire Preferred reward a
+  narrower set. A $100 annual hotel credit plus transferable Citi ThankYou points make the
+  fee easy to justify for everyday spenders, not just travelers. Approvals skew toward solid
+  credit (median score around 759), so realistic but not a sure thing for thin files.
+

--- a/data/cards/citi-strata.yaml
+++ b/data/cards/citi-strata.yaml
@@ -51,3 +51,9 @@ apr:
     min: 18.49
     max: 28.49
 apply_link: https://www.citi.com/credit-cards/citi-strata-credit-card
+our_take: >
+  A strong no-annual-fee everyday earner: 3x on groceries, gas, transit, and a self-select
+  category, plus 2x dining and 5x on Citi Travel bookings. The 0% intro APR on purchases and
+  balance transfers for 15 months is a useful bonus on top. The catch is the points are most
+  valuable when paired with a transfer partner card like the Strata Premier, so on its own
+  treat it as a flexible fee-free earner rather than a premium travel card.

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -16,6 +16,16 @@ annual_fee_intro:
   months: 12
 foreign_transaction_fee: false
 reward_type: "miles"
+our_take: >
+  This is the business companion to Citi's consumer AAdvantage card: a $99 fee
+  (waived year one), 2x on American Airlines and on common business categories
+  like gas and telecom, plus a 65,000-mile bonus and the standard free checked
+  bag and preferred boarding. The standout perk is a companion certificate good
+  for up to two companions after $30,000 in annual spend, which can outweigh the
+  fee for owners who route real expenses through it. It is worth it mainly for
+  business owners loyal to American; everyone else gets more flexibility from a
+  general business rewards card. The few approvals on record skew toward strong
+  credit.
 tags:
   - travel
   - airline

--- a/data/cards/coinbase-one.yaml
+++ b/data/cards/coinbase-one.yaml
@@ -14,3 +14,9 @@ rewards:
     value: 2
     unit: percent
     note: "Up to 4% with higher crypto balances on Coinbase; requires Coinbase One membership"
+our_take: >
+  A flat-rate card aimed at crypto users: 2% back paid in your choice of crypto, scaling
+  up to 4% if you hold a large Coinbase balance and keep a Coinbase One membership. For
+  anyone not deep in the Coinbase ecosystem, a no-strings 2% cash card like Wells Fargo
+  Active Cash gives the same base rate without the membership requirement or crypto price
+  swings on your rewards.

--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -38,3 +38,11 @@ apr:
     max: 26.74
 apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-business-card
 foreign_transaction_fee: false
+our_take: >
+  Effectively free if you are already paying for a Costco membership (no separate
+  annual fee), and the gas rate is the draw: 4% on up to $7,000 a year in gas and
+  EV charging, plus 3% on dining and travel and no foreign transaction fees. The
+  rewards mirror the personal Costco Anywhere card, so it is best for business
+  owners who fuel up a lot and shop Costco. The big catches are that cash back
+  comes once a year as a certificate redeemable only at Costco, and you must keep
+  an active membership to hold the card.

--- a/data/cards/costco-anywhere-visa-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-card-by-citi.yaml
@@ -37,3 +37,10 @@ apr:
     max: 26.74
 apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-card
 foreign_transaction_fee: false
+our_take: >
+  This is the Costco member's default card: 4% on gas (up to $7,000 a year),
+  3% on dining and travel, and 2% inside Costco, all with no annual fee if you
+  already pay for membership. The catches are real: rewards arrive once a year
+  as a certificate redeemable only at Costco, and the 2% applies only to Costco
+  itself, not other warehouse clubs. If you don't shop Costco, a flat 2% card
+  like Active Cash pays out more flexibly and without the once-yearly lockup.

--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -5,6 +5,12 @@ image: "amex_delta_blue_skymiles.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-blue-american-express-card/
 foreign_transaction_fee: false
+our_take: >
+  The entry-level Delta card: no annual fee, 2x on Delta and dining, and no
+  foreign transaction fees, but it skips the checked bags, priority boarding,
+  and companion certificate that justify the paid Gold and Platinum versions.
+  Get it only if you fly Delta lightly and want to keep miles alive without a
+  fee; frequent flyers will earn far more value stepping up to Gold.
 annual_fee: 0
 reward_type: "miles"
 tags:

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -5,6 +5,14 @@ image: "amex_delta_skymiles_gold.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-gold-american-express-card/
 foreign_transaction_fee: false
+our_take: >
+  The entry Delta card for frequent flyers: a free first checked bag and Main
+  Cabin 1 priority boarding effectively pay the $150 fee if you fly Delta a few
+  times a year, and the current 90k-mile bonus is one of the better offers in
+  its tier (ends 2026-07-15). Earning is thin outside Delta, dining, and U.S.
+  supermarkets at 2x, with no foreign transaction fees. If you want lounge
+  access or a stronger elite head start, step up to the $350 Delta Platinum,
+  which carries a richer bonus and 3x on Delta and direct hotels.
 annual_fee: 150
 reward_type: "miles"
 benefits:

--- a/data/cards/delta-skymiles-gold-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-business-american-express-card.yaml
@@ -4,6 +4,12 @@ slug: "delta-skymiles-gold-business-american-express-card"
 image: "amex_delta_skymiles_gold_business.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-gold
+our_take: >
+  A reasonable entry-level Delta card for small businesses that fly Delta a few times a year:
+  the first checked bag free and Main Cabin 1 boarding can cover the $150 fee on their own, plus
+  2x on Delta, dining, and shipping. Earning is modest at 2x and 1x elsewhere, so it is about
+  the airline perks, not the points rate. The personal Delta Gold currently carries a larger
+  signup bonus, so compare the two if a business card is not essential.
 category: "business"
 annual_fee: 150
 reward_type: "miles"

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -5,6 +5,14 @@ image: "amex_delta_skymiles_platinum.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-platinum-american-express-card/
 foreign_transaction_fee: false
+our_take: >
+  This one earns its keep through perks, not its earn rates: the annual Main
+  Cabin companion certificate alone can offset most of the $350 fee, and you
+  also get a free first checked bag and a stack of monthly credits for
+  rideshare, dining, and Delta Stays. The 3x on Delta and 2x on dining and
+  groceries is fine but not the draw. It only makes sense if you fly Delta
+  regularly and will actually redeem the companion pass and credits, otherwise
+  the cheaper Delta Gold covers most casual flyers.
 annual_fee: 350
 reward_type: "miles"
 benefits:

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -7,6 +7,13 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-
 foreign_transaction_fee: false
 annual_fee: 650
 reward_type: "miles"
+our_take: >
+  The Reserve is for frequent Delta flyers who want Sky Club access, the
+  first-class companion certificate, and an MQD headstart toward Medallion status.
+  Earning is thin outside Delta (3x on Delta, 1x elsewhere), so the $650 fee only
+  makes sense if you use the Sky Clubs and the recurring Resy, Delta Stays, and
+  rideshare credits. If you fly Delta less often, the $350 Platinum covers most of
+  the same ground for far less.
 benefits:
   - name: "Delta Sky Club Access"
     value: 0

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -35,3 +35,9 @@ apr:
     max: 26.49
 apply_link: https://www.discover.com/credit-cards/cash-back/it-card.html
 foreign_transaction_fee: false
+our_take: >
+  One of the stronger no-fee cash-back cards: 5% on rotating quarterly categories up to
+  $1,500 in spend, 1% on everything else, no annual fee, and no foreign transaction fees.
+  The catch is that the 5% requires quarterly activation and is capped, so it works best
+  paired with a flat-rate card for the rest of your spend. Approvals in our data lean toward
+  solid credit, with a median score in the mid-700s.

--- a/data/cards/discover-it-for-students-card.yaml
+++ b/data/cards/discover-it-for-students-card.yaml
@@ -32,6 +32,13 @@ apr:
     max: 25.49
 apply_link: https://www.discover.com/credit-cards/student/it-card.html
 foreign_transaction_fee: false
+our_take: >
+  One of the stronger starter cards for students: 5% on rotating quarterly categories (up to
+  $1,500 in spend), 1% elsewhere, no annual fee, and no foreign transaction fees for study
+  abroad. The standout is Cashback Match, which doubles all your first-year rewards with no
+  cap, effectively making that first year 10% on bonus categories. Approvals here skew toward
+  students with limited history and modest income, so it is realistically attainable while
+  you build credit.
 benefits:
   - name: "Cashback Match"
     value: 0

--- a/data/cards/discover-it-gas-and-restaurants.yaml
+++ b/data/cards/discover-it-gas-and-restaurants.yaml
@@ -5,3 +5,8 @@ accepting_applications: false
 image: "discover-it-gas-restaurants.png"
 annual_fee: 0
 reward_type: "cashback"
+our_take: >
+  This card is no longer open to new applicants, so it is mainly a reference for existing
+  cardholders. If you want a no-fee Discover cash-back card today, the it Cash Back is the
+  one still accepting applications. Nothing to act on here unless you already hold it.
+

--- a/data/cards/discover-it-miles.yaml
+++ b/data/cards/discover-it-miles.yaml
@@ -24,3 +24,10 @@ apr:
     max: 26.49
 apply_link: https://www.discover.com/credit-cards/travel/
 foreign_transaction_fee: false
+our_take: >
+  Discover it Miles earns a flat 1.5x on everything with no annual fee and no
+  foreign transaction fee, and Discover's first-year match effectively doubles
+  your earnings the first year. Miles redeem at a fixed 1 cent each as a travel
+  credit or cash, so there are no transfer partners or premium travel perks here.
+  It is a clean, low-friction pick for someone who wants simple travel cash back,
+  though Discover's narrower merchant acceptance abroad is the main thing to weigh.

--- a/data/cards/discover-it-secured-credit-card.yaml
+++ b/data/cards/discover-it-secured-credit-card.yaml
@@ -28,3 +28,10 @@ apr:
     min: 26.49
     max: 26.49
 apply_link: https://www.discover.com/credit-cards/secured-credit-card/
+our_take: >
+  One of the best secured cards for building credit because it earns real rewards: 2% on
+  gas and dining (up to $1,000 combined per quarter) and 1% on everything else, with no
+  annual fee and automatic reviews to graduate to an unsecured line. Reported approvals
+  skew toward fair credit and are not guaranteed, so fund the deposit and keep balances
+  low against the 26.49% APR. It out-earns rewardless secured cards while still being a
+  genuine credit-builder.

--- a/data/cards/discover-it-student-chrome-card.yaml
+++ b/data/cards/discover-it-student-chrome-card.yaml
@@ -33,3 +33,11 @@ apr:
     max: 25.49
 apply_link: https://www.discover.com/credit-cards/student/chrome-card.html
 foreign_transaction_fee: false
+our_take: >
+  A starter card for students who want simple, capped rewards without tracking
+  rotating categories: 2% at gas and restaurants on up to $1,000 combined per
+  quarter, 1% elsewhere, no annual fee, and no foreign transaction fees. It also
+  brings an 18-month 0% intro APR on balance transfers, unusually long for a
+  student card. If you can handle quarterly activation, Discover's rotating 5%
+  student card earns more; this one trades that upside for set-and-forget
+  simplicity, making it a fine first card to build credit responsibly.

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -56,3 +56,11 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/inspire
 foreign_transaction_fee: false
+our_take: >
+  The Inspire is the top Disney card, with a $149 fee buying a $400 Disney eGift
+  card up front, 10% back on Disney+/Hulu/ESPN+, and 3% on Disney purchases.
+  But the earn rates are mediocre for a fee card (most spend lands at 1-2%), and
+  the $50 annual Disney credit plus streaming back barely covers the cost unless
+  you spend heavily in the Disney ecosystem. For most fans the $49 Disney
+  Premier or even the no-fee Disney Visa is the saner choice; reach for the
+  Inspire only if you are a frequent park-goer who values the extra perks.

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -70,5 +70,11 @@ benefits:
     description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false
+our_take: >
+  Built for Disney superfans: 5% back on Disney+, Hulu, and ESPN+, 2% on a
+  broad set of everyday categories, and a $300 welcome offer, with rewards
+  redeemable as Disney gift cards and in-park discounts. The $49 annual fee and
+  Disney-locked redemptions make it a poor everyday card, so it is worth it only
+  if you regularly spend at the parks or on Disney streaming.
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/premier
 

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -22,6 +22,13 @@ apr:
     max: 29.99
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/rewards
 foreign_transaction_fee: true
+our_take: >
+  This is a fan card, not a rewards card: a flat 1% in Disney Rewards Dollars is
+  weak next to no-fee cards earning 1.5% to 2% cash back you can spend anywhere.
+  It earns its keep through Disney perks and the $150 welcome offer if you are a
+  regular at the parks or store. Skip it as an everyday card, especially since it
+  charges foreign transaction fees, and reach for a flat-rate cash-back card
+  instead.
 benefits:
   - name: "DoorDash DashPass"
     value: 0

--- a/data/cards/expedia-rewards-card-from-citi.yaml
+++ b/data/cards/expedia-rewards-card-from-citi.yaml
@@ -5,3 +5,8 @@ accepting_applications: false
 image: "citi-expedia-rewards.png"
 annual_fee: 0
 reward_type: "points"
+our_take: >
+  This co-branded Expedia card is no longer open to new applicants, so it is here for reference
+  only. It had no annual fee and earned points toward Expedia travel. If you book through
+  Expedia today, a general travel card or a portal-flexible option like Citi Strata Premier
+  will be more useful.

--- a/data/cards/expedia-rewards-voyager-card-from-citi.yaml
+++ b/data/cards/expedia-rewards-voyager-card-from-citi.yaml
@@ -5,3 +5,8 @@ accepting_applications: false
 image: "citi-expedia-rewards-voyager.png"
 annual_fee: 0
 reward_type: "points"
+our_take: >
+  This Citi-issued Expedia co-brand is no longer open to new applicants, so
+  it is mainly a reference point rather than a card to chase. If you are an
+  existing holder, hang onto it only if you still get value from its Expedia
+  earning; otherwise current travelers are better served by an open card.

--- a/data/cards/fidelity-rewards-visa-signature.yaml
+++ b/data/cards/fidelity-rewards-visa-signature.yaml
@@ -33,6 +33,12 @@ apr:
 apply_link: https://www.fidelity.com/spend-save/visa-signature-card
 special_apply_link: https://www.fidelity.com/go/visa-signature-rewards-1502
 foreign_transaction_fee: false
+our_take: >
+  The Fidelity Rewards Visa is a clean 2% flat-rate card with no annual fee and no
+  foreign transaction fee, best suited to people who already use Fidelity since the
+  full 2% only lands when rewards are deposited into an eligible Fidelity account.
+  It is competitive with the Wells Fargo Active Cash and Citi Double Cash, and the
+  built-in retirement-funnel makes it a quiet way to auto-invest your cash back.
 benefits:
   - name: "Global Entry or TSA PreCheck Credit"
     value: 100

--- a/data/cards/gemini-credit.yaml
+++ b/data/cards/gemini-credit.yaml
@@ -29,3 +29,10 @@ apr:
     max: 34.99
 apply_link: https://www.gemini.com/credit-card
 foreign_transaction_fee: false
+our_take: >
+  The hook here is that rewards pay out in crypto, with 4% on gas (capped at $300/month),
+  3% dining, 2% groceries, and 1% on everything else, all with no annual fee or foreign
+  transaction fees. It makes sense if you actively use Gemini and want to accumulate crypto,
+  not dollars. As a plain cash-back card it is unremarkable, the high end of the APR runs up
+  to 34.99%, and the rewards' value rides on whatever coin you hold, so carry no balance and
+  treat the payout as speculative.

--- a/data/cards/graphite-business-cash-unlimited.yaml
+++ b/data/cards/graphite-business-cash-unlimited.yaml
@@ -8,6 +8,12 @@ category: "business"
 annual_fee: 295
 apply_link: "https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/graphite-business-cash-unlimited-card/"
 foreign_transaction_fee: false
+our_take: >
+  A flat 2% business card with no foreign transaction fees and 5% on Amex Travel bookings,
+  but the $295 annual fee is the sticking point. No-fee 2% business cards like Amex's own
+  Blue Business Cash and Wells Fargo Signify earn the same everyday rate for nothing, and the
+  $1,500 bonus here demands a hefty $50,000 in six months. This makes sense only for a
+  high-volume business that will use the travel rate and One AP credits enough to bury the fee.
 tags:
   - business
   - cashback

--- a/data/cards/hawaiian-airlines-business-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-business-mastercard.yaml
@@ -35,6 +35,13 @@ signup_bonus:
   type: "miles"
   spend_requirement: 4000
   timeframe_months: 3
+our_take: >
+  A niche business card for owners who fly Hawaiian or Alaska, now earning into the combined
+  Atmos Rewards program: 3x on those airlines, 2x on gas, dining, and office supplies, and a
+  50,000-mile sign-up bonus for $99 a year. The big annual spend bonuses (20k at $50k, 40k at
+  $100k) only pay off for heavy spenders. Unless those two airlines are central to your
+  travel, a flexible business rewards card will stretch further.
+
 apr:
   regular:
     min: 20.24

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -40,3 +40,11 @@ apr:
   regular:
     min: 20.24
     max: 29.99
+our_take: >
+  For a $99 fee this Barclays co-brand earns 3x on Hawaiian Airlines and a useful
+  2x on gas, dining, and groceries, which is broader everyday earning than most
+  airline cards offer. With the Alaska-Hawaiian merger, the value increasingly
+  hinges on how those miles convert, so treat it as a card for people flying
+  Hawaiian routes who want a few bonus categories alongside the airline loyalty.
+  The 50,000-mile bonus after $2,000 of spend is easy to hit; just don't expect
+  premium travel perks at this price.

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -5,6 +5,13 @@ image: "amex_hilton_honors_aspire.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors-aspire/
 foreign_transaction_fee: false
+our_take: >
+  The top Hilton card and a strong value if you stay with Hilton regularly: automatic
+  Diamond status, a free night each year, and 14x at Hilton properties, with up to $400
+  in resort credits, $200 in flight credits, and a CLEAR credit that together can cover
+  most of the $550 fee. If you do not put the credits and free night to use, step down to
+  the Surpass ($150) or the no-fee Hilton card, since the Aspire only pays off for
+  committed Hilton guests.
 annual_fee: 550
 reward_type: "points"
 rewards:

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -5,6 +5,14 @@ image: "amex_hilton_honors_surpass.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors-surpass/
 annual_fee: 150
+our_take: >
+  The middle Hilton card, and the sweet spot for regular Hilton guests: 12x at
+  Hilton properties, 6x on U.S. dining, groceries, and gas, automatic Gold status,
+  and up to $200 a year in Hilton credits that largely offset the $150 fee. The
+  no-fee Hilton Honors card earns less and lacks the credits, while the $550 Aspire
+  adds Diamond status and a far richer credit stack. Pick the Surpass if you stay
+  at Hilton a few times a year but cannot justify the Aspire's fee; the catch is
+  Hilton points are low-value, so the math works best for Hilton loyalists.
 reward_type: "points"
 rewards:
   - category: hotels

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -5,6 +5,13 @@ image: "amex_hilton_honors.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors/
 foreign_transaction_fee: false
+our_take: >
+  This is the no-fee entry into Hilton: 7x at Hilton properties, a solid 5x on
+  U.S. dining, groceries, and gas, and free Silver status, with no annual fee or
+  foreign transaction fee. It is the right pick for occasional Hilton guests who
+  want hotel points without committing to a fee. If you stay often, the $150
+  Surpass earns 12x at Hilton and adds Gold status with free breakfast, which
+  usually outweighs its fee for regulars.
 card_referral_link: "https://www.americanexpress.com/en-us/credit-cards/referral/prospect/hilton-honors/personal?ref="
 annual_fee: 0
 reward_type: "points"

--- a/data/cards/hotels-com-rewards-visa.yaml
+++ b/data/cards/hotels-com-rewards-visa.yaml
@@ -5,3 +5,8 @@ accepting_applications: false
 image: "wells-fargo-hotels-com.png"
 annual_fee: 0
 reward_type: null
+our_take: >
+  This Wells Fargo co-brand is closed to new applicants and is kept here for
+  reference only. If you want a travel card with no annual fee, the Wells Fargo
+  Autograph or a flexible points card like the Capital One Venture Rewards
+  gives you a real ongoing earn rate instead.

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -6,6 +6,13 @@ image: "iberia-plus.png"
 annual_fee: 95
 foreign_transaction_fee: false
 reward_type: "miles"
+our_take: >
+  A niche card for Avios collectors: 3x on Iberia, British Airways, and Aer
+  Lingus flights, a 75k-mile bonus, and no foreign transaction fees for a $95
+  fee. The signature draw is the companion voucher worth up to $1,000 after
+  $30,000 in annual spend, which is the main reason to keep it past year one. It
+  only makes sense if you fly the Iberia/BA/Aer Lingus network or value Avios;
+  otherwise a flexible travel card will serve you better.
 tags:
   - airline
   - travel

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -92,3 +92,9 @@ apr:
     max: 29.99
 apply_link: https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/premier
 foreign_transaction_fee: false
+our_take: >
+  For anyone who stays at IHG brands like Holiday Inn or Kimpton, this is an easy keeper: the
+  anniversary free night (up to 40,000 points, toppable with points) and the 4th-night-free
+  benefit on award stays usually outrun the $99 fee on a single trip. Automatic Platinum Elite
+  status and up to 26x at IHG round it out, and the large signup bonus is one of the better
+  hotel offers around. The catch is it only pays off if you actually stay at IHG properties.

--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -83,3 +83,11 @@ apr:
     max: 29.99
 apply_link: https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/traveler
 foreign_transaction_fee: false
+our_take: >
+  The no-fee IHG card for occasional guests: up to 17x at IHG hotels, the
+  fourth-reward-night-free perk, and no foreign transaction fee make it an easy
+  keeper if you stay at IHG even a few times a year. The gap to watch is the
+  $99 Premier, which earns up to 26x, throws in an annual free night and
+  automatic Platinum status, and usually pays for itself on a single stay. Pick
+  the Traveler only if you want to avoid any annual fee and don't stay often
+  enough to use a free night.

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -37,6 +37,13 @@ apr:
   regular:
     min: 19.49
     max: 29.49
+our_take: >
+  The JetBlue Business earns 6x on JetBlue and adds business-friendly 2x on dining
+  and office supplies, and the $99 fee is easy to justify if you fly JetBlue:
+  free first checked bag, 50% off inflight purchases, and a 5,000-point anniversary
+  bonus. The catch is the rewards are TrueBlue points, which are most valuable on
+  JetBlue itself, so this is a card for loyal JetBlue flyers rather than a
+  general business card.
 benefits:
   - name: "Anniversary Points Bonus"
     value: 5000

--- a/data/cards/jetblue-card.yaml
+++ b/data/cards/jetblue-card.yaml
@@ -39,6 +39,12 @@ apr:
   regular:
     min: 19.74
     max: 29.74
+our_take: >
+  The no-fee JetBlue card is for occasional JetBlue flyers: 3x on JetBlue, 2x on dining and
+  groceries, no foreign transaction fees, and 50% off inflight purchases. The small 10,000-point
+  bonus and modest earn rates keep it lightweight. If you fly JetBlue often, the $99 Plus card
+  earns 6x on JetBlue and carries a much larger 60,000-point bonus, so the fee pays off fast.
+  Get this one only if you want a JetBlue card with no annual cost.
 benefits:
   - name: "50% Off Inflight Purchases"
     value: 50

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -8,6 +8,12 @@ image: "barclays-jetblue-plus.png"
 annual_fee: 99
 foreign_transaction_fee: false
 reward_type: "points"
+our_take: >
+  For regular JetBlue flyers this is an easy pick and one of the stronger airline cards on
+  our list: 6x on JetBlue, a free first checked bag, and a 5,000-point anniversary bonus that
+  roughly offsets the $99 fee on its own. The free bag alone usually pays for the card if you
+  fly JetBlue even twice a year, and the no-fee JetBlue card skips both the bag and the 6x.
+  The catch is it is only worth carrying if JetBlue is genuinely your airline.
 tags:
   - travel
   - airline

--- a/data/cards/jetblue-premier-card.yaml
+++ b/data/cards/jetblue-premier-card.yaml
@@ -40,6 +40,12 @@ apr:
   regular:
     min: 19.49
     max: 29.49
+our_take: >
+  JetBlue's top-tier card at $499 a year, aimed at loyalists who will use the perks: 6x on
+  JetBlue, up to $300 in annual TrueBlue travel credits, BlueHouse lounge access, Priority
+  Pass, a free first bag, and a 15% award rebate. It earns the same 6x as the $99 JetBlue
+  Plus, so the $400 premium only pays off if you regularly tap the lounges, credits, and
+  Mosaic fast-track. Casual JetBlue flyers should drop down to the Plus.
 benefits:
   - name: "TrueBlue Travel Statement Credits"
     value: 300

--- a/data/cards/marriott-bonvoy-bevy-american-express.yaml
+++ b/data/cards/marriott-bonvoy-bevy-american-express.yaml
@@ -5,6 +5,14 @@ image: "marriott-bonvoy-bevy.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy-bevy/
 foreign_transaction_fee: false
+our_take: >
+  The Bevy slots between Marriott's $95 Boundless and $650 Brilliant, pairing a
+  $250 fee with Gold Elite status, 6x at Marriott, and an unusually strong 4x on
+  dining and U.S. supermarkets (up to $15,000/yr). Its weak spot is the annual
+  Free Night Award: you have to spend $15,000 in a year to earn it, where the
+  cheaper Boundless includes a renewal free night with no spend hurdle. Get the Bevy
+  for the high signup bonus and bonus categories if you put real everyday spend
+  on it; if the certificate is what you want, Boundless is the easier value.
 annual_fee: 250
 reward_type: "points"
 rewards:

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -60,3 +60,9 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/bold
 foreign_transaction_fee: false
+our_take: >
+  The no-fee entry into Marriott Bonvoy: automatic Silver Elite status, 5 elite night
+  credits a year, and 3x at Marriott, with no foreign transaction fees. It is a fine way
+  to hold Bonvoy status without paying for it, but the earn rates are thin and it gives no
+  annual free night. Occasional Marriott guests who want a yearly free night are usually
+  better off paying the $95 for the Boundless.

--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -84,3 +84,11 @@ apr:
     max: 27.49
 apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/boundless
 foreign_transaction_fee: false
+our_take: >
+  A solid mid-tier Marriott card whose value lives in the annual free night award
+  (up to 35,000 points), which can more than cover the $95 fee on a single stay,
+  plus 15 elite night credits and automatic Silver status. Day-to-day earning is
+  fine but not exciting: 6x at Marriott and 3x on grocery, gas, and dining up to a
+  combined $6,000 a year. If you want a higher free-night ceiling and lounge perks,
+  the pricier Bevy and Brilliant step up; the Boundless is the pick for occasional
+  Marriott stayers who just want one cheap free night a year.

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -5,6 +5,14 @@ image: "amex_marriott_bonvoy_brilliant.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy-brilliant/
 foreign_transaction_fee: false
+our_take: >
+  Marriott's premium card is a perk card, not an earn card: the $650 fee is
+  offset by $300 in annual dining credits, an 85,000-point free night, Platinum
+  Elite status, Priority Pass, and 25 elite night credits. It makes sense for
+  loyal Marriott guests who will use the free night and dining credit, since the
+  free night alone can cover most of the fee. If you don't need top-tier status,
+  the $250 Bevy delivers a similar free night and 6x at Marriott for far less,
+  so only step up to the Brilliant for the lounge access and elite benefits.
 annual_fee: 650
 reward_type: "points"
 rewards:

--- a/data/cards/navy-federal-cash-rewards-plus.yaml
+++ b/data/cards/navy-federal-cash-rewards-plus.yaml
@@ -7,6 +7,13 @@ image: "navy-federal-cash-rewards-plus.png"
 annual_fee: 0
 foreign_transaction_fee: false
 reward_type: "cashback"
+our_take: >
+  A clean flat-rate cash-back card for Navy Federal members: 2% on everything
+  (if approved at a $5,000+ limit, otherwise 1.5%), no annual fee, and no foreign
+  transaction fees, which makes it competitive with the best no-fee 2% cards.
+  The standout is Navy Federal's low APR (14.15% to 18% versus the high-20s
+  elsewhere) plus no balance transfer fees and a 1.99% intro BT rate. Membership
+  is required, but if you qualify it is one of the better everyday cards going.
 tags:
   - cashback
   - rewards

--- a/data/cards/navy-federal-cash-rewards-secured.yaml
+++ b/data/cards/navy-federal-cash-rewards-secured.yaml
@@ -28,4 +28,10 @@ benefits:
     description: "Rental car collision damage waiver coverage when the rental is paid with the card"
     category: "travel"
     enrollment_required: false
+our_take: >
+  A no-fee secured card for Navy Federal members rebuilding or establishing credit, with a
+  flat 1% back and a fixed 18% APR. The standout feature is the upgrade path: you can be
+  reviewed for the unsecured cashRewards card starting at six months and get your deposit back.
+  It earns less than some unsecured starter cards, but for a secured product the path off it
+  is the point. Membership in Navy Federal is required.
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards-secured.html

--- a/data/cards/navy-federal-cash-rewards.yaml
+++ b/data/cards/navy-federal-cash-rewards.yaml
@@ -37,4 +37,11 @@ benefits:
     description: "Rental car collision damage waiver coverage when the rental is paid with the card"
     category: "travel"
     enrollment_required: false
+our_take: >
+  A solid no-fee flat-rate card for Navy Federal members: 1.5% on everything (or
+  2% if your credit limit lands at $5,000 or more as the Plus version), with low
+  ongoing APRs and no foreign transaction or balance transfer fees. Membership
+  is limited to the military community, but for those who qualify the rock-bottom
+  rates and fee structure beat most mainstream cash-back cards, especially if you
+  occasionally carry a balance.
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards-alt.html

--- a/data/cards/navy-federal-flagship-rewards.yaml
+++ b/data/cards/navy-federal-flagship-rewards.yaml
@@ -6,6 +6,13 @@ category: "travel"
 image: "navy-federal-flagship-rewards.png"
 annual_fee: 49
 foreign_transaction_fee: false
+our_take: >
+  A standout for military members and their families: 3x on a broad travel
+  bucket, 2x on everything else, no foreign transaction fee, and a low APR
+  ceiling around 18% that beats most travel cards by a wide margin. The $49 fee
+  is among the cheapest in the premium-travel tier, and it adds a Global Entry
+  credit and no balance transfer fees. The only real gate is eligibility,
+  since you need a Navy Federal membership to apply.
 reward_type: "points"
 tags:
   - travel

--- a/data/cards/navy-federal-go-biz-rewards.yaml
+++ b/data/cards/navy-federal-go-biz-rewards.yaml
@@ -28,3 +28,9 @@ benefits:
     category: "insurance"
     enrollment_required: false
 apply_link: https://www.navyfederal.org/services/business/credit-cards.html
+our_take: >
+  The GO BIZ Rewards is a plain no-fee business card whose real draw is the APR:
+  a 16.65% to 18% range that runs well below most business cards, useful if a
+  balance ever lingers. Earning is just a flat 1x with no signup bonus, so the
+  rewards are an afterthought; get it for the cheap financing and free employee
+  cards, and only if you qualify for Navy Federal membership.

--- a/data/cards/navy-federal-go-rewards.yaml
+++ b/data/cards/navy-federal-go-rewards.yaml
@@ -37,3 +37,9 @@ benefits:
     category: "travel"
     enrollment_required: false
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/go-rewards.html
+our_take: >
+  A no-fee card for Navy Federal members built around dining (3x) and gas (2x), with no
+  foreign transaction fees and unusually low regular APRs topping out at 18%. That low rate
+  is the real selling point if you ever carry a balance. For pure earning, Navy Federal's own
+  More Rewards Amex pays 3x across dining, groceries, gas, and transit for the same $0 fee,
+  so reach for this one mainly for the rate or if you want a Mastercard.

--- a/data/cards/navy-federal-more-rewards-american-express.yaml
+++ b/data/cards/navy-federal-more-rewards-american-express.yaml
@@ -7,6 +7,13 @@ image: "navy-federal-more-rewards-american-express.png"
 annual_fee: 0
 foreign_transaction_fee: false
 reward_type: "points"
+our_take: >
+  A standout no-fee everyday card if you qualify for Navy Federal membership: 3x on dining,
+  groceries, gas, and transit, no foreign transaction fees, and no balance transfer fees,
+  which is rare. The catch is access, since you need a military, veteran, or family
+  connection to join. Within that group it covers the big spending categories at a flat 3x
+  with zero annual cost, which competing no-fee category cards struggle to match across all
+  four.
 tags:
   - rewards
   - dining

--- a/data/cards/navy-federal-platinum.yaml
+++ b/data/cards/navy-federal-platinum.yaml
@@ -29,3 +29,10 @@ benefits:
     category: "travel"
     enrollment_required: false
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/platinum-alt.html
+our_take: >
+  Built for paying down debt if you qualify for Navy Federal membership: no annual fee, no
+  balance transfer fees, and a standard APR as low as 10.24%, well under most issuers. The
+  intro transfer rate is 0.99% rather than a true 0%, so the BankAmericard gives a longer
+  interest-free window, but Navy Federal wins if you cannot clear the balance inside an intro
+  period. It earns no rewards, so treat it as a payoff tool, not a daily card.
+

--- a/data/cards/nhl-discover-it.yaml
+++ b/data/cards/nhl-discover-it.yaml
@@ -33,3 +33,11 @@ apr:
     min: 18.24
     max: 28.24
 apply_link: https://www.discover.com/credit-cards/cash-back/nhl-card.html
+our_take: >
+  This is the standard Discover it Cash Back in NHL team branding: same 5%
+  rotating quarterly categories (up to $1,500, activation required), 1% on
+  everything else, no annual fee, and Discover's first-year cashback match. The
+  hockey design and any team-tied perks are the only real difference from the
+  plain version, so choose it if you want the team look. As cash back goes it is
+  a strong no-fee option, just remember to activate each quarter and watch
+  Discover's narrower acceptance abroad.

--- a/data/cards/paypal-cashback-mastercard.yaml
+++ b/data/cards/paypal-cashback-mastercard.yaml
@@ -24,3 +24,9 @@ apr:
     max: 33.24
 apply_link: https://www.paypal.com/us/digital-wallet/manage-money/paypal-cashback-mastercard
 foreign_transaction_fee: true
+our_take: >
+  Worth it only if you check out with PayPal a lot: 3% back when you pay through PayPal
+  online or via in-store QR, dropping to 1.5% everywhere else, with no annual fee. Since
+  the 3% is gated to PayPal and the card charges foreign transaction fees, most people
+  are better served by a flat 2% card like Wells Fargo Active Cash that pays everywhere
+  without the PayPal requirement.

--- a/data/cards/playstation-visa.yaml
+++ b/data/cards/playstation-visa.yaml
@@ -38,6 +38,14 @@ apr:
   regular:
     min: 17.74
     max: 31.74
+our_take: >
+  A niche card for PlayStation diehards: 5x on PlayStation, PlayStation Direct,
+  and Sony Store purchases, plus 3x on streaming and 2x on dining, with no annual
+  fee. Points only redeem for PlayStation Store codes and gift cards, so the value
+  is locked into the Sony ecosystem and there is no flexibility if your habits
+  change. It also charges foreign transaction fees and tops out at a high 31.74%
+  APR, so treat it as a spend-and-redeem card for gaming, not a primary everyday
+  card.
 benefits:
   - name: "PlayStation Store redemptions"
     description: "Points redeemable for PlayStation Store codes and digital gift cards via the Account Center"

--- a/data/cards/pnc-cash-rewards.yaml
+++ b/data/cards/pnc-cash-rewards.yaml
@@ -48,3 +48,10 @@ apr:
     min: 18.49
     max: 28.49
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-cash-rewards-visa-credit-card.html
+our_take: >
+  The Cash Rewards offers 4% gas, 3% dining, and 2% groceries with no annual
+  fee, but those bonus rates share a single $8,000 annual cap and drop to 1%
+  after, which limits the payoff for heavier spenders. The $200 bonus after
+  $1,000 of spend is fine, and the 15-month 0% balance transfer intro is a
+  bonus. If your spending is more spread out, PNC's own Cash Unlimited (flat 2%
+  on everything, no caps) is the simpler pick.

--- a/data/cards/pnc-cash-unlimited.yaml
+++ b/data/cards/pnc-cash-unlimited.yaml
@@ -37,4 +37,10 @@ benefits:
     description: "24/7 concierge service for reservations, tickets, and travel arrangements"
     frequency: "ongoing"
     category: "other"
+our_take: >
+  A straightforward flat 2% on everything with no annual fee or foreign
+  transaction fees, plus a useful 15-month 0% balance transfer window and cell
+  phone protection. It earns the same as the better-known Wells Fargo Active
+  Cash and Fidelity 2% cards but skips a signup bonus, so it is a fine pick if
+  you bank with PNC and want simplicity rather than the best welcome offer.
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-cash-unlimited-visa-credit-card.html

--- a/data/cards/pnc-secured.yaml
+++ b/data/cards/pnc-secured.yaml
@@ -8,3 +8,9 @@ tags:
   - secured
   - credit_builder
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-secured-credit-card.html
+our_take: >
+  A no-frills credit builder: no annual fee and no rewards, just a secured line
+  to establish or rebuild credit. It does the basic job, but earning options
+  exist in this space, so a rewards-earning secured card like Bank of America's
+  Cash Rewards Secured gives you cash back while you build. Use it to graduate to
+  an unsecured card, then move on.

--- a/data/cards/pnc-spend-wise.yaml
+++ b/data/cards/pnc-spend-wise.yaml
@@ -42,4 +42,10 @@ benefits:
     description: "Up to $800 per claim ($50 deductible) for cell phone damage or theft when you pay your monthly bill with the card; 2 claims per 12 months"
     frequency: "ongoing"
     category: "telecom"
+our_take: >
+  A no-fee 0% intro card with 18 months on both purchases and balance transfers, useful if you
+  need to finance a purchase or pay down a balance. The twist is the APR reduction program,
+  which can lower your ongoing rate over time if you spend and pay on schedule, plus some
+  protection perks like cell phone and price coverage. It earns no rewards, though, and the
+  21-month no-interest cards from Wells Fargo Reflect or U.S. Bank Shield give a longer runway.
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-spend-wise-visa-credit-card.html

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -3,6 +3,13 @@ bank: "Barclays"
 slug: "princess-cruises-rewards-visa-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/banking/cards/princess-cruises-rewards-visa-card/
+our_take: >
+  A narrow co-brand: 2x points only on Princess Cruises purchases and 1x on
+  everything else, with no annual fee and a small 20,000-point bonus after just
+  $500 of spend. It makes sense only if you cruise with Princess regularly and
+  want to bank points toward future sailings. As an everyday card it is weak,
+  since a flat 2% cash-back card earns more on general spending without locking
+  you into one cruise line.
 category: "travel"
 image: "barclays-princess.png"
 annual_fee: 0

--- a/data/cards/rakuten-american-express.yaml
+++ b/data/cards/rakuten-american-express.yaml
@@ -42,3 +42,10 @@ apr:
   regular:
     min: 19.49
     max: 28.49
+our_take: >
+  This card is built for Rakuten loyalists: 4% on Rakuten.com (up to $7,000 a year)
+  and 5% on Rakuten Dining stack on top of the usual cash-back portal, with a $200
+  signup bonus and 15 months of 0% intro APR on purchases, all for no annual fee.
+  Off the Rakuten ecosystem the rates are ordinary (2% groceries and dining, 1% on
+  everything else), so a flat 2% card like the Active Cash will beat it for general
+  spending.

--- a/data/cards/rei-co-op-mastercard.yaml
+++ b/data/cards/rei-co-op-mastercard.yaml
@@ -18,6 +18,12 @@ rewards:
   - category: everything_else
     value: 1.5
     unit: percent
+our_take: >
+  This makes sense for REI regulars: 5% back at REI and a flat 1.5% on everything else, with
+  no annual fee and no foreign transaction fees. The rewards come as REI credit, so the value
+  is tied to spending it back at the co-op rather than as cash. If REI is not a meaningful part
+  of your budget, a plain 1.5% or 2% flat-rate card does the everyday spend just as well without
+  locking your rewards to one retailer.
 signup_bonus:
   value: 100
   type: cash

--- a/data/cards/robinhood-gold-card.yaml
+++ b/data/cards/robinhood-gold-card.yaml
@@ -39,3 +39,10 @@ apr:
     max: 29.99
 apply_link: https://robinhood.com/creditcard/
 foreign_transaction_fee: false
+our_take: >
+  The headline 3% flat cash back on everything is the best unlimited rate going, beating
+  standard 2% cards by a wide margin, with 5% on travel booked through Robinhood and no
+  foreign transaction fees. The real cost is the Robinhood Gold subscription you must keep to
+  hold the card, so factor that fee in: at moderate spend the 3% still wins, but it erodes the
+  edge for light spenders. Access has also been gated by waitlist, and the 29.99% APR means
+  this only pays off if you clear the balance every month.

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -105,3 +105,11 @@ rewards:
     unit: percent
 apply_link: https://robinhood.com/us/en/creditcard/platinum/
 foreign_transaction_fee: false
+our_take: >
+  Robinhood's $695 premium card leans on a long list of lifestyle credits (DoorDash, dining,
+  hotel and travel statement credits, plus health perks like One Medical and Oura) and
+  Priority Pass access, much of it routed through the Robinhood app. The earning is
+  credit-heavy, not rate-heavy: outside 5% dining and the 5% to 10% travel booked through
+  Robinhood's own portal, base spend earns just 1%. It only pays off if you live in the
+  Robinhood ecosystem and will actually use the credits.
+

--- a/data/cards/serve-from-american-express.yaml
+++ b/data/cards/serve-from-american-express.yaml
@@ -3,3 +3,9 @@ bank: "American Express"
 slug: "serve-from-american-express"
 accepting_applications: false
 annual_fee: 0
+our_take: >
+  Serve was American Express's no-annual-fee prepaid, reloadable account, not a
+  credit card, so there was no credit check, no rewards earning, and no line of
+  credit to build history with. It is no longer open to new applicants, so there
+  is nothing to apply for here. Anyone looking to build credit should choose a
+  secured card instead.

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -86,3 +86,10 @@ benefits:
     category: "groceries"
     enrollment_required: true
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/plus
+our_take: >
+  The cheapest way into the Southwest card lineup at $99, and it still delivers the parts
+  that matter to loyalists: 3,000 anniversary points, 10,000 Companion Pass qualifying
+  points each year, and no foreign transaction fees, on top of a large 80,000-point
+  signup bonus. Earning is modest at 2x on Southwest, gas, and groceries, so if you fly
+  Southwest often the Premier ($149) adds more anniversary points and tier credits for not
+  much more. Pick the Plus if you want Companion Pass help without the bigger fee.

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -81,3 +81,11 @@ tags:
   - travel
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/premier
 foreign_transaction_fee: false
+our_take: >
+  The mid-tier Southwest card, best for frequent flyers chasing the Companion Pass:
+  3x on Southwest, 6,000 anniversary points, a 10,000-point Companion Pass boost
+  each year, and no foreign transaction fees, all for a $149 fee. It sits between
+  the cheaper Plus ($99, lower perks) and the Priority ($229, which adds a $75
+  travel credit and 4x Southwest); the Premier is the value middle if you do not
+  fly enough to use the Priority's extras. Note there are no lounge or upgrade
+  benefits here, and the rewards are useful only if you actually fly Southwest.

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -89,3 +89,11 @@ tags:
   - rewards
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/priority
 foreign_transaction_fee: false
+our_take: >
+  The Priority is the top Southwest card, and at $229 the math works through its
+  credits: a $75 annual Southwest travel credit, 7,500 anniversary points, free
+  first checked bag, and a $120 Instacart credit, which together can roughly
+  wash the fee for regular Southwest flyers. The 10,000 annual Companion Pass
+  qualifying points are the real draw if you chase that pass. If you fly
+  Southwest only a few times a year, the $99 Plus or $149 Premier carries a
+  lower fee for largely the same earn structure.

--- a/data/cards/starbucks-rewards-visa-card.yaml
+++ b/data/cards/starbucks-rewards-visa-card.yaml
@@ -5,3 +5,8 @@ image: "chase-starbucks-rewards.png"
 accepting_applications: false
 annual_fee: 0
 reward_type: null
+our_take: >
+  This Chase Starbucks co-brand has been discontinued and is no longer open to
+  new applicants, so treat it as reference only. For everyday spending with no
+  annual fee, a flat-rate cash-back card like the Wells Fargo Active Cash or
+  Chase Freedom Unlimited is a far more useful pick.

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -131,3 +131,12 @@ tags:
   - premium
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/american-express-business-platinum-credit-card-amex/
 foreign_transaction_fee: false
+our_take: >
+  The most loaded business travel card there is: Centurion and Priority Pass
+  lounge access, 5x on Amex Travel flights and prepaid hotels, a 200k-point
+  bonus, and a stack of credits (Dell, Indeed, wireless, Adobe, CLEAR, hotels)
+  that can more than cover the $895 fee. The math only works if you actually use
+  those credits, since they are split across vendors and require enrollment;
+  ignore them and the fee is hard to swallow. Everyday non-travel earning is just
+  1x (2x on $5,000+ purchases), so pair it with a category card for the rest of
+  your spend.

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -6,6 +6,13 @@ accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/platinum/
 foreign_transaction_fee: false
 card_referral_link: "https://americanexpress.com/en-us/referral/platinum-card?ref="
+our_take: >
+  The Platinum is a luxury travel card built around perks, not spending: the best lounge access
+  in the market (Centurion plus Priority Pass), 5x on flights, and one of the largest signup
+  bonuses out there. The $895 fee is steep and only makes sense if you use the stack of
+  credits for airlines, hotels, streaming, Walmart+, Equinox, and more, which take effort to
+  redeem. Outside of travel it earns just 1x, so heavy frequent travelers get the value;
+  everyone else likely overpays.
 annual_fee: 895
 reward_type: "points"
 rewards:

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -88,3 +88,11 @@ tags:
   - travel
   - premium
 apply_link: https://creditcards.chase.com/travel-credit-cards/united/club-infinite
+our_take: >
+  This is a card you buy for the United Club membership, which runs well over
+  $700 on its own, plus two free checked bags, Premier Access, and a deep bench
+  of credits for hotels, rideshare, Instacart, and JSX. Earn rates are modest
+  at 5x on United and 2x on travel and dining, so the value is entirely in the
+  lounge and perks. The $695 fee only pays off if you fly United often enough
+  to live in the clubs; if you don't need lounge access, the Quest or Explorer
+  deliver United benefits for far less.

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -101,3 +101,10 @@ tags:
   - rewards
 apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-explorer
 foreign_transaction_fee: false
+our_take: >
+  The Explorer is the workhorse United card: the free first checked bag and two
+  United Club passes alone can outweigh the $150 fee for anyone who flies United a
+  few times a year, and it adds priority boarding, a Global Entry credit, and 3x on
+  United. It is one of the more practical mid-tier airline cards, but earning
+  outside United is thin (2x dining and hotels, 1x everything else), so pair it with
+  a stronger everyday card.

--- a/data/cards/united-gateway.yaml
+++ b/data/cards/united-gateway.yaml
@@ -38,6 +38,12 @@ tags:
   - travel
 apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-gateway
 foreign_transaction_fee: false
+our_take: >
+  Among the better no-fee airline cards: 2x on United, gas, and transit, no foreign
+  transaction fees, and a solid 30,000-mile bonus. It is a clean way to earn United miles
+  without paying an annual fee, and stands out for people who fly United occasionally. The
+  tradeoff is no free checked bag or lounge access, so frequent United flyers will get more
+  from a fee-paying United card whose checked-bag perk alone offsets the cost.
 benefits:
   - name: "Checked Bags"
     value: 0

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -129,3 +129,10 @@ tags:
   - travel
   - premium
 apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-quest
+our_take: >
+  The mid-tier United card for frequent flyers, and one of the stronger airline cards on our
+  lists, anchored by a $200 annual United travel credit, two free checked bags, and a deep
+  stack of credits (rideshare, Instacart, JSX, hotels) that can more than cover the $350 fee
+  if you actually use them. The 60,000-mile bonus is solid, but this only beats the cheaper
+  $150 Explorer for people who fly United often enough to redeem the credits and the
+  anniversary award discounts. Casual United flyers should size up the Explorer first.

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -64,3 +64,10 @@ apr:
     max: 27.49
 apply_link: https://www.usbank.com/credit-cards/altitude-connect-visa-signature-credit-card.html
 foreign_transaction_fee: false
+our_take: >
+  Unusually generous for a no-annual-fee travel card: 4x on travel and gas, 5x through the
+  travel portal, plus a Global Entry credit and Visa lounge access, perks usually reserved for
+  cards that charge a fee. The catch is the gas 4x caps at $1,000 a quarter, and US Bank
+  points stretch furthest booked through its own travel center. A strong keeper for occasional
+  travelers who want lounge access at no annual cost.
+

--- a/data/cards/us-bank-altitude-go-visa-signature.yaml
+++ b/data/cards/us-bank-altitude-go-visa-signature.yaml
@@ -39,6 +39,14 @@ apr:
     min: 17.49
     max: 27.49
 apply_link: https://www.usbank.com/credit-cards/altitude-go-visa-signature-credit-card.html
+our_take: >
+  The Altitude Go is one of the stronger no-fee dining cards, earning 4x at
+  restaurants (including takeout and delivery) plus 2x on groceries, gas, and
+  streaming, which is a lot of category coverage for $0. The 4x dining rate beats
+  most fee-free competitors, and the $15 annual streaming credit can offset a
+  subscription. The main limits are the modest 20,000-point signup bonus and that
+  points are most useful inside the U.S. Bank ecosystem, so it is best as a
+  dedicated dining-and-everyday card rather than a primary travel card.
 benefits:
   - name: "Streaming Service Credit"
     value: 15

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -6,6 +6,12 @@ category: "travel"
 image: "us-bank-altitude-reserve.png"
 annual_fee: 400
 reward_type: "points"
+our_take: >
+  No longer open to new applicants, but for existing holders it remains a strong mobile-wallet
+  travel card: the $325 annual travel credit cuts the real cost of the $400 fee to under
+  $100, and you get Priority Pass lounge access and a Global Entry/TSA PreCheck credit. The
+  value hinges on using the mobile-wallet travel credit, so it suits frequent travelers who
+  pay with their phone and use the lounges.
 benefits:
   - name: "Annual Travel Credit"
     value: 325

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -49,3 +49,11 @@ apr:
     min: 17.74
     max: 27.99
 apply_link: https://www.usbank.com/credit-cards/cash-plus-visa-signature-credit-card.html
+our_take: >
+  One of the more flexible no-fee 5% cards: you pick two 5% categories each quarter
+  from a list that includes utilities, cell phone, streaming, and fast food on up
+  to $2,000 combined, plus a chosen 2% everyday category. That utilities and
+  phone-bill 5% is rare and genuinely valuable, but the upside hinges on
+  remembering to re-select categories every quarter, and unchosen spend earns just
+  1%. A 15-month 0% intro APR and a $250 bonus after $1,000 spend round it out as
+  a strong pick for people willing to manage the quarterly setup.

--- a/data/cards/us-bank-secured.yaml
+++ b/data/cards/us-bank-secured.yaml
@@ -4,6 +4,13 @@ slug: "us-bank-secured"
 image: "us-bank-secured.png"
 accepting_applications: true
 apply_link: https://www.usbank.com/credit-cards/secured-visa-credit-card.html
+our_take: >
+  This is a straightforward credit-builder: no annual fee, a refundable deposit
+  that sets your limit, and reporting to the bureaus so on-time payments rebuild
+  your score. It is approachable for thin or damaged credit and stands among the
+  more solid no-fee secured options. The tradeoff is it earns nothing, so for
+  the same $0 fee a rewards-earning secured card like the Discover it Secured
+  (cashback that Discover matches in year one) gives you more while you build.
 annual_fee: 0
 category: "secured"
 tags:

--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -61,4 +61,10 @@ benefits:
     frequency: "per_claim"
     category: "telecom"
     enrollment_required: false
+our_take: >
+  The draw is 6% back at two retailers you choose each quarter (Amazon, Target,
+  Walmart, Costco, and others) on up to $1,500 in combined spend, plus a 3%
+  rotating everyday category. That can be lucrative if you concentrate shopping
+  at big-box stores, but the $95 fee (waived year one) and quarterly selection
+  hassle mean casual shoppers are better off with a simple no-fee card.
 apply_link: https://www.usbank.com/credit-cards/shopper-cash-rewards-visa-signature-credit-card.html

--- a/data/cards/us-bank-smartly-visa-signature.yaml
+++ b/data/cards/us-bank-smartly-visa-signature.yaml
@@ -4,6 +4,13 @@ slug: "us-bank-smartly-visa-signature"
 image: "smartly-signature.png"
 accepting_applications: true
 apply_link: https://www.usbank.com/credit-cards/bank-smartly-visa-signature-credit-card.html
+our_take: >
+  A flat 2% on everything with no annual fee and 0% intro APR on purchases and
+  balance transfers for 12 months, which puts it in the same tier as Wells Fargo
+  Active Cash and Citi Double Cash. The real upside comes if you bank with U.S.
+  Bank: stacking Bank Smartly deposits can push the rate well above 2%, so this
+  card rewards loyalty more than the standalone 2x. Without those balances it is
+  a fine, unremarkable 2% card, and note there is no signup bonus.
 category: "cashback"
 annual_fee: 0
 reward_type: "cashback"

--- a/data/cards/us-bank-split.yaml
+++ b/data/cards/us-bank-split.yaml
@@ -9,6 +9,12 @@ tags:
   - rewards
 apply_link: https://www.usbank.com/credit-cards/offers/split-card-world-mastercard-credit-card.html
 foreign_transaction_fee: true
+our_take: >
+  The Split is a niche product built around one feature: every purchase of $100 or more is
+  automatically split into a 3-month interest-free, fee-free payment plan. That is handy if you
+  want to spread out larger buys without paying interest, but it earns no rewards and charges a
+  foreign transaction fee. For most people a no-fee rewards card or a longer 0% intro card is
+  the more flexible choice.
 benefits:
   - name: "3-Month Interest-Free Plans"
     description: "No interest or fees on 3-month payment plans for all purchases of $100 or more."

--- a/data/cards/usaa-cashback-rewards-plus.yaml
+++ b/data/cards/usaa-cashback-rewards-plus.yaml
@@ -29,3 +29,10 @@ apr:
   regular:
     min: 16.90
     max: 30.90
+our_take: >
+  A strong no-fee everyday card for the USAA-eligible: 5% on gas and on
+  military base purchases plus 3% on groceries, all with annual caps, and 1% on
+  the rest. For members who fill up often and shop on base, the capped 5% tiers
+  add up fast for zero fee. The limits are eligibility, since you need a USAA
+  membership, and the caps, which make it a category card rather than a
+  catch-all earner.

--- a/data/cards/usaa-eagle-navigator.yaml
+++ b/data/cards/usaa-eagle-navigator.yaml
@@ -29,6 +29,13 @@ apr:
   regular:
     min: 18.99
     max: 28.99
+our_take: >
+  The Eagle Navigator is a solid mid-tier travel card for the USAA crowd: a flat
+  2x on everything and 3x on travel, a $95 fee, and a Global Entry credit, plus the
+  fee is waived and the APR drops while you are on active duty. The 30,000-point
+  signup bonus is modest next to bank-agnostic travel cards, so the real reason to
+  pick it is USAA membership and the military protections rather than headline
+  rewards.
 benefits:
   - name: "Global Entry / TSA PreCheck Credit"
     value: 100

--- a/data/cards/usaa-preferred-cash-rewards.yaml
+++ b/data/cards/usaa-preferred-cash-rewards.yaml
@@ -14,6 +14,12 @@ rewards:
   - category: everything_else
     value: 1.5
     unit: percent
+our_take: >
+  A straightforward no-fee card for USAA members: a flat 1.5% on everything, a $250 bonus
+  after $1,000 of spend, and 0% intro APR on purchases and balance transfers for 12 months.
+  It is fine as a simple everyday card, but the 1.5% rate is beaten by widely available flat
+  2% cards like Wells Fargo Active Cash. Get it mainly if you already bank with USAA and want
+  to keep your cards under one roof.
 signup_bonus:
   value: 250
   type: cash

--- a/data/cards/usaa-rate-advantage.yaml
+++ b/data/cards/usaa-rate-advantage.yaml
@@ -14,3 +14,9 @@ apr:
   regular:
     min: 10.40
     max: 24.40
+our_take: >
+  A low-rate card for USAA members who carry a balance: a 15-month 0% intro on transfers and,
+  more notably, an ongoing regular APR that starts as low as 10.40%, well below most cards.
+  It earns no rewards and has no signup bonus, so the entire pitch is cheap borrowing. For a
+  pure 0% balance-transfer runway, the Wells Fargo Reflect and U.S. Bank Shield go longer at
+  21 months, but neither matches this card's low rate once the intro period ends.

--- a/data/cards/usaa-rewards.yaml
+++ b/data/cards/usaa-rewards.yaml
@@ -22,3 +22,10 @@ apr:
   regular:
     min: 13.40
     max: 27.40
+our_take: >
+  A simple no-fee rewards card for the USAA military community: 2x on dining and gas, 1x
+  everywhere else, with a notably low APR floor of 13.40% for those who occasionally carry a
+  balance. The flat 2x categories are modest next to no-fee cards that pay 3x or more, so the
+  appeal is membership convenience and the low rate, not best-in-class earning. Fine as a
+  keep-it-simple everyday card if you already bank with USAA.
+

--- a/data/cards/usaa-secured-american-express.yaml
+++ b/data/cards/usaa-secured-american-express.yaml
@@ -12,3 +12,11 @@ apr:
   regular:
     min: 11.40
     max: 21.40
+our_take: >
+  This is a no-fee secured card for building or rebuilding credit, and its
+  standout feature is the APR: an 11.40% to 21.40% range that sits far below most
+  secured cards, where rates near 26% to 29% are typical. That makes it more
+  forgiving if you ever carry a balance, though the goal with any secured card is
+  to pay in full. The catch is eligibility, since USAA membership is generally
+  limited to the military community; if you qualify, it is one of the cheaper
+  ways to establish credit.

--- a/data/cards/usaa-secured-visa-platinum.yaml
+++ b/data/cards/usaa-secured-visa-platinum.yaml
@@ -12,3 +12,9 @@ apr:
   regular:
     min: 11.40
     max: 21.40
+our_take: >
+  A no-frills secured card whose standout is its APR, which starts as low as 11.40% and
+  tops out around 21.40%, well below the 26%+ that secured cards like Discover and Capital
+  One charge. It earns no rewards, so it is purely a credit-builder, and it requires USAA
+  membership tied to military service. If you qualify for USAA and might carry a balance,
+  the low rate makes it one of the cheaper secured options to build credit with.

--- a/data/cards/venmo-credit-card.yaml
+++ b/data/cards/venmo-credit-card.yaml
@@ -47,3 +47,11 @@ apr:
     max: 31.99
 apply_link: https://venmo.com/about/creditcard
 foreign_transaction_fee: false
+our_take: >
+  A no-fee card that auto-adjusts to your spending: 3% on your top category and 2%
+  on your second each statement period, from a list of eight, with 1% on the rest.
+  It is a good fit for existing Venmo users who want rewards without picking
+  categories, and there are no foreign transaction fees. The tradeoff is the lack
+  of a real signup bonus and a high APR up to 31.99%, so flat 2%-on-everything
+  cards like the Wells Fargo Active Cash or Citi Double Cash will out-earn it
+  unless your spending is concentrated in those top two categories.

--- a/data/cards/wells-fargo-active-cash.yaml
+++ b/data/cards/wells-fargo-active-cash.yaml
@@ -30,6 +30,13 @@ apr:
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/active-cash-credit-card
 foreign_transaction_fee: true
+our_take: >
+  The Active Cash is a clean flat-rate workhorse: 2% on everything with no
+  annual fee, a $200 bonus after just $500 of spend, a 12-month 0% intro APR,
+  and cell phone protection thrown in. It is one of the stronger no-fee
+  cash-back picks and a fine one-card setup. Two small catches: it charges a
+  foreign transaction fee, and unlike Citi's Double Cash it offers no portal
+  bonus, so for overseas use look elsewhere.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 0

--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -58,6 +58,12 @@ apr:
     min: 18.49
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/attune-credit-card
+our_take: >
+  A niche no-fee card paying 4% on an unusual mix: fitness and self-care,
+  entertainment, streaming, pet care, public transit, EV charging, and
+  secondhand stores. If your spending genuinely clusters in those lifestyle
+  categories it is one of the stronger no-fee earners, but the plain 1% on
+  everything else means most people will out-earn it with a flat 2% card.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 0

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -60,3 +60,10 @@ apr:
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/autograph-journey-visa-credit-card
 foreign_transaction_fee: false
+our_take: >
+  A strong mid-tier travel card: 5x on hotels, 4x on airlines, and 3x on dining and other
+  travel, plus a $100 annual airline credit and no foreign transaction fee for $95. The travel
+  earning rates beat the Chase Sapphire Preferred and Citi Strata Premier in their own
+  categories, and the 60,000-point bonus only needs $4,000 in three months. The main caveat is
+  that Wells Fargo's points transfer to fewer partners than Chase or Amex, so weigh how you
+  plan to redeem.

--- a/data/cards/wells-fargo-autograph.yaml
+++ b/data/cards/wells-fargo-autograph.yaml
@@ -49,3 +49,11 @@ apr:
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/autograph-visa-credit-card
 foreign_transaction_fee: false
+our_take: >
+  A lot of card for no annual fee: 3x on dining, travel, gas, transit, and
+  streaming, no foreign transaction fees, and cell phone protection up to $600
+  per claim, which makes it one of the stronger no-fee everyday cards. The
+  20k-point bonus after just $1,000 of spend is easy to hit. The catch is that
+  the base points are worth about a cent each unless you also hold a Wells Fargo
+  card that unlocks transfer partners, so the value is highest if you stay
+  within the categories.

--- a/data/cards/wells-fargo-cash-back-college.yaml
+++ b/data/cards/wells-fargo-cash-back-college.yaml
@@ -13,3 +13,10 @@ rewards:
   - category: everything_else
     value: 1
     unit: percent
+our_take: >
+  This student card is no longer open to new applicants, and even when it was
+  the flat 1% back was thin. Students today get far more from no-fee options
+  like the Capital One Savor Student at 3% on dining, groceries, and
+  entertainment, or Discover it for Students with rotating 5% categories.
+  Existing holders should treat this as a starter card and graduate to a real
+  rewards card once they qualify.

--- a/data/cards/wells-fargo-cash-wise-visa.yaml
+++ b/data/cards/wells-fargo-cash-wise-visa.yaml
@@ -5,3 +5,8 @@ image: "cash_wise.png"
 accepting_applications: false
 annual_fee: 0
 reward_type: "cashback"
+our_take: >
+  The Cash Wise was Wells Fargo's flat-rate cash-back card, but it has been
+  retired and no longer accepts applications. Its modern replacement is the
+  Active Cash, which pays a clean 2% on everything with no annual fee, so send
+  new applicants there.

--- a/data/cards/wells-fargo-choice-privileges-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-mastercard.yaml
@@ -42,6 +42,12 @@ apr:
     max: 28.74
 apply_link: https://creditcards.wellsfargo.com/choice-hotel-privileges-mastercard
 foreign_transaction_fee: false
+our_take: >
+  A no-fee hotel card aimed at Choice Hotels guests: 5x at Choice properties, 3x on a wide
+  set of everyday categories like gas, groceries, and phone bills, automatic Gold Elite
+  status, and a 60,000-point welcome bonus. The unusually broad 3x earning makes it useful
+  even between hotel stays. Just remember Choice points are low-value, so the rewards stretch
+  furthest if you actually book Choice-brand hotels rather than redeem for anything else.
 benefits:
   - name: "Automatic Gold Elite Status"
     value: 0

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -7,6 +7,13 @@ category: "travel"
 annual_fee: 95
 foreign_transaction_fee: false
 reward_type: "points"
+our_take: >
+  A focused hotel card for Choice Privileges loyalists: 10x at Choice properties, automatic
+  Platinum Elite status, and a 30,000-point anniversary bonus worth roughly three free nights,
+  which alone tends to outvalue the $95 fee. The unusual 5x on gas, groceries, home
+  improvement, and phone bills makes it useful beyond hotels too. The no-fee Choice Privileges
+  Mastercard covers casual stays, so step up to this one only if you book Choice hotels enough
+  to use the elite status and anniversary nights.
 tags:
   - travel
   - hotel

--- a/data/cards/wells-fargo-platinum.yaml
+++ b/data/cards/wells-fargo-platinum.yaml
@@ -7,3 +7,9 @@ annual_fee: 0
 category: "balance_transfer"
 tags:
   - balance_transfer
+our_take: >
+  The Wells Fargo Platinum is no longer open to new applicants and has effectively been
+  replaced by the Wells Fargo Reflect for balance transfers. If you want a 0% intro APR card
+  from Wells Fargo today, look at the Reflect with its 21-month window instead. Nothing here
+  to pursue unless you already hold the card.
+

--- a/data/cards/wells-fargo-propel-american-express.yaml
+++ b/data/cards/wells-fargo-propel-american-express.yaml
@@ -26,3 +26,11 @@ rewards:
   - category: "everything_else"
     value: 1
     unit: "points_per_dollar"
+our_take: >
+  The Propel was a rare no-fee card that earned 3x across a wide swath of
+  categories: dining, travel, transit, gas, and streaming, which made it a
+  favorite for people who wanted broad bonus earning without a fee. It is no
+  longer open to new applicants (Wells Fargo replaced it with the Autograph
+  line), so it is here mostly for existing holders. If you can't get this one,
+  the current Wells Fargo Autograph keeps the same no-fee, multi-category 3x
+  formula.

--- a/data/cards/wells-fargo-rewards.yaml
+++ b/data/cards/wells-fargo-rewards.yaml
@@ -5,3 +5,7 @@ image: "wells_fargo_rewards.png"
 accepting_applications: false
 annual_fee: 0
 reward_type: "points"
+our_take: >
+  This Wells Fargo Rewards card is no longer open to new applicants and has been replaced
+  by the bank's current rewards lineup. If you want a no-fee Wells Fargo card today, look
+  at Active Cash for a flat 2% or the Autograph for category rewards instead.

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -4,6 +4,14 @@ slug: "wells-fargo-signify-business-cash"
 accepting_applications: true
 apply_link: https://creditcards.wellsfargo.com/business-credit-cards/signify-business-cash-credit-card/
 foreign_transaction_fee: false
+our_take: >
+  A clean, no-fee business card built on simplicity: a flat 2% back on every
+  purchase with no categories to track, no foreign transaction fees, and a 12-month
+  0% intro APR on purchases. The $500 bonus after $5,000 in spend is one of the
+  better no-fee business offers around, and the flat 2% means it earns well as a
+  catch-all for mixed business spending. If your purchases concentrate in specific
+  categories, a tiered business card may beat it, but for broad spend this is hard
+  to fault.
 image: "wells-fargo-signify-business-cash.png"
 category: "business"
 annual_fee: 0

--- a/data/cards/wells-fargo-visa-signature.yaml
+++ b/data/cards/wells-fargo-visa-signature.yaml
@@ -5,3 +5,8 @@ image: "wells_fargo_visa_signature.png"
 accepting_applications: false
 annual_fee: 0
 reward_type: "points"
+our_take: >
+  This is a legacy no-fee Wells Fargo points card that is no longer open to new
+  applicants, so it is not a card to chase today. Existing holders can keep it
+  for the lack of an annual fee, but Wells Fargo's current lineup, like the flat
+  2% Active Cash, is where new cardholders should look.

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -48,3 +48,10 @@ signup_bonus:
   timeframe_months: 3
 apply_link: https://creditcards.chase.com/business-credit-cards/world-of-hyatt/hyatt-business-card
 foreign_transaction_fee: false
+our_take: >
+  Aimed at business owners loyal to Hyatt: up to 9x at Hyatt properties,
+  automatic Discoverist status, an annual Category 1-4 free night, and one of
+  the larger signup bonuses at 60,000 points after $5,000 in spend. The $199 fee
+  and Hyatt-centric perks only pay off if you stay with Hyatt regularly, since
+  the value comes almost entirely from the free night and elite-night credits
+  rather than everyday earning.

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -62,3 +62,10 @@ apr:
     max: 29.99
 apply_link: https://creditcards.chase.com/travel-credit-cards/world-of-hyatt-credit-card
 foreign_transaction_fee: false
+our_take: >
+  For Hyatt loyalists this $95 card is easy to justify: the annual Category 1-4
+  free night often covers the fee on its own, and you get automatic Discoverist
+  status plus 5 qualifying night credits toward higher tiers each year. Earning
+  is up to 9x at Hyatt and 2x on dining, flights, and transit, with no foreign
+  transaction fees. The catch is it is only worth it if you actually stay at
+  Hyatt; outside the brand the rewards are ordinary.

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -3,6 +3,13 @@ bank: "Barclays"
 slug: "wyndham-rewards-earner-business-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner-business-card/
+our_take: >
+  The best fit for road-warrior small businesses that stay at Wyndham brands like La Quinta or
+  Days Inn: 8x at Wyndham, 5x on gas, office supplies, shipping, and EV charging, plus
+  automatic top-tier Diamond status and a 20% redemption discount that stretches points
+  further. The 15,000-point anniversary bonus alone can cover a couple of award nights, easily
+  offsetting the $149 fee for regular Wyndham guests. If you rarely stay at Wyndham, the value
+  drops off fast since everyday spend earns just 1x.
 category: "business"
 image: "barclays-wyndham-earner-business.png"
 annual_fee: 149

--- a/data/cards/wyndham-rewards-earner-card.yaml
+++ b/data/cards/wyndham-rewards-earner-card.yaml
@@ -7,6 +7,14 @@ category: "travel"
 image: "barclays-wyndham-earner.png"
 annual_fee: 0
 foreign_transaction_fee: false
+our_take: >
+  The no-fee entry to Wyndham's lineup: 5x at Hotels by Wyndham, 2x on dining,
+  groceries, and gas, automatic Gold status, and a 10% discount on award-night
+  redemptions, with no foreign transaction fee. Because Wyndham free nights cap
+  out at a flat point cost, the value here can be very high for budget hotel
+  stays. If you stay often, the $95 Plus (6x hotels, 4x on the bonus
+  categories) earns enough more to justify its fee, but the base card is a
+  reasonable keeper precisely because it costs nothing.
 reward_type: "points"
 tags:
   - hotel

--- a/data/cards/wyndham-rewards-earner-plus-card.yaml
+++ b/data/cards/wyndham-rewards-earner-plus-card.yaml
@@ -44,6 +44,13 @@ apr:
   regular:
     min: 19.24
     max: 29.99
+our_take: >
+  The Earner Plus is the sweet spot of Wyndham's lineup: 6x at Wyndham hotels plus
+  a useful 4x on dining, groceries, and travel, and a 15,000-point anniversary
+  bonus that can cover a free night or two and easily justify the $95 fee. Add
+  automatic Diamond status in year one, and it is worth the step up from the no-fee
+  Earner if you stay at Wyndham at all regularly. Just remember Wyndham points are
+  low-value, so this pays off through cheap award nights, not flexible rewards.
 benefits:
   - name: "Anniversary Points Bonus"
     value: 15000

--- a/data/cards/wyndham-rewards-earner-premier-card.yaml
+++ b/data/cards/wyndham-rewards-earner-premier-card.yaml
@@ -34,6 +34,14 @@ rewards:
     value: 1
     unit: points_per_dollar
     note: "Also earns 4x on Wyndham Vacation Club purchases"
+our_take: >
+  The top-tier Wyndham card justifies its $395 fee mostly through credits and elite perks:
+  30,000 anniversary points (enough for up to four award nights), automatic Diamond status,
+  8x at Wyndham hotels, and a stack of statement credits for streaming, meal delivery, a
+  wholesale club, and Global Entry. The math works only if you stay at Wyndham properties and
+  actually use those credits; otherwise the $95 Earner Plus delivers most of the value at a
+  fraction of the fee. Wyndham points are low-value, so this is a card for committed Wyndham
+  loyalists, not casual travelers.
 signup_bonus:
   value: 120000
   type: "points"


### PR DESCRIPTION
## Summary
Adds the `our_take` editorial field to every card that lacked one: **180 cards** (182 total now have it).

Each blurb is:
- **2-3 sentences**, plain financial-brief voice (no em dashes, no AI-tell phrasing).
- **Grounded in the card's own numbers** (rewards rates, signup bonus, annual fee, APR, key benefits).
- **Comparable-aware** — compared against same-category and same-issuer peers (e.g. Gold vs other dining cards, Venture X vs Sapphire Reserve, Double Cash vs other flat 2% cards).
- **Approval-data informed** — median credit score / income cited only where the live approval sample was meaningful; omitted (not invented) on cards with zero or tiny samples.
- **Best-category strength** noted qualitatively rather than by fixed rank, since rankings change over time and this text is static.
- Discontinued / closed cards get honest reference-only takes pointing to current alternatives.

## Integrity
- All 182 cards parse as valid YAML.
- Every non-`our_take` field is byte-identical to `main` (verified field-by-field).
- Zero em/en dashes; no `our_take` value absorbed structured YAML.
- `npm run build:cards` passes; `our_take` propagates into `cards.json` and renders via `CardClient.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)