### PR TITLE
feat(affiliates): add 18 FlexOffers links from 2026-07-10 approvals

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-09T12:39:22.389Z",
+  "generated_at": "2026-07-10T12:31:51.323Z",
   "count": 844,
   "stores": [
     {
@@ -211,7 +211,11 @@
           "note": "Via Apple Pay"
         }
       ],
-      "intro": "Ace Hardware is a cooperative of about 5,000 independently-owned hardware stores in the\nU.S., smaller and more service-oriented than Home Depot or Lowe's. Ace's own Ace Rewards\nloyalty program layers on top of card cashback. Notably, Ace Hardware is one of the\nmerchants that earns 3% on the Apple Card via Apple Pay, alongside the home-improvement\ncategory match on general-purpose cards.\n"
+      "intro": "Ace Hardware is a cooperative of about 5,000 independently-owned hardware stores in the\nU.S., smaller and more service-oriented than Home Depot or Lowe's. Ace's own Ace Rewards\nloyalty program layers on top of card cashback. Notably, Ace Hardware is one of the\nmerchants that earns 3% on the Apple Card via Apple Pay, alongside the home-improvement\ncategory match on general-purpose cards.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9988&trid=1552713.161558&foc=17&fot=9999&fos=6&url=https%3A%2F%2Facehardware.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Acer",
@@ -1389,7 +1393,11 @@
         "online_shopping"
       ],
       "website": "https://www.bestbuy.com",
-      "intro": "Best Buy is the largest U.S. specialty electronics retailer, with about 950 stores and a\nstrong bestbuy.com presence. In-store and online purchases generally code as electronics\nor online shopping rather than as a department store, so the answer here usually comes\ndown to a flat online-retail card or a flat-rate card. The My Best Buy Visa offers\nin-house financing and 5-6% back at Best Buy specifically, but the math only works for\nshoppers spending several thousand dollars a year on electronics.\n"
+      "intro": "Best Buy is the largest U.S. specialty electronics retailer, with about 950 stores and a\nstrong bestbuy.com presence. In-store and online purchases generally code as electronics\nor online shopping rather than as a department store, so the answer here usually comes\ndown to a flat online-retail card or a flat-rate card. The My Best Buy Visa offers\nin-house financing and 5-6% back at Best Buy specifically, but the math only works for\nshoppers spending several thousand dollars a year on electronics.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10014&trid=1552713.712&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.bestbuy.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Best Western",
@@ -2703,7 +2711,11 @@
           "note": "If selected as one of your 2 quarterly retailers (up to $1,500/quarter, then 1.5%)"
         }
       ],
-      "intro": "Costco Wholesale runs about 600 warehouses worldwide and a sizable online catalog at\ncostco.com. The pricing model revolves around member-only bulk buying, so card choice\nmatters most for people running weekly grocery and gas trips through the warehouse. Two\nquirks worth knowing: Costco accepts only Visa cards in-warehouse (no Mastercard, Amex,\nor Discover), and Costco gas pumps code as wholesale clubs — not gas — so a 5% gas card\nwill not trigger at the pump here.\n"
+      "intro": "Costco Wholesale runs about 600 warehouses worldwide and a sizable online catalog at\ncostco.com. The pricing model revolves around member-only bulk buying, so card choice\nmatters most for people running weekly grocery and gas trips through the warehouse. Two\nquirks worth knowing: Costco accepts only Visa cards in-warehouse (no Mastercard, Amex,\nor Discover), and Costco gas pumps code as wholesale clubs — not gas — so a 5% gas card\nwill not trigger at the pump here.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110106609&trid=1552713.248906&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.costco.com%2Fjoin-costco.html%2F",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Cox Communications",
@@ -3249,7 +3261,11 @@
         "car_rentals"
       ],
       "website": "https://www.dollar.com",
-      "intro": "Dollar Rent A Car is a budget brand within the Hertz family aimed at cost-conscious renters. Its charges code as car rental, part of the travel umbrella, and earn best on cards with a travel or rental-car category bonus. A travel card that also includes rental collision coverage can let you skip the expensive counter insurance, so review your card's benefits first.\n"
+      "intro": "Dollar Rent A Car is a budget brand within the Hertz family aimed at cost-conscious renters. Its charges code as car rental, part of the travel umbrella, and earn best on cards with a travel or rental-car category bonus. A travel card that also includes rental collision coverage can let you skip the expensive counter insurance, so review your card's benefits first.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.35267&trid=1552713.158829&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.dollar.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Dollar Shave Club",
@@ -3862,7 +3878,11 @@
         "online_shopping"
       ],
       "website": "https://www.famousfootwear.com",
-      "intro": "Famous Footwear is the family footwear chain of Caleres Inc, with about 850 U.S.\nstores and famousfootwear.com, selling athletic and casual shoes from Nike, Adidas,\nSkechers, and others. The free Famously You Rewards program offers tiered cashback\nand a birthday gift, layering on top of credit card rewards. Direct purchases\ntypically code as department store at the register and online shopping for web\norders, and there is no current branded credit card.\n"
+      "intro": "Famous Footwear is the family footwear chain of Caleres Inc, with about 850 U.S.\nstores and famousfootwear.com, selling athletic and casual shoes from Nike, Adidas,\nSkechers, and others. The free Famously You Rewards program offers tiered cashback\nand a birthday gift, layering on top of credit card rewards. Direct purchases\ntypically code as department store at the register and online shopping for web\norders, and there is no current branded credit card.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38507&trid=1552713.280&foc=17&fot=9999&fos=6&url=https%3A%2F%2Ffamousfootwear.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Fandango",
@@ -4086,7 +4106,11 @@
         "groceries"
       ],
       "website": "https://www.foodlion.com",
