### PR TITLE
fix(content-agent): queue posts to twitter only

### DIFF
--- a/scripts/content-agent/post.js
+++ b/scripts/content-agent/post.js
@@ -15,6 +15,10 @@ async function queueTweet({ text, sourceId, linkUrl }) {
     link_url: linkUrl,
     source_type: 'content-agent',
     source_id: sourceId,
+    // Content-agent items are tweets only. Without this the service fans out to
+    // every active platform (Facebook included) — these quick takes are X-native
+    // and shouldn't hit FB unless they graduate to a full article.
+    platforms: ['twitter'],
   };
 
   const res = await fetch(`${apiUrl}/social/queue`, {


### PR DESCRIPTION
The service's default fan-out is ALL active platforms when no `platforms` field is passed — so content-agent tweets were also posting to Facebook (confirmed: the Amex Delta Vacations item went out as a FB post). These quick takes are X-native; FB should only get full articles. Passes `platforms: ['twitter']` on the queue payload (same mechanism card-wire uses for its dedicated account).