### PR TITLE
news: Q3 2026 rotating 5% categories (Chase Freedom Flex + Discover)

### DIFF
--- a/data/news/2026-06-30-q3-2026-rotating-cash-back-categories.yaml
+++ b/data/news/2026-06-30-q3-2026-rotating-cash-back-categories.yaml
@@ -1,0 +1,64 @@
+id: "q3-2026-rotating-cash-back-categories"
+date: "2026-06-30"
+title: "Chase and Discover Reveal Q3 2026 5% Categories"
+summary: "Chase Freedom Flex and Discover it Cash Back have announced their Q3 2026 rotating 5% categories (July through September). Both reward gas and EV charging on up to $1,500 in spending after activation, with Chase adding transit, live entertainment, and United Way, and Discover adding flights, transit, and drugstores."
+tags:
+  - "bonus-change"
+card_slugs:
+  - "chase-freedom-flex"
+  - "discover-it-cash-back"
+  - "discover-it-for-students-card"
+  - "nhl-discover-it"
+card_names:
+  - "Chase Freedom Flex"
+  - "Discover it Cash Back"
+  - "Discover it for Students"
+  - "NHL Discover it"
+source: "Chase"
+source_url: "https://media.chase.com/news/chase-freedom-2026-q3-categories"
+body: |
+  The two biggest quarterly rotating cash-back cards have set their Q3 2026 bonus categories, covering July through September. Both Chase Freedom Flex and Discover it Cash Back lead with **gas stations and EV charging** this quarter, but the two calendars diverge from there. As always, cardholders must activate the categories to earn the elevated 5% rate on up to $1,500 in combined purchases.
+
+  ## Chase Freedom Flex: Q3 2026 Categories
+
+  For July 1 through September 30, Chase Freedom Flex cardholders earn 5% cash back in four categories:
+
+  **Gas Stations and EV Charging.** Purchases at gas stations and at electric vehicle charging stations both qualify.
+
+  **Public Transit.** This covers trains, buses, ferries, subways, tolls (including toll bridges and highways), parking lots, and parking garages.
+
+  **Select Live Entertainment.** Eligible purchases at qualifying live entertainment venues and events.
+
+  **Donations to United Way.** Contributions made to United Way earn the bonus rate.
+
+  You can earn 5% on up to **$1,500 in combined purchases** across all four categories, for a maximum of **$75 in bonus cash back** this quarter. Spending above the cap earns the standard rate. Activation is required and the deadline to activate is **September 14, 2026**. The same calendar applies to the older Chase Freedom card for existing cardholders.
+
+  ## Discover it Cash Back: Q3 2026 Categories
+
+  Discover's Q3 2026 calendar also runs July through September and centers on travel and everyday spending:
+
+  **Gas Stations and EV Charging.** Purchases at gas stations and public EV charging stations qualify. Stations attached to supermarkets or warehouse clubs may not be coded correctly.
+
+  **Public Transportation and Flights.** This includes airlines plus local commuter transport such as buses, trains, and ferries.
+
+  **Drugstores.** In-store and online drugstore and pharmacy purchases count toward the category.
+
+  As with Chase, you earn 5% on up to **$1,500 in combined purchases** (a maximum of **$75 back**), then 1% afterward. One key difference: Discover's activation is **not retroactive**, so you only earn 5% on purchases made after you activate. The activation window runs from June 1 through September 30, 2026, so it pays to activate on day one. The same categories apply to the Discover it for Students and NHL Discover it cards.
+
+  For new Discover cardholders, the first-year **Cashback Match** promotion doubles all cash back earned in the first 12 months, effectively making this quarter's bonus categories worth **10% back**.
+
+  ## How the Two Calendars Compare
+
+  Both cards share gas and EV charging this quarter and both cap the bonus at $1,500 in spending. The overlap means a single fill-up or charging session earns 5% on either card. Beyond that, the strategy splits by how you spend:
+
+  - **Commuters and travelers** get strong value from both: Chase rewards transit and parking, while Discover rewards flights and public transportation.
+  - **Chase Freedom Flex** is the better fit if you attend concerts or live events, given its Select Live Entertainment category.
+  - **Discover it Cash Back** edges ahead for routine spending thanks to drugstores, and new cardholders effectively double the rate with Cashback Match.
+
+  Carrying both cards lets you stack the calendars and cover gas, transit, flights, live entertainment, and drugstore purchases all at 5%.
+
+  ## Don't Forget to Activate
+
+  Neither card pays the bonus rate automatically. Chase cardholders have until **September 14** to activate (Chase applies the 5% retroactively to earlier Q3 purchases once activated), while Discover cardholders should activate as early as possible because the rate is not retroactive. Activation takes a minute through each issuer's app or website.
+
+  The Q4 2026 categories (October through December) have not yet been announced. Both issuers typically reveal the next quarter's calendar about two to four weeks before it begins.


### PR DESCRIPTION
Adds a news article covering the Q3 2026 (July–September) rotating 5% cash-back categories for the two main quarterly-rotator card families.

## Cards covered
- **Chase Freedom Flex**: Gas & EV Charging, Public Transit, Select Live Entertainment, United Way donations ($1,500 cap; activate by Sept 14)
- **Discover it Cash Back / for Students / NHL**: Gas & EV Charging, Public Transportation & Flights, Drugstores ($1,500 cap; activation not retroactive)

## Notes
- Single combined article modeled on the prior Q2 2026 Discover precedent.
- Title 47 chars (under SEO budget); `bonus-change` tag; all four card images resolve in the build.
- Verified against Chase's official newsroom release (first-party) and CNBC/AwardWallet for Discover (Discover's own calendar page was erroring).
- Only the YAML source is committed; `news.json` is gitignored and rebuilt by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)