### PR TITLE
feat(best): intro under title (full-width) + rectangular cards/table/buttons

### DIFF
--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -108,6 +108,11 @@ export default async function BestDetailPage({ params }: Props) {
       <section className="page-hero wrap">
         <h1 className="page-title">{page.title}</h1>
         <p className="page-sub">{page.description}</p>
+        {page.intro && (
+          <div className="hero-intro">
+            <ArticleContent content={page.intro} />
+          </div>
+        )}
         <div
           style={{
             display: 'flex',
@@ -150,12 +155,6 @@ export default async function BestDetailPage({ params }: Props) {
       </section>
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>
-        {page.intro && (
-          <div className="article-body" style={{ marginBottom: 36 }}>
-            <ArticleContent content={page.intro} />
-          </div>
-        )}
-
         <BestRankingViews cards={enrichedCards} panel={page.panel} />
 
         <Link

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1396,6 +1396,16 @@
   margin-bottom: 0;
 }
 
+/* Best detail: rectangular look. Zero out radius on the comparison table,
+   the per-card containers, inner callouts, and buttons. Circular elements
+   (rank badges, model icons, status dots use rounded-full) are left alone. */
+.landing-v2.best-detail-v2 .rounded,
+.landing-v2.best-detail-v2 .rounded-md,
+.landing-v2.best-detail-v2 .rounded-lg,
+.landing-v2.best-detail-v2 .rounded-xl {
+  border-radius: 0;
+}
+
 /* ---------- Explore v2 (editorial / journal theme) ---------- */
 .landing-v2.explore-v2 .explore-hero {
   padding-block: 28px 28px;

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1374,6 +1374,28 @@
   margin: 0 0 12px;
 }
 
+/* Best detail: let the hero copy span the full main-content width, and render
+   the page intro as flowing text right under the subtitle (not a boxed card). */
+.landing-v2.best-detail-v2 .page-sub {
+  max-width: none;
+}
+.landing-v2.best-detail-v2 .hero-intro {
+  max-width: none;
+  margin-top: 10px;
+}
+.landing-v2.best-detail-v2 .hero-intro .prose,
+.landing-v2.best-detail-v2 .hero-intro .prose p {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ink-2);
+}
+.landing-v2.best-detail-v2 .hero-intro .prose p {
+  margin: 0 0 10px;
+}
+.landing-v2.best-detail-v2 .hero-intro .prose p:last-child {
+  margin-bottom: 0;
+}
+
 /* ---------- Explore v2 (editorial / journal theme) ---------- */
 .landing-v2.explore-v2 .explore-hero {
   padding-block: 28px 28px;


### PR DESCRIPTION
Two changes to all `/best/[slug]` detail pages (shared template + scoped CSS):

**1. Intro moved into the hero, full width**
- The page `intro` now renders as flowing text directly under the subtitle (below the title), instead of a boxed card lower down. That box is removed.
- Subtitle **and** intro now span the full main-content width (the `.page-sub` 620px cap is removed on best-detail pages).

**2. Rectangular look**
- Zero border-radius on the comparison table, per-card containers, inner callouts, and the View Card Details / apply buttons.
- Circular elements (rank badges, model icons, status dots — all `rounded-full`) are intentionally left round.

Untouched: the multi-model ranking selector (Consensus / Claude / GPT / Gemini) — verified still rendering in local preview.

Verified locally on an isolated worktree preview (`/best/best-0-apr-cards`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)