### PR TITLE
chore(ci): bump configure-aws-credentials v5 -> v6

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm run build:articles
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2

--- a/.github/workflows/build-best.yml
+++ b/.github/workflows/build-best.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build:best
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2

--- a/.github/workflows/build-cards.yml
+++ b/.github/workflows/build-cards.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run build:cards
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2

--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build:news
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2

--- a/.github/workflows/check-referrals.yml
+++ b/.github/workflows/check-referrals.yml
@@ -55,7 +55,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
           aws-region: us-east-1

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -50,7 +50,7 @@ jobs:
           use-installer: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds-Deploy
           aws-region: us-east-1


### PR DESCRIPTION
## Correcting #1619

The v5 bump **did not work**. I verified it by dispatching `check-referrals` on `main` after merge — the run passed, but the deprecation annotation re-fired, now naming `@v5`:

> Node.js 20 is deprecated. ... are being forced to run on Node.js 24: `aws-actions/configure-aws-credentials@v5`

Root cause: `v5` resolves to v5.1.1, which still declares `runs.using: node20`. I had assumed v5 was the newest major (I only listed `v5*` tags) and read v5.0.0's notes. In fact the latest release is **v6.2.2**, and the node24 move shipped *only* in v6.0.0.

```
v4      runs.using = node20
v5      runs.using = node20   <- #1619 landed here, no effect
v5.1.1  runs.using = node20
v6      runs.using = node24   <- what we actually needed
v6.2.2  runs.using = node24
```

## Compatibility

v6.0.0's **only** breaking change is the node24 move itself, which requires runner >= v2.327.1. Our runners are on **2.335.1**. No breaking changes landed in 6.1.x or 6.2.x.

Everything checked for #1619 still holds: all six call sites pass only `role-to-assume` and `aws-region` (so v5.0.0's boolean-input tightening is a non-issue), and all six declare `id-token: write` for OIDC.

## Diff

Six `uses:` lines, nothing else:

```
6 +        uses: aws-actions/configure-aws-credentials@v6
6 -        uses: aws-actions/configure-aws-credentials@v5
```

## Verification

All workflows parse as valid YAML. Unlike #1619, this one gets verified properly: I'll dispatch `check-referrals` after merge and confirm the annotation is **gone**, not just that the run is green.