### PR TITLE
fix(card-check): stop tiered-SUB guard from swallowing replaced offers

### DIFF
--- a/data/cards/capital-one-venture-business.yaml
+++ b/data/cards/capital-one-venture-business.yaml
@@ -20,11 +20,10 @@ rewards:
     value: 2
     unit: points_per_dollar
 signup_bonus:
-  value: 150000
+  value: 100000
   type: "miles"
-  spend_requirement: 37500
-  timeframe_months: 6
-  note: "Earn up to 75,000 miles once you spend $7,500 in the first 3 months and an additional 75,000 miles once you spend $30,000 in the first 6 months. Offer ends 2026-06-08."
+  spend_requirement: 10000
+  timeframe_months: 3
 benefits:
   - name: "Business Travel Credit"
     value: 50

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -402,7 +402,31 @@ function normalizeTimeframeMonths(v) {
   return v;
 }
 
-function detectChanges(card, extracted) {
+// A tiered note carries the tier amounts it describes ("70,000 miles ... an
+// additional 20,000 miles"). Pull them out so the tier-collapse guard can
+// insist that a proposed downgrade actually LANDS on one of them. Only counts
+// followed by a reward unit qualify — spend figures ("$3,000 on purchases")
+// never sit next to points/miles/nights, so they don't leak in.
+function tierAmountsInNote(noteText) {
+  const matches = noteText.matchAll(
+    /(\d[\d,]{2,})\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+nights?)/gi
+  );
+  return [...matches].map(m => Number(m[1].replace(/,/g, '')));
+}
+
+// The script writes "Offer ends YYYY-MM-DD." into notes when the apply page
+// states an end date (see the extraction prompt). Read it back: once that date
+// has passed, the note is a description of a DEAD offer and has no authority
+// over what the live page says today.
+function noteOfferHasExpired(noteText, now) {
+  const m = noteText.match(/Offer ends (\d{4})-(\d{2})-(\d{2})/i);
+  if (!m) return false;
+  const end = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return today > end;
+}
+
+function detectChanges(card, extracted, now = new Date()) {
   if (!extracted) return [];
 
   const current = card.data;
@@ -519,17 +543,31 @@ function detectChanges(card, extracted) {
     // Note: pre-2026-06-04 the convention was inverted (floor-as-value) and
     // this guard skipped value INCREASES instead. See PR #1358 / memory
     // feedback_tiered_sub_convention for the convention change.
+    //
+    // Both suppressions trust the stored note to describe the LIVE offer. When
+    // an issuer replaces a tiered offer with a smaller flat one, that trust is
+    // misplaced and the guard silently swallows a real change on every run
+    // (Capital One Venture Business: tiered 75k+75k retired, replaced by a flat
+    // 100,000 / $10,000 / 3 months — suppressed because 100000 < 150000). Two
+    // narrowings keep the guard honest:
+    //
+    //   a. An expired "Offer ends" date in the note disarms it entirely.
+    //   b. Tier collapse requires the proposed value to actually EQUAL one of
+    //      the tier amounts the note names. A base-tier misparse returns a
+    //      number that is written in the note (70,000 / 30,000 / 75,000); a
+    //      replacement offer returns one that isn't.
     const noteText = cur.note || '';
     const tieredAdditionalMatch =
       noteText.match(/(\d[\d,]*)\s+(?:additional|more)\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+night)/i) ||
       noteText.match(/(?:additional|more)\s+(\d[\d,]*)\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+night)/i);
-    const noteDescribesTiered = !!tieredAdditionalMatch;
+    const noteDescribesTiered = !!tieredAdditionalMatch && !noteOfferHasExpired(noteText, now);
 
     const tierCollapse =
       noteDescribesTiered &&
       sb.value != null &&
       cur.value != null &&
-      sb.value < cur.value;
+      sb.value < cur.value &&
+      tierAmountsInNote(noteText).includes(sb.value);
 
     const spendOvercount =
       noteDescribesTiered &&

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -85,6 +85,89 @@ test('base-tier-only value downgrade 90000 → 70000 is suppressed', () => {
   assert.deepEqual(fieldsChanged(changes), []);
 });
 
