### PR TITLE
Delta Gold Business: live offer is 90k/$6k

### DIFF
--- a/data/cards/delta-skymiles-gold-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-business-american-express-card.yaml
@@ -39,10 +39,11 @@ rewards:
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 60000
+  value: 90000
   type: "miles"
-  spend_requirement: 4000
+  spend_requirement: 6000
   timeframe_months: 6
+  note: "Limited-time offer, up from 60,000. Offer ends 2026-07-15."
 apr:
   regular:
     min: 19.49


### PR DESCRIPTION
The live Amex page shows the Delta SkyMiles Gold Business welcome offer is **90,000 bonus miles after $6,000 in the first 6 months** (up from a struck-through 60,000), expiring **7/15/26**. Our YAML was stale on both the value (60,000) and the spend ($4,000).

card-page-check can't catch this: Amex blocks the automated fetch, so the extractor received no offer content and returned `value: 0` (the false positive rejected in #1576). The strikethrough handling never got a chance to run because the offer text never arrived.

`build:cards` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)