### PR TITLE
fix(cards): set Robinhood Gold annual fee to $50

### DIFF
--- a/data/cards/robinhood-gold-card.yaml
+++ b/data/cards/robinhood-gold-card.yaml
@@ -4,7 +4,7 @@ slug: "robinhood-gold-card"
 accepting_applications: true
 image: "robinhood-gold-card.png"
 release_date: "2024-03-26"
-annual_fee: 0
+annual_fee: 50
 benefits:
   - name: "Travel Insurance"
     value: 0


### PR DESCRIPTION
## What

Sets `annual_fee` for **Robinhood Gold** from `0` to `50` in `data/cards/robinhood-gold-card.yaml`.

## Why

The Robinhood Gold Card has a $0 card annual fee, but you cannot get or keep the card without an active **Robinhood Gold** subscription, which costs **$5/month or $50/year**. Treating it as a true no-fee card understates the real cost of ownership and can over-rank it in comparison/ranking math (e.g. best-card-for-me net-earnings).

Setting `annual_fee: 50` captures the effective yearly cost. The `our_take` field already notes the subscription requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)