### PR TITLE
feat(wallet): close a card (distinct from remove from wallet)

### DIFF
--- a/apps/api/migrations/049a_add_closed_date_to_user_cards.sql
+++ b/apps/api/migrations/049a_add_closed_date_to_user_cards.sql
@@ -1,0 +1,6 @@
+-- Closing a card is distinct from removing it from the wallet. A closed card
+-- is kept in user_cards (so the credit-history span is preserved: acquired_month
+-- /acquired_year is the open date, closed_date the close date) but drops out of
+-- the active wallet — GET /wallet and the ranker filter on closed_date IS NULL.
+-- The closure itself is logged in wallet_card_events (event_type = 'card_closed').
+ALTER TABLE user_cards ADD COLUMN closed_date DATE NULL DEFAULT NULL;

--- a/apps/api/migrations/049b_allow_null_new_card_id_wallet_events.sql
+++ b/apps/api/migrations/049b_allow_null_new_card_id_wallet_events.sql
@@ -1,0 +1,5 @@
+-- A 'card_closed' event has no target card, so new_card_id must be nullable.
+-- Existing 'product_change' rows always set it, so relaxing the constraint is
+-- backward-compatible. The events query LEFT JOINs the new card and already
+-- tolerates a null match.
+ALTER TABLE wallet_card_events MODIFY COLUMN new_card_id INT NULL;

--- a/apps/api/src/handlers/user-wallet.js
+++ b/apps/api/src/handlers/user-wallet.js
@@ -6,8 +6,9 @@
 //   PUT    /wallet/reorder                  — set sort_order for a list of wallet rows (drag-to-reorder)
 //   GET    /wallet/events                   — list product-change events for the user
 //   PUT    /wallet/{id}                     — update acquired_month / acquired_year on a specific instance
-//   DELETE /wallet/{id}                     — remove a specific instance
+//   DELETE /wallet/{id}                     — remove a specific instance (hard delete, no history kept)
 //   POST   /wallet/{id}/product-change      — convert a wallet row from one card to another (same issuer); logs the event
+//   POST   /wallet/{id}/close               — mark a wallet row closed (keeps the row + credit-history span); logs the event
 //
 // Per-card identity is `user_cards.id` (auto-increment). Ratings live in `card_ratings`
 // keyed by (user_id, card_id) — one rating per card type, shared across duplicates.
