### PR TITLE
fix(cards): de-duplicate DashPass benefit on Chase Sapphire Preferred

### DIFF
--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -11,11 +11,6 @@ benefits:
     description: "Statement credit for hotel stays booked through Chase Travel"
     frequency: "annual"
     category: "hotel"
-  - name: "DoorDash DashPass"
-    value: 0
-    description: "Complimentary DoorDash DashPass membership"
-    frequency: "ongoing"
-    category: "dining"
   - name: "Anniversary Bonus Points"
     description: "Earn bonus points equal to 10% of total purchases made the previous year on each account anniversary."
     frequency: "annual"


### PR DESCRIPTION
Cleanup after #1514. CSP already had a bare `DoorDash DashPass` (value 0) benefit; #1514 added a richer `DoorDash DashPass Membership` (value 120, with the $10/month detail). This removes the redundant value-0 entry so there's a single DashPass benefit.

`build:cards` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)