### PR TITLE
chore(ci): bump configure-aws-credentials v4 -> v5

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm run build:articles
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2

--- a/.github/workflows/build-best.yml
+++ b/.github/workflows/build-best.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build:best
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2

--- a/.github/workflows/build-cards.yml
+++ b/.github/workflows/build-cards.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run build:cards
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2

--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build:news
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2

--- a/.github/workflows/check-referrals.yml
+++ b/.github/workflows/check-referrals.yml
@@ -55,7 +55,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
           aws-region: us-east-1

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -50,7 +50,7 @@ jobs:
           use-installer: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
           aws-region: us-east-1


### PR DESCRIPTION
## Why

Every workflow run currently emits:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `aws-actions/configure-aws-credentials@v4`

v5 targets Node 24 natively and clears the warning. Surfaced while verifying the [check-referrals fix](https://github.com/CreditOdds/creditodds/pull/1617).

## Compatibility

`v5.0.0`'s **only** breaking change is stricter validation of invalid boolean inputs ([#1445](https://github.com/aws-actions/configure-aws-credentials/issues/1445)).

All six call sites pass only `role-to-assume` and `aws-region` — no boolean inputs — so none are affected:

| Workflow | role | region |
|---|---|---|
| `check-referrals.yml` | `...-Deploy` | us-east-1 |
| `deploy-api.yml` | `...-Deploy` | us-east-1 |
| `build-cards.yml` | `GitHubActions-CreditOdds` | us-east-2 |
| `build-news.yml` | `GitHubActions-CreditOdds` | us-east-2 |
| `build-articles.yml` | `GitHubActions-CreditOdds` | us-east-2 |
| `build-best.yml` | `GitHubActions-CreditOdds` | us-east-2 |

All six already declare `id-token: write`, which v5 still requires for OIDC. The `v5` major tag resolves to `v5.1.1` (2025-11-24).

## Diff

Six `uses:` lines, nothing else:

```
6 +        uses: aws-actions/configure-aws-credentials@v5
6 -        uses: aws-actions/configure-aws-credentials@v4
```

## Verification

All workflow files still parse as valid YAML. Since these workflows only run on push/schedule, the bump is exercised the next time each fires — `deploy-api.yml` won't run on this PR because it touches no `apps/api/**` path. Recommend confirming with a `check-referrals` dispatch after merge.