+// ─── Replaced offers must NOT be swallowed by the tiered guard ──────────────
+
+// Capital One Venture Business: the tiered 75k + 75k offer ended 2026-06-08 and
+// was replaced by a flat 100,000 / $10,000 / 3 months. The guard suppressed the
+// whole signup_bonus block every run ("No changes") because the stale note still
+// said "additional 75,000 miles" and 100,000 < 150,000.
+const VENTURE_BUSINESS = {
+  data: {
+    name: 'Capital One Venture Business',
+    signup_bonus: {
+      value: 150000,
+      type: 'miles',
+      spend_requirement: 37500,
+      timeframe_months: 6,
+      note: 'Earn up to 75,000 miles once you spend $7,500 in the first 3 months and an additional 75,000 miles once you spend $30,000 in the first 6 months. Offer ends 2026-06-08.',
+    },
+  },
+};
+
+const LIVE_OFFER = { signup_bonus: { value: 100000, spend_requirement: 10000, timeframe_months: 3 } };
+const AFTER_EXPIRY = new Date('2026-07-08T00:00:00Z');
+const BEFORE_EXPIRY = new Date('2026-06-01T00:00:00Z');
+
+console.log('\nReplaced-offer detection (stale tiered note):');
+
+test('an expired "Offer ends" date disarms the tiered guard entirely', () => {
+  const changes = detectChanges(VENTURE_BUSINESS, LIVE_OFFER, AFTER_EXPIRY);
+  assert.deepEqual(fieldsChanged(changes), [
+    'signup_bonus.spend_requirement',
+    'signup_bonus.timeframe_months',
+    'signup_bonus.value',
+  ]);
+  const value = changes.find(c => c.field === 'signup_bonus.value');
+  assert.equal(value.old_value, 150000);
+  assert.equal(value.new_value, 100000);
+});
+
+test('a value matching NO tier in the note surfaces even while the offer is live', () => {
+  // Same card, evaluated a week before the stated end date: 100,000 appears
+  // nowhere in the note (its tiers are 75,000 and 75,000), so it cannot be a
+  // base-tier misparse.
+  const changes = detectChanges(VENTURE_BUSINESS, LIVE_OFFER, BEFORE_EXPIRY);
+  assert.deepEqual(fieldsChanged(changes), [
+    'signup_bonus.spend_requirement',
+    'signup_bonus.timeframe_months',
+    'signup_bonus.value',
+  ]);
+});
+
+test('a value matching a named tier is still suppressed before the end date', () => {
+  // The genuine base-tier misparse this guard exists for: 75,000 IS in the note.
+  const changes = detectChanges(
+    VENTURE_BUSINESS,
+    { signup_bonus: { value: 75000, spend_requirement: 7500, timeframe_months: 3 } },
+    BEFORE_EXPIRY
+  );
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('spend_requirement overcount is suppressed while live, surfaces once expired', () => {
+  const overcount = { signup_bonus: { value: 150000, spend_requirement: 37501, timeframe_months: 6 } };
+  assert.deepEqual(fieldsChanged(detectChanges(VENTURE_BUSINESS, overcount, BEFORE_EXPIRY)), []);
+  assert.deepEqual(fieldsChanged(detectChanges(VENTURE_BUSINESS, overcount, AFTER_EXPIRY)), [
+    'signup_bonus.spend_requirement',
+  ]);
+});
+
+test('a note with no end date keeps the guard armed regardless of date', () => {
+  assert.deepEqual(
+    fieldsChanged(detectChanges(DELTA_GOLD, { signup_bonus: { value: 70000 } }, AFTER_EXPIRY)),
+    []
+  );
+});
+
+test('spend figures in the note are not mistaken for tier amounts', () => {
+  // Hyatt's note contains "$3,000" and "$15,000" — neither is followed by a
+  // reward unit, so a proposed value of 3000 must not read as a tier match.
+  const changes = detectChanges(WORLD_OF_HYATT, {
+    signup_bonus: { value: 3000, spend_requirement: 15000, timeframe_months: 6 },
+  });
+  assert.deepEqual(fieldsChanged(changes), ['signup_bonus.value']);
+});
+
 // ─── Legitimate changes must still surface ──────────────────────────────────
 
 console.log('\nLegitimate changes still surface:');


### PR DESCRIPTION
## Problem

`check-card-pages.js` reported **No changes** for Capital One Venture Business this morning, even though the live page shows a flat **100,000 miles / \$10,000 / 3 months** offer while the YAML still stored the retired tiered 150,000.

```
Checking: Capital One Venture Business
  Ignoring signup_bonus changes: current note describes a tiered offer (75,000)
    — proposed value 150000 → 100000 looks like a base-tier-only misparse
  No changes
```

The tiered-bonus suppressor treats `signup_bonus.note` as an accurate description of the *live* offer. Any note containing "additional N miles" made **every** proposed value below the stored max look like a base-tier misparse. Capital One retired the tiered offer (the note's own `Offer ends 2026-06-08` had passed a month earlier) and replaced it with a smaller flat one, so the guard swallowed a real change, and would have kept doing so on every future run until someone hand-edited the note.

## Fix

Two independent narrowings, either of which catches this case:

**a. An expired `Offer ends` date disarms the guard.** The extraction prompt already writes ISO end dates into notes; nothing ever read them back. An expired note describes a dead offer and has no authority over the live page.

**b. Tier collapse requires the proposed value to actually land on a named tier.** A genuine base-tier misparse returns a number written in the note (70,000 / 30,000 / 75,000). A replacement offer returns one that isn't. 100,000 appears nowhere in the Venture note, whose tiers are 75,000 and 75,000.

Tier amounts are extracted only when followed by a reward unit (`points`/`miles`/`nights`), so spend figures like `$3,000 on purchases` can't be misread as tiers. `detectChanges` now takes an injectable `now` so the expiry path is testable.

Also refreshes `capital-one-venture-business.yaml` to the live offer (verified against the issuer page; annual fee unchanged at \$95).

## Tests

`node scripts/check-card-pages.test.js` passes. New cases:

- expired end date surfaces value + spend + timeframe
- a value matching no named tier surfaces even while the offer is live
- a value matching a named tier is **still suppressed** before the end date
- spend overcount still suppressed while live, surfaces once expired
- a note with no end date keeps the guard armed
- spend figures in the note are not mistaken for tier amounts

Both regressions the guard exists for still suppress: World of Hyatt overlapping-spend double-count (#1365/#1376) and Delta Gold tier collapse.