### PR TITLE
feat(news): use AI hero image on the landing news lane

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { useMemo, useState, type KeyboardEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import CardImage from '@/components/ui/CardImage';
+
+const NEWS_IMG_CDN = 'https://d3ay3etzd1512y.cloudfront.net/news_images';
 import { categoryLabels, pickHeadlineReward } from '@/lib/cardDisplayUtils';
 import { cardMatchesSearch, expandSearchTerm } from '@/lib/searchAliases';
 import type { EditorialViewCounts } from '@/lib/api';
@@ -48,6 +51,7 @@ export type LandingNewsItem = {
   date: string;
   summary: string;
   cardImages: { src?: string; alt: string }[];
+  newsImage?: string;
 };
 export type LandingBestPage = {
   slug: string;
@@ -452,6 +456,8 @@ type EditorialItem = {
   title: string;
   summary: string;
   cardImages: { src?: string; alt: string }[];
+  /** Full-bleed hero image (news AI scene). Preferred over the fanned cardImages. */
+  image?: string;
   ts: number;
   views: number;
 };
@@ -487,6 +493,7 @@ function NewsLane({
       title: n.title,
       summary: n.summary,
       cardImages: n.cardImages,
+      image: n.newsImage ? `${NEWS_IMG_CDN}/${n.newsImage}` : undefined,
       ts: toTs(n.date),
       views: editorialViews.news[n.id] ?? 0,
     }));
@@ -519,7 +526,15 @@ function NewsLane({
       <div className="ed-grid">
         <Link href={lead.href} className="ed-lead">
           <div className="ed-cv">
-            {hasLeadArt ? (
+            {lead.image ? (
+              <Image
+                src={lead.image}
+                alt={lead.title}
+                fill
+                sizes="(max-width: 900px) 100vw, 520px"
+                style={{ objectFit: 'cover' }}
+              />
+            ) : hasLeadArt ? (
               <div className="stack">
                 {leadImages.slice(0, 3).map((img, j, arr) => {
                   const center = (arr.length - 1) / 2;

--- a/apps/web-next/src/app/page.tsx
+++ b/apps/web-next/src/app/page.tsx
@@ -102,7 +102,7 @@ function slimNews(news: NewsItem[], cardImageBySlug: Map<string, string | undefi
             alt: cardNameBySlug.get(slug) || names[i] || '',
           }))
         : links.slice(0, 3).map((src, i) => ({ src, alt: names[i] || '' }));
-      return { id: n.id, title: n.title, date: n.date, summary: n.summary, cardImages };
+      return { id: n.id, title: n.title, date: n.date, summary: n.summary, cardImages, newsImage: n.news_image };
     });
 }
 


### PR DESCRIPTION
## What

Follow-up to [#1548](https://github.com/CreditOdds/creditodds/pull/1548). The homepage **Lane 03 / Editorial** ("Reporting & news") lead cover still fanned the card thumbnails on a purple gradient. When the lead item is a news story that has a `news_image`, it now shows that AI scene as a full-bleed cover — matching the `/news` page.

Falls back to the existing fanned card thumbnails / plate for articles and any news item without a scene image.

## Changes

- `page.tsx` `slimNews`: pass `news_image` through as `newsImage` on `LandingNewsItem`.
- `LandingClient.tsx`: add `LandingNewsItem.newsImage` + `EditorialItem.image`; render a `fill` `<Image>` in `.ed-cv` when the lead has a scene image.

## Verified locally

Lead cover on `/` now resolves to `news_images/<id>.png` via the Next image optimizer, painted at 643×170 `object-fit: cover`. Typecheck clean. Only the featured/lead cover shows an image in this lane (the digest rows are text-only), so the change is scoped to the lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)