### PR TITLE
cards: update rotating 5% categories to Q3 2026 (merge July 1)

### DIFF
--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -14,13 +14,19 @@ rewards:
     unit: "percent"
     mode: "quarterly_rotating"
     # Chase Travel (travel_portal) is a permanent 5% on this card, so it is
-    # intentionally NOT listed here. Donations to Feeding America don't map to
-    # a spending category — kept in the umbrella note for context.
+    # intentionally NOT listed here. Donations to United Way don't map to
+    # a spending category, so they're kept in the umbrella note for context.
     current_categories:
-      - category: "amazon"
-        note: "Amazon.com (Q2 2026 rotation)"
-    current_period: "Q2 2026"
-    note: "Q2 2026: Amazon, Chase Travel, and donations to Feeding America"
+      - category: "gas"
+        note: "Gas stations (Q3 2026 rotation)"
+      - category: "ev_charging"
+        note: "EV charging (Q3 2026 rotation)"
+      - category: "transit"
+        note: "Public transit (Q3 2026 rotation)"
+      - category: "entertainment"
+        note: "Select live entertainment (Q3 2026 rotation)"
+    current_period: "Q3 2026"
+    note: "Q3 2026: gas stations and EV charging, public transit, select live entertainment, and donations to United Way"
     spend_cap: 1500
     cap_period: quarterly
     rate_after_cap: 1

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -14,8 +14,8 @@ rewards:
     value: 5
     unit: percent
     mode: quarterly_rotating
-    current_categories: [dining, home_improvement]
-    current_period: "Q2 2026"
+    current_categories: [gas, ev_charging, transit, airlines, drugstores]
+    current_period: "Q3 2026"
     note: "Activation required each quarter"
     spend_cap: 1500
     cap_period: quarterly

--- a/data/cards/discover-it-for-students-card.yaml
+++ b/data/cards/discover-it-for-students-card.yaml
@@ -14,8 +14,8 @@ rewards:
     value: 5
     unit: percent
     mode: quarterly_rotating
-    current_categories: [dining, home_improvement]
-    current_period: "Q2 2026"
+    current_categories: [gas, ev_charging, transit, airlines, drugstores]
+    current_period: "Q3 2026"
     note: "Activation required each quarter"
     spend_cap: 1500
     cap_period: quarterly

--- a/data/cards/nhl-discover-it.yaml
+++ b/data/cards/nhl-discover-it.yaml
@@ -13,8 +13,8 @@ rewards:
     value: 5
     unit: percent
     mode: quarterly_rotating
-    current_categories: [dining, home_improvement]
-    current_period: "Q2 2026"
+    current_categories: [gas, ev_charging, transit, airlines, drugstores]
+    current_period: "Q3 2026"
     note: "Activation required each quarter"
     spend_cap: 1500
     cap_period: quarterly


### PR DESCRIPTION
**⚠️ Do not merge until July 1, 2026** (start of Q3). Merging early would show Q3 categories during Q2 and trigger the stale-period warning in reverse.

Updates the `current_period` and `current_categories` on the four quarterly-rotating cards for Q3 2026 (July–September). Companion to the news article in [#1545](https://github.com/CreditOdds/creditodds/pull/1545).

## Changes
- **Chase Freedom Flex**: gas, EV charging, transit, select live entertainment. United Way donations don't map to a spending category, so they stay in the umbrella `note` (same pattern previously used for Feeding America).
- **Discover it Cash Back / for Students / NHL**: gas, EV charging, transit, airlines, drugstores.

## Verification
- `npm run build:cards` passes (182 cards, no validation errors). All category IDs exist in `categories.yaml`.
- The build currently emits an expected "stale period" warning only because today is still Q2; it clears automatically once it's Q3 (i.e. when this is meant to merge).
- `cards.json` intentionally **not** committed — CI rebuilds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)