### PR TITLE
perf: gzip API responses + dedupe admin card-catalog fetches

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -121,6 +121,10 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: Prod
+      # Gzip responses over 1 KB (API Gateway sends identity by default even
+      # when the client offers Accept-Encoding). /cards alone is ~368 KB raw
+      # vs ~70 KB gzipped.
+      MinimumCompressionSize: 1024
       Auth:
         DefaultAuthorizer: FirebaseAuthorizer
         Authorizers:

--- a/apps/web-next/src/hooks/useCardCatalog.ts
+++ b/apps/web-next/src/hooks/useCardCatalog.ts
@@ -3,6 +3,23 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Card, getAllCards } from '@/lib/api';
 
+// Share one in-flight/settled catalog fetch across all hook consumers.
+// Several components mount the hook at once (e.g. the admin stats tab), and
+// concurrent fetches don't dedupe through the browser cache, so without this
+// each mount pulls the full ~370 KB catalog again. Cleared on failure so a
+// remount can retry.
+let catalogPromise: Promise<Card[]> | null = null;
+
+function fetchCatalog(): Promise<Card[]> {
+  if (!catalogPromise) {
+    catalogPromise = getAllCards().catch((err) => {
+      catalogPromise = null;
+      throw err;
+    });
+  }
+  return catalogPromise;
+}
+
 interface UseCardCatalogOptions {
   activeOnly?: boolean;
 }
@@ -28,7 +45,7 @@ export function useCardCatalog(options: UseCardCatalogOptions = {}) {
   useEffect(() => {
     let isMounted = true;
 
-    getAllCards()
+    fetchCatalog()
       .then((data) => {
         if (!isMounted) return;
 


### PR DESCRIPTION
## Summary

Fixes Sentry **CREDITODDS-JAVASCRIPT-NEXTJS-Q** (large HTTP payload: `GET /cards` shipping 376,444 B / 1.15s on `/_admin`).

Two changes:

### 1. Enable gzip on the API Gateway REST API (`apps/api/template.yml`)
`GET https://api.creditodds.com/cards` currently returns `content-length: 376444` with no `content-encoding`, even when the client sends `Accept-Encoding: gzip, br` — API Gateway never compresses unless `MinimumCompressionSize` is set. Setting it to 1024 gzips every response over 1 KB.

Measured against production: 376 KB raw → **70 KB** gzipped (81% smaller). This benefits every consumer of the API, not just the admin page.

### 2. Share one catalog fetch across `useCardCatalog` consumers (`apps/web-next`)
The admin stats tab mounts `ApplyClicksTab` and `ApplyOutcomesTab` together, each calling `useCardCatalog()` → two identical full-catalog fetches racing in parallel (in-flight requests don't dedupe through the browser cache). The card-data and submit-record panels fetch again when opened. A module-level promise in the hook now shares a single fetch across all consumers, cleared on failure so remounts can retry.

## Verification
- `sam validate --lint` passes
- `tsc --noEmit` passes
- Dev server: `/admin` compiles and redirects unauthenticated visitors to `/login` with no console errors (full dedup check needs an authenticated admin session)

## Deploy notes
Backend change deploys automatically via `deploy-api.yml` on merge (touches `apps/api/**`); frontend via the Amplify webhook.