### PR TITLE
feat(x-agent): manual-dispatch bypass for the active-hours gate

### DIFF
--- a/.github/workflows/x-agent.yml
+++ b/.github/workflows/x-agent.yml
@@ -20,6 +20,11 @@ on:
         default: 'shadow'
         type: choice
         options: [shadow, live]
+      force:
+        description: 'Bypass the active-hours gate (manual runs only)'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   id-token: write
@@ -61,4 +66,7 @@ jobs:
           # dispatch overrides via its input.
           X_AGENT_MODE: ${{ github.event.inputs.mode || vars.X_AGENT_MODE || 'shadow' }}
           X_AGENT_KILL: ${{ vars.X_AGENT_KILL || '' }}
+          # Manual dispatch bypasses the active-hours gate by default; scheduled
+          # runs leave this empty and keep respecting active hours.
+          X_AGENT_FORCE: ${{ github.event.inputs.force }}
         run: node scripts/x-agent/run.js

--- a/scripts/x-agent/config.js
+++ b/scripts/x-agent/config.js
@@ -81,6 +81,13 @@ const KILL_SWITCH = ['1', 'true', 'yes'].includes(
   String(process.env.X_AGENT_KILL || '').toLowerCase()
 );
 
+// Force flag: bypass the active-hours gate for this run. Set by manual dispatch
+// so an operator can trigger an off-hours run on demand. Scheduled runs leave it
+// unset and keep respecting active hours.
+const FORCE = ['1', 'true', 'yes'].includes(
+  String(process.env.X_AGENT_FORCE || '').toLowerCase()
+);
+
 module.exports = {
   MODE,
   TARGETS,
@@ -89,4 +96,5 @@ module.exports = {
   MODELS,
   CANDIDATES_PER_TWEET,
   KILL_SWITCH,
+  FORCE,
 };

--- a/scripts/x-agent/run.js
+++ b/scripts/x-agent/run.js
@@ -13,7 +13,7 @@
  * Usage: node scripts/x-agent/run.js
  */
 
-const { MODE, TARGETS, REPLYABLE_TIERS, KILL_SWITCH, CANDIDATES_PER_TWEET } = require('./config');
+const { MODE, TARGETS, REPLYABLE_TIERS, KILL_SWITCH, FORCE, CANDIDATES_PER_TWEET } = require('./config');
 const state = require('./state');
 const rails = require('./rails');
 const { generateCandidates } = require('./generate');
@@ -37,8 +37,11 @@ async function main() {
   state.rolloverDay(st);
 
   if (!rails.isActiveHours()) {
-    log(`Outside active hours (ET hour ${rails.currentHourET()}). Skipping to conserve reads.`);
-    return;
+    if (!FORCE) {
+      log(`Outside active hours (ET hour ${rails.currentHourET()}). Skipping to conserve reads.`);
+      return;
+    }
+    log(`Outside active hours (ET hour ${rails.currentHourET()}), but X_AGENT_FORCE is set — proceeding.`);
   }
 
   const handles = TARGETS.filter((t) => REPLYABLE_TIERS.includes(t.tier)).map((t) => t.handle);


### PR DESCRIPTION
Keeps the active-hours gate for scheduled hourly runs, but adds an `X_AGENT_FORCE` flag so a manual `workflow_dispatch` can run on demand outside active hours.

- `config.js`: new `FORCE` flag from `X_AGENT_FORCE`.
- `run.js`: gate now `if outside hours && !FORCE -> skip`; with FORCE it logs and proceeds.
- `x-agent.yml`: new `force` boolean dispatch input (default true); scheduled runs leave `X_AGENT_FORCE` empty and keep respecting the gate.

Verified locally: no-force skips off-hours; `X_AGENT_FORCE=1` bypasses and proceeds to the search.