### PR TITLE
Update fallback affiliate CTA copy

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/StoreAffiliateCta.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/StoreAffiliateCta.tsx
@@ -25,7 +25,7 @@ export default function StoreAffiliateCta({
     affiliate.cta ??
     (affiliate.offer
       ? `See ${affiliate.offer} at ${storeName}`
-      : `Shop at ${storeName} with CreditOdds`);
+      : `See exclusive discounts at ${storeName}`);
 
   // Keep the arrow welded to the final word. Without this, a label that wraps
   // (narrow screens, long store names) can strand the arrow alone on its own

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -8736,14 +8736,14 @@
   margin: 0;
 }
 /* inline-block, not inline-flex: on narrow screens a long label like
-   "Shop at Banana Republic with CreditOdds" wraps, and as a flex item the
+   "See exclusive discounts at Banana Republic" wraps, and as a flex item the
    label box would stretch to the full line, stranding the arrow against the
    button's right edge. Letting the arrow flow inline keeps it welded to the
    last word at every width. */
 .landing-v2.store-v2 .store-affiliate-btn {
   display: inline-block;
   /* 0 1 auto, not `none`: the button must be allowed to shrink and wrap its
-     label, or a long one ("Shop at Extended Stay America with CreditOdds")
+     label, or a long one ("See exclusive discounts at Extended Stay America")
      pushes the panel past the viewport on mobile. */
   flex: 0 1 auto;
   position: relative;


### PR DESCRIPTION
## Summary
- change fallback affiliate CTA copy to “See exclusive discounts at [Store]”
- preserve custom CTA and merchant-offer labels
- update nearby wrapping documentation

## Testing
- `npx eslint 'src/app/best-card-for/[slug]/StoreAffiliateCta.tsx' --max-warnings=0`
- `git diff --check`