### PR TITLE
fix(card-check): let the live page overrule a stale tiered note

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -303,7 +303,8 @@ Extract the following fields and return ONLY valid JSON — no markdown fences, 
     "spend_requirement": <number or null>,
     "timeframe_months": <number or null>,
     "authorized_user_bonus": <number or null>,
-    "bonus_note": <string or null>
+    "bonus_note": <string or null>,
+    "offer_is_tiered": <true|false or null>
   },
   "apr": {
     "purchase_intro_months": <number or null>,
@@ -323,6 +324,11 @@ Rules:
     - timeframe_months = the **longest** window across all tiers (typically the same window throughout, e.g. 6)
     - bonus_note = describes the tier structure in the issuer's own words, and includes the offer end date when present on the page (see BONUS NOTE rule below)
   NEVER return just the first/base tier in value — always return the maximum attainable bonus. Floor-as-value is the OLD convention and is being phased out.
+- OFFER IS TIERED: signup_bonus.offer_is_tiered describes the welcome offer AS ADVERTISED ON THE PAGE RIGHT NOW. Judge it from the page alone — ignore anything you know or infer about the card's past offers.
+    - true = the live welcome offer has two or more earn steps ("earn X after $A, plus an additional Y after $B").
+    - false = the live welcome offer is a single flat bonus with one spend requirement ("earn 100,000 miles when you spend $10,000 in the first 3 months"). A lone authorized-user bonus alongside a flat offer is still false — an AU bonus is not an earn tier.
+    - null ONLY when the page states no welcome offer at all, or the wording is too ambiguous to judge.
+  This field decides whether a stored tier breakdown is still accurate, so answer it from the live page even when every other field is null.
 - BONUS NOTE: Use bonus_note ONLY to describe structural aspects of the one-time welcome offer that the base fields (value/spend_requirement/timeframe_months) cannot express. Allowed cases, with example phrasing:
   - Tiered/multi-step earn (describe each tier so readers see how the max breaks down): "Earn 70,000 miles after $3,000 spend in first 6 months, plus an additional 20,000 miles after an additional $2,000 spend within first 6 months. Offer ends 2026-07-15."
   - Multi-component bonus delivered as separate pieces: "$400 Disney eGift Card upon approval + $200 statement credit after spending $1,000 in first 3 months"
@@ -456,7 +462,10 @@ function noteOfferHasExpired(noteText, now) {
   return today > end;
 }
 
-function detectChanges(card, extracted, now = new Date()) {
+// `suppressions` is an out-param: every guard that swallows a change appends a
+// record so the run can report what it chose not to show. A silent suppressor is
+// indistinguishable from a correct one.
+function detectChanges(card, extracted, now = new Date(), suppressions = []) {
   if (!extracted) return [];
 
   const current = card.data;
@@ -586,11 +595,25 @@ function detectChanges(card, extracted, now = new Date()) {
     //      the tier amounts the note names. A base-tier misparse returns a
     //      number that is written in the note (70,000 / 30,000 / 75,000); a
     //      replacement offer returns one that isn't.
+    //   c. The LIVE PAGE OVERRULES THE NOTE. (a) and (b) are still note-derived,
+    //      so they can't see a replacement offer that carries no end date and
+    //      happens to land on a named tier — e.g. Hyatt's tiered 30k+30k
+    //      collapsing to a flat 30,000 is, by value alone, indistinguishable
+    //      from the base-tier misparse this guard exists to suppress. Only the
+    //      page can settle it, so the extractor reports offer_is_tiered for the
+    //      offer as advertised today. When it says false, the stored breakdown
+    //      describes a dead offer: surface the change and retire the note.
+    //      When it can't tell (null), fall back to the note heuristics.
+    //
+    // Ordering matters: a suppression that fires forever is invisible, so every
+    // skip is recorded in `suppressions` and reported at the end of the run.
     const noteText = cur.note || '';
     const tieredAdditionalMatch =
       noteText.match(/(\d[\d,]*)\s+(?:additional|more)\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+night)/i) ||
       noteText.match(/(?:additional|more)\s+(\d[\d,]*)\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+night)/i);
-    const noteDescribesTiered = !!tieredAdditionalMatch && !noteOfferHasExpired(noteText, now);
+    const pageSaysFlat = sb.offer_is_tiered === false;
+    const noteDescribesTiered =
+      !!tieredAdditionalMatch && !noteOfferHasExpired(noteText, now) && !pageSaysFlat;
 
     const tierCollapse =
       noteDescribesTiered &&
@@ -614,6 +637,15 @@ function detectChanges(card, extracted, now = new Date()) {
       console.log(
         `  Ignoring signup_bonus changes: current note describes a tiered offer (${tieredAdditionalMatch[1]}) — ${reason}`
       );
+      suppressions.push({
+        card_name: current.name,
+        guard: tierCollapse ? 'tier-collapse' : 'spend-overcount',
+        reason,
+        // Recorded so a human can tell a stable, correct suppression from one
+        // that has quietly outlived the offer it was written for.
+        page_says_tiered: sb.offer_is_tiered ?? 'unknown',
+        note: noteText,
+      });
     }
 
     for (const key of ['value', 'spend_requirement', 'timeframe_months']) {
@@ -666,6 +698,21 @@ function detectChanges(card, extracted, now = new Date()) {
           new_value: sb.bonus_note,
         });
       }
+    }
+
+    // Retire a tier breakdown the live page no longer advertises. Without this
+    // the note outlives the offer it describes and re-arms the guard against
+    // the NEXT change (the Venture Business note had to be deleted by hand).
+    // Only fires when nothing above already proposed a note — the extractor's
+    // own bonus_note, when it supplies one, is the better replacement.
+    const noteAlreadyProposed = changes.some(c => c.field === 'signup_bonus.note');
+    if (
+      pageSaysFlat &&
+      !!tieredAdditionalMatch &&
+      !noteAlreadyProposed &&
+      !ignoreFields.has('signup_bonus.note')
+    ) {
+      changes.push({ field: 'signup_bonus.note', old_value: cur.note, new_value: null });
     }
   }
 
