### PR TITLE
feat(best): multi-model panel ranking (Claude + OpenAI + Gemini)

### DIFF
--- a/.github/workflows/refresh-best-pages.yml
+++ b/.github/workflows/refresh-best-pages.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Refresh best page highlights
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: node scripts/refresh-best-pages.js
 
       - name: Validate best.json

--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -3,8 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getBestPage, getBestPages } from "@/lib/best";
 import { getAllCards } from "@/lib/api";
-import { BestCardList } from "@/components/best/BestCardList";
-import { BestComparisonTable } from "@/components/best/BestComparisonTable";
+import { BestRankingViews } from "@/components/best/BestRankingViews";
 import { ArticleContent } from "@/components/articles/ArticleContent";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
@@ -157,8 +156,7 @@ export default async function BestDetailPage({ params }: Props) {
           </div>
         )}
 
-        <BestComparisonTable cards={enrichedCards} />
-        <BestCardList cards={enrichedCards} />
+        <BestRankingViews cards={enrichedCards} panel={page.panel} />
 
         <Link
           href="/best"

--- a/apps/web-next/src/components/best/BestCardList.tsx
+++ b/apps/web-next/src/components/best/BestCardList.tsx
@@ -1,7 +1,7 @@
 import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
 import { Card } from '@/lib/api';
