### PR TITLE
card-check: anchor the offer-body gate to a new-account window

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -526,15 +526,36 @@ function noteOfferHasExpired(noteText, now) {
 // value and defaults offer_is_tiered:false. Trusting that "flat" reading would
 // delete a live tiered note (#1598).
 //
-// Keyed strictly on the offer's spend-requirement language ("after you spend $X",
-// "after $N ...") — that only appears once the offer body renders. Header labels
-// like "Welcome Offer" are deliberately NOT used: Amex ships that header with a
-// "Loading" body (Delta Gold Business, #1590), so it's present even when the offer
-// isn't. Unknown input (no pageContent, e.g. unit tests) is treated as present so
-// callers without it keep their prior behavior.
+// Keyed on the offer's spend-requirement language ("after you spend $X",
+// "after $N ...") ANCHORED to a new-account window phrase nearby ("in your first
+// 3 months", "within the first 90 days", "of account opening", "of Card
+// Membership"). Spend language alone is NOT enough: ongoing BENEFITS use the same
+// construction — Marriott Bevy's "Free Night Award after spending $15,000 ... in
+// a calendar year" and Brilliant's "Each calendar year after spending $60,000"
+// defeated the spend-only gate and re-deleted live tiered notes (#1613). Only a
+// welcome offer ties the spend to the account's first N months/days, so require
+// that anchor within ±150 chars of the spend match.
+//
+// Header labels like "Welcome Offer" are deliberately NOT used: Amex ships that
+// header with a "Loading" body (Delta Gold Business, #1590), so it's present even
+// when the offer isn't. The window phrase alone is also not enough — intro-APR
+// copy says "for the first 15 months" with no spend language. Unknown input (no
+// pageContent, e.g. unit tests) is treated as present so callers without it keep
+// their prior behavior.
 function pageShowsSignupOffer(pageContent) {
   if (pageContent == null) return true;
-  return /\bafter (?:you )?(?:spend|spending|make|making)\b|\bafter \$\s?[\d,]+/i.test(pageContent);
+  // "after you use your new Card to make $X" is Amex's Marriott offer wording —
+  // the plain (?:you )?(make) alternative misses it because of the intervening
+  // "use your new Card to".
+  const spendRe = /\bafter (?:you )?(?:spend|spending|make|making)\b|\bafter you use your new card\b|\bafter \$\s?[\d,]+/gi;
+  const windowRe = /\bfirst\s+(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:months?|days?)\b|\baccount opening\b|\bcard membership\b|\bopening your account\b/i;
+  let m;
+  while ((m = spendRe.exec(pageContent)) !== null) {
+    const start = Math.max(0, m.index - 150);
+    const end = Math.min(pageContent.length, m.index + m[0].length + 150);
+    if (windowRe.test(pageContent.slice(start, end))) return true;
+  }
+  return false;
 }
 
 function detectChanges(card, extracted, now = new Date(), suppressions = [], pageContent = null) {

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -299,12 +299,45 @@ test('no pageContent (unit-test / legacy call) keeps prior behavior', () => {
   assert.ok(fieldsChanged(changes).includes('signup_bonus.note'));
 });
 
-test('pageShowsSignupOffer: offer-body language vs earn-rate-only vs Loading header', () => {
-  assert.equal(pageShowsSignupOffer('Earn 140,000 Bonus Points after spending $4,000 in the first 3 months'), true);
-  assert.equal(pageShowsSignupOffer('bonus miles after $ 500 in purchases'), true); // Citi spacing
-  assert.equal(pageShowsSignupOffer('after you make $6,000 in purchases'), true);
+test('pageShowsSignupOffer: spend language must anchor to a new-account window', () => {
+  // Real offer bodies — spend + first-N-months window nearby (issuer wordings)
+  assert.equal(pageShowsSignupOffer('Earn 140,000 Bonus Points after spending $4,000 in the first 3 months from account opening'), true);
+  assert.equal(pageShowsSignupOffer('bonus miles after $ 500 in purchases in the first 3 months'), true); // Citi spacing
+  assert.equal(pageShowsSignupOffer('after you make $6,000 in purchases within the first 6 months of Card Membership'), true);
+  assert.equal(pageShowsSignupOffer('after you make $4,000 or more in purchases within the first 90 days of opening your account'), true); // BofA
+  assert.equal(pageShowsSignupOffer('after you spend $6,000 in purchases within your first six months of Card Membership'), true); // spelled-out count
+  // Not offers
   assert.equal(pageShowsSignupOffer('Earn 3X Miles. Welcome Offer Key Details Loading'), false); // header only
+  assert.equal(pageShowsSignupOffer('0% intro APR for the first 15 months on purchases'), false); // window without spend
   assert.equal(pageShowsSignupOffer(null), true); // unknown → present (back-compat)
+});
+
+test('pageShowsSignupOffer: BENEFIT spend thresholds do not count (#1613 Marriott)', () => {
+  // Verbatim from the 2026-07-10 run's fetched text — these defeated the spend-only gate.
+  const BEVY_BENEFIT = 'nvoy Bevy Free Night Award benefit, Card Members can earn 1 Free Night Award after spending $15,000 on eligible purchases with their Marriott Bonvoy Bevy card in a calendar year';
+  const BRILLIANT_BENEFIT = 'Each calendar year after spending $60,000 on eligible purchases on your Marriott Bonvoy Brilliant Card, Card Members are eligible for Ambassador Elite status';
+  assert.equal(pageShowsSignupOffer(BEVY_BENEFIT), false);
+  assert.equal(pageShowsSignupOffer(BRILLIANT_BENEFIT), false);
+  // And the same page with a genuinely rendered offer still passes
+  const BRILLIANT_WITH_OFFER = BRILLIANT_BENEFIT + ' Card Member Offer: Earn 100,000 Marriott Bonvoy bonus points after you use your new Card to make $6,000 in purchases within the first 6 months of Card Membership.';
+  assert.equal(pageShowsSignupOffer(BRILLIANT_WITH_OFFER), true);
+});
+
+test('de-tiering is NOT trusted when only benefit spend text rendered (#1613 end-to-end)', () => {
+  // Echoed value + offer_is_tiered:false + benefit-only page → no note deletion.
+  const bevyBody = 'Earn 6X points at hotels. Card Members can earn 1 Free Night Award after spending $15,000 on eligible purchases in a calendar year. Welcome Offer Key Details';
+  const card = {
+    data: {
+      name: 'Marriott Bonvoy Bevy',
+      signup_bonus: { value: 135000, type: 'points', spend_requirement: 7000, timeframe_months: 6, note: 'Earn 85,000 Marriott Bonvoy bonus points after $5,000 in purchases within first 6 months, plus an additional 50,000 bonus points after an additional $2,000 in purchases within first 6 months of Card Membership.' },
+    },
+  };
+  const changes = detectChanges(
+    card,
+    { signup_bonus: { value: 135000, spend_requirement: 7000, timeframe_months: 6, bonus_note: null, offer_is_tiered: false } },
+    new Date(), [], bevyBody,
+  );
+  assert.deepEqual(fieldsChanged(changes), []);
 });
 
 // ─── Suppressions are recorded, never silent ────────────────────────────────


### PR DESCRIPTION
## Problem
#1603's gate keyed on spend language alone (`after spending $X`). Ongoing **benefits** use the same construction — Bevy's "Free Night Award after spending $15,000 ... in a calendar year" and Brilliant's "Each calendar year after spending $60,000" (Ambassador threshold) — so pages whose welcome offer never rendered still passed the gate, and today's run (#1613) re-proposed deleting both live tiered notes.

## Fix
Welcome offers uniquely tie spend to the account's **first N months/days**. `pageShowsSignupOffer` now requires a new-account window phrase ("in your first 3 months", "within the first 90 days", "of account opening", "of Card Membership") within ±150 chars of the spend match. Window-phrase-alone is also insufficient (intro-APR copy says "for the first 15 months"), so both must co-occur.

Also widens the spend pattern to Amex's Marriott wording **"after you use your new Card to make $X"**, which the plain alternatives missed — without this, a genuinely rendered flat Marriott offer would have been invisible to the gate.

## Verification
- Regression tests use the **verbatim** Bevy/Brilliant benefit text from the 2026-07-10 run log.
- Ran the new gate against the **full real fetched bodies** from that run: Bevy → false, Brilliant → false (notes kept), World of Hyatt → true (real offer still trusted).
- End-to-end test: echoed value + `offer_is_tiered:false` + benefit-only body → zero changes proposed.
- 54 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)