### PR TITLE
diag(x-agent): quote-tweet mode for test post

### DIFF
--- a/.github/workflows/x-agent-testpost.yml
+++ b/.github/workflows/x-agent-testpost.yml
@@ -10,6 +10,11 @@ on:
         description: 'Tweet URL or id to reply to (must have open replies)'
         required: true
         type: string
+      quote:
+        description: 'Post as a quote tweet instead of a reply'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -32,4 +37,5 @@ jobs:
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
           TWEET: ${{ github.event.inputs.tweet }}
+          QUOTE: ${{ github.event.inputs.quote }}
         run: node scripts/x-agent/testpost.js

--- a/scripts/x-agent/testpost.js
+++ b/scripts/x-agent/testpost.js
@@ -32,6 +32,9 @@ async function main() {
   const tweet = { author: t.author, tier: 'competitor', text: t.text, id: t.id };
   const candidates = await generateCandidates(tweet, { dataPoint: null });
 
+  const asQuote = ['1', 'true', 'yes'].includes(String(process.env.QUOTE || '').toLowerCase());
+  console.log(asQuote ? '(mode: QUOTE TWEET)\n' : '(mode: REPLY)\n');
+
   for (const c of candidates) {
     const verdict = await judgeCandidate(tweet, c.text);
     if (!verdict.pass) {
@@ -39,8 +42,10 @@ async function main() {
       continue;
     }
     console.log(`Posting <${c.register} q:${verdict.score}>: ${c.text}`);
-    const replyId = await twitter.postReply(c.text, t.id);
-    console.log(`\nPOSTED ✅ https://x.com/creditodds/status/${replyId}`);
+    const newId = asQuote
+      ? await twitter.postQuote(c.text, t.id)
+      : await twitter.postReply(c.text, t.id);
+    console.log(`\nPOSTED ✅ https://x.com/creditodds/status/${newId}`);
     return;
   }
   console.log('No candidate passed the judge.');

--- a/scripts/x-agent/twitter.js
+++ b/scripts/x-agent/twitter.js
@@ -89,6 +89,19 @@ async function getTweet(id) {
 /**
  * Post a reply to a given tweet. Returns the new tweet id.
  */
+async function postQuote(text, quoteTweetId) {
+  const client = getClient();
+  try {
+    const { data } = await client.v2.tweet(text, { quote_tweet_id: quoteTweetId });
+    return data.id;
+  } catch (err) {
+    const detail = err && (err.data || err.errors) ? JSON.stringify(err.data || err.errors) : '';
+    const e = new Error(`${err.message}${detail ? ` | ${detail}` : ''}`);
+    e.code = err.code;
+    throw e;
+  }
+}
+
 async function postReply(text, inReplyToTweetId) {
   const client = getClient();
   try {
@@ -125,4 +138,4 @@ async function getMetrics(ids) {
   return out;
 }
 
-module.exports = { searchRecent, getTweet, postReply, getMetrics, buildQuery };
+module.exports = { searchRecent, getTweet, postReply, postQuote, getMetrics, buildQuery };


### PR DESCRIPTION
Adds `postQuote()` and a `quote` input to the test-post diagnostic. Every API *reply* from @creditodds is blocked by X (403, even on wide-open tweets), while manual replies work. Quote tweets are original posts, not replies, so they should bypass the restriction. This tests that hypothesis.