### PR TITLE
fix(card-check): retry with the browser when a page hides only the SUB

### DIFF
--- a/.github/workflows/check-card-pages.yml
+++ b/.github/workflows/check-card-pages.yml
@@ -17,7 +17,10 @@ permissions:
 jobs:
   check-card-pages:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Must stay above SCRIPT_TIMEOUT_MS (30 min) in scripts/check-card-pages.js, with
+    # headroom for setup, the skip summary, and PR creation. If they were equal, the
+    # job would be hard-killed at the script's own deadline and never open the PR.
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -390,6 +390,26 @@ function isExtractionEmpty(extracted) {
   return true;
 }
 
+// isExtractionEmpty only catches a page that yielded NOTHING. A page can render
+// its annual fee server-side and its welcome offer client-side — Amex's Delta
+// business pages ship the fee in the HTML and leave "Welcome Offer & Key
+// Details … Loading" where the bonus belongs. The fee alone made the extraction
+// look non-empty, the browser retry never ran, and the extractor returned
+// value: 0 for the placeholder, proposing 90,000 → 0 on a card whose offer had
+// not moved (caught in review on PR #1589). value: 0 also slips past the
+// "a null never erases a real value" rule, since 0 is not null.
+//
+// So retry whenever the page gave us no signup-bonus signal for a card that
+// stores one. This deliberately does NOT suppress a zero — a card really can
+// lose its public offer (see the Amazon Store card, #1579). It only insists we
+// look at a fully rendered page before believing it.
+function needsBrowserRetry(extracted, currentSignupBonus) {
+  if (isExtractionEmpty(extracted)) return true;
+  if (!(currentSignupBonus?.value > 0)) return false;
+  const proposed = extracted.signup_bonus?.value;
+  return proposed == null || proposed === 0;
+}
+
 // Haiku occasionally returns the signup-bonus timeframe as a raw DAY count instead
 // of months (e.g. "180 days" → 180 rather than 6), which surfaced a bogus
 // timeframe_months: 180 on Wyndham Earner Business (#1426). No real welcome offer
@@ -841,10 +861,12 @@ async function main() {
         }
 
         // Self-heal: simple-fetch HTML can be 200 OK but missing JS-rendered
