### PR TITLE
infra: migrate backend to us-east-1, co-located with the database

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -53,7 +53,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
-          aws-region: us-east-2
+          aws-region: us-east-1
 
       # SAM's esbuild BuildMethod (used by the bundled handlers) needs esbuild
       # discoverable on PATH at build time. SAM's per-function npm install is
@@ -75,9 +75,9 @@ jobs:
         run: |
           sam deploy \
             --stack-name CreditCardOddsAPI \
-            --s3-bucket codepipeline-us-east-2-534542813767 \
+            --resolve-s3 \
             --s3-prefix CreditCardOddsAPI \
-            --region us-east-2 \
+            --region us-east-1 \
             --capabilities CAPABILITY_IAM \
             --no-confirm-changeset \
             --no-fail-on-empty-changeset

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -82,20 +82,26 @@ Parameters:
     Default: production
   VpcPrivateSubnetIds:
     Type: CommaDelimitedList
-    Description: Private subnets from the creditodds-network stack (infra/network.yml). All functions attach here so DB traffic egresses from the stack's single NAT EIP.
-    Default: subnet-07c1b621c70d72719,subnet-02aa47f397dd8e08d
+    Description: NAT-routed private subnets the functions attach to. Defaults are the shared us-east-1 VPC (vpc-0cc30471) next to the database; the retired us-east-2 stack used the creditodds-network subnets.
+    Default: subnet-38dcb136,subnet-7a936d4b
   VpcLambdaSecurityGroupId:
     Type: String
-    Description: Lambda security group from the creditodds-network stack.
-    Default: sg-06399ba7e0a0b885c
+    Description: Security group for the functions. Default is the shared VPC's self-referencing default SG, which is what grants database access.
+    Default: sg-d83c41e6
 
 # Auto-instrument every Lambda with Sentry via the official Node layer + a
 # NODE_OPTIONS preload. This needs no per-handler code changes and does NOT
 # bundle the SDK (it ships in the layer), which is the supported path for our
 # esbuild-bundled handlers. When SentryDsn is empty the SDK stays inert, so
 # deploys without a DSN behave exactly as before.
-# Layer ARN is region/version specific — this stack deploys to us-east-2; the
-# pinned version (v75 = SDK 10.61.0) comes from Sentry's release registry.
+# Layer ARNs are region/version specific, so the pinned version (v75 =
+# SDK 10.61.0, from Sentry's release registry) is mapped per region below.
+Mappings:
+  RegionConfig:
+    us-east-1:
+      SentryLayerArn: arn:aws:lambda:us-east-1:943013980633:layer:SentryNodeServerlessSDKv10:75
+    us-east-2:
+      SentryLayerArn: arn:aws:lambda:us-east-2:943013980633:layer:SentryNodeServerlessSDKv10:75
 #
 # Memory note: the layer + OpenTelemetry adds ~30-40MB of resident memory.
 # Functions previously at the 128MB minimum were running at ~94% utilization
@@ -104,7 +110,7 @@ Parameters:
 Globals:
   Function:
     Layers:
-      - arn:aws:lambda:us-east-2:943013980633:layer:SentryNodeServerlessSDKv10:75
+      - !FindInMap [RegionConfig, !Ref AWS::Region, SentryLayerArn]
     Environment:
       Variables:
         NODE_OPTIONS: -r @sentry/aws-serverless/awslambda-auto


### PR DESCRIPTION
## Why

The database (database-3, Aurora, us-east-1) sat a region away from our compute: every query paid 11-13ms cross-region latency and DB traffic transited the public internet via our NAT ($36/month). Co-locating in the shared us-east-1 VPC makes DB traffic private in-VPC and eliminates the NAT. (Same pattern Fledge already executed.)

## What's deployed (already live in us-east-1)

- **CreditCardOddsAPI** + **CreditOddsSocialPostingService** deployed to us-east-1, attached to the shared VPC (vpc-0cc30471, subnets subnet-38dcb136/subnet-7a936d4b, SG sg-d83c41e6). Verified: reads + INSERT paths 200, social DB reads, publisher swapped (us-east-2 schedule disabled, us-east-1 enabled).
- **New custom domains** (`api.creditodds.com`, `social-api.creditodds.com`) front the us-east-1 APIs — callers previously hardcoded raw execute-api URLs, so this is the last URL migration ever. Amplify apps + `SOCIAL_API_URL` secret already repointed.
- us-east-2 stacks stay up untouched as instant rollback during a multi-day soak.

## This PR

- `template.yml`: VPC defaults → shared us-east-1 VPC; Sentry layer ARN mapped per region
- `deploy-api.yml`: CI region → us-east-1 (+ `--resolve-s3`); **merging this is the CI cutover**

## After soak (separate steps, gated)

Delete us-east-2 app stacks; `creditodds-network` (NAT EIP 3.13.85.124) must wait for Verne, which imports its exports.