### PR TITLE
news: Amex Platinum Digital Entertainment Credit drops Peacock bundles/add-ons 8/1/26

### DIFF
--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -59,8 +59,9 @@ benefits:
     category: "rideshare"
     enrollment_required: true
   - name: "Digital Entertainment Credit"
-    value: 240
-    description: "$20/month toward select streaming subscriptions: Disney Bundle, Peacock, NYT, Audible, SiriusXM"
+    value: 300
+    value_per_cycle: 25
+    description: "$25/month toward eligible subscriptions with Disney+, ESPN, Hulu, Paramount+, Peacock, NYT, WSJ, and YouTube (from 8/1/26 Peacock bundles and add-ons are ineligible)"
     frequency: "monthly"
     category: "streaming"
     enrollment_required: true

--- a/data/news/2026-07-09-amex-platinum-peacock-add-ons-ineligible.yaml
+++ b/data/news/2026-07-09-amex-platinum-peacock-add-ons-ineligible.yaml
@@ -1,0 +1,35 @@
+id: "amex-platinum-peacock-add-ons-ineligible"
+date: "2026-07-09"
+title: "Amex Platinum Digital Entertainment Credit Drops Peacock Bundles and Add-Ons"
+summary: "Effective August 1, 2026, Peacock bundled subscriptions and add-on services will no longer count toward the Platinum Card's $300 Digital Entertainment Credit. Only standalone Peacock plans purchased directly from Peacock remain eligible."
+tags:
+  - "benefit-change"
+bank: "American Express"
+card_slug: "the-platinum-card"
+card_name: "The Platinum Card"
+source: "American Express Benefit Terms"
+source_url: "https://www.americanexpress.com/us/credit-cards/card/platinum/"
+body: |
+  American Express is tightening what counts toward the **Digital Entertainment Credit** on **The Platinum Card**. Per updated benefit terms, effective **August 1, 2026**, Peacock purchases are only eligible if they are standalone subscriptions bought directly from Peacock:
+
+  > Effective August 1, 2026, Peacock bundled services subscriptions, add-on services subscriptions or subscriptions purchased through a third-party will be ineligible for the Digital Entertainment Credit benefit.
+
+  ## What changes
+
+  Some cardholders had been attaching add-ons such as Apple TV to their Peacock subscription and getting the whole charge reimbursed by the credit. Starting August 1, 2026, the following Peacock purchases no longer qualify:
+
+  - **Add-on subscriptions** sold by Peacock (for example, premium channel add-ons like Apple TV)
+  - **Bundled subscriptions**, whether bundled with cable services or other third-party services
+  - **Subscriptions purchased through a third party**, along with promotional offers through third parties and gift cards
+
+  ## What still works
+
+  Standalone Peacock plans purchased directly at peacocktv.com remain eligible. The updated terms call out **Peacock Premium**, **Peacock Premium Plus**, and **Peacock Select** by name.
+
+  The benefit itself is unchanged: enrolled cardholders earn up to **$25 in statement credits each month**, up to **$300 per calendar year**, on eligible purchases made directly with the participating partners. The current partner list is Disney+, ESPN streaming, Hulu, The New York Times, Paramount+, Peacock, The Wall Street Journal, and YouTube.
+
+  ## Why it matters
+
+  The Peacock carve-out is stricter than the treatment of most other partners. Disney+, Hulu, and ESPN terms still list add-ons as eligible when purchased directly, while Peacock becomes standalone-only. If you route a Peacock bundle or add-on through your Platinum Card for the credit, you have through **July 31, 2026** under the current rules; after that, only the base subscription charge will qualify.
+
+  Enrollment through American Express is still required to receive the benefit, and credits can take up to 8 weeks to post.


### PR DESCRIPTION
## News

Adds a news item for the Amex Platinum **Digital Entertainment Credit** change: effective **August 1, 2026**, Peacock bundled subscriptions, add-on services (e.g. Apple TV attached to Peacock), and third-party purchases are ineligible for the credit. Standalone Peacock plans (Premium, Premium Plus, Select) purchased directly from Peacock remain eligible. Source: updated Amex benefit terms.

## Card data

Also refreshes the stale Digital Entertainment Credit benefit on `the-platinum-card.yaml`:
- value $240 -> $300 ($25/month, per current terms), adds `value_per_cycle: 25`
- partner list updated to Disney+, ESPN, Hulu, Paramount+, Peacock, NYT, WSJ, YouTube (was Disney Bundle, Peacock, NYT, Audible, SiriusXM)
- notes the 8/1/26 Peacock standalone-only restriction

Validated with `npm run build:cards` and `npm run build:news`.