### PR TITLE
fix(news): give Bilt/Wells Fargo story a unique id

### DIFF
--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -45,6 +45,12 @@ jobs:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2
 
+      - name: Sync news hero images (generate missing via OpenAI)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          S3_IMAGES_BUCKET_NAME: ${{ secrets.S3_IMAGES_BUCKET_NAME }}
+        run: node scripts/sync-news-images.js
+
       - name: Upload news.json to S3
         run: aws s3 cp data/news.json s3://${{ secrets.S3_BUCKET_NAME }}/news.json --content-type application/json --cache-control "max-age=300"
 

--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -2,10 +2,13 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import CardImage from '@/components/ui/CardImage';
 import type { NewsItem, NewsTag } from '@/lib/news';
 import '../landing.css';
+
+const NEWS_IMG_CDN = 'https://d3ay3etzd1512y.cloudfront.net/news_images';
 
 interface NewsV2ClientProps {
   items: NewsItem[];
@@ -67,7 +70,7 @@ export default function NewsV2Client({ items }: NewsV2ClientProps) {
     return items.filter((i) => (i.tags ?? []).includes(filter));
   }, [filter, items]);
 
-  const imaged = filtered.filter((i) => Boolean(i.card_image_link));
+  const imaged = filtered.filter((i) => Boolean(i.news_image || i.card_image_link));
   const featured = imaged[0];
   const secondary = imaged.slice(1, 4);
   const usedIds = new Set(
@@ -126,16 +129,28 @@ export default function NewsV2Client({ items }: NewsV2ClientProps) {
           <div className="news-grid">
             <Link href={`/news/${featured.id}`} className="feat-article">
               <div className="feat-cover">
-                <div className="cover-pattern" />
-                <div className="cover-card">
-                  <CardImage
-                    cardImageLink={featured.card_image_link}
-                    alt={featured.card_names?.[0] || featured.title}
+                {featured.news_image ? (
+                  <Image
+                    src={`${NEWS_IMG_CDN}/${featured.news_image}`}
+                    alt={featured.title}
                     fill
-                    sizes="240px"
+                    sizes="(max-width: 900px) 100vw, 480px"
                     style={{ objectFit: 'cover' }}
                   />
-                </div>
+                ) : (
+                  <>
+                    <div className="cover-pattern" />
+                    <div className="cover-card">
+                      <CardImage
+                        cardImageLink={featured.card_image_link}
+                        alt={featured.card_names?.[0] || featured.title}
+                        fill
+                        sizes="240px"
+                        style={{ objectFit: 'cover' }}
+                      />
+                    </div>
+                  </>
+                )}
               </div>
               <div className="feat-body">
                 <div className="feat-meta">
@@ -184,16 +199,28 @@ export default function NewsV2Client({ items }: NewsV2ClientProps) {
             {secondary.map((item) => (
               <Link key={item.id} href={`/news/${item.id}`} className="news-card">
                 <div className="nc-cover">
-                  <div className="nc-pattern" />
-                  <div className="nc-card-thumb">
-                    <CardImage
-                      cardImageLink={item.card_image_link}
-                      alt={item.card_names?.[0] || item.title}
+                  {item.news_image ? (
+                    <Image
+                      src={`${NEWS_IMG_CDN}/${item.news_image}`}
+                      alt={item.title}
                       fill
-                      sizes="160px"
+                      sizes="(max-width: 640px) 100vw, 320px"
                       style={{ objectFit: 'cover' }}
                     />
-                  </div>
+                  ) : (
+                    <>
+                      <div className="nc-pattern" />
+                      <div className="nc-card-thumb">
+                        <CardImage
+                          cardImageLink={item.card_image_link}
+                          alt={item.card_names?.[0] || item.title}
+                          fill
+                          sizes="160px"
+                          style={{ objectFit: 'cover' }}
+                        />
+                      </div>
+                    </>
+                  )}
                 </div>
                 <div className="nc-body">
                   <div className="nc-meta">

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { getNews, getNewsItem, tagLabels } from "@/lib/news";
 import { ArticleContent } from "@/components/articles/ArticleContent";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
@@ -12,6 +13,8 @@ import { V2Footer } from "@/components/landing-v2/Chrome";
 import ViewTracker from "@/components/ViewTracker";
 import { truncateTitle } from "@/lib/seo";
 import "../../landing.css";
+
+const NEWS_IMG_CDN = "https://d3ay3etzd1512y.cloudfront.net/news_images";
 
 interface NewsDetailPageProps {
   params: Promise<{ id: string }>;
@@ -37,6 +40,18 @@ export async function generateMetadata({ params }: NewsDetailPageProps): Promise
       url: `https://creditodds.com/news/${item.id}`,
       type: "article",
       publishedTime: item.date,
+      ...(item.news_image
+        ? {
+            images: [
+              {
+                url: `${NEWS_IMG_CDN}/${item.news_image}`,
+                width: 1536,
+                height: 1024,
+                alt: item.title,
+              },
+            ],
+          }
+        : {}),
     },
     alternates: {
       canonical: `https://creditodds.com/news/${item.id}`,
@@ -78,7 +93,9 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
     datePublished: item.date,
     dateModified: item.date,
     url,
-    image: `https://creditodds.com/news/${item.id}/opengraph-image`,
+    image: item.news_image
+      ? `${NEWS_IMG_CDN}/${item.news_image}`
+      : `https://creditodds.com/news/${item.id}/opengraph-image`,
     author: { "@type": "Organization", name: "CreditOdds" },
     publisher: {
       "@type": "Organization",
@@ -163,6 +180,28 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
                 </Link>
               ))}
             </div>
+          )}
+
+          {item.news_image && (
+            <figure
+              style={{
+                position: 'relative',
+                aspectRatio: '3 / 2',
+                margin: '22px 0 8px',
+                borderRadius: 16,
+                overflow: 'hidden',
+                border: '1px solid var(--line, rgba(0,0,0,0.08))',
+              }}
+            >
+              <Image
+                src={`${NEWS_IMG_CDN}/${item.news_image}`}
+                alt={item.title}
+                fill
+                sizes="(max-width: 820px) 100vw, 760px"
+                style={{ objectFit: 'cover' }}
+                priority
+              />
+            </figure>
           )}
 
           <div className="article-body">

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -28,6 +28,8 @@ export interface NewsItem {
   source?: string;
   source_url?: string;
   body?: string;
+  /** AI-generated hero image filename under news_images/ on the assets CDN. */
+  news_image?: string;
 }
 
 export interface NewsResponse {

--- a/data/news/2026-02-07-bilt-card-transition.yaml
+++ b/data/news/2026-02-07-bilt-card-transition.yaml
@@ -1,4 +1,4 @@
-id: "bilt-card-transition"
+id: "bilt-wells-fargo-partnership-ends"
 date: "2026-02-07"
 title: "Bilt Credit Card Partnership with Wells Fargo Ends"
 summary: "Wells Fargo officially terminates its partnership with Bilt after nearly four years. Customers receiving surprise Wells Fargo Autograph cards as transition occurs."

--- a/data/news/schema.json
+++ b/data/news/schema.json
@@ -85,6 +85,10 @@
       "type": "string",
       "maxLength": 15000,
       "description": "Full article body in markdown (optional)"
+    },
+    "news_image": {
+      "type": "string",
+      "description": "AI-generated hero image filename under news_images/ on the assets CDN (optional). Auto-populated by scripts/sync-news-images.js; set here to override with a specific filename."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:web-next": "npm run build -w @creditodds/web-next",
     "build:cards": "node scripts/build-cards.js",
     "build:news": "node scripts/build-news.js",
+    "sync:news-images": "node scripts/sync-news-images.js",
     "build:articles": "node scripts/build-articles.js",
     "build:best": "node scripts/build-best.js",
     "build:stores": "node scripts/build-stores.js",

--- a/scripts/queue-social.js
+++ b/scripts/queue-social.js
@@ -291,6 +291,14 @@ async function main() {
       const socialFilename = item.social_image || `${item.slug}-social.png`;
       imageUrl = `https://d3ay3etzd1512y.cloudfront.net/article_images/${socialFilename}`;
       console.log(`  Image: ${imageUrl}`);
+    } else if (type === 'news' && item.id) {
+      // sync-news-images.js (run earlier in build-news.yml) generates and
+      // uploads news_images/<id>.png. It stamps news.json, not this YAML, so we
+      // rebuild the conventional URL from the id. fetchImageAsBase64 falls back
+      // gracefully if the image isn't on the CDN yet.
+      const newsFilename = item.news_image || `${item.id}.png`;
+      imageUrl = `https://d3ay3etzd1512y.cloudfront.net/news_images/${newsFilename}`;
+      console.log(`  Image: ${imageUrl}`);
     }
 
     try {

--- a/scripts/sync-news-images.js
+++ b/scripts/sync-news-images.js
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * sync-news-images.js
+ *
+ * For each item in data/news.json, ensures a single "clickbait" hero image
+ * exists on S3 at `news_images/<id>.png`, then stamps the filename into the
+ * item's `news_image` field (in data/news.json, in place).
+ *
+ * The image is a surreal-but-photoreal scene (beach, circus, stadium, …,
+ * picked deterministically by the news id) in which the REAL card art for the
+ * cards the story is about is composited in as the hero subject. We use
+ * OpenAI's gpt-image-1 EDITS endpoint with the actual card PNGs as reference
+ * images (`input_fidelity: high`) so the cards stay recognizable rather than
+ * being invented from scratch. News items with no associated card fall back to
+ * the text-to-image generations endpoint with a generic card in the scene.
+ *
+ * The stamped `news_image` is used as the news-page hero and the OG image, and
+ * is attached to the social post (see scripts/queue-social.js).
+ *
+ * Idempotent: S3 is the source of truth. If the object already exists we just
+ * stamp the field and skip generation — so re-running is cheap and CI-safe.
+ * data/news.json is gitignored / rebuilt in CI, so nothing is committed here.
+ *
+ * Env:
+ *   OPENAI_API_KEY          (required when any generation is needed)
+ *   S3_IMAGES_BUCKET_NAME   (required for uploads — same bucket as card_images)
+ *
+ * Flags:
+ *   --force <id>       Regenerate this news id even if S3 already has it.
+ *   --force-all        Regenerate every news item (expensive).
+ *   --only <id>        Process just this one id (handy for previews).
+ *   --limit <n>        Stop after generating <n> images this run (backfill in batches).
+ *   --quality <q>      gpt-image-1 quality: low | medium | high (default high).
+ *   --dry-run          Log what would happen, but don't call OpenAI or S3.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const os = require('os');
+const crypto = require('crypto');
+
+const NEWS_JSON = path.join(__dirname, '..', 'data', 'news.json');
+const S3_PREFIX = 'news_images';
+const CARD_CDN = 'https://d3ay3etzd1512y.cloudfront.net/card_images';
+const MAX_CARDS = 3; // cards fanned into one scene — more than this gets crowded
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const forceAll = args.includes('--force-all');
+const argVal = (flag) => {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const forceIds = new Set(
+  args.map((a, i) => (a === '--force' ? args[i + 1] : null)).filter(Boolean)
+);
+const onlyId = argVal('--only');
+const limit = argVal('--limit') ? parseInt(argVal('--limit'), 10) : Infinity;
+const quality = argVal('--quality') || 'high';
+
+const bucket = process.env.S3_IMAGES_BUCKET_NAME;
+const openaiKey = process.env.OPENAI_API_KEY;
+
+function log(msg) {
+  process.stdout.write(`[sync-news-images] ${msg}\n`);
+}
+
+// ── Scene pool ────────────────────────────────────────────────────────────
+// Setting-only phrases; the card subject clause is appended per item. Picked
+// deterministically by news id so each story gets a stable scene but the feed
+// stays varied. Add more entries to increase variety.
+const SCENES = [
+  'a sunny tropical beach at golden hour, with golden sand, turquoise water, a distant boardwalk ferris wheel and seagulls',
+  'the spotlit center ring of a vintage circus big-top, with a red-and-gold stage, confetti in the air and a blurred cheering crowd',
+  'a chic rooftop cocktail bar at night, with a glittering city skyline bokeh and warm string lights',
+  'the grass at center field of a packed sports stadium under bright floodlights, with a roaring blurred crowd in the stands',
+  'a cozy retro American diner, with a glossy chrome counter, warm neon signage, a checkerboard floor and vinyl booths',
+  'a snowy mountain ski slope at golden hour, with fresh powder snow, pine trees, a timber lodge and sparkling alpenglow light',
+  'a neon-soaked retro arcade at night, with glowing pinball machines and vivid magenta and cyan light',
+  'a rain-slicked neon city street at night, with shimmering reflections on wet pavement and a cinematic glow',
+  'a lush botanical greenhouse at sunrise, with giant tropical leaves, orchids, dewdrops and soft golden light through glass',
+  'a colorful carnival midway at dusk, with glowing game booths, a ferris wheel, string lights and a cotton-candy pastel sky',
+];
+
+function pickScene(id) {
+  const hash = crypto.createHash('md5').update(id).digest();
+  return SCENES[hash[0] % SCENES.length];
+}
+
+// ── Prompt builders ───────────────────────────────────────────────────────
+
+function buildEditPrompt(scene, cardNames) {
+  const subject =
+    cardNames.length === 1
+      ? `The hero subject is one giant, glossy real credit card standing upright: ${cardNames[0]} (shown in the reference image).`
+      : `The hero subjects are ${cardNames.length} giant, glossy real credit cards standing together, one per reference image in order: ${cardNames
+          .map((n, i) => `(${i + 1}) ${n}`)
+          .join(', ')}.`;
+  return [
+    `A hyper-realistic, cinematic wide photograph set at ${scene}.`,
+    subject,
+    `Reproduce each card's real artwork, exact colors, and logos faithfully and keep them clearly recognizable — do NOT redesign the cards, do NOT change their colors, and do NOT add any fake text, numbers, or extra logos.`,
+    `The cards should dominate the composition, larger than life, and read instantly even at thumbnail size.`,
+    `Warm dramatic lighting, shallow depth of field, editorial finance-magazine energy.`,
+    `Absolutely no added text, captions, headlines, or watermarks anywhere in the image.`,
+  ].join(' ');
+}
+
+function buildThemePrompt(scene, item) {
+  return [
+    `A hyper-realistic, cinematic wide photograph set at ${scene}.`,
+    `The hero subject is a single sleek, glossy credit card standing upright, larger than life, catching the light.`,
+    `The mood playfully nods to this credit-card news headline: "${item.title}".`,
+    `Warm dramatic lighting, shallow depth of field, editorial finance-magazine energy.`,
+    `Absolutely no text, captions, headlines, numbers, or watermarks anywhere in the image.`,
+  ].join(' ');
+}
+
+// ── OpenAI ────────────────────────────────────────────────────────────────
+
+async function fetchCardBuffer(filename) {
+  try {
+    const res = await fetch(`${CARD_CDN}/${filename}`);
+    if (!res.ok) return null;
+    return Buffer.from(await res.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+// gpt-image-1 EDITS: real card art in, scene out. Cards stay faithful.
+async function callOpenAIEdit(prompt, cards) {
+  if (!openaiKey) throw new Error('OPENAI_API_KEY not set — cannot generate');
+  const form = new FormData();
+  form.append('model', 'gpt-image-1');
+  form.append('prompt', prompt);
+  form.append('size', '1536x1024');
+  form.append('quality', quality);
+  form.append('input_fidelity', 'high');
+  form.append('n', '1');
+  for (const c of cards) {
+    form.append('image[]', new Blob([c.buf], { type: 'image/png' }), c.filename);
+  }
+  const res = await fetch('https://api.openai.com/v1/images/edits', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${openaiKey}` },
+    body: form,
+  });
+  if (!res.ok) throw new Error(`OpenAI HTTP ${res.status}: ${await res.text()}`);
+  const json = await res.json();
+  const b64 = json.data?.[0]?.b64_json;
+  if (!b64) throw new Error(`No image: ${JSON.stringify(json).slice(0, 300)}`);
+  return Buffer.from(b64, 'base64');
+}
+
+// gpt-image-1 GENERATIONS: for news items with no associated card art.
+async function callOpenAIGenerate(prompt) {
+  if (!openaiKey) throw new Error('OPENAI_API_KEY not set — cannot generate');
+  const res = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${openaiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-image-1',
+      prompt,
+      size: '1536x1024',
+      quality,
+      n: 1,
+    }),
+  });
+  if (!res.ok) throw new Error(`OpenAI HTTP ${res.status}: ${await res.text()}`);
+  const json = await res.json();
+  const b64 = json.data?.[0]?.b64_json;
+  if (!b64) throw new Error(`No image: ${JSON.stringify(json).slice(0, 300)}`);
+  return Buffer.from(b64, 'base64');
+}
+
+async function generateNewsImage(item) {
+  const scene = pickScene(item.id);
+  const links = (item.card_image_links || []).slice(0, MAX_CARDS);
+  const names = (item.card_names || []).slice(0, links.length);
+
+  // Fetch the real card art; drop any that 404.
+  const cards = [];
+  for (let i = 0; i < links.length; i++) {
+    const buf = await fetchCardBuffer(links[i]);
+    if (buf) cards.push({ buf, filename: links[i], name: names[i] || `card ${i + 1}` });
+  }
+
+  let buf;
+  if (cards.length > 0) {
+    buf = await callOpenAIEdit(buildEditPrompt(scene, cards.map((c) => c.name)), cards);
+  } else {
+    buf = await callOpenAIGenerate(buildThemePrompt(scene, item));
+  }
+  const tmp = path.join(os.tmpdir(), `news-${item.id}.png`);
+  fs.writeFileSync(tmp, buf);
+  return tmp;
+}
+
+// ── S3 ────────────────────────────────────────────────────────────────────
+
+function s3HasObject(key) {
+  if (dryRun) return false;
+  if (!bucket) throw new Error('S3_IMAGES_BUCKET_NAME not set');
+  try {
+    execSync(`aws s3api head-object --bucket "${bucket}" --key "${key}"`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function uploadToS3(key, localPath) {
+  if (dryRun) {
+    log(`(dry-run) would upload ${localPath} → s3://${bucket}/${key}`);
+    return;
+  }
+  execSync(
+    `aws s3 cp "${localPath}" "s3://${bucket}/${key}" ` +
+      `--content-type image/png --cache-control "max-age=86400"`,
+    { stdio: 'inherit' }
+  );
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!fs.existsSync(NEWS_JSON)) {
+    throw new Error(`${NEWS_JSON} not found — run build:news first`);
+  }
+  const data = JSON.parse(fs.readFileSync(NEWS_JSON, 'utf8'));
+  const items = data.items || data;
+  if (!Array.isArray(items)) throw new Error('news.json shape unexpected');
+
+  const results = { generated: [], stamped: [], skipped: 0, failed: [] };
+  let generatedThisRun = 0;
+
+  for (const item of items) {
+    if (!item.id) continue;
+    if (onlyId && item.id !== onlyId) continue;
+
+    const key = `${S3_PREFIX}/${item.id}.png`;
+    const expected = `${item.id}.png`;
+    const force = forceAll || forceIds.has(item.id);
+
+    // Author-provided override in YAML — respect it verbatim.
+    if (item.news_image && !force) {
+      results.skipped++;
+      continue;
+    }
+
+    if (!force && s3HasObject(key)) {
+      if (item.news_image !== expected) {
+        item.news_image = expected;
+        results.stamped.push(item.id);
+      } else {
+        results.skipped++;
+      }
+      continue;
+    }
+
+    if (generatedThisRun >= limit) {
+      log(`limit ${limit} reached — stopping (remaining items left unstamped)`);
+      break;
+    }
+
+    log(`generating for ${item.id}${force ? ' (forced)' : ''} — ${(item.card_image_links || []).slice(0, MAX_CARDS).length} card ref(s)`);
+    if (dryRun) {
+      item.news_image = expected;
+      generatedThisRun++;
+      results.generated.push(item.id);
+      continue;
+    }
+    try {
+      const localPath = await generateNewsImage(item);
+      uploadToS3(key, localPath);
+      item.news_image = expected;
+      generatedThisRun++;
+      results.generated.push(item.id);
+    } catch (err) {
+      log(`ERROR generating for ${item.id}: ${err.message}`);
+      results.failed.push(item.id);
+    }
+  }
+
+  fs.writeFileSync(NEWS_JSON, JSON.stringify(data, null, 2) + '\n');
+
+  log(
+    `done — generated: ${results.generated.length}, stamped from S3: ${results.stamped.length}, ` +
+      `skipped: ${results.skipped}, failed: ${results.failed.length}, total: ${items.length}`
+  );
+  if (results.generated.length) log(`generated: ${results.generated.join(', ')}`);
+  if (results.failed.length) log(`FAILED:    ${results.failed.join(', ')}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/sync-news-images.js
+++ b/scripts/sync-news-images.js
@@ -192,7 +192,19 @@ async function generateNewsImage(item) {
 
   let buf;
   if (cards.length > 0) {
-    buf = await callOpenAIEdit(buildEditPrompt(scene, cards.map((c) => c.name)), cards);
+    try {
+      buf = await callOpenAIEdit(buildEditPrompt(scene, cards.map((c) => c.name)), cards);
+    } catch (err) {
+      // Some card art (licensed IP / characters, e.g. Disney) trips OpenAI's
+      // moderation when passed as a reference image. Fall back to the card-less
+      // text-to-image scene so the item still gets a hero image.
+      if (/moderation_blocked|safety system/i.test(err.message)) {
+        log(`  edit moderation-blocked for ${item.id} — falling back to card-less scene`);
+        buf = await callOpenAIGenerate(buildThemePrompt(scene, item));
+      } else {
+        throw err;
+      }
+    }
   } else {
     buf = await callOpenAIGenerate(buildThemePrompt(scene, item));
   }


### PR DESCRIPTION
Two news YAML files shared `id: "bilt-card-transition"`, colliding on one `/news/bilt-card-transition` URL and one hero image, despite being two distinct stories:

- `data/news/2026-01-14-bilt-card-transition.yaml` — "Bilt Transitioning to New Card Program (Bilt 2.0)"
- `data/news/2026-02-07-bilt-card-transition.yaml` — "Bilt Credit Card Partnership with Wells Fargo Ends"

Renamed the Feb 7 story's `id` to `bilt-wells-fargo-partnership-ends`. The Jan 14 story keeps the original id (and thus keeps the existing `/news/bilt-card-transition` URL + `news_images/bilt-card-transition.png`).

## Verification
- `npm run build:news` → **81 items, 81 unique ids, 0 dupes** (was 80 unique).
- `sync-news-images.js --only bilt-wells-fargo-partnership-ends --dry-run` confirms it targets the new id and generates 1 image. The real run happens in CI (`build-news.yml`) on merge, which is idempotent with S3 as source of truth, so the new id's hero image is generated automatically.
- Grep confirms no code links to the Feb 7 story's old URL; news pages render dynamically from `news.json`.