### PR TITLE
card-wire: reconcile stranded wire rows on a schedule

### DIFF
--- a/.github/workflows/reconcile-card-wire.yml
+++ b/.github/workflows/reconcile-card-wire.yml
@@ -1,0 +1,81 @@
+name: Reconcile CardWire posts
+
+# Safety net for stranded card_wire rows.
+#
+# build-cards.yml only tweets when its "Sync cards to database" step succeeds AND
+# returns wire_changes. Any other path writes the card_wire row with no tweet:
+#   - the sync step fails (2026-07-10: ResourceNotFoundException against the
+#     deleted us-east-2 Lambda, fixed in #1617) and the post step is skipped;
+#   - the sync Lambda is invoked directly (backfills, remediation), which never
+#     calls post-card-wire.js;
+#   - the post step itself errors.
+# In each case the SUB increase silently never reaches X.
+#
+# This job re-posts every sign-up-bonus increase from the last 48h. Re-posting is
+# a no-op for anything already tweeted: each post carries
+# idempotency_key = source_id (wire-<slug>-<YYYY-MM-DD>) and the social API
+# returns `deduped: true` for a key it has seen. Reconciled entries are keyed by
+# the wire row's own date, so a row stranded yesterday can't be re-keyed under
+# today and double-post.
+#
+# The window is short on purpose: recovering a stranded row is good, tweeting a
+# week-old bonus bump as news is not. Use workflow_dispatch with a larger
+# `hours` for a deliberate catch-up.
+
+on:
+  schedule:
+    # Every 30 minutes. The happy path already publishes within seconds
+    # (social-queue kicks the scheduler for card-wire posts), so this only needs
+    # to bound the worst case for the rare stranded row.
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      hours:
+        description: 'Look-back window in hours (default 48)'
+        required: false
+        default: '48'
+        type: string
+      dry_run:
+        description: 'Render and print without posting'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  # Two overlapping runs would race on the same idempotency key. The API would
+  # dedupe via its unique index, but serialising keeps the logs honest.
+  group: reconcile-card-wire
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Reconcile CardWire posts
+        env:
+          SOCIAL_API_URL: ${{ secrets.SOCIAL_API_URL }}
+          SOCIAL_API_KEY: ${{ secrets.SOCIAL_API_KEY }}
+          HOURS: ${{ inputs.hours || '48' }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            node scripts/post-card-wire.js --reconcile "$HOURS" --dry-run
+          else
+            node scripts/post-card-wire.js --reconcile "$HOURS"
+          fi

--- a/scripts/post-card-wire.js
+++ b/scripts/post-card-wire.js
@@ -9,9 +9,24 @@
  * Usage:
  *   node scripts/post-card-wire.js --changes '<JSON>'
  *   node scripts/post-card-wire.js --changes '<JSON>' --dry-run
+ *   node scripts/post-card-wire.js --reconcile [hours]   (default 48)
  *
  * The --changes JSON is the wire_changes array from the /sync-cards response:
  *   [{ "card": "Chase Sapphire Preferred", "changes": [{ "field": "annual_fee", "old_value": "95", "new_value": "250" }] }]
+ *
+ * --reconcile reads recent rows straight from the card_wire table (via /card-wire)
+ * instead of a sync response, and re-posts any SUB increase in the window. This is
+ * the safety net for rows that get written without a tweet: build-cards.yml only
+ * posts when its sync step succeeds AND returns wire_changes, so a failed sync
+ * step or a direct Lambda invoke strands the row silently (World of Hyatt
+ * 60k -> 75k on 2026-07-10). Re-posting is safe because every post carries
+ * idempotency_key = source_id, and the social API returns `deduped: true` for a
+ * key it has already seen — so an already-tweeted change is a no-op.
+ *
+ * source_id is `wire-<slug>-<YYYY-MM-DD>`. Reconciled entries carry the wire
+ * row's own date so the key matches whatever the normal path would have used
+ * that day; without that, a row stranded yesterday would be keyed under today
+ * and could double-post.
  *
  * Env vars: SOCIAL_API_URL, SOCIAL_API_KEY
  */
@@ -113,6 +128,47 @@ function hasSubIncrease(changes) {
     c => c.field === 'signup_bonus_value' &&
       getDirection(c.field, c.old_value, c.new_value) === 'positive'
   );
+}
+
+// ── Reconciliation: read stranded rows straight from the card wire ──
+
+// Pull recent card_wire rows and rebuild the same shape the sync response would
+// have produced, so the rest of the pipeline is identical. Only SUB increases
+// tweet, so we filter to signup_bonus_value here and let hasSubIncrease() make
+// the final call on direction.
+//
+// The window is deliberately short (default 48h): a stranded row is worth
+// recovering, but silently tweeting a week-old bonus bump as news is worse than
+// not tweeting it. Widen it with `--reconcile <hours>` for a deliberate catch-up.
+async function fetchRecentWireChanges(hours) {
+  const res = await fetch(`${API_BASE}/card-wire?limit=200&_=${Date.now()}`);
+  if (!res.ok) throw new Error(`Failed to fetch card wire: ${res.status}`);
+  const rows = (await res.json()).changes || [];
+
+  const cutoff = Date.now() - hours * 3600 * 1000;
+  const byCard = new Map();
+
+  for (const row of rows) {
+    if (row.field !== 'signup_bonus_value') continue;
+    const changedAt = Date.parse(row.changed_at);
+    if (!Number.isFinite(changedAt) || changedAt < cutoff) continue;
+    if (getDirection(row.field, row.old_value, row.new_value) !== 'positive') continue;
+
+    const name = row.card_name;
+    if (!byCard.has(name)) {
+      // Key the post under the day the change landed, not today — otherwise a
+      // row stranded yesterday gets today's idempotency key and double-posts.
+      byCard.set(name, { card: name, date: row.changed_at.slice(0, 10), changes: [] });
+    }
+    byCard.get(name).changes.push({
+      field: row.field,
+      old_value: row.old_value,
+      new_value: row.new_value,
+      unit: row.unit,
+    });
+  }
+
+  return [...byCard.values()];
 }
 
 // ── Card data lookup ──
