### PR TITLE
fix(web): retry mid-stream body terminations in fetchWithRetry

### DIFF
--- a/apps/web-next/src/lib/fetchWithRetry.test.ts
+++ b/apps/web-next/src/lib/fetchWithRetry.test.ts
@@ -44,6 +44,25 @@ describe("fetchWithRetry", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("retries when the response body terminates mid-stream", async () => {
+    // fetch() resolves 200, but reading the body throws "terminated" (undici
+    // keep-alive socket drop) — must retry, not surface to the caller.
+    const terminating = {
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      arrayBuffer: () => Promise.reject(new TypeError("terminated")),
+    } as unknown as Response;
+    const good = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const fetchMock = vi.fn().mockResolvedValueOnce(terminating).mockResolvedValue(good);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await fetchWithRetry("https://x.test", undefined, { backoffMs: 0 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(await out.json()).toEqual({ ok: true });
+  });
+
   it("does not retry a 4xx", async () => {
     const fetchMock = vi.fn().mockResolvedValue(res(404));
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/web-next/src/lib/fetchWithRetry.ts
+++ b/apps/web-next/src/lib/fetchWithRetry.ts
@@ -1,9 +1,19 @@
 // Retry wrapper for idempotent (GET) data reads used by server-side rendering /
-// ISR. Transient network failures (ETIMEDOUT, ECONNRESET, "fetch failed")
-// between our SSR server and the upstream CDN/API are brief and almost always
-// succeed on a second attempt. Retrying here keeps a blip from failing an ISR
-// render — which otherwise reports to Sentry and, on a cold cache, errors the
-// page (see the /best/[slug] "fetch failed" incident, 2026-06-25).
+// ISR. Transient network failures between our SSR server and the upstream
+// CDN/API are brief and almost always succeed on a second attempt. Retrying
+// here keeps a blip from failing an ISR render — which otherwise reports to
+// Sentry and, on a cold cache, errors the page.
+//
+// Two failure modes are covered, both seen in production on 2026-06-25:
+//   1. The fetch() itself rejects — ETIMEDOUT / "fetch failed" / TLS handshake
+//      aborted (/best/[slug], /best-card-for/[slug]).
+//   2. The fetch() resolves 200 but the connection drops *while the body is
+//      read* — "terminated" / "other side closed", an undici keep-alive race
+//      where the upstream closes a pooled socket mid-response (/card-wire).
+// To catch (2), we read the body INSIDE the retry loop and return a buffered
+// Response, so a mid-stream termination retries here instead of exploding later
+// in the caller's res.json(). Callers see an ordinary Response (res.ok /
+// res.json() work) that now reads from memory and can't terminate.
 //
 // IMPORTANT: only use this for GET reads. Never wrap POST/mutations — a retry
 // after the server already applied the write would double-apply it.
@@ -12,6 +22,9 @@ const DEFAULT_RETRIES = 2;
 const DEFAULT_BACKOFF_MS = 250;
 
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// Statuses that the Response constructor requires to have a null body.
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
 
 export async function fetchWithRetry(
   input: string | URL,
@@ -25,14 +38,26 @@ export async function fetchWithRetry(
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       const res = await fetch(input, init);
+
       // Retry transient upstream failures (5xx), but never client errors (4xx).
       if (res.status >= 500 && attempt < retries) {
+        await res.body?.cancel();
         await delay(backoffMs * (attempt + 1));
         continue;
       }
-      return res;
+
+      // Buffer the body here so a mid-stream socket termination is caught and
+      // retried in this loop rather than surfacing later in the caller's read.
+      const buffer = await res.arrayBuffer();
+      const body = NULL_BODY_STATUSES.has(res.status) || res.status < 200 ? null : buffer;
+      return new Response(body, {
+        status: res.status,
+        statusText: res.statusText,
+        headers: res.headers,
+      });
     } catch (error) {
-      // Network-level failure (e.g. ETIMEDOUT / "fetch failed"). Retry if budget remains.
+      // Network-level failure during the request or the body read
+      // (ETIMEDOUT / "fetch failed" / "terminated"). Retry if budget remains.
       lastError = error;
       if (attempt < retries) {
         await delay(backoffMs * (attempt + 1));
@@ -40,7 +65,7 @@ export async function fetchWithRetry(
       }
     }
   }
-  // Exhausted retries on a network error — rethrow the original so callers and
-  // Sentry still see the real failure.
+  // Exhausted retries — rethrow the original so callers and Sentry still see
+  // the real failure.
   throw lastError;
 }


### PR DESCRIPTION
## Why
A third transient SSR failure — `TypeError: terminated` on `/card-wire` (issue 7575771275) — but a **different shape** from the previous two. The breadcrumbs show both fetches returning **200**, then:

```
warning: Failed to set fetch cache .../Prod/cards  TypeError: terminated
error:   ⨯ TypeError: terminated
```

The `fetch()` resolved successfully; the upstream dropped the keep-alive connection (`other side closed`) **while the response body was being read** — during `res.json()` / Next's fetch-cache write. That's *after* `await fetch()`, so PR #1481's retry (which only wrapped the `fetch()` call) couldn't catch it. Classic undici keep-alive race: API Gateway/CloudFront closes a pooled socket just as we read on it.

## Change
`fetchWithRetry` now **reads the body inside the retry loop** (`res.arrayBuffer()`) and returns a **buffered `Response`**. A mid-stream termination is therefore caught and retried here instead of exploding later in the caller. Callers are unaffected — they still get an ordinary `Response` (`res.ok` / `res.json()` work), now backed by memory so it can't terminate on read.

- Null-body statuses (204/205/304) are reconstructed with a `null` body to satisfy the `Response` constructor.
- 5xx-retry path cancels the unread body before retrying.
- No call-site changes — the helper is enhanced in place, so all 15 SSR reads from #1481 get this automatically.

## Tests
`fetchWithRetry.test.ts` — 6 cases now, adding **body-terminates-mid-stream → retry → success**. `tsc` + `eslint` clean.

## Note
This builds on #1481 (already merged). Together they cover both failure modes: `fetch()` rejection *and* body-stream termination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)