### PR TITLE
feat(ratings): anonymous rate-a-card from the card page

### DIFF
--- a/apps/api/migrations/050a_allow_null_user_id_card_ratings.sql
+++ b/apps/api/migrations/050a_allow_null_user_id_card_ratings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE card_ratings MODIFY user_id VARCHAR(128) NULL;

--- a/apps/api/migrations/050b_add_ip_hash_to_card_ratings.sql
+++ b/apps/api/migrations/050b_add_ip_hash_to_card_ratings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE card_ratings ADD COLUMN ip_hash CHAR(64) NULL AFTER user_id;

--- a/apps/api/migrations/050c_add_comment_to_card_ratings.sql
+++ b/apps/api/migrations/050c_add_comment_to_card_ratings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE card_ratings ADD COLUMN comment VARCHAR(2000) NULL AFTER rating;

--- a/apps/api/migrations/050d_add_unique_ip_card_to_card_ratings.sql
+++ b/apps/api/migrations/050d_add_unique_ip_card_to_card_ratings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE card_ratings ADD UNIQUE KEY unique_ip_card (ip_hash, card_id);

--- a/apps/api/src/click-identity.js
+++ b/apps/api/src/click-identity.js
@@ -26,6 +26,25 @@ function getFirebaseAdmin() {
   }
 }
 
+// The API sits behind CloudFront, so requestContext.identity.sourceIp is a
+// CloudFront edge address, not the visitor. In the X-Forwarded-For chain the
+// last entry is CloudFront's own IP (appended by the API Gateway hop) and the
+// second-to-last is the address CloudFront saw as its TCP peer — the real
+// client. Anything earlier is client-supplied and spoofable.
+function getClientIp(event) {
+  const xff =
+    event.headers?.["X-Forwarded-For"] || event.headers?.["x-forwarded-for"];
+  if (xff) {
+    const chain = xff
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (chain.length >= 2) return chain[chain.length - 2];
+    if (chain.length === 1) return chain[0];
+  }
+  return event.requestContext?.identity?.sourceIp || null;
+}
+
 function hashIp(ip) {
   if (!ip) return null;
   const pepper = process.env.IP_HASH_PEPPER;
@@ -57,4 +76,4 @@ async function getOptionalUserId(event) {
   }
 }
 
-module.exports = { hashIp, getOptionalUserId };
+module.exports = { getClientIp, hashIp, getOptionalUserId };

--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -1,4 +1,14 @@
 const mysql = require("../db");
+const { getClientIp, hashIp, getOptionalUserId } = require("../click-identity");
+
+const COMMENT_MAX = 2000;
+
+function normalizeComment(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.length > COMMENT_MAX ? trimmed.substring(0, COMMENT_MAX) : trimmed;
+}
 
 const responseHeaders = {
   // Authenticated, user-specific responses: never cache at browser or any
@@ -82,6 +92,90 @@ exports.CardRatingsHandler = async (event) => {
             count: results[0].count,
             average: results[0].average ? parseFloat(results[0].average.toFixed(2)) : null,
           }),
