### PR TITLE
fix(web): widen SSR fetch retries + drop self-healing network noise in Sentry

### DIFF
--- a/apps/web-next/sentry.server.config.ts
+++ b/apps/web-next/sentry.server.config.ts
@@ -2,6 +2,7 @@
 // Loaded by src/instrumentation.ts via register() when the server boots.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from '@sentry/nextjs';
+import { isTransientNetworkError } from '@/lib/transientNetworkError';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -14,4 +15,13 @@ Sentry.init({
 
   // Surface noisy local logs without shipping them.
   debug: false,
+
+  // Drop self-healing transient network blips (fetchWithRetry + ISR already
+  // recover from these, so users never see them and they aren't actionable).
+  beforeSend(event, hint) {
+    if (isTransientNetworkError(hint?.originalException)) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/apps/web-next/src/lib/fetchWithRetry.ts
+++ b/apps/web-next/src/lib/fetchWithRetry.ts
@@ -18,10 +18,21 @@
 // IMPORTANT: only use this for GET reads. Never wrap POST/mutations — a retry
 // after the server already applied the write would double-apply it.
 
-const DEFAULT_RETRIES = 2;
-const DEFAULT_BACKOFF_MS = 250;
+// 4 retries (5 attempts) over a ~2.5s window. The upstream (API Gateway /
+// CloudFront) periodically closes idle keep-alive sockets, and Node's fetch can
+// reuse a just-closed one ("other side closed"); a wider window lets a brief
+// hiccup — or a poisoned connection pool — clear before we give up.
+const DEFAULT_RETRIES = 4;
+const DEFAULT_BACKOFF_MS = 200;
 
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// Linear backoff with a little jitter so concurrent renders don't retry in
+// lockstep. No jitter when backoff is 0 (keeps tests fast/deterministic).
+const backoffFor = (attempt: number, backoffMs: number) => {
+  const base = backoffMs * (attempt + 1);
+  return base > 0 ? base + Math.floor(Math.random() * 100) : 0;
+};
 
 // Statuses that the Response constructor requires to have a null body.
 const NULL_BODY_STATUSES = new Set([204, 205, 304]);
@@ -42,7 +53,7 @@ export async function fetchWithRetry(
       // Retry transient upstream failures (5xx), but never client errors (4xx).
       if (res.status >= 500 && attempt < retries) {
         await res.body?.cancel();
-        await delay(backoffMs * (attempt + 1));
+        await delay(backoffFor(attempt, backoffMs));
         continue;
       }
 
@@ -60,7 +71,7 @@ export async function fetchWithRetry(
       // (ETIMEDOUT / "fetch failed" / "terminated"). Retry if budget remains.
       lastError = error;
       if (attempt < retries) {
-        await delay(backoffMs * (attempt + 1));
+        await delay(backoffFor(attempt, backoffMs));
         continue;
       }
     }

--- a/apps/web-next/src/lib/transientNetworkError.test.ts
+++ b/apps/web-next/src/lib/transientNetworkError.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { isTransientNetworkError } from "./transientNetworkError";
+
+describe("isTransientNetworkError", () => {
+  it("matches a bare transient message", () => {
+    expect(isTransientNetworkError(new TypeError("fetch failed"))).toBe(true);
+    expect(isTransientNetworkError(new TypeError("terminated"))).toBe(true);
+  });
+
+  it("matches the real undici cause chain (fetch failed -> SocketError)", () => {
+    // Shape Node produces: TypeError("fetch failed") with .cause = the SocketError.
+    const socketErr = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    const fetchErr = Object.assign(new TypeError("fetch failed"), { cause: socketErr });
+    expect(isTransientNetworkError(fetchErr)).toBe(true);
+  });
+
+  it("matches by error code", () => {
+    expect(isTransientNetworkError(Object.assign(new Error("read"), { code: "ECONNRESET" }))).toBe(
+      true,
+    );
+  });
+
+  it("does NOT match a real application error", () => {
+    expect(isTransientNetworkError(new Error("Cannot read properties of undefined"))).toBe(false);
+    expect(isTransientNetworkError(new TypeError("x is not a function"))).toBe(false);
+  });
+
+  it("handles null / non-error input safely", () => {
+    expect(isTransientNetworkError(null)).toBe(false);
+    expect(isTransientNetworkError(undefined)).toBe(false);
+    expect(isTransientNetworkError("just a string")).toBe(false);
+  });
+
+  it("does not loop forever on a circular cause chain", () => {
+    const a = new Error("boom") as Error & { cause?: unknown };
+    const b = new Error("bang") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(isTransientNetworkError(a)).toBe(false);
+  });
+});

--- a/apps/web-next/src/lib/transientNetworkError.ts
+++ b/apps/web-next/src/lib/transientNetworkError.ts
@@ -1,0 +1,34 @@
+// Recognises transient network failures between our SSR server and the upstream
+// CDN/API. These are self-healing — fetchWithRetry retries them and ISR keeps
+// serving the last-good cached page — so the residual ones that still reach
+// Sentry are not individually actionable and get dropped (see
+// sentry.server.config.ts). A genuine sustained outage still surfaces as
+// elevated 5xx/latency elsewhere.
+export const TRANSIENT_NETWORK_SIGNATURES = [
+  'fetch failed',
+  'terminated',
+  'other side closed',
+  'Client network socket disconnected',
+  'socket hang up',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EPIPE',
+  'UND_ERR_SOCKET',
+  'UND_ERR_CONNECT_TIMEOUT',
+];
+
+export function isTransientNetworkError(error: unknown): boolean {
+  // Walk the cause chain — undici nests the underlying SocketError under the
+  // TypeError("fetch failed") as `.cause`.
+  let current: unknown = error;
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    const e = current as { message?: unknown; code?: unknown; cause?: unknown };
+    const message = typeof e.message === 'string' ? e.message : '';
+    const code = typeof e.code === 'string' ? e.code : '';
+    if (TRANSIENT_NETWORK_SIGNATURES.some((sig) => message.includes(sig) || code === sig)) {
+      return true;
+    }
+    current = e.cause;
+  }
+  return false;
+}


### PR DESCRIPTION
## Why
After the retry fixes (#1481/#1482) deployed, transient `fetch failed` / `other side closed` errors **still** reached Sentry (e.g. issue 7575968400 on `/best-card-for/enterprise`, after the 6:00pm Amplify build). Root cause is the undici keep-alive race against AWS: API Gateway/CloudFront close idle pooled sockets and Node's `fetch` reuses a just-closed one. A 2-retry/750ms window can be outlasted by a brief hiccup.

**These are self-healing with zero user impact** — `fetchWithRetry` retries them and ISR serves the last-good cached page during background revalidation. So the only real cost was alert fatigue.

## Changes
**1. Wider retry window** — `fetchWithRetry` goes from 2 → 4 retries with jitter (~2.5s total), giving brief upstream hiccups and poisoned connection pools time to clear.

**2. Drop the residual noise in Sentry** — `sentry.server.config.ts` `beforeSend` now drops events whose error is a known transient network signature, walking the undici `.cause` chain (the real shape is `TypeError("fetch failed")` → `.cause = SocketError("other side closed", code: UND_ERR_SOCKET)`). Matched signatures: `fetch failed`, `terminated`, `other side closed`, `ECONNRESET`, `ETIMEDOUT`, `UND_ERR_SOCKET`, etc. A genuine sustained outage still surfaces as elevated 5xx/latency elsewhere — we're only suppressing individually-unactionable, self-healing blips.

Filter logic extracted to `src/lib/transientNetworkError.ts` and unit-tested (6 cases incl. the real cause chain, code matching, non-matching app errors, null input, and circular-cause safety). `fetchWithRetry` tests still green (12 total). `tsc` + `eslint` clean.

## Tradeoff
We accept that we'll no longer be paged for these specific transient blips. Given they're self-healing and were firing ~hourly with no user impact, that's the intended outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)