### PR TITLE
style(toast): single-line compact toasts

### DIFF
--- a/apps/web-next/src/app/globals.css
+++ b/apps/web-next/src/app/globals.css
@@ -48,6 +48,7 @@ body {
 /* ------------------------------------------------------------------ */
 :root {
   --toastify-toast-bd-radius: 0;
+  --toastify-toast-min-height: 0;
   --toastify-toast-shadow: 0 1px 0 rgba(26, 19, 48, 0.04),
     0 12px 32px -12px rgba(26, 19, 48, 0.28);
   --toastify-color-success: #0c8450;
@@ -65,7 +66,23 @@ body {
   font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
   font-size: 14px;
   font-weight: 500;
-  padding: 14px 16px;
+  padding: 10px 14px;
+}
+
+/* Keep the icon + message on a single compact line. */
+.Toastify__toast-body {
+  color: #1a1330;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0;
+  margin: 0;
+}
+
+.Toastify__toast-body > div:last-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .Toastify__toast--success {
@@ -74,10 +91,6 @@ body {
 
 .Toastify__toast--error {
   border-left-color: #d23a62;
-}
-
-.Toastify__toast-body {
-  color: #1a1330;
 }
 
 .Toastify__close-button {


### PR DESCRIPTION
Follow-up to #1601. Makes toast notifications a single compact line — icon (check / !) then message on one row — which shortens the box.

## Changes (apps/web-next/src/app/globals.css)
- Drop min-height (was 64px) so short messages don't force a tall box
- Lay the toast body out as a flex row, icon + text vertically centered
- Message stays on one line (nowrap + ellipsis)
- Tighter padding (10px 14px)

Result: toast height drops from ~64px to ~43px. Verified in the dev preview (both success and error variants measured at 43px, single line).