### PR TITLE
fix(news): populate related-card images in CI build

### DIFF
--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # cards.json is gitignored, so it is absent from a fresh checkout. build-news.js
+      # looks up each related card's image filename in data/cards.json; without it every
+      # card_image_links entry resolves to null and gets filtered to [], leaving related
+      # cards with no art on the live site. Build cards first so the lookup succeeds.
+      - name: Build cards.json
+        run: npm run build:cards
+
       - name: Build news.json
         run: npm run build:news
 

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -73,12 +73,18 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
   if (!item) notFound();
 
   const relatedCards: RelatedCardInfo[] = [];
-  if (item.card_slugs && item.card_names && item.card_image_links) {
+  if (item.card_slugs && item.card_names) {
     for (let i = 0; i < item.card_slugs.length; i++) {
+      // Skip entries with no resolved image. An empty card_image_links array is
+      // truthy, so a stale/partial news.json (image lookup failed at build time)
+      // would otherwise render related cards with a blank gray placeholder rather
+      // than being omitted. Better to show nothing than broken art.
+      const image = item.card_image_links?.[i];
+      if (!image) continue;
       relatedCards.push({
         slug: item.card_slugs[i],
         name: item.card_names[i],
-        image: item.card_image_links[i] || '',
+        image,
         bank: item.bank || '',
       });
     }

--- a/scripts/build-news.js
+++ b/scripts/build-news.js
@@ -128,6 +128,20 @@ function buildNews() {
   const newsItems = [];
   const errors = [];
 
+  // Fail loud if cards.json didn't load. Without it, every related-card image
+  // lookup below resolves to null and gets filtered to [], silently shipping a
+  // news.json where related cards render the gray placeholder instead of card
+  // art. That is a systemic build error, not a per-item content issue, so stop
+  // rather than deploy broken data. (data/cards.json is gitignored — CI must run
+  // `npm run build:cards` before this script.)
+  if (Object.keys(cardsLookup).length === 0) {
+    console.error(
+      'ERROR: cards lookup is empty — data/cards.json is missing or unreadable.\n' +
+      'Run `npm run build:cards` before building news, or related-card images will be blank.'
+    );
+    process.exit(1);
+  }
+
   // Read all YAML files in the news directory
   const files = fs.readdirSync(NEWS_DIR).filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
 
@@ -168,7 +182,11 @@ function buildNews() {
       if (item.card_slugs) {
         item.card_image_links = item.card_slugs.map(slug => {
           const card = cardsLookup[slug];
-          return card ? card.image : null;
+          if (!card) {
+            console.warn(`  WARN: card_slug "${slug}" not found in cards.json — related-card image will be blank`);
+            return null;
+          }
+          return card.image;
         }).filter(Boolean);
         if (item.card_image_links.length > 0) {
           item.card_image_link = item.card_image_links[0];


### PR DESCRIPTION
## Problem

Related cards on news articles show a gray placeholder instead of card art (e.g. [the Amex Platinum Peacock article](https://creditodds.com/news/amex-platinum-peacock-add-ons-ineligible)). The card *link* works because it's built from the slug; the *image* is blank because the deployed data has no image filename. This affects **all 51 card-linked articles**, not just Platinum.

## Root cause

`build-news.js` resolves each related card's image filename by looking up the slug in `data/cards.json`:

```js
item.card_image_links = item.card_slugs.map(slug => {
  const card = cardsLookup[slug];
  return card ? card.image : null;
}).filter(Boolean);
```

`data/cards.json` is **gitignored**, and `build-news.yml` only ran `npm run build:news` — never `build:cards`. So on the CI runner the file is absent, `loadCardsLookup()` returns `{}`, every slug resolves to `null`, and `.filter(Boolean)` collapses `card_image_links` to `[]`. The deployed `news.json` (on `d2hxvzw7msbtvt.cloudfront.net`) ships empty image arrays for every article. Locally it looks fine because a (stale) `cards.json` is present, masking the CI bug.

On the page, an empty array is truthy, so the guard passes and `card_image_links[i] || ''` yields `''`, which makes `CardImage` fall back to `generic-card.svg`.

## Fix

- **`build-news.yml`** — run `build:cards` before `build:news` so the image lookup succeeds on CI.
- **`build-news.js`** — exit 1 when the cards lookup is empty (this systemic failure previously shipped silently), and warn per-slug when an individual `card_slug` doesn't resolve.
- **`news/[id]/page.tsx`** — skip related cards with no resolved image instead of rendering a blank placeholder.

## Verification

Ran `npm run build:news` locally; the Platinum item now resolves `card_image_links: ["amex_the_platinum_card.png"]`. The live fix takes effect once this merges and `build-news.yml` rebuilds/redeploys `news.json` (runs on pushes to `data/news/**`, or via its `workflow_dispatch` button).