### PR TITLE
chore(cards): reword Bilt Cash copy to reflect the either/or tradeoff

### DIFF
--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -10,7 +10,10 @@ reward_type: "points"
 release_date: "2025-01-15"
 our_take: >
   Bilt Blue is the no-fee entry point to the Bilt ecosystem: its draw is paying
-  rent by card with no transaction fee, plus 4% Bilt Cash on everyday purchases.
+  rent by card with no transaction fee. You can instead opt for 4% Bilt Cash on
+  everyday spend in place of the rent points boost, though Bilt Cash is a
+  separate, lower value currency (used mostly for point accelerators) rather
+  than cash back.
   Outside of rent and the limited Bilt Dining network the base earn is only 1x,
   so it makes the most sense for renters who want rewards on their biggest
   monthly bill. If you spend heavily elsewhere, pair it with a stronger everyday
@@ -42,4 +45,4 @@ rewards:
   - category: everything_else
     value: 1
     unit: points_per_dollar
-    note: "Also earns 4% Bilt Cash on everyday purchases"
+    note: "Everyday spend earns the base 1x in points. Bilt also offers a 4% Bilt Cash option on everyday spend as an alternative to the up to 1.25x rent points (you choose one track, not both); Bilt Cash is a separate currency used mainly for point accelerators, not cash back."

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -8,9 +8,10 @@ foreign_transaction_fee: false
 our_take: >
   Bilt's premium card exists for one reason: paying rent with no transaction fee
   while still earning points, which no mainstream card does. At $495 it leans on
-  the $400 hotel credit, $200 Bilt Cash, and Priority Pass to offset the fee,
-  and the 4% Bilt Cash on everyday spend (separate from the 2x base points) is a
-  quirky extra. It is built for renters who pay a lot and will actually use the
+  the $400 hotel credit, $200 Bilt Cash, and Priority Pass to offset the fee.
+  The 4% Bilt Cash on everyday spend is an alternative to the rent points boost
+  rather than a bonus on top of the 2x points, and it is a separate, lower value
+  currency, so treat it as a minor extra. It is built for renters who pay a lot and will actually use the
   travel credits and lounge access; if rent isn't a major expense, the $495 fee
   is hard to justify.
 annual_fee: 495
@@ -68,7 +69,7 @@ rewards:
   - category: everything_else
     value: 2
     unit: points_per_dollar
-    note: "Also earns 4% Bilt Cash on everyday purchases (separate currency). Bilt Cash can be redeemed as point accelerators that temporarily boost $5,000 of spend to 3x points (up to 5 accelerators per year)."
+    note: "Everyday spend earns the base 2x in points. The 4% Bilt Cash option on everyday spend is an alternative to the up to 1.25x rent points, not an addition, and is a separate currency rather than cash back; its main use is buying point accelerators that temporarily lift $5,000 of spend to 3x points (up to 5 per year)."
 signup_bonus:
   value: 50000
   type: "points"


### PR DESCRIPTION
The "4% Bilt Cash on everyday purchases" copy on **Bilt Blue** and **Bilt Palladium** read as additive value *on top of* the base points, overstating the cards (it looked like ~3% points + 4% cash).

In reality, Bilt Cash is:
- a **mutually-exclusive** Bilt-exclusive bonus — you choose it *instead of* the up-to-1.25x rent/mortgage points boost, not in addition; and
- a **separate, lower-value currency** used mainly to buy point accelerators, not 1:1 cash back.

Reworded both reward notes and the `our_take` copy on each card to frame it as the either/or tradeoff. No earning rates changed; `build:cards` passes; no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)