+        };
+        break;
+      } catch (error) {
+        await mysql.end();
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: String(error) }),
+        };
+        break;
+      }
+
+    // POST /ratings — public rate-a-card. Signed-in callers (valid Firebase
+    // token) upsert on (user_id, card_id); anonymous callers upsert on
+    // (ip_hash, card_id) so one IP gets one vote per card, editable.
+    case "POST":
+      try {
+        const body = typeof event.body === "string" ? JSON.parse(event.body || "{}") : (event.body || {});
+        const { card_name: cardName, rating } = body;
+        const comment = normalizeComment(body.comment);
+
+        if (!cardName || rating === undefined || rating === null) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "card_name and rating are required" }),
+          };
+          break;
+        }
+
+        if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "rating must be an integer between 1 and 5" }),
+          };
+          break;
+        }
+
+        const cardId = await resolveCardId(cardName);
+        if (!cardId) {
+          await mysql.end();
+          response = {
+            statusCode: 404,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "Card not found" }),
+          };
+          break;
+        }
+
+        const userId = await getOptionalUserId(event);
+        if (userId) {
+          await mysql.query(
+            `INSERT INTO card_ratings (user_id, card_id, rating, comment)
+             VALUES (?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE rating = VALUES(rating), comment = VALUES(comment), updated_at = NOW()`,
+            [userId, cardId, rating, comment]
+          );
+        } else {
+          const ipHash = hashIp(getClientIp(event));
+          if (!ipHash) {
+            // Without a stable identity we can't enforce one vote per
+            // visitor, so reject rather than accept unlimited votes.
+            await mysql.end();
+            response = {
+              statusCode: 400,
+              headers: responseHeaders,
+              body: JSON.stringify({ error: "Unable to accept rating" }),
+            };
+            break;
+          }
+          await mysql.query(
+            `INSERT INTO card_ratings (ip_hash, card_id, rating, comment)
+             VALUES (?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE rating = VALUES(rating), comment = VALUES(comment), updated_at = NOW()`,
+            [ipHash, cardId, rating, comment]
+          );
+        }
+        await mysql.end();
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({ success: true, rating }),
         };
         break;
       } catch (error) {

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -1451,19 +1451,30 @@ Resources:
       Runtime: nodejs22.x
       MemorySize: 256
       Timeout: 100
-      Description: Public card ratings aggregate endpoint
+      Description: Public card ratings aggregate and anonymous rating endpoint
       Environment:
         Variables:
           ENDPOINT: !Ref ENDPOINT
           DATABASE: !Ref DATABASE
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
+          IP_HASH_PEPPER: !Ref IpHashPepper
+          FIREBASE_PROJECT_ID: creditodds
       Events:
         GetRatings:
           Type: Api
           Properties:
             Path: /ratings
             Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+        PostRating:
+          Type: Api
+          Properties:
+            Path: /ratings
+            Method: POST
             RestApiId:
               Ref: CreditCardOddsAPI
             Auth:

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState, useMemo, useEffect, useRef, useId } from "react";
+import { Suspense, useState, useMemo, useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
 import CardImage from "@/components/ui/CardImage";
 import Link from "next/link";
@@ -27,6 +27,7 @@ import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, fr
 import { NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { Article } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
+import RateCardStars from "@/components/forms/RateCardStars";
 import ApplyOutcomePrompt, { markApplyPending } from "@/components/forms/ApplyOutcomePrompt";
 import CardyComparePopup from "@/components/ui/CardyComparePopup";
 import { CreditCardSchema, BreadcrumbSchema } from "@/components/seo/JsonLd";
@@ -84,35 +85,6 @@ function getStableReferralIndex(cardKey: string, referralCount: number): number 
     hash = (hash * 31 + cardKey.charCodeAt(i)) | 0;
   }
   return Math.abs(hash) % referralCount;
-}
-
-function StarIcon({
-  fill = 1,
-  size = 14,
-}: {
-  fill?: number;
-  size?: number;
-}) {
-  const gradientId = useId();
-  const pct = Math.max(0, Math.min(1, fill)) * 100;
-  const path =
-    "M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z";
-  return (
-    <svg width={size} height={size} viewBox="0 0 20 20">
-      <defs>
-        <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
-          <stop offset={`${pct}%`} stopColor="currentColor" stopOpacity={1} />
-          <stop offset={`${pct}%`} stopColor="currentColor" stopOpacity={0} />
-        </linearGradient>
-      </defs>
-      <path
-        d={path}
-        fill={`url(#${gradientId})`}
-        stroke="currentColor"
-        strokeWidth={1.2}
-      />
-    </svg>
-  );
 }
 
 const MIN_DATA_POINTS_FOR_CHARTS = 5;
@@ -1794,34 +1766,13 @@ export default function CardClient({
             </div>
           )}
 
