### PR TITLE
infra: fixed egress IP (VPC + NAT) and creditodds_app DB user docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,21 @@
 - `apps/web-next/` - Next.js frontend
 - `data/cards/` - YAML card definitions
 
+## Networking & Database Access
+
+- All backend Lambdas (this repo's `CreditCardOddsAPI` stack and the separate
+  `CreditOddsSocialPostingService` stack) run inside the `creditodds-network`
+  VPC (us-east-2, defined in `infra/network.yml`). Outbound traffic leaves via
+  a single NAT gateway Elastic IP — **3.13.85.124** — which is the only
+  address the shared Aurora cluster's security group allowlists on TCP 3306.
+- The database (`database-3` cluster, us-east-1) is shared with other apps.
+  CreditOdds connects as the schema-scoped user `creditodds_app` (grants on
+  `creditodds.*` only). Never use the cluster `admin` user. The credential
+  lives in SSM Parameter Store (us-east-2): `/creditodds/db/{host,database,username,password}`.
+- Consequence: the DB is NOT reachable from a local machine or from any
+  compute outside the VPC. Anything that needs SQL access must run as a
+  Lambda in the VPC (e.g. `RunMigrationHandler` for migrations).
+
 ## Deployment
 
 - Backend: `cd apps/api && sam build && sam deploy`

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -80,6 +80,14 @@ Parameters:
     Type: String
     Description: Sentry "environment" tag applied to all backend events.
     Default: production
+  VpcPrivateSubnetIds:
+    Type: CommaDelimitedList
+    Description: Private subnets from the creditodds-network stack (infra/network.yml). All functions attach here so DB traffic egresses from the stack's single NAT EIP.
+    Default: subnet-07c1b621c70d72719,subnet-02aa47f397dd8e08d
+  VpcLambdaSecurityGroupId:
+    Type: String
+    Description: Lambda security group from the creditodds-network stack.
+    Default: sg-06399ba7e0a0b885c
 
 # Auto-instrument every Lambda with Sentry via the official Node layer + a
 # NODE_OPTIONS preload. This needs no per-handler code changes and does NOT
@@ -103,6 +111,15 @@ Globals:
         SENTRY_DSN: !Ref SentryDsn
         SENTRY_TRACES_SAMPLE_RATE: !Ref SentryTracesSampleRate
         SENTRY_ENVIRONMENT: !Ref SentryEnvironment
+    # Every function runs in the creditodds-network VPC so outbound traffic
+    # (Aurora in us-east-1, Google Places, Plaid, Firebase, Sentry) leaves via
+    # the NAT gateway's static EIP - the only address the database security
+    # group allowlists on 3306. SAM adds AWSLambdaVPCAccessExecutionRole to the
+    # generated roles automatically when VpcConfig is present.
+    VpcConfig:
+      SecurityGroupIds:
+        - !Ref VpcLambdaSecurityGroupId
+      SubnetIds: !Ref VpcPrivateSubnetIds
 
 # Resources declares the AWS resources that you want to include in the stack
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html

