### PR TITLE
feat(best-card-for): track store page visits + affiliate clicks

### DIFF
--- a/apps/api/migrations/048_create_store_page_events.sql
+++ b/apps/api/migrations/048_create_store_page_events.sql
@@ -1,0 +1,15 @@
+-- Track daily engagement on the /best-card-for/{slug} store pages.
+-- Two event types share one table:
+--   'visit'          — a page view (fired once per client on mount)
+--   'affiliate_click'— an outbound click on the store's affiliate CTA
+-- Stores are file-based YAML (no numeric id), so rows key by store_slug.
+-- The store-event handler also self-heals this table (CREATE TABLE IF NOT
+-- EXISTS on first write), so it functions even before this migration runs.
+CREATE TABLE IF NOT EXISTS store_page_events (
+  event_type VARCHAR(24) NOT NULL,
+  store_slug VARCHAR(191) NOT NULL,
+  event_date DATE NOT NULL,
+  event_count INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (event_type, store_slug, event_date),
+  INDEX idx_store_event_date (event_date)
+);

--- a/apps/api/src/handlers/store-event.js
+++ b/apps/api/src/handlers/store-event.js
@@ -1,0 +1,192 @@
+// Track engagement on the /best-card-for/{slug} store pages and return
+// per-store counts for the admin dashboard.
+//
+// Two event types share one aggregate table (store_page_events):
+//   'visit'           — a page view (fired once per client on mount)
+//   'affiliate_click' — an outbound click on the store's affiliate CTA
+//
+// POST is public (anonymous visitors fire the beacons). GET is admin-only —
+// it exposes traffic/conversion analytics, so it is gated the same way the
+// admin.js endpoints are (Firebase custom claim `admin`, or a fallback UID).
+const mysql = require("../db");
+
+// Keep in sync with FALLBACK_ADMIN_IDS / isAdmin in src/handlers/admin.js.
+const FALLBACK_ADMIN_IDS = ['zXOyHmGl7HStyAqEdLsgXLA5inS2'];
+
+function isAdmin(event) {
+  const userId = event.requestContext?.authorizer?.sub;
+  const adminClaim = event.requestContext?.authorizer?.admin;
+  if (adminClaim === 'true') return true;
+  return FALLBACK_ADMIN_IDS.includes(userId);
+}
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+const VALID_TYPES = ["visit", "affiliate_click"];
+
+// Self-heal: if 048_create_store_page_events.sql hasn't been applied yet, the
+// table won't exist and every write/read would 500. Create-if-missing matches
+// that migration's schema so tracking works without the migration dance.
+const ENSURE_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS store_page_events (
+    event_type VARCHAR(24) NOT NULL,
+    store_slug VARCHAR(191) NOT NULL,
+    event_date DATE NOT NULL,
+    event_count INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (event_type, store_slug, event_date),
+    INDEX idx_store_event_date (event_date)
+  )
+`;
+
+let tableEnsured = false;
+async function ensureTable() {
+  if (tableEnsured) return;
+  await mysql.query(ENSURE_TABLE_SQL);
+  tableEnsured = true;
+}
+
+exports.StoreEventHandler = async (event) => {
+  console.info("received:", event.httpMethod, event.path);
+
+  let response = {};
+
+  switch (event.httpMethod) {
+    case "OPTIONS":
+      response = {
+        statusCode: 200,
+        headers: responseHeaders,
+        body: JSON.stringify({ statusText: "OK" }),
+      };
+      break;
+
+    case "POST":
+      try {
+        const body = JSON.parse(event.body);
+        const { event_type, store_slug } = body;
+
+        if (!VALID_TYPES.includes(event_type)) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "event_type must be 'visit' or 'affiliate_click'" }),
+          };
+          break;
+        }
+        if (typeof store_slug !== "string" || !store_slug || store_slug.length > 191) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "store_slug must be a non-empty string (<=191 chars)" }),
+          };
+          break;
+        }
+
+        // Filter out obvious bots (mirrors content-view.js).
+        const userAgent = event.headers?.['User-Agent'] || event.headers?.['user-agent'] || '';
+        if (/bot|crawler|spider|scraper/i.test(userAgent)) {
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({ success: true }),
+          };
+          break;
+        }
+
+        await ensureTable();
+        await mysql.query(
+          `INSERT INTO store_page_events (event_type, store_slug, event_date, event_count)
+           VALUES (?, ?, CURDATE(), 1)
+           ON DUPLICATE KEY UPDATE event_count = event_count + 1`,
+          [event_type, store_slug]
+        );
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ success: true }),
+        };
+      } catch (error) {
+        console.error("Error tracking store event:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to track store event" }),
+        };
+      }
+      break;
+
+    case "GET":
+      // Admin-only: traffic + conversion analytics.
+      if (!isAdmin(event)) {
+        response = {
+          statusCode: 403,
+          headers: { ...responseHeaders, "Cache-Control": "no-store" },
+          body: JSON.stringify({ error: "Forbidden: Admin access required" }),
+        };
+        break;
+      }
+      try {
+        const period = event.queryStringParameters?.period;
+        const where = [];
+        const params = [];
+        // period in days; '0' (or absent) means all-time.
+        if (period && period !== '0') {
+          const days = Math.min(Math.max(parseInt(period, 10) || 30, 1), 365);
+          where.push(`event_date >= CURDATE() - INTERVAL ? DAY`);
+          params.push(days);
+        }
+        const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+        await ensureTable();
+        const rows = await mysql.query(
+          `SELECT store_slug,
+                  SUM(CASE WHEN event_type = 'visit' THEN event_count ELSE 0 END) AS visits,
+                  SUM(CASE WHEN event_type = 'affiliate_click' THEN event_count ELSE 0 END) AS clicks
+           FROM store_page_events
+           ${whereSql}
+           GROUP BY store_slug
+           ORDER BY visits DESC`,
+          params
+        );
+        await mysql.end();
+
+        const stores = rows.map((r) => ({
+          slug: r.store_slug,
+          visits: Number(r.visits) || 0,
+          clicks: Number(r.clicks) || 0,
+        }));
+
+        response = {
+          statusCode: 200,
+          headers: { ...responseHeaders, "Cache-Control": "no-store" },
+          body: JSON.stringify({ stores }),
+        };
+      } catch (error) {
+        console.error("Error fetching store event stats:", error);
+        response = {
+          statusCode: 500,
+          headers: { ...responseHeaders, "Cache-Control": "no-store" },
+          body: JSON.stringify({ error: "Failed to fetch store event stats" }),
+        };
+      }
+      break;
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: `StoreEvent only accepts GET and POST methods, you tried: ${event.httpMethod}`,
+      };
+      break;
+  }
+
+  console.info(`response from: ${event.path} statusCode: ${response.statusCode}`);
+  return response;
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -750,6 +750,57 @@ Resources:
             RestApiId:
               Ref: CreditCardOddsAPI
 
+  StoreEventFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/store-event.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
+    Properties:
+      Handler: src/handlers/store-event.StoreEventHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 100
+      Description: Track /best-card-for store page visits + affiliate clicks, return admin stats
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        TrackStoreEvent:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /store-event
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        GetStoreEvents:
+          # Admin-only; goes through the default Firebase authorizer so the
+          # handler's isAdmin() check can read the caller's claims.
+          Type: Api
+          Properties:
+            Path: /store-event
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        StoreEventOptions:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /store-event
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+
   CardCompareEventFunction:
     Type: AWS::Serverless::Function
     Metadata:

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -16,6 +16,8 @@ import {
   getAdminGraphs,
   getCardApplyClicksBreakdown,
   getApplyOutcomesBreakdown,
+  getStorePageEventStats,
+  StorePageEventStat,
   deleteAdminRecord,
   deleteAdminReferral,
   updateReferralApproval,
@@ -52,7 +54,8 @@ import {
   UserIcon,
   CreditCardIcon,
   CursorArrowRaysIcon,
-  ClipboardDocumentCheckIcon
+  ClipboardDocumentCheckIcon,
+  BuildingStorefrontIcon
 } from "@heroicons/react/24/outline";
 
 // Master admin user ID (Firebase UID)
@@ -355,6 +358,7 @@ export default function AdminPage() {
               />
               <ApplyClicksTab />
               <ApplyOutcomesTab />
+              <StoreTrafficTab getToken={getToken} />
             </>
           )}
           {activeTab === 'records' && (
@@ -995,6 +999,169 @@ function ApplyOutcomesTab() {
                 <span style={{ color: 'var(--muted-2)' }}>{row.just_looking.toLocaleString()}</span>
                 <span style={{ fontWeight: 600 }}>{row.total.toLocaleString()}</span>
                 <span className="av-mono" style={{ color: 'var(--ink-2)' }}>{row.decided > 0 ? pct(row.rate) : '—'}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ============ STORE TRAFFIC TAB ============
+// Visits + affiliate-CTA clicks on the /best-card-for/{slug} store pages.
+// Visits are tracked on every store page; affiliate clicks only exist for
+// stores that have an affiliate CTA, so per-store CTR = clicks / visits.
+const STORE_TRAFFIC_RANGES = APPLY_CLICK_RANGES;
+
+type StoreTrafficSortKey = 'visits' | 'clicks' | 'ctr';
+
+interface StoreTrafficRow extends StorePageEventStat {
+  ctr: number; // clicks / visits; 0 when no visits
+}
+
+function StoreTrafficTab({ getToken }: { getToken: () => Promise<string | null> }) {
+  const [periodDays, setPeriodDays] = useState(30);
+  const [stats, setStats] = useState<StorePageEventStat[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<StoreTrafficSortKey>('visits');
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    setLoadError(null);
+    getToken()
+      .then((token) => {
+        if (!token) throw new Error('no token');
+        return getStorePageEventStats(token, periodDays);
+      })
+      .then((data) => {
+        if (!isMounted) return;
+        setStats(data);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setLoadError('Failed to load store traffic data');
+        setStats([]);
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [periodDays, getToken]);
+
+  const rows: StoreTrafficRow[] = stats.map((s) => ({
+    ...s,
+    ctr: s.visits > 0 ? s.clicks / s.visits : 0,
+  }));
+
+  rows.sort((a, b) => b[sortKey] - a[sortKey] || b.visits - a.visits);
+
+  const totals = rows.reduce(
+    (acc, row) => {
+      acc.visits += row.visits;
+      acc.clicks += row.clicks;
+      return acc;
+    },
+    { visits: 0, clicks: 0 }
+  );
+  const overallCtr = totals.visits > 0 ? totals.clicks / totals.visits : 0;
+
+  const rangeLabel =
+    STORE_TRAFFIC_RANGES.find((r) => r.days === periodDays)?.label ?? `${periodDays}d`;
+
+  return (
+    <section className="av-section">
+      <div className="av-section-head">
+        <div>
+          <h2 className="av-section-h">
+            <BuildingStorefrontIcon className="av-section-h-icon" />
+            Store page traffic
+          </h2>
+          <p className="av-section-sub">visits + affiliate-link clicks on /best-card-for store pages.</p>
+        </div>
+        <div className="av-range">
+          {STORE_TRAFFIC_RANGES.map((range) => (
+            <button
+              key={range.days}
+              type="button"
+              onClick={() => setPeriodDays(range.days)}
+              className={'av-range-btn' + (periodDays === range.days ? ' active' : '')}
+            >
+              {range.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="av-readoff av-readoff-4">
+        <div className="av-readoff-cell">
+          <div className="av-readoff-k">Total visits</div>
+          <div className="av-readoff-v">{totals.visits.toLocaleString()}</div>
+          <div className="av-readoff-foot">last {rangeLabel}</div>
+        </div>
+        <div className="av-readoff-cell">
+          <div className="av-readoff-k">Affiliate clicks</div>
+          <div className="av-readoff-v av-accent">{totals.clicks.toLocaleString()}</div>
+          <div className="av-readoff-foot">outbound CTA</div>
+        </div>
+        <div className="av-readoff-cell">
+          <div className="av-readoff-k">Click-through rate</div>
+          <div className="av-readoff-v">{pct(overallCtr)}</div>
+          <div className="av-readoff-foot">clicks / visits</div>
+        </div>
+        <div className="av-readoff-cell">
+          <div className="av-readoff-k">Stores tracked</div>
+          <div className="av-readoff-v">{rows.length.toLocaleString()}</div>
+          <div className="av-readoff-foot">with activity</div>
+        </div>
+      </div>
+
+      {loadError && (
+        <div className="av-banner av-banner-err" style={{ marginTop: 14 }}>
+          {loadError}
+        </div>
+      )}
+
+      <div className="av-section-head" style={{ marginTop: 24 }}>
+        <h3 className="av-section-h" style={{ fontSize: 14 }}>Stores by traffic ({rangeLabel})</h3>
+        <span className="av-section-meta">{rows.length} stores</span>
+      </div>
+
+      {loading ? (
+        <div className="av-tape av-tape-empty">Loading…</div>
+      ) : rows.length === 0 ? (
+        <div className="av-tape av-tape-empty">No store page activity recorded in this window.</div>
+      ) : (
+        <div className="av-tape">
+          <div className="av-tape-scroll">
+            <div className="av-tape-head" style={{ gridTemplateColumns: '32px minmax(200px, 1.6fr) 90px 90px 80px' }}>
+              <span>#</span>
+              <span>Store</span>
+              <button type="button" onClick={() => setSortKey('visits')} className={sortKey === 'visits' ? 'active' : ''}>Visits {sortKey === 'visits' && '↓'}</button>
+              <button type="button" onClick={() => setSortKey('clicks')} className={sortKey === 'clicks' ? 'active' : ''}>Clicks {sortKey === 'clicks' && '↓'}</button>
+              <button type="button" onClick={() => setSortKey('ctr')} className={sortKey === 'ctr' ? 'active' : ''}>CTR {sortKey === 'ctr' && '↓'}</button>
+            </div>
+            {rows.map((row, index) => (
+              <div key={row.slug} className="av-tape-row" style={{ gridTemplateColumns: '32px minmax(200px, 1.6fr) 90px 90px 80px' }}>
+                <span className="av-list-num">{index + 1}</span>
+                <div className="av-card-meta">
+                  <a
+                    href={`/best-card-for/${row.slug}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="av-card-name"
+                    style={{ textDecoration: 'none' }}
+                  >
+                    {row.slug}
+                  </a>
+                </div>
+                <span style={{ fontWeight: 600 }}>{row.visits.toLocaleString()}</span>
+                <span className="av-accent">{row.clicks.toLocaleString()}</span>
+                <span className="av-mono" style={{ color: 'var(--ink-2)' }}>{pct(row.ctr)}</span>
               </div>
             ))}
           </div>

