### PR TITLE
fix(cards): zero out spend-gated companion vouchers in annual value

### DIFF
--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -35,6 +35,7 @@ apr:
     max: 28.49
 benefits:
   - name: "Companion Pass"
+    value: 0
     description: "Complimentary economy companion ticket valid for 12 months when you spend $30,000 on the card in a calendar year"
     frequency: "annual"
     category: "travel"

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -32,6 +32,7 @@ apr:
     max: 29.99
 benefits:
   - name: "Travel Together Ticket"
+    value: 0
     description: "Companion travel ticket (or 50% Avios discount for solo travel) when you spend $30,000 in a calendar year"
     frequency: "annual"
     category: "travel"

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -39,7 +39,7 @@ apr:
     max: 29.99
 benefits:
   - name: "Iberia Companion Voucher"
-    value: 1000
+    value: 0
     description: "Companion voucher worth up to $1,000 for two tickets on the same Iberia flight when you spend $30,000 in a calendar year"
     frequency: "annual"
     category: "travel"


### PR DESCRIPTION
## Problem

The Iberia Visa Signature page showed a **Total annual value of \$1,000**, driven by the Iberia Companion Voucher carrying `value: 1000`. That voucher is gated behind **\$30,000 of annual spend** and is worth "up to" \$1,000 only if you actually book two tickets on the same flight — it is not a guaranteed annual credit, so it should not be summed into annual value.

## Fix

All three IAG/Chase Visa companion vouchers are the same product with the same \$30k spend gate. Set each to `value: 0`:

- **Iberia** Companion Voucher: was `value: 1000` → `0` (this is the bug the user spotted)
- **Aer Lingus** Companion Pass: had **no `value` field** → `0`
- **British Airways** Travel Together Ticket: had **no `value` field** → `0`

### Why `value: 0` and not just removing the field

`CardBenefits.tsx` splits benefits into `credits = b.value > 0` (summed into the total) and `perks = b.value === 0` (shown without a dollar amount). With the field omitted, `b.value` is `undefined` — caught by **neither** filter, so the benefit silently disappears from the card page. That's a latent bug the Aer Lingus and BA cards already had. `value: 0` keeps the voucher visible as a perk (with its full "up to \$1,000 after \$30,000 spend" description) while contributing \$0 to annual value.

## Verification

`npm run build:cards` passes (182 cards). `cards.json` not committed — CI rebuilds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)