### PR TITLE
fix(api): hash the real client IP, not the CloudFront edge IP

### DIFF
--- a/apps/api/src/click-identity.js
+++ b/apps/api/src/click-identity.js
@@ -26,6 +26,25 @@ function getFirebaseAdmin() {
   }
 }
 
+// The API sits behind CloudFront, so requestContext.identity.sourceIp is a
+// CloudFront edge address, not the visitor. In the X-Forwarded-For chain the
+// last entry is CloudFront's own IP (appended by the API Gateway hop) and the
+// second-to-last is the address CloudFront saw as its TCP peer — the real
+// client. Anything earlier is client-supplied and spoofable.
+function getClientIp(event) {
+  const xff =
+    event.headers?.["X-Forwarded-For"] || event.headers?.["x-forwarded-for"];
+  if (xff) {
+    const chain = xff
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (chain.length >= 2) return chain[chain.length - 2];
+    if (chain.length === 1) return chain[0];
+  }
+  return event.requestContext?.identity?.sourceIp || null;
+}
+
 function hashIp(ip) {
   if (!ip) return null;
   const pepper = process.env.IP_HASH_PEPPER;
@@ -57,4 +76,4 @@ async function getOptionalUserId(event) {
   }
 }
 
-module.exports = { hashIp, getOptionalUserId };
+module.exports = { getClientIp, hashIp, getOptionalUserId };

--- a/apps/api/src/handlers/apply-outcome.js
+++ b/apps/api/src/handlers/apply-outcome.js
@@ -14,7 +14,7 @@
 //   These are anonymous tier-1 signals. They do NOT feed the public odds
 //   charts — full data points live in the records table.
 const mysql = require("../db");
-const { hashIp, getOptionalUserId } = require("../click-identity");
+const { getClientIp, hashIp, getOptionalUserId } = require("../click-identity");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":
@@ -105,7 +105,7 @@ exports.ApplyOutcomeHandler = async (event) => {
           break;
         }
 
-        const ip = event.requestContext?.identity?.sourceIp || null;
+        const ip = getClientIp(event);
         const ipHash = hashIp(ip);
         const userId = await getOptionalUserId(event);
         const identityKey = userId || ipHash;

--- a/apps/api/src/handlers/best-card-here-report.js
+++ b/apps/api/src/handlers/best-card-here-report.js
@@ -3,7 +3,7 @@
 // account can flag a wrong category / wrong card / missing merchant in
 // two taps. One row per submission; admins read directly from the DB.
 const mysql = require("../db");
-const { hashIp, getOptionalUserId } = require("../click-identity");
+const { getClientIp, hashIp, getOptionalUserId } = require("../click-identity");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":
@@ -127,7 +127,7 @@ exports.BestCardHereReportHandler = async (event) => {
           break;
         }
 
-        const ip = event.requestContext?.identity?.sourceIp || null;
+        const ip = getClientIp(event);
         const ipHash = hashIp(ip);
         const userId = await getOptionalUserId(event);
 

--- a/apps/api/src/handlers/card-apply-click.js
+++ b/apps/api/src/handlers/card-apply-click.js
@@ -12,7 +12,7 @@
 //   from it. We keep summing it into total counts for historical continuity,
 //   but uniques only reflect new (post-rollout) clicks.
 const mysql = require("../db");
-const { hashIp, getOptionalUserId } = require("../click-identity");
+const { getClientIp, hashIp, getOptionalUserId } = require("../click-identity");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":
@@ -100,7 +100,7 @@ exports.CardApplyClickHandler = async (event) => {
           break;
         }
 
-        const ip = event.requestContext?.identity?.sourceIp || null;
+        const ip = getClientIp(event);
         const ipHash = hashIp(ip);
         const userId = await getOptionalUserId(event);
 

--- a/apps/api/src/handlers/referral-stats.js
+++ b/apps/api/src/handlers/referral-stats.js
@@ -1,6 +1,6 @@
 // Track referral impressions and clicks
 const mysql = require("../db");