-import { BestPageCard } from '@/lib/best';
+import { BestPageCard, BestPanel } from '@/lib/best';
 import { ApplyButtons } from './ApplyButtons';
 import {
   getCentsPerPoint,
@@ -18,6 +18,31 @@ interface EnrichedCard extends BestPageCard {
 
 interface BestCardListProps {
   cards: EnrichedCard[];
+  panel?: BestPanel;
+  /** 'consensus', a model key, or undefined when no panel is available. */
+  activeView?: string;
+}
+
+/**
+ * Shows how the panel's models ranked this card — a spread chip in consensus
+ * view, or null when there is no panel data.
+ */
+function ConsensusChip({ entry }: { entry: EnrichedCard }) {
+  const ranks = entry.consensus?.ranks;
+  if (!ranks) return null;
+  const values = Object.values(ranks);
+  if (values.length < 2) return null;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const unanimous = min === max;
+  return (
+    <span
+      className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700 whitespace-nowrap"
+      title={Object.entries(ranks).map(([k, v]) => `${k}: #${v}`).join(' · ')}
+    >
+      {unanimous ? `All models · #${min}` : `Models · #${min}–#${max}`}
+    </span>
+  );
 }
 
 function RankChange({ currentRank, previousRank }: { currentRank: number; previousRank?: number }) {
@@ -39,7 +64,8 @@ function RankChange({ currentRank, previousRank }: { currentRank: number; previo
   );
 }
 
-export function BestCardList({ cards }: BestCardListProps) {
+export function BestCardList({ cards, activeView }: BestCardListProps) {
+  const isConsensus = !activeView || activeView === 'consensus';
   return (
     <div className="space-y-6">
       {cards.map((entry, index) => {
@@ -60,13 +86,14 @@ export function BestCardList({ cards }: BestCardListProps) {
               <Link href={`/card/${card.slug}`} className="text-lg font-bold text-gray-900 hover:text-indigo-600 transition-colors">
                 {card.card_name}
               </Link>
-              {entry.badge && (
+              {isConsensus && entry.badge && (
                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-800 whitespace-nowrap">
                   {entry.badge}
                 </span>
               )}
-              <span className="ml-auto flex-shrink-0">
-                <RankChange currentRank={rank} previousRank={entry.previous_rank} />
+              <span className="ml-auto flex-shrink-0 flex items-center gap-2">
+                {isConsensus && <ConsensusChip entry={entry} />}
+                {isConsensus && <RankChange currentRank={rank} previousRank={entry.previous_rank} />}
               </span>
             </div>
 

--- a/apps/web-next/src/components/best/BestRankingViews.tsx
+++ b/apps/web-next/src/components/best/BestRankingViews.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Card } from '@/lib/api';
+import { BestPageCard, BestPanel } from '@/lib/best';
+import { BestComparisonTable } from './BestComparisonTable';
+import { BestCardList } from './BestCardList';
+
+type EnrichedCard = BestPageCard & { card: Card };
+
+interface BestRankingViewsProps {
+  cards: EnrichedCard[];
+  panel?: BestPanel;
+}
+
+const CONSENSUS = 'consensus';
+
+export function BestRankingViews({ cards, panel }: BestRankingViewsProps) {
+  const models = panel?.models ?? [];
+  // Only offer per-model views when we have a real panel (2+ models) and the
+  // cards actually carry per-model ranks.
+  const hasPanel =
+    models.length >= 2 && cards.some(c => c.consensus?.ranks && Object.keys(c.consensus.ranks).length > 0);
+
+  const [view, setView] = useState<string>(CONSENSUS);
+
+  const ordered = useMemo(() => {
+    if (view === CONSENSUS || !hasPanel) return cards;
+    return [...cards].sort((a, b) => {
+      const ra = a.consensus?.ranks?.[view] ?? Number.MAX_SAFE_INTEGER;
+      const rb = b.consensus?.ranks?.[view] ?? Number.MAX_SAFE_INTEGER;
+      return ra - rb;
+    });
+  }, [view, cards, hasPanel]);
+
+  return (
+    <>
+      {hasPanel && (
+        <div style={{ marginBottom: 20 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              flexWrap: 'wrap',
+              fontSize: 13,
+              color: 'var(--muted)',
+            }}
+          >
+            <span style={{ fontWeight: 600 }}>View ranking by:</span>
+            <div
+              role="tablist"
+              aria-label="Ranking view"
+              style={{
+                display: 'inline-flex',
+                gap: 4,
+                padding: 4,
+                borderRadius: 10,
+                background: 'color-mix(in oklab, var(--accent) 6%, transparent)',
+                border: '1px solid var(--line, rgba(0,0,0,0.08))',
+                flexWrap: 'wrap',
+              }}
+            >
+              <ViewButton label="Consensus" active={view === CONSENSUS} onClick={() => setView(CONSENSUS)} />
+              {models.map(m => (
+                <ViewButton
+                  key={m.key}
+                  label={m.label}
+                  active={view === m.key}
+                  onClick={() => setView(m.key)}
+                />
+              ))}
+            </div>
+          </div>
+          <p style={{ marginTop: 8, fontSize: 12.5, color: 'var(--muted)' }}>
+            {view === CONSENSUS
+              ? `Consensus ranking — combined ${panel?.method === 'borda' ? 'Borda-count ' : ''}vote of ${models.length} models.`
+              : `Showing ${models.find(m => m.key === view)?.label ?? 'this model'}'s individual ranking.`}
+          </p>
+        </div>
+      )}
+
+      <BestComparisonTable cards={ordered} />
+      <BestCardList cards={ordered} panel={panel} activeView={hasPanel ? view : undefined} />
+    </>
+  );
+}
+
+function ViewButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      style={{
+        padding: '5px 12px',
+        borderRadius: 7,
+        border: 'none',
+        cursor: 'pointer',
+        fontSize: 13,
+        fontWeight: 600,
+        background: active ? 'var(--accent)' : 'transparent',
+        color: active ? '#fff' : 'var(--ink, #1a1a2e)',
+        transition: 'background 0.15s, color 0.15s',
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/web-next/src/components/best/BestRankingViews.tsx
+++ b/apps/web-next/src/components/best/BestRankingViews.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/lib/api';
 import { BestPageCard, BestPanel } from '@/lib/best';
 import { BestComparisonTable } from './BestComparisonTable';
 import { BestCardList } from './BestCardList';
+import { ModelIcon } from './ModelIcon';
 
 type EnrichedCard = BestPageCard & { card: Card };
 
@@ -66,6 +67,7 @@ export function BestRankingViews({ cards, panel }: BestRankingViewsProps) {
                 <ViewButton
                   key={m.key}
                   label={m.label}
+                  icon={<ModelIcon modelKey={m.key} />}
                   active={view === m.key}
                   onClick={() => setView(m.key)}
                 />
@@ -74,7 +76,7 @@ export function BestRankingViews({ cards, panel }: BestRankingViewsProps) {
           </div>
           <p style={{ marginTop: 8, fontSize: 12.5, color: 'var(--muted)' }}>
             {view === CONSENSUS
-              ? `Consensus ranking — combined ${panel?.method === 'borda' ? 'Borda-count ' : ''}vote of ${models.length} models.`
+              ? `Consensus ranking, combined ${panel?.method === 'borda' ? 'Borda-count ' : ''}vote of ${models.length} models.`
               : `Showing ${models.find(m => m.key === view)?.label ?? 'this model'}'s individual ranking.`}
           </p>
         </div>
@@ -86,7 +88,17 @@ export function BestRankingViews({ cards, panel }: BestRankingViewsProps) {
   );
 }
 
-function ViewButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+function ViewButton({
+  label,
+  active,
+  onClick,
+  icon,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  icon?: React.ReactNode;
+}) {
   return (
     <button
       type="button"
@@ -94,6 +106,9 @@ function ViewButton({ label, active, onClick }: { label: string; active: boolean
       aria-selected={active}
       onClick={onClick}
       style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
         padding: '5px 12px',
         borderRadius: 7,
         border: 'none',
@@ -105,6 +120,7 @@ function ViewButton({ label, active, onClick }: { label: string; active: boolean
         transition: 'background 0.15s, color 0.15s',
       }}
     >
+      {icon}
       {label}
     </button>
   );

--- a/apps/web-next/src/components/best/ModelIcon.tsx
+++ b/apps/web-next/src/components/best/ModelIcon.tsx
@@ -1,0 +1,76 @@
+// Brand marks for the model panel toggle. OpenAI uses currentColor so it
+// inverts on the active (purple) tab; Claude and Gemini keep brand colors.
+
+const SIZE = 14;
+
+function OpenAIMark() {
+  return (
+    <svg width={SIZE} height={SIZE} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.1419.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+    </svg>
+  );
+}
+
+function ClaudeMark() {
+  // Anthropic / Claude sunburst, rendered in brand coral.
+  const cx = 12;
+  const cy = 12;
+  const blades = Array.from({ length: 12 }, (_, i) => {
+    const angle = (i * 30 * Math.PI) / 180;
+    const inner = 2.4;
+    const outer = i % 2 === 0 ? 10 : 7.6;
+    return (
+      <line
+        key={i}
+        x1={cx + inner * Math.cos(angle)}
+        y1={cy + inner * Math.sin(angle)}
+        x2={cx + outer * Math.cos(angle)}
+        y2={cy + outer * Math.sin(angle)}
+        stroke="#D97757"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+      />
+    );
+  });
+  return (
+    <svg width={SIZE} height={SIZE} viewBox="0 0 24 24" aria-hidden="true">
+      {blades}
+    </svg>
+  );
+}
+
+function GeminiMark() {
+  return (
+    <svg width={SIZE} height={SIZE} viewBox="0 0 24 24" aria-hidden="true">
+      <defs>
+        <linearGradient id="co-gemini-grad" x1="0" y1="0" x2="24" y2="24" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#1BA1E3" />
+          <stop offset="0.3" stopColor="#5489D6" />
+          <stop offset="0.55" stopColor="#9B72CB" />
+          <stop offset="0.82" stopColor="#D96570" />
+          <stop offset="1" stopColor="#F49C46" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M12 24A14.304 14.304 0 0 0 0 12 14.304 14.304 0 0 0 12 0a14.305 14.305 0 0 0 12 12 14.305 14.305 0 0 0-12 12"
+        fill="url(#co-gemini-grad)"
+      />
+    </svg>
+  );
+}
+
+const MARKS: Record<string, () => React.ReactElement> = {
+  openai: OpenAIMark,
+  claude: ClaudeMark,
+  gemini: GeminiMark,
+};
+
+export function ModelIcon({ modelKey }: { modelKey: string }) {
+  const Mark = MARKS[modelKey];
+  if (!Mark) return null;
+  return (
+    <span style={{ display: 'inline-flex', flexShrink: 0 }}>
+      <Mark />
+    </span>
+  );
+}

--- a/apps/web-next/src/lib/best.ts
+++ b/apps/web-next/src/lib/best.ts
@@ -1,11 +1,29 @@
 // Best pages API types and fetching
 import { fetchWithRetry } from './fetchWithRetry';
 
+export interface BestConsensus {
+  score?: number;
+  ranks?: Record<string, number>;
+}
+
+export interface BestPanelModel {
+  key: string;
+  label: string;
+  model?: string;
+}
+
+export interface BestPanel {
+  method?: string;
+  generated_at?: string;
+  models: BestPanelModel[];
+}
+
 export interface BestPageCard {
   slug: string;
   highlight?: string;
   badge?: string;
   previous_rank?: number;
+  consensus?: BestConsensus;
 }
 
 export interface BestPage {
@@ -20,6 +38,7 @@ export interface BestPage {
   seo_title?: string;
   seo_description?: string;
   intro?: string;
+  panel?: BestPanel;
   cards: BestPageCard[];
 }
 

--- a/data/best/schema.json
+++ b/data/best/schema.json
@@ -59,6 +59,36 @@
       "type": "string",
       "description": "Optional intro text in Markdown format"
     },
+    "panel": {
+      "type": "object",
+      "description": "Metadata about the model panel that produced the consensus ranking",
+      "required": ["models"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "Aggregation method used to combine model votes (e.g. 'borda')"
+        },
+        "generated_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "Date the panel ranking was generated (YYYY-MM-DD)"
+        },
+        "models": {
+          "type": "array",
+          "minItems": 1,
+          "description": "The models that voted, in panel order",
+          "items": {
+            "type": "object",
+            "required": ["key", "label"],
+            "properties": {
+              "key": { "type": "string", "pattern": "^[a-z0-9-]+$", "description": "Stable key used in each card's consensus.ranks" },
+              "label": { "type": "string", "description": "Display label (e.g. 'Claude', 'GPT', 'Gemini')" },
+              "model": { "type": "string", "description": "Exact model id used" }
+            }
+          }
+        }
+      }
+    },
     "cards": {
       "type": "array",
       "minItems": 1,
@@ -83,6 +113,21 @@
             "type": "integer",
             "minimum": 1,
             "description": "Previous rank position (only present if card moved since last ranking)"
+          },
+          "consensus": {
+            "type": "object",
+            "description": "Per-card panel consensus data (powers per-model views on the frontend)",
+            "properties": {
+              "score": {
+                "type": "number",
+                "description": "Aggregate Borda score (higher = ranked better by the panel)"
+              },
+              "ranks": {
+                "type": "object",
+                "description": "Each model's rank for this card, keyed by panel model key",
+                "additionalProperties": { "type": "integer", "minimum": 1 }
+              }
+            }
           }
         }
       },

--- a/scripts/refresh-best-pages.js
+++ b/scripts/refresh-best-pages.js
@@ -1,20 +1,34 @@
 #!/usr/bin/env node
 
 /**
- * Refresh Best Pages Script
+ * Refresh Best Pages Script — multi-model panel
  *
- * Re-ranks all data/best/*.yaml pages using Claude. For each page:
- * 1. Loads current card list and enriches with live data from cards.json
- * 2. Sends to Claude to re-rank, reassign badges, rewrite highlights,
- *    and provide reasoning for each ranking decision
- * 3. Writes updated YAML with new order, badges, highlights, and
- *    reasoning comments
+ * Re-ranks all data/best/*.yaml pages using a PANEL of models, then writes
+ * a single consensus ranking. For each page:
+ *   1. Loads current card list and enriches with live data from cards.json
+ *   2. Sends an IDENTICAL ranking prompt to every available voter model
+ *      (Claude, OpenAI, Gemini) and collects each model's ranked order.
+ *   3. Aggregates the votes with a Borda count → consensus order.
+ *   4. Claude (the "writer") writes the intro + per-card badge/highlight for
+ *      the consensus order (prose is never voted on — one editorial voice).
+ *   5. Writes updated YAML with the consensus order, badges, highlights,
+ *      reasoning comments, a `panel:` block, and per-card `consensus:` data
+ *      (score + every model's rank) so the frontend can offer per-model views.
+ *
+ * Graceful degradation: a voter that errors / returns bad JSON is dropped from
+ * the panel for that run (logged), and the refresh still ships with the
+ * survivors. Anthropic is required (it is the writer); if it fails on a page,
+ * the page keeps its previous prose but still adopts the consensus order.
  *
  * Creates a summary file (.refresh-best-summary.md) for the PR body.
  *
  * Env:
- *   ANTHROPIC_API_KEY (required)
- *   RANKING_MODEL (optional, default: claude-haiku-4-5-20251001)
+ *   ANTHROPIC_API_KEY    (required — Claude votes AND writes)
+ *   OPENAI_API_KEY       (optional — adds GPT to the panel)
+ *   GEMINI_API_KEY       (optional — adds Gemini to the panel)
+ *   RANKING_MODEL        (optional, default: claude-haiku-4-5-20251001)
+ *   OPENAI_RANKING_MODEL (optional, default: gpt-4o-mini)
+ *   GEMINI_RANKING_MODEL (optional, default: gemini-2.0-flash)
  */
 
 const fs = require('fs');
@@ -24,7 +38,39 @@ const yaml = require('js-yaml');
 const BEST_DIR = path.join(__dirname, '..', 'data', 'best');
 const CARDS_FILE = path.join(__dirname, '..', 'data', 'cards.json');
 const SUMMARY_FILE = path.join(__dirname, '..', '.refresh-best-summary.md');
-const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+
+const AGGREGATION_METHOD = 'borda';
+
+// ─── Panel definition ────────────────────────────────────────────────────────
+// `key` is the stable identifier stored in YAML and used by the frontend toggle.
+// Anthropic is `required` because it is also the writer.
+
+const PANEL = [
+  {
+    key: 'claude',
+    label: 'Claude',
+    envKey: 'ANTHROPIC_API_KEY',
+    model: process.env.RANKING_MODEL || 'claude-haiku-4-5-20251001',
+    call: callAnthropic,
+    required: true,
+  },
+  {
+    key: 'openai',
+    label: 'GPT',
+    envKey: 'OPENAI_API_KEY',
+    model: process.env.OPENAI_RANKING_MODEL || 'gpt-4o-mini',
+    call: callOpenAI,
+  },
+  {
+    key: 'gemini',
+    label: 'Gemini',
+    envKey: 'GEMINI_API_KEY',
+    model: process.env.GEMINI_RANKING_MODEL || 'gemini-2.0-flash',
+    call: callGemini,
+  },
+];
+
+const WRITER_KEY = 'claude';
 
 // ─── Data loading ────────────────────────────────────────────────────────────
 
@@ -50,7 +96,7 @@ function loadBestPages() {
   return pages;
 }
 
-// ─── Card data extraction (only the fields Claude needs) ─────────────────────
+// ─── Card data extraction (only the fields models need) ──────────────────────
 
 function getCardContext(card) {
   if (!card) return null;
@@ -75,83 +121,23 @@ function getCardContext(card) {
       description: r.description,
     }));
   }
-  if (card.apr) {
-    ctx.apr = card.apr;
-  }
-  if (card.intro_apr) {
-    ctx.intro_apr = card.intro_apr;
-  }
+  if (card.apr) ctx.apr = card.apr;
+  if (card.intro_apr) ctx.intro_apr = card.intro_apr;
   return ctx;
 }
 
-// ─── Claude API call ─────────────────────────────────────────────────────────
-
-async function rankPage(page, cardsLookup) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error('ANTHROPIC_API_KEY required');
-
-  const model = process.env.RANKING_MODEL || DEFAULT_MODEL;
-
-  // Build card context for each entry
-  const cardsWithData = page.data.cards.map(entry => {
-    const liveCard = cardsLookup[entry.slug];
-    return {
-      slug: entry.slug,
-      badge: entry.badge || null,
-      current_rank: page.data.cards.indexOf(entry) + 1,
-      current_highlight: entry.highlight || '',
-      card_data: getCardContext(liveCard),
-    };
-  });
-
-  const prompt = `You are re-ranking the cards for a "Best Credit Cards" page on CreditOdds based on current card terms.
-
-PAGE: "${page.data.title}"
-PAGE DESCRIPTION: "${page.data.description}"
-CURRENT INTRO:
-${page.data.intro || '(none)'}
-
-CARDS (current ranked order):
-${JSON.stringify(cardsWithData, null, 2)}
-
-YOUR TASK:
-1. RE-RANK these cards from best to worst based on their current card_data. Consider: signup bonus value and attainability, ongoing reward rates for the page's category, annual fee vs value, and overall competitiveness. The #1 card should be the single best option for most people in this category.
-2. REASSIGN BADGES — assign 2-4 badges across the list to highlight standout cards (e.g. "Best Overall", "Best No-Fee", "Best Value", "Best Premium", "Best for Beginners"). Not every card needs a badge. Use null for cards without one.
-3. REWRITE each card's "highlight" text using CURRENT card_data numbers. Keep 1-3 sentences, concise and factual. Mention specific numbers (bonus value, spend requirement, annual fee, reward rates).
-4. REWRITE the page "intro" paragraph to reflect the current landscape. Keep it 1-3 sentences.
-5. Provide REASONING for each card's rank — 2-3 sentences explaining why it's ranked where it is.
-
-RANKING GUIDELINES:
-- Cards with stronger signup bonuses (higher value, lower spend requirement) should rank higher when other factors are similar.
-- No-annual-fee cards that offer strong rewards punch above their weight.
-- A high annual fee is justified only if the rewards and perks clearly offset it.
-- Category relevance matters: for a "Best Cash Back" page, a card's cash back rates matter most. For "Best Travel", transfer partners, travel perks, and portal multipliers matter most.
-- Consider the full picture: a card with a slightly lower bonus but much better ongoing rewards may deserve a higher rank.
-
-RULES:
-- Do NOT add or remove cards — only reorder the ones provided.
-- ONLY use facts from the card_data provided. Never invent or assume numbers.
-- If card_data is null (card not found in cards.json), keep its current position and return its current_highlight unchanged.
-- If a signup_bonus value is a string like "4 Free Night Awards", use it as-is.
-- Match the existing concise, factual, comparative editorial tone. No hype words like "incredible", "amazing", or "unbeatable".
-- Do not mention CreditOdds or link to anything.
-
-Return ONLY valid JSON (no markdown fences) in this exact format:
-{
-  "intro": "updated intro text",
-  "cards": [
-    {
-      "slug": "card-slug",
-      "badge": "Badge Name or null",
-      "highlight": "updated highlight text",
-      "reasoning": "2-3 sentence explanation of this ranking position"
-    }
-  ]
+function buildCardsWithData(page, cardsLookup) {
+  return page.data.cards.map((entry, i) => ({
+    slug: entry.slug,
+    current_rank: i + 1,
+    card_data: getCardContext(cardsLookup[entry.slug]),
+  }));
 }
 
-The cards array MUST be in your new ranked order (index 0 = #1 rank).`;
+// ─── Provider adapters (each returns raw response text) ───────────────────────
 
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
+async function callAnthropic(model, prompt, apiKey) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -164,43 +150,294 @@ The cards array MUST be in your new ranked order (index 0 = #1 rank).`;
       messages: [{ role: 'user', content: prompt }],
     }),
   });
+  if (!res.ok) throw new Error(`Anthropic API ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.content?.[0]?.text || '';
+}
 
-  if (!response.ok) {
-    const errText = await response.text();
-    throw new Error(`Claude API error: ${response.status} — ${errText}`);
-  }
+async function callOpenAI(model, prompt, apiKey) {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      response_format: { type: 'json_object' },
+      temperature: 0.2,
+      max_tokens: 4096,
+    }),
+  });
+  if (!res.ok) throw new Error(`OpenAI API ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content || '';
+}
 
-  const data = await response.json();
-  const text = (data.content[0]?.text || '{}')
-    .replace(/^```json?\n?/, '')
+async function callGemini(model, prompt, apiKey) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: {
+        responseMimeType: 'application/json',
+        temperature: 0.2,
+        maxOutputTokens: 4096,
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`Gemini API ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+}
+
+function stripFences(text) {
+  return (text || '')
+    .replace(/^```json?\n?/i, '')
     .replace(/\n?```$/, '')
     .trim();
+}
 
-  try {
-    const result = JSON.parse(text);
-    // Validate all slugs are present
-    const inputSlugs = new Set(page.data.cards.map(c => c.slug));
-    const outputSlugs = new Set(result.cards.map(c => c.slug));
-    for (const slug of inputSlugs) {
-      if (!outputSlugs.has(slug)) {
-        console.warn(`    Warning: Claude dropped card "${slug}" — adding back at end`);
-        const original = page.data.cards.find(c => c.slug === slug);
-        result.cards.push({
-          slug,
-          badge: original.badge || null,
-          highlight: original.highlight || '',
-          reasoning: 'Kept from previous ranking (not included in AI response).',
-        });
-      }
+// ─── Prompts ─────────────────────────────────────────────────────────────────
+
+const SHARED_GUIDELINES = `RANKING GUIDELINES:
+- Cards with stronger signup bonuses (higher value, lower spend requirement) should rank higher when other factors are similar.
+- No-annual-fee cards that offer strong rewards punch above their weight.
+- A high annual fee is justified only if the rewards and perks clearly offset it.
+- Category relevance matters: for a "Best Cash Back" page a card's cash back rates matter most; for "Best Travel" transfer partners, travel perks, and portal multipliers matter most.
+- Consider the full picture: a card with a slightly lower bonus but much better ongoing rewards may deserve a higher rank.
+
+RULES:
+- Rank ALL provided cards. Do NOT add, remove, or invent cards.
+- ONLY use facts from the card_data provided. Never invent or assume numbers.
+- If card_data is null (card not found), rank it near the bottom.`;
+
+function buildVoterPrompt(page, cardsWithData) {
+  return `You are ranking the cards for a "Best Credit Cards" page on CreditOdds based on current card terms.
+
+PAGE: "${page.data.title}"
+PAGE DESCRIPTION: "${page.data.description}"
+
+CARDS (current order, to be re-ranked):
+${JSON.stringify(cardsWithData, null, 2)}
+
+YOUR TASK:
+Rank every card from best (#1) to worst based on its current card_data. The #1 card should be the single best option for most people in this category. Consider signup bonus value and attainability, ongoing reward rates for the page's category, annual fee vs value, and overall competitiveness.
+
+${SHARED_GUIDELINES}
+
+Return ONLY valid JSON (no markdown fences) in this exact format, listing EVERY card slug exactly once, best first:
+{
+  "ranking": ["best-card-slug", "second-best-slug", "..."]
+}`;
+}
+
+function buildWriterPrompt(page, orderedCardsWithData) {
+  return `You are writing the editorial copy for a "Best Credit Cards" page on CreditOdds. The ranking has ALREADY been decided by a panel of models — your job is to write the prose for this fixed order, NOT to re-rank.
+
+PAGE: "${page.data.title}"
+PAGE DESCRIPTION: "${page.data.description}"
+CURRENT INTRO:
+${page.data.intro || '(none)'}
+
+CARDS (FINAL ranked order — index 0 is #1, do NOT reorder):
+${JSON.stringify(orderedCardsWithData, null, 2)}
+
+YOUR TASK:
+1. REWRITE the page "intro" paragraph to reflect the current landscape. Keep it 1-3 sentences.
+2. For EACH card, in the SAME order given:
+   a. Assign a "badge" — across the whole list use 2-4 badges total to highlight standout cards (e.g. "Best Overall" for #1, "Best No-Fee", "Best Value", "Best Premium", "Best for Beginners"). Most cards get null. The #1 card should usually get "Best Overall".
+   b. Write a "highlight" — 1-3 sentences, concise and factual, using CURRENT card_data numbers (bonus value, spend requirement, annual fee, reward rates).
+   c. Write a "reasoning" — 2-3 sentences explaining the card's strengths and why it sits where it does in the ranking.
+
+RULES:
+- Keep the cards array in the EXACT order provided. Do NOT reorder, add, or remove cards.
+- ONLY use facts from card_data. Never invent or assume numbers.
+- If a signup_bonus value is a string like "4 Free Night Awards", use it as-is.
+- Match the existing concise, factual, comparative editorial tone. No hype words like "incredible", "amazing", or "unbeatable". Do not use em dashes.
+- Do not mention CreditOdds or link to anything.
+
+Return ONLY valid JSON (no markdown fences) in this exact format:
+{
+  "intro": "updated intro text",
+  "cards": [
+    { "slug": "card-slug", "badge": "Badge Name or null", "highlight": "updated highlight text", "reasoning": "2-3 sentence explanation" }
+  ]
+}`;
+}
+
+// ─── Voting + aggregation ────────────────────────────────────────────────────
+
+function parseRanking(text, inputSlugs) {
+  const parsed = JSON.parse(stripFences(text));
+  let ranking = Array.isArray(parsed) ? parsed : parsed.ranking;
+  if (!Array.isArray(ranking)) throw new Error('no ranking array in response');
+
+  const known = new Set(inputSlugs);
+  const seen = new Set();
+  const cleaned = [];
+  for (const slug of ranking) {
+    if (known.has(slug) && !seen.has(slug)) {
+      seen.add(slug);
+      cleaned.push(slug);
     }
-    // Remove any cards Claude added that weren't in the input
-    result.cards = result.cards.filter(c => inputSlugs.has(c.slug));
-    return result;
-  } catch (err) {
-    console.warn(`  Could not parse Claude response for ${page.data.title}: ${err.message}`);
-    console.warn(`  Raw response: ${text.slice(0, 500)}`);
+  }
+  // A vote must cover at least half the pool to count; otherwise it is unreliable.
+  if (cleaned.length < Math.ceil(inputSlugs.length / 2)) {
+    throw new Error(`only ${cleaned.length}/${inputSlugs.length} valid slugs returned`);
+  }
+  return cleaned;
+}
+
+async function collectVotes(page, cardsWithData) {
+  const inputSlugs = page.data.cards.map(c => c.slug);
+  const prompt = buildVoterPrompt(page, cardsWithData);
+  const votes = [];
+
+  for (const provider of PANEL) {
+    const apiKey = process.env[provider.envKey];
+    if (!apiKey) {
+      if (provider.required) throw new Error(`${provider.envKey} required (Claude is the writer)`);
+      console.log(`    ${provider.label}: no ${provider.envKey} — skipping`);
+      continue;
+    }
+    try {
+      const text = await provider.call(provider.model, prompt, apiKey);
+      const ranking = parseRanking(text, inputSlugs);
+      votes.push({ key: provider.key, label: provider.label, model: provider.model, ranking });
+      console.log(`    ${provider.label} (${provider.model}): ranked ${ranking.length} cards`);
+    } catch (err) {
+      console.warn(`    ${provider.label}: dropped from panel — ${err.message}`);
+    }
+  }
+  return votes;
+}
+
+// Borda count: rank r out of N earns (N - r + 1) points. A card a voter omits
+// is treated as last (rank N) so omissions are penalized, not rewarded.
+function aggregate(votes, inputSlugs) {
+  const N = inputSlugs.length;
+  const scores = new Map(inputSlugs.map(s => [s, 0]));
+  const ranks = new Map(inputSlugs.map(s => [s, {}]));
+
+  for (const vote of votes) {
+    const rankOf = new Map();
+    vote.ranking.forEach((slug, i) => rankOf.set(slug, i + 1));
+    for (const slug of inputSlugs) {
+      const r = rankOf.has(slug) ? rankOf.get(slug) : N;
+      scores.set(slug, scores.get(slug) + (N - r + 1));
+      ranks.get(slug)[vote.key] = r;
+    }
+  }
+
+  const bestRank = slug => {
+    const vals = Object.values(ranks.get(slug));
+    return vals.length ? Math.min(...vals) : N;
+  };
+
+  const order = [...inputSlugs].sort((a, b) => {
+    if (scores.get(b) !== scores.get(a)) return scores.get(b) - scores.get(a);
+    // Tie-break 1: best single-model rank wins.
+    if (bestRank(a) !== bestRank(b)) return bestRank(a) - bestRank(b);
+    // Tie-break 2: keep incumbent order for stability.
+    return inputSlugs.indexOf(a) - inputSlugs.indexOf(b);
+  });
+
+  return { order, scores, ranks };
+}
+
+// ─── Writer pass ─────────────────────────────────────────────────────────────
+
+async function writeProse(page, orderedCardsWithData, inputSlugs) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const writer = PANEL.find(p => p.key === WRITER_KEY);
+  const text = await writer.call(writer.model, buildWriterPrompt(page, orderedCardsWithData), apiKey);
+  const parsed = JSON.parse(stripFences(text));
+  if (!Array.isArray(parsed.cards)) throw new Error('writer returned no cards array');
+
+  const bySlug = new Map(parsed.cards.map(c => [c.slug, c]));
+  const known = new Set(inputSlugs);
+  // Re-key strictly to the consensus order; ignore any reordering the writer did.
+  const cards = orderedCardsWithData
+    .filter(c => known.has(c.slug))
+    .map(c => {
+      const w = bySlug.get(c.slug) || {};
+      return {
+        slug: c.slug,
+        badge: w.badge && w.badge !== 'null' ? w.badge : null,
+        highlight: w.highlight || '',
+        reasoning: w.reasoning || '',
+      };
+    });
+  return { intro: parsed.intro || page.data.intro || '', cards };
+}
+
+// Fallback prose: reuse the page's existing badges/highlights in consensus order.
+function fallbackProse(page, order) {
+  const prev = new Map(page.data.cards.map(c => [c.slug, c]));
+  return {
+    intro: page.data.intro || '',
+    cards: order.map(slug => {
+      const p = prev.get(slug) || {};
+      return {
+        slug,
+        badge: p.badge || null,
+        highlight: p.highlight || '',
+        reasoning: 'Kept from previous ranking (writer model unavailable this run).',
+      };
+    }),
+  };
+}
+
+// ─── Per-page orchestration ──────────────────────────────────────────────────
+
+async function rankPage(page, cardsLookup) {
+  const inputSlugs = page.data.cards.map(c => c.slug);
+  const cardsWithData = buildCardsWithData(page, cardsLookup);
+
+  const votes = await collectVotes(page, cardsWithData);
+  if (votes.length === 0) {
+    console.warn('    No usable votes — skipping page');
     return null;
   }
+
+  const { order, scores, ranks } = aggregate(votes, inputSlugs);
+
+  // Card data in the new consensus order, for the writer.
+  const dataBySlug = new Map(cardsWithData.map(c => [c.slug, c]));
+  const orderedCardsWithData = order.map(slug => dataBySlug.get(slug));
+
+  let prose;
+  try {
+    prose = await writeProse(page, orderedCardsWithData, inputSlugs);
+    console.log(`    Writer (${PANEL.find(p => p.key === WRITER_KEY).model}): wrote prose for ${prose.cards.length} cards`);
+  } catch (err) {
+    console.warn(`    Writer failed (${err.message}) — keeping previous highlights/badges`);
+    prose = fallbackProse(page, order);
+  }
+
+  // Merge prose + consensus data into the final card list (already in order).
+  const proseBySlug = new Map(prose.cards.map(c => [c.slug, c]));
+  const cards = order.map(slug => {
+    const p = proseBySlug.get(slug) || { slug, badge: null, highlight: '', reasoning: '' };
+    return {
+      slug,
+      badge: p.badge || null,
+      highlight: p.highlight || '',
+      reasoning: p.reasoning || '',
+      score: scores.get(slug),
+      ranks: ranks.get(slug),
+    };
+  });
+
+  return {
+    intro: prose.intro,
+    cards,
+    panel: votes.map(v => ({ key: v.key, label: v.label, model: v.model })),
+  };
 }
 
 // ─── YAML generation ─────────────────────────────────────────────────────────
@@ -209,19 +446,18 @@ function buildYaml(page, updates, today) {
   const d = page.data;
   const lines = [];
 
-  // Reasoning comment block at the top
   const divider = '# ' + '='.repeat(60);
   lines.push(divider);
   lines.push(`# ${d.title} — Ranking Reasoning (${today})`);
+  lines.push(`# Consensus of: ${updates.panel.map(p => p.label).join(', ')} (${AGGREGATION_METHOD} count)`);
   lines.push(divider);
   lines.push('#');
   for (let i = 0; i < updates.cards.length; i++) {
     const card = updates.cards[i];
     const badgeStr = card.badge ? ` (${card.badge})` : '';
-    lines.push(`# #${i + 1} ${card.slug}${badgeStr}`);
-    // Wrap reasoning to ~76 chars per line
-    const reasoningLines = wordWrap(card.reasoning || '', 74);
-    for (const rl of reasoningLines) {
+    const rankStr = formatRanksComment(card.ranks, updates.panel);
+    lines.push(`# #${i + 1} ${card.slug}${badgeStr}  [${rankStr}]`);
+    for (const rl of wordWrap(card.reasoning || '', 74)) {
       lines.push(`#   ${rl}`);
     }
     lines.push('#');
@@ -229,7 +465,7 @@ function buildYaml(page, updates, today) {
   lines.push(divider);
   lines.push('');
 
-  // Metadata fields
+  // Metadata
   lines.push(`id: ${d.id}`);
   lines.push(`slug: ${d.slug}`);
   lines.push(`title: ${d.title}`);
@@ -245,13 +481,24 @@ function buildYaml(page, updates, today) {
   const intro = updates.intro || d.intro;
   if (intro) {
     lines.push('intro: |');
-    const introLines = intro.trim().split('\n');
-    for (const il of introLines) {
+    for (const il of intro.trim().split('\n')) {
       lines.push(`  ${il}`);
     }
   }
 
-  // Cards — include previous_rank when position changed
+  // Panel metadata (powers the per-model toggle on the frontend)
+  lines.push('');
+  lines.push('panel:');
+  lines.push(`  method: ${AGGREGATION_METHOD}`);
+  lines.push(`  generated_at: "${today}"`);
+  lines.push('  models:');
+  for (const p of updates.panel) {
+    lines.push(`    - key: ${p.key}`);
+    lines.push(`      label: ${p.label}`);
+    lines.push(`      model: ${p.model}`);
+  }
+
+  // Cards — include previous_rank when position changed + consensus block
   const oldOrder = page.data.cards.map(c => c.slug);
   lines.push('');
   lines.push('cards:');
@@ -260,17 +507,20 @@ function buildYaml(page, updates, today) {
     const newRank = i + 1;
     const oldRank = oldOrder.indexOf(card.slug) + 1;
     lines.push(`  - slug: ${card.slug}`);
-    if (card.badge) {
-      lines.push(`    badge: ${card.badge}`);
-    }
-    if (oldRank > 0 && oldRank !== newRank) {
-      lines.push(`    previous_rank: ${oldRank}`);
-    }
+    if (card.badge) lines.push(`    badge: ${card.badge}`);
+    if (oldRank > 0 && oldRank !== newRank) lines.push(`    previous_rank: ${oldRank}`);
     lines.push(`    highlight: ${card.highlight}`);
+    lines.push('    consensus:');
+    lines.push(`      score: ${card.score}`);
+    lines.push(`      ranks: { ${updates.panel.map(p => `${p.key}: ${card.ranks[p.key]}`).join(', ')} }`);
     lines.push('');
   }
 
   return lines.join('\n');
+}
+
+function formatRanksComment(ranks, panel) {
+  return panel.map(p => `${p.label} #${ranks[p.key]}`).join(', ');
 }
 
 function wordWrap(text, maxLen) {
@@ -296,46 +546,33 @@ function detectChanges(page, updates) {
   const oldOrder = page.data.cards.map(c => c.slug);
   const newOrder = updates.cards.map(c => c.slug);
 
-  // Detect ranking changes
   const rankChanges = [];
   for (let i = 0; i < newOrder.length; i++) {
     const slug = newOrder[i];
     const oldRank = oldOrder.indexOf(slug) + 1;
     const newRank = i + 1;
     if (oldRank !== newRank) {
-      const direction = newRank < oldRank ? 'up' : 'down';
-      const arrow = newRank < oldRank ? '\u2191' : '\u2193'; // ↑ or ↓
       rankChanges.push({
         slug,
         oldRank,
         newRank,
-        direction,
-        arrow,
+        direction: newRank < oldRank ? 'up' : 'down',
+        arrow: newRank < oldRank ? '↑' : '↓',
       });
     }
   }
+  if (rankChanges.length > 0) changes.push({ type: 'ranking', rankChanges });
 
-  if (rankChanges.length > 0) {
-    changes.push({ type: 'ranking', rankChanges });
-  }
-
-  // Detect badge changes
   for (const newCard of updates.cards) {
     const oldCard = page.data.cards.find(c => c.slug === newCard.slug);
     if (!oldCard) continue;
     const oldBadge = oldCard.badge || null;
     const newBadge = newCard.badge || null;
     if (oldBadge !== newBadge) {
-      changes.push({
-        type: 'badge',
-        slug: newCard.slug,
-        old: oldBadge || '(none)',
-        new: newBadge || '(none)',
-      });
+      changes.push({ type: 'badge', slug: newCard.slug, old: oldBadge || '(none)', new: newBadge || '(none)' });
     }
   }
 
-  // Detect intro change
   if (updates.intro && updates.intro.trim() !== (page.data.intro || '').trim()) {
     changes.push({ type: 'intro' });
   }
@@ -345,32 +582,33 @@ function detectChanges(page, updates) {
 
 // ─── PR summary ──────────────────────────────────────────────────────────────
 
-function generateSummary(allResults, today, model) {
+function generateSummary(allResults, today) {
   let md = `## Refresh Best Pages — ${today}\n\n`;
-  md += `Re-ranked using **${model}** with current card data from cards.json.\n`;
+  md += 'Re-ranked by a **panel of models** (Borda consensus), with current card data from cards.json.\n';
   md += '**Review each ranking change before merging.**\n\n';
 
   let totalChanges = 0;
 
-  for (const { page, changes } of allResults) {
+  for (const { page, changes, updates } of allResults) {
     if (changes.length === 0) continue;
     totalChanges += changes.length;
 
     md += `### ${page.data.title}\n\n`;
+    md += `Panel: ${updates.panel.map(p => `${p.label} (\`${p.model}\`)`).join(', ')}\n\n`;
 
-    // Show ranking changes
     const rankChange = changes.find(c => c.type === 'ranking');
     if (rankChange) {
       md += '**Ranking Changes:**\n\n';
-      md += '| Card | Old Rank | New Rank | Change |\n';
-      md += '|------|----------|----------|--------|\n';
+      md += '| Card | Old Rank | New Rank | Change | Per-model ranks |\n';
+      md += '|------|----------|----------|--------|-----------------|\n';
       for (const rc of rankChange.rankChanges) {
-        md += `| ${rc.slug} | #${rc.oldRank} | #${rc.newRank} | ${rc.arrow} ${rc.direction} |\n`;
+        const card = updates.cards.find(c => c.slug === rc.slug);
+        const perModel = updates.panel.map(p => `${p.label} #${card.ranks[p.key]}`).join(', ');
+        md += `| ${rc.slug} | #${rc.oldRank} | #${rc.newRank} | ${rc.arrow} ${rc.direction} | ${perModel} |\n`;
       }
       md += '\n';
     }
 
-    // Show badge changes
     const badgeChanges = changes.filter(c => c.type === 'badge');
     if (badgeChanges.length > 0) {
       md += '**Badge Changes:**\n\n';
@@ -384,7 +622,7 @@ function generateSummary(allResults, today, model) {
   if (totalChanges === 0) return '';
 
   md += '### How to Review\n';
-  md += '1. Check the ranking reasoning in the YAML comment block at the top of each file\n';
+  md += '1. Check the ranking reasoning + per-model ranks in the YAML comment block at the top of each file\n';
   md += '2. Verify highlights reflect current card terms\n';
   md += '3. Run `npm run build:best` to validate\n\n';
   md += '---\n*Automated PR — review carefully before merging.*\n';
@@ -395,12 +633,12 @@ function generateSummary(allResults, today, model) {
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
-  const model = process.env.RANKING_MODEL || DEFAULT_MODEL;
-  console.log('=== Refresh Best Pages ===');
-  console.log(`Model: ${model}\n`);
+  console.log('=== Refresh Best Pages (multi-model panel) ===');
+  const available = PANEL.filter(p => process.env[p.envKey]);
+  console.log(`Panel: ${available.map(p => `${p.label} (${p.model})`).join(', ') || '(none)'}\n`);
 
   if (!process.env.ANTHROPIC_API_KEY) {
-    console.error('Error: ANTHROPIC_API_KEY environment variable is required');
+    console.error('Error: ANTHROPIC_API_KEY is required (Claude is the writer)');
     process.exit(1);
   }
 
@@ -426,15 +664,11 @@ async function main() {
       console.warn(`  Error: ${err.message} — skipping\n`);
       continue;
     }
-
     if (!updates) {
       console.log('  No response — skipping\n');
       continue;
     }
 
-    console.log(`  Received ${updates.cards.length} cards in ranked order`);
-
-    // Detect changes
     const changes = detectChanges(page, updates);
     const rankChange = changes.find(c => c.type === 'ranking');
     if (rankChange) {
@@ -446,17 +680,15 @@ async function main() {
       console.log('  No ranking changes');
     }
 
-    // Always write the file (highlights and reasoning are always refreshed)
     const yamlContent = buildYaml(page, updates, today);
     fs.writeFileSync(page.filepath, yamlContent);
     console.log(`  Written to ${page.file}`);
 
-    allResults.push({ page, changes });
+    allResults.push({ page, changes, updates });
     console.log('');
   }
 
-  // Generate PR summary
-  const summary = generateSummary(allResults, today, model);
+  const summary = generateSummary(allResults, today);
   if (summary) {
     fs.writeFileSync(SUMMARY_FILE, summary);
     console.log(`PR summary written to ${SUMMARY_FILE}`);

--- a/scripts/refresh-best-pages.js
+++ b/scripts/refresh-best-pages.js
@@ -65,7 +65,7 @@ const PANEL = [
     key: 'gemini',
     label: 'Gemini',
     envKey: 'GEMINI_API_KEY',
-    model: process.env.GEMINI_RANKING_MODEL || 'gemini-2.0-flash',
+    model: process.env.GEMINI_RANKING_MODEL || 'gemini-3.5-flash',
     call: callGemini,
   },
 ];

--- a/scripts/refresh-best-pages.js
+++ b/scripts/refresh-best-pages.js
@@ -201,6 +201,17 @@ function stripFences(text) {
     .trim();
 }
 
+// User-facing copy must never contain em dashes (project style rule). Models
+// usually comply, but guarantee it: collapse " — " to ", " and any stray em
+// dash to a comma. En dashes (ranges) are left alone.
+function sanitizeProse(text) {
+  if (!text) return text;
+  return text
+    .replace(/\s*—\s*/g, ', ')
+    .replace(/,\s*,/g, ',')
+    .trim();
+}
+
 // ─── Prompts ─────────────────────────────────────────────────────────────────
 
 const SHARED_GUIDELINES = `RANKING GUIDELINES:
@@ -368,11 +379,11 @@ async function writeProse(page, orderedCardsWithData, inputSlugs) {
       return {
         slug: c.slug,
         badge: w.badge && w.badge !== 'null' ? w.badge : null,
-        highlight: w.highlight || '',
+        highlight: sanitizeProse(w.highlight || ''),
         reasoning: w.reasoning || '',
       };
     });
-  return { intro: parsed.intro || page.data.intro || '', cards };
+  return { intro: sanitizeProse(parsed.intro || page.data.intro || ''), cards };
 }
 
 // Fallback prose: reuse the page's existing badges/highlights in consensus order.

--- a/scripts/refresh-best-pages.js
+++ b/scripts/refresh-best-pages.js
@@ -185,13 +185,19 @@ async function callGemini(model, prompt, apiKey) {
       generationConfig: {
         responseMimeType: 'application/json',
         temperature: 0.2,
-        maxOutputTokens: 4096,
+        maxOutputTokens: 8192,
+        // Disable "thinking": Gemini 2.5+/3.x Flash otherwise spend the output
+        // budget on reasoning and return empty/truncated JSON on larger lists.
+        thinkingConfig: { thinkingBudget: 0 },
       },
     }),
   });
   if (!res.ok) throw new Error(`Gemini API ${res.status}: ${await res.text()}`);
   const data = await res.json();
-  return data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+  const candidate = data.candidates?.[0];
+  const text = candidate?.content?.parts?.map(p => p.text).filter(Boolean).join('') || '';
+  if (!text) throw new Error(`empty response (finishReason: ${candidate?.finishReason || 'unknown'})`);
+  return text;
 }
 
 function stripFences(text) {


### PR DESCRIPTION
## What

Extends the bi-monthly `/best` re-ranking from a single model (Claude) to a **panel** of models that each vote, with a **Borda-count consensus** as the published order.

- **Voters:** Claude, OpenAI (GPT), Gemini — each gets an *identical* ranking prompt and returns an ordered slug list.
- **Aggregation:** Borda count → single consensus order. Omitted slugs are penalized (treated as last); stable tie-breaks (best single-model rank, then incumbent order).
- **Writer:** Claude alone writes intro/badge/highlight prose for the consensus order. Prose is never voted on, so the editorial voice stays consistent.
- **Graceful degradation:** a voter that errors or returns bad JSON is dropped from the panel for that run (logged). Anthropic is required (it's the writer); if the writer fails on a page, that page keeps its prior prose but still adopts the consensus order.

## Data

Each YAML page gains an optional `panel:` block and each card an optional `consensus: { score, ranks }`. All new fields are optional — existing pages render unchanged until the next refresh.

## Frontend

- `BestRankingViews` adds a **Consensus | Claude | GPT | Gemini** toggle that client-side reorders the same cards by each model's stored rank (no extra fetch).
- `BestCardList` shows a per-card **agreement chip** (rank spread across models) in the consensus view.

## Ops

- Workflow passes `OPENAI_API_KEY` + `GEMINI_API_KEY` (already added as repo secrets) to the refresh step.
- Default models: `claude-haiku-4-5-20251001`, `gpt-4o-mini`, `gemini-2.0-flash` — each overridable via `*_RANKING_MODEL` env vars.

## Verification

- `tsc --noEmit` clean; `npm run build:best` validates all 7 pages with the new optional fields absent.
- First live run triggered via `workflow_dispatch` on this branch (see the stacked "Refresh Best Pages" PR for real multi-model output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)