### PR TITLE
Update store affiliate CTA placement

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/StoreAffiliateCta.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/StoreAffiliateCta.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useId } from 'react';
 import posthog from 'posthog-js';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
 import type { StoreAffiliate } from '@/lib/stores';
@@ -34,18 +35,14 @@ export default function StoreAffiliateCta({
   const words = label.trim().split(/\s+/);
   const tail = words.pop() ?? '';
   const head = words.join(' ');
+  const titleId = useId();
 
   return (
-    <aside className="store-affiliate" aria-labelledby="store-affiliate-title">
+    <aside className="store-affiliate" aria-labelledby={titleId}>
       <div className="store-affiliate-body">
-        <h2 id="store-affiliate-title" className="store-affiliate-title">
+        <h2 id={titleId} className="store-affiliate-title">
           Shopping at {storeName}?
         </h2>
-        <p className="store-affiliate-disclosure">
-          {affiliate.offer && `Offer shown as listed by ${storeName}, and subject to change. `}
-          CreditOdds may earn a commission on purchases made through this link. It never
-          affects how we rank cards.
-        </p>
       </div>
 
       <a

--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -277,6 +277,14 @@ export default async function BestCardForStorePage({ params }: PageProps) {
               </li>
             ))}
           </ol>
+          {store.affiliate && (
+            <StoreAffiliateCta
+              storeName={store.name}
+              storeSlug={store.slug}
+              affiliate={store.affiliate}
+              topPickName={picks[0]?.card.card_name}
+            />
+          )}
           </>
         )}
 

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -8474,6 +8474,9 @@
   display: grid;
   gap: 12px;
 }
+.landing-v2.store-v2 .store-picks + .store-affiliate {
+  margin-top: 24px;
+}
 .landing-v2.store-v2 .store-pick {
   display: flex;
   align-items: flex-start;
@@ -8717,11 +8720,8 @@
 .landing-v2.store-v2 .store-affiliate:first-child {
   margin-top: -12px;
 }
-/* Title and disclosure share the left column so they stack tight against each
-   other. Keeping the disclosure as a sibling of the button instead would leave
-   a dead band under the title: the button is the tallest item in the row, and
-   align-items: center splits its extra height above and below the copy.
-   flex-basis 360px is the wrap trigger — below that the button drops beneath. */
+/* Title column. flex-basis 360px is the wrap trigger — below that the button
+   drops beneath. */
 .landing-v2.store-v2 .store-affiliate-body {
   flex: 1 1 360px;
   min-width: 0;
@@ -8805,12 +8805,6 @@
   height: 15px;
   margin-left: 8px;
   vertical-align: -2px;
-}
-.landing-v2.store-v2 .store-affiliate-disclosure {
-  margin: 5px 0 0;
-  font-size: 12px;
-  line-height: 1.45;
-  color: var(--muted);
 }
 
 /* The hero intro paragraph is shared as .page-sub (max-width: 620px) across


### PR DESCRIPTION
## Summary
- remove the affiliate disclosure sentence from store CTA modules
- render the affiliate CTA again after the ranked credit card list
- use unique CTA heading ids so duplicate CTA modules remain accessible

## Verification
- npx eslint 'src/app/best-card-for/[slug]/StoreAffiliateCta.tsx' --max-warnings=0
- curl -I -s http://localhost:3000/best-card-for/aliexpress
- confirmed rendered AliExpress page contains two store affiliate sections and no removed disclosure copy

Note: full npm run lint still fails on existing unrelated repo-wide lint issues.