### PR TITLE
feat(content-agent): Phase 2 — auto-tweet fact-checked items

### DIFF
--- a/.github/workflows/content-agent.yml
+++ b/.github/workflows/content-agent.yml
@@ -47,6 +47,8 @@ jobs:
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SOCIAL_API_URL: ${{ secrets.SOCIAL_API_URL }}
+          SOCIAL_API_KEY: ${{ secrets.SOCIAL_API_KEY }}
           CONTENT_AGENT_STATE_S3: s3://${{ secrets.S3_BUCKET_NAME }}/content-agent/state.json
           # Phase 1 is shadow regardless; the repo var is here for Phase 2/3.
           CONTENT_AGENT_MODE: ${{ vars.CONTENT_AGENT_MODE || 'shadow' }}

--- a/scripts/content-agent/README.md
+++ b/scripts/content-agent/README.md
@@ -4,8 +4,10 @@ Watches competitor accounts and turns notable card/points developments into **ou
 original articles and tweets. Compliant with X's no-programmatic-replies policy — it
 only creates original content, never replies.
 
-**Status: Phase 1 (shadow) built.** Decides + fact-checks + reports to Slack; posts and
-publishes nothing.
+**Status: Phase 2 live.** Tweet-worthy items that pass the fact-check gate are drafted
+(tweetgen.js), judged, and queued as ORIGINAL posts via the social-posting-service
+(blackout-aware, X + FB fanout). Article-worthy items are still report-only (Phase 3).
+`CONTENT_AGENT_MODE=shadow` reverts to report-only.
 
 ## Pipeline (hourly)
 

--- a/scripts/content-agent/post.js
+++ b/scripts/content-agent/post.js
@@ -1,0 +1,44 @@
+/**
+ * Queue an original post via the social-posting-service (same contract as
+ * queue-social.js: text_content / link_url / source_type / source_id, x-api-key).
+ * Routing through the service gets us the blackout window, scheduling, and the
+ * X + Facebook fanout for free.
+ */
+
+async function queueTweet({ text, sourceId, linkUrl }) {
+  const apiUrl = process.env.SOCIAL_API_URL;
+  const apiKey = process.env.SOCIAL_API_KEY;
+  if (!apiUrl || !apiKey) throw new Error('SOCIAL_API_URL and SOCIAL_API_KEY are required');
+
+  const body = {
+    text_content: text,
+    link_url: linkUrl,
+    source_type: 'content-agent',
+    source_id: sourceId,
+  };
+
+  const res = await fetch(`${apiUrl}/social/queue`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const t = await res.text();
+    throw new Error(`Queue API error: ${res.status} - ${t}`);
+  }
+  return res.json();
+}
+
+function buildLinkUrl(sourceId) {
+  const params = new URLSearchParams({
+    utm_source: 'twitter',
+    utm_medium: 'social',
+    utm_campaign: 'content-agent',
+    utm_content: sourceId,
+  });
+  // Generic destination until we can map topics to specific pages; the tweet text
+  // itself carries the value.
+  return `https://creditodds.com/news?${params}`;
+}
+
+module.exports = { queueTweet, buildLinkUrl };

--- a/scripts/content-agent/run.js
+++ b/scripts/content-agent/run.js
@@ -20,6 +20,8 @@ const state = require('./state');
 const { triage } = require('./triage');
 const { checkDuplicate } = require('./dedup');
 const { factCheck } = require('./factcheck');
+const { generateTweet, judgeTweet } = require('./tweetgen');
+const { queueTweet, buildLinkUrl } = require('./post');
 
 function log(...a) { console.log(...a); }
 
