### PR TITLE
feat(x-agent): remove active-hours gate (run every hour)

### DIFF
--- a/scripts/x-agent/config.js
+++ b/scripts/x-agent/config.js
@@ -52,9 +52,6 @@ const RAILS = {
   // Only consider tweets newer than this (a reply to a stale tweet is pointless
   // and reads as a bot trawling history).
   maxTweetAgeMinutes: 90,
-  // Only operate during these ET hours (inclusive start, exclusive end).
-  // Keeps us out of the overnight window and conserves the read budget.
-  activeHoursET: { start: 8, end: 23 },
   // Both judge passes must clear a candidate before it can post.
   requireBothJudgePasses: true,
   // Reject a candidate if it is too similar to any of the last N posted replies

--- a/scripts/x-agent/rails.js
+++ b/scripts/x-agent/rails.js
@@ -6,22 +6,6 @@
 const { RAILS } = require('./config');
 const { todayET } = require('./state');
 
-/** Current hour (0-23) in America/New_York. */
-function currentHourET() {
-  const h = new Date().toLocaleString('en-US', {
-    timeZone: 'America/New_York',
-    hour: '2-digit',
-    hour12: false,
-  });
-  return parseInt(h, 10) % 24;
-}
-
-function isActiveHours() {
-  const h = currentHourET();
-  const { start, end } = RAILS.activeHoursET;
-  return h >= start && h < end;
-}
-
 function tweetAgeMinutes(createdAt) {
   if (!createdAt) return Infinity;
   return (Date.now() - new Date(createdAt).getTime()) / 60000;
@@ -73,8 +57,6 @@ function canPostNow(state, targetHandle) {
 }
 
 module.exports = {
-  isActiveHours,
-  currentHourET,
   tweetAgeMinutes,
   tweetFreshEnough,
   isRepetitive,

--- a/scripts/x-agent/run.js
+++ b/scripts/x-agent/run.js
@@ -36,11 +36,6 @@ async function main() {
   const st = state.load();
   state.rolloverDay(st);
 
-  if (!rails.isActiveHours()) {
-    log(`Outside active hours (ET hour ${rails.currentHourET()}). Skipping to conserve reads.`);
-    return;
-  }
-
   const handles = TARGETS.filter((t) => REPLYABLE_TIERS.includes(t.tier)).map((t) => t.handle);
   const tierByHandle = new Map(TARGETS.map((t) => [t.handle.toLowerCase(), t.tier]));
 


### PR DESCRIPTION
Drops the ET active-hours skip so the agent runs on every hourly cron regardless of time of day. Removes the now-dead `activeHoursET` config and the `isActiveHours`/`currentHourET` helpers.

Validated live: dispatched on this branch in shadow mode at ~11pm ET (previously gated). Real X search returned 30 tweets, filtered to 2 fresh/eligible, generated + double-judged, selected 1 shadow reply to @Drofcredit, posted nothing, saved state to S3, and pinged Slack. Full pipeline confirmed working end to end against live data.