-      "intro": "Food Lion is a Southeastern U.S. grocery chain with about 1,100 stores, owned by\nAhold Delhaize. Codes cleanly as groceries on every card we track. Strongest\npairings are Blue Cash Preferred (6% on U.S. supermarkets), the Capital One SavorOne\n(3% groceries), and U.S. Bank Shopper Cash Rewards if Food Lion is one of the two\nselected retailers. The MVP loyalty program runs separate digital coupons that\nstack on top of any card's bonus rate.\n"
+      "intro": "Food Lion is a Southeastern U.S. grocery chain with about 1,100 stores, owned by\nAhold Delhaize. Codes cleanly as groceries on every card we track. Strongest\npairings are Blue Cash Preferred (6% on U.S. supermarkets), the Capital One SavorOne\n(3% groceries), and U.S. Bank Shopper Cash Rewards if Food Lion is one of the two\nselected retailers. The MVP loyalty program runs separate digital coupons that\nstack on top of any card's bonus rate.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10965&trid=1552713.226393&foc=17&fot=9999&fos=6&url=https%3A%2F%2Ffoodlion.com%2F",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Foot Locker",
@@ -4359,7 +4383,11 @@
         "groceries"
       ],
       "website": "https://giantfood.com",
-      "intro": "Giant Food is the Mid-Atlantic flagship of Ahold Delhaize's U.S. grocery group, with\nabout 165 stores across DC, Maryland, Virginia, and Delaware. Codes cleanly as\ngroceries on every card we track. Best pairings are Blue Cash Preferred (6%),\nCapital One SavorOne (3%), and U.S. Bank Shopper Cash Rewards (6% if selected).\nThe Giant Flexible Rewards program issues per-gallon fuel savings at participating\nShell and Giant stations that stack on top of card bonuses.\n"
+      "intro": "Giant Food is the Mid-Atlantic flagship of Ahold Delhaize's U.S. grocery group, with\nabout 165 stores across DC, Maryland, Virginia, and Delaware. Codes cleanly as\ngroceries on every card we track. Best pairings are Blue Cash Preferred (6%),\nCapital One SavorOne (3%), and U.S. Bank Shopper Cash Rewards (6% if selected).\nThe Giant Flexible Rewards program issues per-gallon fuel savings at participating\nShell and Giant stations that stack on top of card bonuses.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10968&trid=1552713.215429&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fgiantfood.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Gilt",
@@ -5860,7 +5888,11 @@
         "online_shopping"
       ],
       "website": "https://www.kohls.com",
-      "intro": "Kohl's is a mid-tier department store with about 1,150 stores and an aggressive Kohl's\nCash rewards program. Most regular shoppers stack manufacturer sales, Kohl's coupons,\nand Kohl's Cash, so card cashback is the smallest of several layers. The Kohl's Card\n(issued by Capital One) gives in-house discounts but no MasterCard/Visa-network rewards.\nFor most shoppers, a department-store-bonus general-purpose card is the right answer.\n"
+      "intro": "Kohl's is a mid-tier department store with about 1,150 stores and an aggressive Kohl's\nCash rewards program. Most regular shoppers stack manufacturer sales, Kohl's coupons,\nand Kohl's Cash, so card cashback is the smallest of several layers. The Kohl's Card\n(issued by Capital One) gives in-house discounts but no MasterCard/Visa-network rewards.\nFor most shoppers, a department-store-bonus general-purpose card is the right answer.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5349&trid=1552713.157993&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fkohls.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Kohler",
@@ -6100,7 +6132,11 @@
         "online_shopping"
       ],
       "website": "https://www.lenovo.com",
-      "intro": "Lenovo, maker of ThinkPad laptops and a wide PC lineup, sells configurable machines directly through its website with frequent promotions. Orders typically code as online shopping or electronics retail, so a card with an online or general retail bonus tends to earn the most, and a shopping portal can stack additional value.\n"
+      "intro": "Lenovo, maker of ThinkPad laptops and a wide PC lineup, sells configurable machines directly through its website with frequent promotions. Orders typically code as online shopping or electronics retail, so a card with an online or general retail bonus tends to earn the most, and a shopping portal can stack additional value.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.3808&trid=1552713.157497&foc=17&fot=9999&fos=6&url=https%3A%2F%2Flenovo.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "LensCrafters",
@@ -6456,7 +6492,11 @@
         "online_shopping"
       ],
       "website": "https://www.maccosmetics.com",
-      "intro": "MAC Cosmetics is a prestige color cosmetics brand owned by The Estée Lauder Companies,\nsold through about 100 U.S. freestanding stores, maccosmetics.com, and a wide\ndepartment store and Ulta wholesale footprint. Direct purchases at MAC stores or the\nwebsite typically code as department store or online shopping, while MAC bought at\nMacy's or Ulta codes under that retailer. The free MAC Lover loyalty program offers\ntiered points and stacks with credit card multipliers.\n"
+      "intro": "MAC Cosmetics is a prestige color cosmetics brand owned by The Estée Lauder Companies,\nsold through about 100 U.S. freestanding stores, maccosmetics.com, and a wide\ndepartment store and Ulta wholesale footprint. Direct purchases at MAC stores or the\nwebsite typically code as department store or online shopping, while MAC bought at\nMacy's or Ulta codes under that retailer. The free MAC Lover loyalty program offers\ntiered points and stacks with credit card multipliers.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41340&trid=1552713.201336&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fmaccosmetics.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Macy's",
@@ -6800,7 +6840,11 @@
         "department_stores"
       ],
       "website": "https://www.melissaanddoug.com",
