### PR TITLE
diag(x-agent): whoami workflow

### DIFF
--- a/.github/workflows/x-agent-whoami.yml
+++ b/.github/workflows/x-agent-whoami.yml
@@ -1,0 +1,27 @@
+name: X Reply Agent Whoami
+
+# One-off diagnostic: prints which X account the TWITTER_* creds authenticate as.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  whoami:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - name: Whoami
+        env:
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+        run: node scripts/x-agent/whoami.js

--- a/scripts/x-agent/whoami.js
+++ b/scripts/x-agent/whoami.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Diagnostic: which X account do the TWITTER_* credentials actually authenticate
+ * as? If this prints anything other than @creditodds, the reply bot is posting as
+ * the wrong account (which explains the "conversation not allowed" 403 when the
+ * real @creditodds can reply manually).
+ */
+
+const { TwitterApi } = require('twitter-api-v2');
+
+async function main() {
+  const client = new TwitterApi({
+    appKey: process.env.TWITTER_API_KEY,
+    appSecret: process.env.TWITTER_API_SECRET,
+    accessToken: process.env.TWITTER_ACCESS_TOKEN,
+    accessSecret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
+  });
+
+  const me = await client.v2.me({ 'user.fields': 'username,name,verified,verified_type,created_at' });
+  console.log('=== Authenticated identity for the TWITTER_* creds ===');
+  console.log(JSON.stringify(me.data, null, 2));
+  console.log(`\n>> Posting as: @${me.data.username} (${me.data.name})`);
+  console.log(`>> verified: ${me.data.verified} / type: ${me.data.verified_type || 'none'}`);
+  if (me.data.username && me.data.username.toLowerCase() !== 'creditodds') {
+    console.log(`\n!!! MISMATCH: creds are NOT @creditodds. This is the bug.`);
+  } else {
+    console.log(`\nOK: creds are @creditodds.`);
+  }
+}
+
+main().catch((err) => {
+  console.error('whoami failed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
One-off diagnostic to print which X account the TWITTER_* creds authenticate as. Needed to confirm whether the reply-bot is posting as @creditodds or a different account (which would explain the 403 when @creditodds can reply manually). Read-only; posts nothing.