@@ -67,15 +68,19 @@ exports.UserWalletHandler = async (event) => {
   const isReorderRoute = routeKey.endsWith("/wallet/reorder");
   const isEventsRoute = routeKey.endsWith("/wallet/events");
   const isProductChangeRoute = routeKey.endsWith("/wallet/{id}/product-change") || routeKey.endsWith("/product-change");
+  const isCloseRoute = routeKey.endsWith("/wallet/{id}/close") || routeKey.endsWith("/close");
   let response = {};
 
   try {
     switch (event.httpMethod) {
       case "GET": {
         if (isEventsRoute) {
-          // Product-change history for the user. Joins both old and new card
-          // names so the frontend can render "Sapphire Preferred → Sapphire
-          // Reserve" without a second lookup. Newest event first.
+          // Wallet history for the user: product changes ("Sapphire Preferred →
+          // Sapphire Reserve") and card closures. Joins both old and new card
+          // names so the frontend can render without a second lookup; a closure
+          // has a null new_card_id so the cn.* columns come back null. Also joins
+          // the wallet row (kept alive for closed cards) so a closure can show
+          // the open→close span. Newest event first.
           const events = await mysql.query(`
             SELECT
               e.id,
@@ -91,10 +96,13 @@ exports.UserWalletHandler = async (event) => {
               co.card_image_link AS old_card_image_link,
               cn.card_name AS new_card_name,
               cn.card_image_link AS new_card_image_link,
-              cn.bank AS bank
+              COALESCE(cn.bank, co.bank) AS bank,
+              uc.acquired_month AS opened_month,
+              uc.acquired_year AS opened_year
             FROM wallet_card_events e
             LEFT JOIN cards co ON e.old_card_id = co.card_id
             LEFT JOIN cards cn ON e.new_card_id = cn.card_id
+            LEFT JOIN user_cards uc ON e.user_card_id = uc.id
             WHERE e.user_id = ?
             ORDER BY e.change_date DESC, e.id DESC
           `, [userId]);
@@ -131,7 +139,7 @@ exports.UserWalletHandler = async (event) => {
           JOIN cards c ON uc.card_id = c.card_id
           LEFT JOIN card_ratings cr
             ON cr.card_id = uc.card_id AND cr.user_id = uc.user_id
-          WHERE uc.user_id = ?
+          WHERE uc.user_id = ? AND uc.closed_date IS NULL
           ORDER BY (uc.sort_order IS NULL), uc.sort_order ASC, uc.created_at ASC, uc.id ASC
         `, [userId]);
 
@@ -321,6 +329,114 @@ exports.UserWalletHandler = async (event) => {
               old_card_id: oldCardId,
               new_card_id: Number(new_card_id),
               change_date: effectiveDate,
+            }),
+          };
+          break;
+        }
+
+        if (isCloseRoute) {
+          // Close a card: the account was closed but should still count toward
+          // credit history. Unlike DELETE (a hard remove), we keep the row and
+          // stamp closed_date, so acquired_month/year → closed_date is the span.
+          // The row drops out of the active wallet (GET filters closed_date IS
+          // NULL) and the closure is logged in wallet_card_events. Keyed by row
+          // id so one instance of a duplicated card can be closed on its own.
+          if (!walletRowId || !Number.isFinite(walletRowId)) {
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "wallet row id is required in path" }),
+            };
+            break;
+          }
+
+          const body = JSON.parse(event.body || "{}");
+          const { close_date, reason, note } = body;
+
+          if (reason && reason !== "voluntary" && reason !== "forced") {
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "reason must be 'voluntary' or 'forced'" }),
+            };
+            break;
+          }
+
+          if (note && typeof note === "string" && note.length > 500) {
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "note must be 500 characters or fewer" }),
+            };
+            break;
+          }
+
+          // Default close_date to today; validate YYYY-MM-DD when provided.
+          let effectiveClose = close_date;
+          if (effectiveClose) {
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(effectiveClose)) {
+              response = {
+                statusCode: 400,
+                headers: responseHeaders,
+                body: JSON.stringify({ error: "close_date must be YYYY-MM-DD" }),
+              };
+              break;
+            }
+          } else {
+            effectiveClose = new Date().toISOString().slice(0, 10);
+          }
+
+          // Verify ownership and that the row isn't already closed.
+          const closeRow = await mysql.query(
+            "SELECT id, card_id, closed_date FROM user_cards WHERE id = ? AND user_id = ?",
+            [walletRowId, userId]
+          );
+          if (closeRow.length === 0) {
+            await mysql.end();
+            response = {
+              statusCode: 404,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "Wallet card not found" }),
+            };
+            break;
+          }
+          if (closeRow[0].closed_date) {
+            await mysql.end();
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "Card is already closed" }),
+            };
+            break;
+          }
+
+          const closedCardId = closeRow[0].card_id;
+
+          // Stamp the close date, then log the event. Two statements (no
+          // transactions in the serverless-mysql wrapper); the event log is a
+          // record-keeping concern, so order matters less than atomicity.
+          await mysql.query(
+            "UPDATE user_cards SET closed_date = ? WHERE id = ? AND user_id = ? AND closed_date IS NULL",
+            [effectiveClose, walletRowId, userId]
+          );
+
+          const closeInsert = await mysql.query(`
+            INSERT INTO wallet_card_events
+              (user_id, user_card_id, event_type, old_card_id, new_card_id, change_date, reason, note)
+            VALUES (?, ?, 'card_closed', ?, NULL, ?, ?, ?)
+          `, [userId, walletRowId, closedCardId, effectiveClose, reason || null, note || null]);
+
+          await mysql.end();
+
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({
+              message: "Card closed",
+              event_id: closeInsert.insertId,
+              wallet_card_id: walletRowId,
+              card_id: closedCardId,
+              close_date: effectiveClose,
             }),
           };
           break;

--- a/apps/api/src/lib/ranker/user-wallet-loader.js
+++ b/apps/api/src/lib/ranker/user-wallet-loader.js
@@ -12,7 +12,7 @@ async function loadUserWallet(userId) {
     `SELECT uc.id, c.card_name
      FROM user_cards uc
      JOIN cards c ON uc.card_id = c.card_id
-     WHERE uc.user_id = ?`,
+     WHERE uc.user_id = ? AND uc.closed_date IS NULL`,
     [userId],
   );
 

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -557,6 +557,22 @@ Resources:
               Ref: CreditCardOddsAPI
             Auth:
               Authorizer: NONE
+        WalletClose:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}/close
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        WalletCloseOptions:
+          Type: Api
+          Properties:
+            Path: /wallet/{id}/close
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
 
   UserCardSelectionsFunction:
     Type: AWS::Serverless::Function

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -33,6 +33,7 @@ const ReferralModal = dynamic(() => import("@/components/forms/ReferralModal"), 
 const AddToWalletModal = dynamic(() => import("@/components/wallet/AddToWalletModal"), { ssr: false, loading: () => null });
 const EditWalletCardModal = dynamic(() => import("@/components/wallet/EditWalletCardModal"), { ssr: false, loading: () => null });
 const ProductChangeModal = dynamic(() => import("@/components/wallet/ProductChangeModal"), { ssr: false, loading: () => null });
+const CloseCardModal = dynamic(() => import("@/components/wallet/CloseCardModal"), { ssr: false, loading: () => null });
 const SelectCategoriesModal = dynamic(() => import("@/components/wallet/SelectCategoriesModal"), { ssr: false, loading: () => null });
 const BestCardByCategory = dynamic(() => import("@/components/wallet/BestCardByCategory"), { ssr: false, loading: () => null });
 const BestCardHere = dynamic(() => import("@/components/wallet/BestCardHere"), { ssr: false, loading: () => null });
@@ -174,6 +175,7 @@ export default function ProfileClient() {
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [editingCard, setEditingCard] = useState<WalletCard | null>(null);
   const [productChangingCard, setProductChangingCard] = useState<WalletCard | null>(null);
+  const [closingCard, setClosingCard] = useState<WalletCard | null>(null);
   const [walletEvents, setWalletEvents] = useState<WalletCardEvent[]>([]);
   const [submitRecordCard, setSubmitRecordCard] = useState<{ card_id: number; card_name: string; card_image_link?: string; bank: string } | null>(null);
   const [showRecordCardPicker, setShowRecordCardPicker] = useState(false);
@@ -917,11 +919,23 @@ export default function ProfileClient() {
           setEditingCard(null);
           setProductChangingCard(current);
         } : undefined}
+        onRequestCloseCard={editingCard ? () => {
+          const current = editingCard;
+          setEditingCard(null);
+          setClosingCard(current);
+        } : undefined}
       />
       <ProductChangeModal
         show={!!productChangingCard}
         card={productChangingCard}
         onClose={() => setProductChangingCard(null)}
+        onSuccess={loadData}
+      />
+      <CloseCardModal
+        show={!!closingCard}
+        card={closingCard}
+        displayName={closingCard ? walletDisplayNames.get(closingCard.id) : undefined}
+        onClose={() => setClosingCard(null)}
         onSuccess={loadData}
       />
       <SelectCategoriesModal
@@ -1068,19 +1082,19 @@ function CardsTab(props: CardsTabProps) {
           </div>
           {walletEvents.length === 0 ? (
             <div style={{ padding: 24, fontSize: 13, color: 'var(--muted)' }}>
-              No product changes recorded yet. When you convert a wallet card to another product from the same issuer, the change shows up here.
+              Nothing recorded yet. When you convert a wallet card to another product from the same issuer, or close a card, it shows up here.
             </div>
           ) : (
             walletEvents.map((e) => {
+              const isClosed = e.event_type === 'card_closed';
               const reasonLabel = e.reason === 'voluntary' ? 'you' : e.reason === 'forced' ? 'bank' : '—';
               const dateLabel = e.change_date ? e.change_date.slice(0, 10) : '';
-              const arrow = ' → ';
               return (
                 <div key={e.id} className="cj-wallet-crow" style={{ cursor: 'default' }}>
                   <span className="cj-cw-thumb">
                     <CardImage
-                      cardImageLink={e.new_card_image_link || undefined}
-                      alt={e.new_card_name || 'new card'}
+                      cardImageLink={(isClosed ? e.old_card_image_link : e.new_card_image_link) || undefined}
+                      alt={(isClosed ? e.old_card_name : e.new_card_name) || 'card'}
                       fill
                       sizes="36px"
                       className="object-contain"
@@ -1088,9 +1102,18 @@ function CardsTab(props: CardsTabProps) {
                   </span>
                   <div className="cj-cw-name">
                     <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                      <span style={{ color: 'var(--muted)' }}>{e.old_card_name || `#${e.old_card_id}`}</span>
-                      {arrow}
-                      {e.new_card_name || `#${e.new_card_id}`}
+                      {isClosed ? (
+                        <>
+                          {e.old_card_name || `#${e.old_card_id}`}
+                          <span style={{ color: 'var(--muted)' }}> · closed</span>
+                        </>
+                      ) : (
+                        <>
+                          <span style={{ color: 'var(--muted)' }}>{e.old_card_name || `#${e.old_card_id}`}</span>
+                          {' → '}
+                          {e.new_card_name || `#${e.new_card_id}`}
+                        </>
+                      )}
                     </span>
                   </div>
                   <div className="cj-cw-renew">{dateLabel}</div>

--- a/apps/web-next/src/app/profile/history/WalletHistoryClient.tsx
+++ b/apps/web-next/src/app/profile/history/WalletHistoryClient.tsx
@@ -19,10 +19,18 @@ function formatDate(iso: string | null | undefined): string {
   return `${MONTHS_SHORT[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
 }
 
-function reasonLabel(reason: WalletCardEvent['reason']): string | null {
-  if (reason === 'voluntary') return 'You requested it';
-  if (reason === 'forced') return 'Bank initiated';
+function reasonLabel(event: WalletCardEvent): string | null {
+  const closed = event.event_type === 'card_closed';
+  if (event.reason === 'voluntary') return closed ? 'You closed it' : 'You requested it';
+  if (event.reason === 'forced') return closed ? 'Bank closed it' : 'Bank initiated';
   return null;
+}
+
+function openedLabel(event: WalletCardEvent): string | null {
+  if (!event.opened_month && !event.opened_year) return null;
+  const m = event.opened_month ? MONTHS_SHORT[event.opened_month - 1] : '';
+  if (event.opened_year) return `${m ? m + ' ' : ''}${event.opened_year}`;
+  return m || null;
 }
 
 export default function WalletHistoryClient() {
@@ -64,7 +72,7 @@ export default function WalletHistoryClient() {
 
           <h1 style={{ fontSize: 28, fontWeight: 600, margin: '0 0 4px' }}>Wallet history</h1>
           <p style={{ fontSize: 14, color: 'var(--muted)', margin: '0 0 24px' }}>
-            Every product change recorded on your wallet cards, newest first.
+            Every product change and card closure recorded on your wallet cards, newest first.
           </p>
 
           {error && <div className="cj-modal-error" style={{ marginBottom: 16 }}>{error}</div>}
@@ -75,14 +83,16 @@ export default function WalletHistoryClient() {
 
           {loaded && events.length === 0 && !error && (
             <div style={{ border: '1px solid var(--border)', borderRadius: 12, padding: 24, color: 'var(--muted)', fontSize: 14 }}>
-              No product changes recorded yet. When you convert a wallet card to another product from the same issuer, the change shows up here.
+              Nothing recorded yet. When you convert a wallet card to another product from the same issuer, or close a card, it shows up here.
             </div>
           )}
 
           {loaded && events.length > 0 && (
             <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 12 }}>
               {events.map((e) => {
-                const reason = reasonLabel(e.reason);
+                const reason = reasonLabel(e);
+                const isClosed = e.event_type === 'card_closed';
+                const opened = openedLabel(e);
                 return (
                   <li
                     key={e.id}
@@ -98,36 +108,59 @@ export default function WalletHistoryClient() {
                         <span className="cj-modal-thumb" style={{ flexShrink: 0 }}>
                           <CardImage
                             cardImageLink={e.old_card_image_link || undefined}
-                            alt={e.old_card_name || 'Old card'}
+                            alt={e.old_card_name || 'Card'}
                             fill
                             className="object-contain"
                             sizes="56px"
                           />
                         </span>
-                        <span style={{ fontSize: 13, color: 'var(--text)', minWidth: 0 }}>
+                        <span style={{ fontSize: 13, fontWeight: isClosed ? 600 : 400, color: 'var(--text)', minWidth: 0 }}>
                           {e.old_card_name || `Card #${e.old_card_id}`}
                         </span>
                       </div>
 
-                      <ArrowRightIcon style={{ width: 14, height: 14, color: 'var(--muted)', flexShrink: 0 }} />
-
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-                        <span className="cj-modal-thumb" style={{ flexShrink: 0 }}>
-                          <CardImage
-                            cardImageLink={e.new_card_image_link || undefined}
-                            alt={e.new_card_name || 'New card'}
-                            fill
-                            className="object-contain"
-                            sizes="56px"
-                          />
+                      {isClosed ? (
+                        <span
+                          style={{
+                            fontSize: 11,
+                            fontWeight: 600,
+                            textTransform: 'uppercase',
+                            letterSpacing: 0.4,
+                            color: 'var(--muted)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 999,
+                            padding: '2px 8px',
+                            flexShrink: 0,
+                          }}
+                        >
+                          Closed
                         </span>
-                        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text)', minWidth: 0 }}>
-                          {e.new_card_name || `Card #${e.new_card_id}`}
-                        </span>
-                      </div>
+                      ) : (
+                        <>
+                          <ArrowRightIcon style={{ width: 14, height: 14, color: 'var(--muted)', flexShrink: 0 }} />
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                            <span className="cj-modal-thumb" style={{ flexShrink: 0 }}>
+                              <CardImage
+                                cardImageLink={e.new_card_image_link || undefined}
+                                alt={e.new_card_name || 'New card'}
+                                fill
+                                className="object-contain"
+                                sizes="56px"
+                              />
+                            </span>
+                            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text)', minWidth: 0 }}>
+                              {e.new_card_name || `Card #${e.new_card_id}`}
+                            </span>
+                          </div>
+                        </>
+                      )}
 
                       <div style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--muted)', textAlign: 'right' }}>
-                        <div>{formatDate(e.change_date)}</div>
+                        <div>
+                          {isClosed
+                            ? `${opened ? `Opened ${opened} · ` : ''}Closed ${formatDate(e.change_date)}`
+                            : formatDate(e.change_date)}
+                        </div>
                         {e.bank && <div style={{ fontSize: 11 }}>{e.bank}</div>}
                       </div>
                     </div>

--- a/apps/web-next/src/components/wallet/CloseCardModal.tsx
+++ b/apps/web-next/src/components/wallet/CloseCardModal.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import CardImage from '@/components/ui/CardImage';
+import { WalletCard, closeWalletCard } from '@/lib/api';
+import { useAuth } from '@/auth/AuthProvider';
+
+interface CloseCardModalProps {
+  show: boolean;
+  card: WalletCard | null;
+  // Display name override for duplicated cards (e.g. "Citi Custom Cash A").
+  displayName?: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export default function CloseCardModal({ show, card, displayName, onClose, onSuccess }: CloseCardModalProps) {
+  const { getToken } = useAuth();
+  const [reason, setReason] = useState<'voluntary' | 'forced' | ''>('');
+  const [closeDate, setCloseDate] = useState<string>(() => new Date().toISOString().slice(0, 10));
+  const [note, setNote] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => { setMounted(true); }, []);
+
+  useEffect(() => {
+    if (!show) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, [show]);
+
+  const resetState = () => {
+    setReason('');
+    setCloseDate(new Date().toISOString().slice(0, 10));
+    setNote('');
+    setError(null);
+  };
+
+  const handleClose = () => {
+    resetState();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!card) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error('Authentication required');
+      await closeWalletCard(
+        card.id,
+        {
+          close_date: closeDate || undefined,
+          reason: reason || undefined,
+          note: note.trim() || undefined,
+        },
+        token,
+      );
+      onSuccess();
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to close card');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!show || !card || !mounted) return null;
+
+  const openedLabel = (() => {
+    if (!card.acquired_month && !card.acquired_year) return null;
+    const m = card.acquired_month ? MONTHS_SHORT[card.acquired_month - 1] : '';
+    if (card.acquired_year) return `${m ? m + ' ' : ''}${card.acquired_year}`;
+    return m || null;
+  })();
+
+  return createPortal(
+    <div className="landing-v2 profile-v2">
+      <div className="cj-modal-root" role="dialog" aria-modal="true">
+        <div className="cj-modal-backdrop" onClick={handleClose} />
+        <div className="cj-modal-shell">
+          <div className="cj-modal-card cj-modal-card-bounded" style={{ maxWidth: 520 }}>
+            <div className="cj-modal-head">
+              <span className="cj-status-dot" />
+              <span className="cj-modal-title">close card</span>
+              <button type="button" className="cj-modal-close" onClick={handleClose} aria-label="Close">
+                <XMarkIcon style={{ width: 16, height: 16 }} />
+              </button>
+            </div>
+
+            <div className="cj-modal-body">
+              {error && <div className="cj-modal-error">{error}</div>}
+
+              <div className="cj-modal-section">
+                <div className="cj-modal-card-row">
+                  <span className="cj-modal-thumb">
+                    <CardImage cardImageLink={card.card_image_link} alt={card.card_name} fill className="object-contain" sizes="56px" />
+                  </span>
+                  <div style={{ minWidth: 0 }}>
+                    <div className="cj-modal-card-name">{displayName ?? card.card_name}</div>
+                    <div className="cj-modal-card-meta">
+                      {card.bank}{openedLabel ? ` · opened ${openedLabel}` : ''}
+                    </div>
+                  </div>
+                </div>
+                <p style={{ fontSize: 12, color: 'var(--muted)', margin: '8px 0 0' }}>
+                  Closing removes this card from your wallet but keeps its history, so it still counts toward your length of credit history. To erase it entirely, use “remove from wallet” instead.
+                </p>
+              </div>
+
+              <div className="cj-modal-section">
+                <label className="cj-modal-label">Close date</label>
+                <input
+                  type="date"
+                  value={closeDate}
+                  onChange={(e) => setCloseDate(e.target.value)}
+                  className="cj-modal-select"
+                  max={new Date().toISOString().slice(0, 10)}
+                />
+              </div>
+
+              <div className="cj-modal-section">
+                <label className="cj-modal-label">Reason <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional)</span></label>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  {([
+                    { value: 'voluntary', label: 'I closed it' },
+                    { value: 'forced', label: 'Bank closed it' },
+                  ] as const).map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setReason(reason === opt.value ? '' : opt.value)}
+                      className={'cj-modal-btn' + (reason === opt.value ? ' cj-modal-btn-primary' : '')}
+                      style={{ flex: 1 }}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="cj-modal-section">
+                <label className="cj-modal-label">Note <span style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, color: 'var(--muted-2)' }}>(optional)</span></label>
+                <textarea
+                  value={note}
+                  onChange={(e) => setNote(e.target.value.slice(0, 500))}
+                  className="cj-modal-select"
+                  rows={2}
+                  placeholder="Anything to remember about this closure…"
+                  style={{ resize: 'vertical', minHeight: 56 }}
+                />
+              </div>
+            </div>
+
+            <div className="cj-modal-footer">
+              <span style={{ fontSize: 11, color: 'var(--muted)' }} />
+              <div className="cj-modal-actions">
+                <button type="button" className="cj-modal-btn" onClick={handleClose}>cancel</button>
+                <button
+                  type="button"
+                  className="cj-modal-btn cj-modal-btn-primary"
+                  onClick={handleSubmit}
+                  disabled={saving}
+                >
+                  {saving ? 'closing…' : 'close card'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
-import { XMarkIcon, TrashIcon, ArrowTopRightOnSquareIcon, ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, TrashIcon, ArrowTopRightOnSquareIcon, ArrowsRightLeftIcon, LockClosedIcon } from '@heroicons/react/24/outline';
 import { updateWalletCard, removeFromWallet, WalletCard, WalletCardEvent, getUserCardRating, submitCardRating } from '@/lib/api';
 import { useAuth } from '@/auth/AuthProvider';
 
@@ -24,6 +24,11 @@ interface EditWalletCardModalProps {
   // Opens the product-change picker. The host is expected to close this modal
   // and show the ProductChangeModal in its place.
   onRequestProductChange?: () => void;
+  // Opens the close-card flow. Like a product change, the host closes this
+  // modal and shows the CloseCardModal in its place. Distinct from the
+  // "remove from wallet" delete in the footer — closing keeps the card's
+  // history for length-of-credit tracking.
+  onRequestCloseCard?: () => void;
 }
 
 const RATING_LABELS: Record<number, string> = {
@@ -49,7 +54,7 @@ const months = [
   { value: 10, label: 'October' }, { value: 11, label: 'November' }, { value: 12, label: 'December' },
 ];
 
-export default function EditWalletCardModal({ show, card, cardSlug, annualFee, displayName, lastProductChange, onClose, onSuccess, onRequestProductChange }: EditWalletCardModalProps) {
+export default function EditWalletCardModal({ show, card, cardSlug, annualFee, displayName, lastProductChange, onClose, onSuccess, onRequestProductChange, onRequestCloseCard }: EditWalletCardModalProps) {
   const { getToken } = useAuth();
   const [acquiredMonth, setAcquiredMonth] = useState<number | undefined>();
   const [acquiredYear, setAcquiredYear] = useState<number | undefined>();
@@ -215,6 +220,16 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, d
                   style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4, marginLeft: cardSlug ? 12 : 0 }}
                 >
                   <ArrowsRightLeftIcon style={{ width: 11, height: 11 }} /> product change
+                </button>
+              )}
+              {onRequestCloseCard && (
+                <button
+                  type="button"
+                  className="cj-modal-link"
+                  onClick={onRequestCloseCard}
+                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4, marginLeft: 12 }}
+                >
+                  <LockClosedIcon style={{ width: 11, height: 11 }} /> close card
                 </button>
               )}
             </div>

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -435,6 +435,9 @@ export interface WalletCard {
   created_at: string;
   user_rating?: number | null;
   selections?: WalletCardSelection[];
+  // Set when the card has been closed. GET /wallet only returns open cards, so
+  // this is null on every row it returns; kept on the type for completeness.
+  closed_date?: string | null;
 }
 
 export async function getWallet(token: string): Promise<WalletCard[]> {
@@ -535,14 +538,17 @@ export async function removeFromWallet(walletRowId: number, token: string): Prom
   return res.json();
 }
 
-// Product-change history: one row per recorded conversion of a wallet card
-// from one product to another (same issuer). Sorted newest-first by the API.
+// Wallet history: one row per recorded lifecycle event on a wallet card —
+// a product change (converted to another product, same issuer) or a closure.
+// Sorted newest-first by the API. For a closure new_card_* is null and
+// change_date is the close date; opened_month/opened_year give the open date
+// so the history can show the full credit-history span.
 export interface WalletCardEvent {
   id: number;
   user_card_id: number | null;
-  event_type: 'product_change';
+  event_type: 'product_change' | 'card_closed';
   old_card_id: number;
-  new_card_id: number;
+  new_card_id: number | null;
   change_date: string;
   reason: 'voluntary' | 'forced' | null;
   note: string | null;
@@ -552,6 +558,8 @@ export interface WalletCardEvent {
   new_card_name: string | null;
   new_card_image_link: string | null;
   bank: string | null;
+  opened_month: number | null;
+  opened_year: number | null;
 }
 
 export async function getWalletEvents(token: string): Promise<WalletCardEvent[]> {
@@ -596,6 +604,41 @@ export async function productChangeWalletCard(
   if (!res.ok) {
     const errorText = await res.text().catch(() => 'Unknown error');
     throw new Error(errorText || `Failed to record product change: ${res.status}`);
+  }
+  return res.json();
+}
+
+// Close a wallet card: keeps the row (and its open date) for credit-history
+// tracking but removes it from the active wallet, and logs a closure event.
+// Distinct from removeFromWallet, which hard-deletes with no history.
+export interface CloseCardBody {
+  close_date?: string;
+  reason?: 'voluntary' | 'forced';
+  note?: string;
+}
+
+export async function closeWalletCard(
+  walletRowId: number,
+  body: CloseCardBody,
+  token: string,
+): Promise<{
+  message: string;
+  event_id: number;
+  wallet_card_id: number;
+  card_id: number;
+  close_date: string;
+}> {
+  const res = await fetch(`${API_BASE}/wallet/${walletRowId}/close`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(errorText || `Failed to close card: ${res.status}`);
   }
   return res.json();
 }


### PR DESCRIPTION
## What

Adds the ability to **close** a card from the profile wallet page, distinct from **removing** it from the wallet.

- **Remove from wallet** = hard delete, no history (unchanged).
- **Close card** = the account was closed but should still count toward length of credit history. The wallet row is kept (so open date `acquired_month/year` + new `closed_date` give the full span), the card drops out of the active wallet, and the closure is logged in `wallet_card_events` as a `card_closed` event that shows on the Wallet history + profile change-log alongside product changes.

Reached via **edit → close card** on a wallet card (next to "product change"). Keyed by `user_cards.id`, so with multiple copies of the same card you close exactly one — the A/B/C labels re-derive automatically for the rest.

## Database changes

- `049a_add_closed_date_to_user_cards.sql` — `ALTER TABLE user_cards ADD COLUMN closed_date DATE NULL`.
- `049b_allow_null_new_card_id_wallet_events.sql` — `ALTER TABLE wallet_card_events MODIFY new_card_id INT NULL` (a closure has no target card).

Both single-statement, run via `RunMigrationHandler` **before** the backend deploy (`GET /wallet` filters `closed_date IS NULL`, so the column must exist first).

## Backend

- `POST /wallet/{id}/close` — ownership-checked, validates `close_date` (YYYY-MM-DD, defaults today) / `reason` (`voluntary`|`forced`) / `note` (≤500), rejects already-closed rows; stamps `closed_date` + inserts the `card_closed` event.
- `GET /wallet` and the ranker wallet loader now filter `closed_date IS NULL` (closed cards leave the wallet and stop influencing recommendations/fees/benefits).
- `GET /wallet/events` joins the wallet row to return `opened_month`/`opened_year` so history can show open → close.
- SAM routes: `WalletClose` (POST) + `WalletCloseOptions` (OPTIONS, `Auth: NONE`).

## Frontend

- `closeWalletCard()` + `CloseCardBody`; `WalletCardEvent` widened for `card_closed` (nullable new card, opened month/year).
- New `CloseCardModal` (close date, reason "I closed it" / "Bank closed it", optional note; copy clarifies it keeps history vs. remove).
- "close card" action in `EditWalletCardModal`; wired in `ProfileClient`.
- Wallet history page + profile change-log render closures (Closed badge, open → close span, "you/bank closed it").

## Verification

`tsc --noEmit` clean, no new ESLint errors, `node --check` on both handlers. The end-to-end close flow needs the two migrations + backend deploy (DB is VPC-only) and an authed session, so it wasn't exercised in a local preview.

## Note

Split cleanly off `main`; unrelated store-page-tracking work that briefly shared this working tree is **not** included.