### PR TITLE
fix(web): retry transient network failures on all SSR data reads

### DIFF
--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -775,7 +775,7 @@ export interface RecentRecord {
 }
 
 export async function getRecentRecords(): Promise<RecentRecord[]> {
-  const res = await fetch(`${API_BASE}/recent-records`, {
+  const res = await fetchWithRetry(`${API_BASE}/recent-records`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) return [];
@@ -796,7 +796,7 @@ export async function trackCardView(cardId: number): Promise<void> {
 // Get card view counts for explore page sorting
 export async function getCardViewCounts(period: 'trending' | 'all-time' = 'trending'): Promise<Record<number, number>> {
   const days = period === 'trending' ? 30 : 0;
-  const res = await fetch(`${API_BASE}/card-view?period=${days}`, {
+  const res = await fetchWithRetry(`${API_BASE}/card-view?period=${days}`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) return {};
@@ -829,7 +829,7 @@ export async function trackContentView(
 // Get article + news view counts over the trailing `periodDays` window.
 // Used to rank the landing page editorial lane by "top viewed this week".
 export async function getContentViewCounts(periodDays = 7): Promise<EditorialViewCounts> {
-  const res = await fetch(`${API_BASE}/content-view?period=${periodDays}`, {
+  const res = await fetchWithRetry(`${API_BASE}/content-view?period=${periodDays}`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) return EMPTY_EDITORIAL_VIEWS;
@@ -864,7 +864,7 @@ export interface ComparePartner {
 // Used to populate "Often compared with" chips on the card detail page.
 export async function getComparePartners(slug: string, limit = 5): Promise<ComparePartner[]> {
   try {
-    const res = await fetch(
+    const res = await fetchWithRetry(
       `${API_BASE}/card-compare-event?slug=${encodeURIComponent(slug)}&limit=${limit}`,
       { next: { revalidate: 600 } },
     );
@@ -1082,7 +1082,7 @@ export interface CardWireEntry {
 }
 
 export async function getCardWire(cardId: number): Promise<CardWireEntry[]> {
-  const res = await fetch(`${API_BASE}/card-wire?card_id=${cardId}&limit=20`, {
+  const res = await fetchWithRetry(`${API_BASE}/card-wire?card_id=${cardId}&limit=20`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) return [];
@@ -1091,7 +1091,7 @@ export async function getCardWire(cardId: number): Promise<CardWireEntry[]> {
 }
 
 export async function getAllCardWire(limit = 100): Promise<CardWireEntry[]> {
-  const res = await fetch(`${API_BASE}/card-wire?limit=${limit}`, {
+  const res = await fetchWithRetry(`${API_BASE}/card-wire?limit=${limit}`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) return [];
@@ -1144,7 +1144,7 @@ export interface LeaderboardResponse {
 }
 
 export async function getLeaderboard(limit = 25): Promise<LeaderboardResponse> {
-  const res = await fetch(`${API_BASE}/leaderboard?limit=${limit}`, {
+  const res = await fetchWithRetry(`${API_BASE}/leaderboard?limit=${limit}`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) {
@@ -1246,7 +1246,7 @@ export interface CardRatingAggregates {
 }
 
 export async function getCardRatings(cardName: string): Promise<CardRatingAggregates> {
-  const res = await fetch(`${API_BASE}/ratings?card_name=${encodeURIComponent(cardName)}`, {
+  const res = await fetchWithRetry(`${API_BASE}/ratings?card_name=${encodeURIComponent(cardName)}`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) return { count: 0, average: null };

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { fetchWithRetry } from './fetchWithRetry';
+
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://d2ojrhbh2dincr.cloudfront.net';
 
 // Best-effort Firebase ID token grab for fire-and-forget click trackers.
@@ -191,7 +193,7 @@ export async function getAllCards(): Promise<Card[]> {
       // Fall through to network fetch if local file isn't built yet.
     }
   }
-  const res = await fetch(`${API_BASE}/cards`, {
+  const res = await fetchWithRetry(`${API_BASE}/cards`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) throw new Error('Failed to fetch cards');
@@ -248,7 +250,7 @@ export async function getCard(cardName: string): Promise<Card> {
         } as Card;
 
         try {
-          const res = await fetch(`${API_BASE}/card?card_name=${encodeURIComponent(cardName)}`, {
+          const res = await fetchWithRetry(`${API_BASE}/card?card_name=${encodeURIComponent(cardName)}`, {
             next: { revalidate: 300 },
           });
           if (res.ok) {
@@ -272,7 +274,7 @@ export async function getCard(cardName: string): Promise<Card> {
       // Fall through to network fetch when local file isn't built yet.
     }
   }
-  const res = await fetch(`${API_BASE}/card?card_name=${encodeURIComponent(cardName)}`, {
+  const res = await fetchWithRetry(`${API_BASE}/card?card_name=${encodeURIComponent(cardName)}`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) throw new Error('Failed to fetch card');
@@ -280,7 +282,7 @@ export async function getCard(cardName: string): Promise<Card> {
 }
 
 export async function getCardGraphs(cardName: string): Promise<GraphData[]> {
-  const res = await fetch(`${API_BASE}/graphs?card_name=${encodeURIComponent(cardName)}`, {
+  const res = await fetchWithRetry(`${API_BASE}/graphs?card_name=${encodeURIComponent(cardName)}`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) throw new Error('Failed to fetch graphs');
@@ -307,7 +309,7 @@ export interface CardRecord {
 }
 
 export async function getCardRecords(cardName: string): Promise<CardRecord[]> {
-  const res = await fetch(`${API_BASE}/card-records?card_name=${encodeURIComponent(cardName)}`, {
+  const res = await fetchWithRetry(`${API_BASE}/card-records?card_name=${encodeURIComponent(cardName)}`, {
     next: { revalidate: 300 },
   });
   if (!res.ok) throw new Error('Failed to fetch card records');

--- a/apps/web-next/src/lib/articles.ts
+++ b/apps/web-next/src/lib/articles.ts
@@ -1,4 +1,5 @@
 // Articles API types and fetching
+import { fetchWithRetry } from './fetchWithRetry';
 
 export type ArticleTag =
   | 'strategy'
@@ -87,7 +88,7 @@ export async function getArticles(): Promise<Article[]> {
 
     // Use local API route on client to avoid CORS, direct CDN on server
     const url = isBrowser ? '/api/articles' : ARTICLES_CDN_URL;
-    const res = await fetch(url, isBrowser ? {} : {
+    const res = await fetchWithRetry(url, isBrowser ? {} : {
       next: { revalidate: 300 }, // Revalidate every 5 minutes (server only)
     });
 

--- a/apps/web-next/src/lib/best.ts
+++ b/apps/web-next/src/lib/best.ts
@@ -1,4 +1,5 @@
 // Best pages API types and fetching
+import { fetchWithRetry } from './fetchWithRetry';
 
 export interface BestPageCard {
   slug: string;
@@ -47,7 +48,7 @@ export async function getBestPages(): Promise<BestPage[]> {
 
     // Use local API route on client to avoid CORS, direct CDN on server
     const url = isBrowser ? '/api/best' : BEST_CDN_URL;
-    const res = await fetch(url, isBrowser ? {} : {
+    const res = await fetchWithRetry(url, isBrowser ? {} : {
       next: { revalidate: 300 },
     });
 

--- a/apps/web-next/src/lib/fetchWithRetry.test.ts
+++ b/apps/web-next/src/lib/fetchWithRetry.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithRetry } from "./fetchWithRetry";
+
+const res = (status: number) => new Response(null, { status });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchWithRetry", () => {
+  it("returns immediately on success without retrying", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(res(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await fetchWithRetry("https://x.test", undefined, { backoffMs: 0 });
+
+    expect(out.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient network error then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValue(res(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await fetchWithRetry("https://x.test", undefined, { backoffMs: 0 });
+
+    expect(out.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a 5xx then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(res(503))
+      .mockResolvedValue(res(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await fetchWithRetry("https://x.test", undefined, { backoffMs: 0 });
+
+    expect(out.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a 4xx", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(res(404));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await fetchWithRetry("https://x.test", undefined, { backoffMs: 0 });
+
+    expect(out.status).toBe(404);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows the original error after exhausting retries", async () => {
+    const err = new TypeError("fetch failed");
+    const fetchMock = vi.fn().mockRejectedValue(err);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchWithRetry("https://x.test", undefined, { retries: 2, backoffMs: 0 }),
+    ).rejects.toBe(err);
+    // initial attempt + 2 retries
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web-next/src/lib/fetchWithRetry.ts
+++ b/apps/web-next/src/lib/fetchWithRetry.ts
@@ -1,0 +1,46 @@
+// Retry wrapper for idempotent (GET) data reads used by server-side rendering /
+// ISR. Transient network failures (ETIMEDOUT, ECONNRESET, "fetch failed")
+// between our SSR server and the upstream CDN/API are brief and almost always
+// succeed on a second attempt. Retrying here keeps a blip from failing an ISR
+// render — which otherwise reports to Sentry and, on a cold cache, errors the
+// page (see the /best/[slug] "fetch failed" incident, 2026-06-25).
+//
+// IMPORTANT: only use this for GET reads. Never wrap POST/mutations — a retry
+// after the server already applied the write would double-apply it.
+
+const DEFAULT_RETRIES = 2;
+const DEFAULT_BACKOFF_MS = 250;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function fetchWithRetry(
+  input: string | URL,
+  init?: RequestInit,
+  opts: { retries?: number; backoffMs?: number } = {},
+): Promise<Response> {
+  const retries = opts.retries ?? DEFAULT_RETRIES;
+  const backoffMs = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(input, init);
+      // Retry transient upstream failures (5xx), but never client errors (4xx).
+      if (res.status >= 500 && attempt < retries) {
+        await delay(backoffMs * (attempt + 1));
+        continue;
+      }
+      return res;
+    } catch (error) {
+      // Network-level failure (e.g. ETIMEDOUT / "fetch failed"). Retry if budget remains.
+      lastError = error;
+      if (attempt < retries) {
+        await delay(backoffMs * (attempt + 1));
+        continue;
+      }
+    }
+  }
+  // Exhausted retries on a network error — rethrow the original so callers and
+  // Sentry still see the real failure.
+  throw lastError;
+}

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -1,4 +1,5 @@
 // News API types and fetching
+import { fetchWithRetry } from './fetchWithRetry';
 
 export type NewsTag =
   | 'new-card'
@@ -83,7 +84,7 @@ export async function getNews(): Promise<NewsItem[]> {
 
     // Use local API route on client to avoid CORS, direct CDN on server
     const url = isBrowser ? '/api/news' : NEWS_CDN_URL;
-    const res = await fetch(url, isBrowser ? {} : {
+    const res = await fetchWithRetry(url, isBrowser ? {} : {
       next: { revalidate: 300 }, // Revalidate every 5 minutes (server only)
     });
 


### PR DESCRIPTION
## Why
Sentry caught `TypeError: fetch failed` on server-side renders — first `/best/[slug]` (`ETIMEDOUT`, issue 7575640446), then `/best-card-for/[slug]` (TLS handshake blip, issue 7575736438). Same class: brief, network-layer failures between the SSR server and the upstream CDN/API. Root trigger was reads like `getAllCards()` having **no network error handling** (the `try/catch` only covered the dev local-file path), so a blip rejected the ISR render.

These transient failures almost always succeed on a retry.

## Change
New `fetchWithRetry` helper:
- 2 retries, short linear backoff (250/500ms)
- retries network errors (ETIMEDOUT / TLS disconnect / "fetch failed") **and** 5xx
- never retries 4xx; rethrows the original error if all attempts fail (real outages still surface in Sentry)

Applied to **every idempotent GET read that feeds a statically-generated page**, identified systematically by its `next: { revalidate }` tag — not page-by-page:
- `api.ts`: getAllCards, getCardData, getCardGraphs, getCardRecords, getRecentRecords, getCardViewCounts, getContentViewCounts, getComparePartners, getCardWireForCard, getCardWire, getLeaderboard, getCardRatings
- `best.ts`: getBestPages · `news.ts`: getNews · `articles.ts`: getArticles

**All 16 POST/mutation endpoints (wallet, records, referrals, click trackers) are deliberately left on plain `fetch`** — retrying a write that already applied server-side could double-apply it.

## Why not just swallow the error?
Returning `[]` on failure lets the render "succeed" with empty data, which ISR then **caches for 300s** — serving an empty page to everyone. Retrying fixes the blip without poisoning the cache; if it still fails, throwing lets Next.js keep serving the last good page.

## Tests
`fetchWithRetry.test.ts` — 5 cases: success (no retry), network-error→retry→success, 5xx→retry→success, 4xx→no retry, exhausted→rethrow original. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)