### PR TITLE
card-page-check: log fetched page text for detected changes

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -716,6 +716,23 @@ function generateSummary(applied) {
   return md;
 }
 
+// ─── Fetched-text audit logging ───────────────────────────────────────────────
+
+// Dump the exact page text handed to Haiku plus Haiku's parsed output, wrapped in
+// greppable delimiters. Lets a reviewer audit a detected change after the fact —
+// search a run log for "FETCHED-TEXT <card>" to see whether the offer figure was
+// even present in what the model saw, vs. present-but-misread. This is the gap
+// that made Delta Gold Business's 60000→0 impossible to diagnose from logs alone
+// (we only logged the char count, not the content). Called for every changed card;
+// set LOG_FETCHED_TEXT=all to also dump unchanged cards (catches silent
+// non-checks, e.g. Amex pages that fetch chrome but no client-rendered offer).
+function logFetchedText(name, url, usedBrowser, pageContent, extracted) {
+  console.log(`  >>>>> FETCHED-TEXT ${name} | ${url} | via ${usedBrowser ? 'browser' : 'simple-fetch'} | ${pageContent.length} chars`);
+  console.log(`  >>>>> EXTRACTED-JSON ${name}: ${JSON.stringify(extracted)}`);
+  console.log(pageContent);
+  console.log(`  <<<<< FETCHED-TEXT-END ${name}`);
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -793,6 +810,7 @@ async function main() {
           const browserContent = await fetchWithBrowser(apply_link);
           if (browserContent) {
             pageContent = browserContent;
+            usedBrowser = true;
             try {
               extracted = await extractCardTerms(name, bank, apply_link, pageContent, card.data.signup_bonus);
             } catch (err) {
@@ -811,9 +829,16 @@ async function main() {
         const changes = detectChanges(card, extracted);
         if (changes.length > 0) {
           console.log(`  ${changes.length} change(s) detected`);
+          // Every detected change becomes a PR row a human must verify against
+          // the source page — log what Haiku saw + returned so it's auditable
+          // later without a re-run.
+          logFetchedText(name, apply_link, usedBrowser, pageContent, extracted);
           allChanges.push({ slug: card.slug, card_name: name, apply_link, changes });
         } else {
           console.log('  No changes');
+          if (process.env.LOG_FETCHED_TEXT === 'all') {
+            logFetchedText(name, apply_link, usedBrowser, pageContent, extracted);
+          }
         }
       })(), PER_CARD_TIMEOUT_MS, name);
     } catch (err) {


### PR DESCRIPTION
## Why
When the extractor emits a bogus value (e.g. Delta Gold Business `60000 → 0` in #1576), the run log only shows `Fetched 12475 chars` — not the content. So there's no way to tell after the fact whether the offer figure was **absent** from the fetched text or **present-but-misread**. My "wasn't in the fetched text" claim was an untestable inference. This closes that gap.

## What
- For **every card that produces a detected change**, dump Haiku's parsed JSON and the exact page text it saw, wrapped in greppable delimiters:
  ```
  >>>>> FETCHED-TEXT <card> | <url> | via browser|simple-fetch | N chars
  >>>>> EXTRACTED-JSON <card>: {...}
  <page text>
  <<<<< FETCHED-TEXT-END <card>
  ```
  To audit a PR row later: search the run log for `FETCHED-TEXT <card>` and check whether the offer figure is in the text.
- Opt-in **`LOG_FETCHED_TEXT=all`** also dumps unchanged cards, to catch *silent non-checks* (Amex pages that fetch chrome but no client-rendered offer, so a real change reads as "No changes").
- Bounded by design: only changed cards by default (~a handful/run), so no ~3 MB log bloat.
- Drive-by fix: `usedBrowser` wasn't set `true` after a browser self-heal retry, so the new fetch-method tag would otherwise mislabel retried cards.

Script-only; 20 unit tests still pass, `node -c` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)