### PR TITLE
feat(best-card-for): add NordVPN store page (first CJ Affiliate link)

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-11T13:01:07.318Z",
-  "count": 875,
+  "generated_at": "2026-07-11T14:26:21.082Z",
+  "count": 876,
   "stores": [
     {
       "name": "1-800 Contacts",
@@ -7797,6 +7797,24 @@
       ],
       "website": "https://www.nordstromrack.com",
       "intro": "Nordstrom Rack is the off-price arm of Nordstrom, with about 240 stores nationwide\nplus the nordstromrack.com site. The format sells the same designer and contemporary\nbrands as the parent department store at marked-down prices, sourced from previous\nseason inventory and direct buys. Nordstrom Rack purchases earn Nordy Club points\nalongside the main Nordstrom store, and the Nordstrom credit and debit cards\n(Visa-branded variants issued by TD Bank) earn elevated points at both Nordstrom and\nNordstrom Rack. Department-store category bonus cards also apply at the register.\n"
+    },
+    {
+      "name": "NordVPN",
+      "slug": "nordvpn",
+      "aliases": [
+        "Nord VPN",
+        "NordVPN.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://nordvpn.com",
+      "parent_company": "Nord Security",
+      "intro": "NordVPN is one of the world's most popular consumer VPN services, owned by Nord Security and\nsold as a monthly or multi-year subscription at nordvpn.com alongside add-ons like NordPass and\nNordLocker. There is no NordVPN co-brand credit card, and because it is a recurring online\nsubscription, the best pairing is a card with a strong online shopping multiplier or a reliable\nflat-rate cashback card. A few cards also treat recurring software subscriptions as a bonus\ncategory, and putting a multi-year plan on a card that is working toward a signup bonus is an\neasy way to chip away at the spend requirement.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-12814518",
+        "network": "cj"
+      }
     },
     {
       "name": "Northern Tool + Equipment",

--- a/data/affiliates.yaml
+++ b/data/affiliates.yaml
@@ -1471,3 +1471,11 @@ merchants:
   # Waterford
   waterford:
     url: "https://track.flexlinkspro.com/g.ashx?foid=156178.58339&trid=1552713.170660&foc=17&fot=9999&fos=6&url=https%3A%2F%2Fwww.waterford.com%2Fen-us"
+
+  # --- Added 2026-07-11 (CJ Affiliate approvals) ---
+  # First non-FlexOffers links: `network: cj` overrides the top-level default.
+  # CJ "CLICK URL" is complete and used as-is (no `&url=` homepage append).
+  # NordVPN
+  nordvpn:
+    url: "https://www.tkqlhce.com/click-101737824-12814518"
+    network: cj

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-11T13:01:07.318Z",
-  "count": 875,
+  "generated_at": "2026-07-11T14:26:21.082Z",
+  "count": 876,
   "stores": [
     {
       "name": "1-800 Contacts",
@@ -7797,6 +7797,24 @@
       ],
       "website": "https://www.nordstromrack.com",
       "intro": "Nordstrom Rack is the off-price arm of Nordstrom, with about 240 stores nationwide\nplus the nordstromrack.com site. The format sells the same designer and contemporary\nbrands as the parent department store at marked-down prices, sourced from previous\nseason inventory and direct buys. Nordstrom Rack purchases earn Nordy Club points\nalongside the main Nordstrom store, and the Nordstrom credit and debit cards\n(Visa-branded variants issued by TD Bank) earn elevated points at both Nordstrom and\nNordstrom Rack. Department-store category bonus cards also apply at the register.\n"
+    },
+    {
+      "name": "NordVPN",
+      "slug": "nordvpn",
+      "aliases": [
+        "Nord VPN",
+        "NordVPN.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://nordvpn.com",
+      "parent_company": "Nord Security",
+      "intro": "NordVPN is one of the world's most popular consumer VPN services, owned by Nord Security and\nsold as a monthly or multi-year subscription at nordvpn.com alongside add-ons like NordPass and\nNordLocker. There is no NordVPN co-brand credit card, and because it is a recurring online\nsubscription, the best pairing is a card with a strong online shopping multiplier or a reliable\nflat-rate cashback card. A few cards also treat recurring software subscriptions as a bonus\ncategory, and putting a multi-year plan on a card that is working toward a signup bonus is an\neasy way to chip away at the spend requirement.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-12814518",
+        "network": "cj"
+      }
     },
     {
       "name": "Northern Tool + Equipment",

--- a/data/stores/nordvpn.yaml
+++ b/data/stores/nordvpn.yaml
@@ -1,0 +1,17 @@
+name: "NordVPN"
+slug: "nordvpn"
+aliases:
+  - "Nord VPN"
+  - "NordVPN.com"
+categories:
+  - online_shopping
+website: "https://nordvpn.com"
+parent_company: "Nord Security"
+intro: |
+  NordVPN is one of the world's most popular consumer VPN services, owned by Nord Security and
+  sold as a monthly or multi-year subscription at nordvpn.com alongside add-ons like NordPass and
+  NordLocker. There is no NordVPN co-brand credit card, and because it is a recurring online
+  subscription, the best pairing is a card with a strong online shopping multiplier or a reliable
+  flat-rate cashback card. A few cards also treat recurring software subscriptions as a bonus
+  category, and putting a multi-year plan on a card that is working toward a signup bonus is an
+  easy way to chip away at the spend requirement.


### PR DESCRIPTION
Adds a `/best-card-for/nordvpn` page wired to a CJ Affiliate link. Per your call to include NordVPN from the CJ Tier A review.

## What's notable
This is the **first non-FlexOffers link** on the site. It uses the per-entry `network: cj` override that `affiliates.yaml` already supports (`entry.network || defaultNetwork` in `build-stores.js`). The CJ "CLICK URL" is complete and used as-is, with no `&url=` homepage append (that's a FlexOffers-only pattern).

- **Page:** `data/stores/nordvpn.yaml` — category `online_shopping`, parent Nord Security, intro framed around recurring subscriptions (no co-brand card; best on online-shopping/flat-rate cards; multi-year plan is easy signup-bonus spend). No em dashes.
- **Link:** `nordvpn` entry, `network: cj`, `url: https://www.tkqlhce.com/click-101737824-12814518`.

## Verification
- `npm run build:stores` → **876 stores / 407 affiliate links**; nordvpn carries `affiliate.network: cj`.
- Page returns **200**, CTA href is the exact CJ URL with `rel="sponsored nofollow noopener noreferrer"`, 12 cards ranked (#1 Blue Cash Everyday 3% online). Screenshot confirmed.

## Note
The generic ranking sub-copy ("earn at NordVPN both in-store and online") reads slightly oddly for a digital-only subscription, but it's shared page boilerplate, not NordVPN-specific. Can refine later if we add more subscription pages.