-      "intro": "Melissa & Doug is known for wooden toys, puzzles, and craft kits sold online and through retail partners. Direct orders on its site generally code as online shopping, and there is no dedicated toy bonus category on most cards. A flat-rate card or one with an online-shopping multiplier is the practical choice for gifts and restocks.\n"
+      "intro": "Melissa & Doug is known for wooden toys, puzzles, and craft kits sold online and through retail partners. Direct orders on its site generally code as online shopping, and there is no dedicated toy bonus category on most cards. A flat-rate card or one with an online-shopping multiplier is the practical choice for gifts and restocks.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41493&trid=1552713.159291&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fmelissaanddoug.com%2F",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Menards",
@@ -7755,7 +7799,11 @@
         "online_shopping"
       ],
       "website": "https://www.pacsun.com",
-      "intro": "Pacsun is a California-rooted apparel chain catering to teens and young adults, with\nabout 325 mall-based stores and a strong online business at pacsun.com. Most cards\ncode in-store transactions as department store and web orders as online shopping. The\nPacsun Rewards program is free and points-based, layering on top of credit card\nearnings since the chain does not run a branded credit card in the U.S.\n"
+      "intro": "Pacsun is a California-rooted apparel chain catering to teens and young adults, with\nabout 325 mall-based stores and a strong online business at pacsun.com. Most cards\ncode in-store transactions as department store and web orders as online shopping. The\nPacsun Rewards program is free and points-based, layering on top of credit card\nearnings since the chain does not run a branded credit card in the U.S.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.28645&trid=1552713.159888&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fpacsun.com%2F",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Panda Express",
@@ -8011,7 +8059,11 @@
         "online_shopping"
       ],
       "website": "https://www.petco.com",
-      "intro": "Petco is one of the two large U.S. pet specialty retailers (alongside PetSmart),\nwith about 1,500 stores plus in-store grooming and veterinary services. In-store\ncharges code as pet store / specialty retail on most cards (some classify as\ngroceries for food-only baskets); petco.com codes as online shopping. The Vital\nCare Premier membership ($24.99/mo) credits back monthly spend at Petco. Pair\nwith a flat-rate cashback or online-shopping-bonus card for petco.com orders.\n"
+      "intro": "Petco is one of the two large U.S. pet specialty retailers (alongside PetSmart),\nwith about 1,500 stores plus in-store grooming and veterinary services. In-store\ncharges code as pet store / specialty retail on most cards (some classify as\ngroceries for food-only baskets); petco.com codes as online shopping. The Vital\nCare Premier membership ($24.99/mo) credits back monthly spend at Petco. Pair\nwith a flat-rate cashback or online-shopping-bonus card for petco.com orders.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10290&trid=1552713.189505&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fpetco.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Peter Thomas Roth",
@@ -8833,7 +8885,11 @@
         "online_shopping"
       ],
       "website": "https://www.rover.com",
-      "intro": "Rover is an online marketplace connecting pet owners with dog walkers, sitters, and boarding hosts. Payments run through its platform and generally code as online shopping or general services rather than a dedicated bonus category, so they earn on cards with an online or flat-rate bonus. A reliable everyday card is the practical pick for booking pet care here.\n"
+      "intro": "Rover is an online marketplace connecting pet owners with dog walkers, sitters, and boarding hosts. Payments run through its platform and generally code as online shopping or general services rather than a dedicated bonus category, so they earn on cards with an online or flat-rate bonus. A reliable everyday card is the practical pick for booking pet care here.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46193&trid=1552713.209001&foc=17&fot=9999&fos=6&url=https%3A%2F%2Frover.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Royal Caribbean",
@@ -9711,7 +9767,11 @@
         "department_stores"
       ],
       "website": "https://www.stevemadden.com",
-      "intro": "Steve Madden designs trend-driven footwear and accessories sold direct and through department stores. Buying on its site codes as online shopping or retail, so a portal or rotating bonus can boost earnings, while store purchases generally land on a flat-rate card with no shoe-specific category.\n"
+      "intro": "Steve Madden designs trend-driven footwear and accessories sold direct and through department stores. Buying on its site codes as online shopping or retail, so a portal or rotating bonus can boost earnings, while store purchases generally land on a flat-rate card with no shoe-specific category.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.37487&trid=1552713.163728&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fstevemadden.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Stila",
@@ -10053,7 +10113,11 @@
         "dining"
       ],
       "website": "https://www.coffeebean.com",
-      "intro": "The Coffee Bean and Tea Leaf is a long-running Los Angeles coffeehouse chain, one of the oldest in the country, famous for its Ice Blended drinks. Cafe spending codes as dining or restaurants on most rewards cards, making a dining bonus the best fit. Packaged coffee and tea ordered online instead tend to code as online shopping.\n"
+      "intro": "The Coffee Bean and Tea Leaf is a long-running Los Angeles coffeehouse chain, one of the oldest in the country, famous for its Ice Blended drinks. Cafe spending codes as dining or restaurants on most rewards cards, making a dining bonus the best fit. Packaged coffee and tea ordered online instead tend to code as online shopping.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8262&trid=1552713.186151&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fcoffeebean.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "The Container Store",
@@ -10063,7 +10127,11 @@
         "online_shopping"
       ],
       "website": "https://www.containerstore.com",
