### PR TITLE
chore(valuations): set Bilt Rewards to 1.0 cpp

### DIFF
--- a/apps/api/src/lib/ranker/valuations.js
+++ b/apps/api/src/lib/ranker/valuations.js
@@ -14,7 +14,7 @@ const valuations = [
   { program: "IHG One Rewards", slug: "ihg-one-rewards", cpp: 0.5, match: ["ihg"], toolSlug: "ihg-one-rewards-points" },
   { program: "Marriott Bonvoy", slug: "marriott-bonvoy", cpp: 0.7, match: ["marriott", "bonvoy"], toolSlug: "marriott-bonvoy-points" },
   { program: "Capital One Miles", slug: "capital-one-miles", cpp: 1.0, match: ["capital one"], toolSlug: "capital-one-miles" },
-  { program: "Bilt Rewards", slug: "bilt-rewards", cpp: 1.5, match: ["bilt"], toolSlug: "bilt-rewards-points" },
+  { program: "Bilt Rewards", slug: "bilt-rewards", cpp: 1.0, match: ["bilt"], toolSlug: "bilt-rewards-points" },
   { program: "Citi ThankYou", slug: "citi-thankyou", cpp: 1.0, match: ["citi"], toolSlug: "citi-thankyou-points" },
   { program: "Choice Privileges", slug: "choice-privileges", cpp: 0.7, match: ["choice"], toolSlug: "choice-privileges-points" },
   { program: "Wells Fargo Rewards", slug: "wells-fargo-rewards", cpp: 1.0, match: ["wells fargo"] },

--- a/apps/ios/CreditOdds/Services/Valuations.swift
+++ b/apps/ios/CreditOdds/Services/Valuations.swift
@@ -24,7 +24,7 @@ enum Valuations {
         Program(cpp: 0.50, match: ["ihg"], exclude: []),
         Program(cpp: 0.70, match: ["marriott", "bonvoy"], exclude: []),
         Program(cpp: 1.00, match: ["capital one"], exclude: []),
-        Program(cpp: 1.50, match: ["bilt"], exclude: []),
+        Program(cpp: 1.00, match: ["bilt"], exclude: []),
         Program(cpp: 1.00, match: ["citi"], exclude: []),
         Program(cpp: 1.00, match: ["wells fargo"], exclude: []),
         Program(cpp: 1.40, match: ["southwest"], exclude: []),

--- a/data/valuations.yaml
+++ b/data/valuations.yaml
@@ -41,7 +41,7 @@ valuations:
     match: ["capital one"]
   - program: "Bilt Rewards"
     slug: "bilt-rewards"
-    cpp: 1.5
+    cpp: 1.0
     match: ["bilt"]
   - program: "Citi ThankYou"
     slug: "citi-thankyou"


### PR DESCRIPTION
The Bilt Rewards valuation was **1.5 cpp with no cited source**, and inconsistent with the table's conservative basis — Chase Ultimate Rewards 1.25, Amex MR 1.2, Capital One 1.0 (all comparable transferable-points programs). Bilt's own fixed portal-redemption floor is 1.25.

Set Bilt to **1.0 cpp** to align with the conservative methodology. This also brings the Bilt Palladium everyday rate (2x) down to a sensible ~2% display instead of ~3%.

Updated all three copies that carry the value:
- `apps/api/src/lib/ranker/valuations.js` (runtime source of truth — web + Lambda)
- `data/valuations.yaml` (canonical config)
- `apps/ios/CreditOdds/Services/Valuations.swift` (iOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)