-        // bonus values (e.g. citi.com). Haiku then returns all-null, which the
-        // detector silently treats as "no changes". Retry once with the browser.
-        if (!usedBrowser && isExtractionEmpty(extracted)) {
-          console.log('  Extraction returned no signal — retrying with browser');
+        // bonus values (e.g. citi.com, Amex business pages). Haiku then returns
+        // nulls — or a 0 for a "Loading" placeholder — which the detector reads
+        // as "no changes" or, worse, as a real SUB going to zero. Retry once
+        // with the browser.
+        if (!usedBrowser && needsBrowserRetry(extracted, card.data.signup_bonus)) {
+          console.log('  Extraction returned no signup-bonus signal — retrying with browser');
           const browserContent = await fetchWithBrowser(apply_link);
           if (browserContent) {
             pageContent = browserContent;
@@ -924,4 +946,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { detectChanges };
+module.exports = { detectChanges, needsBrowserRetry };

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -21,7 +21,17 @@ const SUMMARY_FILE = path.join(__dirname, '..', '.card-page-check-summary.md');
 const FETCH_DELAY_MS = 2000;
 const FETCH_TIMEOUT_MS = 15000;
 const PER_CARD_TIMEOUT_MS = 60000;   // 60s max per card (fetch + extraction)
-const SCRIPT_TIMEOUT_MS = 20 * 60 * 1000; // 20 min overall safety net
+// Overall safety net. Widening the browser-retry condition (needsBrowserRetry)
+// makes every card whose welcome offer is client-side — most of the ~20 Amex
+// cards — pay one extra Playwright fetch (~13s measured) per run, roughly +4 min
+// on a run that already took ~14 min. Raised 20 → 30 min so that added work
+// doesn't silently truncate coverage.
+//
+// MUST stay comfortably below `timeout-minutes` in .github/workflows/check-card-pages.yml
+// (currently 45): the job needs headroom after this deadline to write the skip
+// summary and open the PR. If the two are equal, GitHub hard-kills the job and
+// the graceful exit path never runs.
+const SCRIPT_TIMEOUT_MS = 30 * 60 * 1000; // 30 min overall safety net
 // Max stripped page text handed to the extractor. Sized so nav-heavy issuer
 // pages still include the card terms — e.g. business.bankofamerica.com leads
 // with ~11k chars of menu chrome and the bonus/spend/timeframe land at ~12k–18k.
@@ -821,9 +831,21 @@ async function main() {
 
   const scriptDeadline = Date.now() + SCRIPT_TIMEOUT_MS;
 
-  for (const card of cardsToCheck) {
+  for (const [i, card] of cardsToCheck.entries()) {
     if (Date.now() > scriptDeadline) {
-      console.warn(`\nScript timeout reached (${SCRIPT_TIMEOUT_MS / 60000} min) — stopping early.`);
+      // Record the cards we never reached. Without this the loop just breaks and
+      // they vanish — absent from both the checked set and the end-of-run skip
+      // summary, so a truncated run is indistinguishable from a clean one.
+      const unreached = cardsToCheck.slice(i);
+      const mins = SCRIPT_TIMEOUT_MS / 60000;
+      console.warn(`\nScript timeout reached (${mins} min) — stopping early; ${unreached.length} card(s) never checked.`);
+      for (const c of unreached) {
+        skippedCards.push({
+          name: c.data.name,
+          url: checkUrlFor(c),
+          reason: `script timeout (${mins} min) reached before this card was checked`,
+        });
+      }
       break;
     }
 

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -12,7 +12,7 @@
 // Run: `node scripts/check-card-pages.test.js`. Exits non-zero on any failure.
 
 const assert = require('node:assert/strict');
-const { detectChanges } = require('./check-card-pages');
+const { detectChanges, needsBrowserRetry } = require('./check-card-pages');
 
 function test(name, fn) {
   try {
@@ -342,6 +342,50 @@ test('a normal months value (≤24) is left untouched', () => {
   });
   const ch = changes.find(c => c.field === 'signup_bonus.timeframe_months');
   assert.equal(ch.new_value, 4);
+});
+
+console.log('');
+// ─── Browser retry when the page hides the welcome offer ────────────────────
+
+// Amex's Delta business pages render the fee server-side and the welcome offer
+// client-side ("Welcome Offer & Key Details … Loading"). The fee made the
+// extraction look non-empty, so the browser retry never fired and the extractor
+// returned value: 0 for the placeholder — proposing 90,000 → 0 (caught on #1589).
+console.log('\nBrowser retry on a missing signup-bonus signal:');
+
+const HAS_SUB = { value: 90000, type: 'miles', spend_requirement: 6000, timeframe_months: 6 };
+
+test('fee extracted but bonus value 0 → retry (the Delta Gold Business case)', () => {
+  const extracted = { annual_fee: 150, signup_bonus: { value: 0, spend_requirement: null } };
+  assert.equal(needsBrowserRetry(extracted, HAS_SUB), true);
+});
+
+test('fee extracted but bonus value null → retry', () => {
+  const extracted = { annual_fee: 150, signup_bonus: { value: null } };
+  assert.equal(needsBrowserRetry(extracted, HAS_SUB), true);
+});
+
+test('a real bonus value → no retry', () => {
+  const extracted = { annual_fee: 150, signup_bonus: { value: 90000 } };
+  assert.equal(needsBrowserRetry(extracted, HAS_SUB), false);
+});
+
+test('a card that stores no bonus never triggers the bonus-signal retry', () => {
+  const extracted = { annual_fee: 95, signup_bonus: { value: null } };
+  assert.equal(needsBrowserRetry(extracted, undefined), false);
+  assert.equal(needsBrowserRetry(extracted, { value: 0 }), false);
+});
+
+test('a wholly empty extraction still retries (existing citi.com behavior)', () => {
+  assert.equal(needsBrowserRetry({ annual_fee: null, signup_bonus: { value: null } }, HAS_SUB), true);
+  assert.equal(needsBrowserRetry(null, undefined), true);
+});
+
+test('a browser-rendered zero is NOT suppressed downstream (Amazon Store, #1579)', () => {
+  // needsBrowserRetry only forces a second look; a genuine 0 must still surface.
+  const card = { data: { name: 'Amazon Store', signup_bonus: { value: 60, type: 'cash', note: null } } };
+  const changes = detectChanges(card, { signup_bonus: { value: 0 } });
+  assert.deepEqual(fieldsChanged(changes), ['signup_bonus.value']);
 });
 
 console.log('');


### PR DESCRIPTION
Found by reviewing today's full card-check run (#1589), which proposed `signup_bonus.value 90000 → 0` on Delta SkyMiles Gold Business — a card whose offer had not moved.

## What happened

Amex's Delta business pages render the annual fee server-side and the welcome offer client-side. The simple fetch captured:

> Delta SkyMiles Gold Business Card **Annual Fee:** \$0 intro annual fee for the first year, then \$150 … **Welcome Offer & Key Details** … Loading … Loading

Two protections should have caught this, and each missed by a hair:

1. `isExtractionEmpty()` only fires when a page yields **nothing**. `annual_fee: 150` extracted fine, so the extraction looked healthy and **the browser retry never ran**.
2. `detectChanges` refuses to let a `null` erase a real value. But the extractor read the `Loading` placeholder and returned **`0`**, and `0` is not `null`.

So a fully-rendered page was never fetched, and a live 90,000-mile SUB was proposed for deletion.

## Fix

Widen the retry condition from "the extraction is empty" to "the extraction has no signup-bonus signal for a card that stores one":

```js
function needsBrowserRetry(extracted, currentSignupBonus) {
  if (isExtractionEmpty(extracted)) return true;
  if (!(currentSignupBonus?.value > 0)) return false;
  const proposed = extracted.signup_bonus?.value;
  return proposed == null || proposed === 0;
}
```

**This does not suppress zeros.** A card really can lose its public offer, and per convention (`feedback_signup_bonus_public_offer`, Amazon Store #1579) that is recorded as `value: 0`. There is deliberately no blanket zero-suppressor here. The retry only insists we look at a *rendered* page before believing the offer is gone — if the browser fetch also shows no offer, the change surfaces exactly as before.

Cost: one extra Playwright fetch per affected card, on a path that already falls back to the browser.

## Tests

`node scripts/check-card-pages.test.js` — 27 passing, 6 new:

- fee extracted but bonus value `0` → retry (the Delta Gold Business case)
- fee extracted but bonus value `null` → retry
- a real bonus value → no retry
- a card storing no bonus never triggers the bonus-signal retry
- a wholly empty extraction still retries (existing citi.com behavior)
- a browser-rendered zero still surfaces downstream (Amazon Store, #1579)

## Related

- #1587 — expired end date / non-tier value no longer suppress a replaced offer (merged)
- #1588 — the live page overrules a stale tiered note; suppressions become visible
- #1589 — today's run; the bad Delta row is dropped there, the two IHG changes verified and kept