### PR TITLE
feat(x-agent): reset flag to force a fresh scan

### DIFF
--- a/.github/workflows/x-agent.yml
+++ b/.github/workflows/x-agent.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: true
         type: boolean
+      reset:
+        description: 'Ignore saved state and do a fresh scan (re-processes recent tweets)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write
@@ -69,4 +74,5 @@ jobs:
           # Manual dispatch bypasses the active-hours gate by default; scheduled
           # runs leave this empty and keep respecting active hours.
           X_AGENT_FORCE: ${{ github.event.inputs.force }}
+          X_AGENT_RESET: ${{ github.event.inputs.reset }}
         run: node scripts/x-agent/run.js

--- a/scripts/x-agent/config.js
+++ b/scripts/x-agent/config.js
@@ -105,6 +105,13 @@ const FORCE = ['1', 'true', 'yes'].includes(
   String(process.env.X_AGENT_FORCE || '').toLowerCase()
 );
 
+// Reset flag: ignore saved S3 state and do a fresh scan (no since_id watermark,
+// no seen-id memory). Set by manual dispatch. Useful to re-scan recent tweets on
+// demand, e.g. to re-hit the post path for debugging.
+const RESET = ['1', 'true', 'yes'].includes(
+  String(process.env.X_AGENT_RESET || '').toLowerCase()
+);
+
 module.exports = {
   MODE,
   TARGETS,
@@ -114,4 +121,5 @@ module.exports = {
   CANDIDATES_PER_TWEET,
   KILL_SWITCH,
   FORCE,
+  RESET,
 };

--- a/scripts/x-agent/run.js
+++ b/scripts/x-agent/run.js
@@ -13,7 +13,7 @@
  * Usage: node scripts/x-agent/run.js
  */
 
-const { MODE, TARGETS, REPLYABLE_TIERS, KILL_SWITCH, FORCE, CANDIDATES_PER_TWEET } = require('./config');
+const { MODE, TARGETS, REPLYABLE_TIERS, KILL_SWITCH, FORCE, RESET, CANDIDATES_PER_TWEET } = require('./config');
 const state = require('./state');
 const rails = require('./rails');
 const { generateCandidates } = require('./generate');
@@ -34,7 +34,8 @@ async function main() {
     return;
   }
 
-  const st = state.load();
+  const st = RESET ? JSON.parse(JSON.stringify(state.EMPTY)) : state.load();
+  if (RESET) log('X_AGENT_RESET set — ignoring saved state, doing a fresh scan.');
   state.rolloverDay(st);
 
   if (!rails.isActiveHours()) {


### PR DESCRIPTION
Adds an `X_AGENT_RESET` flag (new `reset` dispatch input, default false) that ignores the saved S3 state and re-scans recent tweets. Lets a manual run re-hit the post path on demand instead of waiting for a brand-new competitor tweet — needed right now to capture the exact 403 error on posting. Also a useful operational lever (clear the agent's memory).