@@ -87,29 +89,62 @@ async function main() {
 
   log(`Actionable (post-dedup): ${actionable.length}`);
 
-  // Phase 1: report to Slack only. Nothing is posted or published.
+  // Act on each candidate. Tweets auto-post in live mode (Phase 2); articles
+  // remain report-only until Phase 3.
   for (const it of actionable) {
     const fc = it.factcheck;
     const gate = it.decision === 'article'
       ? (fc.confidence >= RAILS.minArticleConfidence && (!RAILS.requirePrimarySourceForArticle || fc.primarySource))
       : (fc.confidence >= RAILS.minTweetConfidence);
-    const wouldAct = gate && ['verified', 'partly'].includes(fc.verdict);
+    const passes = gate && ['verified', 'partly'].includes(fc.verdict);
+
+    // Draft the tweet for anything tweet-worthy that passes, in both modes —
+    // in shadow it shows in Slack, in live it posts.
+    let draft = null;
+    let judged = null;
+    if (passes && it.decision === 'tweet') {
+      try {
+        draft = await generateTweet(it);
+        judged = await judgeTweet(it, draft);
+      } catch (err) {
+        log(`  tweetgen error: ${err.message}`);
+      }
+    }
+
+    let action = 'reported';
+    if (MODE === 'live' && passes && it.decision === 'tweet' && judged?.pass) {
+      if (st.day.tweets >= RAILS.maxTweetsPerDay) {
+        action = 'held (daily tweet cap)';
+      } else {
+        try {
+          const sourceId = `ca-${it.tweet.id}`;
+          await queueTweet({ text: draft, sourceId, linkUrl: buildLinkUrl(sourceId) });
+          st.day.tweets += 1;
+          action = 'QUEUED TWEET';
+        } catch (err) {
+          action = `queue failed: ${err.message}`;
+          log(`  ${action}`);
+        }
+      }
+    }
 
     const srcLines = fc.sources.slice(0, 3).map((s) => `   • ${s.primary ? '(primary) ' : ''}<${s.url}|${s.title}>`).join('\n');
+    const tag = MODE === 'live' ? (action === 'QUEUED TWEET' ? ':rotating_light: LIVE' : 'LIVE') : 'SHADOW';
     const lines = [
-      `*:mag: [SHADOW] would ${it.decision.toUpperCase()}* — ${wouldAct ? ':white_check_mark: passes gate' : ':no_entry: held (gate not met)'}`,
+      `*:mag: [${tag}] ${it.decision.toUpperCase()}* — ${passes ? ':white_check_mark: passes gate' : ':no_entry: held (gate not met)'}${action !== 'reported' ? ` · *${action}*` : ''}`,
       `topic: *${it.topic}* (from <https://x.com/${it.tweet.author}/status/${it.tweet.id}|@${it.tweet.author}>)`,
       `claim: ${it.claim}`,
       `fact-check: *${fc.verdict}* · confidence ${fc.confidence.toFixed(2)} · primary source: ${fc.primarySource ? 'yes' : 'no'}`,
       fc.notes ? `notes: ${fc.notes}` : '',
+      draft ? `draft tweet${judged && !judged.pass ? ` (:no_entry: judge: ${judged.detail})` : ''}: "${draft}"` : '',
       srcLines ? `sources:\n${srcLines}` : '   (no corroborating sources found)',
     ].filter(Boolean);
     await slack.send({ text: lines.join('\n') });
-    log(`  [${it.decision}] ${wouldAct ? 'PASS' : 'held'} — ${it.topic} (${fc.verdict}/${fc.confidence.toFixed(2)})`);
+    log(`  [${it.decision}] ${passes ? 'PASS' : 'held'} (${action}) — ${it.topic} (${fc.verdict}/${fc.confidence.toFixed(2)})`);
   }
 
   if (actionable.length) {
-    await slack.send({ text: `:memo: content agent (shadow): ${actionable.length} candidate(s) this run — ${actionable.filter((i) => i.decision === 'article').length} article, ${actionable.filter((i) => i.decision === 'tweet').length} tweet.` });
+    await slack.send({ text: `:memo: content agent (${MODE}): ${actionable.length} candidate(s) this run — ${actionable.filter((i) => i.decision === 'article').length} article, ${actionable.filter((i) => i.decision === 'tweet').length} tweet. Tweets today: ${st.day.tweets}/${RAILS.maxTweetsPerDay}.` });
   }
 
   state.save(st);

--- a/scripts/content-agent/tweetgen.js
+++ b/scripts/content-agent/tweetgen.js
@@ -1,0 +1,79 @@
+/**
+ * Generate an original @creditodds tweet from a fact-checked item, then gate it
+ * with the mechanical rules + a safety/quality judge. These are ORIGINAL posts
+ * (never replies/quotes/@mentions — X blocks those programmatically and
+ * unsolicited @mentions are restricted), so the generator is told: no @handles.
+ */
+
+const { chat, chatJson } = require('../x-agent/llm');
+const { mechanicalCheck } = require('../x-agent/judge');
+const { MODELS } = require('./config');
+
+async function generateTweet(item) {
+  const src = item.factcheck.sources.find((s) => s.primary) || item.factcheck.sources[0];
+  const raw = await chat({
+    model: MODELS.factcheck, // stronger model; these go out with no human review
+    temperature: 0.8,
+    maxTokens: 300,
+    json: true,
+    messages: [
+      {
+        role: 'system',
+        content: `You write original tweets for @creditodds, the data-driven credit card
+site. Voice: sharp human, not a corporate account. Direct, punchy, a little wry.
+Rules (hard):
+- Max 240 characters.
+- ONLY state facts consistent with the verified claim and fact-check notes below.
+  Never embellish numbers or add details that are not in the claim.
+- Do NOT @mention any account and do NOT use hashtags.
+- No em dashes. 0-1 emoji. No corporate filler ("exciting news", "stay tuned").
+- Frame it as OUR report of the development, optionally with a practical take
+  (who benefits, what to check). Do not credit or reference other blogs/accounts.`,
+      },
+      {
+        role: 'user',
+        content: `Development: ${item.topic}
+Verified claim: ${item.claim}
+Fact-check notes: ${item.factcheck.notes}
+${src ? `Primary basis: ${src.title}` : ''}
+
+Return JSON: {"tweet":"<the tweet text>"}`,
+      },
+    ],
+  });
+  const parsed = JSON.parse(raw);
+  return (parsed.tweet || '').trim();
+}
+
+async function judgeTweet(item, text) {
+  const mech = mechanicalCheck(text);
+  if (!mech.pass) return { pass: false, stage: 'mechanical', detail: mech.reasons.join('; ') };
+  if (/@\w+/.test(text)) return { pass: false, stage: 'mechanical', detail: 'contains an @mention (not allowed in API posts)' };
+
+  const v = await chatJson({
+    model: MODELS.factcheck,
+    temperature: 0,
+    maxTokens: 250,
+    messages: [
+      {
+        role: 'system',
+        content: `You review an original tweet for the @creditodds brand account before it
+auto-posts with no human review. Fail it if it: states anything beyond the verified
+claim; touches legal/political/sensitive topics; is hostile or mocks anyone; sounds
+corporate or spammy; or is factually fuzzy. Score quality 0-10 (7+ = postable).`,
+      },
+      {
+        role: 'user',
+        content: `Verified claim: "${item.claim}"
+Fact-check notes: "${item.factcheck.notes}"
+Proposed tweet: "${text}"
+
+Return JSON: {"pass": true|false, "score": <0-10>, "reason": "<short>"}`,
+      },
+    ],
+  });
+  const pass = v.pass === true && typeof v.score === 'number' && v.score >= 7;
+  return { pass, stage: pass ? 'passed' : 'quality', score: v.score, detail: v.reason || '' };
+}
+
+module.exports = { generateTweet, judgeTweet };


### PR DESCRIPTION
Enables the tweet path. Tweet-worthy items that pass the fact-check gate (confidence >=0.7, verdict verified/partly) are:
1. drafted as **original posts** by `tweetgen.js` — facts strictly limited to the verified claim, no @mentions (API-restricted), no hashtags;
2. judged (mechanical rules + safety/quality, score >=7);
3. queued via the **social-posting-service** (`post.js`, same contract as `queue-social.js`) — blackout window + X/FB fanout for free. Daily cap 8, UTM-tagged link.

Shadow mode now also drafts the tweet so Slack shows exactly what would post. Articles stay report-only until Phase 3.

Validated locally: draft for the Sapphire 100k item came out on-brand, factually exact (100k / $6k / 3mo), judge 9/10.