@@ -724,7 +771,10 @@ function applyChanges(allChanges, allCards) {
       } else if (field.startsWith('signup_bonus.')) {
         const subfield = field.split('.')[1];
         if (!parsedData.signup_bonus) parsedData.signup_bonus = {};
-        parsedData.signup_bonus[subfield] = new_value;
+        // new_value null means "retire this subfield" (a stale tier breakdown).
+        // Drop the key rather than dumping `note: null` into the YAML.
+        if (new_value === null) delete parsedData.signup_bonus[subfield];
+        else parsedData.signup_bonus[subfield] = new_value;
         yamlText = replaceYamlBlock(yamlText, 'signup_bonus', parsedData.signup_bonus);
         modified = true;
       } else if (field.startsWith('apr.')) {
@@ -750,6 +800,51 @@ function applyChanges(allChanges, allCards) {
   }
 
   return applied;
+}
+
+// Suppressed changes are the script's blind spot: a guard that swallows the same
+// proposal on every run looks exactly like a card whose terms never move. Print
+// them, and when running under Actions push them to the job summary too — a run
+// that finds no changes opens no PR, so stdout would be the only trace and it
+// ages out with the logs. `page_says_tiered` is the column to read: `true` means
+// the live page corroborates the stored tier breakdown and the suppression is
+// sound; `unknown` means the extractor couldn't tell and the skip rests on the
+// note alone, which is the case worth spot-checking. (`false` can't appear —
+// it disarms the guard rather than suppressing.)
+function reportSuppressions(suppressions) {
+  if (suppressions.length === 0) return;
+
+  console.log(`\n🔇 Suppressed ${suppressions.length} proposed change(s) as likely misparses:`);
+  for (const s of suppressions) {
+    console.log(`  - ${s.card_name} [${s.guard}] ${s.reason}`);
+    console.log(`      page_says_tiered=${s.page_says_tiered}`);
+  }
+  console.log('');
+
+  const stepSummary = process.env.GITHUB_STEP_SUMMARY;
+  if (!stepSummary) return;
+
+  const rows = suppressions
+    .map(s => `| ${s.card_name} | ${s.guard} | ${s.page_says_tiered} | ${s.reason} |`)
+    .join('\n');
+  const md = [
+    '## Suppressed changes',
+    '',
+    'These proposals were withheld as likely extraction misparses. `page_says_tiered = true`',
+    'means the live page still advertises the stored tier breakdown, so the skip is sound.',
+    '`unknown` means the extractor could not tell and the skip rests on the stored note alone —',
+    'worth spot-checking against the issuer page.',
+    '',
+    '| Card | Guard | page_says_tiered | Reason |',
+    '| --- | --- | --- | --- |',
+    rows,
+    '',
+  ].join('\n');
+  try {
+    fs.appendFileSync(stepSummary, md);
+  } catch (err) {
+    console.warn(`  Could not write job summary: ${err.message}`);
+  }
 }
 
 // ─── PR summary ───────────────────────────────────────────────────────────────