--- a/infra/network.yml
+++ b/infra/network.yml
@@ -1,0 +1,156 @@
+# CreditOdds shared network stack (us-east-2) — fixed egress IP for all
+# Lambda compute (CreditCardOddsAPI + CreditOddsSocialPostingService).
+#
+# Why: the shared Aurora cluster (database-3, us-east-1) is dropping its
+# 0.0.0.0/0 security-group rule and will allowlist exactly one /32 on 3306.
+# Un-VPC'd Lambdas egress from ephemeral AWS IPs, so every function is
+# attached to the private subnets here and all outbound traffic (DB,
+# Google Places, Plaid, Sentry, Firebase, ...) leaves via one NAT gateway
+# Elastic IP. Cost: ~$32/month NAT hourly + $0.045/GB processed.
+#
+# Deploy:  aws cloudformation deploy --region us-east-2 \
+#            --template-file infra/network.yml --stack-name creditodds-network
+# The NAT EIP (stack output NatEip) is the address the database side must
+# allowlist. Single-NAT/single-AZ by design: one static IP is the requirement;
+# if us-east-2a fails, NAT egress fails with it (accepted trade-off).
+AWSTemplateFormatVersion: 2010-09-09
+Description: CreditOdds Lambda egress network - VPC, single NAT gateway with static EIP
+
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.42.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags: [{ Key: Name, Value: creditodds-network }]
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags: [{ Key: Name, Value: creditodds-igw }]
+
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.42.0.0/24
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      Tags: [{ Key: Name, Value: creditodds-public-a }]
+
+  # Two private subnets across AZs for Lambda availability; both route out
+  # through the single NAT so the egress IP stays constant.
+  PrivateSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.42.16.0/20
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      Tags: [{ Key: Name, Value: creditodds-private-a }]
+
+  PrivateSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.42.32.0/20
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      Tags: [{ Key: Name, Value: creditodds-private-b }]
+
+  NatEip:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags: [{ Key: Name, Value: creditodds-nat-eip }]
+
+  NatGateway:
+    Type: AWS::EC2::NatGateway
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      AllocationId: !GetAtt NatEip.AllocationId
+      SubnetId: !Ref PublicSubnet
+      Tags: [{ Key: Name, Value: creditodds-nat }]
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags: [{ Key: Name, Value: creditodds-public-rt }]
+
+  PublicDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetRouteAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTable
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags: [{ Key: Name, Value: creditodds-private-rt }]
+
+  PrivateDefaultRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGateway
+
+  PrivateSubnetARouteAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetA
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnetBRouteAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetB
+      RouteTableId: !Ref PrivateRouteTable
+
+  # S3 traffic (social uploads, SAM artifacts) bypasses the NAT for free.
+  S3GatewayEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcId: !Ref Vpc
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
+      VpcEndpointType: Gateway
+      RouteTableIds:
+        - !Ref PrivateRouteTable
+
+  LambdaSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: CreditOdds Lambdas - all egress, no ingress
+      VpcId: !Ref Vpc
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          CidrIp: 0.0.0.0/0
+      Tags: [{ Key: Name, Value: creditodds-lambda-sg }]
+
+Outputs:
+  NatEip:
+    Description: Static egress IP - allowlist this /32 on the database security group (TCP 3306)
+    Value: !Ref NatEip
+  PrivateSubnetAId:
+    Value: !Ref PrivateSubnetA
+    Export: { Name: creditodds-network-PrivateSubnetAId }
+  PrivateSubnetBId:
+    Value: !Ref PrivateSubnetB
+    Export: { Name: creditodds-network-PrivateSubnetBId }
+  LambdaSecurityGroupId:
+    Value: !Ref LambdaSecurityGroup
+    Export: { Name: creditodds-network-LambdaSecurityGroupId }


### PR DESCRIPTION
## Why

The shared Aurora cluster (`database-3`, us-east-1) is removing its `0.0.0.0/0` security-group rule, and the cluster `admin` password rotates right after. CreditOdds Lambdas currently run outside any VPC (ephemeral egress IPs) and connect as `admin` — both about to break.

## What

- **`infra/network.yml`** — new `creditodds-network` stack (us-east-2): VPC, one NAT gateway with static EIP **3.13.85.124**, two private subnets (2 AZs), S3 gateway endpoint, Lambda security group. Single-NAT by design: the DB side allowlists exactly one /32.
- **`apps/api/template.yml`** — `Globals.Function.VpcConfig` attaches all 42 functions to the private subnets (SAM adds `AWSLambdaVPCAccessExecutionRole` automatically). Subnet/SG IDs are parameters with defaults.
- **`CLAUDE.md`** — documents the network, the schema-scoped `creditodds_app` DB user (SSM: `/creditodds/db/*`), and that the DB is no longer reachable outside the VPC.

The same VpcConfig change goes to `CreditOdds/social-posting-service` (also connects to this DB); that stack is deployed from its own repo.

## Deployment

The network stack and both SAM stacks are deployed manually (documented manual path); this PR records the template state. The `admin` → `creditodds_app` credential swap is parameter-only (`sam deploy --parameter-overrides USERNAME/PASSWORD`), no code change — `apps/api/src/db.js` already reads env vars.