-      "intro": "The Container Store is the leading U.S. specialty retailer for organization and\nstorage, known for The Elfa custom closet system, kitchen organizers, and Russell\n+ Hazel desk goods. Purchases typically code as general retail, so flat-rate cards\nlike the Citi Double Cash earn the same 2 percent as on most shopping.\n\nBig custom closet installations can run into the thousands, which makes signup bonus\nminimum spend a useful angle. Cards with rotating online shopping quarters, such as\nChase Freedom Flex, occasionally lift containerstore.com orders to 5 percent, and the\nfree Organized Insider loyalty program adds tiered discounts on top of card rewards.\n"
+      "intro": "The Container Store is the leading U.S. specialty retailer for organization and\nstorage, known for The Elfa custom closet system, kitchen organizers, and Russell\n+ Hazel desk goods. Purchases typically code as general retail, so flat-rate cards\nlike the Citi Double Cash earn the same 2 percent as on most shopping.\n\nBig custom closet installations can run into the thousands, which makes signup bonus\nminimum spend a useful angle. Cards with rotating online shopping quarters, such as\nChase Freedom Flex, occasionally lift containerstore.com orders to 5 percent, and the\nfree Organized Insider loyalty program adds tiered discounts on top of card rewards.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.24840&trid=1552713.189823&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fcontainerstore.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "The Farmer's Dog",
@@ -10198,7 +10266,11 @@
         "car_rentals"
       ],
       "website": "https://www.thrifty.com",
-      "intro": "Thrifty is a value rental brand under Hertz, frequently found at airports alongside its sister labels. Rentals code as car rental within the travel category and earn on cards that bonus travel or car rentals specifically. Because many travel cards bundle rental loss-and-damage protection, it is worth confirming your coverage before paying for the counter waiver.\n"
+      "intro": "Thrifty is a value rental brand under Hertz, frequently found at airports alongside its sister labels. Rentals code as car rental within the travel category and earn on cards that bonus travel or car rentals specifically. Because many travel cards bundle rental loss-and-damage protection, it is worth confirming your coverage before paying for the counter waiver.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.3088&trid=1552713.158782&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fthrifty.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Thrive Causemetics",

--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -39,6 +39,14 @@ describe("isBenignClientError", () => {
     expect(isBenignClientError(wrapped)).toBe(true);
   });
 
