### PR TITLE
Atmos Ascent: fix signup companion note ($99 Companion Fare)

### DIFF
--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -31,7 +31,7 @@ signup_bonus:
   type: "points"
   spend_requirement: 2500
   timeframe_months: 3
-  note: "Plus Buy One, Get One companion ticket ($0 fare plus taxes and fees from $23)"
+  note: "Plus a $99 Companion Fare (plus taxes and fees from $23)"
 benefits:
   - name: "Companion Fare"
     value: 0


### PR DESCRIPTION
The live Atmos Rewards Ascent limited-time offer pairs the 70,000-point bonus with a **$99 Companion Fare** (plus taxes and fees from $23). The YAML note still said "Buy One, Get One companion ticket ($0 fare)", which is outdated.

Updates the `signup_bonus.note` to match the live page. card-page-check didn't flag it because it only diffs note wording when the SUB value also changes (which it didn't this run). `build:cards` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)