### PR TITLE
card-wire: add manual post workflow + idempotency key

### DIFF
--- a/.github/workflows/post-card-wire-manual.yml
+++ b/.github/workflows/post-card-wire-manual.yml
@@ -1,0 +1,66 @@
+name: Post CardWire (manual)
+
+# Manually post CardWire updates to the @card_wire X account.
+#
+# Why this exists: card-wire tweets normally fire from build-cards.yml, but only
+# when its "Sync cards to database" step succeeds AND returns wire_changes. Any
+# other path leaves the card_wire row written with no tweet — e.g. on 2026-07-10
+# the sync step died with ResourceNotFoundException (it still pointed at the
+# deleted us-east-2 Lambda, fixed in #1617), the post step was skipped, and the
+# World of Hyatt 60k -> 75k row was later backfilled by a direct Lambda invoke
+# that never calls post-card-wire.js.
+#
+# post-card-wire.js sends idempotency_key = source_id (wire-<slug>-<YYYY-MM-DD>),
+# so re-running this for a card already posted today is a no-op (the social API
+# returns deduped: true). Safe to retry.
+#
+# Only a sign-up-bonus INCREASE produces a tweet; other fields are ignored by the
+# script, so passing them is harmless.
+
+on:
+  workflow_dispatch:
+    inputs:
+      changes:
+        description: 'wire_changes JSON, e.g. [{"card":"World of Hyatt","changes":[{"field":"signup_bonus_value","old_value":"60000","new_value":"75000","unit":"points"}]}]'
+        required: true
+        type: string
+      dry_run:
+        description: 'Render the image and print the text without posting'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Post CardWire update
+        env:
+          SOCIAL_API_URL: ${{ secrets.SOCIAL_API_URL }}
+          SOCIAL_API_KEY: ${{ secrets.SOCIAL_API_KEY }}
+          # Pass via env, not inline ${{ }}, so a card name containing a quote
+          # can't break out of the shell argument or inject commands.
+          WIRE_CHANGES: ${{ inputs.changes }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            node scripts/post-card-wire.js --changes "$WIRE_CHANGES" --dry-run
+          else
+            node scripts/post-card-wire.js --changes "$WIRE_CHANGES"
+          fi

--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -509,6 +509,12 @@ async function queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffe
     link_url: linkUrl,
     source_type: 'card-wire',
     source_id: sourceId,
+    // sourceId is `wire-<slug>-<YYYY-MM-DD>`, i.e. one post per card per day —
+    // exactly the right idempotency scope. Sending it lets the social API
+    // dedupe (returns `deduped: true`) instead of double-tweeting, so a retry,
+    // a re-run of the manual workflow, or a future reconciler that re-posts
+    // stranded card_wire rows is always safe.
+    idempotency_key: sourceId,
     // SUB-increase tweets route only to the dedicated @card_wire X account.
     // (Omitting platforms would fan out to every connected account.)
     platforms: ['twitter_cardwire'],


### PR DESCRIPTION
Groundwork for recovering the stranded World of Hyatt tweet (and preventing double-posts).

## Why
The Hyatt `60,000 → 75,000` SUB increase never tweeted. `build-cards.yml`'s **Sync cards to database** step failed with `ResourceNotFoundException` (it still invoked the deleted us-east-2 Lambda — fixed in #1617 forty minutes later), so the dependent **Post CardWire updates to Twitter** step was **skipped**. The wire row was then written by a direct Lambda invoke, which never calls `post-card-wire.js`. Confirmed: **zero card-wire posts hit the social queue in 7 days.**

## Changes
- **`post-card-wire-manual.yml`** — `workflow_dispatch` to post a `wire_changes` payload (with `dry_run`). Recovers a stranded `card_wire` row without a full rebuild + resync.
- **`post-card-wire.js`** — send `idempotency_key = source_id` (`wire-<slug>-<YYYY-MM-DD>`). The social API already dedupes on this key (`deduped: true`), so retries / re-runs / a future reconciler can't double-tweet. Previously no key was sent at all.

## Verified
Local dry run renders the image (210KB) and text `⬆️ Sign-up Bonus: 60,000 pts → 75,000 pts` with the `@Chase` handle; key is 42 chars (limit 128); workflow YAML parses.

Note: card-wire posts are already **immediate** — `social-queue.js` does `if (cardwire) triggerSchedulerNow(insertId)` and marks them `blackout_exempt` with priority 200. Nothing was queued, so the queue was never the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)