### PR TITLE
feat(best): SERP freshness dates for /best pages

### DIFF
--- a/.github/workflows/bump-best-updated-at.yml
+++ b/.github/workflows/bump-best-updated-at.yml
@@ -1,0 +1,71 @@
+name: Bump Best Updated-At Date
+
+# Every ~11 days, refresh the `updated_at` date on every /best ranking page
+# so the dateModified signal that Google reads (CollectionPage JSON-LD +
+# OpenGraph article:modified_time) stays current between full re-ranks.
+#
+# This is the lightweight freshness touch — it only rewrites the date. The
+# heavyweight LLM re-rank that actually changes the rankings lives in
+# refresh-best-pages.yml (1st & 15th of each month, via PR).
+#
+# Cadence caveat: GitHub cron cannot express a true rolling 11-day interval,
+# because the day-of-month field resets every month. `*/11` fires on days
+# 1, 12, and 23 of every month — ~11-day gaps, with a shorter gap at the
+# month rollover (e.g. the 23rd to the next 1st). Closest practical match.
+#
+# Like publish-scheduled-articles.yml, this pushes with the default
+# GITHUB_TOKEN and then explicitly dispatches build-best.yml — because
+# GITHUB_TOKEN pushes do not trigger downstream workflows, but
+# workflow_dispatch events do.
+
+on:
+  schedule:
+    - cron: '0 12 */11 * *'  # days 1, 12, 23 each month, noon UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  actions: write  # required to call `gh workflow run` against build-best.yml
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump updated_at to today (UTC)
+        id: bump
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          # Rewrite every `updated_at: "..."` line in the best YAML to today.
+          sed -i -E "s/^updated_at: \".*\"/updated_at: \"$TODAY\"/" data/best/*.yaml
+          if git diff --quiet data/best/; then
+            echo "No date change needed — already $TODAY."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "today=$TODAY" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/best/*.yaml
+          git commit -m "chore(best): bump updated_at to ${{ steps.bump.outputs.today }}"
+          git push
+
+      - name: Dispatch build-best workflow
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GITHUB_TOKEN pushes don't trigger downstream workflows, but
+          # workflow_dispatch events do — so we chain explicitly into the
+          # build/deploy (build:best, S3 upload, CloudFront, Amplify).
+          gh workflow run build-best.yml --ref main

--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { getBestPage, getBestPages } from "@/lib/best";
 import { getAllCards } from "@/lib/api";
 import { BestRankingViews } from "@/components/best/BestRankingViews";
 import { ArticleContent } from "@/components/articles/ArticleContent";
-import { BreadcrumbSchema } from "@/components/seo/JsonLd";
+import { BreadcrumbSchema, CollectionPageSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import "../../landing.css";
 
@@ -64,26 +64,18 @@ export default async function BestDetailPage({ params }: Props) {
 
   const pageUrl = `https://creditodds.com/best/${page.slug}`;
 
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: page.title,
-    description: page.description,
-    url: pageUrl,
-    numberOfItems: enrichedCards.length,
-    itemListElement: enrichedCards.map((entry, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: entry.card.card_name,
-      url: `https://creditodds.com/card/${entry.card.slug}`,
-    })),
-  };
-
   return (
     <div className="landing-v2 best-detail-v2">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      <CollectionPageSchema
+        url={pageUrl}
+        name={page.title}
+        description={page.description}
+        datePublished={page.date}
+        dateModified={page.updated_at || page.date}
+        items={enrichedCards.map((entry) => ({
+          name: entry.card.card_name,
+          url: `https://creditodds.com/card/${entry.card.slug}`,
+        }))}
       />
       <BreadcrumbSchema
         items={[

--- a/apps/web-next/src/app/best/page.tsx
+++ b/apps/web-next/src/app/best/page.tsx
@@ -1,22 +1,31 @@
 import { Metadata } from "next";
 import { getBestPages } from "@/lib/best";
 import { getAllCards } from "@/lib/api";
-import { BreadcrumbSchema } from "@/components/seo/JsonLd";
+import { BreadcrumbSchema, CollectionPageSchema } from "@/components/seo/JsonLd";
 import BestV2Client from "./BestV2Client";
 
-export const metadata: Metadata = {
-  title: "Best Credit Cards of 2026",
-  description: "Curated rankings of the best credit cards of 2026 across categories. Data-driven picks updated with live approval odds and bonus values.",
-  openGraph: {
-    title: "Best Credit Cards of 2026 | CreditOdds",
-    description: "Curated rankings of the best credit cards of 2026 across categories.",
-    url: "https://creditodds.com/best",
-    type: "website",
-  },
-  alternates: {
-    canonical: "https://creditodds.com/best",
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const pages = await getBestPages();
+  const latestUpdate = pages
+    .map((p) => p.updated_at || p.date)
+    .filter(Boolean)
+    .sort()
+    .reverse()[0];
+  return {
+    title: "Best Credit Cards of 2026",
+    description: "Curated rankings of the best credit cards of 2026 across categories. Data-driven picks updated with live approval odds and bonus values.",
+    openGraph: {
+      title: "Best Credit Cards of 2026 | CreditOdds",
+      description: "Curated rankings of the best credit cards of 2026 across categories.",
+      url: "https://creditodds.com/best",
+      type: "article",
+      ...(latestUpdate ? { modifiedTime: latestUpdate } : {}),
+    },
+    alternates: {
+      canonical: "https://creditodds.com/best",
+    },
+  };
+}
 
 export const revalidate = 300;
 
@@ -45,27 +54,30 @@ export default async function BestIndexPage() {
       }));
   }
 
-  const collectionJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "CollectionPage",
-    name: "Best Credit Cards",
-    description: "Curated rankings of the best credit cards across categories.",
-    url: "https://creditodds.com/best",
-    mainEntity: {
-      "@type": "ItemList",
-      itemListElement: pages.slice(0, 10).map((page, index) => ({
-        "@type": "ListItem",
-        position: index + 1,
-        url: `https://creditodds.com/best/${page.slug}`,
-      })),
-    },
-  };
+  // Most recent update across all ranking pages — drives the page-level
+  // dateModified so Google can surface a freshness date in the SERP.
+  const latestUpdate = pages
+    .map((p) => p.updated_at || p.date)
+    .filter(Boolean)
+    .sort()
+    .reverse()[0];
+  const earliestPublished = pages
+    .map((p) => p.date)
+    .filter(Boolean)
+    .sort()[0];
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
+      <CollectionPageSchema
+        url="https://creditodds.com/best"
+        name="Best Credit Cards"
+        description="Curated rankings of the best credit cards across categories."
+        datePublished={earliestPublished}
+        dateModified={latestUpdate}
+        items={pages.slice(0, 10).map((page) => ({
+          name: page.title,
+          url: `https://creditodds.com/best/${page.slug}`,
+        }))}
       />
       <BreadcrumbSchema
         items={[

--- a/data/best/best-0-apr-cards.yaml
+++ b/data/best/best-0-apr-cards.yaml
@@ -48,7 +48,7 @@ slug: best-0-apr-cards
 title: Best 0% APR Credit Cards
 description: The best 0% intro APR credit cards for purchases and balance transfers, all with no annual fee.
 date: "2026-03-01"
-updated_at: "2026-06-25"
+updated_at: "2026-06-29"
 seo_title: Best 0% APR Credit Cards of 2026
 seo_description: Compare the best 0% intro APR credit cards of 2026. Up to 24 months of 0% APR on purchases and balance transfers.
 intro: |

--- a/data/best/best-airline-cards.yaml
+++ b/data/best/best-airline-cards.yaml
@@ -125,7 +125,7 @@ slug: best-airline-cards
 title: Best Airline Credit Cards
 description: The top co-branded airline credit cards ranked by signup bonuses, earning rates, and travel perks.
 date: "2026-03-01"
-updated_at: "2026-06-25"
+updated_at: "2026-06-29"
 seo_title: Best Airline Credit Cards of 2026
 seo_description: Compare the best airline credit cards of 2026. Delta, United, American, Southwest, JetBlue, and more — ranked by value.
 intro: |

--- a/data/best/best-cash-back-cards.yaml
+++ b/data/best/best-cash-back-cards.yaml
@@ -80,7 +80,7 @@ slug: best-cash-back-cards
 title: Best Cash Back Credit Cards
 description: The top cash back credit cards ranked by earning rates, bonus categories, and signup offers — all with no annual fee unless noted.
 date: "2026-03-01"
-updated_at: "2026-06-25"
+updated_at: "2026-06-29"
 seo_title: Best Cash Back Credit Cards of 2026
 seo_description: Compare the best cash back credit cards of 2026. Flat-rate 2% cards, 5% rotating categories, and the best signup bonuses.
 intro: |

--- a/data/best/best-dining-grocery-cards.yaml
+++ b/data/best/best-dining-grocery-cards.yaml
@@ -90,7 +90,7 @@ slug: best-dining-grocery-cards
 title: Best Credit Cards for Dining and Groceries
 description: The top credit cards for earning rewards on restaurants and grocery store purchases, from premium to no-annual-fee options.
 date: "2026-03-01"
-updated_at: "2026-06-25"
+updated_at: "2026-06-29"
 seo_title: Best Credit Cards for Dining and Groceries of 2026
 seo_description: Compare the best dining and grocery credit cards of 2026. Earn 3-4x points or up to 6% cash back on food spending.
 intro: |

--- a/data/best/best-secured-cards.yaml
+++ b/data/best/best-secured-cards.yaml
@@ -46,7 +46,7 @@ slug: best-secured-cards
 title: Best Secured Credit Cards
 description: The best secured credit cards for building or rebuilding credit, all with no annual fee.
 date: "2026-03-01"
-updated_at: "2026-06-25"
+updated_at: "2026-06-29"
 seo_title: Best Secured Credit Cards of 2026
 seo_description: Compare the best secured credit cards of 2026 for building credit. All have $0 annual fees and report to all three bureaus.
 intro: |

--- a/data/best/best-signup-bonuses.yaml
+++ b/data/best/best-signup-bonuses.yaml
@@ -106,7 +106,7 @@ slug: best-signup-bonuses
 title: Best Credit Card Signup Bonuses
 description: The most valuable credit card signup bonuses available right now, ranked by bonus value and overall appeal.
 date: "2026-03-01"
-updated_at: "2026-06-25"
+updated_at: "2026-06-29"
 seo_title: Best Credit Card Signup Bonuses of 2026
 seo_description: Compare the best credit card signup bonuses of 2026. Ranked by value — from 175k points to $200 cash back.
 intro: |

--- a/data/best/best-travel-cards.yaml
+++ b/data/best/best-travel-cards.yaml
@@ -88,7 +88,7 @@ slug: best-travel-cards
 title: Best Travel Credit Cards
 description: The top travel credit cards ranked by rewards, travel perks, and overall value — from premium to no-annual-fee options.
 date: "2026-03-01"
-updated_at: "2026-06-25"
+updated_at: "2026-06-29"
 seo_title: Best Travel Credit Cards of 2026
 seo_description: Compare the best travel credit cards of 2026. From Chase Sapphire Reserve to no-fee options — ranked by rewards and perks.
 intro: |


### PR DESCRIPTION
## Why

We're losing the "best credit card for <category>" SERP to competitors who show an "Updated X days ago" byline. Our `/best` pages already had the data (`date` / `updated_at` in YAML), a visible "Updated" badge, OG `modifiedTime`, and sitemap `lastmod` — but the **JSON-LD was a bare `ItemList` with no date**, so Google had no strong structured-data signal to attach a freshness date to the snippet.

## What's in here

**1. Emit dates in structured data (the core fix)**
- `/best/[slug]`: replaced the inline `ItemList` with the existing `CollectionPageSchema` component, passing `datePublished` (`page.date`) and `dateModified` (`page.updated_at || page.date`). The ranked list is preserved as `mainEntity`.
- `/best` index: added `datePublished` (earliest) + `dateModified` (latest `updated_at` across lists) to its `CollectionPage` JSON-LD, and converted static `metadata` → `generateMetadata` so OG `type=article` + `modifiedTime` reflect the latest refresh.

**2. Bump all `updated_at` to today** (2026-06-29) across the 7 ranking YAML files.

**3. New `bump-best-updated-at.yml` workflow** — every ~11 days, rewrites `updated_at` to the current date, pushes, and dispatches `build-best.yml`. Mirrors the `publish-scheduled-articles.yml` auth/dispatch pattern. Keeps the `dateModified` signal current between the full LLM re-ranks in `refresh-best-pages.yml`.

## Verification

- `npx tsc --noEmit` clean.
- Ran the dev server and parsed rendered JSON-LD on both pages: `CollectionPage` now emits `datePublished` + `dateModified`; index also emits `og:type=article` + `article:modified_time`.
- `npm run build:best` validates all 7 pages.
- New workflow validated as parseable YAML; `sed` rewrite confirmed against the real file format.

## Notes

- **Cron caveat:** GitHub cron can't express a true rolling 11-day interval (day-of-month resets monthly). `*/11` fires on the 1st/12th/23rd — closest practical match. Can switch to a daily "≥11 days since last bump" check if a true interval is preferred.
- **`best.json` not committed** — `build-best.yml` rebuilds and syncs it from YAML on push (same convention as cards.json).
- Bumping `updated_at` without re-ranking is a weak freshness signal long-term; the durable driver is `refresh-best-pages.yml` actually changing rankings on the 1st & 15th.

🤖 Generated with [Claude Code](https://claude.com/claude-code)