-const { hashIp, getOptionalUserId } = require("../click-identity");
+const { getClientIp, hashIp, getOptionalUserId } = require("../click-identity");
 
 const responseHeaders = {
   "Access-Control-Allow-Headers":
@@ -51,7 +51,7 @@ exports.ReferralStatsHandler = async (event) => {
         // forward; ip_hash (sha256(pepper + ip)) is the stable per-IP token
         // we use for unique-click counting. user_id is the Firebase uid when
         // the caller is signed in, otherwise null.
-        const ipAddress = event.requestContext?.identity?.sourceIp || null;
+        const ipAddress = getClientIp(event);
         const userAgent = event.headers?.['User-Agent'] || event.headers?.['user-agent'] || null;
         const ipHash = hashIp(ipAddress);
         const userId = await getOptionalUserId(event);

--- a/apps/api/src/handlers/user-records.js
+++ b/apps/api/src/handlers/user-records.js
@@ -1,5 +1,6 @@
 // Create clients and set shared const values outside of the handler.
 const mysql = require("../db");
+const { getClientIp } = require("../click-identity");
 
 // Yup Schema Validation for Record Submit
 const yup = require("yup");
@@ -185,7 +186,7 @@ exports.UserRecordsHandler = async (event) => {
               length_credit: value.length_credit,
               starting_credit_limit: value.starting_credit_limit,
               submitter_id: submitterId,
-              submitter_ip_address: event.requestContext.identity.sourceIp,
+              submitter_ip_address: getClientIp(event),
               submit_datetime: new Date(),
               bank_customer: value.bank_customer,
               reason_denied: value.reason_denied,

--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -1,6 +1,7 @@
 // Create clients and set shared const values outside of the handler.
 const mysql = require("../db");
 const { validateReferralLink } = require("../lib/validate-referral-link");
+const { getClientIp } = require("../click-identity");
 
 const responseHeaders = {
   // Authenticated, user-specific responses: never cache at browser or any
@@ -140,7 +141,7 @@ exports.UserReferralsHandler = async (event) => {
           card_id: postBody.card_id,
           referral_link: postBody.referral_link,
           submitter_id: userId,
-          submitter_ip_address: event.requestContext.identity.sourceIp,
+          submitter_ip_address: getClientIp(event),
           submit_datetime: new Date(),
         });
         await mysql.end();


### PR DESCRIPTION
## Problem

The API sits behind CloudFront (api.creditodds.com), so `event.requestContext.identity.sourceIp` is a **CloudFront edge address**, not the visitor. Every handler that peppers-and-hashes the caller's IP for anonymous identity was collapsing many visitors onto a small set of edge IPs, which weakens per-IP uniqueness chains (inflated dedupe collisions, deflated unique counts).

## Fix

Adds `getClientIp(event)` to `apps/api/src/click-identity.js`. It is an **exact copy of the helper introduced on the open #1615 branch**, so the two branches merge cleanly. It takes the second-to-last `X-Forwarded-For` entry, which is the hop CloudFront actually saw as its TCP peer and is not client-spoofable (anything earlier in the chain is client-supplied), falling back to `sourceIp` when no XFF chain exists.

### Call sites switched

Peppered `ip_hash` consumers:
- `handlers/card-apply-click.js`
- `handlers/apply-outcome.js`
- `handlers/best-card-here-report.js`
- `handlers/referral-stats.js`

Same bug, raw IP storage (found during the audit):
- `handlers/user-referrals.js` (`submitter_ip_address` on referral submit)
- `handlers/user-records.js` (`submitter_ip_address` on record submit)

Audited clean: `handlers/admin.js` only reads stored `ip_hash` values, never touches `sourceIp`.

## Verified

Unit-tested the helper against the CloudFront chain shape (`client, cf-edge`), a spoof attempt (`fake, client, cf-edge` → returns the real client), a single-entry chain, and the no-header fallback. `node --check` passes on all touched files.

## Note on data continuity

`ip_hash` values change for every visitor going forward, so uniqueness chains reset once. That is acceptable and by design — same effect as a pepper rotation.