### PR TITLE
feat(admin): capture denial reason + total open cards on manual submit

### DIFF
--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -7,6 +7,24 @@ const { validateReferralLink } = require("../lib/validate-referral-link");
 // Fallback admin user IDs (Firebase UIDs) - used if custom claims not set
 const FALLBACK_ADMIN_IDS = ['zXOyHmGl7HStyAqEdLsgXLA5inS2'];
 
+// Structured codes for the issuer-cited reason on a denial. Kept in sync with
+// REASON_DENIED_CODES in apps/api/src/handlers/user-records.js and the
+// REASON_DENIED_OPTIONS list on the client so admin manual entry captures the
+// same denial reasons as the public submit-record form.
+const REASON_DENIED_CODES = [
+  "too_many_inquiries",
+  "too_many_recent_accounts",
+  "length_of_credit_too_short",
+  "credit_score_too_low",
+  "high_utilization",
+  "too_much_credit_with_issuer",
+  "income_too_low",
+  "recent_delinquency",
+  "bankruptcy_or_public_record",
+  "other",
+  "not_specified",
+];
+
 // Check if user is admin via custom claim or fallback list
 function isAdmin(event) {
   const userId = event.requestContext?.authorizer?.sub;
@@ -144,6 +162,7 @@ exports.AdminRecordsHandler = async (event) => {
         // Return extra fields when filtering by card
         const extraFields = cardIdFilter
           ? `, r.credit_score_source, r.starting_credit_limit, r.bank_customer, r.reason_denied,
+             r.reason_denied_code, r.total_open_cards,
              r.inquiries_3, r.inquiries_12, r.inquiries_24, r.admin_review`
           : '';
 
@@ -227,6 +246,8 @@ exports.AdminRecordsHandler = async (event) => {
           length_credit: yup.number().integer().min(0).max(100).nullable(),
           starting_credit_limit: yup.number().integer().min(0).max(1000000).nullable(),
           reason_denied: yup.string().max(254).nullable(),
+          reason_denied_code: yup.string().oneOf([...REASON_DENIED_CODES, null]).nullable(),
+          total_open_cards: yup.number().integer().min(0).max(500).nullable(),
           date_applied: yup.date(),
           bank_customer: yup.boolean(),
           inquiries_3: yup.number().integer().min(0).max(50).nullable(),
@@ -240,6 +261,7 @@ exports.AdminRecordsHandler = async (event) => {
         if (validated.result !== undefined) {
           if (validated.result) {
             validated.reason_denied = null;
+            validated.reason_denied_code = null;
           } else {
             validated.starting_credit_limit = null;
           }
@@ -303,7 +325,9 @@ exports.AdminRecordsHandler = async (event) => {
           listed_income: yup.number().integer().min(0).max(1000000).required(),
           length_credit: yup.number().integer().min(0).max(100).nullable(),
           starting_credit_limit: yup.number().integer().min(0).max(1000000).nullable(),
-          reason_denied: yup.string().max(254),
+          reason_denied: yup.string().max(254).nullable(),
+          reason_denied_code: yup.string().oneOf([...REASON_DENIED_CODES, null]).nullable(),
+          total_open_cards: yup.number().integer().min(0).max(500).nullable(),
           date_applied: yup.date().required(),
           bank_customer: yup.boolean().required(),
           inquiries_3: yup.number().integer().min(0).max(50).nullable(),
@@ -316,6 +340,7 @@ exports.AdminRecordsHandler = async (event) => {
         // Clear irrelevant fields based on result
         if (value.result) {
           value.reason_denied = null;
+          value.reason_denied_code = null;
         } else {
           value.starting_credit_limit = null;
         }
@@ -334,6 +359,8 @@ exports.AdminRecordsHandler = async (event) => {
           submit_datetime: new Date(),
           bank_customer: value.bank_customer,
           reason_denied: value.reason_denied,
+          reason_denied_code: value.reason_denied_code ?? null,
+          total_open_cards: value.total_open_cards ?? null,
           inquiries_3: value.inquiries_3,
           inquiries_12: value.inquiries_12,
           inquiries_24: value.inquiries_24,

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -1787,8 +1787,10 @@ function EditRecordModal({
   const [creditScoreSource, setCreditScoreSource] = useState(record.credit_score_source ?? 0);
   const [income, setIncome] = useState(record.listed_income);
   const [lengthCredit, setLengthCredit] = useState<number | null>(record.length_credit ?? null);
+  const [totalOpenCards, setTotalOpenCards] = useState<number | null>(record.total_open_cards ?? null);
   const [result, setResult] = useState(!!record.result);
   const [startingCreditLimit, setStartingCreditLimit] = useState<number | null>(record.starting_credit_limit ?? null);
+  const [reasonDeniedCode, setReasonDeniedCode] = useState(record.reason_denied_code ?? '');
   const [bankCustomer, setBankCustomer] = useState(!!record.bank_customer);
   const [inquiries3, setInquiries3] = useState<number | null>(record.inquiries_3 ?? null);
   const [inquiries12, setInquiries12] = useState<number | null>(record.inquiries_12 ?? null);
@@ -1802,8 +1804,10 @@ function EditRecordModal({
       credit_score_source: creditScoreSource,
       listed_income: income,
       length_credit: lengthCredit,
+      total_open_cards: totalOpenCards,
       result,
       starting_credit_limit: result ? startingCreditLimit : null,
+      reason_denied_code: result ? null : (reasonDeniedCode || null),
       bank_customer: bankCustomer,
       inquiries_3: inquiries3,
       inquiries_12: inquiries12,
@@ -1857,17 +1861,31 @@ function EditRecordModal({
                 />
               </div>
 
-              <div className="av-field">
-                <label className="av-field-label">Age of Oldest Account (years)</label>
-                <input
-                  type="number"
-                  value={lengthCredit ?? ''}
-                  onChange={(e) => setLengthCredit(e.target.value === '' ? null : parseInt(e.target.value))}
-                  min={0}
-                  max={100}
-                  placeholder="Optional"
-                  className="av-input"
-                />
+              <div className="av-grid-2">
+                <div className="av-field">
+                  <label className="av-field-label">Age of Oldest Account (years)</label>
+                  <input
+                    type="number"
+                    value={lengthCredit ?? ''}
+                    onChange={(e) => setLengthCredit(e.target.value === '' ? null : parseInt(e.target.value))}
+                    min={0}
+                    max={100}
+                    placeholder="Optional"
+                    className="av-input"
+                  />
+                </div>
+                <div className="av-field">
+                  <label className="av-field-label">Total Open Cards</label>
+                  <input
+                    type="number"
+                    value={totalOpenCards ?? ''}
+                    onChange={(e) => setTotalOpenCards(e.target.value === '' ? null : parseInt(e.target.value))}
+                    min={0}
+                    max={500}
+                    placeholder="Optional"
+                    className="av-input"
+                  />
+                </div>
               </div>
 
               <div className="av-field" style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -1951,6 +1969,22 @@ function EditRecordModal({
                   />
                 </div>
               )}
+
+              {!result && (
+                <div className="av-field">
+                  <label className="av-field-label">Reason for Denial</label>
+                  <select
+                    value={reasonDeniedCode}
+                    onChange={(e) => setReasonDeniedCode(e.target.value)}
+                    className="av-select"
+                  >
+                    <option value="">Select a reason…</option>
+                    {REASON_DENIED_OPTIONS.map((opt) => (
+                      <option key={opt.code} value={opt.code}>{opt.label}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
             </div>
             <div className="av-modal-foot">
               <button type="submit" disabled={processing} className="av-btn av-btn-primary">
@@ -1969,6 +2003,23 @@ function EditRecordModal({
 
 // ============ SUBMIT RECORD TAB ============
 
+// Keep in sync with REASON_DENIED_OPTIONS in
+// apps/web-next/src/components/forms/SubmitRecordModal.tsx and
+// REASON_DENIED_CODES in apps/api/src/handlers/user-records.js.
+const REASON_DENIED_OPTIONS: ReadonlyArray<{ code: string; label: string }> = [
+  { code: 'not_specified', label: "Issuer didn't say" },
+  { code: 'too_many_inquiries', label: 'Too many recent inquiries' },
+  { code: 'too_many_recent_accounts', label: 'Too many recently opened accounts' },
+  { code: 'length_of_credit_too_short', label: 'Credit history too short' },
+  { code: 'credit_score_too_low', label: 'Credit score too low' },
+  { code: 'high_utilization', label: 'High utilization / too much revolving debt' },
+  { code: 'too_much_credit_with_issuer', label: 'Too much credit already with this issuer' },
+  { code: 'income_too_low', label: 'Income too low' },
+  { code: 'recent_delinquency', label: 'Recent delinquency or late payment' },
+  { code: 'bankruptcy_or_public_record', label: 'Bankruptcy or public record' },
+  { code: 'other', label: 'Other' },
+];
+
 function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<string | null>; onSuccess: () => void }) {
   const { cards, error: cardCatalogError } = useCardCatalog({ activeOnly: true });
   const [cardSearch, setCardSearch] = useState('');
@@ -1983,12 +2034,14 @@ function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<stri
     return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
   });
   const [lengthCredit, setLengthCredit] = useState<number | null>(null);
+  const [totalOpenCards, setTotalOpenCards] = useState<number | null>(null);
   const [bankCustomer, setBankCustomer] = useState(false);
   const [inquiries3, setInquiries3] = useState<number | null>(null);
   const [inquiries12, setInquiries12] = useState<number | null>(null);
   const [inquiries24, setInquiries24] = useState<number | null>(null);
   const [result, setResult] = useState(true);
   const [startingCreditLimit, setStartingCreditLimit] = useState<number | null>(null);
+  const [reasonDeniedCode, setReasonDeniedCode] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
@@ -2011,12 +2064,14 @@ function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<stri
     const now = new Date();
     setDateApplied(`${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`);
     setLengthCredit(null);
+    setTotalOpenCards(null);
     setBankCustomer(false);
     setInquiries3(null);
     setInquiries12(null);
     setInquiries24(null);
     setResult(true);
     setStartingCreditLimit(null);
+    setReasonDeniedCode('');
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -2051,7 +2106,9 @@ function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<stri
         result,
         listed_income: income,
         length_credit: lengthCredit ?? undefined,
+        total_open_cards: totalOpenCards ?? undefined,
         starting_credit_limit: result && startingCreditLimit != null ? startingCreditLimit : undefined,
+        reason_denied_code: !result && reasonDeniedCode ? reasonDeniedCode : undefined,
         date_applied: dateAppliedValue,
         bank_customer: bankCustomer,
         inquiries_3: inquiries3 ?? undefined,
@@ -2207,17 +2264,31 @@ function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<stri
             </div>
           </div>
 
-          <div className="av-field">
-            <label className="av-field-label">Age of oldest account (years)</label>
-            <input
-              type="number"
-              value={lengthCredit ?? ''}
-              onChange={(e) => setLengthCredit(e.target.value === '' ? null : parseInt(e.target.value))}
-              min={0}
-              max={100}
-              placeholder="Optional"
-              className="av-input"
-            />
+          <div className="av-grid-2">
+            <div className="av-field">
+              <label className="av-field-label">Age of oldest account (years)</label>
+              <input
+                type="number"
+                value={lengthCredit ?? ''}
+                onChange={(e) => setLengthCredit(e.target.value === '' ? null : parseInt(e.target.value))}
+                min={0}
+                max={100}
+                placeholder="Optional"
+                className="av-input"
+              />
+            </div>
+            <div className="av-field">
+              <label className="av-field-label">Total open cards</label>
+              <input
+                type="number"
+                value={totalOpenCards ?? ''}
+                onChange={(e) => setTotalOpenCards(e.target.value === '' ? null : parseInt(e.target.value))}
+                min={0}
+                max={500}
+                placeholder="Optional"
+                className="av-input"
+              />
+            </div>
           </div>
 
           <div className="av-field" style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -2299,6 +2370,22 @@ function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<stri
                 placeholder="Optional"
                 className="av-input"
               />
+            </div>
+          )}
+
+          {!result && (
+            <div className="av-field">
+              <label className="av-field-label">Reason for denial</label>
+              <select
+                value={reasonDeniedCode}
+                onChange={(e) => setReasonDeniedCode(e.target.value)}
+                className="av-select"
+              >
+                <option value="">Select a reason…</option>
+                {REASON_DENIED_OPTIONS.map((opt) => (
+                  <option key={opt.code} value={opt.code}>{opt.label}</option>
+                ))}
+              </select>
             </div>
           )}
 

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1350,6 +1350,8 @@ export interface AdminRecordDetail extends AdminRecord {
   starting_credit_limit?: number | null;
   bank_customer?: boolean;
   reason_denied?: string | null;
+  reason_denied_code?: string | null;
+  total_open_cards?: number | null;
   inquiries_3?: number | null;
   inquiries_12?: number | null;
   inquiries_24?: number | null;


### PR DESCRIPTION
## Problem

The admin portal's **manual "submit a record"** form didn't let you record *why* an applicant was denied, and it also omitted **Total Open Cards** — both of which the public [SubmitRecordModal](apps/web-next/src/components/forms/SubmitRecordModal.tsx) collects. Admin-entered denials were saved with no denial reason at all, creating a data gap versus user-submitted records.

## Fix

Bring every record-submission surface in line with the latest public form:

**Backend — `apps/api/src/handlers/admin.js`**
- Added shared `REASON_DENIED_CODES` (mirrors `user-records.js`).
- `POST /admin/records`: validate + persist `reason_denied_code` and `total_open_cards`; null out the reason code on approvals.
- `PUT /admin/records`: same two fields, so admin edits stay consistent.
- Record-detail `GET` now returns `reason_denied_code` + `total_open_cards` for prefill.

**Frontend — `apps/web-next/src/app/admin/page.tsx`**
- `SubmitRecordTab` and `EditRecordModal` both gained a **Total Open Cards** input and a **Reason for Denial** dropdown (shown when Denied), reusing the exact option set/labels from the public form.

**Types — `apps/web-next/src/lib/api.ts`**
- `AdminRecordDetail` extended with `reason_denied_code` + `total_open_cards`.

The denial-reason option list is now duplicated in three spots (public modal, admin page, backend) with cross-referencing "keep in sync" comments, matching the existing convention.

## Verification
- `tsc --noEmit` passes on `apps/web-next`.
- Both backend handlers `require()` cleanly.
- ESLint clean on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)