@@ -547,21 +603,37 @@ async function queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffe
 
 // ── Main ──
 
+const DEFAULT_RECONCILE_HOURS = 48;
+
 function parseArgs() {
   const args = process.argv.slice(2);
   let changesJson = null;
   let dryRun = false;
+  let reconcileHours = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--changes' && args[i + 1]) {
       changesJson = args[++i];
     } else if (args[i] === '--dry-run') {
       dryRun = true;
+    } else if (args[i] === '--reconcile') {
+      // Optional hours argument; a bare --reconcile uses the default window.
+      const next = args[i + 1];
+      reconcileHours = next && /^\d+$/.test(next) ? Number(args[++i]) : DEFAULT_RECONCILE_HOURS;
     }
+  }
+
+  if (reconcileHours !== null) {
+    if (changesJson) {
+      console.error('--reconcile and --changes are mutually exclusive');
+      process.exit(1);
+    }
+    return { changes: null, dryRun, reconcileHours };
   }
 
   if (!changesJson) {
     console.error('Usage: node scripts/post-card-wire.js --changes \'<JSON>\' [--dry-run]');
+    console.error('       node scripts/post-card-wire.js --reconcile [hours] [--dry-run]');
     process.exit(1);
   }
 
@@ -573,11 +645,19 @@ function parseArgs() {
     process.exit(1);
   }
 
