### PR TITLE
feat(best): top-3 card previews on /best index + refreshed cross-promo

### DIFF
--- a/apps/web-next/src/app/best/BestV2Client.tsx
+++ b/apps/web-next/src/app/best/BestV2Client.tsx
@@ -2,38 +2,16 @@
 
 import Link from 'next/link';
 import { V2Footer } from '@/components/landing-v2/Chrome';
-import {
-  TrophyIcon,
-  GiftIcon,
-  PaperAirplaneIcon,
-  PercentBadgeIcon,
-  ShieldCheckIcon,
-  ShoppingCartIcon,
-  BanknotesIcon,
-  GlobeAltIcon,
-  SparklesIcon,
-} from '@heroicons/react/24/solid';
+import CardImage from '@/components/ui/CardImage';
 import type { BestPage } from '@/lib/best';
 import '../landing.css';
 
 interface BestV2ClientProps {
   pages: BestPage[];
+  previews: Record<string, { src?: string; alt: string }[]>;
   totalIssuers: number;
   totalCards: number;
 }
-
-const PAGE_ICONS: Record<
-  string,
-  React.ComponentType<React.SVGProps<SVGSVGElement>>
-> = {
-  'best-signup-bonuses': GiftIcon,
-  'best-airline-cards': PaperAirplaneIcon,
-  'best-0-apr-cards': PercentBadgeIcon,
-  'best-dining-grocery-cards': ShoppingCartIcon,
-  'best-secured-cards': ShieldCheckIcon,
-  'best-cash-back-cards': BanknotesIcon,
-  'best-travel-cards': GlobeAltIcon,
-};
 
 function formatShortDate(iso?: string): string {
   if (!iso) return '';
@@ -44,6 +22,7 @@ function formatShortDate(iso?: string): string {
 
 export default function BestV2Client({
   pages,
+  previews,
   totalIssuers,
   totalCards,
 }: BestV2ClientProps) {
@@ -74,16 +53,30 @@ export default function BestV2Client({
       </section>
 
       <div className="wrap">
-        <Link href="/best-card-for" className="best-cross-promo">
-          <span className="bcp-kicker">By store</span>
-          <span className="bcp-text">
-            <strong>Shopping somewhere specific?</strong> See the best card to use at
-            every major U.S. retailer we track — Amazon, Costco, Whole Foods, and more.
-          </span>
-          <span className="bcp-arrow" aria-hidden>
-            →
-          </span>
-        </Link>
+        <div className="best-promos">
+          <Link href="/best-card-for" className="best-promo">
+            <span className="bp-kicker">By store</span>
+            <h3 className="bp-title">Best card for every store</h3>
+            <p className="bp-desc">
+              See the top card to use at every major U.S. retailer we track, from
+              Amazon and Costco to Whole Foods.
+            </p>
+            <span className="bp-cta">
+              Browse by store <span aria-hidden>→</span>
+            </span>
+          </Link>
+          <Link href="/best-card-for-me" className="best-promo">
+            <span className="bp-kicker">For you</span>
+            <h3 className="bp-title">Best card for me</h3>
+            <p className="bp-desc">
+              Answer a few questions about your wallet and spending, and get a
+              ranked shortlist of the cards to get next.
+            </p>
+            <span className="bp-cta">
+              Find my next card <span aria-hidden>→</span>
+            </span>
+          </Link>
+        </div>
 
         <div className="best-hero-stats">
           <div className="bhs">
@@ -118,20 +111,37 @@ export default function BestV2Client({
           </div>
         ) : (
           <div className="best-grid">
-            {pages.map((page, index) => {
-              const Icon = PAGE_ICONS[page.slug] ?? SparklesIcon;
+            {pages.map((page) => {
               return (
                 <Link key={page.id} href={`/best/${page.slug}`} className="best-card">
-                  <div className="best-cover">
-                    <div className="best-cover-pattern" />
-                    <div className="best-cover-num">
-                      Series · {String(index + 1).padStart(2, '0')}
-                    </div>
-                    <Icon className="best-cover-icon" width={56} height={56} />
-                  </div>
                   <div className="best-body">
                     <h2 className="best-title">{page.title}</h2>
                     <p className="best-desc">{page.description}</p>
+                    {(previews[page.slug]?.length ?? 0) > 0 && (
+                      <div className="best-preview">
+                        <div className="best-preview-stack">
+                          {previews[page.slug].map((img, i) => (
+                            <div className="bf-mini" key={i}>
+                              <CardImage
+                                cardImageLink={img.src}
+                                alt={img.alt}
+                                fill
+                                sizes="64px"
+                                style={{ objectFit: 'cover', borderRadius: 4 }}
+                              />
+                              {i === 0 && (
+                                <span className="bf-crown" aria-hidden="true">
+                                  <svg viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M4 18h16l1-9-5 3.5L12 6l-4 6.5L3 9z" />
+                                  </svg>
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                        <span className="best-preview-label">Top picks</span>
+                      </div>
+                    )}
                     <div className="best-meta">
                       <span>Updated · {formatShortDate(page.updated_at || page.date)}</span>
                       <span className="count">{page.cards.length} cards</span>

--- a/apps/web-next/src/app/best/page.tsx
+++ b/apps/web-next/src/app/best/page.tsx
@@ -27,6 +27,24 @@ export default async function BestIndexPage() {
     cards.map((c) => c.bank?.trim()).filter(Boolean)
   ).size;
 
+  // Top-3 card image previews per ranking page (mirrors the landing page).
+  const cardImageBySlug = new Map<string, string | undefined>();
+  const cardNameBySlug = new Map<string, string>();
+  for (const c of cards) {
+    cardImageBySlug.set(c.slug, c.card_image_link);
+    cardNameBySlug.set(c.slug, c.card_name);
+  }
+  const previews: Record<string, { src?: string; alt: string }[]> = {};
+  for (const page of pages) {
+    previews[page.slug] = page.cards
+      .filter((c) => cardImageBySlug.has(c.slug))
+      .slice(0, 3)
+      .map((c) => ({
+        src: cardImageBySlug.get(c.slug),
+        alt: cardNameBySlug.get(c.slug) || c.slug,
+      }));
+  }
+
   const collectionJsonLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -55,7 +73,7 @@ export default async function BestIndexPage() {
           { name: 'Best Cards', url: 'https://creditodds.com/best' },
         ]}
       />
-      <BestV2Client pages={pages} totalIssuers={totalIssuers} totalCards={cards.length} />
+      <BestV2Client pages={pages} previews={previews} totalIssuers={totalIssuers} totalCards={cards.length} />
     </>
   );
 }

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3310,61 +3310,68 @@
 }
 
 /* ---------- Best cards index ---------- */
-.landing-v2 .best-cross-promo {
-  display: flex;
-  align-items: center;
+.landing-v2 .best-promos {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 16px;
   margin: 24px 0 0;
-  padding: 14px 18px;
+}
+.landing-v2 .best-promo {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 22px;
   background: var(--card);
   border: 1px solid var(--line-2);
-  border-left: 3px solid var(--accent);
-  border-radius: 8px;
+  border-radius: 0;
   text-decoration: none;
   color: inherit;
   transition: border-color 0.15s ease, background 0.15s ease;
 }
-.landing-v2 .best-cross-promo:hover {
+.landing-v2 .best-promo:hover {
   border-color: var(--ink);
   background: var(--paper-2);
 }
-.landing-v2 .best-cross-promo .bcp-kicker {
+.landing-v2 .best-promo .bp-kicker {
   font-family: 'Inter Tight', sans-serif;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--accent);
-  flex-shrink: 0;
 }
-.landing-v2 .best-cross-promo .bcp-text {
-  font-size: 14px;
+.landing-v2 .best-promo .bp-title {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
   color: var(--ink);
-  line-height: 1.45;
-  flex: 1;
+  margin: 0;
 }
-.landing-v2 .best-cross-promo .bcp-text strong {
+.landing-v2 .best-promo .bp-desc {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink-2);
+  margin: 0;
+}
+.landing-v2 .best-promo .bp-cta {
+  margin-top: auto;
+  padding-top: 12px;
+  font-size: 13px;
   font-weight: 600;
-}
-.landing-v2 .best-cross-promo .bcp-arrow {
-  font-size: 18px;
-  color: var(--muted);
-  transition: color 0.15s ease, transform 0.15s ease;
-  flex-shrink: 0;
-}
-.landing-v2 .best-cross-promo:hover .bcp-arrow {
   color: var(--accent);
+}
+.landing-v2 .best-promo .bp-cta span {
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+.landing-v2 .best-promo:hover .bp-cta span {
   transform: translateX(2px);
 }
 @media (max-width: 640px) {
-  .landing-v2 .best-cross-promo {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 6px;
-    padding: 12px 14px;
-  }
-  .landing-v2 .best-cross-promo .bcp-arrow {
-    display: none;
+  .landing-v2 .best-promos {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -3375,7 +3382,7 @@
   background: var(--line);
   margin: 24px 0 40px;
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: 0;
   overflow: hidden;
 }
 .landing-v2 .bhs {
@@ -3433,7 +3440,7 @@
 .landing-v2 .best-card {
   background: var(--card);
   border: 1px solid var(--line-2);
-  border-radius: 14px;
+  border-radius: 0;
   overflow: hidden;
   text-decoration: none;
   color: inherit;
@@ -3445,35 +3452,6 @@
   border-color: var(--ink);
   transform: translateY(-2px);
   box-shadow: var(--shadow);
-}
-.landing-v2 .best-cover {
-  position: relative;
-  aspect-ratio: 16 / 9;
-  background: var(--paper-2);
-  overflow: hidden;
-}
-.landing-v2 .best-cover .best-cover-pattern {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(ellipse at 20% 30%, color-mix(in oklab, var(--accent) 28%, transparent) 0%, transparent 55%),
-    radial-gradient(ellipse at 80% 70%, color-mix(in oklab, var(--accent) 16%, transparent) 0%, transparent 55%);
-}
-.landing-v2 .best-cover .best-cover-num {
-  position: absolute;
-  left: 20px;
-  top: 16px;
-  font-size: 13px;
-  color: color-mix(in oklab, var(--accent) 80%, var(--ink));
-  font-weight: 600;
-}
-.landing-v2 .best-cover .best-cover-icon {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  color: var(--accent);
-  opacity: 0.9;
 }
 .landing-v2 .best-body {
   padding: 22px;
@@ -3500,6 +3478,63 @@
   line-height: 1.55;
   color: var(--ink-2);
   margin: 0;
+}
+.landing-v2 .best-body .best-preview {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 4px 0 2px;
+}
+.landing-v2 .best-body .best-preview-stack {
+  display: flex;
+  align-items: center;
+  padding: 4px 0 4px 3px;
+}
+.landing-v2 .best-body .bf-mini {
+  position: relative;
+  flex: 0 0 auto;
+  width: 60px;
+  height: 38px;
+  border-radius: 6px;
+  border: 2px solid var(--card);
+  background: var(--paper-2);
+}
+.landing-v2 .best-body .bf-mini + .bf-mini {
+  margin-left: -18px;
+}
+.landing-v2 .best-body .bf-mini:nth-child(1) {
+  z-index: 3;
+}
+.landing-v2 .best-body .bf-mini:nth-child(2) {
+  z-index: 2;
+}
+.landing-v2 .best-body .bf-mini:nth-child(3) {
+  z-index: 1;
+}
+.landing-v2 .best-body .bf-crown {
+  position: absolute;
+  top: -9px;
+  left: -8px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  border: 2px solid var(--card);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 4;
+}
+.landing-v2 .best-body .bf-crown svg {
+  width: 11px;
+  height: 11px;
+}
+.landing-v2 .best-body .best-preview-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.02em;
 }
 .landing-v2 .best-body .best-meta {
   margin-top: auto;


### PR DESCRIPTION
## What

Reworks the `/best` index so each of the 7 ranking cards previews its top picks, and replaces the cross-promo banner with a cleaner two-up layout.

### Changes
- **Top-3 previews** — every ranking card now shows a fanned stack of the top-3 card images (overlapping minis + a crown on the #1 pick + "Top picks" label), reusing the landing page's editorial-rankings treatment. Previews are joined from the already-loaded card list, so they stay in sync with `data/best.json`.
- **Cleaner cards** — dropped the purple cover header (icon/pattern/series number). Cards are now plain square white tiles. Removed the now-dead heroicon imports, `PAGE_ICONS` map, and `.best-cover*` CSS.
- **Square corners** — ranking cards, promo tiles, and the hero stat bar all have sharp corners to match the rest of the site.
- **Cross-promo** — replaced the single left-accent "By Store" banner with two matched promo tiles:
  - **Best card for every store** → `/best-card-for`
  - **Best card for me** → `/best-card-for-me`

### Verification
Ran locally and verified on `/best`: all 7 cards render 3 minis + 1 crown each, both promo links resolve to the correct routes, stat bar + cards are `border-radius: 0`, no console errors, mobile (single-column) layout holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)