### PR TITLE
Add card details section, square highest-bonus callout

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -869,17 +869,22 @@ export default function CardClient({
           <a href="#earn" className="cj-toc-link">
             <span className="cj-toc-num">02</span>Earn &amp; credits
           </a>
+          {(card.apr || typeof card.foreign_transaction_fee === "boolean") && (
+            <a href="#details" className="cj-toc-link">
+              <span className="cj-toc-num">03</span>Card details
+            </a>
+          )}
           <a href="#odds" className="cj-toc-link">
-            <span className="cj-toc-num">03</span>Approval odds
+            <span className="cj-toc-num">04</span>Approval odds
           </a>
           {newsEntries.length > 0 && (
             <a href="#wire" className="cj-toc-link">
-              <span className="cj-toc-num">04</span>News
+              <span className="cj-toc-num">05</span>News
             </a>
           )}
           {articles.length > 0 && (
             <a href="#reading" className="cj-toc-link">
-              <span className="cj-toc-num">05</span>Reading
+              <span className="cj-toc-num">06</span>Reading
             </a>
           )}
         </aside>
@@ -1239,39 +1244,77 @@ export default function CardClient({
                 )}
               </div>
             </div>
-
-            {card.apr &&
-              (card.apr.purchase_intro || card.apr.balance_transfer_intro) && (
-                <div className="cj-intro-apr">
-                  <div className="cj-intro-apr-label">Intro APR</div>
-                  <div className="cj-intro-apr-rows">
-                    {card.apr.balance_transfer_intro && (
-                      <div>
-                        <b>{card.apr.balance_transfer_intro.rate}%</b> for{" "}
-                        {card.apr.balance_transfer_intro.months} months on
-                        balance transfers
-                      </div>
-                    )}
-                    {card.apr.purchase_intro && (
-                      <div>
-                        <b>{card.apr.purchase_intro.rate}%</b> for{" "}
-                        {card.apr.purchase_intro.months} months on purchases
-                      </div>
-                    )}
-                    {card.apr.regular && (
-                      <div className="cj-intro-apr-then">
-                        Then {card.apr.regular.min}%–{card.apr.regular.max}%
-                        variable APR
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
           </section>
 
-          {/* 03 Approval odds */}
+          {/* 03 Card details */}
+          {(card.apr ||
+            typeof card.foreign_transaction_fee === "boolean") && (
+            <section id="details" className="cj-section">
+              <div className="cj-section-num">03 · card details</div>
+              <h2 className="cj-section-h2">
+                Card <em className="cj-section-accent">details</em>
+              </h2>
+              <table className="cj-table">
+                <tbody>
+                  {card.apr?.regular && (
+                    <tr>
+                      <td>
+                        <div className="cj-cell-primary">Regular APR</div>
+                      </td>
+                      <td className="cj-tr">
+                        {card.apr.regular.min === card.apr.regular.max
+                          ? `${card.apr.regular.min}%`
+                          : `${card.apr.regular.min}%–${card.apr.regular.max}%`}{" "}
+                        variable
+                      </td>
+                    </tr>
+                  )}
+                  {card.apr?.purchase_intro && (
+                    <tr>
+                      <td>
+                        <div className="cj-cell-primary">
+                          Intro APR on purchases
+                        </div>
+                      </td>
+                      <td className="cj-tr">
+                        {card.apr.purchase_intro.rate}% for{" "}
+                        {card.apr.purchase_intro.months} months
+                      </td>
+                    </tr>
+                  )}
+                  {card.apr?.balance_transfer_intro && (
+                    <tr>
+                      <td>
+                        <div className="cj-cell-primary">
+                          Intro APR on balance transfers
+                        </div>
+                      </td>
+                      <td className="cj-tr">
+                        {card.apr.balance_transfer_intro.rate}% for{" "}
+                        {card.apr.balance_transfer_intro.months} months
+                      </td>
+                    </tr>
+                  )}
+                  {typeof card.foreign_transaction_fee === "boolean" && (
+                    <tr>
+                      <td>
+                        <div className="cj-cell-primary">
+                          Foreign transaction fee
+                        </div>
+                      </td>
+                      <td className="cj-tr">
+                        {card.foreign_transaction_fee ? "Yes" : "None"}
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </section>
+          )}
+
+          {/* 04 Approval odds */}
           <section id="odds" className="cj-section">
-            <div className="cj-section-num">03 · approval odds</div>
+            <div className="cj-section-num">04 · approval odds</div>
             <div className="cj-odds-header">
               <h2 className="cj-section-h2">
                 Approval <em className="cj-section-accent">odds</em>
@@ -1595,7 +1638,7 @@ export default function CardClient({
           {/* 04 News */}
           {newsEntries.length > 0 && (
             <section id="wire" className="cj-section">
-              <div className="cj-section-num">04 · news</div>
+              <div className="cj-section-num">05 · news</div>
               <h2 className="cj-section-h2">
                 In the <em className="cj-section-accent">news</em>
               </h2>
@@ -1642,7 +1685,7 @@ export default function CardClient({
           {/* 05 Reading */}
           {articles.length > 0 && (
             <section id="reading" className="cj-section">
-              <div className="cj-section-num">05 · reading</div>
+              <div className="cj-section-num">06 · reading</div>
               <h2 className="cj-section-h2">
                 Further <em className="cj-section-accent">reading</em>
               </h2>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7359,7 +7359,7 @@
   padding: 10px 12px;
   margin-bottom: 12px;
   border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--line-2));
-  border-radius: 8px;
+  border-radius: 0;
   background: color-mix(in oklab, var(--accent) 6%, var(--paper));
 }
 .landing-v2 .cj-wire-high-label {


### PR DESCRIPTION
## Summary
- Make the **Highest bonus on record** callout rectangular (border-radius `8px` → `0`).
- Add a new **03 · card details** section under **02 · earn & credits** on the card page, with a table of:
  - Regular APR (collapses to a single value when min == max)
  - Intro APR on purchases
  - Intro APR on balance transfers
  - Foreign transaction fee (`Yes` / `None`)
- Moved the APR display out of the earn & credits section (removed the old `cj-intro-apr` block) to avoid duplication.
- Renumbered Approval odds (03→04), News (04→05), Reading (05→06) in both the section headers and the left-rail table of contents, and added a matching "03 Card details" ToC link.

The new section renders when a card has APR data or a defined FTF flag (140/182 and 114/182 cards respectively).

## Verification
- TypeScript typecheck passes (no errors in `CardClient.tsx`).
- Browser preview was unavailable this session (another dev server held the `.next` lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)