### PR TITLE
fix(ci): route everything_else base-rate cuts to review, not auto-PR

### DIFF
--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -742,6 +742,7 @@ function diffRewards(current, proposed) {
   const added = [];
   const removed = [];
   const changed = [];
+  const downgraded = [];
   for (const [cat, p] of prop) {
     const c = cur.get(cat);
     if (!c) {
@@ -774,6 +775,15 @@ function diffRewards(current, proposed) {
       // includes the loyalty program's member/elite earning, not just the
       // card. Skip silently (see Guard 4 above).
       continue;
+    } else if (cat === 'everything_else' && p.value < c.value) {
+      // Guard 5 — base-rate DOWNGRADE on everything_else. The extractor
+      // repeatedly reads a card's flat base rate as 1 (confirmed 2026-07-10:
+      // Venture X 2→1, VentureOne 1.25→1, Bilt Palladium 2→1, U.S. Bank
+      // Shopper 1.5→1 — all wrong). A real base-rate cut does happen, but
+      // it's rare and high-stakes, so route it to the human review queue
+      // instead of auto-PRing it. (Capped/composed everything_else downgrades
+      // are already skipped silently by the guard above.)
+      downgraded.push({ from: c, to: p });
     } else if (
       c.value !== p.value ||
       c.spend_cap !== p.spend_cap ||
@@ -795,7 +805,7 @@ function diffRewards(current, proposed) {
     if (PORTAL_ALIAS_GROUP.has(cat) && proposalHasPortalRow) continue;
     removed.push(c);
   }
-  return { added, removed, changed };
+  return { added, removed, changed, downgraded };
 }
 
 // Tokenize a benefit name into meaningful words for fuzzy duplicate detection.
@@ -1323,13 +1333,26 @@ function applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff) {
 // ─── Review-queue formatting ────────────────────────────────────────────────
 
 function appendReviewEntries(cardName, applyLink, reviewItems, rewardsDiff, ftxnDiff) {
-  if (reviewItems.length === 0 && rewardsDiff.added.length === 0 && rewardsDiff.removed.length === 0) {
+  const downgraded = rewardsDiff.downgraded || [];
+  if (
+    reviewItems.length === 0 &&
+    rewardsDiff.added.length === 0 &&
+    rewardsDiff.removed.length === 0 &&
+    downgraded.length === 0
+  ) {
     return;
   }
   const lines = [];
   lines.push(`\n## ${cardName}`);
   lines.push(`**Apply link:** ${applyLink}\n`);
 
+  if (downgraded.length > 0) {
+    lines.push(`### Base-rate decrease proposed — verify against the live page before applying`);
+    for (const { from, to } of downgraded) {
+      const u = to.unit === 'percent' ? '%' : 'x';
+      lines.push(`- \`${to.category}\`: ${from.value}${u} → ${to.value}${u} (the extractor frequently misreads flat base rates as 1 — confirm the cut is real)`);
+    }
+  }
   if (rewardsDiff.added.length > 0) {
     lines.push(`### New reward category proposed (needs human routing)`);
     for (const r of rewardsDiff.added) {
@@ -1518,8 +1541,18 @@ async function main() {
       );
     }
 
+    if (rewardsDiff.downgraded.length > 0) {
+      for (const { from, to } of rewardsDiff.downgraded) {
+        console.log(`  [review] ${to.category} base-rate cut ${from.value}→${to.value} routed to review (not auto-PR'd)`);
+      }
+    }
+
     appendReviewEntries(card.data.name, card.data.apply_link, benefitsDiff.review, rewardsDiff, ftxnDiff);
-    summary.reviewItems += benefitsDiff.review.length + rewardsDiff.added.length + rewardsDiff.removed.length;
+    summary.reviewItems +=
+      benefitsDiff.review.length +
+      rewardsDiff.added.length +
+      rewardsDiff.removed.length +
+      rewardsDiff.downgraded.length;
 
     await new Promise(r => setTimeout(r, FETCH_DELAY_MS));
   }

--- a/scripts/check-card-rewards-and-benefits.test.js
+++ b/scripts/check-card-rewards-and-benefits.test.js
@@ -240,6 +240,50 @@ test('Legit co-brand earn increase (no bundle language) still surfaces', () => {
   assert.equal(diff.changed[0].to.value, 3);
 });
 
+console.log('\nBase-rate downgrade guard (everything_else):');
+
+test('everything_else cut routes to review, not auto-PR', () => {
+  // The 2026-07-10 batch: Venture X 2→1, VentureOne 1.25→1, Bilt 2→1,
+  // U.S. Bank Shopper 1.5→1 — all misreads. A downward everything_else
+  // proposal must land in `downgraded` (review queue), never `changed`.
+  const current = [{ category: 'everything_else', value: 2, unit: 'points_per_dollar' }];
+  const proposed = [{ category: 'everything_else', value: 1, unit: 'points_per_dollar' }];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.changed.length, 0, 'downgrade must not be auto-PR\'d');
+  assert.equal(diff.downgraded.length, 1, 'downgrade must be routed to review');
+  assert.equal(diff.downgraded[0].from.value, 2);
+  assert.equal(diff.downgraded[0].to.value, 1);
+});
+
+test('fractional everything_else cut (1.25→1) also routes to review', () => {
+  const current = [{ category: 'everything_else', value: 1.25, unit: 'points_per_dollar' }];
+  const proposed = [{ category: 'everything_else', value: 1, unit: 'points_per_dollar' }];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.changed.length, 0);
+  assert.equal(diff.downgraded.length, 1);
+});
+
+test('everything_else INCREASE still auto-PRs (not treated as a downgrade)', () => {
+  // A plausible upward move (below the big-jump guard) is a real change and
+  // must still flow to `changed`.
+  const current = [{ category: 'everything_else', value: 1, unit: 'percent' }];
+  const proposed = [{ category: 'everything_else', value: 1.5, unit: 'percent' }];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.downgraded.length, 0, 'an increase is not a downgrade');
+  assert.equal(diff.changed.length, 1, 'a plausible base-rate increase still surfaces');
+  assert.equal(diff.changed[0].to.value, 1.5);
+});
+
+test('non-everything_else category cut still auto-PRs', () => {
+  // The guard is scoped to everything_else only — a bonus-category rate
+  // change is comparatively low-stakes and keeps auto-PRing.
+  const current = [{ category: 'dining', value: 4, unit: 'percent' }];
+  const proposed = [{ category: 'dining', value: 3, unit: 'percent' }];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.downgraded.length, 0);
+  assert.equal(diff.changed.length, 1, 'a bonus-category change still surfaces as a change');
+});
+
 console.log('\nFTF page-content validation:');
 
 test('pageEvidencesNoFtf returns false when page has fee-table line item', () => {


### PR DESCRIPTION
## Problem

The rewards/benefits checker auto-PRs any *changed* reward value. The 2026-07-10 dispatch run exposed a systematic failure mode: the extractor keeps misreading a card's flat base (`everything_else`) rate as **1x**. It opened four separate downgrade PRs in one batch, and every one was wrong:

| PR | Card | Bad change | Actual rate |
|---|---|---|---|
| #1624 | Bilt Palladium | 2 → 1 | 2x base (Bilt program overview) |
| #1625 | Capital One Venture X | 2 → 1 | 2x on everything |
| #1626 | Capital One VentureOne | 1.25 → 1 | 1.25x on everything |
| #1634 | US Bank Shopper Cash Rewards | 1.5 → 1 | 1.5% on all other |

Four cards, one bug. If any had merged unreviewed, it would have quietly corrupted that card's core earn data — the exact false-data risk the review queue exists to prevent.

## Fix

`diffRewards` already routes *added* and *removed* reward categories to the weekly human review issue rather than auto-PRing them; only a *changed value* went straight to a PR. This adds **Guard 5**: a downward `everything_else` proposal is collected into a new `downgraded` bucket that surfaces in the review issue instead of the auto-PR path.

- Real base-rate cuts do happen, but they're rare and high-stakes, so a human now confirms them against the live page.
- Capped/composed `everything_else` downgrades were already skipped silently by the existing cap guard; this sits after it and catches the uncapped case that was slipping through.
- **Increases and non-`everything_else` changes are unaffected** and still auto-PR as before.

`applyChangesToYaml` only ever reads `rewardsDiff.changed`, so a `downgraded` entry can never be written to YAML — verified.

## Tests

Adds four cases to the existing `diffRewards` suite (`node scripts/check-card-rewards-and-benefits.test.js`), all passing:
- `everything_else` cut (2→1) routes to `downgraded`, not `changed`
- fractional cut (1.25→1) routes to `downgraded`
- an `everything_else` *increase* still auto-PRs
- a non-`everything_else` (bonus category) cut still auto-PRs

Full suite is green.