### PR TITLE
feat(landing): taller featured story + accent selection on best-for-me

### DIFF
--- a/apps/web-next/src/app/landing-v3.css
+++ b/apps/web-next/src/app/landing-v3.css
@@ -393,7 +393,7 @@
   border-color: var(--ink);
 }
 .landing-v3 .ed-cv {
-  height: 170px;
+  height: 204px;
   background: linear-gradient(135deg, var(--accent-2), var(--paper-3));
   position: relative;
   overflow: hidden;
@@ -976,7 +976,7 @@
     gap: 16px;
   }
   .landing-v3 .ed-cv {
-    height: 170px;
+    height: 204px;
   }
   .landing-v3 .lnk {
     flex-basis: 70%;

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -10078,9 +10078,9 @@
   border-color: var(--ink);
 }
 .best-for-me-v2 .bcfm-option.is-selected {
-  border-color: var(--ink);
-  background: var(--paper-2);
-  box-shadow: inset 3px 0 0 0 var(--ink);
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 6%, var(--paper));
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 .best-for-me-v2 .bcfm-option-label {
   font-weight: 600;


### PR DESCRIPTION
## What

Two small landing/quiz polish tweaks.

### 1. Taller featured story (news lane)
The editorial lead card image (`.ed-cv`) grows from 170px → 204px (~20% taller), so the featured story anchors the lane instead of sitting flush with the headline digest beside it. Applied to the base rule and the stacked-layout override.

### 2. Cleaner selection on /best-card-for-me
The selected quiz option used a heavy black inset left bar (`inset 3px 0 0 0 var(--ink)`), which read as out-of-place. Swapped it for the site's accent "active" language — a full accent outline with a faint accent tint — matching the live-bonus box and focus states elsewhere.

## Verification
Both checked locally in the dev preview: featured card image renders ~20% taller; the selected option shows a purple accent outline + light fill with no left bar.