### PR TITLE
fix(ci): remove 14-day recency skip from rewards/benefits checker

### DIFF
--- a/.github/workflows/check-card-rewards-and-benefits.yml
+++ b/.github/workflows/check-card-rewards-and-benefits.yml
@@ -14,11 +14,6 @@ on:
         description: 'Specific card slug to check (leave empty for all)'
         required: false
         default: ''
-      force:
-        description: 'Bypass the 14-day recently-edited skip (check all matched cards now)'
-        type: boolean
-        required: false
-        default: false
 
 permissions:
   contents: write
@@ -28,7 +23,7 @@ permissions:
 jobs:
   check-rewards-and-benefits:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 50
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -51,7 +46,6 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CARD_SLUG: ${{ github.event.inputs.card_slug || '' }}
-          FORCE_CHECK: ${{ github.event.inputs.force || 'false' }}
         run: node scripts/check-card-rewards-and-benefits.js
 
       - name: Validate updated card YAMLs

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -34,7 +34,9 @@ const SUMMARY_FILE = path.join(ROOT, '.card-rewards-benefits-summary.md');
 const FETCH_DELAY_MS = 2000;
 const FETCH_TIMEOUT_MS = 15000;
 const PER_CARD_TIMEOUT_MS = 90 * 1000;
-const SCRIPT_TIMEOUT_MS = 25 * 60 * 1000;
+// A full sweep of every active card runs ~20 min. Keep real headroom: hitting
+// this cap stops the run early, silently dropping the tail of the alphabet.
+const SCRIPT_TIMEOUT_MS = 35 * 60 * 1000;
 
 // ─── Timeout helpers ─────────────────────────────────────────────────────────
 
@@ -78,23 +80,6 @@ function filterCardsForCheck(allCards, slugFilter) {
     }
   }
   return cards;
-}
-
-// Skip cards whose YAML was edited in the last N days — protects fresh manual
-// edits from being stomped by the auto-checker.
-function wasRecentlyEdited(filepath, days = 14) {
-  try {
-    const out = execFileSync(
-      'git',
-      ['log', '-1', '--format=%ct', '--', filepath],
-      { cwd: ROOT, encoding: 'utf8' }
-    ).trim();
-    if (!out) return false;
-    const lastEditMs = parseInt(out, 10) * 1000;
-    return Date.now() - lastEditMs < days * 24 * 60 * 60 * 1000;
-  } catch {
-    return false;
-  }
 }
 
 // ─── Per-card removed-benefit history ───────────────────────────────────────
@@ -1427,10 +1412,6 @@ function writeRotatingPeriodSection(stale) {
 
 async function main() {
   const slugFilter = process.env.CARD_SLUG || '';
-  // Manual runs can bypass the 14-day recency guard: either explicitly via
-  // FORCE_CHECK=true, or implicitly when a specific CARD_SLUG is targeted
-  // (asking for one card by name is a clear intent to check it now).
-  const forceCheck = process.env.FORCE_CHECK === 'true' || slugFilter !== '';
   const allCards = loadAllCards();
   const cards = filterCardsForCheck(allCards, slugFilter);
   const policy = loadPolicy();
@@ -1449,14 +1430,12 @@ async function main() {
   }
 
   console.log(`\nChecking ${cards.length} active card(s) with apply_link...`);
-  if (forceCheck) console.log('FORCE_CHECK active — bypassing the 14-day recency skip.');
   console.log('');
 
   const summary = {
     fetched: 0,
     extractFailed: 0,
     fetchFailed: 0,
-    skippedRecentlyEdited: 0,
     cardsModified: 0,
     autoChanges: 0,
     reviewItems: 0,
@@ -1469,12 +1448,6 @@ async function main() {
     if (Date.now() - startMs > SCRIPT_TIMEOUT_MS) {
       console.warn(`Script-level timeout reached, stopping early.`);
       break;
-    }
-
-    if (!forceCheck && wasRecentlyEdited(card.filepath)) {
-      console.log(`[skip] ${card.data.name} — YAML edited within last 14 days`);
-      summary.skippedRecentlyEdited++;
-      continue;
     }
 
     console.log(`[fetch] ${card.data.name}`);


### PR DESCRIPTION
## The problem

`check-card-rewards-and-benefits` has barely been running. The last scheduled run (2026-07-05) **checked 2 cards out of 148** and finished in four minutes.

The script gated each card on `wasRecentlyEdited(filepath, 14)`, which skipped any card whose YAML was touched by *any* commit in the last two weeks. It keyed on `git log -1` for the whole file, so it could not distinguish a rewards edit from a typo fix.

Then `c12ea135` ("content: add our_take editorial blurbs to 180 cards") touched every card YAML in a single commit and muted the checker across the board:

| Scheduled run | Fetched | Skipped | Duration |
|---|---|---|---|
| 2026-06-21 | 113 | 35 | 18 min |
| 2026-06-28 | ~0 | ~all | 1 min |
| 2026-07-05 | 2 | 146 | 4 min |

There is a self-reinforcing version of the same bug: when the checker's own auto-PR merges, that resets the card's clock for another 14 days. The cards whose terms actually move were the ones most reliably skipped.

## The fix

Remove the guard, along with the `FORCE_CHECK` env var and the workflow `force` input that existed only to bypass it.

The stated rationale for the guard was protecting fresh manual edits from being stomped. That does not hold up:

- The script opens PRs for human review; it never pushes to `main`.
- `getRemovedBenefitsForCard()` already deny-lists benefits a human deliberately removed, which is the correctly-scoped version of the same protection.
- The sibling `check-card-pages.js` never had such a guard.

Because every card now gets fetched, this also raises `SCRIPT_TIMEOUT_MS` from 25 to 35 minutes and the job's `timeout-minutes` from 40 to 50. The 2026-06-29 manual dispatch fetched all 148 cards in ~20 min without tripping the old cap, so the sweep fits, but only just. Tripping it stops the script early and silently drops the tail of the alphabet.

## Verification

Ran the script locally against the real card set. It reported `Checking 148 active card(s)` and logged **0 skips against 143 fetches** in 40 seconds before being killed. Extraction failed per-card with `OPENAI_API_KEY required`, which is expected without the secret and confirms the fetch loop is reached. `AAA Daily Advantage Visa Signature`, the first `[skip]` in the 2026-07-05 CI log, is now the first `[fetch]`. No card YAMLs were modified and no stray artifacts written.

## Heads up

The first full run after this merges will sweep ~148 cards that have not been genuinely checked in weeks, and the workflow opens **one PR per modified card**. Expect a larger-than-usual batch. Worth a `workflow_dispatch` run to gauge volume before Sunday's cron fires.