### PR TITLE
style(toast): match sharp odds-terminal theme

### DIFF
--- a/apps/web-next/src/app/globals.css
+++ b/apps/web-next/src/app/globals.css
@@ -41,6 +41,58 @@ body {
   }
 }
 
+/* ------------------------------------------------------------------ */
+/* Toast notifications — match the sharp, rectangular odds-terminal look */
+/* (react-toastify ships rounded/gray defaults; these override them).    */
+/* Scoped to the root container, not .landing-v2, so values are literal. */
+/* ------------------------------------------------------------------ */
+:root {
+  --toastify-toast-bd-radius: 0;
+  --toastify-toast-shadow: 0 1px 0 rgba(26, 19, 48, 0.04),
+    0 12px 32px -12px rgba(26, 19, 48, 0.28);
+  --toastify-color-success: #0c8450;
+  --toastify-color-error: #d23a62;
+  --toastify-icon-color-success: #0c8450;
+  --toastify-icon-color-error: #d23a62;
+  --toastify-color-progress-success: #0c8450;
+  --toastify-color-progress-error: #d23a62;
+}
+
+.Toastify__toast {
+  border: 1px solid #ddd7ec;
+  border-left-width: 4px;
+  color: #1a1330;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 14px 16px;
+}
+
+.Toastify__toast--success {
+  border-left-color: #0c8450;
+}
+
+.Toastify__toast--error {
+  border-left-color: #d23a62;
+}
+
+.Toastify__toast-body {
+  color: #1a1330;
+}
+
+.Toastify__close-button {
+  color: #1a1330;
+  opacity: 0.4;
+  align-self: center;
+}
+
+.Toastify__close-button:hover,
+.Toastify__close-button:focus {
+  opacity: 0.9;
+}
+
+/* Full-width mobile toasts stay square (react-toastify sets radius 0). */
+
 /* Shimmer animation for referral buttons */
 @keyframes shimmer {
   0% {


### PR DESCRIPTION
Restyles toast notifications (referral/record submit + error states) to the site's sharp, rectangular odds-terminal look. The app shipped stock react-toastify with no overrides.

## Changes (apps/web-next/src/app/globals.css)
- **Square corners** — border-radius 0 (was rounded 6px)
- **1px border** #ddd7ec with a **4px colored left stripe**
- **Ink text** #1a1330 in **Inter**, 500 weight (was gray #757575)
- **Crisp shadow** 0 12px 32px -12px
- **Success** stripe/icon/progress → site green #0c8450
- **Error** stripe/icon/progress → --warn red #d23a62
- Subtle ink close button

Colors are literal hex (not the --ink/--accent vars) because ToastContainer renders at the document root, outside .landing-v2 where those vars are scoped. The override block sits in globals.css, which loads after ReactToastify.css so it wins the cascade.

Verified in the dev preview: computed border-radius 0, green/red left stripes confirmed on both variants.