### PR TITLE
fix(web): resolve wallet cards whose name drifted after a rename

### DIFF
--- a/apps/web-next/src/app/best-card-for-me/BestCardForMeClient.tsx
+++ b/apps/web-next/src/app/best-card-for-me/BestCardForMeClient.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '@/auth/AuthProvider';
 import { cardMatchesSearch } from '@/lib/searchAliases';
 import { SPEND_BUCKETS, SPEND_BUCKET_LABELS } from '@/lib/nextCardRanking';
 import { getWallet, addToWallet, type Card, type SignupBonus } from '@/lib/api';
-import { createCardLookups } from '@/app/profile/profileSelectors';
+import { createCardLookups, normalizeCardName } from '@/app/profile/profileSelectors';
 import { CategoryIcon, categoryLabels } from '@/lib/cardDisplayUtils';
 
 // ---- Result shape returned by /api/best-card-for-me -------------------------
@@ -305,7 +305,14 @@ export default function BestCardForMeClient({ allCards }: { allCards: Card[] }) 
     const lookups = createCardLookups(allCards);
     return (wallet: { card_id: number; card_name: string }[]) =>
       wallet
-        .map((w) => (lookups.byWalletId.get(w.card_id) ?? lookups.byName.get(w.card_name))?.slug)
+        .map(
+          (w) =>
+            (
+              lookups.byWalletId.get(w.card_id) ??
+              lookups.byName.get(w.card_name) ??
+              lookups.byNameNormalized.get(normalizeCardName(w.card_name))
+            )?.slug,
+        )
         .filter((s): s is string => !!s);
   }, [allCards]);
 

--- a/apps/web-next/src/app/profile/profileSelectors.test.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.test.ts
@@ -6,6 +6,7 @@ import {
   getRelevantNews,
   getTotalAnnualFees,
   getWalletVisibility,
+  normalizeCardName,
 } from "./profileSelectors";
 
 describe("profileSelectors", () => {
@@ -59,5 +60,36 @@ describe("profileSelectors", () => {
       lookups
     );
     expect(eligibleFromRecords.map((c) => c.card_name)).toEqual(["Chase Sapphire Preferred"]);
+  });
+
+  it("resolves a wallet card whose name drifted after a rename (U.S. Bank -> US Bank)", () => {
+    // Catalog holds the renamed card; the wallet still holds the OLD name and an
+    // id that isn't among the catalog's db ids (mirrors a stale local catalog,
+    // where exact-id and exact-name matching both miss).
+    const catalog = [
+      {
+        card_id: "us-bank-cash-plus-visa-signature",
+        db_card_id: 352,
+        card_name: "US Bank Cash+ Visa Signature",
+        annual_fee: 75,
+        slug: "us-bank-cash-plus-visa-signature",
+        active: true,
+      },
+    ];
+    const lk = createCardLookups(catalog as never);
+    const staleWallet = [{ card_id: 999, card_name: "U.S. Bank Cash+ Visa Signature" }];
+
+    // Exact id and exact name both miss...
+    expect(lk.byWalletId.has(999)).toBe(false);
+    expect(lk.byName.has("U.S. Bank Cash+ Visa Signature")).toBe(false);
+    // ...but the normalized fallback still resolves the card, so it's recognized
+    // (its fee is counted, not dropped as an unknown card).
+    expect(getTotalAnnualFees(staleWallet as never, lk)).toBe(75);
+
+    // Old and new names fold together; the meaningful "+" in Cash+ is preserved.
+    expect(normalizeCardName("U.S. Bank Cash+ Visa Signature")).toBe(
+      normalizeCardName("US Bank Cash+ Visa Signature")
+    );
+    expect(normalizeCardName("US Bank Cash+ Visa Signature")).toContain("cash+");
   });
 });

--- a/apps/web-next/src/app/profile/profileSelectors.ts
+++ b/apps/web-next/src/app/profile/profileSelectors.ts
@@ -14,15 +14,27 @@ export interface EligibleReferralCard {
 
 export interface CardLookups {
   byName: Map<string, Card>;
+  byNameNormalized: Map<string, Card>;
   byWalletId: Map<number, Card>;
+}
+
+// Fold punctuation/case drift that breaks exact card-name matching between the
+// wallet (stored in the DB) and the catalog. The main offender is the "U.S.
+// Bank" -> "US Bank" rename: a wallet still holding the old name must still
+// resolve to the renamed catalog card. Periods are dropped ("U.S." -> "US");
+// meaningful marks like the "+" in "Cash+" are preserved.
+export function normalizeCardName(name: string): string {
+  return name.toLowerCase().replace(/\./g, "").replace(/\s+/g, " ").trim();
 }
 
 export function createCardLookups(allCards: Card[]): CardLookups {
   const byName = new Map<string, Card>();
+  const byNameNormalized = new Map<string, Card>();
   const byWalletId = new Map<number, Card>();
 
   for (const card of allCards) {
     byName.set(card.card_name, card);
+    byNameNormalized.set(normalizeCardName(card.card_name), card);
 
     const primaryId = Number(card.card_id);
     if (!Number.isNaN(primaryId)) {
@@ -34,11 +46,15 @@ export function createCardLookups(allCards: Card[]): CardLookups {
     }
   }
 
-  return { byName, byWalletId };
+  return { byName, byNameNormalized, byWalletId };
 }
 
 function getCardForWalletCard(walletCard: WalletCard, lookups: CardLookups) {
-  return lookups.byWalletId.get(walletCard.card_id) ?? lookups.byName.get(walletCard.card_name);
+  return (
+    lookups.byWalletId.get(walletCard.card_id) ??
+    lookups.byName.get(walletCard.card_name) ??
+    lookups.byNameNormalized.get(normalizeCardName(walletCard.card_name))
+  );
 }
 
 export function getEligibleReferralCards(


### PR DESCRIPTION
## Symptoms (reported)

For a user who owns **US Bank Cash+ Visa Signature**, on Best Card For Me:
- it didn't show up in the "Your wallet" step (not pre-filled), and
- it was still **recommended**, even though it's in their wallet.

## Root cause

The card was renamed `"U.S. Bank Cash+ Visa Signature"` → `"US Bank Cash+ Visa Signature"` in [#1237](https://github.com/CreditOdds/creditodds/pull/1237). The wallet-to-catalog resolver (`createCardLookups` / `walletToSlugs`) matches by numeric db id, then falls back to an **exact** `card_name` match.

When the catalog has no db ids (the tracked-but-stale local `cards.json` the dev server reads — it still carries the old name and no `db_card_id`) **and** the wallet still holds the old-punctuation name, both matches miss. The card resolves to nothing, so it's neither pre-filled nor excluded from recommendations. (Prod `/cards` carries `db_card_id: 352`, so this reproduces on the local dev server; the resolver was simply too brittle to name drift.)

## Fix

Add a normalized-name fallback shared by the profile lookups and the BCFM wallet prefill:

- `normalizeCardName()` drops periods and folds case/whitespace, so `"U.S. Bank Cash+ Visa Signature"` and `"US Bank Cash+ Visa Signature"` fold together.
- The meaningful `"+"` in `Cash+` is preserved (never collapses distinct cards).
- Resolution order is unchanged for exact matches: db id → exact name → **normalized name**.

## Verification

- New regression test in `profileSelectors.test.ts`: a wallet holding the old name (and an id absent from the catalog) still resolves via the normalized fallback. 4/4 tests pass.
- Replicated the exact failure against the real stale local catalog: the wallet card now resolves to `us-bank-cash-plus-visa-signature`.
- tsc + ESLint clean.