@@ -828,6 +923,7 @@ async function main() {
 
   const allChanges = [];
   const skippedCards = [];
+  const allSuppressions = [];
 
   const scriptDeadline = Date.now() + SCRIPT_TIMEOUT_MS;
 
@@ -908,7 +1004,7 @@ async function main() {
         }
 
         // Compare against YAML
-        const changes = detectChanges(card, extracted);
+        const changes = detectChanges(card, extracted, new Date(), allSuppressions);
         if (changes.length > 0) {
           console.log(`  ${changes.length} change(s) detected`);
           // Every detected change becomes a PR row a human must verify against
@@ -939,6 +1035,8 @@ async function main() {
     console.log('');
   }
 
+  reportSuppressions(allSuppressions);
+
   if (allChanges.length === 0) {
     console.log('No changes detected. Exiting.');
     if (fs.existsSync(SUMMARY_FILE)) fs.unlinkSync(SUMMARY_FILE);
@@ -968,4 +1066,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { detectChanges, needsBrowserRetry };
+module.exports = { detectChanges, applyChanges, needsBrowserRetry };

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -168,6 +168,120 @@ test('spend figures in the note are not mistaken for tier amounts', () => {
   assert.deepEqual(fieldsChanged(changes), ['signup_bonus.value']);
 });
 
+// ─── The live page overrules the stored note ────────────────────────────────
+
+// The residual hole after the expiry + tier-value narrowings: a tiered note with
+// NO end date whose replacement offer happens to equal a named tier. Hyatt's
+// 30k + 30k collapsing to a flat 30,000 is, by value alone, identical to the
+// base-tier misparse the guard exists to suppress. Only the page can settle it.
+
+console.log('\nLive page overrules the stored note (offer_is_tiered):');
+
+test('offer_is_tiered=false surfaces a change that lands exactly on a named tier', () => {
+  const changes = detectChanges(WORLD_OF_HYATT, {
+    signup_bonus: { value: 30000, spend_requirement: 3000, timeframe_months: 3, offer_is_tiered: false },
+  });
+  assert.deepEqual(fieldsChanged(changes), [
+    'signup_bonus.note',
+    'signup_bonus.spend_requirement',
+    'signup_bonus.timeframe_months',
+    'signup_bonus.value',
+  ]);
+});
+
+test('offer_is_tiered=false retires the stale tier breakdown (note → null)', () => {
+  const changes = detectChanges(WORLD_OF_HYATT, {
+    signup_bonus: { value: 30000, spend_requirement: 3000, timeframe_months: 3, offer_is_tiered: false },
+  });
+  const note = changes.find(c => c.field === 'signup_bonus.note');
+  assert.equal(note.new_value, null);
+  assert.equal(note.old_value, WORLD_OF_HYATT.data.signup_bonus.note);
+});
+
+test("offer_is_tiered=false prefers the extractor's replacement note over deletion", () => {
+  const changes = detectChanges(WORLD_OF_HYATT, {
+    signup_bonus: {
+      value: 30000,
+      spend_requirement: 3000,
+      timeframe_months: 3,
+      offer_is_tiered: false,
+      bonus_note: 'Plus $300 Bilt Cash as a signup bonus',
+    },
+  });
+  const note = changes.find(c => c.field === 'signup_bonus.note');
+  assert.equal(note.new_value, 'Plus $300 Bilt Cash as a signup bonus');
+});
+
+test('offer_is_tiered=true keeps the guard armed (the #1365/#1376 false positive)', () => {
+  const changes = detectChanges(WORLD_OF_HYATT, {
+    signup_bonus: { value: 60000, spend_requirement: 18000, timeframe_months: 6, offer_is_tiered: true },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('offer_is_tiered omitted (null) falls back to the note heuristics', () => {
+  // Unchanged behavior for a model that declines to judge: base-tier collapse
+  // still suppressed, and no note is retired.
+  const changes = detectChanges(WORLD_OF_HYATT, {
+    signup_bonus: { value: 30000, spend_requirement: 3000, timeframe_months: 3, offer_is_tiered: null },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('a flat page does not retire a note on a card whose note was never tiered', () => {
+  const card = {
+    data: {
+      name: 'Bilt',
+      signup_bonus: { value: 60000, type: 'points', spend_requirement: 3000, timeframe_months: 3, note: 'Plus $300 Bilt Cash as a signup bonus' },
+    },
+  };
+  const changes = detectChanges(card, {
+    signup_bonus: { value: 60000, spend_requirement: 3000, timeframe_months: 3, offer_is_tiered: false },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('check_ignore on signup_bonus.note blocks stale-note retirement', () => {
+  const ignored = {
+    data: { ...WORLD_OF_HYATT.data, check_ignore: ['signup_bonus.note'] },
+  };
+  const changes = detectChanges(ignored, {
+    signup_bonus: { value: 30000, spend_requirement: 3000, timeframe_months: 3, offer_is_tiered: false },
+  });
+  assert.ok(!fieldsChanged(changes).includes('signup_bonus.note'));
+  assert.ok(fieldsChanged(changes).includes('signup_bonus.value'));
+});
+
+// ─── Suppressions are recorded, never silent ────────────────────────────────
+
+console.log('\nSuppressions are recorded:');
+
+test('a suppressed tier collapse is appended to the suppressions out-param', () => {
+  const suppressions = [];
+  detectChanges(
+    WORLD_OF_HYATT,
+    { signup_bonus: { value: 30000, spend_requirement: 3000, timeframe_months: 3, offer_is_tiered: true } },
+    new Date('2026-07-08T00:00:00Z'),
+    suppressions
+  );
+  assert.equal(suppressions.length, 1);
+  assert.equal(suppressions[0].guard, 'tier-collapse');
+  assert.equal(suppressions[0].card_name, 'World of Hyatt');
+  assert.equal(suppressions[0].page_says_tiered, true);
+});
+
+test('a suppression with no page verdict records page_says_tiered=unknown', () => {
+  const suppressions = [];
+  detectChanges(DELTA_GOLD, { signup_bonus: { value: 70000 } }, new Date('2026-07-08T00:00:00Z'), suppressions);
+  assert.equal(suppressions[0].page_says_tiered, 'unknown');
+});
+
+test('a run with nothing suppressed records nothing', () => {
+  const suppressions = [];
+  detectChanges(WORLD_OF_HYATT, { signup_bonus: { value: 65000 } }, new Date(), suppressions);
+  assert.deepEqual(suppressions, []);
+});
+
 // ─── Legitimate changes must still surface ──────────────────────────────────
 
 console.log('\nLegitimate changes still surface:');


### PR DESCRIPTION
Follow-up to #1587. That PR fixed the Capital One Venture Business symptom; this one closes the class.

## The class of bug

The tiered-SUB guard validates **incoming page data against the stored note**. The note is the most stale-prone field in the record, so any offer change it doesn't anticipate is rejected — forever, and silently.

#1587 added two narrowings, both still note-derived:

- an expired `Offer ends` date disarms the guard
- tier collapse requires the proposed value to equal a tier the note names

Neither can see a replacement offer that carries **no end date** and **happens to land on a named tier**. World of Hyatt is exactly that shape: a drop from tiered 30k + 30k to a flat 30,000 is, by value alone, identical to the base-tier misparse the guard exists to catch. 7 of the 9 active tiered-note cards have no end date.

**Repetition can't break the tie.** The obvious instinct — "suppressed N runs in a row → escalate" — fails, because genuine misparses recur every run too. Hyatt's `15000 → 18000` came back on #1365 *and* #1376. A counter would escalate precisely the false positives the guard was built to hide.

## The fix: ask the page

The only discriminating evidence is the live page, so the extractor now returns `signup_bonus.offer_is_tiered`, describing the offer **as advertised today**:

| verdict | behavior |
| --- | --- |
| `false` | stored breakdown describes a dead offer → surface the change **and retire the note** |
| `true` | corroborated → suppress, as before |
| `null` | extractor declined to judge → fall back to the note heuristics (status quo) |

Retiring the note matters on its own: until someone deleted it by hand, a stale tier breakdown re-armed the guard against the *next* change. `applyChanges` now deletes a subfield when `new_value === null` rather than writing `note: null` (verified end-to-end: the key is dropped, sibling blocks untouched).

The `null` fallback is deliberate. If the model can't tell, we keep today's behavior rather than trading silent suppression for false-positive churn.

## Suppressions are no longer silent

The actual defect underneath all of this: **a guard that swallows the same proposal every run is indistinguishable from a card whose terms never move.** Suppressions were `console.log` only, and a run that suppresses everything opens no PR — so stdout was the sole trace, aging out with the Actions logs.

Every suppression is now recorded and reported to stdout and to the **Actions job summary**, with a `page_says_tiered` column. `true` = corroborated by the page. `unknown` = the skip rests on the stored note alone, and is worth spot-checking. (`false` can't appear; it disarms the guard instead.)

## Tests

`node scripts/check-card-pages.test.js` — 34 passing, 13 new:

- `offer_is_tiered=false` surfaces a change landing exactly on a named tier, and retires the note
- ...but prefers the extractor's replacement `bonus_note` over deletion when it supplies one
- `offer_is_tiered=true` keeps the guard armed (the #1365/#1376 false positive)
- `offer_is_tiered` null/omitted falls back to note heuristics
- a flat page does not retire a non-tiered note; `check_ignore` blocks retirement
- suppressions are appended with the right guard name and `page_says_tiered` value

Both regressions the guard exists for still suppress: World of Hyatt overlapping-spend and Delta Gold tier collapse.