+  it("drops Safari/WebExtension runtime.sendMessage tab-missing noise", () => {
+    expect(
+      isBenignClientError(
+        new Error("Invalid call to runtime.sendMessage(). Tab not found."),
+      ),
+    ).toBe(true);
+  });
+
   it("keeps a real AbortError that isn't IndexedDB-related", () => {
     // e.g. a genuine fetch abort we'd still want to see — bare name only is
     // benign, but a descriptive non-idb abort message is not matched.
@@ -51,6 +59,14 @@ describe("isBenignClientError", () => {
     expect(
       isBenignClientError(
         domException("Cannot read properties of undefined", "TypeError", 0),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps unrelated extension API failures", () => {
+    expect(
+      isBenignClientError(
+        new Error("Invalid call to runtime.sendMessage(). Permission denied."),
       ),
     ).toBe(false);
   });

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -9,12 +9,20 @@
 // unhandled rejection. The page itself loads fine — these are not actionable,
 // so we drop them in instrumentation-client.ts (mirrors the server-side
 // self-healing-network filter in transientNetworkError.ts).
+//
+// Mobile Safari can also surface WebExtension content-script messaging failures
+// as page-level unhandled rejections even though the page never calls the
+// extension API. These are user-extension/WebKit noise, not app failures.
 const BENIGN_CLIENT_SIGNATURES = [
   'The transaction was aborted',
   'database connection is closing',
   'idb-get',
   'idb-set',
   'IndexedDB',
+];
+
+const BENIGN_EXTENSION_SIGNATURES = [
+  'Invalid call to runtime.sendMessage(). Tab not found.',
 ];
 
 // DOMException.ABORT_ERR — the numeric code carried by AbortErrors.
@@ -33,6 +41,10 @@ export function isBenignClientError(error: unknown): boolean {
     const name = typeof e.name === 'string' ? e.name : '';
     const message = typeof e.message === 'string' ? e.message : '';
     const isAbort = name === 'AbortError' || e.code === ABORT_ERR_CODE;
+
+    if (BENIGN_EXTENSION_SIGNATURES.some((sig) => message.includes(sig))) {
+      return true;
+    }
 
     if (isAbort) {
       // Bare "AbortError: AbortError" (Firebase's rethrow loses the original

--- a/data/affiliates.yaml
+++ b/data/affiliates.yaml
@@ -1309,5 +1309,64 @@ merchants:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25202.3966290&trid=1552713.193401&foc=16&fot=9999&fos=6"
     offer: "buy one get one 50% off shorts"
 
-# Approved in FlexOffers but intentionally not listed above:
-#   Costco Membership: no text link in FlexOffers (banners/widgets only)
+  # --- Added 2026-07-10 from FlexOffers approved-advertiser list ---
+  # Deep links (foc=17) with the merchant homepage appended to `&url=`. No
+  # `offer` attached: the sheet lists commission rates, not evergreen consumer
+  # offers (per the offer rules above). Costco Membership now has a trackable
+  # deep link (previously banners/widgets only), so it is included here.
+  # Three more approvals (everyplate, factor, stop-and-shop) had a null
+  # FlexLink in the sheet and are pending a link from their Get Links page.
+  # Ace Hardware
+  ace-hardware:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.9988&trid=1552713.161558&foc=17&fot=9999&fos=6&url=https%3A%2F%2Facehardware.com"
+  # Best Buy
+  best-buy:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10014&trid=1552713.712&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.bestbuy.com"
+  # Costco Membership
+  costco:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110106609&trid=1552713.248906&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.costco.com%2Fjoin-costco.html%2F"
+  # Dollar Rent-a-Car
+  dollar-rent-a-car:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.35267&trid=1552713.158829&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.dollar.com"
+  # Famous Footwear
+  famous-footwear:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.38507&trid=1552713.280&foc=17&fot=9999&fos=6&url=https%3A%2F%2Ffamousfootwear.com"
+  # Food Lion
+  food-lion:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10965&trid=1552713.226393&foc=17&fot=9999&fos=6&url=https%3A%2F%2Ffoodlion.com%2F"
+  # Giant Food
+  giant-food:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10968&trid=1552713.215429&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fgiantfood.com"
+  # Kohl's
+  kohls:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.5349&trid=1552713.157993&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fkohls.com"
+  # Lenovo USA
+  lenovo:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.3808&trid=1552713.157497&foc=17&fot=9999&fos=6&url=https%3A%2F%2Flenovo.com"
+  # MAC Cosmetics
+  mac-cosmetics:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.41340&trid=1552713.201336&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fmaccosmetics.com"
+  # Melissa and Doug
+  melissa-and-doug:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.41493&trid=1552713.159291&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fmelissaanddoug.com%2F"
+  # PacSun
+  pacsun:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.28645&trid=1552713.159888&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fpacsun.com%2F"
+  # PETCO
+  petco:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10290&trid=1552713.189505&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fpetco.com"
+  # Rover
+  rover:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.46193&trid=1552713.209001&foc=17&fot=9999&fos=6&url=https%3A%2F%2Frover.com"
+  # Steve Madden
+  steve-madden:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.37487&trid=1552713.163728&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fstevemadden.com"
+  # The Coffee Bean & Tea Leaf
+  the-coffee-bean-and-tea-leaf:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8262&trid=1552713.186151&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fcoffeebean.com"
+  # The Container Store
+  the-container-store:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.24840&trid=1552713.189823&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fcontainerstore.com"
+  # Thrifty Rent-A-Car
+  thrifty:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.3088&trid=1552713.158782&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fthrifty.com"

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-09T12:39:22.389Z",
+  "generated_at": "2026-07-10T12:31:51.323Z",
   "count": 844,
   "stores": [
     {
@@ -211,7 +211,11 @@
           "note": "Via Apple Pay"
         }
       ],
-      "intro": "Ace Hardware is a cooperative of about 5,000 independently-owned hardware stores in the\nU.S., smaller and more service-oriented than Home Depot or Lowe's. Ace's own Ace Rewards\nloyalty program layers on top of card cashback. Notably, Ace Hardware is one of the\nmerchants that earns 3% on the Apple Card via Apple Pay, alongside the home-improvement\ncategory match on general-purpose cards.\n"
+      "intro": "Ace Hardware is a cooperative of about 5,000 independently-owned hardware stores in the\nU.S., smaller and more service-oriented than Home Depot or Lowe's. Ace's own Ace Rewards\nloyalty program layers on top of card cashback. Notably, Ace Hardware is one of the\nmerchants that earns 3% on the Apple Card via Apple Pay, alongside the home-improvement\ncategory match on general-purpose cards.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9988&trid=1552713.161558&foc=17&fot=9999&fos=6&url=https%3A%2F%2Facehardware.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Acer",
@@ -1389,7 +1393,11 @@
         "online_shopping"
       ],
       "website": "https://www.bestbuy.com",
-      "intro": "Best Buy is the largest U.S. specialty electronics retailer, with about 950 stores and a\nstrong bestbuy.com presence. In-store and online purchases generally code as electronics\nor online shopping rather than as a department store, so the answer here usually comes\ndown to a flat online-retail card or a flat-rate card. The My Best Buy Visa offers\nin-house financing and 5-6% back at Best Buy specifically, but the math only works for\nshoppers spending several thousand dollars a year on electronics.\n"
+      "intro": "Best Buy is the largest U.S. specialty electronics retailer, with about 950 stores and a\nstrong bestbuy.com presence. In-store and online purchases generally code as electronics\nor online shopping rather than as a department store, so the answer here usually comes\ndown to a flat online-retail card or a flat-rate card. The My Best Buy Visa offers\nin-house financing and 5-6% back at Best Buy specifically, but the math only works for\nshoppers spending several thousand dollars a year on electronics.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10014&trid=1552713.712&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.bestbuy.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Best Western",
@@ -2703,7 +2711,11 @@
           "note": "If selected as one of your 2 quarterly retailers (up to $1,500/quarter, then 1.5%)"
         }
       ],
-      "intro": "Costco Wholesale runs about 600 warehouses worldwide and a sizable online catalog at\ncostco.com. The pricing model revolves around member-only bulk buying, so card choice\nmatters most for people running weekly grocery and gas trips through the warehouse. Two\nquirks worth knowing: Costco accepts only Visa cards in-warehouse (no Mastercard, Amex,\nor Discover), and Costco gas pumps code as wholesale clubs — not gas — so a 5% gas card\nwill not trigger at the pump here.\n"
+      "intro": "Costco Wholesale runs about 600 warehouses worldwide and a sizable online catalog at\ncostco.com. The pricing model revolves around member-only bulk buying, so card choice\nmatters most for people running weekly grocery and gas trips through the warehouse. Two\nquirks worth knowing: Costco accepts only Visa cards in-warehouse (no Mastercard, Amex,\nor Discover), and Costco gas pumps code as wholesale clubs — not gas — so a 5% gas card\nwill not trigger at the pump here.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110106609&trid=1552713.248906&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.costco.com%2Fjoin-costco.html%2F",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Cox Communications",
@@ -3249,7 +3261,11 @@
         "car_rentals"
       ],
       "website": "https://www.dollar.com",
-      "intro": "Dollar Rent A Car is a budget brand within the Hertz family aimed at cost-conscious renters. Its charges code as car rental, part of the travel umbrella, and earn best on cards with a travel or rental-car category bonus. A travel card that also includes rental collision coverage can let you skip the expensive counter insurance, so review your card's benefits first.\n"
+      "intro": "Dollar Rent A Car is a budget brand within the Hertz family aimed at cost-conscious renters. Its charges code as car rental, part of the travel umbrella, and earn best on cards with a travel or rental-car category bonus. A travel card that also includes rental collision coverage can let you skip the expensive counter insurance, so review your card's benefits first.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.35267&trid=1552713.158829&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.dollar.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Dollar Shave Club",
@@ -3862,7 +3878,11 @@
         "online_shopping"
       ],
       "website": "https://www.famousfootwear.com",
-      "intro": "Famous Footwear is the family footwear chain of Caleres Inc, with about 850 U.S.\nstores and famousfootwear.com, selling athletic and casual shoes from Nike, Adidas,\nSkechers, and others. The free Famously You Rewards program offers tiered cashback\nand a birthday gift, layering on top of credit card rewards. Direct purchases\ntypically code as department store at the register and online shopping for web\norders, and there is no current branded credit card.\n"
+      "intro": "Famous Footwear is the family footwear chain of Caleres Inc, with about 850 U.S.\nstores and famousfootwear.com, selling athletic and casual shoes from Nike, Adidas,\nSkechers, and others. The free Famously You Rewards program offers tiered cashback\nand a birthday gift, layering on top of credit card rewards. Direct purchases\ntypically code as department store at the register and online shopping for web\norders, and there is no current branded credit card.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38507&trid=1552713.280&foc=17&fot=9999&fos=6&url=https%3A%2F%2Ffamousfootwear.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Fandango",
@@ -4086,7 +4106,11 @@
         "groceries"
       ],
       "website": "https://www.foodlion.com",
