### PR TITLE
fix(x-agent): surface X API error detail on post failure

### DIFF
--- a/scripts/x-agent/twitter.js
+++ b/scripts/x-agent/twitter.js
@@ -68,8 +68,19 @@ async function searchRecent(handles, { sinceId, maxResults = 30 } = {}) {
  */
 async function postReply(text, inReplyToTweetId) {
   const client = getClient();
-  const { data } = await client.v2.reply(text, inReplyToTweetId);
-  return data.id;
+  try {
+    const { data } = await client.v2.reply(text, inReplyToTweetId);
+    return data.id;
+  } catch (err) {
+    // Surface the X API's actual error body (title/detail/errors) — a bare
+    // "code 403" hides whether it's a permissions, duplicate, or scope problem.
+    const detail = err && (err.data || err.errors)
+      ? JSON.stringify(err.data || err.errors)
+      : '';
+    const e = new Error(`${err.message}${detail ? ` | ${detail}` : ''}`);
+    e.code = err.code;
+    throw e;
+  }
 }
 
 /**


### PR DESCRIPTION
The live run's post failed with a bare `Request failed with code 403`, which hides the actual cause (permissions vs duplicate vs scope). This captures the X API error body (`title`/`detail`/`errors`) into the thrown message so the run log shows exactly why.

Context: the full pipeline (search 20 accounts, relevance filter, generate, double-judge, select) worked end to end — only the final POST 403'd. Most likely the Access Token/Secret in GH secrets are read-only (generated before the app was set to Read+Write). This patch confirms the diagnosis on the next run.