### PR TITLE
fix(card): gray out 'Highest bonus on record' box when not current

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1735,7 +1735,9 @@ export default function CardClient({
             <div className="cj-rail-block cj-wire-rail">
               <div className="cj-rail-label">Card wire</div>
               {highestSub && (
-                <div className="cj-wire-high">
+                <div
+                  className={`cj-wire-high${highestSub.isCurrent ? "" : " cj-wire-high-stale"}`}
+                >
                   <span className="cj-wire-high-label">
                     Highest bonus on record
                   </span>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7429,6 +7429,13 @@
   border-radius: 0;
   background: color-mix(in oklab, var(--accent) 6%, var(--paper));
 }
+.landing-v2 .cj-wire-high-stale {
+  border-color: var(--line-2);
+  background: color-mix(in oklab, var(--ink) 4%, var(--paper));
+}
+.landing-v2 .cj-wire-high-stale .cj-wire-high-val {
+  color: var(--ink);
+}
 .landing-v2 .cj-wire-high-label {
   flex: 1 1 100%;
   font-size: 11px;


### PR DESCRIPTION
## What

On the card page, the "Highest bonus on record" box in the Card wire rail always used the purple accent styling. Now it renders in gray (neutral `--line-2` border, `--ink` value text, subtle fill) when the current signup bonus is below the recorded high, reserving the purple accent for when the record is actually live.

## Changes
- `CardClient.tsx` — add `cj-wire-high-stale` class to the box when `!highestSub.isCurrent`.
- `landing.css` — new `.cj-wire-high-stale` rule graying border, background, and value color.

## Verification
Checked locally in the dev preview: on a card whose current bonus is below its record, the box renders gray; when the record is live (`isCurrent`), it keeps the purple styling and "Live now" badge.