### PR TITLE
feat(x-agent): Slack notifications for the reply agent

### DIFF
--- a/.github/workflows/x-agent-digest.yml
+++ b/.github/workflows/x-agent-digest.yml
@@ -39,4 +39,5 @@ jobs:
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
           X_AGENT_STATE_S3: s3://${{ secrets.S3_BUCKET_NAME }}/x-agent/state.json
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: node scripts/x-agent/digest.js

--- a/.github/workflows/x-agent.yml
+++ b/.github/workflows/x-agent.yml
@@ -56,6 +56,7 @@ jobs:
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
           X_AGENT_STATE_S3: s3://${{ secrets.S3_BUCKET_NAME }}/x-agent/state.json
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           # Scheduled runs use the repo variable (default shadow); a manual
           # dispatch overrides via its input.
           X_AGENT_MODE: ${{ github.event.inputs.mode || vars.X_AGENT_MODE || 'shadow' }}

--- a/scripts/x-agent/digest.js
+++ b/scripts/x-agent/digest.js
@@ -9,6 +9,7 @@
 
 const state = require('./state');
 const twitter = require('./twitter');
+const slack = require('./slack');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -53,6 +54,21 @@ async function main() {
 
   if (!recent.length) console.log('\n(nothing in the last 24h)');
   console.log('\n===== END DIGEST =====\n');
+
+  // Mirror a compact summary to Slack.
+  const slackLines = [
+    `*:bar_chart: X reply agent — daily digest*`,
+    `last 24h: *${live.length}* live · *${shadow.length}* shadow · daily live count ${st.day?.count || 0}`,
+  ];
+  for (const p of live) {
+    const m = metrics[p.replyId] || {};
+    slackLines.push(`• :rotating_light: <https://x.com/creditodds/status/${p.replyId}|@${p.author}> ♥${m.like_count ?? '?'} ↻${m.retweet_count ?? '?'} 👁${m.impression_count ?? '?'} — ${p.text}`);
+  }
+  for (const p of shadow) {
+    slackLines.push(`• :eyes: re @${p.author} [q${p.score}] — ${p.text}`);
+  }
+  if (!recent.length) slackLines.push('_(nothing in the last 24h)_');
+  await slack.send({ text: slackLines.join('\n') });
 }
 
 main().catch((err) => { console.error('Fatal:', err); process.exit(1); });

--- a/scripts/x-agent/run.js
+++ b/scripts/x-agent/run.js
@@ -19,6 +19,7 @@ const rails = require('./rails');
 const { generateCandidates } = require('./generate');
 const { judgeCandidate } = require('./judge');
 const twitter = require('./twitter');
+const slack = require('./slack');
 
 const MAX_TWEETS_PER_RUN = 8; // bound LLM cost per invocation
 
@@ -129,8 +130,13 @@ async function main() {
         text: selected.text, register: selected.register, score: selected.score,
         mode: 'live', ts,
       });
+      await slack.notifyReply({
+        mode: 'live', author: selected.tweet.author, register: selected.register,
+        score: selected.score, text: selected.text, tweetId: selected.tweet.id, replyId,
+      });
     } catch (err) {
       log(`  POST FAILED: ${err.message}`);
+      await slack.send({ text: `:warning: x-agent post FAILED replying to @${selected.tweet.author}: ${err.message}` });
     }
   } else {
     log('  SHADOW mode — not posting.');
@@ -138,6 +144,10 @@ async function main() {
       tweetId: selected.tweet.id, replyId: null, author: selected.tweet.author,
       text: selected.text, register: selected.register, score: selected.score,
       mode: 'shadow', ts,
+    });
+    await slack.notifyReply({
+      mode: 'shadow', author: selected.tweet.author, register: selected.register,
+      score: selected.score, text: selected.text, tweetId: selected.tweet.id,
     });
   }
 

--- a/scripts/x-agent/slack.js
+++ b/scripts/x-agent/slack.js
@@ -1,0 +1,46 @@
+/**
+ * Slack notifications for the reply agent. Posts to SLACK_WEBHOOK_URL if set,
+ * otherwise a no-op. Failures never throw — a Slack hiccup must not break the
+ * agent or fail the workflow.
+ */
+
+async function send({ text, blocks } = {}) {
+  const url = process.env.SLACK_WEBHOOK_URL;
+  if (!url) return false;
+  try {
+    const body = blocks ? { blocks, text: text || ' ' } : { text };
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.warn(`slack: webhook returned ${res.status}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn(`slack: send failed (${err.message})`);
+    return false;
+  }
+}
+
+/**
+ * Notify about a single selected reply (live or shadow). This is the trial's
+ * real-time safety feed: every reply the agent commits to shows up immediately.
+ */
+async function notifyReply({ mode, author, register, score, text, tweetId, replyId }) {
+  const tag = mode === 'live' ? ':rotating_light: LIVE POSTED' : ':eyes: SHADOW (would post)';
+  const original = `https://x.com/${author}/status/${tweetId}`;
+  const lines = [
+    `*${tag}*  _${register}_ · q${score}`,
+    `> ${text}`,
+    `↳ replying to <${original}|@${author}>`,
+  ];
+  if (mode === 'live' && replyId) {
+    lines.push(`✅ <https://x.com/creditodds/status/${replyId}|view the posted reply>`);
+  }
+  return send({ text: lines.join('\n') });
+}
+
+module.exports = { send, notifyReply };


### PR DESCRIPTION
Adds Slack visibility to the X reply agent (built on top of #1557).

- **`slack.js`** — posts to `SLACK_WEBHOOK_URL` if set; no-op and never throws if unset, so a Slack hiccup can't break the agent or fail a run.
- **Real-time post ping** (`run.js`) — the moment the agent commits to a reply, it pings Slack with a `LIVE`/`SHADOW` label, the reply text, quality score, a link to the original tweet, and (when live) a link to the posted reply. The trial's live safety feed.
- **Daily digest → Slack** (`digest.js`) — mirrors the 24h summary to Slack in addition to the Actions log.
- Both workflows now pass `SLACK_WEBHOOK_URL` (secret already exists).

Smoke-tested: modules load, digest runs, Slack cleanly no-ops when the webhook is absent.