-          {ratings.average !== null && ratings.count > 0 && (
-            <div className="cj-rating">
-              <div>
-                <div className="cj-rating-v">
-                  {ratings.average.toFixed(1)}{" "}
-                  <small>/ 5</small>
-                </div>
-                <div
-                  style={{
-                    fontSize: 11,
-                    color: "var(--muted)",
-                    marginTop: 2,
-                  }}
-                >
-                  {ratings.count}{" "}
-                  {ratings.count === 1 ? "rating" : "ratings"}
-                </div>
-              </div>
-              <div className="cj-rating-stars">
-                {[1, 2, 3, 4, 5].map((s) => (
-                  <StarIcon
-                    key={s}
-                    fill={(ratings.average ?? 0) - (s - 1)}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
+          <RateCardStars
+            cardName={card.card_name}
+            slug={card.slug}
+            cardImageLink={card.card_image_link}
+            bank={card.bank}
+            ratings={ratings}
+          />
 
           <Link
             href={`/compare?cards=${card.slug}`}

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -8178,6 +8178,57 @@
 }
 .landing-v2 .cj-rating-v small { color: var(--muted); font-size: 14px; font-weight: 400; }
 .landing-v2 .cj-rating-stars { color: var(--gold); display: flex; gap: 1px; }
+.landing-v2 .cj-rating-side {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+.landing-v2 .cj-rating-star-btn {
+  appearance: none;
+  background: none;
+  border: 0;
+  padding: 2px;
+  margin: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  line-height: 0;
+}
+.landing-v2 .cj-rating-star-btn:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+.landing-v2 .cj-rating-mine {
+  font-size: 10.5px;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+/* Star selector inside the rate-card modal */
+.landing-v2 .cj-rate-stars {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  color: var(--gold);
+  padding: 4px 0 2px;
+}
+.landing-v2 .cj-rate-star-btn {
+  appearance: none;
+  background: none;
+  border: 0;
+  padding: 2px;
+  margin: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  line-height: 0;
+}
+.landing-v2 .cj-rate-star-btn:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
 
 /* Skeleton loader — subtle shimmer, scoped to journal */
 .landing-v2 .cj-skeleton {

--- a/apps/web-next/src/components/forms/RateCardStars.tsx
+++ b/apps/web-next/src/components/forms/RateCardStars.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { createPortal } from "react-dom";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import CardImage from "@/components/ui/CardImage";
+import { useAuth } from "@/auth/AuthProvider";
+import {
+  CardRatingAggregates,
+  getUserCardRating,
+  submitPublicCardRating,
+} from "@/lib/api";
+
+// Same fractional-fill star as the read-only rail display it replaces.
+function StarIcon({ fill = 1, size = 14 }: { fill?: number; size?: number }) {
+  const gradientId = useId();
+  const pct = Math.max(0, Math.min(1, fill)) * 100;
+  const path =
+    "M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z";
+  return (
+    <svg width={size} height={size} viewBox="0 0 20 20" aria-hidden="true">
+      <defs>
+        <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
+          <stop offset={`${pct}%`} stopColor="currentColor" stopOpacity={1} />
+          <stop offset={`${pct}%`} stopColor="currentColor" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <path
+        d={path}
+        fill={`url(#${gradientId})`}
+        stroke="currentColor"
+        strokeWidth={1.2}
+      />
+    </svg>
+  );
+}
+
+interface RateCardStarsProps {
+  cardName: string;
+  slug: string;
+  cardImageLink?: string;
+  bank?: string;
+  ratings: CardRatingAggregates;
+}
+
+// Remembers an anonymous visitor's submitted rating so the widget can show it
+// on return visits. The server independently enforces one vote per IP.
+const storageKey = (slug: string) => `co_card_rating_${slug}`;
+
+export default function RateCardStars({
+  cardName,
+  slug,
+  cardImageLink,
+  bank,
+  ratings,
+}: RateCardStarsProps) {
+  const { authState, getToken } = useAuth();
+  const [mounted, setMounted] = useState(false);
+  const [hoverValue, setHoverValue] = useState<number | null>(null);
+  const [myRating, setMyRating] = useState<number | null>(null);
+  const [justSubmitted, setJustSubmitted] = useState(false);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalRating, setModalRating] = useState(5);
+  const [modalHover, setModalHover] = useState<number | null>(null);
+  const [comment, setComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    try {
+      const saved = localStorage.getItem(storageKey(slug));
+      const parsed = saved ? parseInt(saved, 10) : NaN;
+      if (parsed >= 1 && parsed <= 5) setMyRating(parsed);
+    } catch {
+      // Ignore storage errors
+    }
+  }, [slug]);
+
+  // Signed-in users: prefer their account rating over any anonymous
+  // localStorage leftover.
+  useEffect(() => {
+    if (!authState.isAuthenticated) return;
+    let cancelled = false;
+    (async () => {
+      const token = await getToken();
+      if (!token) return;
+      const rating = await getUserCardRating(cardName, token).catch(() => null);
+      if (!cancelled && rating && rating >= 1 && rating <= 5) setMyRating(rating);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authState.isAuthenticated, cardName, getToken]);
+
+  // Lock body scroll while the modal is open. Plain overflow:hidden (NOT
+  // position:fixed) to avoid the iOS touch-freeze bug.
+  useEffect(() => {
+    if (!modalOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [modalOpen]);
+
+  const openModal = (value: number) => {
+    setModalRating(value);
+    setModalHover(null);
+    setError(null);
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    if (submitting) return;
+    setModalOpen(false);
+  };
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const token = authState.isAuthenticated ? await getToken() : null;
+      await submitPublicCardRating(cardName, modalRating, comment, token);
+      setMyRating(modalRating);
+      setJustSubmitted(true);
+      if (!token) {
+        try {
+          localStorage.setItem(storageKey(slug), String(modalRating));
+        } catch {
+          // Ignore storage errors
+        }
+      }
+      setModalOpen(false);
+      setComment("");
+    } catch {
+      setError("Could not submit your rating. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const hasAggregate = ratings.count > 0 && ratings.average !== null;
+
+  // Star fill priority: live hover preview > community average > the
+  // visitor's own rating (only shown when there is no aggregate yet).
+  const starFill = (s: number): number => {
+    if (hoverValue !== null) return s <= hoverValue ? 1 : 0;
+    if (hasAggregate) return (ratings.average ?? 0) - (s - 1);
+    if (myRating) return s <= myRating ? 1 : 0;
+    return 0;
+  };
+
+  const hint = justSubmitted
+    ? "Thanks, your rating is in"
+    : myRating
+      ? `Your rating: ${myRating}/5`
+      : "Tap a star to rate";
+
+  return (
+    <>
+      <div className="cj-rating">
+        <div>
+          {hasAggregate ? (
+            <div className="cj-rating-v">
+              {(ratings.average ?? 0).toFixed(1)} <small>/ 5</small>
+            </div>
+          ) : (
+            <div className="cj-rating-v" style={{ fontSize: 14 }}>
+              Rate this card
+            </div>
+          )}
+          <div
+            style={{
+              fontSize: 11,
+              color: "var(--muted)",
+              marginTop: 2,
+            }}
+          >
+            {ratings.count > 0
+              ? `${ratings.count} ${ratings.count === 1 ? "rating" : "ratings"}`
+              : "No ratings yet"}
+          </div>
+        </div>
+        <div className="cj-rating-side">
+          <div
+            className="cj-rating-stars cj-rating-stars-interactive"
+            onMouseLeave={() => setHoverValue(null)}
+          >
+            {[1, 2, 3, 4, 5].map((s) => (
+              <button
+                key={s}
+                type="button"
+                className="cj-rating-star-btn"
+                aria-label={`Rate ${s} star${s === 1 ? "" : "s"}`}
+                onMouseEnter={() => setHoverValue(s)}
+                onFocus={() => setHoverValue(s)}
+                onBlur={() => setHoverValue(null)}
+                onClick={() => openModal(s)}
+              >
+                <StarIcon fill={starFill(s)} />
+              </button>
+            ))}
+          </div>
+          <div className="cj-rating-mine">{hint}</div>
+        </div>
+      </div>
+
+      {modalOpen &&
+        mounted &&
+        createPortal(
+          <div className="landing-v2 profile-v2">
+            <div className="cj-modal-root" role="dialog" aria-modal="true">
+              <div className="cj-modal-backdrop" onClick={closeModal} />
+              <div className="cj-modal-shell">
+                <div className="cj-modal-card cj-modal-card-bounded">
+                  <div className="cj-modal-head">
+                    <span className="cj-status-dot" />
+                    <span className="cj-modal-title">rate this card</span>
+                    <button
+                      type="button"
+                      className="cj-modal-close"
+                      onClick={closeModal}
+                      aria-label="Close"
+                    >
+                      <XMarkIcon style={{ width: 16, height: 16 }} />
+                    </button>
+                  </div>
+
+                  <div className="cj-modal-body">
+                    <div className="cj-modal-section">
+                      <div className="cj-modal-card-row">
+                        <span className="cj-modal-thumb">
+                          <CardImage
+                            cardImageLink={cardImageLink}
+                            alt={cardName}
+                            fill
+                            className="object-contain"
+                            sizes="56px"
+                          />
+                        </span>
+                        <div style={{ minWidth: 0 }}>
+                          <div className="cj-modal-card-name">{cardName}</div>
+                          {bank && <div className="cj-modal-card-meta">{bank}</div>}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="cj-modal-section">
+                      <label className="cj-modal-label">Your rating</label>
+                      <div
+                        className="cj-rate-stars"
+                        onMouseLeave={() => setModalHover(null)}
+                      >
+                        {[1, 2, 3, 4, 5].map((s) => (
+                          <button
+                            key={s}
+                            type="button"
+                            className="cj-rate-star-btn"
+                            aria-label={`${s} star${s === 1 ? "" : "s"}`}
+                            aria-pressed={modalRating === s}
+                            onMouseEnter={() => setModalHover(s)}
+                            onClick={() => setModalRating(s)}
+                          >
+                            <StarIcon
+                              fill={s <= (modalHover ?? modalRating) ? 1 : 0}
+                              size={28}
+                            />
+                          </button>
+                        ))}
+                      </div>
+                      <p
+                        style={{
+                          textAlign: "center",
+                          fontSize: 11.5,
+                          color: "var(--muted)",
+                          marginTop: 2,
+                        }}
+                      >
+                        {(modalHover ?? modalRating)}/5
+                      </p>
+                    </div>
+
+                    <div className="cj-modal-section">
+                      <label htmlFor="rate-card-comment" className="cj-modal-label">
+                        Comment <span style={{ color: "var(--muted)", fontWeight: 400 }}>(optional)</span>
+                      </label>
+                      <textarea
+                        id="rate-card-comment"
+                        className="cj-modal-input"
+                        style={{ minHeight: 84, resize: "vertical" }}
+                        placeholder="What should other people know about this card?"
+                        maxLength={2000}
+                        value={comment}
+                        onChange={(e) => setComment(e.target.value)}
+                      />
+                    </div>
+
+                    {error && <div className="cj-modal-error">{error}</div>}
+                  </div>
+
+                  <div className="cj-modal-footer">
+                    <div className="cj-modal-actions" style={{ marginLeft: "auto" }}>
+                      <button
+                        type="button"
+                        className="cj-modal-btn"
+                        onClick={closeModal}
+                        disabled={submitting}
+                      >
+                        cancel
+                      </button>
+                      <button
+                        type="button"
+                        className="cj-modal-btn cj-modal-btn-primary"
+                        onClick={handleSubmit}
+                        disabled={submitting}
+                      >
+                        {submitting ? "submitting…" : "submit rating"}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1347,6 +1347,31 @@ export async function getUserCardRating(cardName: string, token: string): Promis
   return data.rating;
 }
 
+// Public rate-a-card endpoint: works signed-out (server dedupes by a salted
+// IP hash) or signed-in (pass a token to upsert the account's rating).
+export async function submitPublicCardRating(
+  cardName: string,
+  rating: number,
+  comment?: string,
+  token?: string | null
+): Promise<void> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API_BASE}/ratings`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      card_name: cardName,
+      rating,
+      ...(comment?.trim() ? { comment: comment.trim() } : {}),
+    }),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to submit rating: ${errorText}`);
+  }
+}
+
 export async function submitCardRating(
   cardName: string,
   rating: number,


### PR DESCRIPTION
## What

Lets any visitor rate a card directly from the card page, no account needed. Hovering the star rating in the right rail previews 1-5 stars; clicking (or tapping) a star opens a modal with that rating preselected and an optional comment field. Anonymous submissions are deduped by a salted SHA-256 hash of the client IP: one vote per IP per card, and resubmitting updates the existing vote instead of adding a new one.

Signed-in users go through the same widget but upsert against their account (same semantics as the wallet edit modal), with their existing rating pre-filled.

Comments are **collected but not displayed** for now; they land in the new `card_ratings.comment` column for a future reviews section.

## Backend

- `POST /ratings` (public, no authorizer) added to `CardRatingsHandler`: validates rating 1-5, resolves optional Firebase token via the existing `getOptionalUserId`, and upserts by `(user_id, card_id)` or `(ip_hash, card_id)`. Rejects anonymous submissions when no stable identity can be derived.
- New `getClientIp(event)` in `click-identity.js`: the API sits behind CloudFront, so `sourceIp` is an edge address. It takes the second-to-last `X-Forwarded-For` entry (the hop CloudFront actually saw), which is not client-spoofable. Note: `card-apply-click.js` and `best-card-here-report.js` still hash `sourceIp` and likely have this latent issue; follow-up candidate.
- `template.yml`: POST event + `IP_HASH_PEPPER` / `FIREBASE_PROJECT_ID` env on `CardRatingsFunction`.

## Migrations (must run before merge)

050a-d, single-statement each: nullable `user_id`, add `ip_hash CHAR(64)`, add `comment VARCHAR(2000)`, add `UNIQUE(ip_hash, card_id)`. Existing signed-in rows keep working; MySQL unique keys allow multiple NULLs so the two identity types coexist.

## Frontend

- New `RateCardStars` component replaces the read-only star row in the card rail and now renders even at zero ratings ("No ratings yet"). Stars are buttons with aria-labels; keyboard focus previews like hover.
- Modal follows the SubmitRecordModal portal pattern (`cj-modal-*`). On success the widget shows "Thanks, your rating is in" and remembers anonymous votes in localStorage (server still enforces one per IP). The CDN-cached aggregate lags up to 5 min by design.

## Verification

- tsc, eslint (only pre-existing findings on CardClient), and a full `next build` pass.
- Dev-server walkthrough: hover preview fills correctly and restores the aggregate on leave, star click opens the modal preselected, comment field works, failed submits show a friendly error and keep the modal open. Mobile (375px) layout fits.
- `getClientIp` unit-checked against spoofed-XFF, CloudFront-chain, and direct-call shapes; `sam validate --lint` passes.
- End-to-end submit can only be tested after the backend deploys (dev points at prod API, which 403s the not-yet-existing POST route).

## Rollout

1. Run migrations 050a-d (RunMigrationHandler wire/deploy/invoke/unwire) **before merging**.
2. Merge: `deploy-api.yml` ships the backend, `deploy-frontend.yml` fires Amplify.

## Known limitations (accepted)

- Shared IPs (offices, CGNAT) collapse to one vote; VPNs can multi-vote. Deterrent, not a guarantee.
- The same person can vote once anonymously and once signed-in (two rows).