### PR TITLE
diag(x-agent): targeted test-post to a known-open tweet

### DIFF
--- a/.github/workflows/x-agent-testpost.yml
+++ b/.github/workflows/x-agent-testpost.yml
@@ -1,0 +1,35 @@
+name: X Reply Agent Test Post
+
+# Diagnostic: generate an on-brand reply and post it to a specific (known-open)
+# tweet, to prove the automation can actually post.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tweet:
+        description: 'Tweet URL or id to reply to (must have open replies)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  testpost:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - name: Test post
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          TWEET: ${{ github.event.inputs.tweet }}
+        run: node scripts/x-agent/testpost.js

--- a/scripts/x-agent/testpost.js
+++ b/scripts/x-agent/testpost.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Targeted test post. Given a tweet URL or id (TWEET env), generates an on-brand
+ * reply with the real generator + judge and posts it. Proves the automation can
+ * actually post to a conversation we know is open — isolating the reply-lock
+ * issue from any real posting problem.
+ *
+ * Usage (in the workflow): TWEET=<url|id> node scripts/x-agent/testpost.js
+ */
+
+const twitter = require('./twitter');
+const { generateCandidates } = require('./generate');
+const { judgeCandidate } = require('./judge');
+
+function parseId(input) {
+  if (!input) return null;
+  const m = String(input).match(/status\/(\d+)/) || String(input).match(/(\d{6,})/);
+  return m ? m[1] : null;
+}
+
+async function main() {
+  const id = parseId(process.env.TWEET);
+  if (!id) {
+    console.error('Set TWEET to a tweet URL or id.');
+    process.exit(1);
+  }
+
+  const t = await twitter.getTweet(id);
+  console.log(`Target: @${t.author} (reply_settings=${t.replySettings})`);
+  console.log(`  "${t.text}"\n`);
+
+  const tweet = { author: t.author, tier: 'competitor', text: t.text, id: t.id };
+  const candidates = await generateCandidates(tweet, { dataPoint: null });
+
+  for (const c of candidates) {
+    const verdict = await judgeCandidate(tweet, c.text);
+    if (!verdict.pass) {
+      console.log(`  killed (${verdict.stage}): ${c.text}`);
+      continue;
+    }
+    console.log(`Posting <${c.register} q:${verdict.score}>: ${c.text}`);
+    const replyId = await twitter.postReply(c.text, t.id);
+    console.log(`\nPOSTED ✅ https://x.com/creditodds/status/${replyId}`);
+    return;
+  }
+  console.log('No candidate passed the judge.');
+}
+
+main().catch((err) => {
+  console.error('testpost failed:', err.message);
+  process.exit(1);
+});

--- a/scripts/x-agent/twitter.js
+++ b/scripts/x-agent/twitter.js
@@ -67,6 +67,26 @@ async function searchRecent(handles, { sinceId, maxResults = 30 } = {}) {
 }
 
 /**
+ * Fetch a single tweet by id (author + text + reply_settings). Used by the
+ * targeted test-post diagnostic.
+ */
+async function getTweet(id) {
+  const client = getClient();
+  const res = await client.v2.get(`tweets/${id}`, {
+    'tweet.fields': 'author_id,reply_settings,created_at',
+    expansions: 'author_id',
+    'user.fields': 'username',
+  });
+  const u = (res.includes?.users || [])[0];
+  return {
+    id: res.data.id,
+    text: res.data.text,
+    author: u?.username || res.data.author_id,
+    replySettings: res.data.reply_settings || null,
+  };
+}
+
+/**
  * Post a reply to a given tweet. Returns the new tweet id.
  */
 async function postReply(text, inReplyToTweetId) {
@@ -105,4 +125,4 @@ async function getMetrics(ids) {
   return out;
 }
 
-module.exports = { searchRecent, postReply, getMetrics, buildQuery };
+module.exports = { searchRecent, getTweet, postReply, getMetrics, buildQuery };


### PR DESCRIPTION
Generates a real on-brand reply (generator + double-judge) and posts it to a specific tweet URL/id passed as a dispatch input. Lets us point it at a tweet we KNOW has open replies to prove the automation actually posts, isolating the per-tweet reply-lock issue from any real posting problem.