### PR TITLE
fix(web): disable Turbopack server source maps to fit Amplify deploy limit

### DIFF
--- a/apps/web-next/next.config.mjs
+++ b/apps/web-next/next.config.mjs
@@ -42,6 +42,17 @@ const contentSecurityPolicy = [
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    // Turbopack (the default builder in Next 16) generates ~37 MB of server
+    // source maps by default. They ship in the .next output and pushed the
+    // Amplify deploy artifact past its 220 MB limit. The Amplify build has no
+    // SENTRY_AUTH_TOKEN, so these maps are never uploaded — pure dead weight.
+    // Disable them. (To get readable server stack traces in Sentry later,
+    // re-enable + upload + delete them in a dedicated CI step rather than
+    // shipping the .map files in the deploy artifact.)
+    turbopackSourceMaps: false,
+  },
+
   // Rewrite /_admin to /admin (underscore folders are private in App Router)
   async rewrites() {
     return [


### PR DESCRIPTION
## Problem

The Amplify deploy of #1495 failed:

> CustomerError: The size of the build output (232129680) exceeds the max allowed size of 230686720 bytes.

The **build itself succeeded** — this is the deploy-artifact size limit (~220 MB), and the output came in ~1.4 MB over. Root cause is cumulative; #1495 happened to tip it past the line.

## Root cause

~37 MB of **server source maps** (503 `.map` files in `.next/server`) that **Turbopack** (Next 16's default builder) generates by default. They're only useful if uploaded to Sentry, but the Amplify build has no `SENTRY_AUTH_TOKEN`, so they ship in `.next` as pure dead weight.

(The first instinct — Sentry's webpack source-map plugin — was a red herring: this is a Turbopack build, so the webpack path never runs.)

## Fix

`experimental.turbopackSourceMaps: false`. Disabled unconditionally rather than gated on the token, so that setting a Sentry token later can't silently re-bloat the artifact and re-break deploys.

## Verification

Local production build with no token (replicating Amplify):

| | before | after |
|---|---|---|
| `.map` files | 503 (37 MB) | **0** |
| `.next` | 161 MB | **124 MB** |

Deploy artifact: 232 MB → **~195 MB**, under the 220 MB limit with ~25 MB headroom. Build exits 0. Source maps don't affect runtime — to get readable server traces in Sentry later, generate + upload + delete them in a dedicated CI step instead of shipping the `.map` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)