### PR TITLE
fix(ci): point Lambda invokes at us-east-1 after region migration

### DIFF
--- a/.github/workflows/build-cards.yml
+++ b/.github/workflows/build-cards.yml
@@ -74,7 +74,11 @@ jobs:
         id: sync
         run: |
           echo "Invoking sync-cards Lambda directly (no public endpoint)..."
+          # NB: --region is explicit because the job's default region is
+          # us-east-2 (where the S3 buckets still live). The Lambdas moved
+          # to us-east-1 with the rest of the stack.
           aws lambda invoke \
+            --region us-east-1 \
             --function-name creditodds-sync-cards \
             --payload '{"source":"github-action"}' \
             --cli-binary-format raw-in-base64-out \

--- a/.github/workflows/check-referrals.yml
+++ b/.github/workflows/check-referrals.yml
@@ -58,7 +58,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
-          aws-region: us-east-2
+          aws-region: us-east-1
 
       - name: Fetch batch from ReferralValidationListFunction
         env:
@@ -77,12 +77,23 @@ jobs:
           # for pages where no match exists). `head -n 1` after `--output
           # text` keeps the first non-empty line and is the same fix used
           # in the deploy workflow.
+          #
+          # NB: resolve the name into a variable and assert it is non-empty.
+          # An empty substitution makes `--function-name` swallow the next
+          # flag, and the CLI then reports a misleading ParamValidation
+          # error instead of "no such function".
+          fn=$(aws lambda list-functions \
+            --region us-east-1 \
+            --query "Functions[?contains(FunctionName, 'ReferralValidationList')].FunctionName" \
+            --output text | tr '\t' '\n' | grep -v '^$' | head -n 1)
+          if [ -z "$fn" ]; then
+            echo "::error::No Lambda matching 'ReferralValidationList' in us-east-1"
+            exit 1
+          fi
+          echo "Using $fn"
           aws lambda invoke \
-            --region us-east-2 \
-            --function-name $(aws lambda list-functions \
-              --region us-east-2 \
-              --query "Functions[?contains(FunctionName, 'ReferralValidationList')].FunctionName" \
-              --output text | tr '\t' '\n' | grep -v '^$' | head -n 1) \
+            --region us-east-1 \
+            --function-name "$fn" \
             --cli-binary-format raw-in-base64-out \
             --payload "{\"limit\": ${LIMIT}}" \
             --cli-read-timeout 70 \
@@ -100,12 +111,18 @@ jobs:
             echo "No results to post."
             exit 0
           fi
+          fn=$(aws lambda list-functions \
+            --region us-east-1 \
+            --query "Functions[?contains(FunctionName, 'ReferralValidationComplete')].FunctionName" \
+            --output text | tr '\t' '\n' | grep -v '^$' | head -n 1)
+          if [ -z "$fn" ]; then
+            echo "::error::No Lambda matching 'ReferralValidationComplete' in us-east-1"
+            exit 1
+          fi
+          echo "Using $fn"
           aws lambda invoke \
-            --region us-east-2 \
-            --function-name $(aws lambda list-functions \
-              --region us-east-2 \
-              --query "Functions[?contains(FunctionName, 'ReferralValidationComplete')].FunctionName" \
-              --output text | tr '\t' '\n' | grep -v '^$' | head -n 1) \
+            --region us-east-1 \
+            --function-name "$fn" \
             --cli-binary-format raw-in-base64-out \
             --payload fileb://results.json \
             --cli-read-timeout 310 \


### PR DESCRIPTION
## Problem

[Check Referrals #24](https://github.com/CreditOdds/creditodds/actions/runs/29097659207) failed. Root cause: the us-east-1 migration (2026-07-09) deleted all us-east-2 Lambdas, but two workflows still invoke them in us-east-2.

**`check-referrals.yml`** — `list-functions` matched zero rows, so `$(...)` expanded to nothing and `--function-name` swallowed the following flag:

```
aws: [ERROR]: An error occurred (ParamValidation): argument --function-name: expected one argument
```

**`build-cards.yml`** — same root cause, clearer error. It has been failing on every push since the migration, which means **no card data has synced to the database since 2026-07-09**:

```
ResourceNotFoundException ... Function not found:
arn:aws:lambda:us-east-2:953352003729:function:creditodds-sync-cards
```

These are the only two workflows that call `aws lambda`. `build-news`/`build-articles`/`build-best` only touch S3 + CloudFront, so they were unaffected and still pass.

## Fix

- Point both Lambda invokes (and `check-referrals`' `list-functions` lookups) at `us-east-1`.
- Resolve the function name into a variable and fail loudly with `::error::` when the lookup returns empty, so future region/name drift reports the real cause instead of an argument-parsing error.

`build-cards.yml` keeps its `us-east-2` default region — the S3 buckets and CloudFront distributions were not migrated. Only the Lambda invoke is pinned.

## Verification

Both names resolve in us-east-1 (the truncated `...CompleteFuncti` confirms the existing 64-char comment):

```
OK: ReferralValidationList     -> CreditCardOddsAPI-ReferralValidationListFunction-QxWkTjukOQyu
OK: ReferralValidationComplete -> CreditCardOddsAPI-ReferralValidationCompleteFuncti-PyPKZd6zN8VS
OK: creditodds-sync-cards
```

Ran the fixed `check-referrals` fetch command verbatim against the live (read-only) List Lambda:

```
Using CreditCardOddsAPI-ReferralValidationListFunction-QxWkTjukOQyu
{ "StatusCode": 200, "ExecutedVersion": "$LATEST" }
Batch size: 3
```

Both workflow files pass `yaml.safe_load`.