### PR TITLE
feat(cards): add Bilt Travel portal earn rates to Blue and Obsidian

### DIFF
--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -31,6 +31,14 @@ tags:
   - rewards
   - travel
 rewards:
+  - category: hotels_portal
+    value: 3
+    unit: points_per_dollar
+    note: "Hotels booked through Bilt Travel"
+  - category: flights_portal
+    value: 2
+    unit: points_per_dollar
+    note: "Flights booked through Bilt Travel"
   - category: everything_else
     value: 1
     unit: points_per_dollar

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -43,6 +43,14 @@ rewards:
     spend_cap: 25000
     cap_period: annual
     rate_after_cap: 1
+  - category: "hotels_portal"
+    value: 4
+    unit: "points_per_dollar"
+    note: "Hotels booked through Bilt Travel"
+  - category: "flights_portal"
+    value: 3
+    unit: "points_per_dollar"
+    note: "Flights booked through Bilt Travel"
   - category: "travel"
     value: 2
     unit: "points_per_dollar"


### PR DESCRIPTION
Bilt Card 2.0 awards **+2x on hotels and +1x on flights** on top of each tier's base rate when booked through the Bilt Travel portal. The Blue and Obsidian YAMLs were missing these.

| Card | Added | Rationale |
|---|---|---|
| **Bilt Blue** (base 1x) | `hotels_portal` 3x, `flights_portal` 2x | 1x base + portal bonus |
| **Bilt Obsidian** (travel base 2x) | `hotels_portal` 4x, `flights_portal` 3x | 2x base + portal bonus |
| **Bilt Palladium** | — | already correct (4x/3x) |
| **Bilt Mastercard** | — | archived (Card 2.0 superseded it) |

Verified 1:1 against [bilt.com/card](https://www.bilt.com/card) (cross-checked via [CNBC comparison](https://www.cnbc.com/select/bilt-credit-card-comparison/)).

**Deliberately omitted** (variable/gated — would overstate): Bilt dining-partner "up to" network rates (4x/6x/5x), Lyft (requires account linking), and the conditional "up to 1.25x" rent (stays in `benefits[]`).

`npm run build:cards` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)