### PR TITLE
feat(best-card-for): show real merchant offers on affiliate buttons

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-09T12:13:40.495Z",
+  "generated_at": "2026-07-09T12:39:22.389Z",
   "count": 844,
   "stores": [
     {
@@ -16,7 +16,8 @@
       "intro": "1-800 Contacts is the largest direct-to-consumer retailer of contact lenses in the\nUnited States, shipping name-brand lenses from Acuvue, Bausch + Lomb, Alcon, and\nCooperVision straight to customers who upload a valid prescription. It also runs a\ntelehealth-style online eye exam and prescription renewal service in some states.\nThere is no 1-800 Contacts co-brand credit card, so the purchase simply codes as\nonline shopping. A flat-rate cashback card or one with an online shopping bonus\ncategory is the most reliable way to earn on orders, and FSA or HSA cards are\ncommonly accepted since lenses are an eligible medical expense.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.52869.1000000157&trid=1552713.158602&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off for new customers"
       }
     },
     {
@@ -42,7 +43,8 @@
       "intro": "1-800-PACK-RAT delivers portable storage containers to a customer's driveway for\ndo-it-yourself packing, then either picks the unit up for offsite storage or hauls\nit to a new address, competing with PODS and U-Haul in the moving and storage space.\nIt is owned by U-Haul's parent company but operates under its own brand and pricing.\nThere is no PACK-RAT credit card, and orders typically code as general online\nshopping or a moving service rather than a dedicated storage category, so a flat-rate\ncashback card or one with a broad online purchases bonus is the practical choice\nwhen booking a container rental online.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.15653.2015612&trid=1552713.243983&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off with code SPRING50"
       }
     },
     {
@@ -61,7 +63,8 @@
       "intro": "1-800-PetMeds is one of the oldest direct-to-consumer pet pharmacies in the country,\nshipping prescription medications, flea and tick preventives, and general pet health\nand wellness products for dogs and cats without requiring a trip to the vet or a\nlocal pharmacy counter. It works with a customer's veterinarian to verify prescriptions\nbefore fulfilling orders. There is no PetMeds co-brand card, so a card that bonuses\npet supplies purchases, or failing that a flat-rate cashback card, is the best way\nto earn on recurring medication and wellness orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9643.322259&trid=1552713.187444&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off your first order with code NEW40"
       }
     },
     {
@@ -106,7 +109,8 @@
       "intro": "5.11 Tactical makes durable pants, boots, packs, and outerwear built for law\nenforcement, military, and outdoor and range use, and it has grown into a broader\nworkwear and everyday-carry brand sold through its own stores and website. There is\nno 5.11 co-brand credit card, so a purchase simply codes as apparel or general online\nshopping. A card that bonuses online purchases, or a flat-rate cashback card, is the\nmost reliable way to earn rewards on gear ordered from the site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14180.3964608&trid=1552713.160494&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off clearance"
       }
     },
     {
@@ -124,7 +128,8 @@
       "intro": "7 For All Mankind is a premium denim label credited with helping popularize\nhigh-end designer jeans in the early 2000s, and it still sells jeans, jackets,\nand other apparel at a noticeable step up in price from mass-market denim brands.\nIt's owned by a larger apparel holding company alongside other fashion labels.\nThere is no 7 For All Mankind credit card, so orders code as apparel or general\nonline shopping. A card with an online shopping or department-store-style bonus\ncategory, or a flat-rate cashback card, is the best way to earn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36145.1010001182&trid=1552713.190539&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first purchase"
       }
     },
     {
@@ -239,7 +244,8 @@
       "intro": "Adam & Eve is a long-running direct-to-consumer retailer of adult products, sold\nthrough its own website and a chain of retail stores, with roots going back to\nthe 1970s as an early mail-order operation in the category. It ships discreetly\nand also runs frequent promotional and clearance sales online. There is no Adam\n& Eve credit card, so an order simply codes as general online shopping or retail.\nA flat-rate cashback card or one that bonuses online purchases is the practical\nway to earn rewards on the site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.6898.330062&trid=1552713.163415&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off with code BEMINE50"
       }
     },
     {
@@ -317,7 +323,8 @@
       "intro": "Aesop is an Australian skincare, haircare, and fragrance brand known for its\nminimalist amber-glass packaging and botanically formulated products, sold\nthrough standalone boutiques, department store counters, and its own website.\nL'Oreal acquired the brand in 2023. There is no Aesop credit card, so purchases\ncode as general online shopping or beauty retail depending on the merchant\ncategory assigned by the card network. A flat-rate cashback card or one that\nbonuses online shopping is the straightforward way to earn on an order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9664.622458&trid=1552713.234849&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -376,7 +383,8 @@
       "intro": "Airalo is an eSIM marketplace that sells prepaid mobile data plans for travelers,\nletting a phone connect to a local or regional carrier's network abroad without\nswapping a physical SIM card. It covers plans for well over 100 countries and is\ncommonly used as an alternative to international roaming fees. There is no Airalo\ncredit card, and eSIM purchases typically code as either travel or a phone or\ntelecom service depending on the issuer, so a card that bonuses travel purchases,\nor a flat-rate cashback card, is the reasonable choice when buying a plan.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.15608.2071037&trid=1552713.235201&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -482,7 +490,8 @@
       "intro": "Alice + Olivia is a New York contemporary fashion label known for playful, feminine\ndresses, separates, and accessories sold through its own boutiques, department\nstores, and website. Founder Stacey Bendet has kept the brand independent and\ndesign-led relative to larger fashion conglomerates. There is no Alice + Olivia\ncredit card, so an order codes as apparel or general online shopping. A card that\nbonuses online shopping or department-store purchases, or a flat-rate cashback\ncard, is the practical way to earn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46320.1000000420&trid=1552713.171105&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off"
       }
     },
     {
@@ -544,7 +553,8 @@
       "intro": "Alpha Industries is an American apparel maker best known for the MA-1 bomber\njacket, originally developed as a U.S. military flight jacket and now sold as a\nstreetwear and outerwear staple through its own stores and website. There is no\nAlpha Industries credit card, so an order codes as apparel or general online\nshopping. A card that bonuses online shopping or clothing purchases, or a\nflat-rate cashback card, is the practical way to earn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10348.694149&trid=1552713.160630&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off"
       }
     },
     {
@@ -694,7 +704,8 @@
       "intro": "American Tourister is a budget-friendly luggage and travel bag brand owned by\nSamsonite, selling hardside and softside suitcases, backpacks, and carry-ons\nthrough its own website, department stores, and travel retailers. It's positioned\nas the value option under the Samsonite umbrella. There is no American Tourister\ncredit card, so a purchase codes as apparel or general online shopping rather\nthan a travel category. A card that bonuses online shopping, or a flat-rate\ncashback card, is the straightforward way to earn on new luggage.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11773.3362296&trid=1552713.228756&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off clearance"
       }
     },
     {
@@ -749,7 +760,8 @@
       "intro": "Anastasia Beverly Hills is a cosmetics brand that built its name on brow products,\nincluding its widely copied brow pencils and kits, and has since expanded into a\nfull makeup line covering eyeshadow palettes, highlighters, and foundation. It\nsells through its own website as well as major beauty retailers like Sephora and\nUlta. There is no Anastasia Beverly Hills credit card, so a direct purchase codes\nas general online shopping. A card that bonuses online shopping, or a flat-rate\ncashback card, is the best way to earn on an order from the brand's own site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.52750.1000000259&trid=1552713.243843&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -767,7 +779,8 @@
       "intro": "Anker is a consumer electronics accessory brand best known for portable chargers,\npower banks, cables, and charging hardware, and it has since expanded into\nheadphones, smart home devices, and robot vacuums under sub-brands like Soundcore\nand eufy. It sells heavily through its own website as well as Amazon and major\nelectronics retailers. There is no Anker credit card, so a direct purchase codes\nas electronics or general online shopping. A card that bonuses electronics stores\nor online shopping, or a flat-rate cashback card, is the practical way to earn on\nan order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43469.1000000368&trid=1552713.201036&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -898,7 +911,8 @@
       "intro": "Ariat makes western and English riding boots, work boots, and equestrian-inspired\napparel, built around performance footwear technology adapted from athletic shoes\nand marketed to riders, ranchers, and outdoor workers. It sells through its own\nwebsite, specialty western and tack stores, and farm supply retailers. There is\nno Ariat credit card, so a direct purchase codes as apparel or general online\nshopping. A card that bonuses online shopping or clothing purchases, or a\nflat-rate cashback card, is the practical way to earn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10644.3947926&trid=1552713.240088&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "buy one get one 50% off"
       }
     },
     {
@@ -951,7 +965,8 @@
       "intro": "ASICS is a Japanese athletic footwear and apparel maker best known for its running\nshoe lines like the Gel-Kayano and Nimbus, and it has a loyal following among\nserious runners and gym-goers in addition to broad casual sneaker demand. The\ncompany also owns the Onitsuka Tiger fashion sneaker label. There is no ASICS\nco-brand credit card, so a purchase from asics.com codes as apparel, sporting\ngoods, or general online shopping depending on the card issuer's merchant coding.\nA flat-rate cashback card or one that bonuses online shopping is the safest bet.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.40996.1000000724&trid=1552713.180034&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off"
       }
     },
     {
@@ -973,7 +988,8 @@
       "intro": "Aspen Dental is a network of over 1,100 independently owned dental practices across the\nUnited States, offering general dentistry, dentures, and emergency care with same-day\nappointments at many locations. Each office is run by a local dentist, though the brand\nprovides shared branding and back-office support across the network. There's no Aspen\nDental co-brand credit card, so for the office visit or treatment charge itself, a general\nflat-rate cashback card or a card that earns bonus rewards on general or drugstore-adjacent\npurchases is the more useful strategy, since dental care doesn't map cleanly to a bonus\ncategory most issuers track.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.20979.3298152&trid=1552713.239908&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off"
       }
     },
     {
@@ -1076,7 +1092,8 @@
       "intro": "Autonomous is a direct-to-consumer furniture brand focused on ergonomic office setups,\nknown for standing desks, ergonomic chairs, and home-office accessories sold exclusively\nthrough its own online store. The company also markets desk accessories and robotics kits\nunder the same umbrella. There's no Autonomous co-brand credit card, so a furniture or\nhome-goods bonus category card is the best fit for larger desk and chair purchases, with a\ngeneral online shopping or flat-rate cashback card as the fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42643.1000000306&trid=1552713.193704&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 18% off"
       }
     },
     {
@@ -1116,7 +1133,8 @@
       "intro": "Avery is a longtime maker of labels, binders, name badges, and printable office and craft\nsupplies, sold both through its own site and through office supply retailers, mass\nmerchants, and craft stores nationwide. The brand is part of CCL Industries and is best\nknown for the label templates that ship standard with most word processors. There's no\nAvery co-brand credit card, so a card that earns bonus rewards on office supply store\npurchases is the natural fit when buying directly from avery.com, with a flat-rate\ncashback card as a solid alternative.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8547.483063&trid=1552713.190782&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code A25OFF1000"
       }
     },
     {
@@ -1152,7 +1170,8 @@
       "intro": "Away is a direct-to-consumer luggage brand known for its hard-shell suitcases with\nbuilt-in battery chargers, along with travel bags, packing accessories, and apparel sold\nthrough its own stores and website. The company grew out of the mid-2010s wave of\nInstagram-native travel brands and has since opened brick-and-mortar shops in several\nmajor cities. There's no Away co-brand credit card, so a general online shopping rewards\ncard or a card with strong travel-purchase protections, like baggage delay or purchase\ncoverage, is the most useful angle for a suitcase purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8621.615456&trid=1552713.233568&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -1178,7 +1197,8 @@
       "intro": "Babylist is an online baby registry and marketplace that lets expecting parents build a\nsingle universal registry pulling in products from any retailer, alongside its own\nBabylist Shop for gear, nursery items, and essentials. The platform has become one of the\nmost widely used registry tools in the U.S., expanding into health content and a Health\nbrand for insurance-covered breast pumps. There's no Babylist co-brand credit card, so\npurchases through the Babylist Shop are best routed through a general online shopping\nrewards card or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13580.1458037&trid=1552713.237794&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off"
       }
     },
     {
@@ -1207,7 +1227,8 @@
       "intro": "Banana Republic Factory is the outlet arm of Banana Republic, selling discounted apparel\nand accessories both through standalone outlet stores and its own website, with a mix of\nmainline overstock and outlet-specific designs. It operates as part of Gap Inc. alongside\nOld Navy, Athleta, and the mainline Banana Republic brand. There's no Banana Republic\nFactory co-brand credit card, since the Gap Inc. family's co-brand cards are tied to the\nGap Good Rewards program rather than the outlet banner specifically, so a select clothing\nor general online shopping rewards card is the better default for purchases here.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10152.3965949&trid=1552713.196751&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off select styles"
       }
     },
     {
@@ -1221,7 +1242,8 @@
       "intro": "Barefoot Dreams is a California loungewear brand best known for its CozyChic blanket and\ncardigan line, sold through its own boutiques, website, and select department stores and\nspecialty retailers. The brand built its reputation on plush, machine-washable throws that\nbecame a popular gift item well beyond its original loungewear niche. There's no Barefoot\nDreams co-brand credit card, so a select clothing or general online shopping rewards card\nis the most useful category to lean on when buying directly from the brand.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.20795.3952919&trid=1552713.237568&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off with code DREAM15"
       }
     },
     {
@@ -1308,7 +1330,8 @@
       "intro": "Beautyrest is a longstanding mattress brand under Serta Simmons Bedding, known for\npocketed-coil innerspring designs and, more recently, cooling and hybrid mattress lines\nsold online and through furniture and mattress retailers nationwide. It's one of the\noldest mattress brands in the U.S. market, with roots dating back over a century. There's\nno Beautyrest co-brand credit card, so a furniture store bonus category card is the\nstrongest fit for a mattress purchase, with a general online shopping or flat-rate\ncashback card as the alternative when buying direct from beautyrest.com.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10598.1938255&trid=1552713.248817&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -1342,7 +1365,8 @@
       "intro": "Benefit Cosmetics is a San Francisco founded beauty brand known for brow products,\nmascara, and a playful, pink-branded retail presence, sold through its own boutiques,\nwebsite, and major beauty retailers like Sephora and Ulta. The brand has been owned by\nLVMH since the early 1990s and remains one of the more recognizable names in prestige\ndrugstore-adjacent makeup. There's no Benefit Cosmetics co-brand credit card, so a card\nthat bonuses department store or general online shopping purchases is the better lever,\nand buying through a department store account can sometimes stack with that retailer's own\nloyalty program.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.24765.169441110001948&trid=1552713.169943&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -1571,7 +1595,8 @@
       "intro": "Blueair is a Swedish air purifier brand known for HEPASilent filtration technology, selling\nhome and office air purifiers and replacement filters through its own site, online\nmarketplaces, and electronics and home goods retailers. Unilever acquired the company in\n2021, folding it into its air and water treatment portfolio. There's no Blueair co-brand\ncredit card, so an electronics store bonus category card is the best fit for a purifier\npurchase, with a general online shopping or flat-rate cashback card as the fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16168.3107588&trid=1552713.243992&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -1624,7 +1649,8 @@
       "intro": "Bombas is a direct-to-consumer sock and apparel brand built on a one-for-one donation\nmodel, giving an item to homelessness relief organizations for every item purchased. The\ncompany has expanded from its original performance socks into underwear, t-shirts, and\nslippers, sold mainly through its own website with some retail partnerships. There's no\nBombas co-brand credit card, so a select clothing or general online shopping rewards card\nis the most useful category for purchases here.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8171.618217&trid=1552713.240202&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off your first purchase"
       }
     },
     {
@@ -1648,7 +1674,8 @@
       "intro": "Bonobos is a menswear brand best known for its fit-focused pants and its early Guideshop\nmodel, where customers try on sizes in a showroom and have orders shipped rather than\ncarrying inventory on site. Originally a Walmart-owned brand, Bonobos was sold to Express\nin 2023 and now sells through its own website and Express stores. There's no Bonobos\nco-brand credit card, so a select clothing or general online shopping rewards card is the\nbetter fit for purchases, though an Express store credit card, if applicable at checkout,\nmay offer its own separate rewards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11113.3963402&trid=1552713.248479&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off select styles"
       }
     },
     {
@@ -1686,7 +1713,8 @@
       "intro": "Bowflex is a home fitness equipment brand known for its resistance-rod strength machines\nand, more recently, connected bikes, treadmills, and adjustable dumbbells sold through its\nown site and major retailers. The brand was acquired out of its former parent Nautilus by\nJohnson Health Tech in 2022. There's no Bowflex co-brand credit card, so a general online\nshopping rewards card or a flat-rate cashback card is the practical choice, and given the\nprice point of most equipment, a card with purchase protection or an extended warranty\nbenefit is worth checking too.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25788.2161948&trid=1552713.159315&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off $400+ with code SAVE15"
       }
     },
     {
@@ -1716,7 +1744,8 @@
       "intro": "Brahmin is an American leather goods brand known for its embossed handbags, wallets, and\naccessories in signature reptile-textured patterns, made in a Massachusetts factory since\nthe 1980s. The line is sold direct online and through department stores and specialty\nboutiques. There's no Brahmin co-brand credit card, so a department-store rewards card is\nthe better fit when buying through a wholesale partner, and a general online shopping or\nflat-rate cashback card works best for direct orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39712.1000000416&trid=1552713.245806&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off orders over $250"
       }
     },
     {
@@ -1731,7 +1760,8 @@
       "intro": "Braun is a German consumer electronics brand best known for electric shavers, epilators,\nand small kitchen appliances like hand blenders, sold through its own site, mass\nretailers, and department stores. The company has been owned by Procter & Gamble since\n2005, sitting alongside grooming brands like Gillette in P&G's portfolio. There's no Braun\nco-brand credit card, so an electronics store bonus category card is the best fit for a\npurchase, with a general online shopping or flat-rate cashback card as the fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23589.3769635&trid=1552713.226436&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off first purchase with code SMOOTH15"
       }
     },
     {
@@ -1824,7 +1854,8 @@
       "intro": "Budget is one of the largest car rental brands in the U.S., positioned as the value option\nwithin Avis Budget Group alongside Avis and Payless, with airport and neighborhood\nlocations across the country and internationally. Its Fastbreak loyalty program lets\nfrequent renters skip the counter. There's no Budget co-brand credit card, so a card\nthat earns bonus rewards on car rentals or the broader travel category is the strongest\nfit, and many travel cards also add supplemental rental car insurance as a card benefit\nworth checking before declining the rental company's own coverage.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110100467.1100135418&trid=1552713.235827&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 35% off"
       }
     },
     {
@@ -1856,7 +1887,8 @@
       "intro": "Budget Truck Rental is the moving-truck division of Avis Budget Group, offering cargo\nvans and box trucks for local and one-way moves through a network of dealer locations\nacross the U.S. It operates separately from the Budget car rental brand, though it shares\nthe same corporate parent and branding. There's no Budget Truck Rental co-brand credit\ncard, so a card that bonuses car rentals or the general travel category is the closest\nfit, with a flat-rate cashback card as a reasonable fallback for a moving-truck charge.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101100538.1011107121&trid=1552713.235867&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off with code 20DIS"
       }
     },
     {
@@ -1886,7 +1918,8 @@
       "intro": "Buffy is a direct-to-consumer bedding brand known for comforters made from recycled\nplastic bottles and eucalyptus-fiber sheets, marketed around sustainability and sold\nalmost entirely through its own website. The company has expanded into pillows, throws,\nand other bedroom textiles since launching in 2018. There's no Buffy co-brand credit\ncard, so a card that bonuses home goods purchases or a general online shopping rewards\ncard is the most useful category to lean on here.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.28059.2836301&trid=1552713.214427&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off sale items"
       }
     },
     {
@@ -1922,7 +1955,8 @@
       "intro": "Bumble and Bumble is a professional-grade hair care and styling brand that got its start\nin a New York City salon in the 1970s, now owned by the Estee Lauder Companies and sold\nthrough its own site, in salons, and at specialty beauty retailers like Sephora and Ulta.\nThere is no Bumble and Bumble co-brand credit card, so shoppers buying shampoo, styling\nproducts, or tools online should lean on a card with a strong online shopping or general\nbeauty rewards category rather than looking for a store-specific option.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38785.1000001546&trid=1552713.179164&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 30% off"
       }
     },
     {
@@ -1960,7 +1994,8 @@
       "intro": "Bushnell is a long-running American optics brand known for binoculars, rifle scopes,\nlaser rangefinders, trail cameras, and golf rangefinders, popular with hunters, shooters,\nand golfers alike. It carries no co-brand credit card of its own, so the better play for\na Bushnell purchase is a sporting goods category card or a general online shopping\nrewards card, with a flat-rate cashback card as a reasonable fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.20977.1329725&trid=1552713.237984&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off sitewide"
       }
     },
     {
@@ -2000,7 +2035,8 @@
       "intro": "Caesars Rewards is the loyalty program spanning Caesars Entertainment's casino resorts,\nincluding Caesars Palace, Harrah's, Horseshoe, and Paris Las Vegas properties across the\nUS. Unlike most brands, Caesars does have a co-brand credit card lineup: the no-annual-fee\nCaesars Rewards Visa and the premium Caesars Rewards Prestige Visa Signature, both issued\nby Comenity/Bread Financial, which earn bonus Reward Credits on stays, dining, and\nentertainment at Caesars properties. Shoppers without one of those cards can still lean\non a general hotel or travel rewards card when booking a room.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.6145.3660150&trid=1552713.194743&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "33% off"
       }
     },
     {
@@ -2028,7 +2064,8 @@
       "intro": "Calvin Klein is a global fashion house under PVH Corp known for its underwear, denim, and\nready-to-wear lines, sold through its own stores and site as well as major department\nstores like Macy's. There is no Calvin Klein co-brand credit card, so a general online\nshopping or apparel rewards card is the right tool for a direct purchase, while a\ndepartment-store card can work well if you're buying through Macy's or a similar\nretailer instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43317.4611686018427577129&trid=1552713.188219&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "buy 1 get 1 50% off sitewide"
       }
     },
     {
@@ -2043,7 +2080,8 @@
       "intro": "Calzedonia is an Italian hosiery and swimwear retailer, part of the Calzedonia Group that\nalso owns Intimissimi and Tezenis, known for tights, leggings, and beachwear sold through\nboutiques across Europe and a US e-commerce site. It has no co-brand credit card, so\nshoppers ordering online should use a select-clothing or general online shopping rewards\ncard rather than looking for a store-specific option.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43180.1000000423&trid=1552713.199589&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off select styles"
       }
     },
     {
@@ -2211,7 +2249,8 @@
       "intro": "Cavender's is a Texas-based western wear retailer with stores across the South and\nSouthwest, selling boots, hats, jeans, and western apparel from brands like Ariat and\nWrangler alongside its own house lines. Cavender's does not offer a store credit card, so\na select-clothing or general online shopping rewards card is the better option for boots\nor apparel bought online or in one of its stores.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.36070.3856555&trid=1552713.246090&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -2266,7 +2305,8 @@
       "intro": "Charles & Keith is a Singapore-founded fashion label specializing in affordable-luxury\nshoes, handbags, and accessories, with a large footprint across Asia and the Middle East\nand a growing US e-commerce presence. The brand has no co-brand credit card in the US\nmarket, so shoppers buying shoes or bags through its site should rely on an online\nshopping rewards card or a select-clothing category card rather than a store-specific one.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13805.3939221&trid=1552713.194849&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off select styles"
       }
     },
     {
@@ -2542,7 +2582,8 @@
       "intro": "Cole Haan is an American footwear and accessories brand known for dress shoes, loafers,\nand its Grand series that blends dress styling with sneaker-like comfort technology, sold\nthrough its own stores, outlets, and site. It has no co-brand credit card, so a\nselect-clothing or general online shopping rewards card is the better fit for a Cole Haan\npurchase rather than a store-specific option.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.45770.1000000714&trid=1552713.196522&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off sale items"
       }
     },
     {
@@ -2583,7 +2624,8 @@
       "intro": "Corkcicle makes insulated drinkware, tumblers, wine chillers, and coolers designed to keep\ndrinks cold or hot for hours, sold through its own site as well as retailers like\nNordstrom and REI. There is no Corkcicle co-brand credit card, so a general online\nshopping rewards card, or a home goods category card if you have one, is the best way to\nearn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13045.3363020&trid=1552713.245365&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off sale items"
       }
     },
     {
@@ -2620,7 +2662,8 @@
       "intro": "COS, short for Collection of Style, is a contemporary fashion label under the H&M Group\nknown for minimalist, architecturally cut clothing and accessories for men and women,\nsold through standalone stores and its own e-commerce site. COS has no co-brand credit\ncard, so shoppers should default to a select-clothing or general online shopping rewards\ncard at checkout, since neither a department-store nor apparel-specific card exists\nfor the brand.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42840.1000000776&trid=1552713.227732&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off your first order"
       }
     },
     {
@@ -2634,7 +2677,8 @@
       "intro": "Cosori is a consumer kitchen appliance brand best known for its air fryers, along with\nblenders, kettles, and other small countertop appliances, sold heavily through Amazon as\nwell as its own site. It carries no co-brand credit card, so an electronics category card\nor a general online shopping rewards card is the right choice for a Cosori purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.41709.3818110&trid=1552713.245911&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off sitewide"
       }
     },
     {
@@ -2854,7 +2898,8 @@
       "intro": "David's Bridal is one of the largest wedding retailers in the United States, selling\nbridal gowns, bridesmaid dresses, prom wear, and wedding accessories through hundreds of\nstores and its online catalog. The chain has gone through multiple bankruptcy\nreorganizations in recent years but continues operating as a go-to option for\nbudget-conscious wedding parties. There's no David's Bridal co-brand credit card, so\nshoppers outfitting a wedding party should reach for a card that earns well on clothing\nor general online shopping purchases, since a single order can easily run into four\nfigures once alterations and accessories are included.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.52798.1000000070&trid=1552713.235285&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off"
       }
     },
     {
@@ -2890,7 +2935,8 @@
       "intro": "DeLonghi is an Italian appliance maker best known in the U.S. for espresso and coffee\nmachines, along with air fryers, heaters, and small kitchen appliances sold through its\nown site, Amazon, and major retailers like Williams Sonoma and Best Buy. The brand\npositions itself at the premium end of home espresso equipment, competing with names like\nBreville and Jura. There's no DeLonghi co-brand credit card, so a purchase direct from\ndelonghi.com is best charged to a card that earns a bonus on home goods or general online\nshopping, or simply a strong flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.33739.2287345&trid=1552713.232052&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off your first order"
       }
     },
     {
@@ -2906,7 +2952,8 @@
       "intro": "Delsey Paris is a French luggage maker dating back to 1946, known for hardside spinner\nsuitcases, packing cubes, and travel accessories sold through department stores,\nspecialty luggage retailers, and its own site. There is no Delsey co-brand credit card,\nso shoppers buying luggage should use a general online shopping rewards card, or a travel\ncard if they'd rather earn points toward their next trip instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.36622.3294033&trid=1552713.234891&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off with code TRAVEL20"
       }
     },
     {
@@ -2951,7 +2998,8 @@
       "intro": "Dermalogica is a professional-grade skincare brand founded in Los Angeles and long\nassociated with spas and licensed estheticians before expanding into direct-to-consumer\nsales online. Its product lines focus on cleansers, serums, and treatments built around\ningredient-driven formulas rather than mass-market drugstore positioning. There's no\nDermalogica co-brand credit card, so shoppers buying direct from dermalogica.com should\nlean on a card that earns a solid rate on online shopping purchases or a flat-rate\ncashback card, since the brand doesn't run its own store-branded financing or rewards\nprogram.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.40620.1000000137&trid=1552713.226144&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 30% off"
       }
     },
     {
@@ -2968,7 +3016,8 @@
       "intro": "Dermstore is an online beauty and skincare retailer that curates dermatologist-recommended\nand prestige skincare brands, from SkinCeuticals and Obagi to smaller clinical labels that\naren't always available at mainstream beauty retailers. It's owned by Target Corporation\nbut operates as a standalone online storefront rather than being sold in Target stores.\nThere's no Dermstore co-brand credit card, so shoppers should use a card that earns well on\nonline shopping purchases or a flat-rate cashback card when checking out, since Dermstore\nitself doesn't offer branded financing.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53945.1000000106&trid=1552713.209693&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -3003,7 +3052,8 @@
       "intro": "DHgate is a Chinese business-to-business and business-to-consumer marketplace that connects\nU.S. shoppers directly with manufacturers and wholesalers across categories like electronics,\napparel, home goods, and gadgets, similar in spirit to AliExpress or Alibaba's consumer arm.\nPrices tend to be low and shipping times longer since most goods ship from overseas sellers.\nThere's no DHgate co-brand credit card, so the best approach is a card that earns a solid\nflat rate or bonus category on general online shopping, since purchases typically code as\na marketplace or general merchandise transaction rather than a specific retail category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12108.1466364&trid=1552713.243958&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 80% off"
       }
     },
     {
@@ -3021,7 +3071,8 @@
       "intro": "Diane von Furstenberg is an American fashion house best known for the wrap dress it\npopularized in the 1970s, now selling ready-to-wear, accessories, and footwear through its\nown boutiques, DVF.com, and department stores like Nordstrom and Bloomingdale's. The brand\nremains privately held and is closely tied to its founder and namesake designer. There's no\nDVF co-brand credit card, so shoppers buying direct should use a card that earns well on\nclothing or general online shopping purchases, or lean on a department-store card if the\npurchase runs through Nordstrom or a similar retail partner instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156174.53601.1000000014&trid=1552713.230273&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -3053,7 +3104,8 @@
       "intro": "Dickies is a workwear brand dating back to 1922, known for durable work pants, coveralls,\nand jackets that have also become a streetwear staple well beyond its original job site\naudience. It's owned by VF Corporation and sells through its own site, Amazon, and retailers\nlike Zappos and Tractor Supply alongside dedicated Dickies stores. There's no Dickies\nco-brand credit card, so a purchase at dickies.com is best charged to a card that earns\nwell on clothing or general online shopping, or a flat-rate cashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25209.2029313&trid=1552713.230392&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off for new customers"
       }
     },
     {
@@ -3072,7 +3124,8 @@
       "intro": "Diesel is an Italian fashion brand best known for premium denim, along with apparel,\nfootwear, and accessories sold through its own boutiques, Diesel.com, and department\nstores. It's part of the OTB Group, the same holding company behind Maison Margiela and\nMarni. There's no Diesel co-brand credit card, so shoppers buying jeans or apparel direct\nfrom the brand should use a card that earns a strong rate on clothing or general online\nshopping purchases, since Diesel itself doesn't extend its own store financing or rewards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.49384.1000000078&trid=1552713.232396&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -3089,7 +3142,8 @@
       "intro": "DIFF Eyewear is a direct-to-consumer sunglasses and optical brand built around a one-for-one\ngiving model, where each pair purchased helps fund a pair of prescription glasses or eye\ncare for someone in need through partner nonprofits. It sells trend-forward, affordably\npriced frames online and through select retail partners rather than running its own\nphysical storefronts. There's no DIFF Eyewear co-brand credit card, so shoppers should lean\non a card that rewards general online shopping purchases or a flat-rate cashback card when\nbuying frames directly from the brand's website.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9933.288188&trid=1552713.211526&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off your next order"
       }
     },
     {
@@ -3117,7 +3171,8 @@
       "intro": "Dinnerly is a budget-focused meal kit delivery service operated by Marley Spoon, positioned\nas a lower-cost alternative to HelloFresh or Blue Apron by trimming packaging and recipe\ncomplexity to keep per-serving prices down. Subscribers pick weekly recipes online and\nreceive pre-portioned ingredients by mail. There's no Dinnerly co-brand credit card, so the\nweekly or monthly charge is best routed through a card that earns a bonus on dining or\nonline grocery-adjacent purchases, since meal kit charges typically code closer to food\ndelivery than standard retail.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.10033.3840387&trid=1552713.195361&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to $185 off your first 5 boxes"
       }
     },
     {
@@ -3242,7 +3297,8 @@
       "intro": "Dooney & Bourke is an American leather goods maker founded in 1975, known for handbags,\nwallets, and accessories sold through its own stores and website as well as department\nstores like Macy's and Nordstrom, and outlet locations. The brand sits in the accessible\nluxury tier, priced above mass-market handbag brands but below European designer houses.\nThere's no Dooney & Bourke co-brand credit card, so a direct purchase is best charged to a\ncard that earns well on online shopping, while purchases made through a department store\ncan also benefit from that retailer's own category bonus.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.6652.625287&trid=1552713.162489&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off clearance"
       }
     },
     {
@@ -3272,7 +3328,8 @@
       "intro": "Dorothy Perkins is a British women's fashion brand selling affordable everyday clothing,\nfrom workwear to occasionwear, primarily through its online store after the closure of its\nUK high street locations. It now operates as an online-only retailer shipping to customers\nin the UK and select international markets including the U.S. There's no Dorothy Perkins\nco-brand credit card, so shoppers ordering from the site should rely on a card that earns\nwell on general online shopping and, if applicable, one with favorable foreign transaction\nterms since charges may process through a UK-based merchant account.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.1134.3978513&trid=1552713.232050&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 75% off"
       }
     },
     {
@@ -3290,7 +3347,8 @@
       "intro": "Dr. Scholl's is a long-running American footwear and foot care brand, historically known\nfor insoles and foot health products and now selling its own line of comfort-focused shoes\nand sandals direct-to-consumer online as well as through department stores and shoe\nretailers. The foot care side of the brand, including insoles and callus treatments, is\nlicensed separately and sold mainly in drugstores. There's no Dr. Scholl's co-brand credit\ncard, so a shoe purchase at drschollsshoes.com is best charged to a card that earns well on\nfootwear or general online shopping purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9749.620939&trid=1552713.235857&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 20% off"
       }
     },
     {
@@ -3316,7 +3374,8 @@
       "intro": "Drunk Elephant is a skincare brand built around a \"clean\" formulation philosophy that\navoids ingredients like essential oils, silicones, and certain fragrances, popular with a\nyounger, social-media-driven audience. It's owned by Shiseido but sells direct through its\nown website as well as Sephora and Ulta. There's no Drunk Elephant co-brand credit card, so\na purchase made directly on the brand's site is best charged to a card that earns well on\nonline shopping, while a Sephora or Ulta purchase can instead take advantage of that\nretailer's own beauty rewards program.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.10029.623157&trid=1552713.232403&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off"
       }
     },
     {
@@ -3409,7 +3468,8 @@
       "intro": "Eagle Creek is a travel gear brand best known for packing cubes, duffels, and rugged\nbackpacks aimed at frequent and adventure travelers, sold direct online as well as through\noutdoor and luggage retailers. The brand went through a bankruptcy closure in 2020 before\nbeing relaunched under new ownership. There's no Eagle Creek co-brand credit card, so\nshoppers stocking up on packing gear should use a card that earns well on general online\nshopping, or consider a travel-focused card since the purchases directly support upcoming\ntrips even if they don't code as a travel merchant.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.31713.1398401&trid=1552713.239618&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -3457,7 +3517,8 @@
       "intro": "ECCO is a Danish footwear company known for comfort-engineered leather shoes and boots,\nmanufactured largely through its own tanneries rather than outsourced production, which is\nunusual for a shoe brand at its scale. It sells through its own retail stores, ecco.com,\nand department stores and shoe retailers worldwide. There's no ECCO co-brand credit card,\nso a direct purchase from ecco.com is best charged to a card that earns a bonus on\nfootwear or general online shopping purchases, or a flat-rate cashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39558.1000002653&trid=1552713.180375&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off $250+ with code ECCODEAL"
       }
     },
     {
@@ -3514,7 +3575,8 @@
       "intro": "Eileen Fisher is an American women's clothing brand known for minimalist, relaxed-fit\npieces made from natural fibers like organic cotton, linen, and wool, sold through its own\nboutiques, website, and select department stores. The company has also built a reputation\naround sustainability, including a take-back and resale program for used garments. There's\nno Eileen Fisher co-brand credit card, so a purchase direct from eileenfisher.com is best\ncharged to a card that earns well on clothing or general online shopping purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42820.1000000372&trid=1552713.213376&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first purchase"
       }
     },
     {
@@ -3610,7 +3672,8 @@
       "intro": "Estee Lauder is the flagship prestige beauty brand of The Estee Lauder Companies, selling\nskincare, makeup, and fragrance through department stores, its own boutiques, and its\ndirect-to-consumer website, alongside sister brands like Clinique, MAC, and Bobbi Brown\nunder the same corporate umbrella. There's no Estee Lauder co-brand credit card, so a\npurchase direct from esteelauder.com is best charged to a card that earns well on general\nonline shopping, while a department store purchase can instead lean on that store's own\ncategory bonus if one applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36314.1010001823&trid=1552713.186487&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -3821,7 +3884,8 @@
       "intro": "Farberware is a longtime American cookware and small kitchen appliance brand, known for\nstainless steel and nonstick pots, pans, bakeware, and countertop gadgets sold through its\nown site and major housewares retailers. The brand dates back over a century and today\noperates under license by different manufacturers depending on the product line. There is\nno Farberware co-brand credit card, so a shopper buying cookware there is best served by a\ncard that bonuses home goods or department-store purchases, or a flat-rate cashback card\nif no specialized category applies to the specific charge.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11993.3959083&trid=1552713.239550&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -3868,7 +3932,8 @@
       "intro": "Fenty Beauty is the cosmetics line founded by Rihanna in 2017, widely credited with\npushing the beauty industry toward broader foundation shade ranges and now sold both\ndirect-to-consumer and through retailers like Sephora. It operates under LVMH's Kendo\nBrands portfolio. There is no Fenty Beauty co-brand credit card, so shoppers should lean\non a card that earns bonus rewards on online shopping or drugstore-adjacent beauty\npurchases, or a flat-rate cashback card, and remember that buying through Sephora instead\nof fentybeauty.com may open up Sephora-specific card benefits.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42834.1000001431&trid=1552713.214878&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -3941,7 +4006,8 @@
       "intro": "FitFlop is a British footwear brand built around biomechanically engineered midsoles meant\nto add cushioning and comfort to sandals, sneakers, and everyday shoes, positioning itself\nbetween a fashion label and a comfort-orthotic brand. It sells through its own site as well\nas department stores and specialty shoe retailers in the U.S. There is no FitFlop co-brand\ncredit card, so a shopper buying shoes there should reach for a card that rewards select\nclothing or online shopping purchases, or a flat-rate cashback card if footwear isn't a\nbonused category on their card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41223.1000001291&trid=1552713.179233&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -4009,7 +4075,8 @@
       "intro": "Florsheim is a heritage American men's shoe brand dating to 1892, known for dress shoes,\nboots, and casual leather footwear sold through its own stores, department stores, and\nonline. The brand has changed ownership several times over its history and today competes\nin the same lane as brands like Johnston & Murphy and Cole Haan. There is no Florsheim\nco-brand credit card, so a shopper buying shoes there should use a card that bonuses\nselect clothing or department-store spend, or a flat-rate cashback card if footwear isn't\na specialized reward category on their card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.3382.119544810000835&trid=1552713.462&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off select styles"
       }
     },
     {
@@ -4162,7 +4229,8 @@
       "intro": "Furla is an Italian leather goods house founded in Bologna in 1927, best known for\nstructured handbags along with wallets, small leather goods, and accessories sold through\nits own boutiques and department stores worldwide. It sits in the accessible-luxury tier,\npriced below houses like Prada or Gucci but above mass-market handbag brands. There is no\nFurla co-brand credit card, so a purchase there is best matched to a premium travel or\ngeneral rewards card that bonuses online or department-store shopping, or a flat-rate\ncashback card for simplicity on a luxury accessory purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101105919.1011116822&trid=1552713.226358&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off"
       }
     },
     {
@@ -4198,7 +4266,8 @@
       "intro": "Gametime is a mobile-first ticket marketplace for sports, concerts, and live events,\nbuilt around a same-day, last-minute buying experience with a countdown-style interface\nshowing how ticket prices trend as an event approaches. It's a resale and secondary\nmarketplace in the same space as SeatGeek, Vivid Seats, and StubHub rather than a primary\nbox office. There is no Gametime co-brand credit card, so ticket purchases there are best\nmatched to a card that bonuses entertainment spend, or a broad travel or dining rewards\ncard if entertainment isn't a defined category on the cardholder's cards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10874.1443269&trid=1552713.214076&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off"
       }
     },
     {
@@ -4266,7 +4335,8 @@
       "intro": "ghd is a British hair-styling brand best known for its ceramic flat irons and curling\nwands, positioned at the premium end of the hair-tools market and sold direct online as\nwell as through salons and beauty retailers. The name is short for \"good hair day,\" the\ncompany's original tagline. There's no ghd co-brand credit card, so a general online\nshopping rewards card or a flat-rate cashback card is the practical way to earn rewards on\nstyling tool purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.8033.3960327&trid=1552713.178100&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off sitewide"
       }
     },
     {
@@ -4306,7 +4376,8 @@
       "intro": "Gilt is a flash-sale e-commerce site that built its name on time-limited discounts on\ndesigner clothing, accessories, and home goods, with a companion Gilt City arm that sold\nlocal deals on dining, spa, and entertainment experiences in major metro areas. It was one\nof the pioneers of the members-only flash-sale model in the 2010s before being absorbed\ninto Rue La La's parent company. There is no Gilt co-brand credit card, so shoppers there\nshould rely on a card that bonuses online shopping or department-store purchases, or a\nflat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.1000009372.1100147967&trid=1552713.158309&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "80% off"
       }
     },
     {
@@ -4348,7 +4419,8 @@
       "intro": "GNC is one of the largest specialty retailers of vitamins, supplements, sports nutrition,\nand protein products in the U.S., operating both physical mall and strip-center stores and\nan active e-commerce business, alongside a GNC-branded product line manufactured\nin-house. There is no GNC co-brand credit card, so shoppers there should default to a card\nthat earns bonus rewards on online or general retail shopping, or a flat-rate cashback\ncard, since supplement purchases don't fall under drugstore or grocery bonus categories on\nmost issuers' charts even though GNC sells health products.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53638.1000000515&trid=1552713.162841&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "buy one get one 50% off vitamins"
       }
     },
     {
@@ -4370,7 +4442,8 @@
       "intro": "Godiva is a Belgian chocolatier founded in Brussels in 1926, known for premium truffles,\ngift boxes, and seasonal chocolate assortments sold through its own boutiques, online\nstore, and gifting partnerships. The brand has changed hands several times, most recently\nsplitting its North American retail business from its international operations. There is\nno Godiva co-brand credit card, so a gift or chocolate purchase there is best matched to a\ncard that bonuses online shopping or general retail, or a dining category card if the\npurchase codes as food and beverage.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101106374.111034562&trid=1552713.159640&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order with code WELCOME15"
       }
     },
     {
@@ -4386,7 +4459,8 @@
       "intro": "Going, formerly known as Scott's Cheap Flights, is a subscription service that alerts\nmembers to discounted and mistake-fare airfares out of their home airports, curated by a\nteam of flight-deal analysts rather than a booking engine itself. Members typically book\nthe flagged fares directly with the airline once alerted. There is no Going co-brand\ncredit card since it isn't a travel bookings site in the traditional sense, so a\nsubscription payment or any related travel booking is best matched to a travel rewards\ncard or a card that bonuses travel purchases broadly.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10802.731100&trid=1552713.237685&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 90% off"
       }
     },
     {
@@ -4400,7 +4474,8 @@
       "intro": "Goldbelly is an online marketplace that ships iconic regional foods nationwide, from\nChicago deep-dish pizza to Katz's Deli pastrami and small-batch bakery goods, letting\nshoppers order famous local restaurants and shops as packaged gifts or personal orders.\nIt functions as a food gifting and delivery platform rather than a single restaurant.\nThere is no Goldbelly co-brand credit card, so an order there is best matched to a card\nthat bonuses dining or online shopping purchases, or a flat-rate cashback card if neither\ncategory is a strong fit on the cardholder's cards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13451.3881759&trid=1552713.215607&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off"
       }
     },
     {
@@ -4447,7 +4522,8 @@
       "intro": "Govee makes smart-home lighting and consumer electronics, including LED strip lights,\nsmart bulbs, RGBIC ambiance lighting, and small appliances like ice makers and air\npurifiers, sold primarily through its own site, Amazon, and other online marketplaces.\nThe brand has built a following among gamers and home-decor enthusiasts for affordable,\napp-controlled lighting setups. There is no Govee co-brand credit card, so a purchase\nthere is best paired with a card that bonuses electronics or online shopping, or a\nflat-rate cashback card if no specialty category applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12845.2840658&trid=1552713.224344&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "60% off"
       }
     },
     {
@@ -4507,7 +4583,8 @@
       "intro": "Grove Collaborative is an online marketplace focused on natural and sustainable household\nand personal care products, selling cleaning supplies, paper goods, and beauty items\nthrough both one-time orders and a recurring subscription model, along with its own\nGrove-branded product lines. The company has publicly emphasized plastic-free packaging\nand carbon-neutral shipping goals. There is no Grove Collaborative co-brand credit card,\nso a purchase there is best matched to a card that bonuses online shopping or general\nretail, or a flat-rate cashback card for household staples.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.8442.2825761&trid=1552713.201205&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off your first order with code WELCOME"
       }
     },
     {
@@ -4538,7 +4615,8 @@
       "intro": "Guess is a Los Angeles-founded denim and fashion label built around a distinctive black\nand white advertising aesthetic, selling jeans, apparel, handbags, watches, and\naccessories through its own stores, guess.com, and a large wholesale presence at\ndepartment stores like Macy's and Nordstrom. There is no Guess co-brand credit card, so\nshoppers checking out online should lean on a card that pays bonus rewards on online\nshopping or general merchandise, and department-store purchases can be routed through a\ncard that rewards spending at Macy's or similar retailers. A flat-rate cashback card\nis a reasonable fallback if you don't want to track category bonuses.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9298.616619&trid=1552713.158989&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off $250+ with code GET30OFF"
       }
     },
     {
@@ -4564,7 +4642,8 @@
       "intro": "Gymboree is a children's clothing brand known for colorful, play-focused apparel for\nbabies and kids, sold primarily through gymboree.com after the retailer's brick and\nmortar stores wound down and its assets were relaunched under new ownership. There is\nno Gymboree co-brand credit card, so the best approach is a card that earns bonus\nrewards on general online shopping or department-store-style purchases, since kids'\napparel does not have its own dedicated card category. A flat-rate cashback card also\nworks well for occasional purchases like these.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10756.2013600&trid=1552713.214444&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "80% off clearance"
       }
     },
     {
@@ -4626,7 +4705,8 @@
       "intro": "Hanes is a longstanding American basics brand selling t-shirts, underwear, socks, and\nloungewear for men, women, and kids, part of apparel conglomerate Hanesbrands alongside\nlabels like Champion and Bali. The brand sells directly through hanes.com in addition\nto wide distribution at mass retailers and department stores. There is no Hanes\nco-brand credit card, so a purchase at hanes.com is best routed through a card that\nearns bonus rewards on general online shopping, or a flat-rate cashback card if you'd\nrather not track categories.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.24366.1010005156&trid=1552713.166211&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off select styles"
       }
     },
     {
@@ -4640,7 +4720,8 @@
       "intro": "Hanna Andersson is a Portland, Oregon-founded children's clothing brand best known for\nsoft, durable cotton basics and its matching family pajama sets, sold through\nhannaandersson.com and a small number of retail stores. There is no Hanna Andersson\nco-brand credit card, so the best way to earn on a purchase is a card that pays bonus\nrewards on general online shopping, since kids' apparel doesn't have its own dedicated\nreward category. A flat-rate cashback card is a solid fallback for occasional orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5644.2692567&trid=1552713.181293&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off for new customers"
       }
     },
     {
@@ -4789,7 +4870,8 @@
       "intro": "Hey Dude is a casual, lightweight footwear brand known for its slip-on shoes and\neveryday comfort styling, acquired by Crocs Inc in 2022 to complement the flagship\nCrocs brand. Shoes are sold through heydude.com along with department stores and\nfootwear retailers. There is no Hey Dude co-brand credit card, so shoppers ordering\ndirect should use a card that earns bonus rewards on general online shopping, or a\nflat-rate cashback card if simplicity matters more than chasing categories.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16269.1358297&trid=1552713.227887&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off select styles"
       }
     },
     {
@@ -4835,7 +4917,8 @@
       "intro": "Hill's Pet Nutrition makes Science Diet and Prescription Diet pet food, a veterinarian-\nrecommended line of dog and cat food owned by Colgate-Palmolive, sold direct at\nhillspet.com as well as through vet clinics, pet retailers, and online marketplaces.\nThere is no Hill's co-brand credit card, so a direct order is best charged to a card\nthat earns bonus rewards on pet supplies or general online shopping, or a flat-rate\ncashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53370.1000000017&trid=1552713.243039&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off your first order with code SUMMER40"
       }
     },
     {
@@ -4974,7 +5057,8 @@
       "intro": "HoMedics is a personal wellness brand selling massagers, humidifiers, air purifiers,\nsound machines, and small health and comfort devices for the home, sold through\nhomedics.com and widely at mass retailers and drugstores. There is no HoMedics\nco-brand credit card, so a direct order is best charged to a card that earns bonus\nrewards on general online shopping or electronics-type purchases, or a flat-rate\ncashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11735.1101069&trid=1552713.239601&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off"
       }
     },
     {
@@ -5091,7 +5175,8 @@
       "intro": "Hugo Boss is a German luxury fashion house selling tailored menswear, women's\nready-to-wear, and accessories under its BOSS and HUGO lines, distributed through its\nown stores, hugoboss.com, and department stores like Nordstrom and Saks. There is no\nHugo Boss co-brand credit card, so shoppers ordering online should lean on a card that\nearns bonus rewards on online shopping, while in-store purchases at a partner\ndepartment store can sometimes route through a store-specific card. A premium travel\nor flat-rate cashback card also works well for higher-ticket purchases like these.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39079.1000000422&trid=1552713.160207&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off sale items"
       }
     },
     {
@@ -5120,7 +5205,8 @@
       "intro": "Hungryroot is a personalized grocery and recipe delivery service that ships a mix of\nfresh produce, proteins, and pantry staples along with quick recipes tailored to a\ncustomer's food preferences, functioning as a hybrid between a meal kit and an online\ngrocery order. There is no Hungryroot co-brand credit card, so a subscription is best\ncharged to a card that earns bonus rewards on dining or groceries, or a flat-rate\ncashback card if your card's category definitions don't clearly cover grocery delivery\nservices.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53058.1000000002&trid=1552713.201413&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off orders $99+"
       }
     },
     {
@@ -5172,7 +5258,8 @@
       "intro": "Hydro Flask is an Oregon-founded brand of insulated stainless steel water bottles and\ndrinkware popular with hikers, campers, and everyday users, now owned by consumer\nproducts company Helen of Troy. Bottles and accessories are sold direct at\nhydroflask.com as well as through outdoor and sporting goods retailers. There is no\nHydro Flask co-brand credit card, so a direct order is best charged to a card that\nearns bonus rewards on sporting goods or general online shopping, or a flat-rate\ncashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18825.1922057&trid=1552713.202999&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -5206,7 +5293,8 @@
       "intro": "Igloo is a longtime American brand of hard and soft-sided coolers, ice chests, and\ndrinkware built for camping, tailgating, and everyday outdoor use, sold direct at\nigloocoolers.com and widely through sporting goods and general merchandise retailers.\nThere is no Igloo co-brand credit card, so a direct order is best charged to a card\nthat earns bonus rewards on sporting goods or general online shopping, or a flat-rate\ncashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46441.1000000006&trid=1552713.208505&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 35% off"
       }
     },
     {
@@ -5288,7 +5376,8 @@
       "intro": "Innisfree is a South Korean skincare and cosmetics brand known for products built\naround natural ingredients sourced from Jeju Island, owned by Korean beauty\nconglomerate Amorepacific and sold direct at innisfree.com along with select retail\nand marketplace partners. There is no Innisfree co-brand credit card, so an order is\nbest charged to a card that earns bonus rewards on general online shopping, or a\nflat-rate cashback card if you prefer not to track categories.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.48045.1000000392&trid=1552713.239749&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off"
       }
     },
     {
@@ -5345,7 +5434,8 @@
       "intro": "J. Jill is an American specialty retailer selling women's apparel positioned around\nrelaxed, comfortable everyday styles, sold through its own stores, catalog, and\njjill.com. There is no J. Jill co-brand credit card, though the retailer offers its own\nstore loyalty and private-label financing program separate from general-purpose credit\ncards. Shoppers who want travel or cashback rewards on a J. Jill purchase should\ninstead use a card that earns bonus rewards on general online or apparel shopping, or a\nflat-rate cashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.54107.198854455&trid=1552713.201947&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off sale styles"
       }
     },
     {
@@ -5520,7 +5610,8 @@
       "intro": "Johnston & Murphy is an American footwear and accessories brand dating back to 1850,\nknown for dress shoes, boots, and increasingly casual and hybrid styles aimed at\nprofessional men, alongside a smaller assortment of belts, bags, and apparel. The\ncompany has operated as a standalone specialty retailer for most of its history and\nhas no co-brand credit card of its own. Shoppers buying dress or business-casual\nshoes here are usually best served by a general online shopping or select-clothing\nrewards card, or a flat-rate cashback card, rather than expecting any store-specific\nfinancing beyond a standard retail account.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38419.1000000980&trid=1552713.162278&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off select styles"
       }
     },
     {
@@ -5534,7 +5625,8 @@
       "intro": "Jonathan Adler is a design-led home furnishings brand built around the namesake\npotter and interior designer, selling ceramics, furniture, lighting, textiles, and\ndecorative accessories with a distinctive maximalist, pop-influenced aesthetic. It\nsells primarily through its own boutiques and website rather than mass retail\npartners, and there is no Jonathan Adler co-brand credit card. Furnishing a room from\nthis brand is a good spot to lean on a card that bonuses furniture or general online\nshopping purchases, or simply a flat-rate cashback card given the brand's\nabove-average price points.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50036.1000000004&trid=1552713.216122&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 65% off"
       }
     },
     {
@@ -5552,7 +5644,8 @@
       "intro": "Jos. A. Bank is a longtime American menswear retailer specializing in suits, dress\nshirts, and business-casual clothing, sold through mall and strip-center stores as\nwell as online. It has been under the same parent company as Men's Wearhouse for\nmore than a decade, but the two brands operate separately and neither carries a\nco-brand credit card tied to CreditOdds' tracked card set. A card that earns bonus\nrewards on clothing or general online shopping purchases is the most useful pairing\nhere, since Jos. A. Bank frequently runs its own storewide promotions independent of\nany bank partnership.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38377.1000016446&trid=1552713.196&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off clearance"
       }
     },
     {
@@ -5576,7 +5669,8 @@
       "intro": "K-Swiss is an American athletic footwear brand founded in the 1960s, best known for\nits classic leather tennis sneakers as well as later training and lifestyle shoe\nlines, sold direct-to-consumer online and through athletic retailers. The brand has\nno co-brand credit card, so a shopper buying sneakers here should look to a card that\nbonuses sporting goods or general online shopping spend rather than expecting any\nbrand-specific financing. K-Swiss has changed ownership several times over the years\nbut continues to operate as a standalone footwear label.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9956.311096&trid=1552713.227940&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off select styles"
       }
     },
     {
@@ -5594,7 +5688,8 @@
       "intro": "Kaplan is a long-running test preparation and professional education company,\noffering courses and materials for standardized tests like the LSAT, MCAT, and GRE\nas well as licensing exams for fields such as nursing and financial services. It\noperates under Graham Holdings and has no co-brand credit card. Since Kaplan\npurchases are typically a single online transaction rather than a recurring\ncategory, a general online shopping rewards card or a flat-rate cashback card is the\nmost practical way to earn on tuition or course fees paid directly to Kaplan.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.1697.1010005031&trid=1552713.200470&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code FRESHSTART25"
       }
     },
     {
@@ -5631,7 +5726,8 @@
       "intro": "Keds is a classic American sneaker brand dating to 1916, known for its simple\ncanvas slip-on and lace-up shoes marketed mainly to women and long associated with\npreppy, casual style. It is owned by Wolverine World Wide, which also owns brands\nlike Merrell and Sperry, and Keds carries no co-brand credit card of its own.\nShoppers stocking up on canvas sneakers here should default to a card that bonuses\nclothing or general online shopping purchases, since there is no shoe-specific\nrewards category to target.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110006127.1100126495&trid=1552713.160396&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off sale styles"
       }
     },
     {
@@ -5662,7 +5758,8 @@
       "intro": "Kendra Scott is an Austin-founded jewelry and accessories brand known for its\ncolorful stone-inlaid earrings, necklaces, and its in-store \"Color Bar\" customization\nconcept, sold through mall boutiques and its own website as well as select\ndepartment stores. The brand is privately held and has no co-brand credit card, so\nthere is no store-specific bonus category to chase. A card that earns elevated\nrewards on general online shopping or department-store purchases, or a flat-rate\ncashback card, is the best fit for jewelry and gift purchases here.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.50471.3951190&trid=1552713.199434&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off"
       }
     },
     {
@@ -5677,7 +5774,8 @@
       "intro": "Keurig is the single-serve coffee brewer company behind the K-Cup pod system,\nselling brewing machines and a wide range of licensed coffee, tea, and cocoa pods\ndirectly through its own site as well as major retailers. It's part of Keurig Dr\nPepper and has no co-brand credit card. Since purchases here are typically small\nappliances or grocery-adjacent coffee pods rather than a distinct bonus category, a\ngeneral online shopping card or a flat-rate cashback card is the most reliable way to\nearn rewards on Keurig orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39219.1000002801&trid=1552713.170716&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -5775,7 +5873,8 @@
       "intro": "Kohler is a major American manufacturer of kitchen and bath fixtures, including\nsinks, faucets, toilets, and bathtubs, alongside a broader industrial and hospitality\nbusiness that includes generators and golf resorts. Kohler products are sold direct\nthrough its own site as well as through home improvement retailers and plumbing\nsuppliers, and the company has no co-brand credit card. Remodeling or fixture\npurchases here pair best with a card that bonuses home improvement spend, or a\nflat-rate cashback card for large one-off purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.44732.1000000352&trid=1552713.215079&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off vanities & sinks"
       }
     },
     {
@@ -5821,7 +5920,8 @@
       "intro": "Kylie Cosmetics is the direct-to-consumer beauty brand founded by Kylie Jenner,\nselling makeup, skincare, and fragrance products primarily through its own website\nalong with select retail partners like Ulta. The company has no co-brand credit\ncard, so there is no dedicated bonus category tied to the brand. A card that earns\nelevated rewards on general online shopping, or a flat-rate cashback card, is the\nmost practical way to earn on purchases made directly through the Kylie Cosmetics\nsite.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46759.1000000061&trid=1552713.224336&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -5904,7 +6004,8 @@
       "intro": "LastPass is a password manager and digital identity security service that stores\nand autofills logins, generates strong passwords, and offers dark web monitoring and\nfamily sharing plans on a subscription basis. It is sold purely as software, has no\nphysical retail presence, and carries no co-brand credit card. Subscription charges\nhere are best captured with a general online shopping or subscription-friendly\nrewards card, or a flat-rate cashback card, since there is no dedicated software or\nsecurity spending category on most cards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.8692.2595725&trid=1552713.206309&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off for new customers"
       }
     },
     {
@@ -5955,7 +6056,8 @@
       "intro": "Lee is one of America's oldest denim brands, founded in 1889 and known for jeans,\nworkwear, and casual clothing sold through its own stores, website, and a wide range\nof department and mass retailers. It is owned by Kontoor Brands, which also owns\nWrangler, and Lee has no co-brand credit card. A shopper buying jeans or casual wear\ndirectly from Lee should look to a card that bonuses clothing or general online\nshopping purchases, or a flat-rate cashback card if no category applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11766.3960014&trid=1552713.237878&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off with code SHORT"
       }
     },
     {
@@ -6051,7 +6153,8 @@
       "intro": "Levoit is a home appliance brand under VeSync that specializes in air purifiers,\nhumidifiers, and small kitchen appliances aimed at the smart-home and wellness\nmarket, sold mainly through its own site and online marketplaces. The brand has no\nco-brand credit card. Purchases here fit best under a card that bonuses electronics\nor general online shopping spend, or a flat-rate cashback card, since Levoit doesn't\nfall into a home improvement or grocery category despite being a household product.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.41708.3910127&trid=1552713.235505&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off"
       }
     },
     {
@@ -6074,7 +6177,8 @@
       "intro": "Life is Good is a Boston-founded lifestyle apparel brand built around its optimistic\n\"Jake\" stick-figure logo, selling t-shirts, hoodies, hats, and accessories through\nits own stores, website, and wholesale partners, with a portion of profits directed\nto its Life is Good Kids Foundation. The brand has no co-brand credit card. Shoppers\nbuying its casual apparel should default to a card that bonuses clothing or general\nonline shopping purchases, or a flat-rate cashback card if neither applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14635.1948131&trid=1552713.158389&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off"
       }
     },
     {
@@ -6105,7 +6209,8 @@
       "intro": "Liquid I.V. is a hydration and wellness brand best known for its powdered\nelectrolyte drink mixes, sold in single-serve packets through its own site, major\nretailers, and subscription orders. It has been owned by Unilever since 2020 and\ncarries no co-brand credit card. Purchases made directly through Liquid I.V.'s\nwebsite are best treated as general online shopping for rewards purposes, so a card\nbonusing that category, or a flat-rate cashback card, is the practical option.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13609.1958902&trid=1552713.242792&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off"
       }
     },
     {
@@ -6131,7 +6236,8 @@
       "intro": "Little Sleepies is a direct-to-consumer kids and baby apparel brand built around\nbamboo viscose pajamas, rompers, and loungewear sold in matching family sets and\nfrequent limited-edition prints. The company sells almost exclusively through its\nown website rather than department stores, which makes it a straightforward\nonline-shopping purchase. There is no Little Sleepies co-brand credit card, so the\nbest approach is a card that pays an elevated rate on online or general retail\npurchases, or a flat-rate cashback card if simplicity matters more than optimizing\nby category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.20265.2102732&trid=1552713.233129&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off sale items"
       }
     },
     {
@@ -6259,7 +6365,8 @@
       "intro": "Lucky Brand is a California-born denim and casual apparel label known for its\nvintage-inspired jeans, along with tees, jackets, and accessories. The brand sells\nthrough its own stores and site as well as inside major department stores like\nMacy's and Dillard's, so purchases can land in either the online-shopping or\ndepartment-store bucket depending on where you check out. There is no Lucky\nBrand co-brand credit card, so shoppers are better served leaning on a card that\nrewards online retail or department-store spending, or a general flat-rate\ncashback card for everyday simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9596.504271&trid=1552713.187771&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 75% off"
       }
     },
     {
@@ -6315,7 +6422,8 @@
       "intro": "Lumens Light + Living is an online retailer specializing in designer lighting\nfixtures, furniture, and home decor, carrying hundreds of brands ranging from\nboutique studios to well-known modern design houses. It functions as a curated\nmarketplace rather than a manufacturer, shipping direct to consumers nationwide.\nThere is no Lumens co-brand credit card, so a home-improvement category card or\na card with strong online-shopping rewards is the better fit for larger lighting\nor furniture purchases, with a flat-rate cashback card as a simple fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.3281.197540&trid=1552713.158720&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 75% off clearance"
       }
     },
     {
@@ -6386,7 +6494,8 @@
       "intro": "Madison Reed makes ammonia-free, salon-quality hair color kits sold direct to\nconsumers online and through its own network of hair color bar salons in select\ncities. The company built its business around at-home color subscriptions as an\nalternative to traditional salon visits. There is no Madison Reed co-brand\ncredit card, so shoppers should rely on a card that rewards online retail\npurchases, or a flat-rate cashback card for a simpler approach to everyday\nbeauty spending.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13741.3966078&trid=1552713.200433&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code BDAY26"
       }
     },
     {
@@ -6414,7 +6523,8 @@
       "intro": "Manscaped is a men's grooming brand best known for its below-the-waist trimmers\nand body grooming tools, alongside skincare and hygiene products it built into a\nbroader personal-care lineup. The company sells primarily through its own site\nand app, with a subscription refill option for blades and grooming supplies.\nThere is no Manscaped co-brand credit card, so the sensible approach is a card\nthat earns extra on online shopping, or a flat-rate cashback card for\nstraightforward everyday purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156139.48084.1000000017&trid=1552713.249081&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 22% off"
       }
     },
     {
@@ -6446,7 +6556,8 @@
       "intro": "Marc Jacobs is an American fashion house known for ready-to-wear apparel,\nhandbags, and fragrances, with the Tote Bag and Daisy perfume line among its\nmost recognizable products. The brand, owned by LVMH parent company overseen\nby designer Marc Jacobs himself, sells through its own boutiques and site as\nwell as through department stores like Nordstrom, Macy's, and Bloomingdale's.\nThere is no Marc Jacobs co-brand credit card, so a card that rewards online\nshopping or department-store purchases is the better fit, with a flat-rate\ncashback card as a simple alternative.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8338.584825&trid=1552713.205419&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -6723,7 +6834,8 @@
       "intro": "MeUndies is a direct-to-consumer underwear and loungewear brand built around a\nmonthly subscription model, known for colorful prints, modal fabric, and\nlimited-edition designer collaborations. The company sells almost entirely\nthrough its own website and app rather than physical retail. There is no\nMeUndies co-brand credit card, so a card that earns a bonus on online shopping\nis the better fit, or a flat-rate cashback card for a simpler approach to\nsubscription-style purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.26749.3868010&trid=1552713.197539&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off your first purchase"
       }
     },
     {
@@ -6800,7 +6912,8 @@
       "intro": "Milani Cosmetics is a Los Angeles-based makeup brand built around affordable,\ndrugstore-priced products, with its Baked Blush and Conceal + Perfect line among\nits best-known items. The brand sells direct online along with wide distribution\nthrough mass retailers like Target, Walmart, and Ulta. There is no Milani\nco-brand credit card, so a card that rewards online shopping is the better lever\nfor a direct purchase, or a flat-rate cashback card if you would rather keep\nthings simple.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50546.1000000123&trid=1552713.232500&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off"
       }
     },
     {
@@ -6833,7 +6946,8 @@
       "intro": "Milk Makeup is a cosmetics brand known for multi-use, skin-forward products\nlike its cream sticks and Hydro Grip primer, marketed toward a younger,\nlow-maintenance beauty audience. The brand originated inside the Milk Studios\nphotography and events company before spinning out and is now owned by e.l.f.\nBeauty. There is no Milk Makeup co-brand credit card, so a card that rewards\nonline shopping is the better fit for a direct purchase, or a flat-rate\ncashback card for everyday simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.21499.1993215&trid=1552713.199552&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 98% off"
       }
     },
     {
@@ -6866,7 +6980,8 @@
       "intro": "Minted is an online marketplace that sells stationery, art prints, wedding\ninvitations, and home decor designed by a community of independent artists and\ndesigners, with pieces selected through crowdsourced design competitions. The\ncompany operates purely as an e-commerce platform with no physical retail\npresence. There is no Minted co-brand credit card, so a card that rewards\nonline shopping purchases is the better fit, or a flat-rate cashback card for\na simpler approach.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.19909.3746698&trid=1552713.200435&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code ENGAGED25"
       }
     },
     {
@@ -6883,7 +6998,8 @@
       "intro": "Misfits Market is an online grocery delivery service that started by selling\n\"ugly\" or surplus produce at a discount to reduce food waste, and has since\nexpanded into a broader grocery box covering pantry staples, meat, and dairy\nshipped direct to subscribers' homes. There is no Misfits Market co-brand\ncredit card, so a groceries-category card is the natural fit for these\npurchases, or a flat-rate cashback card if you would rather not track\ncategories.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12419.2170579&trid=1552713.236533&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 30% off"
       }
     },
     {
@@ -6955,7 +7071,8 @@
       "intro": "Moroccanoil is a hair care brand built around its original argan oil treatment,\nwhich grew into a full line of shampoos, conditioners, and styling products\nused widely in professional salons as well as sold direct to consumers. The\nbrand is distributed through salons, beauty retailers, and its own website.\nThere is no Moroccanoil co-brand credit card, so a card that rewards online\nshopping is the better fit for a direct purchase, or a flat-rate cashback card\nfor a simpler approach to beauty spending.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43410.1000000587&trid=1552713.211705&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code STYLERS2026"
       }
     },
     {
@@ -7000,7 +7117,8 @@
       "intro": "Munchkin is a baby and toddler products company known for items like the Miracle 360\nsippy cup, bath toys, feeding gear, and diaper-disposal systems, sold at munchkin.com\nas well as through major retailers like Target and Walmart. It's a private, independent\nbrand with no credit card of its own. Since Munchkin purchases are usually made online\nor as part of a broader baby-registry shop, a card that rewards online shopping or\noffers flat-rate cashback is the simplest way to earn on these purchases, rather than\nlooking for a category-specific multiplier that doesn't really exist for baby gear.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.7649.483108&trid=1552713.163230&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with sign up"
       }
     },
     {
@@ -7028,7 +7146,8 @@
       "intro": "Naked Wines is a direct-to-consumer wine retailer built around funding independent\nwinemakers, where members pay a monthly deposit toward future bottle purchases at\nmember-only pricing. It ships wine straight to customers' doors in states where that's\nlegal, positioning itself against traditional wine shops and big-box wine sections.\nThere's no Naked Wines credit card, and grocery or dining category cards typically don't\ncover wine-club shipments since these purchases usually code as online retail, so a\nstrong online-shopping or flat-rate cashback card is the most reliable way to earn on\nNaked Wines orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13852.1723735&trid=1552713.163400&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off with code IMPACT12PK"
       }
     },
     {
@@ -7064,7 +7183,8 @@
       "intro": "Nars is a makeup and skincare brand founded by photographer and makeup artist Francois\nNars, known for products like the Orgasm blush and a range that leans into bold color\nand a photo-ready finish. Shiseido acquired Nars in 2000, and the brand sells through\nits own site, department-store beauty counters, and retailers like Sephora and Ulta.\nThere is no Nars-branded credit card, so shoppers should look to a department-store or\ngeneral online-shopping rewards card, or a flat-rate cashback card, to earn on Nars\npurchases rather than expecting a beauty-specific bonus category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8113.610942&trid=1552713.194170&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 48% off"
       }
     },
     {
@@ -7099,7 +7219,8 @@
       "intro": "Native Shoes is a Vancouver-founded footwear brand best known for lightweight,\ninjection-molded EVA shoes in the style of the Jefferson sneaker, marketed as an\neasy-care, machine-washable alternative to canvas sneakers for kids and adults alike.\nIt sells primarily direct-to-consumer online alongside placement in outdoor and family\nretailers. There is no Native Shoes credit card, so the best approach for these\npurchases is a card that rewards select clothing or shoe purchases, or a general\nonline-shopping or flat-rate cashback card if a category-specific multiplier isn't\navailable.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14513.1998567&trid=1552713.234726&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with sign up"
       }
     },
     {
@@ -7118,7 +7239,8 @@
       "intro": "Nautica is an American apparel brand built around a nautical, preppy aesthetic, selling\nmen's, women's, and kids' clothing along with accessories and home goods, and it's\nlicensed and operated today under Authentic Brands Group. Nautica products show up both\nat its own stores and site and widely across department stores like Macy's and Kohl's.\nThere's no Nautica-branded credit card, so shoppers should reach for a department-store\nrewards card when buying in-store, or a select-clothing or general online-shopping card\nfor purchases made directly at nautica.com.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.5361.260311&trid=1552713.161992&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -7202,7 +7324,8 @@
       "intro": "New Era is the headwear company that holds the official on-field cap license for MLB and\nsupplies sideline and licensed caps for the NFL, NBA, and other leagues, alongside its\nown streetwear and lifestyle cap lines. It sells through neweracap.com, team shops, and\ngeneral retailers. There is no New Era credit card, so a shopper buying fitted or\nsnapback caps should lean on a select-clothing or online-shopping rewards card, or a\nflat-rate cashback card, rather than expecting a sports-merchandise specific bonus\ncategory.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.45269.1000000343&trid=1552713.215793&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 45% off select styles"
       }
     },
     {
@@ -7317,7 +7440,8 @@
       "intro": "Nutribullet is a kitchen appliance brand best known for its compact, high-torque blenders\nmarketed around single-serve smoothies and nutrient extraction, and it has since\nexpanded into full-size blenders, food processors, and air fryers. It sells directly at\nnutribullet.com as well as through big-box and department retailers. There's no\nNutribullet-branded credit card, so purchases are best covered by a card that earns\nbonus rewards on home-goods or kitchenware purchases, or a general online-shopping or\nflat-rate cashback card for a one-time appliance buy.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9496.622476&trid=1552713.211957&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -7379,7 +7503,8 @@
       "intro": "Olaplex is a hair care brand built around bond-building chemistry originally developed\nfor use in salons, with its No. 3 Hair Perfector becoming a widely recognized at-home\ntreatment product. The company sells direct at olaplex.com and through beauty retailers\nlike Sephora and Ulta as well as professional salons. There is no Olaplex-branded credit\ncard, so shoppers should look to a general online-shopping rewards card or a flat-rate\ncashback card to earn on Olaplex purchases, since beauty and hair care don't typically\nhave their own dedicated bonus category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.49376.1000000046&trid=1552713.232646&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -7409,7 +7534,8 @@
       "intro": "Olipop is a functional soda brand that markets prebiotic-fortified sodas as a healthier\nalternative to traditional sugary soft drinks, sold direct at olipop.com by subscription\nor one-time order, as well as in grocery and convenience stores nationwide. It's an\nindependent, venture-backed beverage company with no credit card of its own. For direct\nonline orders, a general online-shopping or flat-rate cashback card is the practical\nchoice, while purchases made in a grocery store aisle would instead earn under a\ngroceries-category card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12980.1270029&trid=1552713.226085&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "32% off with code SODALOVE"
       }
     },
     {
@@ -7447,7 +7573,8 @@
       "intro": "Omaha Steaks is a family-owned, direct-to-consumer purveyor of steaks, seafood, and other\nfrozen meats and prepared foods, shipped nationwide from its Nebraska base and popular\nboth for personal restocking and as a gift item. Orders are placed and shipped directly\nthrough omahasteaks.com rather than through a grocery store, so they often code as\nonline retail or dining rather than groceries. There's no Omaha Steaks credit card, so a\ndining-category card, or a general online-shopping or flat-rate cashback card, is the\nbest way to earn on an order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.147.4611686018427592559&trid=1552713.185&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off sitewide"
       }
     },
     {
@@ -7477,7 +7604,8 @@
       "intro": "One Kings Lane is an online home decor and furniture retailer that built its name on\nflash sales of designer furnishings before shifting to a more traditional e-commerce\nstorefront covering furniture, lighting, rugs, and decorative accessories. It sells\nexclusively online rather than through physical stores. There's no One Kings Lane credit\ncard, so shoppers furnishing a home through the site should look to a furniture or\nhome-goods rewards card, or a general online-shopping or flat-rate cashback card for\nsmaller decor purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.10043.582414&trid=1552713.233565&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off"
       }
     },
     {
@@ -7519,7 +7647,8 @@
       "intro": "Osprey is an outdoor gear company known for its backpacking, hiking, and travel packs,\nbuilt around features like its All Mighty Guarantee lifetime repair policy that has made\nit a favorite among thru-hikers and backpackers. Products are sold direct at osprey.com\nas well as through outdoor retailers like REI. There's no Osprey credit card, so a\nsporting-goods or outdoor-retailer rewards card is the natural fit for a pack purchase,\nwith a general online-shopping or flat-rate cashback card as a solid alternative.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.20745.2991713&trid=1552713.243977&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off sale items"
       }
     },
     {
@@ -7548,7 +7677,8 @@
       "intro": "Outdoor Voices is an activewear brand built around a \"doing things\" ethos that pitches\nitself as more casual and everyday than performance-focused athletic brands, known for\nleggings, the Exercise Dress, and its colorful, minimalist aesthetic. It sells primarily\ndirect-to-consumer through outdoorvoices.com and a small number of its own retail\nlocations. There is no Outdoor Voices credit card, so a select-clothing or\nsporting-goods rewards card is a good fit for activewear purchases, with a general\nonline-shopping or flat-rate cashback card as a fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25944.3907598&trid=1552713.207781&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off your first order"
       }
     },
     {
@@ -7577,7 +7707,8 @@
       "intro": "Owlet is a baby-tech company best known for its Smart Sock and camera products that\nmonitor an infant's heart rate, oxygen levels, and sleep, aimed at giving new parents\npeace of mind overnight. It sells direct at owletcare.com and through major baby and\nelectronics retailers. There is no Owlet-branded credit card, so a purchase is best\ncovered by a card that rewards electronics or online-shopping purchases, or a\nflat-rate cashback card, since baby-monitoring tech doesn't have its own dedicated\nbonus category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.93077.3306615&trid=1552713.224412&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with code BIRTHCOLLECTIVE10"
       }
     },
     {
@@ -7595,7 +7726,8 @@
       "intro": "OXO is a kitchen and household tools brand best known for its Good Grips line of\nergonomic, easy-to-use utensils, gadgets, and storage products, now owned by Newell\nBrands alongside names like Rubbermaid and Sharpie. Products are sold at oxo.com and\nwidely across grocery, home-goods, and department stores. There's no OXO-branded credit\ncard, so a card that earns bonus rewards on home-improvement or kitchenware purchases is\nthe best fit, with a general online-shopping or flat-rate cashback card as a solid\nfallback for smaller orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9558.2991709&trid=1552713.207703&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 20% off"
       }
     },
     {
@@ -7792,7 +7924,8 @@
       "intro": "Penske Truck Rental is one of the largest consumer and commercial truck rental\noperations in North America, renting box trucks, cargo vans, and pickups for moves,\nhauling, and small business use out of thousands of locations. It operates alongside\nPenske Truck Leasing and Penske Logistics under the broader Penske Corporation,\nfounded by racing executive Roger Penske. There is no Penske co-brand credit card, so\na general rental car and travel category card, or a flat-rate cashback card, is the\npractical choice for earning rewards on a rental booked through Penske.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101106404.111000691&trid=1552713.242188&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with code GETMOVING"
       }
     },
     {
@@ -7817,7 +7950,8 @@
       "intro": "Perricone MD is a skincare brand founded by dermatologist Dr. Nicholas Perricone,\nknown for anti-aging formulas built around ingredients like vitamin C ester and\nneuropeptides, sold direct at perriconemd.com as well as through department stores and\nspecialty beauty retailers. The line spans serums, moisturizers, and supplements\npositioned at the premium end of the skincare market. There is no Perricone MD\nco-brand credit card, so a card that earns bonus rewards on online shopping or\ndepartment store purchases, or a general beauty and drugstore category card, is the\nbetter route for maximizing rewards on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.21122.3969291&trid=1552713.178759&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off with code EYE50"
       }
     },
     {
@@ -7834,7 +7968,8 @@
       "intro": "Personalization Mall sells custom-engraved and monogrammed gifts, including\nornaments, home decor, drinkware, and kids' items, that shoppers personalize with\nnames, dates, or photos before checkout. The company was acquired by 1-800-Flowers.com\nin 2018 and now operates as part of that company's family of gifting brands alongside\n1-800-Flowers and Harry & David. There is no Personalization Mall co-brand credit\ncard, so a card that rewards online shopping purchases, or a flat-rate cashback card,\nis the simplest way to earn something back on a personalized gift order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.29824.3960848&trid=1552713.243972&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -8025,7 +8160,8 @@
       "intro": "Polk Audio is a Maryland founded speaker and home theater brand dating to 1972, known\nfor bookshelf and floorstanding speakers, soundbars, and subwoofers sold direct online\nand through electronics retailers. It operates under SoundUnited, the audio group that\nalso owns Definitive Technology, Denon, and Marantz. There is no Polk Audio co-brand\ncredit card, so a card that earns bonus rewards at electronics stores, or one that\nboosts online shopping purchases when buying direct from polkaudio.com, is the better\noption for audio equipment purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101106052.1100105683&trid=1552713.225844&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -8150,7 +8286,8 @@
       "intro": "Prose is a direct-to-consumer haircare brand that sells custom-formulated shampoo,\nconditioner, and styling products based on an online quiz that asks about hair type,\ngoals, and local climate. Each order is mixed and bottled to match the individual\ncustomer rather than sold as a fixed product line, and the brand ships on a recurring\nsubscription basis. There is no Prose co-brand credit card, so a card that earns bonus\nrewards on online shopping purchases, or a flat-rate cashback card, is the simplest\nway to earn something back on a Prose order or subscription renewal.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11046.1964687&trid=1552713.202760&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off your first order"
       }
     },
     {
@@ -8163,7 +8300,8 @@
       "intro": "Public Goods is a membership based online retailer selling sustainably sourced\nhousehold staples, personal care items, and pantry goods under its own uniform, minimalist\nbranded packaging rather than reselling other companies' products. Shoppers pay a\nyearly membership fee for access to member pricing across categories like cleaning\nsupplies, toiletries, and kitchen basics. There is no Public Goods co-brand credit\ncard, so a card that earns bonus rewards on online shopping purchases, or a flat-rate\ncashback card, is the best way to earn rewards on an order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11802.918004&trid=1552713.226288&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off your first purchase with code RMN10"
       }
     },
     {
@@ -8192,7 +8330,8 @@
       "intro": "Puffy is a direct-to-consumer mattress and bedding brand that ships foam mattresses,\npillows, and sheets in a box, competing with other bed-in-a-box companies like Casper\nand Nectar on long sleep trials and lifetime warranties sold entirely online rather\nthan through physical showrooms. The lineup has expanded into adjustable bed frames\nand bedroom furniture over time. There is no Puffy co-brand credit card, so a card\nthat earns bonus rewards at furniture stores, or one that boosts online shopping\npurchases, is the better fit for a mattress or bedding purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12125.1617842&trid=1552713.239252&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off with code EDU"
       }
     },
     {
@@ -8269,7 +8408,8 @@
       "intro": "Quill is a business-to-business office supply retailer selling paper, ink and\ntoner, breakroom items, cleaning products, and technology to small businesses and\noffices, largely through catalog and online ordering rather than physical stores.\nStaples acquired Quill in 1998 and continues to run it as a distinct brand aimed at\nbusiness customers who order in bulk. There is no Quill co-brand credit card, so an\noffice supply category card, or a flat-rate business cashback card, is the better\noption for earning rewards on Quill purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110006434.1011166830&trid=1552713.159251&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "52% off"
       }
     },
     {
@@ -8385,7 +8525,8 @@
       "intro": "Razer is a Singapore and California based gaming hardware company known for its\ngreen snake logo and Chroma RGB lighting, selling gaming laptops, keyboards, mice,\nheadsets, and accessories aimed at PC and console gamers. The company is publicly\ntraded and also runs Razer Gold, a virtual currency used across many game platforms.\nThere is no Razer co-brand credit card, so a card that earns bonus rewards at\nelectronics stores, or one that boosts online shopping purchases when ordering\ndirect from razer.com, is the better fit for gaming gear purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10229.1781361&trid=1552713.163469&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "75% off"
       }
     },
     {
@@ -8404,7 +8545,8 @@
       "intro": "RC Willey Home Furnishings is a large-format furniture, mattress, electronics, and\nappliance retailer based in Utah with stores across the Mountain West, Nevada, and\nCalifornia. Warren Buffett's Berkshire Hathaway acquired the company in 1995 and has\nkept its original management and regional footprint largely intact since. There is no\nRC Willey co-brand credit card, so a card that earns bonus rewards at furniture\nstores, or one that boosts home improvement or electronics purchases, is the best fit\nfor a large furniture or appliance purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39945.1000001540&trid=1552713.195269&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 75% off clearance"
       }
     },
     {
@@ -8418,7 +8560,8 @@
       "intro": "Rebecca Minkoff is a New York founded fashion label started by its namesake designer,\nknown for handbags like the MAB and Mini M.A.C. as well as ready-to-wear clothing,\nshoes, and accessories sold through its own stores, website, and department store\npartners like Nordstrom and Bloomingdale's. The brand built its early following on\naccessible, trend-driven leather goods. There is no Rebecca Minkoff co-brand credit\ncard, so a card that earns bonus rewards on online shopping or clothing purchases is\nthe better fit for a handbag or apparel order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9950.511647&trid=1552713.162599&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off select styles"
       }
     },
     {
@@ -8465,7 +8608,8 @@
       "intro": "Reef is a California born footwear brand best known for its sandals, especially\nbottle-opener flip-flops and other surf-culture styles, along with boots and\ncasual shoes sold online and through outdoor and surf retailers. The brand grew out\nof the beach and surf scene and remains closely tied to that lifestyle marketing.\nThere is no Reef co-brand credit card, so a card that earns bonus rewards on online\nshopping or clothing and footwear purchases, or a flat-rate cashback card, is the\npractical choice when buying from reef.com.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23921.1999849&trid=1552713.194581&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -8508,7 +8652,8 @@
       "intro": "Rent the Runway is a clothing and accessory rental service that lets members borrow\ndesigner dresses, workwear, and outerwear for a set period or on a rotating monthly\nsubscription instead of buying them outright, returning items in prepaid packaging\nwhen finished. The company is publicly traded and works with hundreds of designer\nand contemporary brands. There is no Rent the Runway co-brand credit card, so a card\nthat earns bonus rewards on online shopping or clothing purchases, or a flat-rate\ncashback card, is the best fit for a rental order or membership charge.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9690.590512&trid=1552713.225416&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 90% off sale items"
       }
     },
     {
@@ -8521,7 +8666,8 @@
       "intro": "ResortPass is a booking platform that sells day access to hotel and resort\namenities, such as pools, cabanas, and spas, to guests who are not staying overnight\nat the property. It partners with hotel chains and independent resorts across the\nUnited States to sell passes by the day, letting travelers and locals use luxury\nfacilities without booking a room. There is no ResortPass co-brand credit card, so a\ngeneral travel category card, or a flat-rate cashback card, is the practical way to\nearn rewards on a day pass purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.50076.3871321&trid=1552713.237733&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "$20 off your first booking over $100"
       }
     },
     {
@@ -8534,7 +8680,8 @@
       "intro": "Restaurant.com sells discounted gift certificates redeemable at thousands of\nindependent and chain restaurants across the United States, letting diners buy a\ncertificate online for less than its face value and use it toward a meal at a\nparticipating location. The site also bundles certificates with local deals and gift\ncards for other retail and entertainment categories. There is no Restaurant.com\nco-brand credit card, so a dining category card, or a flat-rate cashback card, is the\nbetter choice for purchases made on the site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.21234.1813802&trid=1552713.157348&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off dining deals"
       }
     },
     {
@@ -8620,7 +8767,8 @@
       "intro": "Roborock is a Beijing based robotics company best known for its lineup of robot vacuums and\nvacuum and mop combo units, which compete directly with iRobot's Roomba line on navigation,\nsuction power, and self-emptying dock features. The brand also makes handheld and cordless\nvacuums and has expanded into other smart home cleaning devices. Roborock does not have a\nco-brand credit card, so shoppers buying direct at roborock.com or through a retailer like\nAmazon or Best Buy are better off leaning on an electronics or general online shopping\nrewards card, or a flat-rate cashback card, to earn on the purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14848.1705455&trid=1552713.240023&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "4% off"
       }
     },
     {
@@ -8653,7 +8801,8 @@
       "intro": "Rosetta Stone is a language learning company that built its brand on distinctive\nimmersion-based software, once sold in boxed CD-ROM kits and now offered as a subscription\napp and website covering dozens of languages. It's owned by IXL Learning, an education\ntechnology company that also operates Wyzant and other learning platforms. There's no\nRosetta Stone co-brand credit card, so a subscription purchase or lifetime plan is best\npaid with a general online shopping or flat-rate cashback card, since language learning\ndoesn't map to any dedicated bonus category most issuers track.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18979.2904352&trid=1552713.172635&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 55% off"
       }
     },
     {
@@ -8736,7 +8885,8 @@
       "intro": "Rue La La is a members-only flash sale retailer, launching limited-time discounted events\non apparel, accessories, home goods, and beauty from both established and boutique brands.\nFounded in Boston in 2007, it's now part of Rue Gilt Groupe, the same corporate family that\nalso runs Gilt and Shop Premium Outlets. There's no Rue La La co-brand credit card, so the\nbest rewards angle for a flash sale purchase is an online shopping or general apparel\ncategory card, or a flat-rate cashback card if the specific category isn't covered.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.1000005478.1011209521&trid=1552713.161427&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 90% off"
       }
     },
     {
@@ -8750,7 +8900,8 @@
       "intro": "Rugs USA is a direct to consumer online retailer specializing in area rugs, runners, and\noutdoor rugs, spanning machine made, hand tufted, and hand knotted styles across a wide\nrange of price points and design aesthetics. The company sells almost exclusively online,\nregularly running large sitewide sales on its inventory. There's no Rugs USA co-brand\ncredit card, so a home goods purchase there is best charged to a home improvement rewards\ncard if one is available, or otherwise a general online shopping or flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9280.3964472&trid=1552713.203964&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off with code SUMMER"
       }
     },
     {
@@ -8903,7 +9054,8 @@
       "intro": "Scholastic is a major publisher and distributor of children's books and educational\nmaterials, best known to generations of families for its in-school Scholastic Book Fairs\nand Book Clubs, and as the longtime US publisher of the Harry Potter series and Clifford\nthe Big Red Dog. It also produces classroom magazines, curriculum resources, and media for\nschools and libraries. There's no Scholastic co-brand credit card, so book and classroom\nsupply purchases through its website are best charged to a general online shopping rewards\ncard, or a flat-rate cashback card if no bonus category applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8138.229226&trid=1552713.158514&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 30% off"
       }
     },
     {
@@ -8951,7 +9103,8 @@
       "intro": "Seed Health is a microbiome science company best known for its DS-01 Daily Synbiotic, a\nprobiotic and prebiotic supplement sold on a subscription basis directly to consumers, along\nwith other gut and women's health products developed with academic research partners. The\nbrand positions itself at the science-forward end of the wellness supplement market rather\nthan as a mass retailer. There's no Seed co-brand credit card, so a subscription order is\nbest charged to a general online shopping or flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.19848.1987528&trid=1552713.240621&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -9014,7 +9167,8 @@
       "intro": "SharkNinja is the consumer products company behind two well-known home brands: Shark, which\nmakes vacuums, steam mops, and air purifiers, and Ninja, which makes kitchen appliances\nlike blenders, air fryers, and coffee makers. The company sells through its own site as\nwell as major retailers like Amazon, Walmart, Target, and Best Buy, and became an\nindependently traded public company after spinning off in 2023. There's no SharkNinja\nco-brand credit card, so a direct purchase is best charged to an electronics or general\nonline shopping rewards card, or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.8359.1823241&trid=1552713.225856&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off with code STYLE20"
       }
     },
     {
@@ -9133,7 +9287,8 @@
       "intro": "Shopbop is an online fashion retailer specializing in designer and contemporary apparel,\nshoes, and accessories, curating collections from hundreds of brands for a customer base\nthat skews toward higher-end, trend-driven fashion. Based in Madison, Wisconsin, it has\nbeen owned by Amazon since 2006 but continues to operate as its own distinct storefront and\nbrand. There's no Shopbop co-brand credit card, so purchases are best charged to an apparel\nor general online shopping rewards card, or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42352.1000000904&trid=1552713.178509&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -9239,7 +9394,8 @@
       "intro": "Sleep Number makes adjustable air chamber mattresses and smart beds sold under its own\nnumbered firmness system, along with the SleepIQ technology that tracks sleep quality and\nautomatically adjusts firmness overnight. The company sells almost entirely direct to\nconsumer through its own retail stores and website rather than through third-party\nfurniture or mattress retailers. There's no Sleep Number co-brand credit card, so a\nmattress or bedding purchase is best charged to a furniture or general online shopping\nrewards card, or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12365.3966027&trid=1552713.225614&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -9304,7 +9460,8 @@
       "intro": "SOCCER.com is an online specialty retailer focused entirely on soccer gear, carrying\ncleats, jerseys, balls, training equipment, and apparel from major brands like Nike,\nadidas, and Puma alongside club and national team kits. It's one of the larger dedicated\nsoccer e-commerce sites in the US market, serving both individual players and team or club\norders. There's no SOCCER.com co-brand credit card, so shoppers should lean on a sporting\ngoods or general online shopping rewards card, or a flat-rate cashback card, when checking out.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8096.576831&trid=1552713.157185&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off"
       }
     },
     {
@@ -9569,7 +9726,8 @@
       "intro": "Stila is a Los Angeles-founded makeup brand known for its Stay All Day liquid lipstick and\nwaterproof eyeliners, sold direct online as well as through Ulta, Sephora, and various\ndepartment stores. It carries no co-brand credit card of its own. Shoppers buying directly\nfrom stilacosmetics.com are best off with a card that rewards general online shopping,\nwhile purchases made in-store at a partner retailer may earn more under that retailer's\nown department-store or drugstore bonus category instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.116637.3227301&trid=1552713.158360&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off with code SAVEMORE"
       }
     },
     {
@@ -9630,7 +9788,8 @@
       "intro": "Stride Rite is a children's footwear brand dating to 1919, known for shoes designed around\nearly walkers and growing feet, sold through its own online store as well as department\nstores and shoe retailers. It does not have a co-brand credit card. Shoppers buying\ndirectly from striderite.com will get the most value from a card with a strong online\nshopping or select-clothing bonus category, while in-store purchases at a partner retailer\nmay fall under that store's own bonus category instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37376.3385185&trid=1552713.159288&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -9785,7 +9944,8 @@
       "intro": "Taskrabbit is an online marketplace that connects people with independent taskers for\nfurniture assembly, moving help, home repairs, and other odd jobs, booked and paid for\nthrough its app or website. It has been owned by IKEA since 2017 and handles a large share\nof IKEA furniture assembly bookings in addition to general handyman tasks. Taskrabbit has\nno co-brand credit card, so a flat-rate cashback card or a card that earns extra on online\nshopping purchases is the most practical way to earn rewards when booking a task.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18223.2951684&trid=1552713.234963&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "$10 off for new customers"
       }
     },
     {
@@ -9870,7 +10030,8 @@
       "intro": "The Bouqs Company is an online flower delivery service that ships farm-direct bouquets cut\nto order rather than sourcing from a traditional florist warehouse, along with plants and\ngift add-ons, sold through its own website and app on a one-time or subscription basis.\nIt has no co-brand credit card. Because it operates purely as an online retailer, a card\nwith a strong online shopping bonus category, or a flat-rate cashback card, will earn the\nmost on an order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.39813.3964750&trid=1552713.161010&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off with code FLASH"
       }
     },
     {
@@ -9933,7 +10094,8 @@
       "intro": "The Knot is a wedding planning platform offering vendor directories, registries, website\nbuilders, and invitation design, operated by The Knot Worldwide alongside sister brands\nlike WeddingWire. Purchases through the site typically flow through The Knot's gift and\nregistry shop or its invitation and stationery store rather than a single storefront. The\nKnot has no co-brand credit card, so a card with a strong online shopping bonus category,\nor a flat-rate cashback card, is the most reliable way to earn rewards on registry or\nstationery purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12032.1985622&trid=1552713.222266&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off with code PAPER15"
       }
     },
     {
@@ -9951,7 +10113,8 @@
       "intro": "The Men's Wearhouse is a men's formalwear and business-apparel retailer known for suit\nsales and tuxedo rentals, operating hundreds of stores nationwide alongside its online\nshop, and owned by Tailored Brands, which also owns Jos. A. Bank. There is no Men's\nWearhouse co-brand credit card, though the retailer does offer its own Perfect Fit loyalty\nprogram. For everyday credit card rewards, shoppers should reach for a card with a strong\nonline shopping or select-clothing bonus category when buying online, or a flat-rate\ncashback card in store.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41420.1000012226&trid=1552713.178339&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off clearance"
       }
     },
     {
@@ -10047,7 +10210,8 @@
       "intro": "Thrive Causemetics is a cruelty-free cosmetics brand built around a buy-one-give-one model\nthat donates products and funds to causes supporting women, sold primarily direct-to-\nconsumer online as well as through Ulta Beauty. It has no co-brand credit card. Orders\nplaced directly on thrivecausemetics.com are best matched to a card with a strong online\nshopping bonus category, while purchases made through Ulta would instead earn under that\nretailer's own department-store or beauty category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110003653.1100176299&trid=1552713.232808&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -10100,7 +10264,8 @@
       "intro": "Timberland is an outdoor footwear and apparel brand best known for its rugged yellow boot,\nnow part of a lineup that includes hiking, work, and casual footwear plus jackets and bags,\nowned by VF Corporation alongside brands like The North Face and Vans. There is no\nTimberland co-brand credit card. Shoppers buying directly through timberland.com will get\nthe most value from a card with a strong online shopping or select-clothing bonus category,\nand a flat-rate cashback card works well for purchases at outlet or partner stores.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25164.2107591&trid=1552713.239487&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off on your birthday"
       }
     },
     {
@@ -10137,7 +10302,8 @@
       "intro": "Tommy Bahama is an island-lifestyle apparel brand known for its silk camp shirts and resort\nwear, also operating a chain of restaurant-and-retail locations, and owned by Oxford\nIndustries. It has no co-brand credit card. Purchases made directly through\ntommybahama.com are best matched to a card with a strong online shopping or\nselect-clothing bonus category, while dining at one of its restaurant locations would\ninstead earn under a card's dining category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101106073.1100207512&trid=1552713.196026&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off women's apparel"
       }
     },
     {
@@ -10220,7 +10386,8 @@
       "intro": "Trade Coffee is a subscription service that matches subscribers with beans from a network\nof independent roasters across the United States based on taste preferences, shipping\nfreshly roasted coffee on a recurring schedule rather than selling a single house blend.\nIt has no co-brand credit card. Because it functions like a recurring food and beverage\npurchase, a card with a strong dining or online shopping bonus category will typically earn\nthe most on a subscription charge.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9472.2913607&trid=1552713.230744&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off your first order"
       }
     },
     {
@@ -10247,7 +10414,8 @@
       "intro": "Tramontina is a Brazilian manufacturer of cookware, cutlery, and kitchen tools, with a\nU.S.-facing catalog of stainless steel and nonstick cookware, knives, and outdoor cooking\ngear sold direct online as well as through retailers like Amazon and Walmart. It has no\nco-brand credit card. Shoppers buying directly from tramontinausa.com are best served by a\ncard with a strong home improvement or online shopping bonus category, while purchases made\nthrough a third-party retailer may earn under that store's own bonus category instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.62429.2605926&trid=1552713.245572&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off first purchase with code WELCOME10"
       }
     },
     {
@@ -10324,7 +10492,8 @@
       "intro": "True Religion is a premium denim brand founded in Los Angeles in 2002, known for its\nsignature horseshoe stitching on back pockets, with a catalog that has since expanded into\nbroader apparel and accessories sold through its own stores and website. It has no\nco-brand credit card. Shoppers buying directly through truereligion.com will get the most\nvalue from a card with a strong online shopping or select-clothing bonus category, and a\nflat-rate cashback card is a solid fallback for purchases at a physical store.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8543.610615&trid=1552713.201072&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "60% off"
       }
     },
     {
@@ -10347,7 +10516,8 @@
       "intro": "Trust & Will is an online estate planning service that lets people build wills, trusts, and\nguardian designations through a guided digital questionnaire instead of hiring a traditional\nestate attorney. Plans are priced as flat one-time or subscription fees rather than by the\nhour, which makes the total cost predictable up front. There's no Trust & Will co-brand\ncredit card, so the smartest way to pay is a flat-rate cashback card or a card that earns\nbonus rewards on general online purchases, since estate planning fees usually fall outside\nany dedicated bonus category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11883.851571&trid=1552713.202805&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with code EXCLUSIVE10"
       }
     },
     {
@@ -10467,7 +10637,8 @@
       "intro": "Universal Standard is a direct-to-consumer apparel brand built around extended sizing,\ntypically running from size 00 up through 40, with core pieces designed to be reordered\nin a consistent fit across seasons. The label sells primarily through its own site and app\nrather than leaning on wholesale department-store distribution. There's no Universal\nStandard co-brand credit card, so shoppers are better served pairing purchases with a\ngeneral online shopping rewards card or a flat-rate cashback card rather than expecting a\ndepartment-store bonus category to apply.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11299.2922125&trid=1552713.215260&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off for new customers"
       }
     },
     {
@@ -10542,7 +10713,8 @@
       "intro": "Vera Bradley is an Indiana-founded lifestyle brand known for quilted cotton handbags,\ntotes, and travel accessories in signature bold prints, sold through its own stores and\nsite as well as through department stores and specialty retailers. The company has since\nexpanded into luggage, home goods, and licensed apparel lines. There is no Vera Bradley\nco-brand credit card, so purchases are best matched to a department-store rewards card\nwhen buying through a wholesale partner, or a general online shopping or flat-rate\ncashback card when ordering directly from verabradley.com.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.24943.1010003564&trid=1552713.157861&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off for new customers"
       }
     },
     {
@@ -10609,7 +10781,8 @@
       "intro": "Vince Camuto is a contemporary footwear and accessories label, founded by the designer of\nthe same name, known for women's heels, boots, and handbags sold through its own stores\nand site as well as department stores and shoe retailers. The brand also licenses apparel\nand eyewear lines. There is no Vince Camuto co-brand credit card, so shoppers should lean\non a department-store rewards card when buying through a wholesale partner, or a general\nonline shopping or flat-rate cashback card for direct purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36963.1010000549&trid=1552713.158615&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off your first order"
       }
     },
     {
@@ -10623,7 +10796,8 @@
       "intro": "vineyard vines is a preppy American apparel brand recognized by its embroidered whale\nlogo, built around Nantucket-inspired menswear, womenswear, and kids' clothing like\nperformance polos, shorts, and dresses. The brand sells through its own stores and site as\nwell as select department and specialty stores. There's no vineyard vines co-brand credit\ncard, so a department-store rewards card fits purchases made through a wholesale partner,\nwhile a general online shopping or flat-rate cashback card works best for direct orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9524.2004980&trid=1552713.197884&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off your first order"
       }
     },
     {
@@ -10668,7 +10842,8 @@
       "intro": "Visible is a Verizon-owned prepaid wireless carrier that sells phone plans exclusively\nonline, running on Verizon's network but without the retail stores, contracts, or bundled\ndevice financing of the parent brand. Plans are flat monthly rates with no separate taxes\nor fees added at checkout. There's no Visible co-brand credit card, so recurring bills are\nbest paid with a card that earns bonus rewards on cell phone or phone bill purchases, or a\nflat-rate cashback card if no phone category applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12909.1586315&trid=1552713.213808&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off when you upgrade"
       }
     },
     {
@@ -10823,7 +10998,8 @@
       "intro": "Weber is the maker of the iconic kettle charcoal grill, a design that dates back to the\n1950s, and has since grown into a full lineup of gas, charcoal, pellet, and electric\ngrills along with smokers, accessories, and a connected app for monitoring cooks. Products\nare sold direct online, through Weber-branded retail, and through home and hardware\nstores. There's no Weber co-brand credit card, so a home improvement category card or a\ngeneral online shopping rewards card is the better fit for grill and accessory purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14695.3749619&trid=1552713.247914&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off"
       }
     },
     {
@@ -10848,7 +11024,8 @@
       "intro": "Weleda is a Swiss company that has made natural and certified-organic skincare, body care,\nand homeopathic remedies since the 1920s, built around botanical ingredients and\nbiodynamic farming practices. Its skin food and calendula lines are the brand's best-known\nU.S. products, sold direct online and through natural-grocery and pharmacy retailers.\nThere's no Weleda co-brand credit card, so a general online shopping rewards card or a\nflat-rate cashback card is the practical choice for purchases made directly through the\nbrand's site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.44684.1000000098&trid=1552713.209906&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -10898,7 +11075,8 @@
       "intro": "Westgate Resorts is a privately held hospitality company that operates timeshare and\nvacation-ownership resorts across popular U.S. destinations like Orlando, Las Vegas, and\nGatlinburg, and also rents units nightly to non-owners much like a traditional resort\nchain. It is not affiliated with the major hotel loyalty programs. There's no Westgate\nResorts co-brand credit card, so a general hotel or travel category card, or a flat-rate\ncashback card, is the better way to pay for stays and maintenance-fee charges.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110106385.1101155989&trid=1552713.245447&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 20% off nightly rates"
       }
     },
     {
@@ -11004,7 +11182,8 @@
       "intro": "Wish is an online marketplace best known for low-priced goods, from apparel and gadgets to\nhome items, shipped largely from third-party sellers and manufacturers overseas. The\nplatform emphasizes deep discounts over brand-name selection, with delivery times that can\nrun longer than typical U.S. retailers. There's no Wish co-brand credit card, so a general\nonline shopping rewards card or a flat-rate cashback card is the practical way to earn\nrewards on purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53195.1000000011&trid=1552713.216420&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off first purchase with code WISHSHOPPING"
       }
     },
     {
@@ -11032,7 +11211,8 @@
       "intro": "Wrangler is a denim and western-wear brand dating back to the 1940s, known for jeans built\nfor riding and rodeo work as well as broader casualwear, and now owned by Kontoor Brands\nalongside Lee. Products are sold direct online and through mass-market, department, and\nfarm-and-ranch retailers. There's no Wrangler co-brand credit card, so a department-store\nrewards card fits purchases made through a wholesale partner, while a general online\nshopping or flat-rate cashback card works best for direct orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25202.3966290&trid=1552713.193401&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "buy one get one 50% off shorts"
       }
     },
     {

--- a/data/affiliates.yaml
+++ b/data/affiliates.yaml
@@ -261,42 +261,52 @@ merchants:
   # 1-800 CONTACTS
   1-800-contacts:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.52869.1000000157&trid=1552713.158602&foc=16&fot=9999&fos=6"
+    offer: "30% off for new customers"
   # 1-800-PACK-RAT
   1-800-pack-rat:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.15653.2015612&trid=1552713.243983&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off with code SPRING50"
   # 1800PetMeds
   1800petmeds:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9643.322259&trid=1552713.187444&foc=16&fot=9999&fos=6"
+    offer: "40% off your first order with code NEW40"
   # 32 Degrees
   32-degrees:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25938.2098587&trid=1552713.195512&foc=16&fot=9999&fos=6"
   # 5.11 Tactical
   511-tactical:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.14180.3964608&trid=1552713.160494&foc=16&fot=9999&fos=6"
+    offer: "25% off clearance"
   # 7 For All Mankind
   7-for-all-mankind:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.36145.1010001182&trid=1552713.190539&foc=16&fot=9999&fos=6"
+    offer: "15% off your first purchase"
   # Adam & Eve
   adam-and-eve:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.6898.330062&trid=1552713.163415&foc=16&fot=9999&fos=6"
+    offer: "50% off with code BEMINE50"
   # Aesop US
   aesop:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9664.622458&trid=1552713.234849&foc=16&fot=9999&fos=6"
+    offer: "15% off"
   # Agent Provocateur
   agent-provocateur:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.39673.4611686018427606343&trid=1552713.234784&foc=16&fot=9999&fos=6"
   # Airalo
   airalo:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.15608.2071037&trid=1552713.235201&foc=16&fot=9999&fos=6"
+    offer: "15% off your first order"
   # Alice + Olivia
   alice-plus-olivia:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.46320.1000000420&trid=1552713.171105&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off"
   # Alo Yoga
   alo-yoga:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9050.342887&trid=1552713.199850&foc=16&fot=9999&fos=6"
   # Alpha Industries
   alpha-industries:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10348.694149&trid=1552713.160630&foc=16&fot=9999&fos=6"
+    offer: "up to 70% off"
   # AltraRunning.com
   altra-running:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25235.2222689&trid=1552713.208254&foc=16&fot=9999&fos=6"
@@ -309,105 +319,133 @@ merchants:
   # American Tourister
   american-tourister:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11773.3362296&trid=1552713.228756&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off clearance"
   # Amerisleep
   amerisleep:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.34206.2911518&trid=1552713.235962&foc=16&fot=9999&fos=6"
   # Anastasia of Beverly Hills
   anastasia-of-beverly-hills:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.52750.1000000259&trid=1552713.243843&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off"
   # Anker US
   anker:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.43469.1000000368&trid=1552713.201036&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off"
   # Ariat
   ariat:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10644.3947926&trid=1552713.240088&foc=16&fot=9999&fos=6"
+    offer: "buy one get one 50% off"
   # Art.com
   art-com:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.45368.1000000115&trid=1552713.215196&foc=16&fot=9999&fos=6"
   # ASICS America
   asics:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.40996.1000000724&trid=1552713.180034&foc=16&fot=9999&fos=6"
+    offer: "30% off"
   # Aspen Dental
   aspen-dental:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.20979.3298152&trid=1552713.239908&foc=16&fot=9999&fos=6"
+    offer: "20% off"
   # Astound Broadband Powered by RCN
   astound-broadband-powered-by-rcn:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.4318.3845202&trid=1552713.180101&foc=16&fot=9999&fos=6"
   # Autonomous Inc.
   autonomous:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.42643.1000000306&trid=1552713.193704&foc=16&fot=9999&fos=6"
+    offer: "up to 18% off"
   # Aventon Bikes
   aventon-bikes:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156099.19453.1322385&trid=1552713.228738&foc=16&fot=9999&fos=6"
   # Avery
   avery:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8547.483063&trid=1552713.190782&foc=16&fot=9999&fos=6"
+    offer: "25% off with code A25OFF1000"
   # Away
   away:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8621.615456&trid=1552713.233568&foc=16&fot=9999&fos=6"
+    offer: "50% off"
   # Babylist
   babylist:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.13580.1458037&trid=1552713.237794&foc=16&fot=9999&fos=6"
+    offer: "10% off"
   # Banana Republic Factory
   banana-republic-factory:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10152.3965949&trid=1552713.196751&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off select styles"
   # Barefoot Dreams, Inc.
   barefoot-dreams:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.20795.3952919&trid=1552713.237568&foc=16&fot=9999&fos=6"
+    offer: "up to 70% off with code DREAM15"
   # Beautyrest
   beautyrest:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10598.1938255&trid=1552713.248817&foc=16&fot=9999&fos=6"
+    offer: "50% off"
   # Benefit Cosmetics
   benefit-cosmetics:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.24765.169441110001948&trid=1552713.169943&foc=16&fot=9999&fos=6"
+    offer: "15% off"
   # Blenders Eyewear
   blenders-eyewear:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.60071.4611686018427604884&trid=1552713.207001&foc=16&fot=9999&fos=6"
   # Blueair
   blueair:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.16168.3107588&trid=1552713.243992&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off"
   # Bombas Socks
   bombas-socks:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8171.618217&trid=1552713.240202&foc=16&fot=9999&fos=6"
+    offer: "25% off your first purchase"
   # Bonobos eCommerce Performance
   bonobos:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11113.3963402&trid=1552713.248479&foc=16&fot=9999&fos=6"
+    offer: "30% off select styles"
   # Bowflex
   bowflex:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25788.2161948&trid=1552713.159315&foc=16&fot=9999&fos=6"
+    offer: "15% off $400+ with code SAVE15"
   # brahmin.com
   brahmin:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.39712.1000000416&trid=1552713.245806&foc=16&fot=9999&fos=6"
+    offer: "15% off orders over $250"
   # Braun
   braun:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.23589.3769635&trid=1552713.226436&foc=16&fot=9999&fos=6"
+    offer: "15% off first purchase with code SMOOTH15"
   # Brooks Brothers
   brooks-brothers:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.10113.589809&trid=1552713.245195&foc=16&fot=9999&fos=6"
   # Budget Car Rental
   budget-car-rental:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110100467.1100135418&trid=1552713.235827&foc=16&fot=9999&fos=6"
+    offer: "up to 35% off"
   # Budget Truck Rental
   budget-truck-rental:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.101100538.1011107121&trid=1552713.235867&foc=16&fot=9999&fos=6"
+    offer: "20% off with code 20DIS"
   # Buffy Inc
   buffy:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.28059.2836301&trid=1552713.214427&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off sale items"
   # Bumble and Bumble US
   bumble-and-bumble:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.38785.1000001546&trid=1552713.179164&foc=16&fot=9999&fos=6"
+    offer: "up to 30% off"
   # Bushnell
   bushnell:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156099.20977.1329725&trid=1552713.237984&foc=16&fot=9999&fos=6"
+    offer: "25% off sitewide"
   # Caesars Rewards: Hotels (Global)
   caesars-rewards:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.6145.3660150&trid=1552713.194743&foc=16&fot=9999&fos=6"
+    offer: "33% off"
   # Calvin Klein
   calvin-klein:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.43317.4611686018427577129&trid=1552713.188219&foc=16&fot=9999&fos=6"
+    offer: "buy 1 get 1 50% off sitewide"
   # Calzedonia
   calzedonia:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.43180.1000000423&trid=1552713.199589&foc=16&fot=9999&fos=6"
+    offer: "50% off select styles"
   # Camp Chef
   camp-chef:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156099.30761.1209073&trid=1552713.239313&foc=16&fot=9999&fos=6"
@@ -420,9 +458,11 @@ merchants:
   # Cavender's
   cavenders:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.36070.3856555&trid=1552713.246090&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off"
   # CHARLES & KEITH (US)
   charles-and-keith:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.13805.3939221&trid=1552713.194849&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off select styles"
   # CheapOair.ca
   cheapoair:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156105.37732.1000000463&trid=1552713.158377&foc=16&fot=9999&fos=6"
@@ -435,21 +475,25 @@ merchants:
   # Cole Haan
   cole-haan:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.45770.1000000714&trid=1552713.196522&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off sale items"
   # Cometeer
   cometeer:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.15716.1950739&trid=1552713.228152&foc=16&fot=9999&fos=6"
   # Corkcicle
   corkcicle:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.13045.3363020&trid=1552713.245365&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off sale items"
   # CORSAIR
   corsair:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.8513.2643428&trid=1552713.233391&foc=16&fot=9999&fos=6"
   # COS
   cos:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.42840.1000000776&trid=1552713.227732&foc=16&fot=9999&fos=6"
+    offer: "10% off your first order"
   # Cosori
   cosori:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.41709.3818110&trid=1552713.245911&foc=16&fot=9999&fos=6"
+    offer: "10% off sitewide"
   # Cruise America
   cruise-america:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.29922.2807206&trid=1552713.245350&foc=16&fot=9999&fos=6"
@@ -459,75 +503,94 @@ merchants:
   # David's Bridal
   davids-bridal:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.52798.1000000070&trid=1552713.235285&foc=16&fot=9999&fos=6"
+    offer: "10% off"
   # Delonghi US
   delonghi:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.33739.2287345&trid=1552713.232052&foc=16&fot=9999&fos=6"
+    offer: "10% off your first order"
   # DELSEY Paris
   delsey-paris:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.36622.3294033&trid=1552713.234891&foc=16&fot=9999&fos=6"
+    offer: "20% off with code TRAVEL20"
   # Dermalogica
   dermalogica:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.40620.1000000137&trid=1552713.226144&foc=16&fot=9999&fos=6"
+    offer: "up to 30% off"
   # Dermstore
   dermstore:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.53945.1000000106&trid=1552713.209693&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off"
   # DEWALT
   dewalt:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156099.27569.1152773&trid=1552713.237589&foc=16&fot=9999&fos=6"
   # DHgate
   dhgate:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12108.1466364&trid=1552713.243958&foc=16&fot=9999&fos=6"
+    offer: "up to 80% off"
   # Diane von Furstenberg EU
   diane-von-furstenberg:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156174.53601.1000000014&trid=1552713.230273&foc=16&fot=9999&fos=6"
+    offer: "15% off"
   # Dickies
   dickies:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25209.2029313&trid=1552713.230392&foc=16&fot=9999&fos=6"
+    offer: "15% off for new customers"
   # Diesel US
   diesel:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.49384.1000000078&trid=1552713.232396&foc=16&fot=9999&fos=6"
+    offer: "50% off"
   # DIFF Eyewear
   diff-eyewear:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9933.288188&trid=1552713.211526&foc=16&fot=9999&fos=6"
+    offer: "40% off your next order"
   # Dinnerly (US)
   dinnerly:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.10033.3840387&trid=1552713.195361&foc=16&fot=9999&fos=6"
+    offer: "up to $185 off your first 5 boxes"
   # DJI
   dji:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.7327.4611686018427603991&trid=1552713.217744&foc=16&fot=9999&fos=6"
   # Dooney & Bourke
   dooney-and-bourke:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.6652.625287&trid=1552713.162489&foc=16&fot=9999&fos=6"
+    offer: "up to 70% off clearance"
   # Dorothy Perkins UK
   dorothy-perkins:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.1134.3978513&trid=1552713.232050&foc=16&fot=9999&fos=6"
+    offer: "up to 75% off"
   # Dr. Scholl's
   dr-scholls:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9749.620939&trid=1552713.235857&foc=16&fot=9999&fos=6"
+    offer: "up to 20% off"
   # Drunk Elephant
   drunk-elephant:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.10029.623157&trid=1552713.232403&foc=16&fot=9999&fos=6"
+    offer: "30% off"
   # Eagle Creek
   eagle-creek:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156099.31713.1398401&trid=1552713.239618&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off"
   # Eastern Mountain Sports
   eastern-mountain-sports:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.53845.1000000002&trid=1552713.159802&foc=16&fot=9999&fos=6"
   # ECCO US & CA
   ecco:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.39558.1000002653&trid=1552713.180375&foc=16&fot=9999&fos=6"
+    offer: "20% off $250+ with code ECCODEAL"
   # ecobee
   ecobee:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.46044.1000000018&trid=1552713.215645&foc=16&fot=9999&fos=6"
   # EILEEN FISHER
   eileen-fisher:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.42820.1000000372&trid=1552713.213376&foc=16&fot=9999&fos=6"
+    offer: "15% off your first purchase"
   # e.l.f. Cosmetics
   elf-cosmetics:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.39724.1000001482&trid=1552713.157129&foc=16&fot=9999&fos=6"
   # Estee Lauder
   estee-lauder:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.36314.1010001823&trid=1552713.186487&foc=16&fot=9999&fos=6"
+    offer: "15% off"
   # Etihad Airways (Global)
   etihad-airways:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.1100166.1011162159&trid=1552713.226079&foc=16&fot=9999&fos=6"
@@ -540,33 +603,39 @@ merchants:
   # Farberware
   farberware:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11993.3959083&trid=1552713.239550&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off"
   # Fender Musical Instruments Corp.
   fender:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.33985.2956212&trid=1552713.242190&foc=16&fot=9999&fos=6"
   # Fenty Beauty (Global)
   fenty-beauty:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.42834.1000001431&trid=1552713.214878&foc=16&fot=9999&fos=6"
+    offer: "50% off"
   # FitFlop
   fitflop:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.41223.1000001291&trid=1552713.179233&foc=16&fot=9999&fos=6"
+    offer: "15% off"
   # Fjällräven
   fjallraven:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156099.29113.1175129&trid=1552713.235909&foc=16&fot=9999&fos=6"
   # Florsheim
   florsheim:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.3382.119544810000835&trid=1552713.462&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off select styles"
   # fuboTV
   fubotv:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.5119.383725&trid=1552713.176972&foc=16&fot=9999&fos=6"
   # Furla US
   furla:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.101105919.1011116822&trid=1552713.226358&foc=16&fot=9999&fos=6"
+    offer: "10% off"
   # G-Star RAW
   g-star-raw:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110101042.101161543&trid=1552713.207312&foc=16&fot=9999&fos=6"
   # Gametime
   gametime:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10874.1443269&trid=1552713.214076&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off"
   # Gazelle
   gazelle:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.17233.3877131&trid=1552713.202442&foc=16&fot=9999&fos=6"
@@ -576,51 +645,64 @@ merchants:
   # ghd (US)
   ghd:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.8033.3960327&trid=1552713.178100&foc=16&fot=9999&fos=6"
+    offer: "25% off sitewide"
   # Gilt & Gilt City
   gilt-and-gilt-city:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.1000009372.1100147967&trid=1552713.158309&foc=16&fot=9999&fos=6"
+    offer: "80% off"
   # Glossier
   glossier:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.7573.2132593&trid=1552713.171220&foc=16&fot=9999&fos=6"
   # GNC
   gnc:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.53638.1000000515&trid=1552713.162841&foc=16&fot=9999&fos=6"
+    offer: "buy one get one 50% off vitamins"
   # Godiva
   godiva:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.101106374.111034562&trid=1552713.159640&foc=16&fot=9999&fos=6"
+    offer: "15% off your first order with code WELCOME15"
   # Going
   going:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10802.731100&trid=1552713.237685&foc=16&fot=9999&fos=6"
+    offer: "up to 90% off"
   # Goldbelly
   goldbelly:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.13451.3881759&trid=1552713.215607&foc=16&fot=9999&fos=6"
+    offer: "30% off"
   # GOVEE
   govee:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12845.2840658&trid=1552713.224344&foc=16&fot=9999&fos=6"
+    offer: "60% off"
   # Greenworks Tools
   greenworks-tools:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.53521.1000000004&trid=1552713.232799&foc=16&fot=9999&fos=6"
   # Grove Collaborative
   grove-collaborative:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.8442.2825761&trid=1552713.201205&foc=16&fot=9999&fos=6"
+    offer: "20% off your first order with code WELCOME"
   # Guess
   guess:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9298.616619&trid=1552713.158989&foc=16&fot=9999&fos=6"
+    offer: "30% off $250+ with code GET30OFF"
   # Gymboree
   gymboree:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10756.2013600&trid=1552713.214444&foc=16&fot=9999&fos=6"
+    offer: "80% off clearance"
   # Hanes.com
   hanes:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.24366.1010005156&trid=1552713.166211&foc=16&fot=9999&fos=6"
+    offer: "50% off select styles"
   # Hanna Andersson
   hanna-andersson:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.5644.2692567&trid=1552713.181293&foc=16&fot=9999&fos=6"
+    offer: "20% off for new customers"
   # Hers
   hers:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.23930.4611686018427603203&trid=1552713.203896&foc=16&fot=9999&fos=6"
   # Hey Dude Shoes
   hey-dude-shoes:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.16269.1358297&trid=1552713.227887&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off select styles"
   # Hickory Farms
   hickory-farms:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.5619.1568327&trid=1552713.196521&foc=16&fot=9999&fos=6"
@@ -630,33 +712,40 @@ merchants:
   # Hill's Pet Nutrition US
   hills-pet-nutrition:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.53370.1000000017&trid=1552713.243039&foc=16&fot=9999&fos=6"
+    offer: "40% off your first order with code SUMMER40"
   # HOKA DE
   hoka:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.17204.3988217&trid=1552713.231962&foc=16&fot=9999&fos=6"
   # Homedics
   homedics:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11735.1101069&trid=1552713.239601&foc=16&fot=9999&fos=6"
+    offer: "10% off"
   # Huel (US)
   huel:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.54599.4611686018427605580&trid=1552713.235672&foc=16&fot=9999&fos=6"
   # Hugo Boss
   hugo-boss:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.39079.1000000422&trid=1552713.160207&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off sale items"
   # Hungryroot
   hungryroot:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.53058.1000000002&trid=1552713.201413&foc=16&fot=9999&fos=6"
+    offer: "30% off orders $99+"
   # Hydro Flask
   hydro-flask:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.18825.1922057&trid=1552713.202999&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off"
   # Icebreaker US
   icebreaker:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25168.2082702&trid=1552713.247495&foc=16&fot=9999&fos=6"
   # Igloo Coolers
   igloo-coolers:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.46441.1000000006&trid=1552713.208505&foc=16&fot=9999&fos=6"
+    offer: "up to 35% off"
   # Innisfree
   innisfree:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.48045.1000000392&trid=1552713.239749&foc=16&fot=9999&fos=6"
+    offer: "25% off"
   # IPSY
   ipsy:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10459.2078428&trid=1552713.226275&foc=16&fot=9999&fos=6"
@@ -666,48 +755,60 @@ merchants:
   # J. Jill
   j-jill:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.54107.198854455&trid=1552713.201947&foc=16&fot=9999&fos=6"
+    offer: "40% off sale styles"
   # JD Sports
   jd-sports:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.43953.1000000043&trid=1552713.206768&foc=16&fot=9999&fos=6"
   # Johnston & Murphy
   johnston-and-murphy:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.38419.1000000980&trid=1552713.162278&foc=16&fot=9999&fos=6"
+    offer: "20% off select styles"
   # Jonathan Adler
   jonathan-adler:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.50036.1000000004&trid=1552713.216122&foc=16&fot=9999&fos=6"
+    offer: "up to 65% off"
   # Jos. A. Bank
   jos-a-bank:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.38377.1000016446&trid=1552713.196&foc=16&fot=9999&fos=6"
+    offer: "up to 70% off clearance"
   # K-Swiss
   k-swiss:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9956.311096&trid=1552713.227940&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off select styles"
   # Kaplan North America
   kaplan:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.1697.1010005031&trid=1552713.200470&foc=16&fot=9999&fos=6"
+    offer: "25% off with code FRESHSTART25"
   # Keds
   keds:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110006127.1100126495&trid=1552713.160396&foc=16&fot=9999&fos=6"
+    offer: "up to 70% off sale styles"
   # KEEN Footwear
   keen-footwear:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.34908.2993656&trid=1552713.243968&foc=16&fot=9999&fos=6"
   # Kendra Scott
   kendra-scott:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.50471.3951190&trid=1552713.199434&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off"
   # Keurig
   keurig:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.39219.1000002801&trid=1552713.170716&foc=16&fot=9999&fos=6"
+    offer: "50% off"
   # Kobo Australia
   kobo:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156124.38131.1000001233&trid=1552713.172439&foc=16&fot=9999&fos=6"
   # Kohler
   kohler:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.44732.1000000352&trid=1552713.215079&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off vanities & sinks"
   # Kylie Cosmetics US
   kylie-cosmetics:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.46759.1000000061&trid=1552713.224336&foc=16&fot=9999&fos=6"
+    offer: "15% off your first order"
   # LastPass
   lastpass:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.8692.2595725&trid=1552713.206309&foc=16&fot=9999&fos=6"
+    offer: "20% off for new customers"
   # LATAM Airlines
   latam-airlines:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25131.3887134&trid=1552713.237808&foc=16&fot=9999&fos=6"
@@ -717,45 +818,55 @@ merchants:
   # Lee Jeans
   lee-jeans:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11766.3960014&trid=1552713.237878&foc=16&fot=9999&fos=6"
+    offer: "50% off with code SHORT"
   # LegalZoom.com
   legalzoom:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.26746.2115304&trid=1552713.240854&foc=16&fot=9999&fos=6"
   # Levoit
   levoit:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.41708.3910127&trid=1552713.235505&foc=16&fot=9999&fos=6"
+    offer: "40% off"
   # Life is Good
   life-is-good:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.14635.1948131&trid=1552713.158389&foc=16&fot=9999&fos=6"
+    offer: "25% off"
   # Lindt Chocolatier
   lindt-chocolatier:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8053.574848&trid=1552713.180430&foc=16&fot=9999&fos=6"
   # Liquid I.V.
   liquid-iv:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.13609.1958902&trid=1552713.242792&foc=16&fot=9999&fos=6"
+    offer: "30% off"
   # Little Sleepies
   little-sleepies:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.20265.2102732&trid=1552713.233129&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off sale items"
   # LOOKFANTASTIC US
   lookfantastic:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.29067.4611686018427603543&trid=1552713.178746&foc=16&fot=9999&fos=6"
   # Lucky Brand
   lucky-brand:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9596.504271&trid=1552713.187771&foc=16&fot=9999&fos=6"
+    offer: "up to 75% off"
   # Lucky Strike
   lucky-strike:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.53231.1000000002&trid=1552713.239304&foc=16&fot=9999&fos=6"
   # Lumens Light + Living
   lumens-light-plus-living:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.3281.197540&trid=1552713.158720&foc=16&fot=9999&fos=6"
+    offer: "up to 75% off clearance"
   # Madison Reed
   madison-reed:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.13741.3966078&trid=1552713.200433&foc=16&fot=9999&fos=6"
+    offer: "25% off with code BDAY26"
   # Manscaped UK
   manscaped:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156139.48084.1000000017&trid=1552713.249081&foc=16&fot=9999&fos=6"
+    offer: "up to 22% off"
   # Marc Jacobs
   marc-jacobs:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8338.584825&trid=1552713.205419&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off"
   # Mario Badescu
   mario-badescu:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.122442.4611686018427605569&trid=1552713.233679&foc=16&fot=9999&fos=6"
@@ -774,24 +885,29 @@ merchants:
   # MeUndies
   meundies:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.26749.3868010&trid=1552713.197539&foc=16&fot=9999&fos=6"
+    offer: "30% off your first purchase"
   # Milani Cosmetics
   milani-cosmetics:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.50546.1000000123&trid=1552713.232500&foc=16&fot=9999&fos=6"
+    offer: "25% off"
   # Milk Bar
   milk-bar:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9484.411983&trid=1552713.211101&foc=16&fot=9999&fos=6"
   # Milk Makeup
   milk-makeup:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.21499.1993215&trid=1552713.199552&foc=16&fot=9999&fos=6"
+    offer: "up to 98% off"
   # Mint Mobile
   mint-mobile:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.7915.2191950&trid=1552713.199305&foc=16&fot=9999&fos=6"
   # Minted
   minted:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.19909.3746698&trid=1552713.200435&foc=16&fot=9999&fos=6"
+    offer: "25% off with code ENGAGED25"
   # Misfits Market
   misfits-market:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12419.2170579&trid=1552713.236533&foc=16&fot=9999&fos=6"
+    offer: "up to 30% off"
   # Mizuno
   mizuno:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.5422.2862402&trid=1552713.158961&foc=16&fot=9999&fos=6"
@@ -801,24 +917,30 @@ merchants:
   # Moroccanoil
   moroccanoil:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.43410.1000000587&trid=1552713.211705&foc=16&fot=9999&fos=6"
+    offer: "25% off with code STYLERS2026"
   # Movado
   movado:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.46238.1000000020&trid=1552713.226379&foc=16&fot=9999&fos=6"
   # Munchkin
   munchkin:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.7649.483108&trid=1552713.163230&foc=16&fot=9999&fos=6"
+    offer: "10% off with sign up"
   # Naked Wines
   naked-wines:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.13852.1723735&trid=1552713.163400&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off with code IMPACT12PK"
   # Nars
   nars:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8113.610942&trid=1552713.194170&foc=16&fot=9999&fos=6"
+    offer: "up to 48% off"
   # Native Shoes
   native-shoes:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.14513.1998567&trid=1552713.234726&foc=16&fot=9999&fos=6"
+    offer: "10% off with sign up"
   # Nautica.com
   nautica:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.5361.260311&trid=1552713.161992&foc=16&fot=9999&fos=6"
+    offer: "15% off"
   # NBA League Pass
   nba-league-pass:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.16284.2176785&trid=1552713.240613&foc=16&fot=9999&fos=6"
@@ -828,42 +950,52 @@ merchants:
   # New Era
   new-era:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.45269.1000000343&trid=1552713.215793&foc=16&fot=9999&fos=6"
+    offer: "up to 45% off select styles"
   # NFL+
   nfl-plus:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.5298.618531&trid=1552713.160987&foc=16&fot=9999&fos=6"
   # Nutribullet
   nutribullet:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9496.622476&trid=1552713.211957&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off"
   # Off-White
   off-white:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110106474.4611686018427604358&trid=1552713.241259&foc=16&fot=9999&fos=6"
   # OLAPLEX
   olaplex:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.49376.1000000046&trid=1552713.232646&foc=16&fot=9999&fos=6"
+    offer: "15% off your first order"
   # Olipop
   olipop:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12980.1270029&trid=1552713.226085&foc=16&fot=9999&fos=6"
+    offer: "32% off with code SODALOVE"
   # OmahaSteaks.com, Inc.
   omaha-steaks:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.147.4611686018427592559&trid=1552713.185&foc=16&fot=9999&fos=6"
+    offer: "50% off sitewide"
   # One Kings Lane
   one-kings-lane:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.10043.582414&trid=1552713.233565&foc=16&fot=9999&fos=6"
+    offer: "20% off"
   # OneTravel.com
   onetravel:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.35420.1010000558&trid=1552713.157114&foc=16&fot=9999&fos=6"
   # Osprey
   osprey:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.20745.2991713&trid=1552713.243977&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off sale items"
   # Outdoor Voices
   outdoor-voices:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25944.3907598&trid=1552713.207781&foc=16&fot=9999&fos=6"
+    offer: "20% off your first order"
   # Owlet
   owlet:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.93077.3306615&trid=1552713.224412&foc=16&fot=9999&fos=6"
+    offer: "10% off with code BIRTHCOLLECTIVE10"
   # OXO
   oxo:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.9558.2991709&trid=1552713.207703&foc=16&fot=9999&fos=6"
+    offer: "up to 20% off"
   # Paul Smith USA
   paul-smith:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.127483.4611686018427606298&trid=1552713.232801&foc=16&fot=9999&fos=6"
@@ -873,12 +1005,15 @@ merchants:
   # Penske Truck Rental
   penske-truck-rental:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.101106404.111000691&trid=1552713.242188&foc=16&fot=9999&fos=6"
+    offer: "10% off with code GETMOVING"
   # PerriconeMD US
   perricone-md:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.21122.3969291&trid=1552713.178759&foc=16&fot=9999&fos=6"
+    offer: "50% off with code EYE50"
   # Personalization Mall
   personalization-mall:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.29824.3960848&trid=1552713.243972&foc=16&fot=9999&fos=6"
+    offer: "50% off"
   # Peter Thomas Roth Labs
   peter-thomas-roth:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.36862.1000000967&trid=1552713.192437&foc=16&fot=9999&fos=6"
@@ -891,48 +1026,60 @@ merchants:
   # Polk Audio Global
   polk-audio:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.101106052.1100105683&trid=1552713.225844&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off"
   # Princess Cruise Lines, Ltd.
   princess-cruises:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.40030.1000000599&trid=1552713.172492&foc=16&fot=9999&fos=6"
   # Prose
   prose:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11046.1964687&trid=1552713.202760&foc=16&fot=9999&fos=6"
+    offer: "50% off your first order"
   # Public Goods
   public-goods:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11802.918004&trid=1552713.226288&foc=16&fot=9999&fos=6"
+    offer: "10% off your first purchase with code RMN10"
   # Puffy Mattress
   puffy-mattress:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12125.1617842&trid=1552713.239252&foc=16&fot=9999&fos=6"
+    offer: "15% off with code EDU"
   # Purple Carrot
   purple-carrot:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.9141.778037&trid=1552713.206350&foc=16&fot=9999&fos=6"
   # Quill
   quill:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110006434.1011166830&trid=1552713.159251&foc=16&fot=9999&fos=6"
+    offer: "52% off"
   # rag & bone
   rag-and-bone:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.19645.3764113&trid=1552713.233128&foc=16&fot=9999&fos=6"
   # Razer Online Store
   razer-online-store:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10229.1781361&trid=1552713.163469&foc=16&fot=9999&fos=6"
+    offer: "75% off"
   # RC Willey
   rc-willey:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.39945.1000001540&trid=1552713.195269&foc=16&fot=9999&fos=6"
+    offer: "up to 75% off clearance"
   # Rebecca Minkoff US
   rebecca-minkoff:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9950.511647&trid=1552713.162599&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off select styles"
   # Reef
   reef:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.23921.1999849&trid=1552713.194581&foc=16&fot=9999&fos=6"
+    offer: "15% off your first order"
   # Rent the Runway
   rent-the-runway:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9690.590512&trid=1552713.225416&foc=16&fot=9999&fos=6"
+    offer: "up to 90% off sale items"
   # ResortPass
   resortpass:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.50076.3871321&trid=1552713.237733&foc=16&fot=9999&fos=6"
+    offer: "$20 off your first booking over $100"
   # Restaurant.com
   restaurant-com:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.21234.1813802&trid=1552713.157348&foc=16&fot=9999&fos=6"
+    offer: "50% off dining deals"
   # Reverb
   reverb:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.67144.4611686018427603056&trid=1552713.232346&foc=16&fot=9999&fos=6"
@@ -942,18 +1089,22 @@ merchants:
   # Roborock
   roborock:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.14848.1705455&trid=1552713.240023&foc=16&fot=9999&fos=6"
+    offer: "4% off"
   # Rosetta Stone
   rosetta-stone:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.18979.2904352&trid=1552713.172635&foc=16&fot=9999&fos=6"
+    offer: "up to 55% off"
   # RTIC Outdoors
   rtic-outdoors:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25922.4611686018427603539&trid=1552713.228765&foc=16&fot=9999&fos=6"
   # Rue La La
   rue-la-la:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.1000005478.1011209521&trid=1552713.161427&foc=16&fot=9999&fos=6"
+    offer: "up to 90% off"
   # Rugs USA
   rugs:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.9280.3964472&trid=1552713.203964&foc=16&fot=9999&fos=6"
+    offer: "20% off with code SUMMER"
   # Samsung
   samsung:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.47773.1000000009&trid=1552713.159074&foc=16&fot=9999&fos=6"
@@ -963,12 +1114,14 @@ merchants:
   # Scholastic
   scholastic:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8138.229226&trid=1552713.158514&foc=16&fot=9999&fos=6"
+    offer: "up to 30% off"
   # Schwinn Fitness
   schwinn-fitness:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25824.2760452&trid=1552713.246191&foc=16&fot=9999&fos=6"
   # Seed Health, Inc
   seed-health:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.19848.1987528&trid=1552713.240621&foc=16&fot=9999&fos=6"
+    offer: "15% off"
   # Segway Inc.
   segway:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156099.31949.1241153&trid=1552713.240078&foc=16&fot=9999&fos=6"
@@ -978,6 +1131,7 @@ merchants:
   # SharkNinja
   sharkninja:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.8359.1823241&trid=1552713.225856&foc=16&fot=9999&fos=6"
+    offer: "20% off with code STYLE20"
   # Shiseido
   shiseido:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.43599.4611686018427606376&trid=1552713.191860&foc=16&fot=9999&fos=6"
@@ -987,18 +1141,21 @@ merchants:
   # Shopbop
   shopbop:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.42352.1000000904&trid=1552713.178509&foc=16&fot=9999&fos=6"
+    offer: "15% off your first order"
   # Skillshare
   skillshare:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.4650.2163448&trid=1552713.196037&foc=16&fot=9999&fos=6"
   # Sleep Number
   sleep-number:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12365.3966027&trid=1552713.225614&foc=16&fot=9999&fos=6"
+    offer: "50% off"
   # Smartwool
   smartwool:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25166.2184624&trid=1552713.245347&foc=16&fot=9999&fos=6"
   # SOCCER.com
   soccer-com:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8096.576831&trid=1552713.157185&foc=16&fot=9999&fos=6"
+    offer: "up to 70% off"
   # SodaStream USA
   sodastream:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.42748.1000000195&trid=1552713.165&foc=16&fot=9999&fos=6"
@@ -1017,18 +1174,21 @@ merchants:
   # Stila Cosmetics
   stila-cosmetics:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.116637.3227301&trid=1552713.158360&foc=16&fot=9999&fos=6"
+    offer: "up to 60% off with code SAVEMORE"
   # Straight Talk
   straight-talk:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.15770.1370616&trid=1552713.158359&foc=16&fot=9999&fos=6"
   # Stride Rite
   stride-rite:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.37376.3385185&trid=1552713.159288&foc=16&fot=9999&fos=6"
+    offer: "15% off your first order"
   # Talkspace
   talkspace:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.14729.2226977&trid=1552713.196110&foc=16&fot=9999&fos=6"
   # Taskrabbit North America
   taskrabbit:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.18223.2951684&trid=1552713.234963&foc=16&fot=9999&fos=6"
+    offer: "$10 off for new customers"
   # Tatcha
   tatcha:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.38643.1000000452&trid=1552713.181394&foc=16&fot=9999&fos=6"
@@ -1038,30 +1198,38 @@ merchants:
   # The Bouqs
   the-bouqs:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.39813.3964750&trid=1552713.161010&foc=16&fot=9999&fos=6"
+    offer: "30% off with code FLASH"
   # The Knot
   the-knot:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12032.1985622&trid=1552713.222266&foc=16&fot=9999&fos=6"
+    offer: "15% off with code PAPER15"
   # The Men's Wearhouse
   the-mens-wearhouse:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.41420.1000012226&trid=1552713.178339&foc=16&fot=9999&fos=6"
+    offer: "up to 70% off clearance"
   # Therabody
   therabody:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10041.3230206&trid=1552713.243987&foc=16&fot=9999&fos=6"
   # Thrive Causemetics
   thrive-causemetics:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110003653.1100176299&trid=1552713.232808&foc=16&fot=9999&fos=6"
+    offer: "up to 40% off"
   # Timberland US
   timberland:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25164.2107591&trid=1552713.239487&foc=16&fot=9999&fos=6"
+    offer: "20% off on your birthday"
   # Tommy Bahama
   tommy-bahama:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.101106073.1100207512&trid=1552713.196026&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off women's apparel"
   # Trade Coffee
   trade-coffee:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.9472.2913607&trid=1552713.230744&foc=16&fot=9999&fos=6"
+    offer: "50% off your first order"
   # Tramontina (US)
   tramontina:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.62429.2605926&trid=1552713.245572&foc=16&fot=9999&fos=6"
+    offer: "10% off first purchase with code WELCOME10"
   # TransUnion Credit Monitoring
   transunion-credit-monitoring:
     url: "https://track.flexlinkspro.com/g.ashx?foid=24.239403.6662804&trid=1552713.239403&foc=16&fot=9999&fos=6"
@@ -1074,18 +1242,22 @@ merchants:
   # True Religion
   true-religion:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8543.610615&trid=1552713.201072&foc=16&fot=9999&fos=6"
+    offer: "60% off"
   # Trust & Will
   trust-and-will:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11883.851571&trid=1552713.202805&foc=16&fot=9999&fos=6"
+    offer: "10% off with code EXCLUSIVE10"
   # TRX Training
   trx-training:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.26332.2748229&trid=1552713.161965&foc=16&fot=9999&fos=6"
   # Universal Standard
   universal-standard:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11299.2922125&trid=1552713.215260&foc=16&fot=9999&fos=6"
+    offer: "20% off for new customers"
   # Vera Bradley Designs, Inc.
   vera-bradley:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.24943.1010003564&trid=1552713.157861&foc=16&fot=9999&fos=6"
+    offer: "20% off for new customers"
   # Viagogo
   viagogo:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110105856.1100139725&trid=1552713.199427&foc=16&fot=9999&fos=6"
@@ -1095,9 +1267,11 @@ merchants:
   # Vince Camuto
   vince-camuto:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.36963.1010000549&trid=1552713.158615&foc=16&fot=9999&fos=6"
+    offer: "20% off your first order"
   # vineyard vines
   vineyard-vines:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.9524.2004980&trid=1552713.197884&foc=16&fot=9999&fos=6"
+    offer: "20% off your first order"
   # Vionic Group LLC
   vionic:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.43354.1000000060&trid=1552713.239779&foc=16&fot=9999&fos=6"
@@ -1107,27 +1281,33 @@ merchants:
   # Visible
   visible:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12909.1586315&trid=1552713.213808&foc=16&fot=9999&fos=6"
+    offer: "up to 50% off when you upgrade"
   # Wacoal America
   wacoal:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.92241.4611686018427604523&trid=1552713.216130&foc=16&fot=9999&fos=6"
   # Weber Inc.
   weber:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.14695.3749619&trid=1552713.247914&foc=16&fot=9999&fos=6"
+    offer: "20% off"
   # Weleda
   weleda:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.44684.1000000098&trid=1552713.209906&foc=16&fot=9999&fos=6"
+    offer: "15% off your first order"
   # West Marine
   west-marine:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.44722.4611686018427605117&trid=1552713.234705&foc=16&fot=9999&fos=6"
   # Westgate Resorts
   westgate-resorts:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110106385.1101155989&trid=1552713.245447&foc=16&fot=9999&fos=6"
+    offer: "up to 20% off nightly rates"
   # Wish US & CA
   wish:
     url: "https://track.flexlinkspro.com/g.ashx?foid=1.53195.1000000011&trid=1552713.216420&foc=16&fot=9999&fos=6"
+    offer: "15% off first purchase with code WISHSHOPPING"
   # Wrangler
   wrangler:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25202.3966290&trid=1552713.193401&foc=16&fot=9999&fos=6"
+    offer: "buy one get one 50% off shorts"
 
 # Approved in FlexOffers but intentionally not listed above:
 #   Costco Membership: no text link in FlexOffers (banners/widgets only)

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-09T12:13:40.495Z",
+  "generated_at": "2026-07-09T12:39:22.389Z",
   "count": 844,
   "stores": [
     {
@@ -16,7 +16,8 @@
       "intro": "1-800 Contacts is the largest direct-to-consumer retailer of contact lenses in the\nUnited States, shipping name-brand lenses from Acuvue, Bausch + Lomb, Alcon, and\nCooperVision straight to customers who upload a valid prescription. It also runs a\ntelehealth-style online eye exam and prescription renewal service in some states.\nThere is no 1-800 Contacts co-brand credit card, so the purchase simply codes as\nonline shopping. A flat-rate cashback card or one with an online shopping bonus\ncategory is the most reliable way to earn on orders, and FSA or HSA cards are\ncommonly accepted since lenses are an eligible medical expense.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.52869.1000000157&trid=1552713.158602&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off for new customers"
       }
     },
     {
@@ -42,7 +43,8 @@
       "intro": "1-800-PACK-RAT delivers portable storage containers to a customer's driveway for\ndo-it-yourself packing, then either picks the unit up for offsite storage or hauls\nit to a new address, competing with PODS and U-Haul in the moving and storage space.\nIt is owned by U-Haul's parent company but operates under its own brand and pricing.\nThere is no PACK-RAT credit card, and orders typically code as general online\nshopping or a moving service rather than a dedicated storage category, so a flat-rate\ncashback card or one with a broad online purchases bonus is the practical choice\nwhen booking a container rental online.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.15653.2015612&trid=1552713.243983&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off with code SPRING50"
       }
     },
     {
@@ -61,7 +63,8 @@
       "intro": "1-800-PetMeds is one of the oldest direct-to-consumer pet pharmacies in the country,\nshipping prescription medications, flea and tick preventives, and general pet health\nand wellness products for dogs and cats without requiring a trip to the vet or a\nlocal pharmacy counter. It works with a customer's veterinarian to verify prescriptions\nbefore fulfilling orders. There is no PetMeds co-brand card, so a card that bonuses\npet supplies purchases, or failing that a flat-rate cashback card, is the best way\nto earn on recurring medication and wellness orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9643.322259&trid=1552713.187444&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off your first order with code NEW40"
       }
     },
     {
@@ -106,7 +109,8 @@
       "intro": "5.11 Tactical makes durable pants, boots, packs, and outerwear built for law\nenforcement, military, and outdoor and range use, and it has grown into a broader\nworkwear and everyday-carry brand sold through its own stores and website. There is\nno 5.11 co-brand credit card, so a purchase simply codes as apparel or general online\nshopping. A card that bonuses online purchases, or a flat-rate cashback card, is the\nmost reliable way to earn rewards on gear ordered from the site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14180.3964608&trid=1552713.160494&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off clearance"
       }
     },
     {
@@ -124,7 +128,8 @@
       "intro": "7 For All Mankind is a premium denim label credited with helping popularize\nhigh-end designer jeans in the early 2000s, and it still sells jeans, jackets,\nand other apparel at a noticeable step up in price from mass-market denim brands.\nIt's owned by a larger apparel holding company alongside other fashion labels.\nThere is no 7 For All Mankind credit card, so orders code as apparel or general\nonline shopping. A card with an online shopping or department-store-style bonus\ncategory, or a flat-rate cashback card, is the best way to earn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36145.1010001182&trid=1552713.190539&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first purchase"
       }
     },
     {
@@ -239,7 +244,8 @@
       "intro": "Adam & Eve is a long-running direct-to-consumer retailer of adult products, sold\nthrough its own website and a chain of retail stores, with roots going back to\nthe 1970s as an early mail-order operation in the category. It ships discreetly\nand also runs frequent promotional and clearance sales online. There is no Adam\n& Eve credit card, so an order simply codes as general online shopping or retail.\nA flat-rate cashback card or one that bonuses online purchases is the practical\nway to earn rewards on the site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.6898.330062&trid=1552713.163415&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off with code BEMINE50"
       }
     },
     {
@@ -317,7 +323,8 @@
       "intro": "Aesop is an Australian skincare, haircare, and fragrance brand known for its\nminimalist amber-glass packaging and botanically formulated products, sold\nthrough standalone boutiques, department store counters, and its own website.\nL'Oreal acquired the brand in 2023. There is no Aesop credit card, so purchases\ncode as general online shopping or beauty retail depending on the merchant\ncategory assigned by the card network. A flat-rate cashback card or one that\nbonuses online shopping is the straightforward way to earn on an order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9664.622458&trid=1552713.234849&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -376,7 +383,8 @@
       "intro": "Airalo is an eSIM marketplace that sells prepaid mobile data plans for travelers,\nletting a phone connect to a local or regional carrier's network abroad without\nswapping a physical SIM card. It covers plans for well over 100 countries and is\ncommonly used as an alternative to international roaming fees. There is no Airalo\ncredit card, and eSIM purchases typically code as either travel or a phone or\ntelecom service depending on the issuer, so a card that bonuses travel purchases,\nor a flat-rate cashback card, is the reasonable choice when buying a plan.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.15608.2071037&trid=1552713.235201&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -482,7 +490,8 @@
       "intro": "Alice + Olivia is a New York contemporary fashion label known for playful, feminine\ndresses, separates, and accessories sold through its own boutiques, department\nstores, and website. Founder Stacey Bendet has kept the brand independent and\ndesign-led relative to larger fashion conglomerates. There is no Alice + Olivia\ncredit card, so an order codes as apparel or general online shopping. A card that\nbonuses online shopping or department-store purchases, or a flat-rate cashback\ncard, is the practical way to earn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46320.1000000420&trid=1552713.171105&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off"
       }
     },
     {
@@ -544,7 +553,8 @@
       "intro": "Alpha Industries is an American apparel maker best known for the MA-1 bomber\njacket, originally developed as a U.S. military flight jacket and now sold as a\nstreetwear and outerwear staple through its own stores and website. There is no\nAlpha Industries credit card, so an order codes as apparel or general online\nshopping. A card that bonuses online shopping or clothing purchases, or a\nflat-rate cashback card, is the practical way to earn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10348.694149&trid=1552713.160630&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off"
       }
     },
     {
@@ -694,7 +704,8 @@
       "intro": "American Tourister is a budget-friendly luggage and travel bag brand owned by\nSamsonite, selling hardside and softside suitcases, backpacks, and carry-ons\nthrough its own website, department stores, and travel retailers. It's positioned\nas the value option under the Samsonite umbrella. There is no American Tourister\ncredit card, so a purchase codes as apparel or general online shopping rather\nthan a travel category. A card that bonuses online shopping, or a flat-rate\ncashback card, is the straightforward way to earn on new luggage.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11773.3362296&trid=1552713.228756&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off clearance"
       }
     },
     {
@@ -749,7 +760,8 @@
       "intro": "Anastasia Beverly Hills is a cosmetics brand that built its name on brow products,\nincluding its widely copied brow pencils and kits, and has since expanded into a\nfull makeup line covering eyeshadow palettes, highlighters, and foundation. It\nsells through its own website as well as major beauty retailers like Sephora and\nUlta. There is no Anastasia Beverly Hills credit card, so a direct purchase codes\nas general online shopping. A card that bonuses online shopping, or a flat-rate\ncashback card, is the best way to earn on an order from the brand's own site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.52750.1000000259&trid=1552713.243843&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -767,7 +779,8 @@
       "intro": "Anker is a consumer electronics accessory brand best known for portable chargers,\npower banks, cables, and charging hardware, and it has since expanded into\nheadphones, smart home devices, and robot vacuums under sub-brands like Soundcore\nand eufy. It sells heavily through its own website as well as Amazon and major\nelectronics retailers. There is no Anker credit card, so a direct purchase codes\nas electronics or general online shopping. A card that bonuses electronics stores\nor online shopping, or a flat-rate cashback card, is the practical way to earn on\nan order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43469.1000000368&trid=1552713.201036&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -898,7 +911,8 @@
       "intro": "Ariat makes western and English riding boots, work boots, and equestrian-inspired\napparel, built around performance footwear technology adapted from athletic shoes\nand marketed to riders, ranchers, and outdoor workers. It sells through its own\nwebsite, specialty western and tack stores, and farm supply retailers. There is\nno Ariat credit card, so a direct purchase codes as apparel or general online\nshopping. A card that bonuses online shopping or clothing purchases, or a\nflat-rate cashback card, is the practical way to earn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10644.3947926&trid=1552713.240088&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "buy one get one 50% off"
       }
     },
     {
@@ -951,7 +965,8 @@
       "intro": "ASICS is a Japanese athletic footwear and apparel maker best known for its running\nshoe lines like the Gel-Kayano and Nimbus, and it has a loyal following among\nserious runners and gym-goers in addition to broad casual sneaker demand. The\ncompany also owns the Onitsuka Tiger fashion sneaker label. There is no ASICS\nco-brand credit card, so a purchase from asics.com codes as apparel, sporting\ngoods, or general online shopping depending on the card issuer's merchant coding.\nA flat-rate cashback card or one that bonuses online shopping is the safest bet.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.40996.1000000724&trid=1552713.180034&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off"
       }
     },
     {
@@ -973,7 +988,8 @@
       "intro": "Aspen Dental is a network of over 1,100 independently owned dental practices across the\nUnited States, offering general dentistry, dentures, and emergency care with same-day\nappointments at many locations. Each office is run by a local dentist, though the brand\nprovides shared branding and back-office support across the network. There's no Aspen\nDental co-brand credit card, so for the office visit or treatment charge itself, a general\nflat-rate cashback card or a card that earns bonus rewards on general or drugstore-adjacent\npurchases is the more useful strategy, since dental care doesn't map cleanly to a bonus\ncategory most issuers track.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.20979.3298152&trid=1552713.239908&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off"
       }
     },
     {
@@ -1076,7 +1092,8 @@
       "intro": "Autonomous is a direct-to-consumer furniture brand focused on ergonomic office setups,\nknown for standing desks, ergonomic chairs, and home-office accessories sold exclusively\nthrough its own online store. The company also markets desk accessories and robotics kits\nunder the same umbrella. There's no Autonomous co-brand credit card, so a furniture or\nhome-goods bonus category card is the best fit for larger desk and chair purchases, with a\ngeneral online shopping or flat-rate cashback card as the fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42643.1000000306&trid=1552713.193704&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 18% off"
       }
     },
     {
@@ -1116,7 +1133,8 @@
       "intro": "Avery is a longtime maker of labels, binders, name badges, and printable office and craft\nsupplies, sold both through its own site and through office supply retailers, mass\nmerchants, and craft stores nationwide. The brand is part of CCL Industries and is best\nknown for the label templates that ship standard with most word processors. There's no\nAvery co-brand credit card, so a card that earns bonus rewards on office supply store\npurchases is the natural fit when buying directly from avery.com, with a flat-rate\ncashback card as a solid alternative.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8547.483063&trid=1552713.190782&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code A25OFF1000"
       }
     },
     {
@@ -1152,7 +1170,8 @@
       "intro": "Away is a direct-to-consumer luggage brand known for its hard-shell suitcases with\nbuilt-in battery chargers, along with travel bags, packing accessories, and apparel sold\nthrough its own stores and website. The company grew out of the mid-2010s wave of\nInstagram-native travel brands and has since opened brick-and-mortar shops in several\nmajor cities. There's no Away co-brand credit card, so a general online shopping rewards\ncard or a card with strong travel-purchase protections, like baggage delay or purchase\ncoverage, is the most useful angle for a suitcase purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8621.615456&trid=1552713.233568&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -1178,7 +1197,8 @@
       "intro": "Babylist is an online baby registry and marketplace that lets expecting parents build a\nsingle universal registry pulling in products from any retailer, alongside its own\nBabylist Shop for gear, nursery items, and essentials. The platform has become one of the\nmost widely used registry tools in the U.S., expanding into health content and a Health\nbrand for insurance-covered breast pumps. There's no Babylist co-brand credit card, so\npurchases through the Babylist Shop are best routed through a general online shopping\nrewards card or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13580.1458037&trid=1552713.237794&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off"
       }
     },
     {
@@ -1207,7 +1227,8 @@
       "intro": "Banana Republic Factory is the outlet arm of Banana Republic, selling discounted apparel\nand accessories both through standalone outlet stores and its own website, with a mix of\nmainline overstock and outlet-specific designs. It operates as part of Gap Inc. alongside\nOld Navy, Athleta, and the mainline Banana Republic brand. There's no Banana Republic\nFactory co-brand credit card, since the Gap Inc. family's co-brand cards are tied to the\nGap Good Rewards program rather than the outlet banner specifically, so a select clothing\nor general online shopping rewards card is the better default for purchases here.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10152.3965949&trid=1552713.196751&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off select styles"
       }
     },
     {
@@ -1221,7 +1242,8 @@
       "intro": "Barefoot Dreams is a California loungewear brand best known for its CozyChic blanket and\ncardigan line, sold through its own boutiques, website, and select department stores and\nspecialty retailers. The brand built its reputation on plush, machine-washable throws that\nbecame a popular gift item well beyond its original loungewear niche. There's no Barefoot\nDreams co-brand credit card, so a select clothing or general online shopping rewards card\nis the most useful category to lean on when buying directly from the brand.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.20795.3952919&trid=1552713.237568&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off with code DREAM15"
       }
     },
     {
@@ -1308,7 +1330,8 @@
       "intro": "Beautyrest is a longstanding mattress brand under Serta Simmons Bedding, known for\npocketed-coil innerspring designs and, more recently, cooling and hybrid mattress lines\nsold online and through furniture and mattress retailers nationwide. It's one of the\noldest mattress brands in the U.S. market, with roots dating back over a century. There's\nno Beautyrest co-brand credit card, so a furniture store bonus category card is the\nstrongest fit for a mattress purchase, with a general online shopping or flat-rate\ncashback card as the alternative when buying direct from beautyrest.com.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10598.1938255&trid=1552713.248817&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -1342,7 +1365,8 @@
       "intro": "Benefit Cosmetics is a San Francisco founded beauty brand known for brow products,\nmascara, and a playful, pink-branded retail presence, sold through its own boutiques,\nwebsite, and major beauty retailers like Sephora and Ulta. The brand has been owned by\nLVMH since the early 1990s and remains one of the more recognizable names in prestige\ndrugstore-adjacent makeup. There's no Benefit Cosmetics co-brand credit card, so a card\nthat bonuses department store or general online shopping purchases is the better lever,\nand buying through a department store account can sometimes stack with that retailer's own\nloyalty program.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.24765.169441110001948&trid=1552713.169943&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -1571,7 +1595,8 @@
       "intro": "Blueair is a Swedish air purifier brand known for HEPASilent filtration technology, selling\nhome and office air purifiers and replacement filters through its own site, online\nmarketplaces, and electronics and home goods retailers. Unilever acquired the company in\n2021, folding it into its air and water treatment portfolio. There's no Blueair co-brand\ncredit card, so an electronics store bonus category card is the best fit for a purifier\npurchase, with a general online shopping or flat-rate cashback card as the fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16168.3107588&trid=1552713.243992&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -1624,7 +1649,8 @@
       "intro": "Bombas is a direct-to-consumer sock and apparel brand built on a one-for-one donation\nmodel, giving an item to homelessness relief organizations for every item purchased. The\ncompany has expanded from its original performance socks into underwear, t-shirts, and\nslippers, sold mainly through its own website with some retail partnerships. There's no\nBombas co-brand credit card, so a select clothing or general online shopping rewards card\nis the most useful category for purchases here.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8171.618217&trid=1552713.240202&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off your first purchase"
       }
     },
     {
@@ -1648,7 +1674,8 @@
       "intro": "Bonobos is a menswear brand best known for its fit-focused pants and its early Guideshop\nmodel, where customers try on sizes in a showroom and have orders shipped rather than\ncarrying inventory on site. Originally a Walmart-owned brand, Bonobos was sold to Express\nin 2023 and now sells through its own website and Express stores. There's no Bonobos\nco-brand credit card, so a select clothing or general online shopping rewards card is the\nbetter fit for purchases, though an Express store credit card, if applicable at checkout,\nmay offer its own separate rewards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11113.3963402&trid=1552713.248479&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off select styles"
       }
     },
     {
@@ -1686,7 +1713,8 @@
       "intro": "Bowflex is a home fitness equipment brand known for its resistance-rod strength machines\nand, more recently, connected bikes, treadmills, and adjustable dumbbells sold through its\nown site and major retailers. The brand was acquired out of its former parent Nautilus by\nJohnson Health Tech in 2022. There's no Bowflex co-brand credit card, so a general online\nshopping rewards card or a flat-rate cashback card is the practical choice, and given the\nprice point of most equipment, a card with purchase protection or an extended warranty\nbenefit is worth checking too.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25788.2161948&trid=1552713.159315&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off $400+ with code SAVE15"
       }
     },
     {
@@ -1716,7 +1744,8 @@
       "intro": "Brahmin is an American leather goods brand known for its embossed handbags, wallets, and\naccessories in signature reptile-textured patterns, made in a Massachusetts factory since\nthe 1980s. The line is sold direct online and through department stores and specialty\nboutiques. There's no Brahmin co-brand credit card, so a department-store rewards card is\nthe better fit when buying through a wholesale partner, and a general online shopping or\nflat-rate cashback card works best for direct orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39712.1000000416&trid=1552713.245806&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off orders over $250"
       }
     },
     {
@@ -1731,7 +1760,8 @@
       "intro": "Braun is a German consumer electronics brand best known for electric shavers, epilators,\nand small kitchen appliances like hand blenders, sold through its own site, mass\nretailers, and department stores. The company has been owned by Procter & Gamble since\n2005, sitting alongside grooming brands like Gillette in P&G's portfolio. There's no Braun\nco-brand credit card, so an electronics store bonus category card is the best fit for a\npurchase, with a general online shopping or flat-rate cashback card as the fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23589.3769635&trid=1552713.226436&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off first purchase with code SMOOTH15"
       }
     },
     {
@@ -1824,7 +1854,8 @@
       "intro": "Budget is one of the largest car rental brands in the U.S., positioned as the value option\nwithin Avis Budget Group alongside Avis and Payless, with airport and neighborhood\nlocations across the country and internationally. Its Fastbreak loyalty program lets\nfrequent renters skip the counter. There's no Budget co-brand credit card, so a card\nthat earns bonus rewards on car rentals or the broader travel category is the strongest\nfit, and many travel cards also add supplemental rental car insurance as a card benefit\nworth checking before declining the rental company's own coverage.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110100467.1100135418&trid=1552713.235827&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 35% off"
       }
     },
     {
@@ -1856,7 +1887,8 @@
       "intro": "Budget Truck Rental is the moving-truck division of Avis Budget Group, offering cargo\nvans and box trucks for local and one-way moves through a network of dealer locations\nacross the U.S. It operates separately from the Budget car rental brand, though it shares\nthe same corporate parent and branding. There's no Budget Truck Rental co-brand credit\ncard, so a card that bonuses car rentals or the general travel category is the closest\nfit, with a flat-rate cashback card as a reasonable fallback for a moving-truck charge.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101100538.1011107121&trid=1552713.235867&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off with code 20DIS"
       }
     },
     {
@@ -1886,7 +1918,8 @@
       "intro": "Buffy is a direct-to-consumer bedding brand known for comforters made from recycled\nplastic bottles and eucalyptus-fiber sheets, marketed around sustainability and sold\nalmost entirely through its own website. The company has expanded into pillows, throws,\nand other bedroom textiles since launching in 2018. There's no Buffy co-brand credit\ncard, so a card that bonuses home goods purchases or a general online shopping rewards\ncard is the most useful category to lean on here.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.28059.2836301&trid=1552713.214427&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off sale items"
       }
     },
     {
@@ -1922,7 +1955,8 @@
       "intro": "Bumble and Bumble is a professional-grade hair care and styling brand that got its start\nin a New York City salon in the 1970s, now owned by the Estee Lauder Companies and sold\nthrough its own site, in salons, and at specialty beauty retailers like Sephora and Ulta.\nThere is no Bumble and Bumble co-brand credit card, so shoppers buying shampoo, styling\nproducts, or tools online should lean on a card with a strong online shopping or general\nbeauty rewards category rather than looking for a store-specific option.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38785.1000001546&trid=1552713.179164&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 30% off"
       }
     },
     {
@@ -1960,7 +1994,8 @@
       "intro": "Bushnell is a long-running American optics brand known for binoculars, rifle scopes,\nlaser rangefinders, trail cameras, and golf rangefinders, popular with hunters, shooters,\nand golfers alike. It carries no co-brand credit card of its own, so the better play for\na Bushnell purchase is a sporting goods category card or a general online shopping\nrewards card, with a flat-rate cashback card as a reasonable fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.20977.1329725&trid=1552713.237984&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off sitewide"
       }
     },
     {
@@ -2000,7 +2035,8 @@
       "intro": "Caesars Rewards is the loyalty program spanning Caesars Entertainment's casino resorts,\nincluding Caesars Palace, Harrah's, Horseshoe, and Paris Las Vegas properties across the\nUS. Unlike most brands, Caesars does have a co-brand credit card lineup: the no-annual-fee\nCaesars Rewards Visa and the premium Caesars Rewards Prestige Visa Signature, both issued\nby Comenity/Bread Financial, which earn bonus Reward Credits on stays, dining, and\nentertainment at Caesars properties. Shoppers without one of those cards can still lean\non a general hotel or travel rewards card when booking a room.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.6145.3660150&trid=1552713.194743&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "33% off"
       }
     },
     {
@@ -2028,7 +2064,8 @@
       "intro": "Calvin Klein is a global fashion house under PVH Corp known for its underwear, denim, and\nready-to-wear lines, sold through its own stores and site as well as major department\nstores like Macy's. There is no Calvin Klein co-brand credit card, so a general online\nshopping or apparel rewards card is the right tool for a direct purchase, while a\ndepartment-store card can work well if you're buying through Macy's or a similar\nretailer instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43317.4611686018427577129&trid=1552713.188219&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "buy 1 get 1 50% off sitewide"
       }
     },
     {
@@ -2043,7 +2080,8 @@
       "intro": "Calzedonia is an Italian hosiery and swimwear retailer, part of the Calzedonia Group that\nalso owns Intimissimi and Tezenis, known for tights, leggings, and beachwear sold through\nboutiques across Europe and a US e-commerce site. It has no co-brand credit card, so\nshoppers ordering online should use a select-clothing or general online shopping rewards\ncard rather than looking for a store-specific option.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43180.1000000423&trid=1552713.199589&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off select styles"
       }
     },
     {
@@ -2211,7 +2249,8 @@
       "intro": "Cavender's is a Texas-based western wear retailer with stores across the South and\nSouthwest, selling boots, hats, jeans, and western apparel from brands like Ariat and\nWrangler alongside its own house lines. Cavender's does not offer a store credit card, so\na select-clothing or general online shopping rewards card is the better option for boots\nor apparel bought online or in one of its stores.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.36070.3856555&trid=1552713.246090&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -2266,7 +2305,8 @@
       "intro": "Charles & Keith is a Singapore-founded fashion label specializing in affordable-luxury\nshoes, handbags, and accessories, with a large footprint across Asia and the Middle East\nand a growing US e-commerce presence. The brand has no co-brand credit card in the US\nmarket, so shoppers buying shoes or bags through its site should rely on an online\nshopping rewards card or a select-clothing category card rather than a store-specific one.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13805.3939221&trid=1552713.194849&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off select styles"
       }
     },
     {
@@ -2542,7 +2582,8 @@
       "intro": "Cole Haan is an American footwear and accessories brand known for dress shoes, loafers,\nand its Grand series that blends dress styling with sneaker-like comfort technology, sold\nthrough its own stores, outlets, and site. It has no co-brand credit card, so a\nselect-clothing or general online shopping rewards card is the better fit for a Cole Haan\npurchase rather than a store-specific option.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.45770.1000000714&trid=1552713.196522&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off sale items"
       }
     },
     {
@@ -2583,7 +2624,8 @@
       "intro": "Corkcicle makes insulated drinkware, tumblers, wine chillers, and coolers designed to keep\ndrinks cold or hot for hours, sold through its own site as well as retailers like\nNordstrom and REI. There is no Corkcicle co-brand credit card, so a general online\nshopping rewards card, or a home goods category card if you have one, is the best way to\nearn on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13045.3363020&trid=1552713.245365&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off sale items"
       }
     },
     {
@@ -2620,7 +2662,8 @@
       "intro": "COS, short for Collection of Style, is a contemporary fashion label under the H&M Group\nknown for minimalist, architecturally cut clothing and accessories for men and women,\nsold through standalone stores and its own e-commerce site. COS has no co-brand credit\ncard, so shoppers should default to a select-clothing or general online shopping rewards\ncard at checkout, since neither a department-store nor apparel-specific card exists\nfor the brand.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42840.1000000776&trid=1552713.227732&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off your first order"
       }
     },
     {
@@ -2634,7 +2677,8 @@
       "intro": "Cosori is a consumer kitchen appliance brand best known for its air fryers, along with\nblenders, kettles, and other small countertop appliances, sold heavily through Amazon as\nwell as its own site. It carries no co-brand credit card, so an electronics category card\nor a general online shopping rewards card is the right choice for a Cosori purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.41709.3818110&trid=1552713.245911&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off sitewide"
       }
     },
     {
@@ -2854,7 +2898,8 @@
       "intro": "David's Bridal is one of the largest wedding retailers in the United States, selling\nbridal gowns, bridesmaid dresses, prom wear, and wedding accessories through hundreds of\nstores and its online catalog. The chain has gone through multiple bankruptcy\nreorganizations in recent years but continues operating as a go-to option for\nbudget-conscious wedding parties. There's no David's Bridal co-brand credit card, so\nshoppers outfitting a wedding party should reach for a card that earns well on clothing\nor general online shopping purchases, since a single order can easily run into four\nfigures once alterations and accessories are included.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.52798.1000000070&trid=1552713.235285&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off"
       }
     },
     {
@@ -2890,7 +2935,8 @@
       "intro": "DeLonghi is an Italian appliance maker best known in the U.S. for espresso and coffee\nmachines, along with air fryers, heaters, and small kitchen appliances sold through its\nown site, Amazon, and major retailers like Williams Sonoma and Best Buy. The brand\npositions itself at the premium end of home espresso equipment, competing with names like\nBreville and Jura. There's no DeLonghi co-brand credit card, so a purchase direct from\ndelonghi.com is best charged to a card that earns a bonus on home goods or general online\nshopping, or simply a strong flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.33739.2287345&trid=1552713.232052&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off your first order"
       }
     },
     {
@@ -2906,7 +2952,8 @@
       "intro": "Delsey Paris is a French luggage maker dating back to 1946, known for hardside spinner\nsuitcases, packing cubes, and travel accessories sold through department stores,\nspecialty luggage retailers, and its own site. There is no Delsey co-brand credit card,\nso shoppers buying luggage should use a general online shopping rewards card, or a travel\ncard if they'd rather earn points toward their next trip instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.36622.3294033&trid=1552713.234891&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off with code TRAVEL20"
       }
     },
     {
@@ -2951,7 +2998,8 @@
       "intro": "Dermalogica is a professional-grade skincare brand founded in Los Angeles and long\nassociated with spas and licensed estheticians before expanding into direct-to-consumer\nsales online. Its product lines focus on cleansers, serums, and treatments built around\ningredient-driven formulas rather than mass-market drugstore positioning. There's no\nDermalogica co-brand credit card, so shoppers buying direct from dermalogica.com should\nlean on a card that earns a solid rate on online shopping purchases or a flat-rate\ncashback card, since the brand doesn't run its own store-branded financing or rewards\nprogram.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.40620.1000000137&trid=1552713.226144&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 30% off"
       }
     },
     {
@@ -2968,7 +3016,8 @@
       "intro": "Dermstore is an online beauty and skincare retailer that curates dermatologist-recommended\nand prestige skincare brands, from SkinCeuticals and Obagi to smaller clinical labels that\naren't always available at mainstream beauty retailers. It's owned by Target Corporation\nbut operates as a standalone online storefront rather than being sold in Target stores.\nThere's no Dermstore co-brand credit card, so shoppers should use a card that earns well on\nonline shopping purchases or a flat-rate cashback card when checking out, since Dermstore\nitself doesn't offer branded financing.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53945.1000000106&trid=1552713.209693&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -3003,7 +3052,8 @@
       "intro": "DHgate is a Chinese business-to-business and business-to-consumer marketplace that connects\nU.S. shoppers directly with manufacturers and wholesalers across categories like electronics,\napparel, home goods, and gadgets, similar in spirit to AliExpress or Alibaba's consumer arm.\nPrices tend to be low and shipping times longer since most goods ship from overseas sellers.\nThere's no DHgate co-brand credit card, so the best approach is a card that earns a solid\nflat rate or bonus category on general online shopping, since purchases typically code as\na marketplace or general merchandise transaction rather than a specific retail category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12108.1466364&trid=1552713.243958&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 80% off"
       }
     },
     {
@@ -3021,7 +3071,8 @@
       "intro": "Diane von Furstenberg is an American fashion house best known for the wrap dress it\npopularized in the 1970s, now selling ready-to-wear, accessories, and footwear through its\nown boutiques, DVF.com, and department stores like Nordstrom and Bloomingdale's. The brand\nremains privately held and is closely tied to its founder and namesake designer. There's no\nDVF co-brand credit card, so shoppers buying direct should use a card that earns well on\nclothing or general online shopping purchases, or lean on a department-store card if the\npurchase runs through Nordstrom or a similar retail partner instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156174.53601.1000000014&trid=1552713.230273&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -3053,7 +3104,8 @@
       "intro": "Dickies is a workwear brand dating back to 1922, known for durable work pants, coveralls,\nand jackets that have also become a streetwear staple well beyond its original job site\naudience. It's owned by VF Corporation and sells through its own site, Amazon, and retailers\nlike Zappos and Tractor Supply alongside dedicated Dickies stores. There's no Dickies\nco-brand credit card, so a purchase at dickies.com is best charged to a card that earns\nwell on clothing or general online shopping, or a flat-rate cashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25209.2029313&trid=1552713.230392&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off for new customers"
       }
     },
     {
@@ -3072,7 +3124,8 @@
       "intro": "Diesel is an Italian fashion brand best known for premium denim, along with apparel,\nfootwear, and accessories sold through its own boutiques, Diesel.com, and department\nstores. It's part of the OTB Group, the same holding company behind Maison Margiela and\nMarni. There's no Diesel co-brand credit card, so shoppers buying jeans or apparel direct\nfrom the brand should use a card that earns a strong rate on clothing or general online\nshopping purchases, since Diesel itself doesn't extend its own store financing or rewards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.49384.1000000078&trid=1552713.232396&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -3089,7 +3142,8 @@
       "intro": "DIFF Eyewear is a direct-to-consumer sunglasses and optical brand built around a one-for-one\ngiving model, where each pair purchased helps fund a pair of prescription glasses or eye\ncare for someone in need through partner nonprofits. It sells trend-forward, affordably\npriced frames online and through select retail partners rather than running its own\nphysical storefronts. There's no DIFF Eyewear co-brand credit card, so shoppers should lean\non a card that rewards general online shopping purchases or a flat-rate cashback card when\nbuying frames directly from the brand's website.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9933.288188&trid=1552713.211526&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off your next order"
       }
     },
     {
@@ -3117,7 +3171,8 @@
       "intro": "Dinnerly is a budget-focused meal kit delivery service operated by Marley Spoon, positioned\nas a lower-cost alternative to HelloFresh or Blue Apron by trimming packaging and recipe\ncomplexity to keep per-serving prices down. Subscribers pick weekly recipes online and\nreceive pre-portioned ingredients by mail. There's no Dinnerly co-brand credit card, so the\nweekly or monthly charge is best routed through a card that earns a bonus on dining or\nonline grocery-adjacent purchases, since meal kit charges typically code closer to food\ndelivery than standard retail.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.10033.3840387&trid=1552713.195361&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to $185 off your first 5 boxes"
       }
     },
     {
@@ -3242,7 +3297,8 @@
       "intro": "Dooney & Bourke is an American leather goods maker founded in 1975, known for handbags,\nwallets, and accessories sold through its own stores and website as well as department\nstores like Macy's and Nordstrom, and outlet locations. The brand sits in the accessible\nluxury tier, priced above mass-market handbag brands but below European designer houses.\nThere's no Dooney & Bourke co-brand credit card, so a direct purchase is best charged to a\ncard that earns well on online shopping, while purchases made through a department store\ncan also benefit from that retailer's own category bonus.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.6652.625287&trid=1552713.162489&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off clearance"
       }
     },
     {
@@ -3272,7 +3328,8 @@
       "intro": "Dorothy Perkins is a British women's fashion brand selling affordable everyday clothing,\nfrom workwear to occasionwear, primarily through its online store after the closure of its\nUK high street locations. It now operates as an online-only retailer shipping to customers\nin the UK and select international markets including the U.S. There's no Dorothy Perkins\nco-brand credit card, so shoppers ordering from the site should rely on a card that earns\nwell on general online shopping and, if applicable, one with favorable foreign transaction\nterms since charges may process through a UK-based merchant account.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.1134.3978513&trid=1552713.232050&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 75% off"
       }
     },
     {
@@ -3290,7 +3347,8 @@
       "intro": "Dr. Scholl's is a long-running American footwear and foot care brand, historically known\nfor insoles and foot health products and now selling its own line of comfort-focused shoes\nand sandals direct-to-consumer online as well as through department stores and shoe\nretailers. The foot care side of the brand, including insoles and callus treatments, is\nlicensed separately and sold mainly in drugstores. There's no Dr. Scholl's co-brand credit\ncard, so a shoe purchase at drschollsshoes.com is best charged to a card that earns well on\nfootwear or general online shopping purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9749.620939&trid=1552713.235857&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 20% off"
       }
     },
     {
@@ -3316,7 +3374,8 @@
       "intro": "Drunk Elephant is a skincare brand built around a \"clean\" formulation philosophy that\navoids ingredients like essential oils, silicones, and certain fragrances, popular with a\nyounger, social-media-driven audience. It's owned by Shiseido but sells direct through its\nown website as well as Sephora and Ulta. There's no Drunk Elephant co-brand credit card, so\na purchase made directly on the brand's site is best charged to a card that earns well on\nonline shopping, while a Sephora or Ulta purchase can instead take advantage of that\nretailer's own beauty rewards program.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.10029.623157&trid=1552713.232403&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off"
       }
     },
     {
@@ -3409,7 +3468,8 @@
       "intro": "Eagle Creek is a travel gear brand best known for packing cubes, duffels, and rugged\nbackpacks aimed at frequent and adventure travelers, sold direct online as well as through\noutdoor and luggage retailers. The brand went through a bankruptcy closure in 2020 before\nbeing relaunched under new ownership. There's no Eagle Creek co-brand credit card, so\nshoppers stocking up on packing gear should use a card that earns well on general online\nshopping, or consider a travel-focused card since the purchases directly support upcoming\ntrips even if they don't code as a travel merchant.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.31713.1398401&trid=1552713.239618&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -3457,7 +3517,8 @@
       "intro": "ECCO is a Danish footwear company known for comfort-engineered leather shoes and boots,\nmanufactured largely through its own tanneries rather than outsourced production, which is\nunusual for a shoe brand at its scale. It sells through its own retail stores, ecco.com,\nand department stores and shoe retailers worldwide. There's no ECCO co-brand credit card,\nso a direct purchase from ecco.com is best charged to a card that earns a bonus on\nfootwear or general online shopping purchases, or a flat-rate cashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39558.1000002653&trid=1552713.180375&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off $250+ with code ECCODEAL"
       }
     },
     {
@@ -3514,7 +3575,8 @@
       "intro": "Eileen Fisher is an American women's clothing brand known for minimalist, relaxed-fit\npieces made from natural fibers like organic cotton, linen, and wool, sold through its own\nboutiques, website, and select department stores. The company has also built a reputation\naround sustainability, including a take-back and resale program for used garments. There's\nno Eileen Fisher co-brand credit card, so a purchase direct from eileenfisher.com is best\ncharged to a card that earns well on clothing or general online shopping purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42820.1000000372&trid=1552713.213376&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first purchase"
       }
     },
     {
@@ -3610,7 +3672,8 @@
       "intro": "Estee Lauder is the flagship prestige beauty brand of The Estee Lauder Companies, selling\nskincare, makeup, and fragrance through department stores, its own boutiques, and its\ndirect-to-consumer website, alongside sister brands like Clinique, MAC, and Bobbi Brown\nunder the same corporate umbrella. There's no Estee Lauder co-brand credit card, so a\npurchase direct from esteelauder.com is best charged to a card that earns well on general\nonline shopping, while a department store purchase can instead lean on that store's own\ncategory bonus if one applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36314.1010001823&trid=1552713.186487&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -3821,7 +3884,8 @@
       "intro": "Farberware is a longtime American cookware and small kitchen appliance brand, known for\nstainless steel and nonstick pots, pans, bakeware, and countertop gadgets sold through its\nown site and major housewares retailers. The brand dates back over a century and today\noperates under license by different manufacturers depending on the product line. There is\nno Farberware co-brand credit card, so a shopper buying cookware there is best served by a\ncard that bonuses home goods or department-store purchases, or a flat-rate cashback card\nif no specialized category applies to the specific charge.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11993.3959083&trid=1552713.239550&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -3868,7 +3932,8 @@
       "intro": "Fenty Beauty is the cosmetics line founded by Rihanna in 2017, widely credited with\npushing the beauty industry toward broader foundation shade ranges and now sold both\ndirect-to-consumer and through retailers like Sephora. It operates under LVMH's Kendo\nBrands portfolio. There is no Fenty Beauty co-brand credit card, so shoppers should lean\non a card that earns bonus rewards on online shopping or drugstore-adjacent beauty\npurchases, or a flat-rate cashback card, and remember that buying through Sephora instead\nof fentybeauty.com may open up Sephora-specific card benefits.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42834.1000001431&trid=1552713.214878&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -3941,7 +4006,8 @@
       "intro": "FitFlop is a British footwear brand built around biomechanically engineered midsoles meant\nto add cushioning and comfort to sandals, sneakers, and everyday shoes, positioning itself\nbetween a fashion label and a comfort-orthotic brand. It sells through its own site as well\nas department stores and specialty shoe retailers in the U.S. There is no FitFlop co-brand\ncredit card, so a shopper buying shoes there should reach for a card that rewards select\nclothing or online shopping purchases, or a flat-rate cashback card if footwear isn't a\nbonused category on their card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41223.1000001291&trid=1552713.179233&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -4009,7 +4075,8 @@
       "intro": "Florsheim is a heritage American men's shoe brand dating to 1892, known for dress shoes,\nboots, and casual leather footwear sold through its own stores, department stores, and\nonline. The brand has changed ownership several times over its history and today competes\nin the same lane as brands like Johnston & Murphy and Cole Haan. There is no Florsheim\nco-brand credit card, so a shopper buying shoes there should use a card that bonuses\nselect clothing or department-store spend, or a flat-rate cashback card if footwear isn't\na specialized reward category on their card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.3382.119544810000835&trid=1552713.462&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off select styles"
       }
     },
     {
@@ -4162,7 +4229,8 @@
       "intro": "Furla is an Italian leather goods house founded in Bologna in 1927, best known for\nstructured handbags along with wallets, small leather goods, and accessories sold through\nits own boutiques and department stores worldwide. It sits in the accessible-luxury tier,\npriced below houses like Prada or Gucci but above mass-market handbag brands. There is no\nFurla co-brand credit card, so a purchase there is best matched to a premium travel or\ngeneral rewards card that bonuses online or department-store shopping, or a flat-rate\ncashback card for simplicity on a luxury accessory purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101105919.1011116822&trid=1552713.226358&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off"
       }
     },
     {
@@ -4198,7 +4266,8 @@
       "intro": "Gametime is a mobile-first ticket marketplace for sports, concerts, and live events,\nbuilt around a same-day, last-minute buying experience with a countdown-style interface\nshowing how ticket prices trend as an event approaches. It's a resale and secondary\nmarketplace in the same space as SeatGeek, Vivid Seats, and StubHub rather than a primary\nbox office. There is no Gametime co-brand credit card, so ticket purchases there are best\nmatched to a card that bonuses entertainment spend, or a broad travel or dining rewards\ncard if entertainment isn't a defined category on the cardholder's cards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10874.1443269&trid=1552713.214076&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off"
       }
     },
     {
@@ -4266,7 +4335,8 @@
       "intro": "ghd is a British hair-styling brand best known for its ceramic flat irons and curling\nwands, positioned at the premium end of the hair-tools market and sold direct online as\nwell as through salons and beauty retailers. The name is short for \"good hair day,\" the\ncompany's original tagline. There's no ghd co-brand credit card, so a general online\nshopping rewards card or a flat-rate cashback card is the practical way to earn rewards on\nstyling tool purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.8033.3960327&trid=1552713.178100&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off sitewide"
       }
     },
     {
@@ -4306,7 +4376,8 @@
       "intro": "Gilt is a flash-sale e-commerce site that built its name on time-limited discounts on\ndesigner clothing, accessories, and home goods, with a companion Gilt City arm that sold\nlocal deals on dining, spa, and entertainment experiences in major metro areas. It was one\nof the pioneers of the members-only flash-sale model in the 2010s before being absorbed\ninto Rue La La's parent company. There is no Gilt co-brand credit card, so shoppers there\nshould rely on a card that bonuses online shopping or department-store purchases, or a\nflat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.1000009372.1100147967&trid=1552713.158309&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "80% off"
       }
     },
     {
@@ -4348,7 +4419,8 @@
       "intro": "GNC is one of the largest specialty retailers of vitamins, supplements, sports nutrition,\nand protein products in the U.S., operating both physical mall and strip-center stores and\nan active e-commerce business, alongside a GNC-branded product line manufactured\nin-house. There is no GNC co-brand credit card, so shoppers there should default to a card\nthat earns bonus rewards on online or general retail shopping, or a flat-rate cashback\ncard, since supplement purchases don't fall under drugstore or grocery bonus categories on\nmost issuers' charts even though GNC sells health products.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53638.1000000515&trid=1552713.162841&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "buy one get one 50% off vitamins"
       }
     },
     {
@@ -4370,7 +4442,8 @@
       "intro": "Godiva is a Belgian chocolatier founded in Brussels in 1926, known for premium truffles,\ngift boxes, and seasonal chocolate assortments sold through its own boutiques, online\nstore, and gifting partnerships. The brand has changed hands several times, most recently\nsplitting its North American retail business from its international operations. There is\nno Godiva co-brand credit card, so a gift or chocolate purchase there is best matched to a\ncard that bonuses online shopping or general retail, or a dining category card if the\npurchase codes as food and beverage.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101106374.111034562&trid=1552713.159640&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order with code WELCOME15"
       }
     },
     {
@@ -4386,7 +4459,8 @@
       "intro": "Going, formerly known as Scott's Cheap Flights, is a subscription service that alerts\nmembers to discounted and mistake-fare airfares out of their home airports, curated by a\nteam of flight-deal analysts rather than a booking engine itself. Members typically book\nthe flagged fares directly with the airline once alerted. There is no Going co-brand\ncredit card since it isn't a travel bookings site in the traditional sense, so a\nsubscription payment or any related travel booking is best matched to a travel rewards\ncard or a card that bonuses travel purchases broadly.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10802.731100&trid=1552713.237685&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 90% off"
       }
     },
     {
@@ -4400,7 +4474,8 @@
       "intro": "Goldbelly is an online marketplace that ships iconic regional foods nationwide, from\nChicago deep-dish pizza to Katz's Deli pastrami and small-batch bakery goods, letting\nshoppers order famous local restaurants and shops as packaged gifts or personal orders.\nIt functions as a food gifting and delivery platform rather than a single restaurant.\nThere is no Goldbelly co-brand credit card, so an order there is best matched to a card\nthat bonuses dining or online shopping purchases, or a flat-rate cashback card if neither\ncategory is a strong fit on the cardholder's cards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13451.3881759&trid=1552713.215607&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off"
       }
     },
     {
@@ -4447,7 +4522,8 @@
       "intro": "Govee makes smart-home lighting and consumer electronics, including LED strip lights,\nsmart bulbs, RGBIC ambiance lighting, and small appliances like ice makers and air\npurifiers, sold primarily through its own site, Amazon, and other online marketplaces.\nThe brand has built a following among gamers and home-decor enthusiasts for affordable,\napp-controlled lighting setups. There is no Govee co-brand credit card, so a purchase\nthere is best paired with a card that bonuses electronics or online shopping, or a\nflat-rate cashback card if no specialty category applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12845.2840658&trid=1552713.224344&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "60% off"
       }
     },
     {
@@ -4507,7 +4583,8 @@
       "intro": "Grove Collaborative is an online marketplace focused on natural and sustainable household\nand personal care products, selling cleaning supplies, paper goods, and beauty items\nthrough both one-time orders and a recurring subscription model, along with its own\nGrove-branded product lines. The company has publicly emphasized plastic-free packaging\nand carbon-neutral shipping goals. There is no Grove Collaborative co-brand credit card,\nso a purchase there is best matched to a card that bonuses online shopping or general\nretail, or a flat-rate cashback card for household staples.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.8442.2825761&trid=1552713.201205&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off your first order with code WELCOME"
       }
     },
     {
@@ -4538,7 +4615,8 @@
       "intro": "Guess is a Los Angeles-founded denim and fashion label built around a distinctive black\nand white advertising aesthetic, selling jeans, apparel, handbags, watches, and\naccessories through its own stores, guess.com, and a large wholesale presence at\ndepartment stores like Macy's and Nordstrom. There is no Guess co-brand credit card, so\nshoppers checking out online should lean on a card that pays bonus rewards on online\nshopping or general merchandise, and department-store purchases can be routed through a\ncard that rewards spending at Macy's or similar retailers. A flat-rate cashback card\nis a reasonable fallback if you don't want to track category bonuses.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9298.616619&trid=1552713.158989&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off $250+ with code GET30OFF"
       }
     },
     {
@@ -4564,7 +4642,8 @@
       "intro": "Gymboree is a children's clothing brand known for colorful, play-focused apparel for\nbabies and kids, sold primarily through gymboree.com after the retailer's brick and\nmortar stores wound down and its assets were relaunched under new ownership. There is\nno Gymboree co-brand credit card, so the best approach is a card that earns bonus\nrewards on general online shopping or department-store-style purchases, since kids'\napparel does not have its own dedicated card category. A flat-rate cashback card also\nworks well for occasional purchases like these.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10756.2013600&trid=1552713.214444&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "80% off clearance"
       }
     },
     {
@@ -4626,7 +4705,8 @@
       "intro": "Hanes is a longstanding American basics brand selling t-shirts, underwear, socks, and\nloungewear for men, women, and kids, part of apparel conglomerate Hanesbrands alongside\nlabels like Champion and Bali. The brand sells directly through hanes.com in addition\nto wide distribution at mass retailers and department stores. There is no Hanes\nco-brand credit card, so a purchase at hanes.com is best routed through a card that\nearns bonus rewards on general online shopping, or a flat-rate cashback card if you'd\nrather not track categories.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.24366.1010005156&trid=1552713.166211&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off select styles"
       }
     },
     {
@@ -4640,7 +4720,8 @@
       "intro": "Hanna Andersson is a Portland, Oregon-founded children's clothing brand best known for\nsoft, durable cotton basics and its matching family pajama sets, sold through\nhannaandersson.com and a small number of retail stores. There is no Hanna Andersson\nco-brand credit card, so the best way to earn on a purchase is a card that pays bonus\nrewards on general online shopping, since kids' apparel doesn't have its own dedicated\nreward category. A flat-rate cashback card is a solid fallback for occasional orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5644.2692567&trid=1552713.181293&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off for new customers"
       }
     },
     {
@@ -4789,7 +4870,8 @@
       "intro": "Hey Dude is a casual, lightweight footwear brand known for its slip-on shoes and\neveryday comfort styling, acquired by Crocs Inc in 2022 to complement the flagship\nCrocs brand. Shoes are sold through heydude.com along with department stores and\nfootwear retailers. There is no Hey Dude co-brand credit card, so shoppers ordering\ndirect should use a card that earns bonus rewards on general online shopping, or a\nflat-rate cashback card if simplicity matters more than chasing categories.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16269.1358297&trid=1552713.227887&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off select styles"
       }
     },
     {
@@ -4835,7 +4917,8 @@
       "intro": "Hill's Pet Nutrition makes Science Diet and Prescription Diet pet food, a veterinarian-\nrecommended line of dog and cat food owned by Colgate-Palmolive, sold direct at\nhillspet.com as well as through vet clinics, pet retailers, and online marketplaces.\nThere is no Hill's co-brand credit card, so a direct order is best charged to a card\nthat earns bonus rewards on pet supplies or general online shopping, or a flat-rate\ncashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53370.1000000017&trid=1552713.243039&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off your first order with code SUMMER40"
       }
     },
     {
@@ -4974,7 +5057,8 @@
       "intro": "HoMedics is a personal wellness brand selling massagers, humidifiers, air purifiers,\nsound machines, and small health and comfort devices for the home, sold through\nhomedics.com and widely at mass retailers and drugstores. There is no HoMedics\nco-brand credit card, so a direct order is best charged to a card that earns bonus\nrewards on general online shopping or electronics-type purchases, or a flat-rate\ncashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11735.1101069&trid=1552713.239601&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off"
       }
     },
     {
@@ -5091,7 +5175,8 @@
       "intro": "Hugo Boss is a German luxury fashion house selling tailored menswear, women's\nready-to-wear, and accessories under its BOSS and HUGO lines, distributed through its\nown stores, hugoboss.com, and department stores like Nordstrom and Saks. There is no\nHugo Boss co-brand credit card, so shoppers ordering online should lean on a card that\nearns bonus rewards on online shopping, while in-store purchases at a partner\ndepartment store can sometimes route through a store-specific card. A premium travel\nor flat-rate cashback card also works well for higher-ticket purchases like these.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39079.1000000422&trid=1552713.160207&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off sale items"
       }
     },
     {
@@ -5120,7 +5205,8 @@
       "intro": "Hungryroot is a personalized grocery and recipe delivery service that ships a mix of\nfresh produce, proteins, and pantry staples along with quick recipes tailored to a\ncustomer's food preferences, functioning as a hybrid between a meal kit and an online\ngrocery order. There is no Hungryroot co-brand credit card, so a subscription is best\ncharged to a card that earns bonus rewards on dining or groceries, or a flat-rate\ncashback card if your card's category definitions don't clearly cover grocery delivery\nservices.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53058.1000000002&trid=1552713.201413&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off orders $99+"
       }
     },
     {
@@ -5172,7 +5258,8 @@
       "intro": "Hydro Flask is an Oregon-founded brand of insulated stainless steel water bottles and\ndrinkware popular with hikers, campers, and everyday users, now owned by consumer\nproducts company Helen of Troy. Bottles and accessories are sold direct at\nhydroflask.com as well as through outdoor and sporting goods retailers. There is no\nHydro Flask co-brand credit card, so a direct order is best charged to a card that\nearns bonus rewards on sporting goods or general online shopping, or a flat-rate\ncashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18825.1922057&trid=1552713.202999&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -5206,7 +5293,8 @@
       "intro": "Igloo is a longtime American brand of hard and soft-sided coolers, ice chests, and\ndrinkware built for camping, tailgating, and everyday outdoor use, sold direct at\nigloocoolers.com and widely through sporting goods and general merchandise retailers.\nThere is no Igloo co-brand credit card, so a direct order is best charged to a card\nthat earns bonus rewards on sporting goods or general online shopping, or a flat-rate\ncashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46441.1000000006&trid=1552713.208505&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 35% off"
       }
     },
     {
@@ -5288,7 +5376,8 @@
       "intro": "Innisfree is a South Korean skincare and cosmetics brand known for products built\naround natural ingredients sourced from Jeju Island, owned by Korean beauty\nconglomerate Amorepacific and sold direct at innisfree.com along with select retail\nand marketplace partners. There is no Innisfree co-brand credit card, so an order is\nbest charged to a card that earns bonus rewards on general online shopping, or a\nflat-rate cashback card if you prefer not to track categories.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.48045.1000000392&trid=1552713.239749&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off"
       }
     },
     {
@@ -5345,7 +5434,8 @@
       "intro": "J. Jill is an American specialty retailer selling women's apparel positioned around\nrelaxed, comfortable everyday styles, sold through its own stores, catalog, and\njjill.com. There is no J. Jill co-brand credit card, though the retailer offers its own\nstore loyalty and private-label financing program separate from general-purpose credit\ncards. Shoppers who want travel or cashback rewards on a J. Jill purchase should\ninstead use a card that earns bonus rewards on general online or apparel shopping, or a\nflat-rate cashback card for simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.54107.198854455&trid=1552713.201947&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off sale styles"
       }
     },
     {
@@ -5520,7 +5610,8 @@
       "intro": "Johnston & Murphy is an American footwear and accessories brand dating back to 1850,\nknown for dress shoes, boots, and increasingly casual and hybrid styles aimed at\nprofessional men, alongside a smaller assortment of belts, bags, and apparel. The\ncompany has operated as a standalone specialty retailer for most of its history and\nhas no co-brand credit card of its own. Shoppers buying dress or business-casual\nshoes here are usually best served by a general online shopping or select-clothing\nrewards card, or a flat-rate cashback card, rather than expecting any store-specific\nfinancing beyond a standard retail account.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38419.1000000980&trid=1552713.162278&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off select styles"
       }
     },
     {
@@ -5534,7 +5625,8 @@
       "intro": "Jonathan Adler is a design-led home furnishings brand built around the namesake\npotter and interior designer, selling ceramics, furniture, lighting, textiles, and\ndecorative accessories with a distinctive maximalist, pop-influenced aesthetic. It\nsells primarily through its own boutiques and website rather than mass retail\npartners, and there is no Jonathan Adler co-brand credit card. Furnishing a room from\nthis brand is a good spot to lean on a card that bonuses furniture or general online\nshopping purchases, or simply a flat-rate cashback card given the brand's\nabove-average price points.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50036.1000000004&trid=1552713.216122&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 65% off"
       }
     },
     {
@@ -5552,7 +5644,8 @@
       "intro": "Jos. A. Bank is a longtime American menswear retailer specializing in suits, dress\nshirts, and business-casual clothing, sold through mall and strip-center stores as\nwell as online. It has been under the same parent company as Men's Wearhouse for\nmore than a decade, but the two brands operate separately and neither carries a\nco-brand credit card tied to CreditOdds' tracked card set. A card that earns bonus\nrewards on clothing or general online shopping purchases is the most useful pairing\nhere, since Jos. A. Bank frequently runs its own storewide promotions independent of\nany bank partnership.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38377.1000016446&trid=1552713.196&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off clearance"
       }
     },
     {
@@ -5576,7 +5669,8 @@
       "intro": "K-Swiss is an American athletic footwear brand founded in the 1960s, best known for\nits classic leather tennis sneakers as well as later training and lifestyle shoe\nlines, sold direct-to-consumer online and through athletic retailers. The brand has\nno co-brand credit card, so a shopper buying sneakers here should look to a card that\nbonuses sporting goods or general online shopping spend rather than expecting any\nbrand-specific financing. K-Swiss has changed ownership several times over the years\nbut continues to operate as a standalone footwear label.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9956.311096&trid=1552713.227940&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off select styles"
       }
     },
     {
@@ -5594,7 +5688,8 @@
       "intro": "Kaplan is a long-running test preparation and professional education company,\noffering courses and materials for standardized tests like the LSAT, MCAT, and GRE\nas well as licensing exams for fields such as nursing and financial services. It\noperates under Graham Holdings and has no co-brand credit card. Since Kaplan\npurchases are typically a single online transaction rather than a recurring\ncategory, a general online shopping rewards card or a flat-rate cashback card is the\nmost practical way to earn on tuition or course fees paid directly to Kaplan.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.1697.1010005031&trid=1552713.200470&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code FRESHSTART25"
       }
     },
     {
@@ -5631,7 +5726,8 @@
       "intro": "Keds is a classic American sneaker brand dating to 1916, known for its simple\ncanvas slip-on and lace-up shoes marketed mainly to women and long associated with\npreppy, casual style. It is owned by Wolverine World Wide, which also owns brands\nlike Merrell and Sperry, and Keds carries no co-brand credit card of its own.\nShoppers stocking up on canvas sneakers here should default to a card that bonuses\nclothing or general online shopping purchases, since there is no shoe-specific\nrewards category to target.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110006127.1100126495&trid=1552713.160396&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off sale styles"
       }
     },
     {
@@ -5662,7 +5758,8 @@
       "intro": "Kendra Scott is an Austin-founded jewelry and accessories brand known for its\ncolorful stone-inlaid earrings, necklaces, and its in-store \"Color Bar\" customization\nconcept, sold through mall boutiques and its own website as well as select\ndepartment stores. The brand is privately held and has no co-brand credit card, so\nthere is no store-specific bonus category to chase. A card that earns elevated\nrewards on general online shopping or department-store purchases, or a flat-rate\ncashback card, is the best fit for jewelry and gift purchases here.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.50471.3951190&trid=1552713.199434&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off"
       }
     },
     {
@@ -5677,7 +5774,8 @@
       "intro": "Keurig is the single-serve coffee brewer company behind the K-Cup pod system,\nselling brewing machines and a wide range of licensed coffee, tea, and cocoa pods\ndirectly through its own site as well as major retailers. It's part of Keurig Dr\nPepper and has no co-brand credit card. Since purchases here are typically small\nappliances or grocery-adjacent coffee pods rather than a distinct bonus category, a\ngeneral online shopping card or a flat-rate cashback card is the most reliable way to\nearn rewards on Keurig orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39219.1000002801&trid=1552713.170716&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -5775,7 +5873,8 @@
       "intro": "Kohler is a major American manufacturer of kitchen and bath fixtures, including\nsinks, faucets, toilets, and bathtubs, alongside a broader industrial and hospitality\nbusiness that includes generators and golf resorts. Kohler products are sold direct\nthrough its own site as well as through home improvement retailers and plumbing\nsuppliers, and the company has no co-brand credit card. Remodeling or fixture\npurchases here pair best with a card that bonuses home improvement spend, or a\nflat-rate cashback card for large one-off purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.44732.1000000352&trid=1552713.215079&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off vanities & sinks"
       }
     },
     {
@@ -5821,7 +5920,8 @@
       "intro": "Kylie Cosmetics is the direct-to-consumer beauty brand founded by Kylie Jenner,\nselling makeup, skincare, and fragrance products primarily through its own website\nalong with select retail partners like Ulta. The company has no co-brand credit\ncard, so there is no dedicated bonus category tied to the brand. A card that earns\nelevated rewards on general online shopping, or a flat-rate cashback card, is the\nmost practical way to earn on purchases made directly through the Kylie Cosmetics\nsite.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46759.1000000061&trid=1552713.224336&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -5904,7 +6004,8 @@
       "intro": "LastPass is a password manager and digital identity security service that stores\nand autofills logins, generates strong passwords, and offers dark web monitoring and\nfamily sharing plans on a subscription basis. It is sold purely as software, has no\nphysical retail presence, and carries no co-brand credit card. Subscription charges\nhere are best captured with a general online shopping or subscription-friendly\nrewards card, or a flat-rate cashback card, since there is no dedicated software or\nsecurity spending category on most cards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.8692.2595725&trid=1552713.206309&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off for new customers"
       }
     },
     {
@@ -5955,7 +6056,8 @@
       "intro": "Lee is one of America's oldest denim brands, founded in 1889 and known for jeans,\nworkwear, and casual clothing sold through its own stores, website, and a wide range\nof department and mass retailers. It is owned by Kontoor Brands, which also owns\nWrangler, and Lee has no co-brand credit card. A shopper buying jeans or casual wear\ndirectly from Lee should look to a card that bonuses clothing or general online\nshopping purchases, or a flat-rate cashback card if no category applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11766.3960014&trid=1552713.237878&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off with code SHORT"
       }
     },
     {
@@ -6051,7 +6153,8 @@
       "intro": "Levoit is a home appliance brand under VeSync that specializes in air purifiers,\nhumidifiers, and small kitchen appliances aimed at the smart-home and wellness\nmarket, sold mainly through its own site and online marketplaces. The brand has no\nco-brand credit card. Purchases here fit best under a card that bonuses electronics\nor general online shopping spend, or a flat-rate cashback card, since Levoit doesn't\nfall into a home improvement or grocery category despite being a household product.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.41708.3910127&trid=1552713.235505&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "40% off"
       }
     },
     {
@@ -6074,7 +6177,8 @@
       "intro": "Life is Good is a Boston-founded lifestyle apparel brand built around its optimistic\n\"Jake\" stick-figure logo, selling t-shirts, hoodies, hats, and accessories through\nits own stores, website, and wholesale partners, with a portion of profits directed\nto its Life is Good Kids Foundation. The brand has no co-brand credit card. Shoppers\nbuying its casual apparel should default to a card that bonuses clothing or general\nonline shopping purchases, or a flat-rate cashback card if neither applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14635.1948131&trid=1552713.158389&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off"
       }
     },
     {
@@ -6105,7 +6209,8 @@
       "intro": "Liquid I.V. is a hydration and wellness brand best known for its powdered\nelectrolyte drink mixes, sold in single-serve packets through its own site, major\nretailers, and subscription orders. It has been owned by Unilever since 2020 and\ncarries no co-brand credit card. Purchases made directly through Liquid I.V.'s\nwebsite are best treated as general online shopping for rewards purposes, so a card\nbonusing that category, or a flat-rate cashback card, is the practical option.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13609.1958902&trid=1552713.242792&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off"
       }
     },
     {
@@ -6131,7 +6236,8 @@
       "intro": "Little Sleepies is a direct-to-consumer kids and baby apparel brand built around\nbamboo viscose pajamas, rompers, and loungewear sold in matching family sets and\nfrequent limited-edition prints. The company sells almost exclusively through its\nown website rather than department stores, which makes it a straightforward\nonline-shopping purchase. There is no Little Sleepies co-brand credit card, so the\nbest approach is a card that pays an elevated rate on online or general retail\npurchases, or a flat-rate cashback card if simplicity matters more than optimizing\nby category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.20265.2102732&trid=1552713.233129&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off sale items"
       }
     },
     {
@@ -6259,7 +6365,8 @@
       "intro": "Lucky Brand is a California-born denim and casual apparel label known for its\nvintage-inspired jeans, along with tees, jackets, and accessories. The brand sells\nthrough its own stores and site as well as inside major department stores like\nMacy's and Dillard's, so purchases can land in either the online-shopping or\ndepartment-store bucket depending on where you check out. There is no Lucky\nBrand co-brand credit card, so shoppers are better served leaning on a card that\nrewards online retail or department-store spending, or a general flat-rate\ncashback card for everyday simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9596.504271&trid=1552713.187771&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 75% off"
       }
     },
     {
@@ -6315,7 +6422,8 @@
       "intro": "Lumens Light + Living is an online retailer specializing in designer lighting\nfixtures, furniture, and home decor, carrying hundreds of brands ranging from\nboutique studios to well-known modern design houses. It functions as a curated\nmarketplace rather than a manufacturer, shipping direct to consumers nationwide.\nThere is no Lumens co-brand credit card, so a home-improvement category card or\na card with strong online-shopping rewards is the better fit for larger lighting\nor furniture purchases, with a flat-rate cashback card as a simple fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.3281.197540&trid=1552713.158720&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 75% off clearance"
       }
     },
     {
@@ -6386,7 +6494,8 @@
       "intro": "Madison Reed makes ammonia-free, salon-quality hair color kits sold direct to\nconsumers online and through its own network of hair color bar salons in select\ncities. The company built its business around at-home color subscriptions as an\nalternative to traditional salon visits. There is no Madison Reed co-brand\ncredit card, so shoppers should rely on a card that rewards online retail\npurchases, or a flat-rate cashback card for a simpler approach to everyday\nbeauty spending.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13741.3966078&trid=1552713.200433&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code BDAY26"
       }
     },
     {
@@ -6414,7 +6523,8 @@
       "intro": "Manscaped is a men's grooming brand best known for its below-the-waist trimmers\nand body grooming tools, alongside skincare and hygiene products it built into a\nbroader personal-care lineup. The company sells primarily through its own site\nand app, with a subscription refill option for blades and grooming supplies.\nThere is no Manscaped co-brand credit card, so the sensible approach is a card\nthat earns extra on online shopping, or a flat-rate cashback card for\nstraightforward everyday purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156139.48084.1000000017&trid=1552713.249081&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 22% off"
       }
     },
     {
@@ -6446,7 +6556,8 @@
       "intro": "Marc Jacobs is an American fashion house known for ready-to-wear apparel,\nhandbags, and fragrances, with the Tote Bag and Daisy perfume line among its\nmost recognizable products. The brand, owned by LVMH parent company overseen\nby designer Marc Jacobs himself, sells through its own boutiques and site as\nwell as through department stores like Nordstrom, Macy's, and Bloomingdale's.\nThere is no Marc Jacobs co-brand credit card, so a card that rewards online\nshopping or department-store purchases is the better fit, with a flat-rate\ncashback card as a simple alternative.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8338.584825&trid=1552713.205419&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -6723,7 +6834,8 @@
       "intro": "MeUndies is a direct-to-consumer underwear and loungewear brand built around a\nmonthly subscription model, known for colorful prints, modal fabric, and\nlimited-edition designer collaborations. The company sells almost entirely\nthrough its own website and app rather than physical retail. There is no\nMeUndies co-brand credit card, so a card that earns a bonus on online shopping\nis the better fit, or a flat-rate cashback card for a simpler approach to\nsubscription-style purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.26749.3868010&trid=1552713.197539&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off your first purchase"
       }
     },
     {
@@ -6800,7 +6912,8 @@
       "intro": "Milani Cosmetics is a Los Angeles-based makeup brand built around affordable,\ndrugstore-priced products, with its Baked Blush and Conceal + Perfect line among\nits best-known items. The brand sells direct online along with wide distribution\nthrough mass retailers like Target, Walmart, and Ulta. There is no Milani\nco-brand credit card, so a card that rewards online shopping is the better lever\nfor a direct purchase, or a flat-rate cashback card if you would rather keep\nthings simple.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50546.1000000123&trid=1552713.232500&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off"
       }
     },
     {
@@ -6833,7 +6946,8 @@
       "intro": "Milk Makeup is a cosmetics brand known for multi-use, skin-forward products\nlike its cream sticks and Hydro Grip primer, marketed toward a younger,\nlow-maintenance beauty audience. The brand originated inside the Milk Studios\nphotography and events company before spinning out and is now owned by e.l.f.\nBeauty. There is no Milk Makeup co-brand credit card, so a card that rewards\nonline shopping is the better fit for a direct purchase, or a flat-rate\ncashback card for everyday simplicity.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.21499.1993215&trid=1552713.199552&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 98% off"
       }
     },
     {
@@ -6866,7 +6980,8 @@
       "intro": "Minted is an online marketplace that sells stationery, art prints, wedding\ninvitations, and home decor designed by a community of independent artists and\ndesigners, with pieces selected through crowdsourced design competitions. The\ncompany operates purely as an e-commerce platform with no physical retail\npresence. There is no Minted co-brand credit card, so a card that rewards\nonline shopping purchases is the better fit, or a flat-rate cashback card for\na simpler approach.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.19909.3746698&trid=1552713.200435&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code ENGAGED25"
       }
     },
     {
@@ -6883,7 +6998,8 @@
       "intro": "Misfits Market is an online grocery delivery service that started by selling\n\"ugly\" or surplus produce at a discount to reduce food waste, and has since\nexpanded into a broader grocery box covering pantry staples, meat, and dairy\nshipped direct to subscribers' homes. There is no Misfits Market co-brand\ncredit card, so a groceries-category card is the natural fit for these\npurchases, or a flat-rate cashback card if you would rather not track\ncategories.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12419.2170579&trid=1552713.236533&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 30% off"
       }
     },
     {
@@ -6955,7 +7071,8 @@
       "intro": "Moroccanoil is a hair care brand built around its original argan oil treatment,\nwhich grew into a full line of shampoos, conditioners, and styling products\nused widely in professional salons as well as sold direct to consumers. The\nbrand is distributed through salons, beauty retailers, and its own website.\nThere is no Moroccanoil co-brand credit card, so a card that rewards online\nshopping is the better fit for a direct purchase, or a flat-rate cashback card\nfor a simpler approach to beauty spending.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43410.1000000587&trid=1552713.211705&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "25% off with code STYLERS2026"
       }
     },
     {
@@ -7000,7 +7117,8 @@
       "intro": "Munchkin is a baby and toddler products company known for items like the Miracle 360\nsippy cup, bath toys, feeding gear, and diaper-disposal systems, sold at munchkin.com\nas well as through major retailers like Target and Walmart. It's a private, independent\nbrand with no credit card of its own. Since Munchkin purchases are usually made online\nor as part of a broader baby-registry shop, a card that rewards online shopping or\noffers flat-rate cashback is the simplest way to earn on these purchases, rather than\nlooking for a category-specific multiplier that doesn't really exist for baby gear.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.7649.483108&trid=1552713.163230&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with sign up"
       }
     },
     {
@@ -7028,7 +7146,8 @@
       "intro": "Naked Wines is a direct-to-consumer wine retailer built around funding independent\nwinemakers, where members pay a monthly deposit toward future bottle purchases at\nmember-only pricing. It ships wine straight to customers' doors in states where that's\nlegal, positioning itself against traditional wine shops and big-box wine sections.\nThere's no Naked Wines credit card, and grocery or dining category cards typically don't\ncover wine-club shipments since these purchases usually code as online retail, so a\nstrong online-shopping or flat-rate cashback card is the most reliable way to earn on\nNaked Wines orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13852.1723735&trid=1552713.163400&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off with code IMPACT12PK"
       }
     },
     {
@@ -7064,7 +7183,8 @@
       "intro": "Nars is a makeup and skincare brand founded by photographer and makeup artist Francois\nNars, known for products like the Orgasm blush and a range that leans into bold color\nand a photo-ready finish. Shiseido acquired Nars in 2000, and the brand sells through\nits own site, department-store beauty counters, and retailers like Sephora and Ulta.\nThere is no Nars-branded credit card, so shoppers should look to a department-store or\ngeneral online-shopping rewards card, or a flat-rate cashback card, to earn on Nars\npurchases rather than expecting a beauty-specific bonus category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8113.610942&trid=1552713.194170&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 48% off"
       }
     },
     {
@@ -7099,7 +7219,8 @@
       "intro": "Native Shoes is a Vancouver-founded footwear brand best known for lightweight,\ninjection-molded EVA shoes in the style of the Jefferson sneaker, marketed as an\neasy-care, machine-washable alternative to canvas sneakers for kids and adults alike.\nIt sells primarily direct-to-consumer online alongside placement in outdoor and family\nretailers. There is no Native Shoes credit card, so the best approach for these\npurchases is a card that rewards select clothing or shoe purchases, or a general\nonline-shopping or flat-rate cashback card if a category-specific multiplier isn't\navailable.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14513.1998567&trid=1552713.234726&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with sign up"
       }
     },
     {
@@ -7118,7 +7239,8 @@
       "intro": "Nautica is an American apparel brand built around a nautical, preppy aesthetic, selling\nmen's, women's, and kids' clothing along with accessories and home goods, and it's\nlicensed and operated today under Authentic Brands Group. Nautica products show up both\nat its own stores and site and widely across department stores like Macy's and Kohl's.\nThere's no Nautica-branded credit card, so shoppers should reach for a department-store\nrewards card when buying in-store, or a select-clothing or general online-shopping card\nfor purchases made directly at nautica.com.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.5361.260311&trid=1552713.161992&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -7202,7 +7324,8 @@
       "intro": "New Era is the headwear company that holds the official on-field cap license for MLB and\nsupplies sideline and licensed caps for the NFL, NBA, and other leagues, alongside its\nown streetwear and lifestyle cap lines. It sells through neweracap.com, team shops, and\ngeneral retailers. There is no New Era credit card, so a shopper buying fitted or\nsnapback caps should lean on a select-clothing or online-shopping rewards card, or a\nflat-rate cashback card, rather than expecting a sports-merchandise specific bonus\ncategory.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.45269.1000000343&trid=1552713.215793&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 45% off select styles"
       }
     },
     {
@@ -7317,7 +7440,8 @@
       "intro": "Nutribullet is a kitchen appliance brand best known for its compact, high-torque blenders\nmarketed around single-serve smoothies and nutrient extraction, and it has since\nexpanded into full-size blenders, food processors, and air fryers. It sells directly at\nnutribullet.com as well as through big-box and department retailers. There's no\nNutribullet-branded credit card, so purchases are best covered by a card that earns\nbonus rewards on home-goods or kitchenware purchases, or a general online-shopping or\nflat-rate cashback card for a one-time appliance buy.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9496.622476&trid=1552713.211957&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off"
       }
     },
     {
@@ -7379,7 +7503,8 @@
       "intro": "Olaplex is a hair care brand built around bond-building chemistry originally developed\nfor use in salons, with its No. 3 Hair Perfector becoming a widely recognized at-home\ntreatment product. The company sells direct at olaplex.com and through beauty retailers\nlike Sephora and Ulta as well as professional salons. There is no Olaplex-branded credit\ncard, so shoppers should look to a general online-shopping rewards card or a flat-rate\ncashback card to earn on Olaplex purchases, since beauty and hair care don't typically\nhave their own dedicated bonus category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.49376.1000000046&trid=1552713.232646&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -7409,7 +7534,8 @@
       "intro": "Olipop is a functional soda brand that markets prebiotic-fortified sodas as a healthier\nalternative to traditional sugary soft drinks, sold direct at olipop.com by subscription\nor one-time order, as well as in grocery and convenience stores nationwide. It's an\nindependent, venture-backed beverage company with no credit card of its own. For direct\nonline orders, a general online-shopping or flat-rate cashback card is the practical\nchoice, while purchases made in a grocery store aisle would instead earn under a\ngroceries-category card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12980.1270029&trid=1552713.226085&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "32% off with code SODALOVE"
       }
     },
     {
@@ -7447,7 +7573,8 @@
       "intro": "Omaha Steaks is a family-owned, direct-to-consumer purveyor of steaks, seafood, and other\nfrozen meats and prepared foods, shipped nationwide from its Nebraska base and popular\nboth for personal restocking and as a gift item. Orders are placed and shipped directly\nthrough omahasteaks.com rather than through a grocery store, so they often code as\nonline retail or dining rather than groceries. There's no Omaha Steaks credit card, so a\ndining-category card, or a general online-shopping or flat-rate cashback card, is the\nbest way to earn on an order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.147.4611686018427592559&trid=1552713.185&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off sitewide"
       }
     },
     {
@@ -7477,7 +7604,8 @@
       "intro": "One Kings Lane is an online home decor and furniture retailer that built its name on\nflash sales of designer furnishings before shifting to a more traditional e-commerce\nstorefront covering furniture, lighting, rugs, and decorative accessories. It sells\nexclusively online rather than through physical stores. There's no One Kings Lane credit\ncard, so shoppers furnishing a home through the site should look to a furniture or\nhome-goods rewards card, or a general online-shopping or flat-rate cashback card for\nsmaller decor purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.10043.582414&trid=1552713.233565&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off"
       }
     },
     {
@@ -7519,7 +7647,8 @@
       "intro": "Osprey is an outdoor gear company known for its backpacking, hiking, and travel packs,\nbuilt around features like its All Mighty Guarantee lifetime repair policy that has made\nit a favorite among thru-hikers and backpackers. Products are sold direct at osprey.com\nas well as through outdoor retailers like REI. There's no Osprey credit card, so a\nsporting-goods or outdoor-retailer rewards card is the natural fit for a pack purchase,\nwith a general online-shopping or flat-rate cashback card as a solid alternative.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.20745.2991713&trid=1552713.243977&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off sale items"
       }
     },
     {
@@ -7548,7 +7677,8 @@
       "intro": "Outdoor Voices is an activewear brand built around a \"doing things\" ethos that pitches\nitself as more casual and everyday than performance-focused athletic brands, known for\nleggings, the Exercise Dress, and its colorful, minimalist aesthetic. It sells primarily\ndirect-to-consumer through outdoorvoices.com and a small number of its own retail\nlocations. There is no Outdoor Voices credit card, so a select-clothing or\nsporting-goods rewards card is a good fit for activewear purchases, with a general\nonline-shopping or flat-rate cashback card as a fallback.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25944.3907598&trid=1552713.207781&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off your first order"
       }
     },
     {
@@ -7577,7 +7707,8 @@
       "intro": "Owlet is a baby-tech company best known for its Smart Sock and camera products that\nmonitor an infant's heart rate, oxygen levels, and sleep, aimed at giving new parents\npeace of mind overnight. It sells direct at owletcare.com and through major baby and\nelectronics retailers. There is no Owlet-branded credit card, so a purchase is best\ncovered by a card that rewards electronics or online-shopping purchases, or a\nflat-rate cashback card, since baby-monitoring tech doesn't have its own dedicated\nbonus category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.93077.3306615&trid=1552713.224412&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with code BIRTHCOLLECTIVE10"
       }
     },
     {
@@ -7595,7 +7726,8 @@
       "intro": "OXO is a kitchen and household tools brand best known for its Good Grips line of\nergonomic, easy-to-use utensils, gadgets, and storage products, now owned by Newell\nBrands alongside names like Rubbermaid and Sharpie. Products are sold at oxo.com and\nwidely across grocery, home-goods, and department stores. There's no OXO-branded credit\ncard, so a card that earns bonus rewards on home-improvement or kitchenware purchases is\nthe best fit, with a general online-shopping or flat-rate cashback card as a solid\nfallback for smaller orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9558.2991709&trid=1552713.207703&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 20% off"
       }
     },
     {
@@ -7792,7 +7924,8 @@
       "intro": "Penske Truck Rental is one of the largest consumer and commercial truck rental\noperations in North America, renting box trucks, cargo vans, and pickups for moves,\nhauling, and small business use out of thousands of locations. It operates alongside\nPenske Truck Leasing and Penske Logistics under the broader Penske Corporation,\nfounded by racing executive Roger Penske. There is no Penske co-brand credit card, so\na general rental car and travel category card, or a flat-rate cashback card, is the\npractical choice for earning rewards on a rental booked through Penske.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101106404.111000691&trid=1552713.242188&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with code GETMOVING"
       }
     },
     {
@@ -7817,7 +7950,8 @@
       "intro": "Perricone MD is a skincare brand founded by dermatologist Dr. Nicholas Perricone,\nknown for anti-aging formulas built around ingredients like vitamin C ester and\nneuropeptides, sold direct at perriconemd.com as well as through department stores and\nspecialty beauty retailers. The line spans serums, moisturizers, and supplements\npositioned at the premium end of the skincare market. There is no Perricone MD\nco-brand credit card, so a card that earns bonus rewards on online shopping or\ndepartment store purchases, or a general beauty and drugstore category card, is the\nbetter route for maximizing rewards on a purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.21122.3969291&trid=1552713.178759&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off with code EYE50"
       }
     },
     {
@@ -7834,7 +7968,8 @@
       "intro": "Personalization Mall sells custom-engraved and monogrammed gifts, including\nornaments, home decor, drinkware, and kids' items, that shoppers personalize with\nnames, dates, or photos before checkout. The company was acquired by 1-800-Flowers.com\nin 2018 and now operates as part of that company's family of gifting brands alongside\n1-800-Flowers and Harry & David. There is no Personalization Mall co-brand credit\ncard, so a card that rewards online shopping purchases, or a flat-rate cashback card,\nis the simplest way to earn something back on a personalized gift order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.29824.3960848&trid=1552713.243972&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -8025,7 +8160,8 @@
       "intro": "Polk Audio is a Maryland founded speaker and home theater brand dating to 1972, known\nfor bookshelf and floorstanding speakers, soundbars, and subwoofers sold direct online\nand through electronics retailers. It operates under SoundUnited, the audio group that\nalso owns Definitive Technology, Denon, and Marantz. There is no Polk Audio co-brand\ncredit card, so a card that earns bonus rewards at electronics stores, or one that\nboosts online shopping purchases when buying direct from polkaudio.com, is the better\noption for audio equipment purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101106052.1100105683&trid=1552713.225844&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -8150,7 +8286,8 @@
       "intro": "Prose is a direct-to-consumer haircare brand that sells custom-formulated shampoo,\nconditioner, and styling products based on an online quiz that asks about hair type,\ngoals, and local climate. Each order is mixed and bottled to match the individual\ncustomer rather than sold as a fixed product line, and the brand ships on a recurring\nsubscription basis. There is no Prose co-brand credit card, so a card that earns bonus\nrewards on online shopping purchases, or a flat-rate cashback card, is the simplest\nway to earn something back on a Prose order or subscription renewal.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11046.1964687&trid=1552713.202760&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off your first order"
       }
     },
     {
@@ -8163,7 +8300,8 @@
       "intro": "Public Goods is a membership based online retailer selling sustainably sourced\nhousehold staples, personal care items, and pantry goods under its own uniform, minimalist\nbranded packaging rather than reselling other companies' products. Shoppers pay a\nyearly membership fee for access to member pricing across categories like cleaning\nsupplies, toiletries, and kitchen basics. There is no Public Goods co-brand credit\ncard, so a card that earns bonus rewards on online shopping purchases, or a flat-rate\ncashback card, is the best way to earn rewards on an order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11802.918004&trid=1552713.226288&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off your first purchase with code RMN10"
       }
     },
     {
@@ -8192,7 +8330,8 @@
       "intro": "Puffy is a direct-to-consumer mattress and bedding brand that ships foam mattresses,\npillows, and sheets in a box, competing with other bed-in-a-box companies like Casper\nand Nectar on long sleep trials and lifetime warranties sold entirely online rather\nthan through physical showrooms. The lineup has expanded into adjustable bed frames\nand bedroom furniture over time. There is no Puffy co-brand credit card, so a card\nthat earns bonus rewards at furniture stores, or one that boosts online shopping\npurchases, is the better fit for a mattress or bedding purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12125.1617842&trid=1552713.239252&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off with code EDU"
       }
     },
     {
@@ -8269,7 +8408,8 @@
       "intro": "Quill is a business-to-business office supply retailer selling paper, ink and\ntoner, breakroom items, cleaning products, and technology to small businesses and\noffices, largely through catalog and online ordering rather than physical stores.\nStaples acquired Quill in 1998 and continues to run it as a distinct brand aimed at\nbusiness customers who order in bulk. There is no Quill co-brand credit card, so an\noffice supply category card, or a flat-rate business cashback card, is the better\noption for earning rewards on Quill purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110006434.1011166830&trid=1552713.159251&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "52% off"
       }
     },
     {
@@ -8385,7 +8525,8 @@
       "intro": "Razer is a Singapore and California based gaming hardware company known for its\ngreen snake logo and Chroma RGB lighting, selling gaming laptops, keyboards, mice,\nheadsets, and accessories aimed at PC and console gamers. The company is publicly\ntraded and also runs Razer Gold, a virtual currency used across many game platforms.\nThere is no Razer co-brand credit card, so a card that earns bonus rewards at\nelectronics stores, or one that boosts online shopping purchases when ordering\ndirect from razer.com, is the better fit for gaming gear purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10229.1781361&trid=1552713.163469&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "75% off"
       }
     },
     {
@@ -8404,7 +8545,8 @@
       "intro": "RC Willey Home Furnishings is a large-format furniture, mattress, electronics, and\nappliance retailer based in Utah with stores across the Mountain West, Nevada, and\nCalifornia. Warren Buffett's Berkshire Hathaway acquired the company in 1995 and has\nkept its original management and regional footprint largely intact since. There is no\nRC Willey co-brand credit card, so a card that earns bonus rewards at furniture\nstores, or one that boosts home improvement or electronics purchases, is the best fit\nfor a large furniture or appliance purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39945.1000001540&trid=1552713.195269&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 75% off clearance"
       }
     },
     {
@@ -8418,7 +8560,8 @@
       "intro": "Rebecca Minkoff is a New York founded fashion label started by its namesake designer,\nknown for handbags like the MAB and Mini M.A.C. as well as ready-to-wear clothing,\nshoes, and accessories sold through its own stores, website, and department store\npartners like Nordstrom and Bloomingdale's. The brand built its early following on\naccessible, trend-driven leather goods. There is no Rebecca Minkoff co-brand credit\ncard, so a card that earns bonus rewards on online shopping or clothing purchases is\nthe better fit for a handbag or apparel order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9950.511647&trid=1552713.162599&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off select styles"
       }
     },
     {
@@ -8465,7 +8608,8 @@
       "intro": "Reef is a California born footwear brand best known for its sandals, especially\nbottle-opener flip-flops and other surf-culture styles, along with boots and\ncasual shoes sold online and through outdoor and surf retailers. The brand grew out\nof the beach and surf scene and remains closely tied to that lifestyle marketing.\nThere is no Reef co-brand credit card, so a card that earns bonus rewards on online\nshopping or clothing and footwear purchases, or a flat-rate cashback card, is the\npractical choice when buying from reef.com.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23921.1999849&trid=1552713.194581&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -8508,7 +8652,8 @@
       "intro": "Rent the Runway is a clothing and accessory rental service that lets members borrow\ndesigner dresses, workwear, and outerwear for a set period or on a rotating monthly\nsubscription instead of buying them outright, returning items in prepaid packaging\nwhen finished. The company is publicly traded and works with hundreds of designer\nand contemporary brands. There is no Rent the Runway co-brand credit card, so a card\nthat earns bonus rewards on online shopping or clothing purchases, or a flat-rate\ncashback card, is the best fit for a rental order or membership charge.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9690.590512&trid=1552713.225416&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 90% off sale items"
       }
     },
     {
@@ -8521,7 +8666,8 @@
       "intro": "ResortPass is a booking platform that sells day access to hotel and resort\namenities, such as pools, cabanas, and spas, to guests who are not staying overnight\nat the property. It partners with hotel chains and independent resorts across the\nUnited States to sell passes by the day, letting travelers and locals use luxury\nfacilities without booking a room. There is no ResortPass co-brand credit card, so a\ngeneral travel category card, or a flat-rate cashback card, is the practical way to\nearn rewards on a day pass purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.50076.3871321&trid=1552713.237733&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "$20 off your first booking over $100"
       }
     },
     {
@@ -8534,7 +8680,8 @@
       "intro": "Restaurant.com sells discounted gift certificates redeemable at thousands of\nindependent and chain restaurants across the United States, letting diners buy a\ncertificate online for less than its face value and use it toward a meal at a\nparticipating location. The site also bundles certificates with local deals and gift\ncards for other retail and entertainment categories. There is no Restaurant.com\nco-brand credit card, so a dining category card, or a flat-rate cashback card, is the\nbetter choice for purchases made on the site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.21234.1813802&trid=1552713.157348&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off dining deals"
       }
     },
     {
@@ -8620,7 +8767,8 @@
       "intro": "Roborock is a Beijing based robotics company best known for its lineup of robot vacuums and\nvacuum and mop combo units, which compete directly with iRobot's Roomba line on navigation,\nsuction power, and self-emptying dock features. The brand also makes handheld and cordless\nvacuums and has expanded into other smart home cleaning devices. Roborock does not have a\nco-brand credit card, so shoppers buying direct at roborock.com or through a retailer like\nAmazon or Best Buy are better off leaning on an electronics or general online shopping\nrewards card, or a flat-rate cashback card, to earn on the purchase.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14848.1705455&trid=1552713.240023&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "4% off"
       }
     },
     {
@@ -8653,7 +8801,8 @@
       "intro": "Rosetta Stone is a language learning company that built its brand on distinctive\nimmersion-based software, once sold in boxed CD-ROM kits and now offered as a subscription\napp and website covering dozens of languages. It's owned by IXL Learning, an education\ntechnology company that also operates Wyzant and other learning platforms. There's no\nRosetta Stone co-brand credit card, so a subscription purchase or lifetime plan is best\npaid with a general online shopping or flat-rate cashback card, since language learning\ndoesn't map to any dedicated bonus category most issuers track.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18979.2904352&trid=1552713.172635&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 55% off"
       }
     },
     {
@@ -8736,7 +8885,8 @@
       "intro": "Rue La La is a members-only flash sale retailer, launching limited-time discounted events\non apparel, accessories, home goods, and beauty from both established and boutique brands.\nFounded in Boston in 2007, it's now part of Rue Gilt Groupe, the same corporate family that\nalso runs Gilt and Shop Premium Outlets. There's no Rue La La co-brand credit card, so the\nbest rewards angle for a flash sale purchase is an online shopping or general apparel\ncategory card, or a flat-rate cashback card if the specific category isn't covered.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.1000005478.1011209521&trid=1552713.161427&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 90% off"
       }
     },
     {
@@ -8750,7 +8900,8 @@
       "intro": "Rugs USA is a direct to consumer online retailer specializing in area rugs, runners, and\noutdoor rugs, spanning machine made, hand tufted, and hand knotted styles across a wide\nrange of price points and design aesthetics. The company sells almost exclusively online,\nregularly running large sitewide sales on its inventory. There's no Rugs USA co-brand\ncredit card, so a home goods purchase there is best charged to a home improvement rewards\ncard if one is available, or otherwise a general online shopping or flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9280.3964472&trid=1552713.203964&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off with code SUMMER"
       }
     },
     {
@@ -8903,7 +9054,8 @@
       "intro": "Scholastic is a major publisher and distributor of children's books and educational\nmaterials, best known to generations of families for its in-school Scholastic Book Fairs\nand Book Clubs, and as the longtime US publisher of the Harry Potter series and Clifford\nthe Big Red Dog. It also produces classroom magazines, curriculum resources, and media for\nschools and libraries. There's no Scholastic co-brand credit card, so book and classroom\nsupply purchases through its website are best charged to a general online shopping rewards\ncard, or a flat-rate cashback card if no bonus category applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8138.229226&trid=1552713.158514&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 30% off"
       }
     },
     {
@@ -8951,7 +9103,8 @@
       "intro": "Seed Health is a microbiome science company best known for its DS-01 Daily Synbiotic, a\nprobiotic and prebiotic supplement sold on a subscription basis directly to consumers, along\nwith other gut and women's health products developed with academic research partners. The\nbrand positions itself at the science-forward end of the wellness supplement market rather\nthan as a mass retailer. There's no Seed co-brand credit card, so a subscription order is\nbest charged to a general online shopping or flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.19848.1987528&trid=1552713.240621&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off"
       }
     },
     {
@@ -9014,7 +9167,8 @@
       "intro": "SharkNinja is the consumer products company behind two well-known home brands: Shark, which\nmakes vacuums, steam mops, and air purifiers, and Ninja, which makes kitchen appliances\nlike blenders, air fryers, and coffee makers. The company sells through its own site as\nwell as major retailers like Amazon, Walmart, Target, and Best Buy, and became an\nindependently traded public company after spinning off in 2023. There's no SharkNinja\nco-brand credit card, so a direct purchase is best charged to an electronics or general\nonline shopping rewards card, or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.8359.1823241&trid=1552713.225856&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off with code STYLE20"
       }
     },
     {
@@ -9133,7 +9287,8 @@
       "intro": "Shopbop is an online fashion retailer specializing in designer and contemporary apparel,\nshoes, and accessories, curating collections from hundreds of brands for a customer base\nthat skews toward higher-end, trend-driven fashion. Based in Madison, Wisconsin, it has\nbeen owned by Amazon since 2006 but continues to operate as its own distinct storefront and\nbrand. There's no Shopbop co-brand credit card, so purchases are best charged to an apparel\nor general online shopping rewards card, or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42352.1000000904&trid=1552713.178509&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -9239,7 +9394,8 @@
       "intro": "Sleep Number makes adjustable air chamber mattresses and smart beds sold under its own\nnumbered firmness system, along with the SleepIQ technology that tracks sleep quality and\nautomatically adjusts firmness overnight. The company sells almost entirely direct to\nconsumer through its own retail stores and website rather than through third-party\nfurniture or mattress retailers. There's no Sleep Number co-brand credit card, so a\nmattress or bedding purchase is best charged to a furniture or general online shopping\nrewards card, or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12365.3966027&trid=1552713.225614&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off"
       }
     },
     {
@@ -9304,7 +9460,8 @@
       "intro": "SOCCER.com is an online specialty retailer focused entirely on soccer gear, carrying\ncleats, jerseys, balls, training equipment, and apparel from major brands like Nike,\nadidas, and Puma alongside club and national team kits. It's one of the larger dedicated\nsoccer e-commerce sites in the US market, serving both individual players and team or club\norders. There's no SOCCER.com co-brand credit card, so shoppers should lean on a sporting\ngoods or general online shopping rewards card, or a flat-rate cashback card, when checking out.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8096.576831&trid=1552713.157185&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off"
       }
     },
     {
@@ -9569,7 +9726,8 @@
       "intro": "Stila is a Los Angeles-founded makeup brand known for its Stay All Day liquid lipstick and\nwaterproof eyeliners, sold direct online as well as through Ulta, Sephora, and various\ndepartment stores. It carries no co-brand credit card of its own. Shoppers buying directly\nfrom stilacosmetics.com are best off with a card that rewards general online shopping,\nwhile purchases made in-store at a partner retailer may earn more under that retailer's\nown department-store or drugstore bonus category instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.116637.3227301&trid=1552713.158360&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 60% off with code SAVEMORE"
       }
     },
     {
@@ -9630,7 +9788,8 @@
       "intro": "Stride Rite is a children's footwear brand dating to 1919, known for shoes designed around\nearly walkers and growing feet, sold through its own online store as well as department\nstores and shoe retailers. It does not have a co-brand credit card. Shoppers buying\ndirectly from striderite.com will get the most value from a card with a strong online\nshopping or select-clothing bonus category, while in-store purchases at a partner retailer\nmay fall under that store's own bonus category instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37376.3385185&trid=1552713.159288&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -9785,7 +9944,8 @@
       "intro": "Taskrabbit is an online marketplace that connects people with independent taskers for\nfurniture assembly, moving help, home repairs, and other odd jobs, booked and paid for\nthrough its app or website. It has been owned by IKEA since 2017 and handles a large share\nof IKEA furniture assembly bookings in addition to general handyman tasks. Taskrabbit has\nno co-brand credit card, so a flat-rate cashback card or a card that earns extra on online\nshopping purchases is the most practical way to earn rewards when booking a task.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18223.2951684&trid=1552713.234963&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "$10 off for new customers"
       }
     },
     {
@@ -9870,7 +10030,8 @@
       "intro": "The Bouqs Company is an online flower delivery service that ships farm-direct bouquets cut\nto order rather than sourcing from a traditional florist warehouse, along with plants and\ngift add-ons, sold through its own website and app on a one-time or subscription basis.\nIt has no co-brand credit card. Because it operates purely as an online retailer, a card\nwith a strong online shopping bonus category, or a flat-rate cashback card, will earn the\nmost on an order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.39813.3964750&trid=1552713.161010&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "30% off with code FLASH"
       }
     },
     {
@@ -9933,7 +10094,8 @@
       "intro": "The Knot is a wedding planning platform offering vendor directories, registries, website\nbuilders, and invitation design, operated by The Knot Worldwide alongside sister brands\nlike WeddingWire. Purchases through the site typically flow through The Knot's gift and\nregistry shop or its invitation and stationery store rather than a single storefront. The\nKnot has no co-brand credit card, so a card with a strong online shopping bonus category,\nor a flat-rate cashback card, is the most reliable way to earn rewards on registry or\nstationery purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12032.1985622&trid=1552713.222266&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off with code PAPER15"
       }
     },
     {
@@ -9951,7 +10113,8 @@
       "intro": "The Men's Wearhouse is a men's formalwear and business-apparel retailer known for suit\nsales and tuxedo rentals, operating hundreds of stores nationwide alongside its online\nshop, and owned by Tailored Brands, which also owns Jos. A. Bank. There is no Men's\nWearhouse co-brand credit card, though the retailer does offer its own Perfect Fit loyalty\nprogram. For everyday credit card rewards, shoppers should reach for a card with a strong\nonline shopping or select-clothing bonus category when buying online, or a flat-rate\ncashback card in store.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41420.1000012226&trid=1552713.178339&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 70% off clearance"
       }
     },
     {
@@ -10047,7 +10210,8 @@
       "intro": "Thrive Causemetics is a cruelty-free cosmetics brand built around a buy-one-give-one model\nthat donates products and funds to causes supporting women, sold primarily direct-to-\nconsumer online as well as through Ulta Beauty. It has no co-brand credit card. Orders\nplaced directly on thrivecausemetics.com are best matched to a card with a strong online\nshopping bonus category, while purchases made through Ulta would instead earn under that\nretailer's own department-store or beauty category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110003653.1100176299&trid=1552713.232808&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 40% off"
       }
     },
     {
@@ -10100,7 +10264,8 @@
       "intro": "Timberland is an outdoor footwear and apparel brand best known for its rugged yellow boot,\nnow part of a lineup that includes hiking, work, and casual footwear plus jackets and bags,\nowned by VF Corporation alongside brands like The North Face and Vans. There is no\nTimberland co-brand credit card. Shoppers buying directly through timberland.com will get\nthe most value from a card with a strong online shopping or select-clothing bonus category,\nand a flat-rate cashback card works well for purchases at outlet or partner stores.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25164.2107591&trid=1552713.239487&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off on your birthday"
       }
     },
     {
@@ -10137,7 +10302,8 @@
       "intro": "Tommy Bahama is an island-lifestyle apparel brand known for its silk camp shirts and resort\nwear, also operating a chain of restaurant-and-retail locations, and owned by Oxford\nIndustries. It has no co-brand credit card. Purchases made directly through\ntommybahama.com are best matched to a card with a strong online shopping or\nselect-clothing bonus category, while dining at one of its restaurant locations would\ninstead earn under a card's dining category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101106073.1100207512&trid=1552713.196026&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off women's apparel"
       }
     },
     {
@@ -10220,7 +10386,8 @@
       "intro": "Trade Coffee is a subscription service that matches subscribers with beans from a network\nof independent roasters across the United States based on taste preferences, shipping\nfreshly roasted coffee on a recurring schedule rather than selling a single house blend.\nIt has no co-brand credit card. Because it functions like a recurring food and beverage\npurchase, a card with a strong dining or online shopping bonus category will typically earn\nthe most on a subscription charge.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9472.2913607&trid=1552713.230744&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "50% off your first order"
       }
     },
     {
@@ -10247,7 +10414,8 @@
       "intro": "Tramontina is a Brazilian manufacturer of cookware, cutlery, and kitchen tools, with a\nU.S.-facing catalog of stainless steel and nonstick cookware, knives, and outdoor cooking\ngear sold direct online as well as through retailers like Amazon and Walmart. It has no\nco-brand credit card. Shoppers buying directly from tramontinausa.com are best served by a\ncard with a strong home improvement or online shopping bonus category, while purchases made\nthrough a third-party retailer may earn under that store's own bonus category instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.62429.2605926&trid=1552713.245572&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off first purchase with code WELCOME10"
       }
     },
     {
@@ -10324,7 +10492,8 @@
       "intro": "True Religion is a premium denim brand founded in Los Angeles in 2002, known for its\nsignature horseshoe stitching on back pockets, with a catalog that has since expanded into\nbroader apparel and accessories sold through its own stores and website. It has no\nco-brand credit card. Shoppers buying directly through truereligion.com will get the most\nvalue from a card with a strong online shopping or select-clothing bonus category, and a\nflat-rate cashback card is a solid fallback for purchases at a physical store.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8543.610615&trid=1552713.201072&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "60% off"
       }
     },
     {
@@ -10347,7 +10516,8 @@
       "intro": "Trust & Will is an online estate planning service that lets people build wills, trusts, and\nguardian designations through a guided digital questionnaire instead of hiring a traditional\nestate attorney. Plans are priced as flat one-time or subscription fees rather than by the\nhour, which makes the total cost predictable up front. There's no Trust & Will co-brand\ncredit card, so the smartest way to pay is a flat-rate cashback card or a card that earns\nbonus rewards on general online purchases, since estate planning fees usually fall outside\nany dedicated bonus category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11883.851571&trid=1552713.202805&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "10% off with code EXCLUSIVE10"
       }
     },
     {
@@ -10467,7 +10637,8 @@
       "intro": "Universal Standard is a direct-to-consumer apparel brand built around extended sizing,\ntypically running from size 00 up through 40, with core pieces designed to be reordered\nin a consistent fit across seasons. The label sells primarily through its own site and app\nrather than leaning on wholesale department-store distribution. There's no Universal\nStandard co-brand credit card, so shoppers are better served pairing purchases with a\ngeneral online shopping rewards card or a flat-rate cashback card rather than expecting a\ndepartment-store bonus category to apply.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11299.2922125&trid=1552713.215260&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off for new customers"
       }
     },
     {
@@ -10542,7 +10713,8 @@
       "intro": "Vera Bradley is an Indiana-founded lifestyle brand known for quilted cotton handbags,\ntotes, and travel accessories in signature bold prints, sold through its own stores and\nsite as well as through department stores and specialty retailers. The company has since\nexpanded into luggage, home goods, and licensed apparel lines. There is no Vera Bradley\nco-brand credit card, so purchases are best matched to a department-store rewards card\nwhen buying through a wholesale partner, or a general online shopping or flat-rate\ncashback card when ordering directly from verabradley.com.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.24943.1010003564&trid=1552713.157861&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off for new customers"
       }
     },
     {
@@ -10609,7 +10781,8 @@
       "intro": "Vince Camuto is a contemporary footwear and accessories label, founded by the designer of\nthe same name, known for women's heels, boots, and handbags sold through its own stores\nand site as well as department stores and shoe retailers. The brand also licenses apparel\nand eyewear lines. There is no Vince Camuto co-brand credit card, so shoppers should lean\non a department-store rewards card when buying through a wholesale partner, or a general\nonline shopping or flat-rate cashback card for direct purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36963.1010000549&trid=1552713.158615&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off your first order"
       }
     },
     {
@@ -10623,7 +10796,8 @@
       "intro": "vineyard vines is a preppy American apparel brand recognized by its embroidered whale\nlogo, built around Nantucket-inspired menswear, womenswear, and kids' clothing like\nperformance polos, shorts, and dresses. The brand sells through its own stores and site as\nwell as select department and specialty stores. There's no vineyard vines co-brand credit\ncard, so a department-store rewards card fits purchases made through a wholesale partner,\nwhile a general online shopping or flat-rate cashback card works best for direct orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9524.2004980&trid=1552713.197884&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off your first order"
       }
     },
     {
@@ -10668,7 +10842,8 @@
       "intro": "Visible is a Verizon-owned prepaid wireless carrier that sells phone plans exclusively\nonline, running on Verizon's network but without the retail stores, contracts, or bundled\ndevice financing of the parent brand. Plans are flat monthly rates with no separate taxes\nor fees added at checkout. There's no Visible co-brand credit card, so recurring bills are\nbest paid with a card that earns bonus rewards on cell phone or phone bill purchases, or a\nflat-rate cashback card if no phone category applies.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12909.1586315&trid=1552713.213808&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 50% off when you upgrade"
       }
     },
     {
@@ -10823,7 +10998,8 @@
       "intro": "Weber is the maker of the iconic kettle charcoal grill, a design that dates back to the\n1950s, and has since grown into a full lineup of gas, charcoal, pellet, and electric\ngrills along with smokers, accessories, and a connected app for monitoring cooks. Products\nare sold direct online, through Weber-branded retail, and through home and hardware\nstores. There's no Weber co-brand credit card, so a home improvement category card or a\ngeneral online shopping rewards card is the better fit for grill and accessory purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14695.3749619&trid=1552713.247914&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "20% off"
       }
     },
     {
@@ -10848,7 +11024,8 @@
       "intro": "Weleda is a Swiss company that has made natural and certified-organic skincare, body care,\nand homeopathic remedies since the 1920s, built around botanical ingredients and\nbiodynamic farming practices. Its skin food and calendula lines are the brand's best-known\nU.S. products, sold direct online and through natural-grocery and pharmacy retailers.\nThere's no Weleda co-brand credit card, so a general online shopping rewards card or a\nflat-rate cashback card is the practical choice for purchases made directly through the\nbrand's site.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.44684.1000000098&trid=1552713.209906&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off your first order"
       }
     },
     {
@@ -10898,7 +11075,8 @@
       "intro": "Westgate Resorts is a privately held hospitality company that operates timeshare and\nvacation-ownership resorts across popular U.S. destinations like Orlando, Las Vegas, and\nGatlinburg, and also rents units nightly to non-owners much like a traditional resort\nchain. It is not affiliated with the major hotel loyalty programs. There's no Westgate\nResorts co-brand credit card, so a general hotel or travel category card, or a flat-rate\ncashback card, is the better way to pay for stays and maintenance-fee charges.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110106385.1101155989&trid=1552713.245447&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "up to 20% off nightly rates"
       }
     },
     {
@@ -11004,7 +11182,8 @@
       "intro": "Wish is an online marketplace best known for low-priced goods, from apparel and gadgets to\nhome items, shipped largely from third-party sellers and manufacturers overseas. The\nplatform emphasizes deep discounts over brand-name selection, with delivery times that can\nrun longer than typical U.S. retailers. There's no Wish co-brand credit card, so a general\nonline shopping rewards card or a flat-rate cashback card is the practical way to earn\nrewards on purchases.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53195.1000000011&trid=1552713.216420&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "15% off first purchase with code WISHSHOPPING"
       }
     },
     {
@@ -11032,7 +11211,8 @@
       "intro": "Wrangler is a denim and western-wear brand dating back to the 1940s, known for jeans built\nfor riding and rodeo work as well as broader casualwear, and now owned by Kontoor Brands\nalongside Lee. Products are sold direct online and through mass-market, department, and\nfarm-and-ranch retailers. There's no Wrangler co-brand credit card, so a department-store\nrewards card fits purchases made through a wholesale partner, while a general online\nshopping or flat-rate cashback card works best for direct orders.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25202.3966290&trid=1552713.193401&foc=16&fot=9999&fos=6",
-        "network": "flexoffers"
+        "network": "flexoffers",
+        "offer": "buy one get one 50% off shorts"
       }
     },
     {


### PR DESCRIPTION
## What

Follow-up to the 286-merchant batch. The FlexOffers feed (refreshed daily) carries an actual deal for most of these merchants, so the affiliate button should lead with it instead of a generic "Shop at X" line.

- **180 merchants** now have an `offer:` → button reads e.g. *"See 30% off for new customers at 1-800 Contacts"*, *"See buy 1 get 1 50% off sitewide at Calvin Klein"*.
- **105 merchants** are left offer-less on purpose: 79 are "Homepage (no deal)" in the feed, and ~26 had no cleanly-quotable discount (a product name that happened to contain a %, B2B/bulk-only pricing, ticket-seller "get 60% off" seller promos). These fall through to the button fallback rather than overclaim.

## Accuracy pass

Offers are distilled to short truthful phrases. An automated diff against the raw promo text caught and fixed 9 mismatches before commit — e.g. Calvin Klein "Buy 1 Get 1 50% Off" was flattened to "50% off sitewide" (fixed to "buy 1 get 1 50% off sitewide"), and spend thresholds (`$250+`, `$400+`) and required coupon codes were restored on Guess, ECCO, Bowflex, etc. Milk Bar's corporate/bulk-only deal was dropped to the fallback since it isn't a general shopper offer.

All phrases follow the `affiliates.yaml` rules (phrase not sentence, no trailing period, no em dash, no CreditOdds framing). The button already renders `offer` + an "Offer shown as listed by {store}, and subject to change" disclosure.

Rebuild: `npm run build:stores` → 844 stores, 357 affiliate links, validation passing.