### PR TITLE
fix(cards): ignore annual_fee for Robinhood Gold on card-page-check

### DIFF
--- a/data/cards/robinhood-gold-card.yaml
+++ b/data/cards/robinhood-gold-card.yaml
@@ -4,6 +4,12 @@ slug: "robinhood-gold-card"
 accepting_applications: true
 image: "robinhood-gold-card.png"
 release_date: "2024-03-26"
+# The $50 annual_fee models the required Robinhood Gold membership ($5/mo or
+# $50/yr) you must hold to get this card. The card page itself lists a $0 annual
+# fee, so card-page-check keeps proposing 50 -> 0. The $50 is an intentional
+# modeling decision (#1494); ignore annual_fee for this card.
+check_ignore:
+  - annual_fee
 annual_fee: 50
 benefits:
   - name: "Travel Insurance"


### PR DESCRIPTION
## Why
The full `check-card-pages` run on gpt-4o flagged exactly one change across the catalog: Robinhood Gold `annual_fee 50 → 0`.

That's a correct page reading but an unwanted proposal. The `$50` is an intentional modeling decision (#1494) representing the **required Robinhood Gold membership** ($5/mo or $50/yr) you must hold to get the card. The card's own page lists a $0 annual fee, so the extractor will keep proposing `50 → 0` on every run.

## What
Add `check_ignore: [annual_fee]` to `data/cards/robinhood-gold-card.yaml`, with a comment explaining the membership rationale. This is the built-in escape hatch (schema-validated, stripped at build time, already used for the analogous Atmos Rewards split-fee case).

## Verification
- `npm run build:cards` succeeds for all 182 cards.
- `check_ignore` is stripped from the published `cards.json` (annual_fee stays 50, field not present in output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)