### PR TITLE
fix(x-agent): only reply to open conversations (reply_settings)

### DIFF
--- a/scripts/x-agent/run.js
+++ b/scripts/x-agent/run.js
@@ -70,12 +70,16 @@ async function main() {
   // Mark everything we pulled as seen so we don't reprocess next run.
   state.markSeen(st, search.tweets.map((t) => t.id));
 
+  // Reply-settings gate: X rejects (403) replies to conversations the author has
+  // locked to followers/mentions. Only 'everyone' tweets are actually repliable.
+  const openReplies = fresh.filter((t) => t.replySettings === 'everyone');
+
   // Relevance gate: skip tweets that aren't about credit / cards / points. Keeps
   // the agent from forcing card replies onto broad influencers' off-topic tweets.
-  const relevant = fresh.filter((t) => relevance.isRelevant(t.text));
+  const relevant = openReplies.filter((t) => relevance.isRelevant(t.text));
 
-  log(`Fetched ${search.tweets.length} tweet(s), ${fresh.length} fresh, ${relevant.length} card-relevant.`);
-  if (!relevant.length) { state.save(st); log('Nothing relevant to do.'); return; }
+  log(`Fetched ${search.tweets.length} tweet(s), ${fresh.length} fresh, ${openReplies.length} open-reply, ${relevant.length} card-relevant.`);
+  if (!relevant.length) { state.save(st); log('Nothing relevant & repliable to do.'); return; }
 
   // 3+4. Generate + judge, collect postable candidates
   const postable = [];

--- a/scripts/x-agent/twitter.js
+++ b/scripts/x-agent/twitter.js
@@ -41,7 +41,9 @@ async function searchRecent(handles, { sinceId, maxResults = 30 } = {}) {
   const params = {
     query: buildQuery(handles),
     max_results: Math.min(Math.max(maxResults, 10), 100),
-    'tweet.fields': 'created_at,author_id,public_metrics',
+    // reply_settings tells us whether the conversation is open to replies. If it
+    // isn't 'everyone', a reply from us is rejected with a 403, so we filter on it.
+    'tweet.fields': 'created_at,author_id,public_metrics,reply_settings',
     expansions: 'author_id',
     'user.fields': 'username',
   };
@@ -56,6 +58,7 @@ async function searchRecent(handles, { sinceId, maxResults = 30 } = {}) {
     author: users.get(t.author_id) || t.author_id,
     text: t.text,
     createdAt: t.created_at,
+    replySettings: t.reply_settings || null,
     metrics: t.public_metrics || null,
   }));
 


### PR DESCRIPTION
## Root cause of the 403
The live post failures were NOT a credentials/permission problem (the write token works). X returns 403 with detail: *"Reply to this conversation is not allowed because you have not been mentioned or otherwise engaged by the author..."* when the author has locked their tweet's replies to followers/mentions.

## Fix
Request `reply_settings` on the search and filter to `everyone` before generating, so the agent only ever selects tweets it can actually reply to. Adds an `open-reply` count to the run log for visibility.

Confirmed the pipeline otherwise works end to end (search 20 accounts, relevance filter, generate, double-judge, select). This removes the last blocker to live posting.