-      "intro": "Food Lion is a Southeastern U.S. grocery chain with about 1,100 stores, owned by\nAhold Delhaize. Codes cleanly as groceries on every card we track. Strongest\npairings are Blue Cash Preferred (6% on U.S. supermarkets), the Capital One SavorOne\n(3% groceries), and U.S. Bank Shopper Cash Rewards if Food Lion is one of the two\nselected retailers. The MVP loyalty program runs separate digital coupons that\nstack on top of any card's bonus rate.\n"
+      "intro": "Food Lion is a Southeastern U.S. grocery chain with about 1,100 stores, owned by\nAhold Delhaize. Codes cleanly as groceries on every card we track. Strongest\npairings are Blue Cash Preferred (6% on U.S. supermarkets), the Capital One SavorOne\n(3% groceries), and U.S. Bank Shopper Cash Rewards if Food Lion is one of the two\nselected retailers. The MVP loyalty program runs separate digital coupons that\nstack on top of any card's bonus rate.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10965&trid=1552713.226393&foc=17&fot=9999&fos=6&url=https%3A%2F%2Ffoodlion.com%2F",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Foot Locker",
@@ -4359,7 +4383,11 @@
         "groceries"
       ],
       "website": "https://giantfood.com",
-      "intro": "Giant Food is the Mid-Atlantic flagship of Ahold Delhaize's U.S. grocery group, with\nabout 165 stores across DC, Maryland, Virginia, and Delaware. Codes cleanly as\ngroceries on every card we track. Best pairings are Blue Cash Preferred (6%),\nCapital One SavorOne (3%), and U.S. Bank Shopper Cash Rewards (6% if selected).\nThe Giant Flexible Rewards program issues per-gallon fuel savings at participating\nShell and Giant stations that stack on top of card bonuses.\n"
+      "intro": "Giant Food is the Mid-Atlantic flagship of Ahold Delhaize's U.S. grocery group, with\nabout 165 stores across DC, Maryland, Virginia, and Delaware. Codes cleanly as\ngroceries on every card we track. Best pairings are Blue Cash Preferred (6%),\nCapital One SavorOne (3%), and U.S. Bank Shopper Cash Rewards (6% if selected).\nThe Giant Flexible Rewards program issues per-gallon fuel savings at participating\nShell and Giant stations that stack on top of card bonuses.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10968&trid=1552713.215429&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fgiantfood.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Gilt",
@@ -5860,7 +5888,11 @@
         "online_shopping"
       ],
       "website": "https://www.kohls.com",
-      "intro": "Kohl's is a mid-tier department store with about 1,150 stores and an aggressive Kohl's\nCash rewards program. Most regular shoppers stack manufacturer sales, Kohl's coupons,\nand Kohl's Cash, so card cashback is the smallest of several layers. The Kohl's Card\n(issued by Capital One) gives in-house discounts but no MasterCard/Visa-network rewards.\nFor most shoppers, a department-store-bonus general-purpose card is the right answer.\n"
+      "intro": "Kohl's is a mid-tier department store with about 1,150 stores and an aggressive Kohl's\nCash rewards program. Most regular shoppers stack manufacturer sales, Kohl's coupons,\nand Kohl's Cash, so card cashback is the smallest of several layers. The Kohl's Card\n(issued by Capital One) gives in-house discounts but no MasterCard/Visa-network rewards.\nFor most shoppers, a department-store-bonus general-purpose card is the right answer.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5349&trid=1552713.157993&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fkohls.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Kohler",
@@ -6100,7 +6132,11 @@
         "online_shopping"
       ],
       "website": "https://www.lenovo.com",
