### PR TITLE
fix(web): drop benign Firebase IndexedDB AbortError noise in Sentry

### DIFF
--- a/apps/web-next/src/instrumentation-client.ts
+++ b/apps/web-next/src/instrumentation-client.ts
@@ -5,6 +5,7 @@
 // and an extra CSP/worker surface.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from '@sentry/nextjs';
+import { isBenignClientError } from '@/lib/benignClientError';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -15,6 +16,17 @@ Sentry.init({
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 1.0,
 
   debug: false,
+
+  // Drop benign teardown noise — chiefly Firebase Analytics' IndexedDB
+  // AbortErrors when the user navigates/reloads mid-transaction. The page
+  // loads fine; these aren't actionable (mirrors the server-side
+  // self-healing-network filter in sentry.server.config.ts).
+  beforeSend(event, hint) {
+    if (isBenignClientError(hint?.originalException)) {
+      return null;
+    }
+    return event;
+  },
 });
 
 // Required for navigation (route change) instrumentation in the App Router.

--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { isBenignClientError } from "./benignClientError";
+
+// Mimics a browser DOMException without depending on the DOM lib in tests.
+const domException = (message: string, name = "AbortError", code = 20) =>
+  ({ name, message, code }) as unknown;
+
+describe("isBenignClientError", () => {
+  it("drops Firebase IndexedDB transaction-aborted errors", () => {
+    expect(
+      isBenignClientError(
+        domException(
+          "The transaction was aborted, so the request cannot be fulfilled.",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops the bare 'AbortError: AbortError' rethrow", () => {
+    expect(isBenignClientError(domException("AbortError"))).toBe(true);
+  });
+
+  it("drops 'database connection is closing' aborts", () => {
+    expect(
+      isBenignClientError(
+        domException(
+          "Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("walks the cause chain when Firebase wraps the DOMException", () => {
+    const wrapped = {
+      name: "Error",
+      message: "wrapped",
+      cause: domException("The transaction was aborted"),
+    };
+    expect(isBenignClientError(wrapped)).toBe(true);
+  });
+
+  it("keeps a real AbortError that isn't IndexedDB-related", () => {
+    // e.g. a genuine fetch abort we'd still want to see — bare name only is
+    // benign, but a descriptive non-idb abort message is not matched.
+    expect(
+      isBenignClientError(domException("The user aborted a request.")),
+    ).toBe(false);
+  });
+
+  it("keeps unrelated errors", () => {
+    expect(
+      isBenignClientError(
+        domException("Cannot read properties of undefined", "TypeError", 0),
+      ),
+    ).toBe(false);
+  });
+
+  it("handles null/undefined safely", () => {
+    expect(isBenignClientError(null)).toBe(false);
+    expect(isBenignClientError(undefined)).toBe(false);
+  });
+});

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -1,0 +1,50 @@
+// Recognises benign client-side errors that are noise rather than real bugs.
+//
+// The main offender is Firebase Analytics' IndexedDB access. When a user
+// navigates away or reloads, the browser tears down the IndexedDB connection
+// while Firebase still has a read/write transaction in flight. The transaction
+// is aborted ("The transaction was aborted..." / "the database connection is
+// closing"), Firebase rethrows it as an AbortError (DOMException code 20), and
+// because nothing awaits that internal promise it surfaces to Sentry as an
+// unhandled rejection. The page itself loads fine — these are not actionable,
+// so we drop them in instrumentation-client.ts (mirrors the server-side
+// self-healing-network filter in transientNetworkError.ts).
+const BENIGN_CLIENT_SIGNATURES = [
+  'The transaction was aborted',
+  'database connection is closing',
+  'idb-get',
+  'idb-set',
+  'IndexedDB',
+];
+
+// DOMException.ABORT_ERR — the numeric code carried by AbortErrors.
+const ABORT_ERR_CODE = 20;
+
+export function isBenignClientError(error: unknown): boolean {
+  // Walk the cause chain in case Firebase wraps the original DOMException.
+  let current: unknown = error;
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    const e = current as {
+      name?: unknown;
+      message?: unknown;
+      code?: unknown;
+      cause?: unknown;
+    };
+    const name = typeof e.name === 'string' ? e.name : '';
+    const message = typeof e.message === 'string' ? e.message : '';
+    const isAbort = name === 'AbortError' || e.code === ABORT_ERR_CODE;
+
+    if (isAbort) {
+      // Bare "AbortError: AbortError" (Firebase's rethrow loses the original
+      // message) or any of the IndexedDB teardown signatures.
+      if (
+        message === 'AbortError' ||
+        BENIGN_CLIENT_SIGNATURES.some((sig) => message.includes(sig))
+      ) {
+        return true;
+      }
+    }
+    current = e.cause;
+  }
+  return false;
+}


### PR DESCRIPTION
## Problem

Two Sentry issues (`AbortError: The transaction was aborted...` and `AbortError: AbortError`) on `/news/:id` — both unhandled promise rejections via `onunhandledrejection`, both with `DOMException.code: 20`. The pages render fine; the errors are non-actionable noise.

## Root cause

Firebase Analytics reads/writes IndexedDB. When a user navigates away or reloads (the navigation breadcrumb's `from`/`to` are the same URL = a reload), the browser closes the IndexedDB connection while a Firebase transaction is in flight. The transaction aborts (`idb-get`/`idb-set` warnings in the breadcrumbs), Firebase rethrows an `AbortError`, and nothing awaits that internal promise — so it lands in Sentry.

## Fix

Mirrors the existing server-side self-healing-network filter (`transientNetworkError.ts` + `sentry.server.config.ts` `beforeSend`):

- `src/lib/benignClientError.ts` — `isBenignClientError()` matches `AbortError`/DOMException code 20 carrying IndexedDB teardown signatures (or Firebase's bare `"AbortError: AbortError"` rethrow), walking the `.cause` chain.
- `src/instrumentation-client.ts` — `beforeSend` drops those events.
- `src/lib/benignClientError.test.ts` — 7 tests covering both Sentry signatures, the cause-chain wrap, and guards that a genuine fetch abort / unrelated error still reports.

Match is deliberately targeted (not "drop all AbortErrors") so real user-facing aborts still surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)