### PR TITLE
feat(x-agent): expand target list to 20 + relevance filter

### DIFF
--- a/scripts/x-agent/config.js
+++ b/scripts/x-agent/config.js
@@ -28,6 +28,23 @@ const TARGETS = [
   { handle: 'drofcredit', tier: 'competitor' },
   { handle: 'godsavethepoint', tier: 'competitor' },
 
+  // Points/miles/credit creators + credit experts (web-verified X-active).
+  { handle: 'dannydealguru', tier: 'competitor' },
+  { handle: 'garyleff', tier: 'competitor' },
+  { handle: 'FrequentMiler', tier: 'competitor' },
+  { handle: 'AskSebby', tier: 'competitor' },
+  { handle: 'TheCreditShifu', tier: 'competitor' },
+  { handle: 'PointsWithACrew', tier: 'competitor' },
+  { handle: 'johnulzheimer', tier: 'competitor' },
+  { handle: '10xTravel', tier: 'competitor' },
+  { handle: 'EyeOfTheFlyer', tier: 'competitor' },
+  { handle: 'FrugalTravelGuy', tier: 'competitor' },
+
+  // Broad personal-finance voices — the relevance filter gates their off-topic
+  // (crypto/investing/real-estate) tweets so we only engage credit-card content.
+  { handle: 'Humphreytalks', tier: 'competitor' },
+  { handle: 'GrahamStephan', tier: 'competitor' },
+
   // Issuers — WATCH ONLY in the trial. Never auto-replied to.
   { handle: 'AmericanExpress', tier: 'issuer' },
   { handle: 'Chase', tier: 'issuer' },

--- a/scripts/x-agent/relevance.js
+++ b/scripts/x-agent/relevance.js
@@ -1,0 +1,42 @@
+/**
+ * Coarse relevance pre-filter. With broad personal-finance influencers on the
+ * target list, most of their tweets are off-topic (crypto, stocks, real estate,
+ * life advice). This cheap keyword gate skips tweets that aren't about credit /
+ * cards / points / finance BEFORE we spend LLM calls generating replies.
+ *
+ * It's deliberately a coarse first pass — the double-judge is the real quality
+ * control. A false positive just costs one wasted generation; a false negative
+ * (skipping a relevant tweet) costs nothing, since skipping is free.
+ */
+
+// Distinctive multi-word phrases (matched as substrings, low false-positive risk).
+const PHRASES = [
+  'credit card', 'credit score', 'credit limit', 'credit utilization',
+  'annual fee', 'sign up bonus', 'sign-up bonus', 'signup bonus',
+  'welcome bonus', 'welcome offer', 'cash back', 'cashback', 'interest rate',
+  'balance transfer', 'american express', 'capital one', 'bank of america',
+  'wells fargo', 'membership rewards', 'ultimate rewards', 'thankyou points',
+  'transfer partner', 'travel credit', 'statement credit', 'foreign transaction',
+  'intro apr', 'no annual fee', 'hard inquiry', 'hard pull', 'authorized user',
+  'minimum payment', 'retention offer', 'points and miles',
+];
+
+// Single tokens matched with word boundaries (avoids matching inside other words,
+// e.g. \bapr\b does not match "April", \bcard\b does not match "discard").
+const WORDS = [
+  'credit', 'cards?', 'amex', 'chase', 'citi', 'citibank', 'discover', 'visa',
+  'mastercard', 'bilt', 'barclays', 'synchrony', 'points', 'miles', 'rewards',
+  'apr', 'apy', 'fico', 'churning', 'churn', 'redeem', 'redemption', 'avios',
+  'skymiles', 'lounge', 'cardholder', 'underwriting', 'creditworthy',
+];
+
+const WORD_RE = new RegExp(`\\b(?:${WORDS.join('|')})\\b`, 'i');
+
+function isRelevant(text) {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  if (PHRASES.some((p) => lower.includes(p))) return true;
+  return WORD_RE.test(lower);
+}
+
+module.exports = { isRelevant };

--- a/scripts/x-agent/run.js
+++ b/scripts/x-agent/run.js
@@ -20,6 +20,7 @@ const { generateCandidates } = require('./generate');
 const { judgeCandidate } = require('./judge');
 const twitter = require('./twitter');
 const slack = require('./slack');
+const relevance = require('./relevance');
 
 const MAX_TWEETS_PER_RUN = 8; // bound LLM cost per invocation
 
@@ -68,12 +69,16 @@ async function main() {
   // Mark everything we pulled as seen so we don't reprocess next run.
   state.markSeen(st, search.tweets.map((t) => t.id));
 
-  log(`Fetched ${search.tweets.length} tweet(s), ${fresh.length} fresh & eligible.`);
-  if (!fresh.length) { state.save(st); log('Nothing to do.'); return; }
+  // Relevance gate: skip tweets that aren't about credit / cards / points. Keeps
+  // the agent from forcing card replies onto broad influencers' off-topic tweets.
+  const relevant = fresh.filter((t) => relevance.isRelevant(t.text));
+
+  log(`Fetched ${search.tweets.length} tweet(s), ${fresh.length} fresh, ${relevant.length} card-relevant.`);
+  if (!relevant.length) { state.save(st); log('Nothing relevant to do.'); return; }
 
   // 3+4. Generate + judge, collect postable candidates
   const postable = [];
-  for (const t of fresh.slice(0, MAX_TWEETS_PER_RUN)) {
+  for (const t of relevant.slice(0, MAX_TWEETS_PER_RUN)) {
     const tweet = { author: t.author, tier: tierByHandle.get(t.author.toLowerCase()), text: t.text, id: t.id };
     let candidates = [];
     try {


### PR DESCRIPTION
Expands the reply agent's monitored accounts from 8 to **20**, and adds a relevance pre-filter so the broader list doesn't produce off-topic replies.

## New accounts (12, web-verified X-active)
**Points/miles/credit creators + experts:** `dannydealguru`, `garyleff` (View from the Wing), `FrequentMiler`, `AskSebby`, `TheCreditShifu`, `PointsWithACrew`, `johnulzheimer` (credit-score expert), `10xTravel`, `EyeOfTheFlyer`, `FrugalTravelGuy`.
**Broad personal-finance voices:** `Humphreytalks` (Humphrey Yang), `GrahamStephan`.

## Deliberately excluded (brand-safety)
`sircalebhammer` (roasts cardholder debt), `ramit` (anti points-chasing), `ErikaKullberg` (fine-print/gotcha angle), `andreijikh` (has feuded with banks), and the Ramsey network (openly anti-credit-card). These would generate hostile engagement from a card brand, not growth. Can revisit behind human review later.

## Relevance filter (`relevance.js`)
Broad PF influencers mostly tweet about crypto/investing/real-estate/life advice. A cheap keyword gate (credit/card/points/APR/rewards/etc.) runs BEFORE generation, so the agent only engages credit-relevant tweets. Coarse by design — the double-judge remains the real quality control; a false positive costs one wasted generation, a false negative costs nothing. Unit-tested 10/10 on sample on/off-topic tweets.

## Budget/safety
- Search query = 456 chars, under X's 512 single-query limit (one `search/recent` call, no splitting → no extra read cost).
- Issuers unchanged: still watch-only, never auto-replied to.
- All rails unchanged (<=12/day, <=1/account/day, etc.).