### PR TITLE
feat(landing): dynamic wallet 'best card here' rotation + calculator logos

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { useMemo, useState, type KeyboardEvent } from 'react';
+import { useEffect, useMemo, useState, type KeyboardEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import CardImage from '@/components/ui/CardImage';
 
@@ -69,19 +69,29 @@ interface LandingClientProps {
   editorialViews: EditorialViewCounts;
 }
 
-const TOOL_LINKS: { name: string; value: string; href: string }[] = [
-  { name: 'Chase UR', value: '1 ≈ 1.25¢', href: '/tools/chase-ultimate-rewards-to-usd' },
-  { name: 'Amex MR', value: '1 ≈ 1.2¢', href: '/tools/amex-membership-rewards-to-usd' },
-  { name: 'Cap One miles', value: '1 ≈ 1.0¢', href: '/tools/capital-one-miles-to-usd' },
-  { name: 'Bilt points', value: '1 ≈ 1.5¢', href: '/tools/bilt-rewards-points-to-usd' },
-  { name: 'Hyatt points', value: '1 ≈ 2.0¢', href: '/tools/world-of-hyatt-points-to-usd' },
-  { name: 'Delta SkyMiles', value: '1 ≈ 1.1¢', href: '/tools/delta-skymiles-to-usd' },
-  { name: 'United miles', value: '1 ≈ 1.2¢', href: '/tools/united-miles-to-usd' },
-  { name: 'Marriott', value: '1 ≈ 0.7¢', href: '/tools/marriott-bonvoy-points-to-usd' },
+const TOOL_LINKS: { name: string; value: string; href: string; logo: string }[] = [
+  { name: 'Chase UR', value: '1 ≈ 1.25¢', href: '/tools/chase-ultimate-rewards-to-usd', logo: '/logos/chase.jpg' },
+  { name: 'Amex MR', value: '1 ≈ 1.2¢', href: '/tools/amex-membership-rewards-to-usd', logo: '/logos/amex.jpg' },
+  { name: 'Cap One miles', value: '1 ≈ 1.0¢', href: '/tools/capital-one-miles-to-usd', logo: '/logos/capital-one.jpg' },
+  { name: 'Bilt points', value: '1 ≈ 1.5¢', href: '/tools/bilt-rewards-points-to-usd', logo: '/logos/bilt.jpg' },
+  { name: 'Hyatt points', value: '1 ≈ 2.0¢', href: '/tools/world-of-hyatt-points-to-usd', logo: '/logos/hyatt.jpg' },
+  { name: 'Delta SkyMiles', value: '1 ≈ 1.1¢', href: '/tools/delta-skymiles-to-usd', logo: '/logos/delta.jpg' },
+  { name: 'United miles', value: '1 ≈ 1.2¢', href: '/tools/united-miles-to-usd', logo: '/logos/united.jpg' },
+  { name: 'Marriott', value: '1 ≈ 0.7¢', href: '/tools/marriott-bonvoy-points-to-usd', logo: '/logos/marriott.jpg' },
 ];
 
-const WALLET_SLUGS = ['chase-sapphire-reserve', 'the-platinum-card', 'bilt-mastercard'];
+const WALLET_SLUGS = ['chase-sapphire-reserve', 'the-platinum-card', 'wells-fargo-active-cash'];
 const WALLET_RENEWALS = ['Renews Jan 27', 'Renews Mar 27', 'Renews in 11d'];
+
+// Rotating "best card here" scenarios that light up the wallet rows in turn.
+// Each scenario maps to one of the WALLET_SLUGS above and mirrors what the real
+// /wallet-picks/nearby ranker would return for that place (rates from card YAML).
+const WALLET_SCENARIOS: { slug: string; place: string; badge: string }[] = [
+  { slug: 'chase-sapphire-reserve', place: 'Blue Bottle Coffee', badge: 'Best · 3x' },
+  { slug: 'the-platinum-card', place: 'United counter · SFO', badge: 'Best · 5x' },
+  { slug: 'wells-fargo-active-cash', place: "Trader Joe's", badge: 'Best · 2%' },
+];
+const WALLET_ROTATE_MS = 5500;
 
 const POPULAR_FALLBACK = [
   'chase-sapphire-preferred',
@@ -605,6 +615,26 @@ function FooterBlocks({ cards }: { cards: LandingCard[] }) {
 
   const totalFee = walletCards.reduce((sum, c) => sum + (c.annual_fee ?? 0), 0);
 
+  // Only rotate through scenarios whose card is actually present in the wallet.
+  const scenarios = useMemo(
+    () => WALLET_SCENARIOS.filter((s) => walletCards.some((c) => c.slug === s.slug)),
+    [walletCards],
+  );
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  useEffect(() => {
+    if (scenarios.length < 2) return;
+    if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+    const id = setInterval(() => {
+      setActiveIdx((i) => (i + 1) % scenarios.length);
+    }, WALLET_ROTATE_MS);
+    return () => clearInterval(id);
+  }, [scenarios.length]);
+
+  const active = scenarios[activeIdx % scenarios.length] ?? null;
+
   return (
     <section className="footer-blocks">
       <div className="wrap">
@@ -623,21 +653,40 @@ function FooterBlocks({ cards }: { cards: LandingCard[] }) {
                 <span>{walletCards.length} cards</span>
                 <span>${totalFee.toLocaleString()}/yr in fees</span>
               </div>
-              {walletCards.map((c, i) => (
-                <div className="wm-row" key={c.slug}>
-                  <div className="wm-thumb">
-                    <CardImage cardImageLink={c.card_image_link} alt={c.card_name} fill sizes="50px" style={{ objectFit: 'cover' }} />
-                  </div>
-                  <div>
-                    <div className="nm">{shortName(c)}</div>
-                    <div className="iss">{c.bank}</div>
-                  </div>
-                  <div className="v">
-                    ${c.annual_fee ?? 0}
-                    <span className="sub">{WALLET_RENEWALS[i]}</span>
-                  </div>
+              {active && (
+                <div className="wm-context" aria-live="polite">
+                  <span className="wm-ctx-place" key={active.place}>
+                    <span className="wm-ctx-pin" aria-hidden>📍</span>
+                    Near you: {active.place}
+                  </span>
+                  <span className="wm-ctx-hint">best card ↓</span>
                 </div>
-              ))}
+              )}
+              {walletCards.map((c, i) => {
+                const isActive = active?.slug === c.slug;
+                return (
+                  <div
+                    className={`wm-row${active ? (isActive ? ' active' : ' dim') : ''}`}
+                    key={c.slug}
+                  >
+                    <div className="wm-thumb">
+                      <CardImage cardImageLink={c.card_image_link} alt={c.card_name} fill sizes="50px" style={{ objectFit: 'cover' }} />
+                    </div>
+                    <div>
+                      <div className="nm">{shortName(c)}</div>
+                      <div className="iss">{c.bank}</div>
+                    </div>
+                    <div className="v">
+                      ${c.annual_fee ?? 0}
+                      {isActive ? (
+                        <span className="sub wm-best">{active.badge}</span>
+                      ) : (
+                        <span className="sub">{WALLET_RENEWALS[i]}</span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
 
@@ -660,6 +709,7 @@ function FooterBlocks({ cards }: { cards: LandingCard[] }) {
               </Link>
               {TOOL_LINKS.map((t) => (
                 <Link key={t.href} href={t.href} className="tmini">
+                  <Image src={t.logo} alt={`${t.name} logo`} width={16} height={16} className="tmini-logo" />
                   <div className="nm">{t.name}</div>
                   <div className="v">{t.value}</div>
                 </Link>

--- a/apps/web-next/src/app/landing-v3.css
+++ b/apps/web-next/src/app/landing-v3.css
@@ -678,6 +678,7 @@
   gap: 8px;
 }
 .landing-v3 .tmini {
+  position: relative;
   border: 1px solid var(--line);
   border-radius: 8px;
   padding: 12px;
@@ -686,6 +687,18 @@
   color: inherit;
   display: block;
   transition: background 0.15s ease;
+}
+.landing-v3 .tmini-logo {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  object-fit: contain;
+}
+.landing-v3 .tmini .nm {
+  padding-left: 22px;
 }
 .landing-v3 .tmini:hover {
   background: var(--accent-2);
@@ -777,6 +790,75 @@
   display: block;
   font-weight: 400;
   margin-top: 1px;
+}
+
+/* Rotating "best card here" context line + row highlight */
+.landing-v3 .wm-context {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in oklab, var(--accent) 6%, var(--card));
+  font-size: 12px;
+  color: var(--ink-2);
+}
+.landing-v3 .wm-ctx-place {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+  animation: wmCtxIn 0.4s ease;
+}
+.landing-v3 .wm-ctx-pin {
+  font-size: 11px;
+}
+.landing-v3 .wm-ctx-hint {
+  color: var(--muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+.landing-v3 .wm-row {
+  transition: opacity 0.35s ease, background 0.35s ease;
+  position: relative;
+}
+.landing-v3 .wm-row.dim {
+  opacity: 0.5;
+}
+.landing-v3 .wm-row.active {
+  background: color-mix(in oklab, var(--accent) 7%, var(--card));
+}
+.landing-v3 .wm-row.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--accent);
+}
+.landing-v3 .wm-row .v .sub.wm-best {
+  color: var(--accent-deep);
+  font-weight: 600;
+}
+@keyframes wmCtxIn {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .landing-v3 .wm-row {
+    transition: none;
+  }
+  .landing-v3 .wm-ctx-place {
+    animation: none;
+  }
 }
 
 /* ---------- Final CTA (dark) ---------- */


### PR DESCRIPTION
## What

Makes the landing page "Track your cards." wallet block dynamic and adds program logos to the "Free calculators." tiles.

### Wallet block
- Swaps the Bilt Mastercard for the **Wells Fargo Active Cash** in the wallet preview.
- Adds a rotating "best card here" context line (📍 Near you: …) that cycles every 5.5s and lights up the matching wallet row (purple accent bar + tint), dimming the others and swapping its renewal text for a `Best · Nx` badge.
- Rates mirror what `/wallet-picks/nearby` would actually return: dining → Sapphire Reserve 3x, flights → Platinum 5x, everything else → Active Cash 2%.
- Respects `prefers-reduced-motion` (renders a static first state) and announces changes via `aria-live`.

### Calculators
- Adds a small (16px) program logo to the top-left of each converter tile (Chase, Amex, Capital One, Bilt, Hyatt, Delta, United, Marriott).

## Verify
- `tsc --noEmit` passes.
- Verified live in the dev preview across all three rotation states and the logo grid.