-  return { changes, dryRun };
+  return { changes, dryRun, reconcileHours: null };
 }
 
 async function main() {
-  const { changes, dryRun } = parseArgs();
+  const { changes: argChanges, dryRun, reconcileHours } = parseArgs();
+
+  let changes = argChanges;
+  if (reconcileHours !== null) {
+    console.log(`=== CardWire Reconcile (last ${reconcileHours}h) ===\n`);
+    changes = await fetchRecentWireChanges(reconcileHours);
+    console.log(`${changes.length} card(s) with a sign-up bonus increase in window`);
+    console.log('Already-posted changes dedupe on idempotency_key; re-posting is a no-op.\n');
+  }
 
   if (!changes || changes.length === 0) {
     console.log('No wire changes to post.');
@@ -617,12 +697,18 @@ async function main() {
     // Build post text
     const { textContent, twitterText } = buildPostText(cardName, cardChanges, bank, bonusType);
     const linkUrl = buildLinkUrl(slug);
-    const sourceId = `wire-${slug}-${new Date().toISOString().slice(0, 10)}`;
+    // Reconciled entries carry the wire row's own date so the idempotency key
+    // matches what the normal path would have used that day. Sync-driven entries
+    // have no date and are posted the moment the change lands, so today is right.
+    const postDate = entry.date || new Date().toISOString().slice(0, 10);
+    const sourceId = `wire-${slug}-${postDate}`;
 
     console.log(`  Text (${textContent.length} chars): ${textContent.replace(/\n/g, ' | ')}`);
     if (twitterText) {
       console.log(`  Twitter variant (${twitterText.length} chars): ${twitterText.replace(/\n/g, ' | ')}`);
     }
+
+    console.log(`  Idempotency key: ${sourceId}`);
 
     if (dryRun) {
       const outPath = path.join(__dirname, '..', `card-wire-preview-${slug}.png`);
@@ -633,7 +719,11 @@ async function main() {
 
     try {
       const result = await queuePost(textContent, twitterText, linkUrl, sourceId, imageBuffer);
-      console.log(`  Queued! Post ID: ${result.id}\n`);
+      if (result.deduped) {
+        console.log(`  Already posted (${sourceId}) — skipped. Post ID: ${result.id}\n`);
+      } else {
+        console.log(`  Queued! Post ID: ${result.id}\n`);
+      }
     } catch (err) {
       console.error(`  Failed to queue: ${err.message}\n`);
     }


### PR DESCRIPTION
Closes the failure mode that lost the World of Hyatt tweet.

## Problem
`build-cards.yml` only tweets when its **Sync cards to database** step succeeds *and* returns `wire_changes`. Every other path writes the `card_wire` row with **no tweet**:
- the sync step fails (2026-07-10: `ResourceNotFoundException` on the deleted us-east-2 Lambda) and the post step is **skipped**;
- the sync Lambda is invoked **directly** (backfills/remediation), which never calls `post-card-wire.js`;
- the post step itself errors.

## Fix
- **`--reconcile [hours]`** (default 48) on `post-card-wire.js`: reads recent rows from `/card-wire` instead of a sync response, filters to SUB increases, and re-posts them through the **same** image/text pipeline (no duplication).
- **Reconciled entries carry the wire row's own date**, so `source_id` — and therefore the idempotency key — matches what the normal path would have used that day. Without this, a row stranded *yesterday* would be re-keyed under *today* and double-post.
- Re-posting is a **no-op** for anything already tweeted (`deduped: true`, now logged distinctly).
- **`reconcile-card-wire.yml`**: every 30 min, plus `workflow_dispatch` with `hours` override and `dry_run`. Short window on purpose — recovering a stranded row is good; tweeting a week-old bonus bump as news is not.
- Dry runs now print the idempotency key.

## Verified against live data
| Check | Result |
|---|---|
| 48h reconcile picks up only increases | Finds **only** World of Hyatt; ignores 7 SUB decreases (IHG ×3, AT&T, Fidelity, Venture Business, Amazon Store) |
| Reconcile keys by the row's date | `wire-world-of-hyatt-credit-card-2026-07-10` — **identical** to the key post 258 used, so it dedupes, not re-tweets |
| Sync path (no date) keys by today | `...-2026-07-10` ✅ |
| Stranded-yesterday keys by yesterday | `...-2026-07-09` (not today) ✅ |
| `--reconcile` + `--changes` guard | rejected ✅ |

Not doing the full move of posting into the sync Lambda: that needs `sharp` (a root dep) added as a native dep to the VPC Lambda, ~642 lines relocated into `apps/api`, new Lambda secrets, and it puts image rendering + outbound HTTP on the critical card-sync path. This gets the same guarantee for a fraction of the risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)