-      "intro": "Lenovo, maker of ThinkPad laptops and a wide PC lineup, sells configurable machines directly through its website with frequent promotions. Orders typically code as online shopping or electronics retail, so a card with an online or general retail bonus tends to earn the most, and a shopping portal can stack additional value.\n"
+      "intro": "Lenovo, maker of ThinkPad laptops and a wide PC lineup, sells configurable machines directly through its website with frequent promotions. Orders typically code as online shopping or electronics retail, so a card with an online or general retail bonus tends to earn the most, and a shopping portal can stack additional value.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.3808&trid=1552713.157497&foc=17&fot=9999&fos=6&url=https%3A%2F%2Flenovo.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "LensCrafters",
@@ -6456,7 +6492,11 @@
         "online_shopping"
       ],
       "website": "https://www.maccosmetics.com",
-      "intro": "MAC Cosmetics is a prestige color cosmetics brand owned by The Estée Lauder Companies,\nsold through about 100 U.S. freestanding stores, maccosmetics.com, and a wide\ndepartment store and Ulta wholesale footprint. Direct purchases at MAC stores or the\nwebsite typically code as department store or online shopping, while MAC bought at\nMacy's or Ulta codes under that retailer. The free MAC Lover loyalty program offers\ntiered points and stacks with credit card multipliers.\n"
+      "intro": "MAC Cosmetics is a prestige color cosmetics brand owned by The Estée Lauder Companies,\nsold through about 100 U.S. freestanding stores, maccosmetics.com, and a wide\ndepartment store and Ulta wholesale footprint. Direct purchases at MAC stores or the\nwebsite typically code as department store or online shopping, while MAC bought at\nMacy's or Ulta codes under that retailer. The free MAC Lover loyalty program offers\ntiered points and stacks with credit card multipliers.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41340&trid=1552713.201336&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fmaccosmetics.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Macy's",
@@ -6800,7 +6840,11 @@
         "department_stores"
       ],
       "website": "https://www.melissaanddoug.com",
-      "intro": "Melissa & Doug is known for wooden toys, puzzles, and craft kits sold online and through retail partners. Direct orders on its site generally code as online shopping, and there is no dedicated toy bonus category on most cards. A flat-rate card or one with an online-shopping multiplier is the practical choice for gifts and restocks.\n"
+      "intro": "Melissa & Doug is known for wooden toys, puzzles, and craft kits sold online and through retail partners. Direct orders on its site generally code as online shopping, and there is no dedicated toy bonus category on most cards. A flat-rate card or one with an online-shopping multiplier is the practical choice for gifts and restocks.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41493&trid=1552713.159291&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fmelissaanddoug.com%2F",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Menards",
@@ -7755,7 +7799,11 @@
         "online_shopping"
       ],
       "website": "https://www.pacsun.com",
-      "intro": "Pacsun is a California-rooted apparel chain catering to teens and young adults, with\nabout 325 mall-based stores and a strong online business at pacsun.com. Most cards\ncode in-store transactions as department store and web orders as online shopping. The\nPacsun Rewards program is free and points-based, layering on top of credit card\nearnings since the chain does not run a branded credit card in the U.S.\n"
+      "intro": "Pacsun is a California-rooted apparel chain catering to teens and young adults, with\nabout 325 mall-based stores and a strong online business at pacsun.com. Most cards\ncode in-store transactions as department store and web orders as online shopping. The\nPacsun Rewards program is free and points-based, layering on top of credit card\nearnings since the chain does not run a branded credit card in the U.S.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.28645&trid=1552713.159888&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fpacsun.com%2F",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Panda Express",
@@ -8011,7 +8059,11 @@
         "online_shopping"
       ],
       "website": "https://www.petco.com",
-      "intro": "Petco is one of the two large U.S. pet specialty retailers (alongside PetSmart),\nwith about 1,500 stores plus in-store grooming and veterinary services. In-store\ncharges code as pet store / specialty retail on most cards (some classify as\ngroceries for food-only baskets); petco.com codes as online shopping. The Vital\nCare Premier membership ($24.99/mo) credits back monthly spend at Petco. Pair\nwith a flat-rate cashback or online-shopping-bonus card for petco.com orders.\n"
+      "intro": "Petco is one of the two large U.S. pet specialty retailers (alongside PetSmart),\nwith about 1,500 stores plus in-store grooming and veterinary services. In-store\ncharges code as pet store / specialty retail on most cards (some classify as\ngroceries for food-only baskets); petco.com codes as online shopping. The Vital\nCare Premier membership ($24.99/mo) credits back monthly spend at Petco. Pair\nwith a flat-rate cashback or online-shopping-bonus card for petco.com orders.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10290&trid=1552713.189505&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fpetco.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Peter Thomas Roth",
@@ -8833,7 +8885,11 @@
         "online_shopping"
       ],
       "website": "https://www.rover.com",
