### PR TITLE
feat(cards): refresh CSP rewards (June 2026) + Venture X Capital One Entertainment

### DIFF
--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -71,6 +71,11 @@ rewards:
   - category: flights_portal
     value: 5
     unit: points_per_dollar
+  - category: entertainment_portal
+    value: 5
+    unit: points_per_dollar
+    note: "Capital One Entertainment platform purchases only — excludes general entertainment, dining reservations, and Capital One Dining"
+    merchant_specific: true
   - category: everything_else
     value: 2
     unit: points_per_dollar

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -11,11 +11,6 @@ benefits:
     description: "Statement credit for hotel stays booked through Chase Travel"
     frequency: "annual"
     category: "hotel"
-  - name: "Anniversary Bonus Points"
-    description: "Earn bonus points equal to 10% of total purchases made the previous year on each account anniversary."
-    frequency: "annual"
-    category: "rewards"
-    enrollment_required: false
   - name: "Global Entry/TSA PreCheck/NEXUS Credit"
     value: 120
     description: "Receive one statement credit of up to $120 every four years as reimbursement for the application fee."
@@ -44,12 +39,15 @@ rewards:
   - category: "travel_portal"
     value: 5
     unit: "points_per_dollar"
+    note: "All Chase Travel purchases — flights, hotels, rental cars, vacation homes, cruises, activities, and tours"
   - category: "dining"
     value: 3
     unit: "points_per_dollar"
-  - category: "streaming"
+    note: "Dining worldwide, including takeout and eligible delivery"
+  - category: "gas"
     value: 3
     unit: "points_per_dollar"
+    note: "Gas and EV charging"
   - category: "groceries"
     value: 3
     unit: "points_per_dollar"
@@ -58,9 +56,18 @@ rewards:
     # online, etc.) — keep merchant_specific to suppress in-store grocery
     # store-page matching (Kroger, Safeway, in-person Whole Foods).
     merchant_specific: true
+  - category: "streaming"
+    value: 3
+    unit: "points_per_dollar"
+  - category: "vacation_rentals"
+    value: 3
+    unit: "points_per_dollar"
+    note: "Vacation homes booked directly with top brands like Airbnb, Vrbo, Plum Guide, HomeAway, Homestay.com, and Vacasa"
+    merchant_specific: true
   - category: "travel"
     value: 2
     unit: "points_per_dollar"
+    note: "All other travel worldwide"
   - category: "everything_else"
     value: 1
     unit: "points_per_dollar"

--- a/data/categories.yaml
+++ b/data/categories.yaml
@@ -23,6 +23,8 @@ categories:
     label: Airlines
   - id: car_rentals
     label: Car Rentals
+  - id: vacation_rentals
+    label: Vacation Rentals
   - id: entertainment
     label: Entertainment
   - id: rotating
@@ -41,6 +43,8 @@ categories:
     label: Car Rentals (via Portal)
   - id: hotels_car_portal
     label: Hotels & Car Rentals (via Portal)
+  - id: entertainment_portal
+    label: Entertainment (via Portal)
   - id: amazon
     label: Amazon.com
   - id: rei


### PR DESCRIPTION
## Chase Sapphire Preferred — June 15, 2026 refresh
Syncs `rewards[]` to the refreshed earning structure (verified 1:1 against chase.com):

| Category | Rate | Change |
|---|---|---|
| Chase Travel (portal) | 5x | note enriched |
| Dining | 3x | unchanged |
| **Gas & EV charging** | **3x** | ➕ NEW (permanent) |
| Online groceries (excl. Walmart/Target/wholesale) | 3x | unchanged |
| Streaming | 3x | unchanged |
| **Vacation homes** (Airbnb, Vrbo, Plum Guide, HomeAway, Homestay, Vacasa) | **3x** | ➕ NEW (permanent, `merchant_specific`) |
| All other travel | 2x | note enriched |
| Everything else | 1x | unchanged |

- **Excluded** Lyft 5x (ends 9/30/2027) and Peloton 5x (ends 12/31/2027) — limited-time promos.
- **Removed** the "Anniversary Bonus Points" (10%) benefit — the refresh ended it for new applicants.

## Capital One Venture X
Adds the 5x **Capital One Entertainment** earn as `entertainment_portal` (merchant-gated) so it doesn't read as general entertainment spend.

## categories.yaml
Adds two controlled-vocab ids: `vacation_rentals`, `entertainment_portal`.

`npm run build:cards` passes.

Sources: [Chase – Meet the New Sapphire Preferred](https://media.chase.com/news/Meet-the-New-Chase-Sapphire-Preferred), [capitalone.com Venture X](https://www.capitalone.com/credit-cards/venture-x/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)