### PR TITLE
fix(ci): stop apply-link check hanging until the 20m timeout

### DIFF
--- a/scripts/check-apply-links.js
+++ b/scripts/check-apply-links.js
@@ -134,9 +134,19 @@ async function fetchWithTimeout(url, timeoutMs) {
 
 let _browser = null;
 let _launchChannel = null; // 'chrome' if real Chrome is available, else bundled chromium
-async function getBrowser() {
-  if (_browser) return _browser;
+let _browserPromise = null;
 
+// Memoize the in-flight launch, not just the resolved browser. Several
+// concurrency workers can hit getBrowser() simultaneously; without this guard
+// they'd each see _browser === null and launch their own Chrome, orphaning all
+// but the last. Those orphaned browsers keep open handles that prevent Node
+// from exiting, so the script hangs until the CI timeout kills it.
+function getBrowser() {
+  if (!_browserPromise) _browserPromise = launchBrowser();
+  return _browserPromise;
+}
+
+async function launchBrowser() {
   // playwright-extra + stealth plugin patches the obvious headless tells
   // (navigator.webdriver, missing plugins, headless UA, WebGL vendor, etc.)
   // that bank WAFs use to return 403 to automated browsers.
@@ -353,8 +363,14 @@ async function main() {
 module.exports = { checkOne, classify, loadActiveCards, targetsForCard };
 
 if (require.main === module) {
-  main().catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+  main()
+    .then(() => {
+      // Force exit even if a stray browser handle lingers — all work is done
+      // and stdout is flushed by this point, so there's nothing left to await.
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
## Problem

The **Check Apply Links** scheduled workflow is cancelled at its 20-minute timeout on nearly every run (e.g. run #74, and 68–74 in a row). It looks like a failure but the check itself succeeds.

In run #74's log the script finishes and writes its result at `15:26:35` (`Done: 0 broken / 149 total`), then the step just hangs until GitHub cancels it at `15:45:04`, leaving orphan `node` + `chrome` processes in the cleanup step.

## Root cause

A race in `getBrowser()`. It memoized only the *resolved* browser (`if (_browser) return _browser`), with no in-flight lock. When multiple concurrency workers called `fetchWithBrowser` → `getBrowser()` at the same moment (the log shows **four** `browser ready` lines within ~90ms, for the four PNC cards that needed browser retries), they all saw `_browser === null` and each launched a Chrome instance. Last write to `_browser` wins; the other instances are orphaned.

`main()` closes only `_browser` (the last one). Playwright keeps open pipes to each orphaned browser subprocess, and those handles keep Node's event loop alive, so the process never exits.

This is flaky by nature — runs 64 and 67 passed because the browser-retry cards happened to dispatch one-at-a-time.

## Fix

- Memoize the in-flight **launch promise** so concurrent callers await a single browser instead of each launching their own (also memoizes the `null` "playwright unavailable" case, avoiding per-call relaunch attempts).
- `process.exit(0)` after `main()` resolves as a belt-and-suspenders guarantee the step can't hang again.

The check logic is unchanged.