-      "intro": "Rover is an online marketplace connecting pet owners with dog walkers, sitters, and boarding hosts. Payments run through its platform and generally code as online shopping or general services rather than a dedicated bonus category, so they earn on cards with an online or flat-rate bonus. A reliable everyday card is the practical pick for booking pet care here.\n"
+      "intro": "Rover is an online marketplace connecting pet owners with dog walkers, sitters, and boarding hosts. Payments run through its platform and generally code as online shopping or general services rather than a dedicated bonus category, so they earn on cards with an online or flat-rate bonus. A reliable everyday card is the practical pick for booking pet care here.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46193&trid=1552713.209001&foc=17&fot=9999&fos=6&url=https%3A%2F%2Frover.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Royal Caribbean",
@@ -9711,7 +9767,11 @@
         "department_stores"
       ],
       "website": "https://www.stevemadden.com",
-      "intro": "Steve Madden designs trend-driven footwear and accessories sold direct and through department stores. Buying on its site codes as online shopping or retail, so a portal or rotating bonus can boost earnings, while store purchases generally land on a flat-rate card with no shoe-specific category.\n"
+      "intro": "Steve Madden designs trend-driven footwear and accessories sold direct and through department stores. Buying on its site codes as online shopping or retail, so a portal or rotating bonus can boost earnings, while store purchases generally land on a flat-rate card with no shoe-specific category.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.37487&trid=1552713.163728&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fstevemadden.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Stila",
@@ -10053,7 +10113,11 @@
         "dining"
       ],
       "website": "https://www.coffeebean.com",
-      "intro": "The Coffee Bean and Tea Leaf is a long-running Los Angeles coffeehouse chain, one of the oldest in the country, famous for its Ice Blended drinks. Cafe spending codes as dining or restaurants on most rewards cards, making a dining bonus the best fit. Packaged coffee and tea ordered online instead tend to code as online shopping.\n"
+      "intro": "The Coffee Bean and Tea Leaf is a long-running Los Angeles coffeehouse chain, one of the oldest in the country, famous for its Ice Blended drinks. Cafe spending codes as dining or restaurants on most rewards cards, making a dining bonus the best fit. Packaged coffee and tea ordered online instead tend to code as online shopping.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8262&trid=1552713.186151&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fcoffeebean.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "The Container Store",
@@ -10063,7 +10127,11 @@
         "online_shopping"
       ],
       "website": "https://www.containerstore.com",
-      "intro": "The Container Store is the leading U.S. specialty retailer for organization and\nstorage, known for The Elfa custom closet system, kitchen organizers, and Russell\n+ Hazel desk goods. Purchases typically code as general retail, so flat-rate cards\nlike the Citi Double Cash earn the same 2 percent as on most shopping.\n\nBig custom closet installations can run into the thousands, which makes signup bonus\nminimum spend a useful angle. Cards with rotating online shopping quarters, such as\nChase Freedom Flex, occasionally lift containerstore.com orders to 5 percent, and the\nfree Organized Insider loyalty program adds tiered discounts on top of card rewards.\n"
+      "intro": "The Container Store is the leading U.S. specialty retailer for organization and\nstorage, known for The Elfa custom closet system, kitchen organizers, and Russell\n+ Hazel desk goods. Purchases typically code as general retail, so flat-rate cards\nlike the Citi Double Cash earn the same 2 percent as on most shopping.\n\nBig custom closet installations can run into the thousands, which makes signup bonus\nminimum spend a useful angle. Cards with rotating online shopping quarters, such as\nChase Freedom Flex, occasionally lift containerstore.com orders to 5 percent, and the\nfree Organized Insider loyalty program adds tiered discounts on top of card rewards.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.24840&trid=1552713.189823&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fcontainerstore.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "The Farmer's Dog",
@@ -10198,7 +10266,11 @@
         "car_rentals"
       ],
       "website": "https://www.thrifty.com",
-      "intro": "Thrifty is a value rental brand under Hertz, frequently found at airports alongside its sister labels. Rentals code as car rental within the travel category and earn on cards that bonus travel or car rentals specifically. Because many travel cards bundle rental loss-and-damage protection, it is worth confirming your coverage before paying for the counter waiver.\n"
+      "intro": "Thrifty is a value rental brand under Hertz, frequently found at airports alongside its sister labels. Rentals code as car rental within the travel category and earn on cards that bonus travel or car rentals specifically. Because many travel cards bundle rental loss-and-damage protection, it is worth confirming your coverage before paying for the counter waiver.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.3088&trid=1552713.158782&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fthrifty.com",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Thrive Causemetics",


### PR DESCRIPTION
Adds affiliate deep links to **18 existing** \`/best-card-for/[slug]\` pages from the 2026-07-10 FlexOffers approved-advertiser batch. No new pages are created — every slug already has a store page, so these just monetize existing traffic.

## Merchants added
ace-hardware, best-buy, costco, dollar-rent-a-car, famous-footwear, food-lion, giant-food, kohls, lenovo, mac-cosmetics, melissa-and-doug, pacsun, petco, rover, steve-madden, the-coffee-bean-and-tea-leaf, the-container-store, thrifty

## Notes
- **Link format:** these are the sheet's \`foc=17\` deep links with the merchant homepage URL-encoded onto \`&url=\` and converted to https. Differs from the older \`foc=16\` text-link entries but credits the same \`trid=1552713\`.
- **Costco Membership** now has a trackable deep link (previously banners/widgets only), so the prior "intentionally not listed" note is retired.
- **Deferred (3):** everyplate, factor, stop-and-shop had a null FlexLink in the sheet — pending a link from their Get Links page.
- **No offers attached:** buttons fall back to the default CTA; evergreen offers can be added later.
- **Not in this batch:** houzz (B2B Houzz Pro, audience mismatch) and t-mobile (home-internet, low card-spend relevance) were held despite having pages.

## Verification
\`npm run build:stores\` passes and attaches **375** affiliate links (was 357). All 18 confirmed present on their store records.