### PR TITLE
news: Chase Freedom Flex cell phone protection ending 09/20/26

### DIFF
--- a/data/news/2026-07-09-chase-freedom-flex-cell-phone-protection-ending.yaml
+++ b/data/news/2026-07-09-chase-freedom-flex-cell-phone-protection-ending.yaml
@@ -1,0 +1,36 @@
+id: "chase-freedom-flex-cell-phone-protection-ending"
+date: "2026-07-09"
+title: "Chase Freedom Flex Loses Cell Phone Protection"
+summary: "Chase's updated Guide to Benefits shows cell phone protection on the Freedom Flex will be discontinued on September 20, 2026. Eligible losses are covered through September 19, 2026, after which the no-annual-fee card no longer includes the perk."
+tags:
+  - "benefit-change"
+  - "discontinued"
+bank: "Chase"
+card_slug: "chase-freedom-flex"
+card_name: "Chase Freedom Flex"
+source: "Chase Guide to Benefits"
+source_url: "https://www.chasebenefits.com/K113-022/pdf/BGC11539.pdf"
+body: |
+  Chase is dropping cell phone protection from the **Chase Freedom Flex**. The card's updated [Guide to Benefits](https://www.chasebenefits.com/K113-022/pdf/BGC11539.pdf) now carries a notice on the coverage:
+
+  > Cell Phone Protection (This benefit will cover eligible losses incurred through 09/19/26 and will be discontinued 09/20/26)
+
+  In plain terms, the benefit still applies to eligible damage or theft that happens **on or before September 19, 2026**. Starting **September 20, 2026**, the Freedom Flex no longer includes cell phone protection at all.
+
+  ## What is going away
+
+  Cell phone protection reimbursed cardholders for damage to or theft of a phone, as long as the full monthly cellular bill was charged to the card. The Freedom Flex version of the benefit covered:
+
+  - The lesser of the repair cost or the replacement cost at current market value, **less a $50 deductible**
+  - Up to **$800 per claim** after the deductible
+  - A maximum of **two paid claims per 12 months**
+
+  To be eligible, you had to pay your entire monthly cellular service provider bill with the card for the billing cycle before the month an incident occurred.
+
+  ## Why it matters
+
+  For a no-annual-fee card, built-in cell phone protection was a genuinely useful perk, especially for cardholders who routed their phone bill through the Freedom Flex specifically to keep it active. Losing it narrows the gap between the Freedom Flex and other no-fee cash back cards.
+
+  If you rely on this coverage, it is worth checking whether another card in your wallet still offers cell phone protection. Several premium and mid-tier cards, along with some other no-fee options, continue to include the benefit, though terms and claim limits vary. Anyone with an open claim or an incident before the cutoff should file according to the existing Guide to Benefits, since coverage remains in force for losses through September 19, 2026.
+
+  We will update this story if Chase extends the benefit or clarifies the change.


### PR DESCRIPTION
Adds a news article covering Chase's Guide to Benefits update: cell phone protection on the **Chase Freedom Flex** is being discontinued **September 20, 2026**, with eligible losses covered through **September 19, 2026**.

- New file: `data/news/2026-07-09-chase-freedom-flex-cell-phone-protection-ending.yaml`
- Tags: `benefit-change`, `discontinued`
- Linked card: chase-freedom-flex
- Source: Chase Guide to Benefits PDF (BGC11539)

`npm run build:news` passes; item present in news.json (count 82 → 83), card image auto-resolves via card_slug on build.