--- a/apps/web-next/src/app/best-card-for/[slug]/StoreAffiliateCta.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/StoreAffiliateCta.tsx
@@ -3,6 +3,7 @@
 import posthog from 'posthog-js';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
 import type { StoreAffiliate } from '@/lib/stores';
+import { trackStoreEvent } from '@/lib/api';
 
 interface Props {
   storeName: string;
@@ -52,15 +53,18 @@ export default function StoreAffiliateCta({
         target="_blank"
         rel="sponsored nofollow noopener noreferrer"
         className="store-affiliate-btn"
-        onClick={() =>
+        onClick={() => {
+          // First-party beacon for the admin traffic dashboard...
+          trackStoreEvent('affiliate_click', storeSlug).catch(() => {});
+          // ...plus the existing PostHog event.
           posthog.capture('affiliate_link_clicked', {
             store_slug: storeSlug,
             store_name: storeName,
             network: affiliate.network,
             top_pick: topPickName,
             offer: affiliate.offer ?? null,
-          })
-        }
+          });
+        }}
       >
         {head && `${head} `}
         <span className="store-affiliate-btn-tail">

--- a/apps/web-next/src/app/best-card-for/[slug]/StoreVisitTracker.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/StoreVisitTracker.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { trackStoreEvent } from '@/lib/api';
+
+// Fires a single fire-and-forget 'visit' event on mount for a /best-card-for
+// store page. Renders nothing. Mirrors ViewTracker (article/news views).
+export default function StoreVisitTracker({ storeSlug }: { storeSlug: string }) {
+  const tracked = useRef(false);
+
+  useEffect(() => {
+    if (!storeSlug || tracked.current) return;
+    tracked.current = true;
+    trackStoreEvent('visit', storeSlug).catch(() => {});
+  }, [storeSlug]);
+
+  return null;
+}

--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { V2Footer } from "@/components/landing-v2/Chrome";
 import { PencilSquareIcon, ExclamationTriangleIcon, CalendarDaysIcon } from "@heroicons/react/24/outline";
 import StorePersonalRow from "./StorePersonalRow";
 import StoreAffiliateCta from "./StoreAffiliateCta";
+import StoreVisitTracker from "./StoreVisitTracker";
 import "../../landing.css";
 
 interface PageProps {
@@ -127,6 +128,9 @@ export default async function BestCardForStorePage({ params }: PageProps) {
       {store.faq && store.faq.length > 0 && (
         <FAQSchema questions={store.faq.map(f => ({ question: f.q, answer: f.a }))} />
       )}
+
+      {/* Fire a one-shot 'visit' beacon for the admin traffic dashboard. */}
+      <StoreVisitTracker storeSlug={store.slug} />
 
       {/* Terminal strip — dark bar with breadcrumb + pick count, matching
           /card and /profile so the editorial chrome is consistent. */}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -838,6 +838,47 @@ export async function getContentViewCounts(periodDays = 7): Promise<EditorialVie
   return { article: views.article || {}, news: views.news || {} };
 }
 
+// Track an engagement event on a /best-card-for/{slug} store page — a page
+// 'visit' or an 'affiliate_click' on the store's affiliate CTA. No auth,
+// fire-and-forget (keepalive so the click event survives navigation).
+export async function trackStoreEvent(
+  eventType: 'visit' | 'affiliate_click',
+  storeSlug: string,
+): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/store-event`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: true,
+      body: JSON.stringify({ event_type: eventType, store_slug: storeSlug }),
+    });
+  } catch {
+    // fire and forget - don't throw on error
+  }
+}
+
+export interface StorePageEventStat {
+  slug: string;
+  visits: number;
+  clicks: number;
+}
+
+// Admin-only: per-store visit + affiliate-click counts for the
+// /best-card-for store pages over the trailing `period` days (0 = all-time).
+// Requires an admin Firebase token. Returns [] on error.
+export async function getStorePageEventStats(
+  token: string,
+  period = 30,
+): Promise<StorePageEventStat[]> {
+  const res = await fetch(`${API_BASE}/store-event?period=${period}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return Array.isArray(data.stores) ? data.stores : [];
+}
+
 // Track a multi-card comparison so we can rank "frequently compared" partners
 // per card. Slugs are deduplicated and unordered server-side; fire-and-forget.
 export async function trackCardCompareEvent(slugs: string[]): Promise<void> {


### PR DESCRIPTION
## Summary

Adds first-party tracking for the `/best-card-for/{slug}` store pages and a dashboard section on `/admin` to view it.

- **New `store_page_events` table** (migration `048`) aggregates daily `visit` and `affiliate_click` counts keyed by store slug. The Lambda also self-heals the table (`CREATE TABLE IF NOT EXISTS` on first write), so no `RunMigrationHandler` wire/deploy/invoke dance is needed.
- **New `StoreEventFunction` Lambda** (`store-event.js`): public `POST /store-event` beacon + admin-gated `GET /store-event` stats (same `isAdmin` gate as `admin.js`).
- **`StoreVisitTracker`** fires a one-shot `visit` beacon on page mount (mirrors the article/news `ViewTracker`).
- **`StoreAffiliateCta`** `onClick` now fires an `affiliate_click` beacon alongside the existing PostHog event.
- **Admin Overview** gains a **"Store page traffic"** section: total visits, affiliate clicks, click-through rate, stores tracked, plus a sortable per-store table (visits / clicks / CTR) with 7d/30d/90d/1y/All ranges.

## Deploy notes

- Backend auto-deploys via `deploy-api.yml` on merge (touches `apps/api/**`). The self-healing table means the endpoint works as soon as the Lambda is live.
- Frontend deploys via the Amplify webhook on merge.

## Verification

- `tsc --noEmit` clean.
- Store page loads 200 and renders; the `visit` beacon fires on mount (verified in dev — it 403s only until the endpoint is deployed, and the `catch` swallows it so the page is unaffected).
- Admin section type-checks and compiles (behind the admin login gate).