### PR TITLE
feat(best-card-for): add 56 CJ Affiliate store pages (Tier A+B include set)

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-11T14:26:21.082Z",
-  "count": 876,
+  "generated_at": "2026-07-11T14:38:33.665Z",
+  "count": 932,
   "stores": [
     {
       "name": "1-800 Contacts",
@@ -346,6 +346,22 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39673.4611686018427606343&trid=1552713.234784&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Aiper",
+      "slug": "aiper",
+      "aliases": [
+        "Aiper.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://aiper.com",
+      "intro": "Aiper is a fast-growing maker of cordless robotic pool cleaners and outdoor gear, sold\ndirect at aiper.com and through Amazon and home retailers. There is no Aiper co-brand credit\ncard, so purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-17262223",
+        "network": "cj"
       }
     },
     {
@@ -952,6 +968,39 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.45368.1000000115&trid=1552713.215196&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Ashampoo",
+      "slug": "ashampoo",
+      "aliases": [
+        "Ashampoo.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.ashampoo.com",
+      "intro": "Ashampoo is a German software company selling Windows utilities, photo, backup, and\nPC-optimization programs as downloads at ashampoo.com. There is no Ashampoo co-brand credit\ncard, so the best fit for a recurring online subscription is a card with a strong online\nshopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward\na signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15757364",
+        "network": "cj"
+      }
+    },
+    {
+      "name": "Ashimary Hair",
+      "slug": "ashimary-hair",
+      "aliases": [
+        "Ashimary",
+        "AshimaryHair.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.ashimaryhair.com",
+      "intro": "Ashimary Hair is a hair brand selling human-hair wigs, bundles, and lace-front extensions\ndirect at ashimaryhair.com. There is no Ashimary Hair co-brand credit card, so purchases\nearn the most on a card with a strong online shopping multiplier or a dependable flat-rate\ncashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17318232",
+        "network": "cj"
       }
     },
     {
@@ -2295,6 +2344,23 @@
       "intro": "Carl's Jr. is the western US half of CKE Restaurants, known for charbroiled burgers like\nthe Western Bacon Cheeseburger and the Famous Star. The chain runs about 1,000 domestic\nlocations, mostly west of the Mississippi, alongside sister brand Hardee's in the east.\nIn-store, drive-thru, and Carl's Jr. app purchases all code as fast-food/restaurants on\nevery credit card network, so cards paying elevated rates on dining (Chase Sapphire\nPreferred at 3x, Amex Gold at 4x, Capital One Savor at 3%) all earn their full bonus here.\n"
     },
     {
+      "name": "Carla Car Rental",
+      "slug": "carla-car-rental",
+      "aliases": [
+        "Carla",
+        "RentCarla.com"
+      ],
+      "categories": [
+        "car_rentals"
+      ],
+      "website": "https://rentcarla.com",
+      "intro": "Carla Car Rental is a car-rental booking app and site that compares rates across major\ncompanies like Hertz, Avis, Budget, and Fox at rentcarla.com. There is no Carla Car Rental\nco-brand credit card, so the best pairing is a card that earns bonus rewards on car rentals\nor general travel, and many travel cards also add rental-car coverage when you pay with\nthem.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-17075184",
+        "network": "cj"
+      }
+    },
+    {
       "name": "CarMax",
       "slug": "carmax",
       "categories": [
@@ -2589,6 +2655,22 @@
       "intro": "Chipotle is one of the largest U.S. fast-casual chains at about 3,500 locations, with a\nwell-developed digital ordering app and Chipotle Rewards loyalty program. All Chipotle\npurchases code as dining/restaurants on every card we track, so 3-5% dining-bonus cards\nearn at the same rate whether you order in-store, on the app, or for delivery direct\nfrom Chipotle.\n"
     },
     {
+      "name": "Choice Home Warranty",
+      "slug": "choice-home-warranty",
+      "aliases": [
+        "ChoiceHomeWarranty.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.choicehomewarranty.com",
+      "intro": "Choice Home Warranty is one of the largest US home-warranty providers, selling annual\nservice plans that cover repairs to home systems and appliances at choicehomewarranty.com.\nThere is no Choice Home Warranty co-brand credit card, so the best fit for a recurring\nonline subscription is a card with a strong online shopping multiplier or a flat-rate\ncashback card, and a multi-year plan is easy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-12337172",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Choice Hotels",
       "slug": "choice-hotels",
       "aliases": [
@@ -2687,6 +2769,23 @@
       }
     },
     {
+      "name": "Click & Grow",
+      "slug": "click-and-grow",
+      "aliases": [
+        "Click and Grow",
+        "ClickAndGrow.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.clickandgrow.com",
+      "intro": "Click & Grow is a maker of self-watering indoor smart gardens and plant pods for growing\nherbs and greens at home, sold at clickandgrow.com. There is no Click & Grow co-brand credit\ncard, so purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-11792320",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Clinique",
       "slug": "clinique",
       "categories": [
@@ -2765,6 +2864,23 @@
       }
     },
     {
+      "name": "Corel",
+      "slug": "corel",
+      "aliases": [
+        "Corel Corporation",
+        "Corel.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.corel.com",
+      "intro": "Corel is a long-running software company behind CorelDRAW, WordPerfect, and PaintShop Pro,\nsold as downloads and subscriptions at corel.com. There is no Corel co-brand credit card, so\nthe best fit for a recurring online subscription is a card with a strong online shopping\nmultiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup\nbonus.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-13647475",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Corkcicle",
       "slug": "corkcicle",
       "categories": [
@@ -2777,6 +2893,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13045.3363020&trid=1552713.245365&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "up to 40% off sale items"
+      }
+    },
+    {
+      "name": "CorneaCare",
+      "slug": "corneacare",
+      "aliases": [
+        "CorneaCare.co"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://corneacare.co",
+      "intro": "CorneaCare is a direct-to-consumer eye-care brand selling dry-eye relief products like\neyelid wipes, warm compresses, and omega-3 supplements on subscription. There is no\nCorneaCare co-brand credit card, so purchases earn the most on a card with a strong online\nshopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-17073223",
+        "network": "cj"
       }
     },
     {
@@ -2929,6 +3061,22 @@
       }
     },
     {
+      "name": "Crowned Skin",
+      "slug": "crowned-skin",
+      "aliases": [
+        "CrownedSkin.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://crownedskin.com",
+      "intro": "Crowned Skin is a direct-to-consumer men's fragrance brand, seen on Shark Tank, selling\nbody-butter and eau de parfum colognes at crownedskin.com and through Macy's and Amazon.\nThere is no Crowned Skin co-brand credit card, so purchases earn the most on a card with a\nstrong online shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-17208127",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Cruise America",
       "slug": "cruise-america",
       "categories": [
@@ -3055,6 +3203,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.52798.1000000070&trid=1552713.235285&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "10% off"
+      }
+    },
+    {
+      "name": "Daz 3D",
+      "slug": "daz-3d",
+      "aliases": [
+        "DAZ 3D",
+        "Daz3D.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.daz3d.com",
+      "intro": "Daz 3D is a 3D art platform offering Daz Studio software plus a marketplace of models,\nfigures, and assets for digital artists at daz3d.com. There is no Daz 3D co-brand credit\ncard, so the best fit for a recurring online subscription is a card with a strong online\nshopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward\na signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-11908275",
+        "network": "cj"
       }
     },
     {
@@ -3685,6 +3850,22 @@
       }
     },
     {
+      "name": "EaseUS",
+      "slug": "easeus",
+      "aliases": [
+        "EaseUS.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.easeus.com",
+      "intro": "EaseUS is a software company known for its data-recovery, backup, and partition tools, sold\nas downloads and subscriptions at easeus.com. There is no EaseUS co-brand credit card, so\nthe best fit for a recurring online subscription is a card with a strong online shopping\nmultiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup\nbonus.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-15414522",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Eastern Mountain Sports",
       "slug": "eastern-mountain-sports",
       "aliases": [
@@ -3811,6 +3992,23 @@
       ],
       "website": "https://www.elpolloloco.com",
       "intro": "El Pollo Loco is a Southwest fast-casual chain centered on citrus-marinated, fire-grilled chicken served with tortillas and salsas. Spending codes as dining or restaurants on most rewards cards, so a dining bonus is the right play. Catering placed through a separate corporate portal can occasionally code differently from an in-store order.\n"
+    },
+    {
+      "name": "Electronic Express",
+      "slug": "electronic-express",
+      "aliases": [
+        "ElectronicExpress.com"
+      ],
+      "categories": [
+        "electronics_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.electronicexpress.com",
+      "intro": "Electronic Express is a US consumer-electronics and appliance retailer with stores across\nTennessee and an online store at electronicexpress.com. There is no Electronic Express\nco-brand credit card, so a card with an electronics or online shopping bonus earns the most,\nand the same gear bought at a big-box electronics retailer can lean on that store's category\nrate.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-16960092",
+        "network": "cj"
+      }
     },
     {
       "name": "Emirates",
@@ -4296,6 +4494,22 @@
       }
     },
     {
+      "name": "Flowers Fast",
+      "slug": "flowers-fast",
+      "aliases": [
+        "FlowersFast.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.flowersfast.com",
+      "intro": "Flowers Fast is an online florist offering same-day and next-day flower, plant, and gift\ndelivery nationwide at flowersfast.com. There is no Flowers Fast co-brand credit card, so\npurchases earn the most on a card with a strong online shopping multiplier or a dependable\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-1035861",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Food Lion",
       "slug": "food-lion",
       "categories": [
@@ -4317,6 +4531,23 @@
       ],
       "website": "https://www.footlocker.com",
       "intro": "Foot Locker is the flagship sneaker and athletic apparel banner of Foot Locker Inc,\nwhich also runs Champs Sports, Kids Foot Locker, and WSS. The chain operates about\n900 U.S. stores plus footlocker.com. The FLX Rewards Visa from Bread Financial earns\nelevated XPoints on FLX-family purchases that can be redeemed for sneaker drops and\nshoes. General-purpose cards code Foot Locker as department store in person and online\nshopping for web orders.\n"
+    },
+    {
+      "name": "FOREO",
+      "slug": "foreo",
+      "aliases": [
+        "Foreo",
+        "Foreo.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.foreo.com",
+      "intro": "FOREO is a Swedish beauty-tech brand best known for its LUNA facial-cleansing devices and\nskincare tools, sold direct at foreo.com and through beauty retailers. There is no FOREO\nco-brand credit card, so purchases earn the most on a card with a strong online shopping\nmultiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15527432",
+        "network": "cj"
+      }
     },
     {
       "name": "Forever 21",
@@ -4358,6 +4589,23 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43381&trid=1552713.206854&foc=17&fot=9999&fos=6&url=https%3A%2F%2Ffoxrentacar.com",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "FragranceShop.com",
+      "slug": "fragranceshop",
+      "aliases": [
+        "FragranceShop",
+        "The Fragrance Shop"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.fragranceshop.com",
+      "intro": "FragranceShop.com is a US discount fragrance retailer selling authentic designer perfume,\ncologne, and gift sets online since 1998 at fragranceshop.com. There is no FragranceShop.com\nco-brand credit card, so purchases earn the most on a card with a strong online shopping\nmultiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-16942205",
+        "network": "cj"
       }
     },
     {
@@ -4482,6 +4730,23 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110101042.101161543&trid=1552713.207312&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "GameFly",
+      "slug": "gamefly",
+      "aliases": [
+        "GameFly.com"
+      ],
+      "categories": [
+        "entertainment",
+        "online_shopping"
+      ],
+      "website": "https://www.gamefly.com",
+      "intro": "GameFly is a video-game rental and subscription service that ships console games by mail and\nsells used titles at gamefly.com. There is no GameFly co-brand credit card, so a card that\npays a bonus on entertainment or general online shopping earns the most.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-10448329",
+        "network": "cj"
       }
     },
     {
@@ -5607,6 +5872,23 @@
       "intro": "In-N-Out Burger is a West Coast cult favorite founded in Baldwin Park, California\nin 1948, with around 400 locations across California, Nevada, Arizona, Utah,\nTexas, Oregon, Colorado, and Idaho. The minimalist menu of Double-Doubles, fries,\nand shakes plus the off-menu Animal Style ordering is the chain's identity. In-N-Out\ntransactions code as restaurants on Visa, Mastercard, and Amex networks.\n\nDining rewards cards capture In-N-Out well. The Amex Gold earns 4x points on U.S.\nrestaurants and is the top earner for frequent visitors, while the Chase Sapphire\nReserve pays 3x. No-annual-fee dining picks include the Capital One SavorOne at 3\npercent and Wells Fargo Autograph at 3x. In-N-Out does not run a customer rewards\nprogram, so credit card rewards are the only structured path to cash back.\n"
     },
     {
+      "name": "Infimobile",
+      "slug": "infimobile",
+      "aliases": [
+        "Infimobile.com"
+      ],
+      "categories": [
+        "cell_phone_providers",
+        "online_shopping"
+      ],
+      "website": "https://www.infimobile.com",
+      "intro": "Infimobile is a US mobile virtual network operator offering low-cost prepaid cell phone\nplans and devices at infimobile.com. There is no Infimobile co-brand credit card, so a few\ncards pay a bonus on phone or cell-provider bills, and otherwise a card with a strong\nrecurring-purchase or flat-rate rate works well.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-17169123",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Innisfree",
       "slug": "innisfree",
       "parent_company": "Amorepacific",
@@ -5633,6 +5915,23 @@
       ],
       "website": "https://www.instacart.com",
       "intro": "Instacart is the largest U.S. grocery delivery and pickup marketplace, partnering\nwith Costco, Wegmans, ALDI, Publix, and many regional chains. Orders placed through\nthe Instacart app or instacart.com generally code as groceries on most cards, but\nsome banks classify the charge as the underlying merchant — worth confirming on\na small order before relying on a 6% grocery card. Several premium cards (Sapphire\nReserve, Venture X) include Instacart+ memberships and statement credits.\n"
+    },
+    {
+      "name": "iolo",
+      "slug": "iolo",
+      "aliases": [
+        "iolo System Mechanic",
+        "System Mechanic"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.iolo.com",
+      "intro": "iolo is the maker of System Mechanic, PC tune-up and optimization software sold as a yearly\nsubscription at iolo.com. There is no iolo co-brand credit card, so the best fit for a\nrecurring online subscription is a card with a strong online shopping multiplier or a\nflat-rate cashback card, and a multi-year plan is easy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-15203012",
+        "network": "cj"
+      }
     },
     {
       "name": "IPSY",
@@ -6039,6 +6338,23 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.34908.2993656&trid=1552713.243968&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Keetsa",
+      "slug": "keetsa",
+      "aliases": [
+        "Keetsa.com"
+      ],
+      "categories": [
+        "furniture_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.keetsa.com",
+      "intro": "Keetsa is an eco-friendly mattress and bedding brand selling memory-foam and hybrid\nmattresses, pillows, and bases direct at keetsa.com and in a handful of showrooms. There is\nno Keetsa co-brand credit card, so for a big one-time mattress purchase the most rewarding\noptions are a furniture or home-goods category card, a strong online shopping bonus, or a\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-11326560",
+        "network": "cj"
       }
     },
     {
@@ -6501,6 +6817,22 @@
       }
     },
     {
+      "name": "Lighting New York",
+      "slug": "lighting-new-york",
+      "aliases": [
+        "LightingNewYork.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.lightingnewyork.com",
+      "intro": "Lighting New York is one of the largest online lighting retailers in the US, selling\nchandeliers, fixtures, fans, and lamps from hundreds of brands at lightingnewyork.com. There\nis no Lighting New York co-brand credit card, so purchases earn the most on a card with a\nstrong online shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17016697",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Lindt",
       "slug": "lindt-chocolatier",
       "aliases": [
@@ -6887,6 +7219,22 @@
       "intro": "Maggiano's Little Italy, owned by Brinker International (Chili's parent), runs about 50\nupscale-casual Italian restaurants known for family-style portions, the Chocolate Zuccotto\nCake, and the Classic Pastas program where guests take home a second pasta with each entree.\nMaggiano's transactions code as dining/restaurants on every credit card. With higher check\naverages than typical casual dining, top dining cards meaningfully boost return: Amex Gold\nat 4x, Chase Sapphire Reserve at 4x, Chase Sapphire Preferred at 3x, Capital One Savor at 3%.\n"
     },
     {
+      "name": "Magzter",
+      "slug": "magzter",
+      "aliases": [
+        "Magzter.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.magzter.com",
+      "intro": "Magzter is a digital newsstand offering unlimited access to thousands of magazines and\nnewspapers through the Magzter Gold subscription at magzter.com. There is no Magzter\nco-brand credit card, so the best fit for a recurring online subscription is a card with a\nstrong online shopping multiplier or a flat-rate cashback card, and a multi-year plan is\neasy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17205347",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Manscaped",
       "slug": "manscaped",
       "aliases": [
@@ -7216,6 +7564,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.26749.3868010&trid=1552713.197539&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "30% off your first purchase"
+      }
+    },
+    {
+      "name": "MFI Medical",
+      "slug": "mfi-medical",
+      "aliases": [
+        "MFIMedical.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://mfimedical.com",
+      "intro": "MFI Medical is an online retailer of medical equipment and supplies for clinics, home care,\nand professionals, selling exam, diagnostic, and mobility gear at mfimedical.com. There is\nno MFI Medical co-brand credit card, so purchases earn the most on a card with a strong\nonline shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-15887082",
+        "network": "cj"
       }
     },
     {
@@ -7777,6 +8141,23 @@
       "intro": "The Nintendo eShop is the digital storefront for Switch games, DLC, and add-on content, payable by card or prepaid eShop credit. Purchases code as online shopping or digital entertainment, so a card with an online-purchase bonus earns the most. Buying discounted eShop gift cards from a grocery or warehouse store first can beat charging the eShop directly.\n"
     },
     {
+      "name": "NordPass",
+      "slug": "nordpass",
+      "aliases": [
+        "NordPass.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://nordpass.com",
+      "parent_company": "Nord Security",
+      "intro": "NordPass is a password manager from Nord Security, sold as a personal or family subscription\nat nordpass.com alongside NordVPN and NordLocker. There is no NordPass co-brand credit card,\nso the best fit for a recurring online subscription is a card with a strong online shopping\nmultiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup\nbonus.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-13868703",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Nordstrom",
       "slug": "nordstrom",
       "aliases": [
@@ -8098,6 +8479,22 @@
       }
     },
     {
+      "name": "Ovago",
+      "slug": "ovago",
+      "aliases": [
+        "OVAGO.com"
+      ],
+      "categories": [
+        "travel"
+      ],
+      "website": "https://www.ovago.com",
+      "intro": "Ovago is an online travel agency specializing in discounted airline tickets, with flight\nbooking and support handled at ovago.com. There is no Ovago co-brand credit card, so the\nbest pairing is a card that earns bonus rewards on travel, which usually covers flights and\ntrips booked through an online travel agency.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-15809797",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Overstock",
       "slug": "overstock",
       "aliases": [
@@ -8185,6 +8582,23 @@
       ],
       "website": "https://www.pandaexpress.com",
       "intro": "Panda Express is the largest American Chinese fast-food chain, best known for its Orange Chicken and mall-and-highway locations nationwide. Purchases code as dining or restaurants on most rewards cards, so a dining multiplier captures the value. Combo orders at a food court counter still register under the same restaurant code as standalone stores.\n"
+    },
+    {
+      "name": "Panda Office",
+      "slug": "panda-office",
+      "aliases": [
+        "PandaOffice",
+        "PandaOffice.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.pandaoffice.com",
+      "intro": "Panda Office is a data-recovery and file-repair software company selling downloadable tools\nfor recovering lost files and photos at pandaoffice.com. There is no Panda Office co-brand\ncredit card, so the best fit for a recurring online subscription is a card with a strong\nonline shopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend\ntoward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-17175455",
+        "network": "cj"
+      }
     },
     {
       "name": "Pandora",
@@ -8358,6 +8772,22 @@
       "intro": "Pep Boys operates roughly 800 auto parts and service centers across the United\nStates, combining a parts counter with tire installation, oil changes, brake work,\nand full-service mechanical repair. Most credit cards code Pep Boys purchases as\nauto services or general retail rather than as a dedicated bonus category, so\nflat-rate cards like the Citi Double Cash often deliver the cleanest 2 percent.\n\nCards with selectable categories can reach Pep Boys when the right bucket is\nchosen. Bank of America Customized Cash and U.S. Bank Cash+ both have wider\ncategories that may capture auto service spending, and Citi Custom Cash pays 5\npercent on the top eligible spending category for cardholders whose monthly spend\nskews toward vehicle maintenance.\n"
     },
     {
+      "name": "Perfumania",
+      "slug": "perfumania",
+      "aliases": [
+        "Perfumania.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.perfumania.com",
+      "intro": "Perfumania is a US discount fragrance retailer selling designer perfume and cologne online\nand in outlet stores at perfumania.com. There is no Perfumania co-brand credit card, so\npurchases earn the most on a card with a strong online shopping multiplier or a dependable\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17277235",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Perricone MD",
       "slug": "perricone-md",
       "aliases": [
@@ -8372,6 +8802,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.21122.3969291&trid=1552713.178759&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "50% off with code EYE50"
+      }
+    },
+    {
+      "name": "Personalabs",
+      "slug": "personalabs",
+      "aliases": [
+        "Personalabs.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.personalabs.com",
+      "intro": "Personalabs is a direct-to-consumer lab-testing service that lets people order their own\nblood and health tests online without a doctor visit at personalabs.com. There is no\nPersonalabs co-brand credit card, so purchases earn the most on a card with a strong online\nshopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15144052",
+        "network": "cj"
       }
     },
     {
@@ -8515,6 +8961,23 @@
       ],
       "website": "https://www.philzcoffee.com",
       "intro": "Philz Coffee is a San Francisco-born specialty chain of about 70 cafes across California,\nthe East Coast, and the DC region, built around custom pour-over brews like Tesora, Ether,\nand the Mint Mojito iced coffee. Orders placed in-cafe, in the Philz app, or ahead via\ncurbside all code as dining/restaurants. Top dining cards earn their full rate at Philz:\nAmex Gold pays 4x Membership Rewards, Chase Sapphire Reserve pays 4x Ultimate Rewards,\nand Capital One SavorOne pays 3% unlimited cash back on every order.\n"
+    },
+    {
+      "name": "Phone.com",
+      "slug": "phone-com",
+      "aliases": [
+        "Phone.com"
+      ],
+      "categories": [
+        "cell_phone_providers",
+        "online_shopping"
+      ],
+      "website": "https://www.phone.com",
+      "intro": "Phone.com is a VoIP business phone service offering virtual numbers, calling, and video\nmeetings on monthly plans at phone.com. There is no Phone.com co-brand credit card, so a few\ncards pay a bonus on phone or cell-provider bills, and otherwise a card with a strong\nrecurring-purchase or flat-rate rate works well.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-10686248",
+        "network": "cj"
+      }
     },
     {
       "name": "Pick 'n Save",
@@ -8665,6 +9128,23 @@
       ],
       "website": "https://www.powells.com",
       "intro": "Powell's Books, the famed Portland independent, sells new and used titles in store and through powells.com. Online orders generally code as online shopping, while the physical City of Books often rings up as general retail. A flat-rate card or one with an online-shopping bonus is the practical choice for book hauls.\n"
+    },
+    {
+      "name": "Power Systems",
+      "slug": "power-systems",
+      "aliases": [
+        "Power-Systems.com"
+      ],
+      "categories": [
+        "sporting_goods",
+        "online_shopping"
+      ],
+      "website": "https://www.power-systems.com",
+      "intro": "Power Systems is a supplier of strength, conditioning, and fitness equipment for gyms,\ntrainers, and home use, sold at power-systems.com. There is no Power Systems co-brand credit\ncard, so a card that pays a bonus on sporting goods or general online shopping is the best\nfit.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-13824793",
+        "network": "cj"
+      }
     },
     {
       "name": "Price Chopper",
@@ -9164,6 +9644,23 @@
       "intro": "Revolve is an online fashion retailer targeting younger shoppers with trend-driven clothing, shoes, and accessories. Purchases code as online shopping, and while it can resemble a department store, there is no broad apparel bonus on most cards. A flat-rate or online-retail card is the most reliable way to earn on your orders.\n"
     },
     {
+      "name": "Rexing",
+      "slug": "rexing",
+      "aliases": [
+        "RexingUSA",
+        "Rexing USA"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.rexingusa.com",
+      "intro": "Rexing is a US brand of dash cams and vehicle electronics, selling front-and-rear recorders,\nmirror cams, and accessories at rexingusa.com. There is no Rexing co-brand credit card, so\npurchases earn the most on a card with a strong online shopping multiplier or a dependable\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-14503215",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Ria Money Transfer",
       "slug": "ria-money-transfer",
       "aliases": [
@@ -9377,6 +9874,22 @@
       ],
       "website": "https://www.ruralking.com",
       "intro": "Rural King is a farm-and-home chain selling everything from feed and tools to firearms and apparel, and its stores can code as a home-improvement or farm-supply merchant or as general retail. A home-improvement bonus may apply but is not assured given the mixed inventory. Purchases at ruralking.com generally code as online shopping, so a flat-rate or online card is a safe default.\n"
+    },
+    {
+      "name": "Russell Stover",
+      "slug": "russell-stover",
+      "aliases": [
+        "RussellStover.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.russellstover.com",
+      "intro": "Russell Stover is a classic American chocolate brand known for its boxed chocolates and\nsugar-free candies, sold direct at russellstover.com and in grocery and drug stores. There\nis no Russell Stover co-brand credit card, so purchases earn the most on a card with a\nstrong online shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-12986504",
+        "network": "cj"
+      }
     },
     {
       "name": "Ruth's Chris Steak House",
@@ -9612,6 +10125,23 @@
       }
     },
     {
+      "name": "Seats.aero",
+      "slug": "seats-aero",
+      "aliases": [
+        "SeatsAero",
+        "Seats aero"
+      ],
+      "categories": [
+        "travel"
+      ],
+      "website": "https://seats.aero",
+      "intro": "Seats.aero is an award-travel search tool that scans airline loyalty programs for available\naward flights, offered as a Pro subscription at seats.aero. There is no Seats.aero co-brand\ncredit card, so the best fit for a recurring online subscription is a card with a strong\nonline shopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend\ntoward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17072392",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Seed Health",
       "slug": "seed-health",
       "categories": [
@@ -9730,6 +10260,23 @@
       "intro": "Shell is one of the largest U.S. gasoline retailers by station count (about 13,000\nlocations), with a Fuel Rewards loyalty program tied to the Shell app. Shell pumps code\ncleanly as gas on every card we track. The Shell Fuel Rewards program offers stackable\nper-gallon discounts that are calculated separately from card cashback.\n"
     },
     {
+      "name": "Shelving Inc",
+      "slug": "shelving-inc",
+      "aliases": [
+        "Shelving.com",
+        "Shelving Inc."
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.shelving.com",
+      "intro": "Shelving Inc is an online retailer of shelving, storage, and organization systems for home,\ngarage, and commercial use at shelving.com. There is no Shelving Inc co-brand credit card,\nso purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-14045900",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Sherwin-Williams",
       "slug": "sherwin-williams",
       "categories": [
@@ -9845,6 +10392,22 @@
       "intro": "Sierra, the off-price outdoor and active brand under TJX, sells discounted gear and apparel that often codes as a department store at its stores, so supermarket and restaurant bonuses do not apply. Shopping sierra.com normally codes as online shopping. With deals already built in, pair a card that rewards online spending or carries a reliable flat rate.\n"
     },
     {
+      "name": "SilverRushStyle",
+      "slug": "silverrushstyle",
+      "aliases": [
+        "Silver Rush Style"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.silverrushstyle.com",
+      "intro": "SilverRushStyle is an online jeweler specializing in handcrafted sterling silver and\ngemstone jewelry at silverrushstyle.com. There is no SilverRushStyle co-brand credit card,\nso purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-11260306",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Sinclair",
       "slug": "sinclair",
       "aliases": [
@@ -9919,6 +10482,23 @@
       }
     },
     {
+      "name": "Sleep & Beyond",
+      "slug": "sleep-and-beyond",
+      "aliases": [
+        "Sleep and Beyond",
+        "SleepAndBeyond.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.sleepandbeyond.com",
+      "intro": "Sleep & Beyond is a maker of organic and natural bedding, including wool mattress toppers,\npillows, and sheets, sold direct at sleepandbeyond.com. There is no Sleep & Beyond co-brand\ncredit card, so purchases earn the most on a card with a strong online shopping multiplier\nor a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-13814567",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Sleep Number",
       "slug": "sleep-number",
       "categories": [
@@ -9982,6 +10562,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.54145.1000000010&trid=1552713.245768&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "70% off"
+      }
+    },
+    {
+      "name": "Soccer Garage",
+      "slug": "soccer-garage",
+      "aliases": [
+        "SoccerGarage.com"
+      ],
+      "categories": [
+        "sporting_goods",
+        "online_shopping"
+      ],
+      "website": "https://www.soccergarage.com",
+      "intro": "Soccer Garage is an online soccer retailer selling cleats, jerseys, goalkeeper gear, and\nteam equipment at soccergarage.com. There is no Soccer Garage co-brand credit card, so a\ncard that pays a bonus on sporting goods or general online shopping is the best fit.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-10479704",
+        "network": "cj"
       }
     },
     {
@@ -10354,6 +10951,22 @@
       "intro": "Subway is the largest restaurant chain in the U.S. by store count, with about\n20,000 domestic locations. Charges code as dining on every card we track. Standard\nhigh-bonus dining cards (Amex Gold 4x capped, Sapphire Preferred 3x, Capital One\nSavorOne 3%) are the obvious pairings. The MyWay Rewards loyalty program and\nrecurring digital coupons in the Subway app stack on top of card bonuses.\n"
     },
     {
+      "name": "Sucuri",
+      "slug": "sucuri",
+      "aliases": [
+        "Sucuri.net"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://sucuri.net",
+      "intro": "Sucuri is a website-security service offering malware cleanup, firewall, and monitoring on\nannual subscriptions at sucuri.net. There is no Sucuri co-brand credit card, so the best fit\nfor a recurring online subscription is a card with a strong online shopping multiplier or a\nflat-rate cashback card, and a multi-year plan is easy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-13942194",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Summit Racing",
       "slug": "summit-racing",
       "aliases": [
@@ -10388,6 +11001,23 @@
       "intro": "Sunbasket ships organic meal kits and prepared meals with an emphasis on clean, dietary-friendly ingredients. Even though it is food, the charges process as an online subscription and typically code as online shopping rather than groceries, so a card with an online or everyday bonus usually beats chasing a supermarket category.\n"
     },
     {
+      "name": "Sunber Hair",
+      "slug": "sunber-hair",
+      "aliases": [
+        "Sunber",
+        "SunberHair.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.sunberhair.com",
+      "intro": "Sunber Hair is a hair brand selling human-hair wigs, weaves, and extensions direct at\nsunberhair.com. There is no Sunber Hair co-brand credit card, so purchases earn the most on\na card with a strong online shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15898110",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Sunoco",
       "slug": "sunoco",
       "aliases": [
@@ -10398,6 +11028,40 @@
       ],
       "website": "https://www.sunoco.com",
       "intro": "Sunoco-branded stations cover about 5,200 U.S. locations primarily across the East\nand Midwest. Pumps code cleanly as gas on every card we track. The Sunoco Rewards\napp stacks 5-10 cents per gallon savings on top of any card's bonus rate. There's\na Sunoco Rewards co-branded credit card, but in absolute cashback most 4-5%\ngeneral gas cards beat it.\n"
+    },
+    {
+      "name": "Surfshark",
+      "slug": "surfshark",
+      "aliases": [
+        "Surfshark VPN",
+        "Surfshark.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://surfshark.com",
+      "intro": "Surfshark is a popular consumer VPN service sold as a monthly or multi-year subscription at\nsurfshark.com alongside antivirus and identity-protection add-ons. There is no Surfshark\nco-brand credit card, so the best fit for a recurring online subscription is a card with a\nstrong online shopping multiplier or a flat-rate cashback card, and a multi-year plan is\neasy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15438544",
+        "network": "cj"
+      }
+    },
+    {
+      "name": "SwitchBot",
+      "slug": "switchbot",
+      "aliases": [
+        "Switch-Bot",
+        "SwitchBot.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.switch-bot.com",
+      "intro": "SwitchBot is a smart-home brand making automated blinds, locks, hubs, and robot vacuums,\nsold direct at switch-bot.com and through Amazon. There is no SwitchBot co-brand credit\ncard, so purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-15037301",
+        "network": "cj"
+      }
     },
     {
       "name": "T-Mobile",
@@ -10502,6 +11166,40 @@
       }
     },
     {
+      "name": "TEAC",
+      "slug": "teac",
+      "aliases": [
+        "TEAC USA",
+        "TEAC America"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://teac.com",
+      "intro": "TEAC is a Japanese audio-electronics brand making turntables, CD players, and hi-fi\ncomponents, sold in the US at teac.com. There is no TEAC co-brand credit card, so purchases\nearn the most on a card with a strong online shopping multiplier or a dependable flat-rate\ncashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-15919843",
+        "network": "cj"
+      }
+    },
+    {
+      "name": "Tech For Less",
+      "slug": "tech-for-less",
+      "aliases": [
+        "TechForLess.com"
+      ],
+      "categories": [
+        "electronics_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.techforless.com",
+      "intro": "Tech For Less is an online retailer of discounted new, refurbished, and open-box electronics\nand computers at techforless.com. There is no Tech For Less co-brand credit card, so a card\nwith an electronics or online shopping bonus earns the most, and the same gear bought at a\nbig-box electronics retailer can lean on that store's category rate.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-13067706",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Tecovas",
       "slug": "tecovas",
       "categories": [
@@ -10542,6 +11240,22 @@
       ],
       "website": "https://www.temu.com",
       "intro": "Temu is a U.S.-facing online marketplace owned by Chinese e-commerce giant PDD\nHoldings, launched stateside in 2022 and aggressively marketed on ultra-low prices and\ndirect-from-manufacturer shipping. Purchases typically code as online shopping or\nmerchandise, so a card with an online-shopping category bonus (Capital One SavorOne\npromotions, Chase Freedom Flex when activated, Citi Custom Cash on online shopping\nmonth) will earn its full multiplier. Temu has no co-brand credit card, so the best\nearn comes from a general online-shopping bonus.\n"
+    },
+    {
+      "name": "Tenergy",
+      "slug": "tenergy",
+      "aliases": [
+        "Tenergy.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://power.tenergy.com",
+      "intro": "Tenergy is a maker of rechargeable batteries, chargers, and small consumer electronics, sold\ndirect and through Amazon. There is no Tenergy co-brand credit card, so purchases earn the\nmost on a card with a strong online shopping multiplier or a dependable flat-rate cashback\ncard.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-14512046",
+        "network": "cj"
+      }
     },
     {
       "name": "Teva",
@@ -10727,6 +11441,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.8270.887764&trid=1552713.245338&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "the $25 new member credit"
+      }
+    },
+    {
+      "name": "The Tight Spot",
+      "slug": "the-tight-spot",
+      "aliases": [
+        "TheTightSpot.com"
+      ],
+      "categories": [
+        "select_clothing",
+        "online_shopping"
+      ],
+      "website": "https://www.thetightspot.com",
+      "intro": "The Tight Spot is an online hosiery boutique carrying thousands of styles of tights,\npantyhose, and stockings from brands like Wolford at thetightspot.com. There is no The Tight\nSpot co-brand credit card, so purchases earn the most on a card with a clothing or online\nshopping category bonus.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-17147704",
+        "network": "cj"
       }
     },
     {
@@ -10944,6 +11675,23 @@
       }
     },
     {
+      "name": "TP-Link",
+      "slug": "tp-link",
+      "aliases": [
+        "TP-Link USA",
+        "TPLink"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.tp-link.com",
+      "intro": "TP-Link is one of the world's largest makers of Wi-Fi routers, mesh systems, and networking\ngear, sold direct and through electronics retailers under its TP-Link and Deco lines. There\nis no TP-Link co-brand credit card, so purchases earn the most on a card with a strong\nonline shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-15624194",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Tractor Supply Co",
       "slug": "tractor-supply",
       "aliases": [
@@ -11007,6 +11755,23 @@
       }
     },
     {
+      "name": "Trampoline Parts and Supply",
+      "slug": "trampoline-parts-and-supply",
+      "aliases": [
+        "TrampolinePartsAndSupply.com",
+        "TPS"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.trampolinepartsandsupply.com",
+      "intro": "Trampoline Parts and Supply is a specialty retailer of replacement trampoline mats, springs,\npads, and nets for most trampoline brands, sold online. There is no Trampoline Parts and\nSupply co-brand credit card, so purchases earn the most on a card with a strong online\nshopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-13124125",
+        "network": "cj"
+      }
+    },
+    {
       "name": "TransUnion",
       "slug": "transunion-credit-monitoring",
       "aliases": [
@@ -11030,6 +11795,22 @@
       ],
       "website": "https://www.travelocity.com",
       "intro": "Travelocity is an Expedia Group online travel agency, long recognized by its Roaming Gnome mascot. Reservations generally code as travel and earn on cards carrying a travel bonus, but a flight or hotel within a package may sometimes code under the actual provider. A travel card with a broad travel category is the dependable choice for these purchases.\n"
+    },
+    {
+      "name": "Treat My UTI",
+      "slug": "treat-my-uti",
+      "aliases": [
+        "TreatMyUTI.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.treatmyuti.com",
+      "intro": "Treat My UTI is a direct-to-consumer wellness brand selling urinary-tract and vaginal-health\nsupplements and test strips at treatmyuti.com. There is no Treat My UTI co-brand credit\ncard, so purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15813416",
+        "network": "cj"
+      }
     },
     {
       "name": "Trip.com",
@@ -11209,6 +11990,23 @@
       "intro": "Ulta Beauty is the largest U.S. beauty retailer by store count at about 1,400 locations,\ncovering both prestige and mass-market lines under one roof. Like Sephora, Ulta in-store\npurchases don't trigger a dedicated card category, so the right card there is usually a\nstrong flat-rate. Online purchases at ulta.com code as online shopping. Ultamate Rewards\nloyalty points stack with card cashback.\n"
     },
     {
+      "name": "UnbeatableSale",
+      "slug": "unbeatablesale",
+      "aliases": [
+        "UnbeatableSale.com"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.unbeatablesale.com",
+      "intro": "UnbeatableSale is an online discount marketplace carrying a wide range of home, health, and\ngeneral-merchandise products at unbeatablesale.com. There is no UnbeatableSale co-brand\ncredit card, so a card with a department store or online shopping bonus earns the most.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-10388384",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Under Armour",
       "slug": "under-armour",
       "categories": [
@@ -11217,6 +12015,23 @@
       ],
       "website": "https://www.underarmour.com",
       "intro": "Under Armour is a Baltimore-based athletic apparel and footwear brand sold through\nabout 175 U.S. Brand House and Factory House stores along with a strong online channel\nat underarmour.com. Direct purchases typically code as department store at the\nregister and online shopping for web orders, while Under Armour gear bought at Dick's\nor other retailers codes under that store. The free UA Rewards program layers on top\nof credit card earnings, and there is no Under Armour branded credit card.\n"
+    },
+    {
+      "name": "UNice",
+      "slug": "unice",
+      "aliases": [
+        "UNice Hair",
+        "UNice.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.unice.com",
+      "intro": "UNice is a popular hair brand selling human-hair wigs, bundles, and extensions direct at\nunice.com and through Amazon. There is no UNice co-brand credit card, so purchases earn the\nmost on a card with a strong online shopping multiplier or a dependable flat-rate cashback\ncard.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-15222018",
+        "network": "cj"
+      }
     },
     {
       "name": "Uniqlo",
@@ -11265,6 +12080,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11299.2922125&trid=1552713.215260&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "20% off for new customers"
+      }
+    },
+    {
+      "name": "UntilGone",
+      "slug": "untilgone",
+      "aliases": [
+        "UntilGone.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.untilgone.com",
+      "intro": "UntilGone is an online daily-deals retailer selling discounted electronics, home goods, and\ngadgets in limited-time offers at untilgone.com. There is no UntilGone co-brand credit card,\nso purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-15292979",
+        "network": "cj"
       }
     },
     {
@@ -11444,6 +12275,23 @@
       }
     },
     {
+      "name": "VIP Cars",
+      "slug": "vip-cars",
+      "aliases": [
+        "VIPCars",
+        "VIP Cars Global"
+      ],
+      "categories": [
+        "car_rentals"
+      ],
+      "website": "https://www.vipcars.com",
+      "intro": "VIP Cars is a car-rental booking service that compares rates from suppliers at airports and\ncities worldwide at vipcars.com. There is no VIP Cars co-brand credit card, so the best\npairing is a card that earns bonus rewards on car rentals or general travel, and many travel\ncards also add rental-car coverage when you pay with them.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-17236308",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Virgin Experience Gifts",
       "slug": "virgin-experience-gifts",
       "categories": [
@@ -11510,6 +12358,38 @@
       ],
       "website": "https://www.vrbo.com",
       "intro": "Vrbo is the second-largest U.S. vacation-rental marketplace after Airbnb, owned\nby Expedia Group. Bookings code as travel on every card we track and as hotels\non a few. Unlike Airbnb, Vrbo focuses exclusively on whole-home rentals (no\nshared spaces). Vrbo bookings count for the Sapphire Reserve and Venture X\ntravel-credit categories. Booking through a card's travel portal earns the\nportal multiplier but typically loses Vrbo Boost host-program perks.\n"
+    },
+    {
+      "name": "VY Jewelry",
+      "slug": "vy-jewelry",
+      "aliases": [
+        "VYJewelry"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://vyjewelry.shop",
+      "intro": "VY Jewelry is a jewelry brand selling 925 sterling silver rings, necklaces, and bracelets\nfor men and women at vyjewelry.shop and through Amazon. There is no VY Jewelry co-brand\ncredit card, so purchases earn the most on a card with a strong online shopping multiplier\nor a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17056490",
+        "network": "cj"
+      }
+    },
+    {
+      "name": "WA Production",
+      "slug": "wa-production",
+      "aliases": [
+        "WAProduction"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.waproduction.com",
+      "intro": "WA Production is a music-production company selling audio plugins, sample packs, and\ntutorials for producers at waproduction.com. There is no WA Production co-brand credit card,\nso the best fit for a recurring online subscription is a card with a strong online shopping\nmultiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup\nbonus.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-14579755",
+        "network": "cj"
+      }
     },
     {
       "name": "Wacoal",
@@ -11796,6 +12676,24 @@
       }
     },
     {
+      "name": "Winebasket",
+      "slug": "winebasket",
+      "aliases": [
+        "Winebasket.com",
+        "Babybasket",
+        "Capalbo's"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.winebasket.com",
+      "intro": "Winebasket is an online gift retailer selling wine, champagne, and gourmet gift baskets for\noccasions at winebasket.com. There is no Winebasket co-brand credit card, so purchases earn\nthe most on a card with a strong online shopping multiplier or a dependable flat-rate\ncashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-14518164",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Wingstop",
       "slug": "wingstop",
       "categories": [
@@ -11857,6 +12755,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25202.3966290&trid=1552713.193401&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "buy one get one 50% off shorts"
+      }
+    },
+    {
+      "name": "Wristband Express",
+      "slug": "wristband-express",
+      "aliases": [
+        "WristbandExpress.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.wristbandexpress.com",
+      "intro": "Wristband Express is an online seller of custom silicone wristbands, event bracelets, and\nlanyards for fundraisers, parties, and businesses at wristbandexpress.com. There is no\nWristband Express co-brand credit card, so purchases earn the most on a card with a strong\nonline shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-11023934",
+        "network": "cj"
       }
     },
     {
@@ -11965,6 +12879,22 @@
       ],
       "website": "https://www.zaxbys.com",
       "intro": "Zaxby's is a Georgia-based chicken-finger and wing quick-service chain with over\n900 restaurants concentrated in the Southeast. The menu features Chicken Finger\nPlates, Boneless and Traditional Wings, Zalads, and a lineup of signature sauces\nlike Zax Sauce and Tongue Torch. Zaxby's transactions code as restaurants on Visa,\nMastercard, and Amex networks.\n\nThe Amex Gold earns 4x points on U.S. restaurants and tops the cards for Zaxby's\nspending, while the Chase Sapphire Reserve pays 3x on dining and adds purchase\nprotection. The Capital One SavorOne and Wells Fargo Autograph each pay 3 percent\nor 3x on restaurants with no annual fee. The Zax Rewardz app program adds visit\npoints that stack with credit card cash back on every Big Zax Snak run.\n"
+    },
+    {
+      "name": "zChocolat",
+      "slug": "zchocolat",
+      "aliases": [
+        "zChocolat.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.zchocolat.com",
+      "intro": "zChocolat is a luxury chocolate brand offering French assortments in mahogany gift boxes\nwith worldwide delivery at zchocolat.com. There is no zChocolat co-brand credit card, so\npurchases earn the most on a card with a strong online shopping multiplier or a dependable\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-10020803",
+        "network": "cj"
+      }
     }
   ]
 }

--- a/data/affiliates.yaml
+++ b/data/affiliates.yaml
@@ -1479,3 +1479,230 @@ merchants:
   nordvpn:
     url: "https://www.tkqlhce.com/click-101737824-12814518"
     network: cj
+
+  # --- Added 2026-07-11 (CJ Affiliate Tier A+B new store pages) ---
+  # network: cj on each entry; CJ CLICK URLs are complete, used as-is.
+  # Aiper
+  aiper:
+    url: "https://www.kqzyfj.com/click-101737824-17262223"
+    network: cj
+  # Ashampoo
+  ashampoo:
+    url: "https://www.jdoqocy.com/click-101737824-15757364"
+    network: cj
+  # Ashimary Hair
+  ashimary-hair:
+    url: "https://www.anrdoezrs.net/click-101737824-17318232"
+    network: cj
+  # Carla Car Rental
+  carla-car-rental:
+    url: "https://www.dpbolvw.net/click-101737824-17075184"
+    network: cj
+  # Choice Home Warranty
+  choice-home-warranty:
+    url: "https://www.tkqlhce.com/click-101737824-12337172"
+    network: cj
+  # Click & Grow
+  click-and-grow:
+    url: "https://www.dpbolvw.net/click-101737824-11792320"
+    network: cj
+  # Corel
+  corel:
+    url: "https://www.kqzyfj.com/click-101737824-13647475"
+    network: cj
+  # CorneaCare
+  corneacare:
+    url: "https://www.tkqlhce.com/click-101737824-17073223"
+    network: cj
+  # Crowned Skin
+  crowned-skin:
+    url: "https://www.tkqlhce.com/click-101737824-17208127"
+    network: cj
+  # Daz 3D
+  daz-3d:
+    url: "https://www.kqzyfj.com/click-101737824-11908275"
+    network: cj
+  # EaseUS
+  easeus:
+    url: "https://www.tkqlhce.com/click-101737824-15414522"
+    network: cj
+  # Electronic Express
+  electronic-express:
+    url: "https://www.jdoqocy.com/click-101737824-16960092"
+    network: cj
+  # Flowers Fast
+  flowers-fast:
+    url: "https://www.anrdoezrs.net/click-101737824-1035861"
+    network: cj
+  # FOREO
+  foreo:
+    url: "https://www.jdoqocy.com/click-101737824-15527432"
+    network: cj
+  # FragranceShop.com
+  fragranceshop:
+    url: "https://www.tkqlhce.com/click-101737824-16942205"
+    network: cj
+  # GameFly
+  gamefly:
+    url: "https://www.anrdoezrs.net/click-101737824-10448329"
+    network: cj
+  # Infimobile
+  infimobile:
+    url: "https://www.kqzyfj.com/click-101737824-17169123"
+    network: cj
+  # iolo
+  iolo:
+    url: "https://www.anrdoezrs.net/click-101737824-15203012"
+    network: cj
+  # Keetsa
+  keetsa:
+    url: "https://www.dpbolvw.net/click-101737824-11326560"
+    network: cj
+  # Lighting New York
+  lighting-new-york:
+    url: "https://www.anrdoezrs.net/click-101737824-17016697"
+    network: cj
+  # Magzter
+  magzter:
+    url: "https://www.anrdoezrs.net/click-101737824-17205347"
+    network: cj
+  # MFI Medical
+  mfi-medical:
+    url: "https://www.kqzyfj.com/click-101737824-15887082"
+    network: cj
+  # NordPass
+  nordpass:
+    url: "https://www.tkqlhce.com/click-101737824-13868703"
+    network: cj
+  # Ovago
+  ovago:
+    url: "https://www.dpbolvw.net/click-101737824-15809797"
+    network: cj
+  # Panda Office
+  panda-office:
+    url: "https://www.tkqlhce.com/click-101737824-17175455"
+    network: cj
+  # Perfumania
+  perfumania:
+    url: "https://www.anrdoezrs.net/click-101737824-17277235"
+    network: cj
+  # Personalabs
+  personalabs:
+    url: "https://www.jdoqocy.com/click-101737824-15144052"
+    network: cj
+  # Phone.com
+  phone-com:
+    url: "https://www.dpbolvw.net/click-101737824-10686248"
+    network: cj
+  # Power Systems
+  power-systems:
+    url: "https://www.anrdoezrs.net/click-101737824-13824793"
+    network: cj
+  # Rexing
+  rexing:
+    url: "https://www.anrdoezrs.net/click-101737824-14503215"
+    network: cj
+  # Russell Stover
+  russell-stover:
+    url: "https://www.tkqlhce.com/click-101737824-12986504"
+    network: cj
+  # Seats.aero
+  seats-aero:
+    url: "https://www.anrdoezrs.net/click-101737824-17072392"
+    network: cj
+  # Shelving Inc
+  shelving-inc:
+    url: "https://www.anrdoezrs.net/click-101737824-14045900"
+    network: cj
+  # SilverRushStyle
+  silverrushstyle:
+    url: "https://www.kqzyfj.com/click-101737824-11260306"
+    network: cj
+  # Sleep & Beyond
+  sleep-and-beyond:
+    url: "https://www.anrdoezrs.net/click-101737824-13814567"
+    network: cj
+  # Soccer Garage
+  soccer-garage:
+    url: "https://www.tkqlhce.com/click-101737824-10479704"
+    network: cj
+  # Sucuri
+  sucuri:
+    url: "https://www.dpbolvw.net/click-101737824-13942194"
+    network: cj
+  # Sunber Hair
+  sunber-hair:
+    url: "https://www.jdoqocy.com/click-101737824-15898110"
+    network: cj
+  # Surfshark
+  surfshark:
+    url: "https://www.jdoqocy.com/click-101737824-15438544"
+    network: cj
+  # SwitchBot
+  switchbot:
+    url: "https://www.tkqlhce.com/click-101737824-15037301"
+    network: cj
+  # TEAC
+  teac:
+    url: "https://www.anrdoezrs.net/click-101737824-15919843"
+    network: cj
+  # Tech For Less
+  tech-for-less:
+    url: "https://www.kqzyfj.com/click-101737824-13067706"
+    network: cj
+  # Tenergy
+  tenergy:
+    url: "https://www.anrdoezrs.net/click-101737824-14512046"
+    network: cj
+  # The Tight Spot
+  the-tight-spot:
+    url: "https://www.kqzyfj.com/click-101737824-17147704"
+    network: cj
+  # TP-Link
+  tp-link:
+    url: "https://www.kqzyfj.com/click-101737824-15624194"
+    network: cj
+  # Trampoline Parts and Supply
+  trampoline-parts-and-supply:
+    url: "https://www.jdoqocy.com/click-101737824-13124125"
+    network: cj
+  # Treat My UTI
+  treat-my-uti:
+    url: "https://www.jdoqocy.com/click-101737824-15813416"
+    network: cj
+  # UnbeatableSale
+  unbeatablesale:
+    url: "https://www.jdoqocy.com/click-101737824-10388384"
+    network: cj
+  # UNice
+  unice:
+    url: "https://www.anrdoezrs.net/click-101737824-15222018"
+    network: cj
+  # UntilGone
+  untilgone:
+    url: "https://www.kqzyfj.com/click-101737824-15292979"
+    network: cj
+  # VIP Cars
+  vip-cars:
+    url: "https://www.jdoqocy.com/click-101737824-17236308"
+    network: cj
+  # VY Jewelry
+  vy-jewelry:
+    url: "https://www.anrdoezrs.net/click-101737824-17056490"
+    network: cj
+  # WA Production
+  wa-production:
+    url: "https://www.dpbolvw.net/click-101737824-14579755"
+    network: cj
+  # Winebasket
+  winebasket:
+    url: "https://www.jdoqocy.com/click-101737824-14518164"
+    network: cj
+  # Wristband Express
+  wristband-express:
+    url: "https://www.kqzyfj.com/click-101737824-11023934"
+    network: cj
+  # zChocolat
+  zchocolat:
+    url: "https://www.kqzyfj.com/click-101737824-10020803"
+    network: cj

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-11T14:26:21.082Z",
-  "count": 876,
+  "generated_at": "2026-07-11T14:38:33.665Z",
+  "count": 932,
   "stores": [
     {
       "name": "1-800 Contacts",
@@ -346,6 +346,22 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.39673.4611686018427606343&trid=1552713.234784&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Aiper",
+      "slug": "aiper",
+      "aliases": [
+        "Aiper.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://aiper.com",
+      "intro": "Aiper is a fast-growing maker of cordless robotic pool cleaners and outdoor gear, sold\ndirect at aiper.com and through Amazon and home retailers. There is no Aiper co-brand credit\ncard, so purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-17262223",
+        "network": "cj"
       }
     },
     {
@@ -952,6 +968,39 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.45368.1000000115&trid=1552713.215196&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Ashampoo",
+      "slug": "ashampoo",
+      "aliases": [
+        "Ashampoo.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.ashampoo.com",
+      "intro": "Ashampoo is a German software company selling Windows utilities, photo, backup, and\nPC-optimization programs as downloads at ashampoo.com. There is no Ashampoo co-brand credit\ncard, so the best fit for a recurring online subscription is a card with a strong online\nshopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward\na signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15757364",
+        "network": "cj"
+      }
+    },
+    {
+      "name": "Ashimary Hair",
+      "slug": "ashimary-hair",
+      "aliases": [
+        "Ashimary",
+        "AshimaryHair.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.ashimaryhair.com",
+      "intro": "Ashimary Hair is a hair brand selling human-hair wigs, bundles, and lace-front extensions\ndirect at ashimaryhair.com. There is no Ashimary Hair co-brand credit card, so purchases\nearn the most on a card with a strong online shopping multiplier or a dependable flat-rate\ncashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17318232",
+        "network": "cj"
       }
     },
     {
@@ -2295,6 +2344,23 @@
       "intro": "Carl's Jr. is the western US half of CKE Restaurants, known for charbroiled burgers like\nthe Western Bacon Cheeseburger and the Famous Star. The chain runs about 1,000 domestic\nlocations, mostly west of the Mississippi, alongside sister brand Hardee's in the east.\nIn-store, drive-thru, and Carl's Jr. app purchases all code as fast-food/restaurants on\nevery credit card network, so cards paying elevated rates on dining (Chase Sapphire\nPreferred at 3x, Amex Gold at 4x, Capital One Savor at 3%) all earn their full bonus here.\n"
     },
     {
+      "name": "Carla Car Rental",
+      "slug": "carla-car-rental",
+      "aliases": [
+        "Carla",
+        "RentCarla.com"
+      ],
+      "categories": [
+        "car_rentals"
+      ],
+      "website": "https://rentcarla.com",
+      "intro": "Carla Car Rental is a car-rental booking app and site that compares rates across major\ncompanies like Hertz, Avis, Budget, and Fox at rentcarla.com. There is no Carla Car Rental\nco-brand credit card, so the best pairing is a card that earns bonus rewards on car rentals\nor general travel, and many travel cards also add rental-car coverage when you pay with\nthem.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-17075184",
+        "network": "cj"
+      }
+    },
+    {
       "name": "CarMax",
       "slug": "carmax",
       "categories": [
@@ -2589,6 +2655,22 @@
       "intro": "Chipotle is one of the largest U.S. fast-casual chains at about 3,500 locations, with a\nwell-developed digital ordering app and Chipotle Rewards loyalty program. All Chipotle\npurchases code as dining/restaurants on every card we track, so 3-5% dining-bonus cards\nearn at the same rate whether you order in-store, on the app, or for delivery direct\nfrom Chipotle.\n"
     },
     {
+      "name": "Choice Home Warranty",
+      "slug": "choice-home-warranty",
+      "aliases": [
+        "ChoiceHomeWarranty.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.choicehomewarranty.com",
+      "intro": "Choice Home Warranty is one of the largest US home-warranty providers, selling annual\nservice plans that cover repairs to home systems and appliances at choicehomewarranty.com.\nThere is no Choice Home Warranty co-brand credit card, so the best fit for a recurring\nonline subscription is a card with a strong online shopping multiplier or a flat-rate\ncashback card, and a multi-year plan is easy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-12337172",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Choice Hotels",
       "slug": "choice-hotels",
       "aliases": [
@@ -2687,6 +2769,23 @@
       }
     },
     {
+      "name": "Click & Grow",
+      "slug": "click-and-grow",
+      "aliases": [
+        "Click and Grow",
+        "ClickAndGrow.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.clickandgrow.com",
+      "intro": "Click & Grow is a maker of self-watering indoor smart gardens and plant pods for growing\nherbs and greens at home, sold at clickandgrow.com. There is no Click & Grow co-brand credit\ncard, so purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-11792320",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Clinique",
       "slug": "clinique",
       "categories": [
@@ -2765,6 +2864,23 @@
       }
     },
     {
+      "name": "Corel",
+      "slug": "corel",
+      "aliases": [
+        "Corel Corporation",
+        "Corel.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.corel.com",
+      "intro": "Corel is a long-running software company behind CorelDRAW, WordPerfect, and PaintShop Pro,\nsold as downloads and subscriptions at corel.com. There is no Corel co-brand credit card, so\nthe best fit for a recurring online subscription is a card with a strong online shopping\nmultiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup\nbonus.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-13647475",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Corkcicle",
       "slug": "corkcicle",
       "categories": [
@@ -2777,6 +2893,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13045.3363020&trid=1552713.245365&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "up to 40% off sale items"
+      }
+    },
+    {
+      "name": "CorneaCare",
+      "slug": "corneacare",
+      "aliases": [
+        "CorneaCare.co"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://corneacare.co",
+      "intro": "CorneaCare is a direct-to-consumer eye-care brand selling dry-eye relief products like\neyelid wipes, warm compresses, and omega-3 supplements on subscription. There is no\nCorneaCare co-brand credit card, so purchases earn the most on a card with a strong online\nshopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-17073223",
+        "network": "cj"
       }
     },
     {
@@ -2929,6 +3061,22 @@
       }
     },
     {
+      "name": "Crowned Skin",
+      "slug": "crowned-skin",
+      "aliases": [
+        "CrownedSkin.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://crownedskin.com",
+      "intro": "Crowned Skin is a direct-to-consumer men's fragrance brand, seen on Shark Tank, selling\nbody-butter and eau de parfum colognes at crownedskin.com and through Macy's and Amazon.\nThere is no Crowned Skin co-brand credit card, so purchases earn the most on a card with a\nstrong online shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-17208127",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Cruise America",
       "slug": "cruise-america",
       "categories": [
@@ -3055,6 +3203,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.52798.1000000070&trid=1552713.235285&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "10% off"
+      }
+    },
+    {
+      "name": "Daz 3D",
+      "slug": "daz-3d",
+      "aliases": [
+        "DAZ 3D",
+        "Daz3D.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.daz3d.com",
+      "intro": "Daz 3D is a 3D art platform offering Daz Studio software plus a marketplace of models,\nfigures, and assets for digital artists at daz3d.com. There is no Daz 3D co-brand credit\ncard, so the best fit for a recurring online subscription is a card with a strong online\nshopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward\na signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-11908275",
+        "network": "cj"
       }
     },
     {
@@ -3685,6 +3850,22 @@
       }
     },
     {
+      "name": "EaseUS",
+      "slug": "easeus",
+      "aliases": [
+        "EaseUS.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.easeus.com",
+      "intro": "EaseUS is a software company known for its data-recovery, backup, and partition tools, sold\nas downloads and subscriptions at easeus.com. There is no EaseUS co-brand credit card, so\nthe best fit for a recurring online subscription is a card with a strong online shopping\nmultiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup\nbonus.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-15414522",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Eastern Mountain Sports",
       "slug": "eastern-mountain-sports",
       "aliases": [
@@ -3811,6 +3992,23 @@
       ],
       "website": "https://www.elpolloloco.com",
       "intro": "El Pollo Loco is a Southwest fast-casual chain centered on citrus-marinated, fire-grilled chicken served with tortillas and salsas. Spending codes as dining or restaurants on most rewards cards, so a dining bonus is the right play. Catering placed through a separate corporate portal can occasionally code differently from an in-store order.\n"
+    },
+    {
+      "name": "Electronic Express",
+      "slug": "electronic-express",
+      "aliases": [
+        "ElectronicExpress.com"
+      ],
+      "categories": [
+        "electronics_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.electronicexpress.com",
+      "intro": "Electronic Express is a US consumer-electronics and appliance retailer with stores across\nTennessee and an online store at electronicexpress.com. There is no Electronic Express\nco-brand credit card, so a card with an electronics or online shopping bonus earns the most,\nand the same gear bought at a big-box electronics retailer can lean on that store's category\nrate.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-16960092",
+        "network": "cj"
+      }
     },
     {
       "name": "Emirates",
@@ -4296,6 +4494,22 @@
       }
     },
     {
+      "name": "Flowers Fast",
+      "slug": "flowers-fast",
+      "aliases": [
+        "FlowersFast.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.flowersfast.com",
+      "intro": "Flowers Fast is an online florist offering same-day and next-day flower, plant, and gift\ndelivery nationwide at flowersfast.com. There is no Flowers Fast co-brand credit card, so\npurchases earn the most on a card with a strong online shopping multiplier or a dependable\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-1035861",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Food Lion",
       "slug": "food-lion",
       "categories": [
@@ -4317,6 +4531,23 @@
       ],
       "website": "https://www.footlocker.com",
       "intro": "Foot Locker is the flagship sneaker and athletic apparel banner of Foot Locker Inc,\nwhich also runs Champs Sports, Kids Foot Locker, and WSS. The chain operates about\n900 U.S. stores plus footlocker.com. The FLX Rewards Visa from Bread Financial earns\nelevated XPoints on FLX-family purchases that can be redeemed for sneaker drops and\nshoes. General-purpose cards code Foot Locker as department store in person and online\nshopping for web orders.\n"
+    },
+    {
+      "name": "FOREO",
+      "slug": "foreo",
+      "aliases": [
+        "Foreo",
+        "Foreo.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.foreo.com",
+      "intro": "FOREO is a Swedish beauty-tech brand best known for its LUNA facial-cleansing devices and\nskincare tools, sold direct at foreo.com and through beauty retailers. There is no FOREO\nco-brand credit card, so purchases earn the most on a card with a strong online shopping\nmultiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15527432",
+        "network": "cj"
+      }
     },
     {
       "name": "Forever 21",
@@ -4358,6 +4589,23 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43381&trid=1552713.206854&foc=17&fot=9999&fos=6&url=https%3A%2F%2Ffoxrentacar.com",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "FragranceShop.com",
+      "slug": "fragranceshop",
+      "aliases": [
+        "FragranceShop",
+        "The Fragrance Shop"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.fragranceshop.com",
+      "intro": "FragranceShop.com is a US discount fragrance retailer selling authentic designer perfume,\ncologne, and gift sets online since 1998 at fragranceshop.com. There is no FragranceShop.com\nco-brand credit card, so purchases earn the most on a card with a strong online shopping\nmultiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-16942205",
+        "network": "cj"
       }
     },
     {
@@ -4482,6 +4730,23 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110101042.101161543&trid=1552713.207312&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "GameFly",
+      "slug": "gamefly",
+      "aliases": [
+        "GameFly.com"
+      ],
+      "categories": [
+        "entertainment",
+        "online_shopping"
+      ],
+      "website": "https://www.gamefly.com",
+      "intro": "GameFly is a video-game rental and subscription service that ships console games by mail and\nsells used titles at gamefly.com. There is no GameFly co-brand credit card, so a card that\npays a bonus on entertainment or general online shopping earns the most.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-10448329",
+        "network": "cj"
       }
     },
     {
@@ -5607,6 +5872,23 @@
       "intro": "In-N-Out Burger is a West Coast cult favorite founded in Baldwin Park, California\nin 1948, with around 400 locations across California, Nevada, Arizona, Utah,\nTexas, Oregon, Colorado, and Idaho. The minimalist menu of Double-Doubles, fries,\nand shakes plus the off-menu Animal Style ordering is the chain's identity. In-N-Out\ntransactions code as restaurants on Visa, Mastercard, and Amex networks.\n\nDining rewards cards capture In-N-Out well. The Amex Gold earns 4x points on U.S.\nrestaurants and is the top earner for frequent visitors, while the Chase Sapphire\nReserve pays 3x. No-annual-fee dining picks include the Capital One SavorOne at 3\npercent and Wells Fargo Autograph at 3x. In-N-Out does not run a customer rewards\nprogram, so credit card rewards are the only structured path to cash back.\n"
     },
     {
+      "name": "Infimobile",
+      "slug": "infimobile",
+      "aliases": [
+        "Infimobile.com"
+      ],
+      "categories": [
+        "cell_phone_providers",
+        "online_shopping"
+      ],
+      "website": "https://www.infimobile.com",
+      "intro": "Infimobile is a US mobile virtual network operator offering low-cost prepaid cell phone\nplans and devices at infimobile.com. There is no Infimobile co-brand credit card, so a few\ncards pay a bonus on phone or cell-provider bills, and otherwise a card with a strong\nrecurring-purchase or flat-rate rate works well.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-17169123",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Innisfree",
       "slug": "innisfree",
       "parent_company": "Amorepacific",
@@ -5633,6 +5915,23 @@
       ],
       "website": "https://www.instacart.com",
       "intro": "Instacart is the largest U.S. grocery delivery and pickup marketplace, partnering\nwith Costco, Wegmans, ALDI, Publix, and many regional chains. Orders placed through\nthe Instacart app or instacart.com generally code as groceries on most cards, but\nsome banks classify the charge as the underlying merchant — worth confirming on\na small order before relying on a 6% grocery card. Several premium cards (Sapphire\nReserve, Venture X) include Instacart+ memberships and statement credits.\n"
+    },
+    {
+      "name": "iolo",
+      "slug": "iolo",
+      "aliases": [
+        "iolo System Mechanic",
+        "System Mechanic"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.iolo.com",
+      "intro": "iolo is the maker of System Mechanic, PC tune-up and optimization software sold as a yearly\nsubscription at iolo.com. There is no iolo co-brand credit card, so the best fit for a\nrecurring online subscription is a card with a strong online shopping multiplier or a\nflat-rate cashback card, and a multi-year plan is easy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-15203012",
+        "network": "cj"
+      }
     },
     {
       "name": "IPSY",
@@ -6039,6 +6338,23 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.34908.2993656&trid=1552713.243968&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Keetsa",
+      "slug": "keetsa",
+      "aliases": [
+        "Keetsa.com"
+      ],
+      "categories": [
+        "furniture_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.keetsa.com",
+      "intro": "Keetsa is an eco-friendly mattress and bedding brand selling memory-foam and hybrid\nmattresses, pillows, and bases direct at keetsa.com and in a handful of showrooms. There is\nno Keetsa co-brand credit card, so for a big one-time mattress purchase the most rewarding\noptions are a furniture or home-goods category card, a strong online shopping bonus, or a\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-11326560",
+        "network": "cj"
       }
     },
     {
@@ -6501,6 +6817,22 @@
       }
     },
     {
+      "name": "Lighting New York",
+      "slug": "lighting-new-york",
+      "aliases": [
+        "LightingNewYork.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.lightingnewyork.com",
+      "intro": "Lighting New York is one of the largest online lighting retailers in the US, selling\nchandeliers, fixtures, fans, and lamps from hundreds of brands at lightingnewyork.com. There\nis no Lighting New York co-brand credit card, so purchases earn the most on a card with a\nstrong online shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17016697",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Lindt",
       "slug": "lindt-chocolatier",
       "aliases": [
@@ -6887,6 +7219,22 @@
       "intro": "Maggiano's Little Italy, owned by Brinker International (Chili's parent), runs about 50\nupscale-casual Italian restaurants known for family-style portions, the Chocolate Zuccotto\nCake, and the Classic Pastas program where guests take home a second pasta with each entree.\nMaggiano's transactions code as dining/restaurants on every credit card. With higher check\naverages than typical casual dining, top dining cards meaningfully boost return: Amex Gold\nat 4x, Chase Sapphire Reserve at 4x, Chase Sapphire Preferred at 3x, Capital One Savor at 3%.\n"
     },
     {
+      "name": "Magzter",
+      "slug": "magzter",
+      "aliases": [
+        "Magzter.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.magzter.com",
+      "intro": "Magzter is a digital newsstand offering unlimited access to thousands of magazines and\nnewspapers through the Magzter Gold subscription at magzter.com. There is no Magzter\nco-brand credit card, so the best fit for a recurring online subscription is a card with a\nstrong online shopping multiplier or a flat-rate cashback card, and a multi-year plan is\neasy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17205347",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Manscaped",
       "slug": "manscaped",
       "aliases": [
@@ -7216,6 +7564,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.26749.3868010&trid=1552713.197539&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "30% off your first purchase"
+      }
+    },
+    {
+      "name": "MFI Medical",
+      "slug": "mfi-medical",
+      "aliases": [
+        "MFIMedical.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://mfimedical.com",
+      "intro": "MFI Medical is an online retailer of medical equipment and supplies for clinics, home care,\nand professionals, selling exam, diagnostic, and mobility gear at mfimedical.com. There is\nno MFI Medical co-brand credit card, so purchases earn the most on a card with a strong\nonline shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-15887082",
+        "network": "cj"
       }
     },
     {
@@ -7777,6 +8141,23 @@
       "intro": "The Nintendo eShop is the digital storefront for Switch games, DLC, and add-on content, payable by card or prepaid eShop credit. Purchases code as online shopping or digital entertainment, so a card with an online-purchase bonus earns the most. Buying discounted eShop gift cards from a grocery or warehouse store first can beat charging the eShop directly.\n"
     },
     {
+      "name": "NordPass",
+      "slug": "nordpass",
+      "aliases": [
+        "NordPass.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://nordpass.com",
+      "parent_company": "Nord Security",
+      "intro": "NordPass is a password manager from Nord Security, sold as a personal or family subscription\nat nordpass.com alongside NordVPN and NordLocker. There is no NordPass co-brand credit card,\nso the best fit for a recurring online subscription is a card with a strong online shopping\nmultiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup\nbonus.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-13868703",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Nordstrom",
       "slug": "nordstrom",
       "aliases": [
@@ -8098,6 +8479,22 @@
       }
     },
     {
+      "name": "Ovago",
+      "slug": "ovago",
+      "aliases": [
+        "OVAGO.com"
+      ],
+      "categories": [
+        "travel"
+      ],
+      "website": "https://www.ovago.com",
+      "intro": "Ovago is an online travel agency specializing in discounted airline tickets, with flight\nbooking and support handled at ovago.com. There is no Ovago co-brand credit card, so the\nbest pairing is a card that earns bonus rewards on travel, which usually covers flights and\ntrips booked through an online travel agency.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-15809797",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Overstock",
       "slug": "overstock",
       "aliases": [
@@ -8185,6 +8582,23 @@
       ],
       "website": "https://www.pandaexpress.com",
       "intro": "Panda Express is the largest American Chinese fast-food chain, best known for its Orange Chicken and mall-and-highway locations nationwide. Purchases code as dining or restaurants on most rewards cards, so a dining multiplier captures the value. Combo orders at a food court counter still register under the same restaurant code as standalone stores.\n"
+    },
+    {
+      "name": "Panda Office",
+      "slug": "panda-office",
+      "aliases": [
+        "PandaOffice",
+        "PandaOffice.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.pandaoffice.com",
+      "intro": "Panda Office is a data-recovery and file-repair software company selling downloadable tools\nfor recovering lost files and photos at pandaoffice.com. There is no Panda Office co-brand\ncredit card, so the best fit for a recurring online subscription is a card with a strong\nonline shopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend\ntoward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-17175455",
+        "network": "cj"
+      }
     },
     {
       "name": "Pandora",
@@ -8358,6 +8772,22 @@
       "intro": "Pep Boys operates roughly 800 auto parts and service centers across the United\nStates, combining a parts counter with tire installation, oil changes, brake work,\nand full-service mechanical repair. Most credit cards code Pep Boys purchases as\nauto services or general retail rather than as a dedicated bonus category, so\nflat-rate cards like the Citi Double Cash often deliver the cleanest 2 percent.\n\nCards with selectable categories can reach Pep Boys when the right bucket is\nchosen. Bank of America Customized Cash and U.S. Bank Cash+ both have wider\ncategories that may capture auto service spending, and Citi Custom Cash pays 5\npercent on the top eligible spending category for cardholders whose monthly spend\nskews toward vehicle maintenance.\n"
     },
     {
+      "name": "Perfumania",
+      "slug": "perfumania",
+      "aliases": [
+        "Perfumania.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.perfumania.com",
+      "intro": "Perfumania is a US discount fragrance retailer selling designer perfume and cologne online\nand in outlet stores at perfumania.com. There is no Perfumania co-brand credit card, so\npurchases earn the most on a card with a strong online shopping multiplier or a dependable\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17277235",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Perricone MD",
       "slug": "perricone-md",
       "aliases": [
@@ -8372,6 +8802,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.21122.3969291&trid=1552713.178759&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "50% off with code EYE50"
+      }
+    },
+    {
+      "name": "Personalabs",
+      "slug": "personalabs",
+      "aliases": [
+        "Personalabs.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.personalabs.com",
+      "intro": "Personalabs is a direct-to-consumer lab-testing service that lets people order their own\nblood and health tests online without a doctor visit at personalabs.com. There is no\nPersonalabs co-brand credit card, so purchases earn the most on a card with a strong online\nshopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15144052",
+        "network": "cj"
       }
     },
     {
@@ -8515,6 +8961,23 @@
       ],
       "website": "https://www.philzcoffee.com",
       "intro": "Philz Coffee is a San Francisco-born specialty chain of about 70 cafes across California,\nthe East Coast, and the DC region, built around custom pour-over brews like Tesora, Ether,\nand the Mint Mojito iced coffee. Orders placed in-cafe, in the Philz app, or ahead via\ncurbside all code as dining/restaurants. Top dining cards earn their full rate at Philz:\nAmex Gold pays 4x Membership Rewards, Chase Sapphire Reserve pays 4x Ultimate Rewards,\nand Capital One SavorOne pays 3% unlimited cash back on every order.\n"
+    },
+    {
+      "name": "Phone.com",
+      "slug": "phone-com",
+      "aliases": [
+        "Phone.com"
+      ],
+      "categories": [
+        "cell_phone_providers",
+        "online_shopping"
+      ],
+      "website": "https://www.phone.com",
+      "intro": "Phone.com is a VoIP business phone service offering virtual numbers, calling, and video\nmeetings on monthly plans at phone.com. There is no Phone.com co-brand credit card, so a few\ncards pay a bonus on phone or cell-provider bills, and otherwise a card with a strong\nrecurring-purchase or flat-rate rate works well.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-10686248",
+        "network": "cj"
+      }
     },
     {
       "name": "Pick 'n Save",
@@ -8665,6 +9128,23 @@
       ],
       "website": "https://www.powells.com",
       "intro": "Powell's Books, the famed Portland independent, sells new and used titles in store and through powells.com. Online orders generally code as online shopping, while the physical City of Books often rings up as general retail. A flat-rate card or one with an online-shopping bonus is the practical choice for book hauls.\n"
+    },
+    {
+      "name": "Power Systems",
+      "slug": "power-systems",
+      "aliases": [
+        "Power-Systems.com"
+      ],
+      "categories": [
+        "sporting_goods",
+        "online_shopping"
+      ],
+      "website": "https://www.power-systems.com",
+      "intro": "Power Systems is a supplier of strength, conditioning, and fitness equipment for gyms,\ntrainers, and home use, sold at power-systems.com. There is no Power Systems co-brand credit\ncard, so a card that pays a bonus on sporting goods or general online shopping is the best\nfit.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-13824793",
+        "network": "cj"
+      }
     },
     {
       "name": "Price Chopper",
@@ -9164,6 +9644,23 @@
       "intro": "Revolve is an online fashion retailer targeting younger shoppers with trend-driven clothing, shoes, and accessories. Purchases code as online shopping, and while it can resemble a department store, there is no broad apparel bonus on most cards. A flat-rate or online-retail card is the most reliable way to earn on your orders.\n"
     },
     {
+      "name": "Rexing",
+      "slug": "rexing",
+      "aliases": [
+        "RexingUSA",
+        "Rexing USA"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.rexingusa.com",
+      "intro": "Rexing is a US brand of dash cams and vehicle electronics, selling front-and-rear recorders,\nmirror cams, and accessories at rexingusa.com. There is no Rexing co-brand credit card, so\npurchases earn the most on a card with a strong online shopping multiplier or a dependable\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-14503215",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Ria Money Transfer",
       "slug": "ria-money-transfer",
       "aliases": [
@@ -9377,6 +9874,22 @@
       ],
       "website": "https://www.ruralking.com",
       "intro": "Rural King is a farm-and-home chain selling everything from feed and tools to firearms and apparel, and its stores can code as a home-improvement or farm-supply merchant or as general retail. A home-improvement bonus may apply but is not assured given the mixed inventory. Purchases at ruralking.com generally code as online shopping, so a flat-rate or online card is a safe default.\n"
+    },
+    {
+      "name": "Russell Stover",
+      "slug": "russell-stover",
+      "aliases": [
+        "RussellStover.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.russellstover.com",
+      "intro": "Russell Stover is a classic American chocolate brand known for its boxed chocolates and\nsugar-free candies, sold direct at russellstover.com and in grocery and drug stores. There\nis no Russell Stover co-brand credit card, so purchases earn the most on a card with a\nstrong online shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-12986504",
+        "network": "cj"
+      }
     },
     {
       "name": "Ruth's Chris Steak House",
@@ -9612,6 +10125,23 @@
       }
     },
     {
+      "name": "Seats.aero",
+      "slug": "seats-aero",
+      "aliases": [
+        "SeatsAero",
+        "Seats aero"
+      ],
+      "categories": [
+        "travel"
+      ],
+      "website": "https://seats.aero",
+      "intro": "Seats.aero is an award-travel search tool that scans airline loyalty programs for available\naward flights, offered as a Pro subscription at seats.aero. There is no Seats.aero co-brand\ncredit card, so the best fit for a recurring online subscription is a card with a strong\nonline shopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend\ntoward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17072392",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Seed Health",
       "slug": "seed-health",
       "categories": [
@@ -9730,6 +10260,23 @@
       "intro": "Shell is one of the largest U.S. gasoline retailers by station count (about 13,000\nlocations), with a Fuel Rewards loyalty program tied to the Shell app. Shell pumps code\ncleanly as gas on every card we track. The Shell Fuel Rewards program offers stackable\nper-gallon discounts that are calculated separately from card cashback.\n"
     },
     {
+      "name": "Shelving Inc",
+      "slug": "shelving-inc",
+      "aliases": [
+        "Shelving.com",
+        "Shelving Inc."
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.shelving.com",
+      "intro": "Shelving Inc is an online retailer of shelving, storage, and organization systems for home,\ngarage, and commercial use at shelving.com. There is no Shelving Inc co-brand credit card,\nso purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-14045900",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Sherwin-Williams",
       "slug": "sherwin-williams",
       "categories": [
@@ -9845,6 +10392,22 @@
       "intro": "Sierra, the off-price outdoor and active brand under TJX, sells discounted gear and apparel that often codes as a department store at its stores, so supermarket and restaurant bonuses do not apply. Shopping sierra.com normally codes as online shopping. With deals already built in, pair a card that rewards online spending or carries a reliable flat rate.\n"
     },
     {
+      "name": "SilverRushStyle",
+      "slug": "silverrushstyle",
+      "aliases": [
+        "Silver Rush Style"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.silverrushstyle.com",
+      "intro": "SilverRushStyle is an online jeweler specializing in handcrafted sterling silver and\ngemstone jewelry at silverrushstyle.com. There is no SilverRushStyle co-brand credit card,\nso purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-11260306",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Sinclair",
       "slug": "sinclair",
       "aliases": [
@@ -9919,6 +10482,23 @@
       }
     },
     {
+      "name": "Sleep & Beyond",
+      "slug": "sleep-and-beyond",
+      "aliases": [
+        "Sleep and Beyond",
+        "SleepAndBeyond.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.sleepandbeyond.com",
+      "intro": "Sleep & Beyond is a maker of organic and natural bedding, including wool mattress toppers,\npillows, and sheets, sold direct at sleepandbeyond.com. There is no Sleep & Beyond co-brand\ncredit card, so purchases earn the most on a card with a strong online shopping multiplier\nor a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-13814567",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Sleep Number",
       "slug": "sleep-number",
       "categories": [
@@ -9982,6 +10562,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.54145.1000000010&trid=1552713.245768&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "70% off"
+      }
+    },
+    {
+      "name": "Soccer Garage",
+      "slug": "soccer-garage",
+      "aliases": [
+        "SoccerGarage.com"
+      ],
+      "categories": [
+        "sporting_goods",
+        "online_shopping"
+      ],
+      "website": "https://www.soccergarage.com",
+      "intro": "Soccer Garage is an online soccer retailer selling cleats, jerseys, goalkeeper gear, and\nteam equipment at soccergarage.com. There is no Soccer Garage co-brand credit card, so a\ncard that pays a bonus on sporting goods or general online shopping is the best fit.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-10479704",
+        "network": "cj"
       }
     },
     {
@@ -10354,6 +10951,22 @@
       "intro": "Subway is the largest restaurant chain in the U.S. by store count, with about\n20,000 domestic locations. Charges code as dining on every card we track. Standard\nhigh-bonus dining cards (Amex Gold 4x capped, Sapphire Preferred 3x, Capital One\nSavorOne 3%) are the obvious pairings. The MyWay Rewards loyalty program and\nrecurring digital coupons in the Subway app stack on top of card bonuses.\n"
     },
     {
+      "name": "Sucuri",
+      "slug": "sucuri",
+      "aliases": [
+        "Sucuri.net"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://sucuri.net",
+      "intro": "Sucuri is a website-security service offering malware cleanup, firewall, and monitoring on\nannual subscriptions at sucuri.net. There is no Sucuri co-brand credit card, so the best fit\nfor a recurring online subscription is a card with a strong online shopping multiplier or a\nflat-rate cashback card, and a multi-year plan is easy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-13942194",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Summit Racing",
       "slug": "summit-racing",
       "aliases": [
@@ -10388,6 +11001,23 @@
       "intro": "Sunbasket ships organic meal kits and prepared meals with an emphasis on clean, dietary-friendly ingredients. Even though it is food, the charges process as an online subscription and typically code as online shopping rather than groceries, so a card with an online or everyday bonus usually beats chasing a supermarket category.\n"
     },
     {
+      "name": "Sunber Hair",
+      "slug": "sunber-hair",
+      "aliases": [
+        "Sunber",
+        "SunberHair.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.sunberhair.com",
+      "intro": "Sunber Hair is a hair brand selling human-hair wigs, weaves, and extensions direct at\nsunberhair.com. There is no Sunber Hair co-brand credit card, so purchases earn the most on\na card with a strong online shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15898110",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Sunoco",
       "slug": "sunoco",
       "aliases": [
@@ -10398,6 +11028,40 @@
       ],
       "website": "https://www.sunoco.com",
       "intro": "Sunoco-branded stations cover about 5,200 U.S. locations primarily across the East\nand Midwest. Pumps code cleanly as gas on every card we track. The Sunoco Rewards\napp stacks 5-10 cents per gallon savings on top of any card's bonus rate. There's\na Sunoco Rewards co-branded credit card, but in absolute cashback most 4-5%\ngeneral gas cards beat it.\n"
+    },
+    {
+      "name": "Surfshark",
+      "slug": "surfshark",
+      "aliases": [
+        "Surfshark VPN",
+        "Surfshark.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://surfshark.com",
+      "intro": "Surfshark is a popular consumer VPN service sold as a monthly or multi-year subscription at\nsurfshark.com alongside antivirus and identity-protection add-ons. There is no Surfshark\nco-brand credit card, so the best fit for a recurring online subscription is a card with a\nstrong online shopping multiplier or a flat-rate cashback card, and a multi-year plan is\neasy spend toward a signup bonus.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15438544",
+        "network": "cj"
+      }
+    },
+    {
+      "name": "SwitchBot",
+      "slug": "switchbot",
+      "aliases": [
+        "Switch-Bot",
+        "SwitchBot.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.switch-bot.com",
+      "intro": "SwitchBot is a smart-home brand making automated blinds, locks, hubs, and robot vacuums,\nsold direct at switch-bot.com and through Amazon. There is no SwitchBot co-brand credit\ncard, so purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.tkqlhce.com/click-101737824-15037301",
+        "network": "cj"
+      }
     },
     {
       "name": "T-Mobile",
@@ -10502,6 +11166,40 @@
       }
     },
     {
+      "name": "TEAC",
+      "slug": "teac",
+      "aliases": [
+        "TEAC USA",
+        "TEAC America"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://teac.com",
+      "intro": "TEAC is a Japanese audio-electronics brand making turntables, CD players, and hi-fi\ncomponents, sold in the US at teac.com. There is no TEAC co-brand credit card, so purchases\nearn the most on a card with a strong online shopping multiplier or a dependable flat-rate\ncashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-15919843",
+        "network": "cj"
+      }
+    },
+    {
+      "name": "Tech For Less",
+      "slug": "tech-for-less",
+      "aliases": [
+        "TechForLess.com"
+      ],
+      "categories": [
+        "electronics_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.techforless.com",
+      "intro": "Tech For Less is an online retailer of discounted new, refurbished, and open-box electronics\nand computers at techforless.com. There is no Tech For Less co-brand credit card, so a card\nwith an electronics or online shopping bonus earns the most, and the same gear bought at a\nbig-box electronics retailer can lean on that store's category rate.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-13067706",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Tecovas",
       "slug": "tecovas",
       "categories": [
@@ -10542,6 +11240,22 @@
       ],
       "website": "https://www.temu.com",
       "intro": "Temu is a U.S.-facing online marketplace owned by Chinese e-commerce giant PDD\nHoldings, launched stateside in 2022 and aggressively marketed on ultra-low prices and\ndirect-from-manufacturer shipping. Purchases typically code as online shopping or\nmerchandise, so a card with an online-shopping category bonus (Capital One SavorOne\npromotions, Chase Freedom Flex when activated, Citi Custom Cash on online shopping\nmonth) will earn its full multiplier. Temu has no co-brand credit card, so the best\nearn comes from a general online-shopping bonus.\n"
+    },
+    {
+      "name": "Tenergy",
+      "slug": "tenergy",
+      "aliases": [
+        "Tenergy.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://power.tenergy.com",
+      "intro": "Tenergy is a maker of rechargeable batteries, chargers, and small consumer electronics, sold\ndirect and through Amazon. There is no Tenergy co-brand credit card, so purchases earn the\nmost on a card with a strong online shopping multiplier or a dependable flat-rate cashback\ncard.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-14512046",
+        "network": "cj"
+      }
     },
     {
       "name": "Teva",
@@ -10727,6 +11441,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.8270.887764&trid=1552713.245338&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "the $25 new member credit"
+      }
+    },
+    {
+      "name": "The Tight Spot",
+      "slug": "the-tight-spot",
+      "aliases": [
+        "TheTightSpot.com"
+      ],
+      "categories": [
+        "select_clothing",
+        "online_shopping"
+      ],
+      "website": "https://www.thetightspot.com",
+      "intro": "The Tight Spot is an online hosiery boutique carrying thousands of styles of tights,\npantyhose, and stockings from brands like Wolford at thetightspot.com. There is no The Tight\nSpot co-brand credit card, so purchases earn the most on a card with a clothing or online\nshopping category bonus.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-17147704",
+        "network": "cj"
       }
     },
     {
@@ -10944,6 +11675,23 @@
       }
     },
     {
+      "name": "TP-Link",
+      "slug": "tp-link",
+      "aliases": [
+        "TP-Link USA",
+        "TPLink"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.tp-link.com",
+      "intro": "TP-Link is one of the world's largest makers of Wi-Fi routers, mesh systems, and networking\ngear, sold direct and through electronics retailers under its TP-Link and Deco lines. There\nis no TP-Link co-brand credit card, so purchases earn the most on a card with a strong\nonline shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-15624194",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Tractor Supply Co",
       "slug": "tractor-supply",
       "aliases": [
@@ -11007,6 +11755,23 @@
       }
     },
     {
+      "name": "Trampoline Parts and Supply",
+      "slug": "trampoline-parts-and-supply",
+      "aliases": [
+        "TrampolinePartsAndSupply.com",
+        "TPS"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.trampolinepartsandsupply.com",
+      "intro": "Trampoline Parts and Supply is a specialty retailer of replacement trampoline mats, springs,\npads, and nets for most trampoline brands, sold online. There is no Trampoline Parts and\nSupply co-brand credit card, so purchases earn the most on a card with a strong online\nshopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-13124125",
+        "network": "cj"
+      }
+    },
+    {
       "name": "TransUnion",
       "slug": "transunion-credit-monitoring",
       "aliases": [
@@ -11030,6 +11795,22 @@
       ],
       "website": "https://www.travelocity.com",
       "intro": "Travelocity is an Expedia Group online travel agency, long recognized by its Roaming Gnome mascot. Reservations generally code as travel and earn on cards carrying a travel bonus, but a flight or hotel within a package may sometimes code under the actual provider. A travel card with a broad travel category is the dependable choice for these purchases.\n"
+    },
+    {
+      "name": "Treat My UTI",
+      "slug": "treat-my-uti",
+      "aliases": [
+        "TreatMyUTI.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.treatmyuti.com",
+      "intro": "Treat My UTI is a direct-to-consumer wellness brand selling urinary-tract and vaginal-health\nsupplements and test strips at treatmyuti.com. There is no Treat My UTI co-brand credit\ncard, so purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-15813416",
+        "network": "cj"
+      }
     },
     {
       "name": "Trip.com",
@@ -11209,6 +11990,23 @@
       "intro": "Ulta Beauty is the largest U.S. beauty retailer by store count at about 1,400 locations,\ncovering both prestige and mass-market lines under one roof. Like Sephora, Ulta in-store\npurchases don't trigger a dedicated card category, so the right card there is usually a\nstrong flat-rate. Online purchases at ulta.com code as online shopping. Ultamate Rewards\nloyalty points stack with card cashback.\n"
     },
     {
+      "name": "UnbeatableSale",
+      "slug": "unbeatablesale",
+      "aliases": [
+        "UnbeatableSale.com"
+      ],
+      "categories": [
+        "department_stores",
+        "online_shopping"
+      ],
+      "website": "https://www.unbeatablesale.com",
+      "intro": "UnbeatableSale is an online discount marketplace carrying a wide range of home, health, and\ngeneral-merchandise products at unbeatablesale.com. There is no UnbeatableSale co-brand\ncredit card, so a card with a department store or online shopping bonus earns the most.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-10388384",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Under Armour",
       "slug": "under-armour",
       "categories": [
@@ -11217,6 +12015,23 @@
       ],
       "website": "https://www.underarmour.com",
       "intro": "Under Armour is a Baltimore-based athletic apparel and footwear brand sold through\nabout 175 U.S. Brand House and Factory House stores along with a strong online channel\nat underarmour.com. Direct purchases typically code as department store at the\nregister and online shopping for web orders, while Under Armour gear bought at Dick's\nor other retailers codes under that store. The free UA Rewards program layers on top\nof credit card earnings, and there is no Under Armour branded credit card.\n"
+    },
+    {
+      "name": "UNice",
+      "slug": "unice",
+      "aliases": [
+        "UNice Hair",
+        "UNice.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.unice.com",
+      "intro": "UNice is a popular hair brand selling human-hair wigs, bundles, and extensions direct at\nunice.com and through Amazon. There is no UNice co-brand credit card, so purchases earn the\nmost on a card with a strong online shopping multiplier or a dependable flat-rate cashback\ncard.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-15222018",
+        "network": "cj"
+      }
     },
     {
       "name": "Uniqlo",
@@ -11265,6 +12080,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11299.2922125&trid=1552713.215260&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "20% off for new customers"
+      }
+    },
+    {
+      "name": "UntilGone",
+      "slug": "untilgone",
+      "aliases": [
+        "UntilGone.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.untilgone.com",
+      "intro": "UntilGone is an online daily-deals retailer selling discounted electronics, home goods, and\ngadgets in limited-time offers at untilgone.com. There is no UntilGone co-brand credit card,\nso purchases earn the most on a card with a strong online shopping multiplier or a\ndependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-15292979",
+        "network": "cj"
       }
     },
     {
@@ -11444,6 +12275,23 @@
       }
     },
     {
+      "name": "VIP Cars",
+      "slug": "vip-cars",
+      "aliases": [
+        "VIPCars",
+        "VIP Cars Global"
+      ],
+      "categories": [
+        "car_rentals"
+      ],
+      "website": "https://www.vipcars.com",
+      "intro": "VIP Cars is a car-rental booking service that compares rates from suppliers at airports and\ncities worldwide at vipcars.com. There is no VIP Cars co-brand credit card, so the best\npairing is a card that earns bonus rewards on car rentals or general travel, and many travel\ncards also add rental-car coverage when you pay with them.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-17236308",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Virgin Experience Gifts",
       "slug": "virgin-experience-gifts",
       "categories": [
@@ -11510,6 +12358,38 @@
       ],
       "website": "https://www.vrbo.com",
       "intro": "Vrbo is the second-largest U.S. vacation-rental marketplace after Airbnb, owned\nby Expedia Group. Bookings code as travel on every card we track and as hotels\non a few. Unlike Airbnb, Vrbo focuses exclusively on whole-home rentals (no\nshared spaces). Vrbo bookings count for the Sapphire Reserve and Venture X\ntravel-credit categories. Booking through a card's travel portal earns the\nportal multiplier but typically loses Vrbo Boost host-program perks.\n"
+    },
+    {
+      "name": "VY Jewelry",
+      "slug": "vy-jewelry",
+      "aliases": [
+        "VYJewelry"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://vyjewelry.shop",
+      "intro": "VY Jewelry is a jewelry brand selling 925 sterling silver rings, necklaces, and bracelets\nfor men and women at vyjewelry.shop and through Amazon. There is no VY Jewelry co-brand\ncredit card, so purchases earn the most on a card with a strong online shopping multiplier\nor a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.anrdoezrs.net/click-101737824-17056490",
+        "network": "cj"
+      }
+    },
+    {
+      "name": "WA Production",
+      "slug": "wa-production",
+      "aliases": [
+        "WAProduction"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.waproduction.com",
+      "intro": "WA Production is a music-production company selling audio plugins, sample packs, and\ntutorials for producers at waproduction.com. There is no WA Production co-brand credit card,\nso the best fit for a recurring online subscription is a card with a strong online shopping\nmultiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup\nbonus.\n",
+      "affiliate": {
+        "url": "https://www.dpbolvw.net/click-101737824-14579755",
+        "network": "cj"
+      }
     },
     {
       "name": "Wacoal",
@@ -11796,6 +12676,24 @@
       }
     },
     {
+      "name": "Winebasket",
+      "slug": "winebasket",
+      "aliases": [
+        "Winebasket.com",
+        "Babybasket",
+        "Capalbo's"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.winebasket.com",
+      "intro": "Winebasket is an online gift retailer selling wine, champagne, and gourmet gift baskets for\noccasions at winebasket.com. There is no Winebasket co-brand credit card, so purchases earn\nthe most on a card with a strong online shopping multiplier or a dependable flat-rate\ncashback card.\n",
+      "affiliate": {
+        "url": "https://www.jdoqocy.com/click-101737824-14518164",
+        "network": "cj"
+      }
+    },
+    {
       "name": "Wingstop",
       "slug": "wingstop",
       "categories": [
@@ -11857,6 +12755,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25202.3966290&trid=1552713.193401&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "buy one get one 50% off shorts"
+      }
+    },
+    {
+      "name": "Wristband Express",
+      "slug": "wristband-express",
+      "aliases": [
+        "WristbandExpress.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.wristbandexpress.com",
+      "intro": "Wristband Express is an online seller of custom silicone wristbands, event bracelets, and\nlanyards for fundraisers, parties, and businesses at wristbandexpress.com. There is no\nWristband Express co-brand credit card, so purchases earn the most on a card with a strong\nonline shopping multiplier or a dependable flat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-11023934",
+        "network": "cj"
       }
     },
     {
@@ -11965,6 +12879,22 @@
       ],
       "website": "https://www.zaxbys.com",
       "intro": "Zaxby's is a Georgia-based chicken-finger and wing quick-service chain with over\n900 restaurants concentrated in the Southeast. The menu features Chicken Finger\nPlates, Boneless and Traditional Wings, Zalads, and a lineup of signature sauces\nlike Zax Sauce and Tongue Torch. Zaxby's transactions code as restaurants on Visa,\nMastercard, and Amex networks.\n\nThe Amex Gold earns 4x points on U.S. restaurants and tops the cards for Zaxby's\nspending, while the Chase Sapphire Reserve pays 3x on dining and adds purchase\nprotection. The Capital One SavorOne and Wells Fargo Autograph each pay 3 percent\nor 3x on restaurants with no annual fee. The Zax Rewardz app program adds visit\npoints that stack with credit card cash back on every Big Zax Snak run.\n"
+    },
+    {
+      "name": "zChocolat",
+      "slug": "zchocolat",
+      "aliases": [
+        "zChocolat.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.zchocolat.com",
+      "intro": "zChocolat is a luxury chocolate brand offering French assortments in mahogany gift boxes\nwith worldwide delivery at zchocolat.com. There is no zChocolat co-brand credit card, so\npurchases earn the most on a card with a strong online shopping multiplier or a dependable\nflat-rate cashback card.\n",
+      "affiliate": {
+        "url": "https://www.kqzyfj.com/click-101737824-10020803",
+        "network": "cj"
+      }
     }
   ]
 }

--- a/data/stores/aiper.yaml
+++ b/data/stores/aiper.yaml
@@ -1,0 +1,12 @@
+name: "Aiper"
+slug: "aiper"
+aliases:
+  - "Aiper.com"
+categories:
+  - online_shopping
+website: "https://aiper.com"
+intro: |
+  Aiper is a fast-growing maker of cordless robotic pool cleaners and outdoor gear, sold
+  direct at aiper.com and through Amazon and home retailers. There is no Aiper co-brand credit
+  card, so purchases earn the most on a card with a strong online shopping multiplier or a
+  dependable flat-rate cashback card.

--- a/data/stores/ashampoo.yaml
+++ b/data/stores/ashampoo.yaml
@@ -1,0 +1,13 @@
+name: "Ashampoo"
+slug: "ashampoo"
+aliases:
+  - "Ashampoo.com"
+categories:
+  - online_shopping
+website: "https://www.ashampoo.com"
+intro: |
+  Ashampoo is a German software company selling Windows utilities, photo, backup, and
+  PC-optimization programs as downloads at ashampoo.com. There is no Ashampoo co-brand credit
+  card, so the best fit for a recurring online subscription is a card with a strong online
+  shopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward
+  a signup bonus.

--- a/data/stores/ashimary-hair.yaml
+++ b/data/stores/ashimary-hair.yaml
@@ -1,0 +1,13 @@
+name: "Ashimary Hair"
+slug: "ashimary-hair"
+aliases:
+  - "Ashimary"
+  - "AshimaryHair.com"
+categories:
+  - online_shopping
+website: "https://www.ashimaryhair.com"
+intro: |
+  Ashimary Hair is a hair brand selling human-hair wigs, bundles, and lace-front extensions
+  direct at ashimaryhair.com. There is no Ashimary Hair co-brand credit card, so purchases
+  earn the most on a card with a strong online shopping multiplier or a dependable flat-rate
+  cashback card.

--- a/data/stores/carla-car-rental.yaml
+++ b/data/stores/carla-car-rental.yaml
@@ -1,0 +1,14 @@
+name: "Carla Car Rental"
+slug: "carla-car-rental"
+aliases:
+  - "Carla"
+  - "RentCarla.com"
+categories:
+  - car_rentals
+website: "https://rentcarla.com"
+intro: |
+  Carla Car Rental is a car-rental booking app and site that compares rates across major
+  companies like Hertz, Avis, Budget, and Fox at rentcarla.com. There is no Carla Car Rental
+  co-brand credit card, so the best pairing is a card that earns bonus rewards on car rentals
+  or general travel, and many travel cards also add rental-car coverage when you pay with
+  them.

--- a/data/stores/choice-home-warranty.yaml
+++ b/data/stores/choice-home-warranty.yaml
@@ -1,0 +1,13 @@
+name: "Choice Home Warranty"
+slug: "choice-home-warranty"
+aliases:
+  - "ChoiceHomeWarranty.com"
+categories:
+  - online_shopping
+website: "https://www.choicehomewarranty.com"
+intro: |
+  Choice Home Warranty is one of the largest US home-warranty providers, selling annual
+  service plans that cover repairs to home systems and appliances at choicehomewarranty.com.
+  There is no Choice Home Warranty co-brand credit card, so the best fit for a recurring
+  online subscription is a card with a strong online shopping multiplier or a flat-rate
+  cashback card, and a multi-year plan is easy spend toward a signup bonus.

--- a/data/stores/click-and-grow.yaml
+++ b/data/stores/click-and-grow.yaml
@@ -1,0 +1,13 @@
+name: "Click & Grow"
+slug: "click-and-grow"
+aliases:
+  - "Click and Grow"
+  - "ClickAndGrow.com"
+categories:
+  - online_shopping
+website: "https://www.clickandgrow.com"
+intro: |
+  Click & Grow is a maker of self-watering indoor smart gardens and plant pods for growing
+  herbs and greens at home, sold at clickandgrow.com. There is no Click & Grow co-brand credit
+  card, so purchases earn the most on a card with a strong online shopping multiplier or a
+  dependable flat-rate cashback card.

--- a/data/stores/corel.yaml
+++ b/data/stores/corel.yaml
@@ -1,0 +1,14 @@
+name: "Corel"
+slug: "corel"
+aliases:
+  - "Corel Corporation"
+  - "Corel.com"
+categories:
+  - online_shopping
+website: "https://www.corel.com"
+intro: |
+  Corel is a long-running software company behind CorelDRAW, WordPerfect, and PaintShop Pro,
+  sold as downloads and subscriptions at corel.com. There is no Corel co-brand credit card, so
+  the best fit for a recurring online subscription is a card with a strong online shopping
+  multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup
+  bonus.

--- a/data/stores/corneacare.yaml
+++ b/data/stores/corneacare.yaml
@@ -1,0 +1,12 @@
+name: "CorneaCare"
+slug: "corneacare"
+aliases:
+  - "CorneaCare.co"
+categories:
+  - online_shopping
+website: "https://corneacare.co"
+intro: |
+  CorneaCare is a direct-to-consumer eye-care brand selling dry-eye relief products like
+  eyelid wipes, warm compresses, and omega-3 supplements on subscription. There is no
+  CorneaCare co-brand credit card, so purchases earn the most on a card with a strong online
+  shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/crowned-skin.yaml
+++ b/data/stores/crowned-skin.yaml
@@ -1,0 +1,12 @@
+name: "Crowned Skin"
+slug: "crowned-skin"
+aliases:
+  - "CrownedSkin.com"
+categories:
+  - online_shopping
+website: "https://crownedskin.com"
+intro: |
+  Crowned Skin is a direct-to-consumer men's fragrance brand, seen on Shark Tank, selling
+  body-butter and eau de parfum colognes at crownedskin.com and through Macy's and Amazon.
+  There is no Crowned Skin co-brand credit card, so purchases earn the most on a card with a
+  strong online shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/daz-3d.yaml
+++ b/data/stores/daz-3d.yaml
@@ -1,0 +1,14 @@
+name: "Daz 3D"
+slug: "daz-3d"
+aliases:
+  - "DAZ 3D"
+  - "Daz3D.com"
+categories:
+  - online_shopping
+website: "https://www.daz3d.com"
+intro: |
+  Daz 3D is a 3D art platform offering Daz Studio software plus a marketplace of models,
+  figures, and assets for digital artists at daz3d.com. There is no Daz 3D co-brand credit
+  card, so the best fit for a recurring online subscription is a card with a strong online
+  shopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward
+  a signup bonus.

--- a/data/stores/easeus.yaml
+++ b/data/stores/easeus.yaml
@@ -1,0 +1,13 @@
+name: "EaseUS"
+slug: "easeus"
+aliases:
+  - "EaseUS.com"
+categories:
+  - online_shopping
+website: "https://www.easeus.com"
+intro: |
+  EaseUS is a software company known for its data-recovery, backup, and partition tools, sold
+  as downloads and subscriptions at easeus.com. There is no EaseUS co-brand credit card, so
+  the best fit for a recurring online subscription is a card with a strong online shopping
+  multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup
+  bonus.

--- a/data/stores/electronic-express.yaml
+++ b/data/stores/electronic-express.yaml
@@ -1,0 +1,14 @@
+name: "Electronic Express"
+slug: "electronic-express"
+aliases:
+  - "ElectronicExpress.com"
+categories:
+  - electronics_stores
+  - online_shopping
+website: "https://www.electronicexpress.com"
+intro: |
+  Electronic Express is a US consumer-electronics and appliance retailer with stores across
+  Tennessee and an online store at electronicexpress.com. There is no Electronic Express
+  co-brand credit card, so a card with an electronics or online shopping bonus earns the most,
+  and the same gear bought at a big-box electronics retailer can lean on that store's category
+  rate.

--- a/data/stores/flowers-fast.yaml
+++ b/data/stores/flowers-fast.yaml
@@ -1,0 +1,12 @@
+name: "Flowers Fast"
+slug: "flowers-fast"
+aliases:
+  - "FlowersFast.com"
+categories:
+  - online_shopping
+website: "https://www.flowersfast.com"
+intro: |
+  Flowers Fast is an online florist offering same-day and next-day flower, plant, and gift
+  delivery nationwide at flowersfast.com. There is no Flowers Fast co-brand credit card, so
+  purchases earn the most on a card with a strong online shopping multiplier or a dependable
+  flat-rate cashback card.

--- a/data/stores/foreo.yaml
+++ b/data/stores/foreo.yaml
@@ -1,0 +1,13 @@
+name: "FOREO"
+slug: "foreo"
+aliases:
+  - "Foreo"
+  - "Foreo.com"
+categories:
+  - online_shopping
+website: "https://www.foreo.com"
+intro: |
+  FOREO is a Swedish beauty-tech brand best known for its LUNA facial-cleansing devices and
+  skincare tools, sold direct at foreo.com and through beauty retailers. There is no FOREO
+  co-brand credit card, so purchases earn the most on a card with a strong online shopping
+  multiplier or a dependable flat-rate cashback card.

--- a/data/stores/fragranceshop.yaml
+++ b/data/stores/fragranceshop.yaml
@@ -1,0 +1,13 @@
+name: "FragranceShop.com"
+slug: "fragranceshop"
+aliases:
+  - "FragranceShop"
+  - "The Fragrance Shop"
+categories:
+  - online_shopping
+website: "https://www.fragranceshop.com"
+intro: |
+  FragranceShop.com is a US discount fragrance retailer selling authentic designer perfume,
+  cologne, and gift sets online since 1998 at fragranceshop.com. There is no FragranceShop.com
+  co-brand credit card, so purchases earn the most on a card with a strong online shopping
+  multiplier or a dependable flat-rate cashback card.

--- a/data/stores/gamefly.yaml
+++ b/data/stores/gamefly.yaml
@@ -1,0 +1,12 @@
+name: "GameFly"
+slug: "gamefly"
+aliases:
+  - "GameFly.com"
+categories:
+  - entertainment
+  - online_shopping
+website: "https://www.gamefly.com"
+intro: |
+  GameFly is a video-game rental and subscription service that ships console games by mail and
+  sells used titles at gamefly.com. There is no GameFly co-brand credit card, so a card that
+  pays a bonus on entertainment or general online shopping earns the most.

--- a/data/stores/infimobile.yaml
+++ b/data/stores/infimobile.yaml
@@ -1,0 +1,13 @@
+name: "Infimobile"
+slug: "infimobile"
+aliases:
+  - "Infimobile.com"
+categories:
+  - cell_phone_providers
+  - online_shopping
+website: "https://www.infimobile.com"
+intro: |
+  Infimobile is a US mobile virtual network operator offering low-cost prepaid cell phone
+  plans and devices at infimobile.com. There is no Infimobile co-brand credit card, so a few
+  cards pay a bonus on phone or cell-provider bills, and otherwise a card with a strong
+  recurring-purchase or flat-rate rate works well.

--- a/data/stores/iolo.yaml
+++ b/data/stores/iolo.yaml
@@ -1,0 +1,13 @@
+name: "iolo"
+slug: "iolo"
+aliases:
+  - "iolo System Mechanic"
+  - "System Mechanic"
+categories:
+  - online_shopping
+website: "https://www.iolo.com"
+intro: |
+  iolo is the maker of System Mechanic, PC tune-up and optimization software sold as a yearly
+  subscription at iolo.com. There is no iolo co-brand credit card, so the best fit for a
+  recurring online subscription is a card with a strong online shopping multiplier or a
+  flat-rate cashback card, and a multi-year plan is easy spend toward a signup bonus.

--- a/data/stores/keetsa.yaml
+++ b/data/stores/keetsa.yaml
@@ -1,0 +1,14 @@
+name: "Keetsa"
+slug: "keetsa"
+aliases:
+  - "Keetsa.com"
+categories:
+  - furniture_stores
+  - online_shopping
+website: "https://www.keetsa.com"
+intro: |
+  Keetsa is an eco-friendly mattress and bedding brand selling memory-foam and hybrid
+  mattresses, pillows, and bases direct at keetsa.com and in a handful of showrooms. There is
+  no Keetsa co-brand credit card, so for a big one-time mattress purchase the most rewarding
+  options are a furniture or home-goods category card, a strong online shopping bonus, or a
+  flat-rate cashback card.

--- a/data/stores/lighting-new-york.yaml
+++ b/data/stores/lighting-new-york.yaml
@@ -1,0 +1,12 @@
+name: "Lighting New York"
+slug: "lighting-new-york"
+aliases:
+  - "LightingNewYork.com"
+categories:
+  - online_shopping
+website: "https://www.lightingnewyork.com"
+intro: |
+  Lighting New York is one of the largest online lighting retailers in the US, selling
+  chandeliers, fixtures, fans, and lamps from hundreds of brands at lightingnewyork.com. There
+  is no Lighting New York co-brand credit card, so purchases earn the most on a card with a
+  strong online shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/magzter.yaml
+++ b/data/stores/magzter.yaml
@@ -1,0 +1,13 @@
+name: "Magzter"
+slug: "magzter"
+aliases:
+  - "Magzter.com"
+categories:
+  - online_shopping
+website: "https://www.magzter.com"
+intro: |
+  Magzter is a digital newsstand offering unlimited access to thousands of magazines and
+  newspapers through the Magzter Gold subscription at magzter.com. There is no Magzter
+  co-brand credit card, so the best fit for a recurring online subscription is a card with a
+  strong online shopping multiplier or a flat-rate cashback card, and a multi-year plan is
+  easy spend toward a signup bonus.

--- a/data/stores/mfi-medical.yaml
+++ b/data/stores/mfi-medical.yaml
@@ -1,0 +1,12 @@
+name: "MFI Medical"
+slug: "mfi-medical"
+aliases:
+  - "MFIMedical.com"
+categories:
+  - online_shopping
+website: "https://mfimedical.com"
+intro: |
+  MFI Medical is an online retailer of medical equipment and supplies for clinics, home care,
+  and professionals, selling exam, diagnostic, and mobility gear at mfimedical.com. There is
+  no MFI Medical co-brand credit card, so purchases earn the most on a card with a strong
+  online shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/nordpass.yaml
+++ b/data/stores/nordpass.yaml
@@ -1,0 +1,14 @@
+name: "NordPass"
+slug: "nordpass"
+aliases:
+  - "NordPass.com"
+categories:
+  - online_shopping
+website: "https://nordpass.com"
+parent_company: "Nord Security"
+intro: |
+  NordPass is a password manager from Nord Security, sold as a personal or family subscription
+  at nordpass.com alongside NordVPN and NordLocker. There is no NordPass co-brand credit card,
+  so the best fit for a recurring online subscription is a card with a strong online shopping
+  multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup
+  bonus.

--- a/data/stores/ovago.yaml
+++ b/data/stores/ovago.yaml
@@ -1,0 +1,12 @@
+name: "Ovago"
+slug: "ovago"
+aliases:
+  - "OVAGO.com"
+categories:
+  - travel
+website: "https://www.ovago.com"
+intro: |
+  Ovago is an online travel agency specializing in discounted airline tickets, with flight
+  booking and support handled at ovago.com. There is no Ovago co-brand credit card, so the
+  best pairing is a card that earns bonus rewards on travel, which usually covers flights and
+  trips booked through an online travel agency.

--- a/data/stores/panda-office.yaml
+++ b/data/stores/panda-office.yaml
@@ -1,0 +1,14 @@
+name: "Panda Office"
+slug: "panda-office"
+aliases:
+  - "PandaOffice"
+  - "PandaOffice.com"
+categories:
+  - online_shopping
+website: "https://www.pandaoffice.com"
+intro: |
+  Panda Office is a data-recovery and file-repair software company selling downloadable tools
+  for recovering lost files and photos at pandaoffice.com. There is no Panda Office co-brand
+  credit card, so the best fit for a recurring online subscription is a card with a strong
+  online shopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend
+  toward a signup bonus.

--- a/data/stores/perfumania.yaml
+++ b/data/stores/perfumania.yaml
@@ -1,0 +1,12 @@
+name: "Perfumania"
+slug: "perfumania"
+aliases:
+  - "Perfumania.com"
+categories:
+  - online_shopping
+website: "https://www.perfumania.com"
+intro: |
+  Perfumania is a US discount fragrance retailer selling designer perfume and cologne online
+  and in outlet stores at perfumania.com. There is no Perfumania co-brand credit card, so
+  purchases earn the most on a card with a strong online shopping multiplier or a dependable
+  flat-rate cashback card.

--- a/data/stores/personalabs.yaml
+++ b/data/stores/personalabs.yaml
@@ -1,0 +1,12 @@
+name: "Personalabs"
+slug: "personalabs"
+aliases:
+  - "Personalabs.com"
+categories:
+  - online_shopping
+website: "https://www.personalabs.com"
+intro: |
+  Personalabs is a direct-to-consumer lab-testing service that lets people order their own
+  blood and health tests online without a doctor visit at personalabs.com. There is no
+  Personalabs co-brand credit card, so purchases earn the most on a card with a strong online
+  shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/phone-com.yaml
+++ b/data/stores/phone-com.yaml
@@ -1,0 +1,13 @@
+name: "Phone.com"
+slug: "phone-com"
+aliases:
+  - "Phone.com"
+categories:
+  - cell_phone_providers
+  - online_shopping
+website: "https://www.phone.com"
+intro: |
+  Phone.com is a VoIP business phone service offering virtual numbers, calling, and video
+  meetings on monthly plans at phone.com. There is no Phone.com co-brand credit card, so a few
+  cards pay a bonus on phone or cell-provider bills, and otherwise a card with a strong
+  recurring-purchase or flat-rate rate works well.

--- a/data/stores/power-systems.yaml
+++ b/data/stores/power-systems.yaml
@@ -1,0 +1,13 @@
+name: "Power Systems"
+slug: "power-systems"
+aliases:
+  - "Power-Systems.com"
+categories:
+  - sporting_goods
+  - online_shopping
+website: "https://www.power-systems.com"
+intro: |
+  Power Systems is a supplier of strength, conditioning, and fitness equipment for gyms,
+  trainers, and home use, sold at power-systems.com. There is no Power Systems co-brand credit
+  card, so a card that pays a bonus on sporting goods or general online shopping is the best
+  fit.

--- a/data/stores/rexing.yaml
+++ b/data/stores/rexing.yaml
@@ -1,0 +1,13 @@
+name: "Rexing"
+slug: "rexing"
+aliases:
+  - "RexingUSA"
+  - "Rexing USA"
+categories:
+  - online_shopping
+website: "https://www.rexingusa.com"
+intro: |
+  Rexing is a US brand of dash cams and vehicle electronics, selling front-and-rear recorders,
+  mirror cams, and accessories at rexingusa.com. There is no Rexing co-brand credit card, so
+  purchases earn the most on a card with a strong online shopping multiplier or a dependable
+  flat-rate cashback card.

--- a/data/stores/russell-stover.yaml
+++ b/data/stores/russell-stover.yaml
@@ -1,0 +1,12 @@
+name: "Russell Stover"
+slug: "russell-stover"
+aliases:
+  - "RussellStover.com"
+categories:
+  - online_shopping
+website: "https://www.russellstover.com"
+intro: |
+  Russell Stover is a classic American chocolate brand known for its boxed chocolates and
+  sugar-free candies, sold direct at russellstover.com and in grocery and drug stores. There
+  is no Russell Stover co-brand credit card, so purchases earn the most on a card with a
+  strong online shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/seats-aero.yaml
+++ b/data/stores/seats-aero.yaml
@@ -1,0 +1,14 @@
+name: "Seats.aero"
+slug: "seats-aero"
+aliases:
+  - "SeatsAero"
+  - "Seats aero"
+categories:
+  - travel
+website: "https://seats.aero"
+intro: |
+  Seats.aero is an award-travel search tool that scans airline loyalty programs for available
+  award flights, offered as a Pro subscription at seats.aero. There is no Seats.aero co-brand
+  credit card, so the best fit for a recurring online subscription is a card with a strong
+  online shopping multiplier or a flat-rate cashback card, and a multi-year plan is easy spend
+  toward a signup bonus.

--- a/data/stores/shelving-inc.yaml
+++ b/data/stores/shelving-inc.yaml
@@ -1,0 +1,13 @@
+name: "Shelving Inc"
+slug: "shelving-inc"
+aliases:
+  - "Shelving.com"
+  - "Shelving Inc."
+categories:
+  - online_shopping
+website: "https://www.shelving.com"
+intro: |
+  Shelving Inc is an online retailer of shelving, storage, and organization systems for home,
+  garage, and commercial use at shelving.com. There is no Shelving Inc co-brand credit card,
+  so purchases earn the most on a card with a strong online shopping multiplier or a
+  dependable flat-rate cashback card.

--- a/data/stores/silverrushstyle.yaml
+++ b/data/stores/silverrushstyle.yaml
@@ -1,0 +1,12 @@
+name: "SilverRushStyle"
+slug: "silverrushstyle"
+aliases:
+  - "Silver Rush Style"
+categories:
+  - online_shopping
+website: "https://www.silverrushstyle.com"
+intro: |
+  SilverRushStyle is an online jeweler specializing in handcrafted sterling silver and
+  gemstone jewelry at silverrushstyle.com. There is no SilverRushStyle co-brand credit card,
+  so purchases earn the most on a card with a strong online shopping multiplier or a
+  dependable flat-rate cashback card.

--- a/data/stores/sleep-and-beyond.yaml
+++ b/data/stores/sleep-and-beyond.yaml
@@ -1,0 +1,13 @@
+name: "Sleep & Beyond"
+slug: "sleep-and-beyond"
+aliases:
+  - "Sleep and Beyond"
+  - "SleepAndBeyond.com"
+categories:
+  - online_shopping
+website: "https://www.sleepandbeyond.com"
+intro: |
+  Sleep & Beyond is a maker of organic and natural bedding, including wool mattress toppers,
+  pillows, and sheets, sold direct at sleepandbeyond.com. There is no Sleep & Beyond co-brand
+  credit card, so purchases earn the most on a card with a strong online shopping multiplier
+  or a dependable flat-rate cashback card.

--- a/data/stores/soccer-garage.yaml
+++ b/data/stores/soccer-garage.yaml
@@ -1,0 +1,12 @@
+name: "Soccer Garage"
+slug: "soccer-garage"
+aliases:
+  - "SoccerGarage.com"
+categories:
+  - sporting_goods
+  - online_shopping
+website: "https://www.soccergarage.com"
+intro: |
+  Soccer Garage is an online soccer retailer selling cleats, jerseys, goalkeeper gear, and
+  team equipment at soccergarage.com. There is no Soccer Garage co-brand credit card, so a
+  card that pays a bonus on sporting goods or general online shopping is the best fit.

--- a/data/stores/sucuri.yaml
+++ b/data/stores/sucuri.yaml
@@ -1,0 +1,12 @@
+name: "Sucuri"
+slug: "sucuri"
+aliases:
+  - "Sucuri.net"
+categories:
+  - online_shopping
+website: "https://sucuri.net"
+intro: |
+  Sucuri is a website-security service offering malware cleanup, firewall, and monitoring on
+  annual subscriptions at sucuri.net. There is no Sucuri co-brand credit card, so the best fit
+  for a recurring online subscription is a card with a strong online shopping multiplier or a
+  flat-rate cashback card, and a multi-year plan is easy spend toward a signup bonus.

--- a/data/stores/sunber-hair.yaml
+++ b/data/stores/sunber-hair.yaml
@@ -1,0 +1,12 @@
+name: "Sunber Hair"
+slug: "sunber-hair"
+aliases:
+  - "Sunber"
+  - "SunberHair.com"
+categories:
+  - online_shopping
+website: "https://www.sunberhair.com"
+intro: |
+  Sunber Hair is a hair brand selling human-hair wigs, weaves, and extensions direct at
+  sunberhair.com. There is no Sunber Hair co-brand credit card, so purchases earn the most on
+  a card with a strong online shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/surfshark.yaml
+++ b/data/stores/surfshark.yaml
@@ -1,0 +1,14 @@
+name: "Surfshark"
+slug: "surfshark"
+aliases:
+  - "Surfshark VPN"
+  - "Surfshark.com"
+categories:
+  - online_shopping
+website: "https://surfshark.com"
+intro: |
+  Surfshark is a popular consumer VPN service sold as a monthly or multi-year subscription at
+  surfshark.com alongside antivirus and identity-protection add-ons. There is no Surfshark
+  co-brand credit card, so the best fit for a recurring online subscription is a card with a
+  strong online shopping multiplier or a flat-rate cashback card, and a multi-year plan is
+  easy spend toward a signup bonus.

--- a/data/stores/switchbot.yaml
+++ b/data/stores/switchbot.yaml
@@ -1,0 +1,13 @@
+name: "SwitchBot"
+slug: "switchbot"
+aliases:
+  - "Switch-Bot"
+  - "SwitchBot.com"
+categories:
+  - online_shopping
+website: "https://www.switch-bot.com"
+intro: |
+  SwitchBot is a smart-home brand making automated blinds, locks, hubs, and robot vacuums,
+  sold direct at switch-bot.com and through Amazon. There is no SwitchBot co-brand credit
+  card, so purchases earn the most on a card with a strong online shopping multiplier or a
+  dependable flat-rate cashback card.

--- a/data/stores/teac.yaml
+++ b/data/stores/teac.yaml
@@ -1,0 +1,13 @@
+name: "TEAC"
+slug: "teac"
+aliases:
+  - "TEAC USA"
+  - "TEAC America"
+categories:
+  - online_shopping
+website: "https://teac.com"
+intro: |
+  TEAC is a Japanese audio-electronics brand making turntables, CD players, and hi-fi
+  components, sold in the US at teac.com. There is no TEAC co-brand credit card, so purchases
+  earn the most on a card with a strong online shopping multiplier or a dependable flat-rate
+  cashback card.

--- a/data/stores/tech-for-less.yaml
+++ b/data/stores/tech-for-less.yaml
@@ -1,0 +1,13 @@
+name: "Tech For Less"
+slug: "tech-for-less"
+aliases:
+  - "TechForLess.com"
+categories:
+  - electronics_stores
+  - online_shopping
+website: "https://www.techforless.com"
+intro: |
+  Tech For Less is an online retailer of discounted new, refurbished, and open-box electronics
+  and computers at techforless.com. There is no Tech For Less co-brand credit card, so a card
+  with an electronics or online shopping bonus earns the most, and the same gear bought at a
+  big-box electronics retailer can lean on that store's category rate.

--- a/data/stores/tenergy.yaml
+++ b/data/stores/tenergy.yaml
@@ -1,0 +1,12 @@
+name: "Tenergy"
+slug: "tenergy"
+aliases:
+  - "Tenergy.com"
+categories:
+  - online_shopping
+website: "https://power.tenergy.com"
+intro: |
+  Tenergy is a maker of rechargeable batteries, chargers, and small consumer electronics, sold
+  direct and through Amazon. There is no Tenergy co-brand credit card, so purchases earn the
+  most on a card with a strong online shopping multiplier or a dependable flat-rate cashback
+  card.

--- a/data/stores/the-tight-spot.yaml
+++ b/data/stores/the-tight-spot.yaml
@@ -1,0 +1,13 @@
+name: "The Tight Spot"
+slug: "the-tight-spot"
+aliases:
+  - "TheTightSpot.com"
+categories:
+  - select_clothing
+  - online_shopping
+website: "https://www.thetightspot.com"
+intro: |
+  The Tight Spot is an online hosiery boutique carrying thousands of styles of tights,
+  pantyhose, and stockings from brands like Wolford at thetightspot.com. There is no The Tight
+  Spot co-brand credit card, so purchases earn the most on a card with a clothing or online
+  shopping category bonus.

--- a/data/stores/tp-link.yaml
+++ b/data/stores/tp-link.yaml
@@ -1,0 +1,13 @@
+name: "TP-Link"
+slug: "tp-link"
+aliases:
+  - "TP-Link USA"
+  - "TPLink"
+categories:
+  - online_shopping
+website: "https://www.tp-link.com"
+intro: |
+  TP-Link is one of the world's largest makers of Wi-Fi routers, mesh systems, and networking
+  gear, sold direct and through electronics retailers under its TP-Link and Deco lines. There
+  is no TP-Link co-brand credit card, so purchases earn the most on a card with a strong
+  online shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/trampoline-parts-and-supply.yaml
+++ b/data/stores/trampoline-parts-and-supply.yaml
@@ -1,0 +1,13 @@
+name: "Trampoline Parts and Supply"
+slug: "trampoline-parts-and-supply"
+aliases:
+  - "TrampolinePartsAndSupply.com"
+  - "TPS"
+categories:
+  - online_shopping
+website: "https://www.trampolinepartsandsupply.com"
+intro: |
+  Trampoline Parts and Supply is a specialty retailer of replacement trampoline mats, springs,
+  pads, and nets for most trampoline brands, sold online. There is no Trampoline Parts and
+  Supply co-brand credit card, so purchases earn the most on a card with a strong online
+  shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/treat-my-uti.yaml
+++ b/data/stores/treat-my-uti.yaml
@@ -1,0 +1,12 @@
+name: "Treat My UTI"
+slug: "treat-my-uti"
+aliases:
+  - "TreatMyUTI.com"
+categories:
+  - online_shopping
+website: "https://www.treatmyuti.com"
+intro: |
+  Treat My UTI is a direct-to-consumer wellness brand selling urinary-tract and vaginal-health
+  supplements and test strips at treatmyuti.com. There is no Treat My UTI co-brand credit
+  card, so purchases earn the most on a card with a strong online shopping multiplier or a
+  dependable flat-rate cashback card.

--- a/data/stores/unbeatablesale.yaml
+++ b/data/stores/unbeatablesale.yaml
@@ -1,0 +1,12 @@
+name: "UnbeatableSale"
+slug: "unbeatablesale"
+aliases:
+  - "UnbeatableSale.com"
+categories:
+  - department_stores
+  - online_shopping
+website: "https://www.unbeatablesale.com"
+intro: |
+  UnbeatableSale is an online discount marketplace carrying a wide range of home, health, and
+  general-merchandise products at unbeatablesale.com. There is no UnbeatableSale co-brand
+  credit card, so a card with a department store or online shopping bonus earns the most.

--- a/data/stores/unice.yaml
+++ b/data/stores/unice.yaml
@@ -1,0 +1,13 @@
+name: "UNice"
+slug: "unice"
+aliases:
+  - "UNice Hair"
+  - "UNice.com"
+categories:
+  - online_shopping
+website: "https://www.unice.com"
+intro: |
+  UNice is a popular hair brand selling human-hair wigs, bundles, and extensions direct at
+  unice.com and through Amazon. There is no UNice co-brand credit card, so purchases earn the
+  most on a card with a strong online shopping multiplier or a dependable flat-rate cashback
+  card.

--- a/data/stores/untilgone.yaml
+++ b/data/stores/untilgone.yaml
@@ -1,0 +1,12 @@
+name: "UntilGone"
+slug: "untilgone"
+aliases:
+  - "UntilGone.com"
+categories:
+  - online_shopping
+website: "https://www.untilgone.com"
+intro: |
+  UntilGone is an online daily-deals retailer selling discounted electronics, home goods, and
+  gadgets in limited-time offers at untilgone.com. There is no UntilGone co-brand credit card,
+  so purchases earn the most on a card with a strong online shopping multiplier or a
+  dependable flat-rate cashback card.

--- a/data/stores/vip-cars.yaml
+++ b/data/stores/vip-cars.yaml
@@ -1,0 +1,13 @@
+name: "VIP Cars"
+slug: "vip-cars"
+aliases:
+  - "VIPCars"
+  - "VIP Cars Global"
+categories:
+  - car_rentals
+website: "https://www.vipcars.com"
+intro: |
+  VIP Cars is a car-rental booking service that compares rates from suppliers at airports and
+  cities worldwide at vipcars.com. There is no VIP Cars co-brand credit card, so the best
+  pairing is a card that earns bonus rewards on car rentals or general travel, and many travel
+  cards also add rental-car coverage when you pay with them.

--- a/data/stores/vy-jewelry.yaml
+++ b/data/stores/vy-jewelry.yaml
@@ -1,0 +1,12 @@
+name: "VY Jewelry"
+slug: "vy-jewelry"
+aliases:
+  - "VYJewelry"
+categories:
+  - online_shopping
+website: "https://vyjewelry.shop"
+intro: |
+  VY Jewelry is a jewelry brand selling 925 sterling silver rings, necklaces, and bracelets
+  for men and women at vyjewelry.shop and through Amazon. There is no VY Jewelry co-brand
+  credit card, so purchases earn the most on a card with a strong online shopping multiplier
+  or a dependable flat-rate cashback card.

--- a/data/stores/wa-production.yaml
+++ b/data/stores/wa-production.yaml
@@ -1,0 +1,13 @@
+name: "WA Production"
+slug: "wa-production"
+aliases:
+  - "WAProduction"
+categories:
+  - online_shopping
+website: "https://www.waproduction.com"
+intro: |
+  WA Production is a music-production company selling audio plugins, sample packs, and
+  tutorials for producers at waproduction.com. There is no WA Production co-brand credit card,
+  so the best fit for a recurring online subscription is a card with a strong online shopping
+  multiplier or a flat-rate cashback card, and a multi-year plan is easy spend toward a signup
+  bonus.

--- a/data/stores/winebasket.yaml
+++ b/data/stores/winebasket.yaml
@@ -1,0 +1,14 @@
+name: "Winebasket"
+slug: "winebasket"
+aliases:
+  - "Winebasket.com"
+  - "Babybasket"
+  - "Capalbo's"
+categories:
+  - online_shopping
+website: "https://www.winebasket.com"
+intro: |
+  Winebasket is an online gift retailer selling wine, champagne, and gourmet gift baskets for
+  occasions at winebasket.com. There is no Winebasket co-brand credit card, so purchases earn
+  the most on a card with a strong online shopping multiplier or a dependable flat-rate
+  cashback card.

--- a/data/stores/wristband-express.yaml
+++ b/data/stores/wristband-express.yaml
@@ -1,0 +1,12 @@
+name: "Wristband Express"
+slug: "wristband-express"
+aliases:
+  - "WristbandExpress.com"
+categories:
+  - online_shopping
+website: "https://www.wristbandexpress.com"
+intro: |
+  Wristband Express is an online seller of custom silicone wristbands, event bracelets, and
+  lanyards for fundraisers, parties, and businesses at wristbandexpress.com. There is no
+  Wristband Express co-brand credit card, so purchases earn the most on a card with a strong
+  online shopping multiplier or a dependable flat-rate cashback card.

--- a/data/stores/zchocolat.yaml
+++ b/data/stores/zchocolat.yaml
@@ -1,0 +1,12 @@
+name: "zChocolat"
+slug: "zchocolat"
+aliases:
+  - "zChocolat.com"
+categories:
+  - online_shopping
+website: "https://www.zchocolat.com"
+intro: |
+  zChocolat is a luxury chocolate brand offering French assortments in mahogany gift boxes
+  with worldwide delivery at zchocolat.com. There is no zChocolat co-brand credit card, so
+  purchases earn the most on a card with a strong online shopping multiplier or a dependable
+  flat-rate cashback card.


### PR DESCRIPTION
Builds the recommended **include set** from the CJ Affiliate Tier A+B review — 56 new `/best-card-for/[slug]` pages, each wired to a CJ tracking link via the `network: cj` override (proven on the NordVPN page #1643). Per your steer to include far more of the list than my first conservative pass.

## What's in
56 merchants across: software/subscriptions, beauty/fragrance/hair, health, home/garden, electronics/auto, gifts/food, jewelry, apparel/sports, travel/comms, and marketplaces. (Full list in the commit body.)

## What's excluded (and why)
- **8 hard skips:** EdenFantasys (adult), Silver Gold Bull (precious metals / cash-advance), WalletHub (direct competitor), PeopleFinders (privacy lead-gen), 12GO / Air Serbia / Travelpro EU (non-US), Signs Banners Magnets (B2B print).
- **Judgment-call / grey-market (held for your decision):** GAMIVO, Gameseal, Canada/Budget/Best Vet pet-pharmacies, Isagenix, RSE, Trinity Road.
- **Diecast** held — couldn't confirm which diecast merchant/domain the CJ program maps to; didn't want to ship a wrong homepage.
- **Duplicates** (already monetized via FlexOffers): Jackery, DHgate, AliExpress — untouched. **Mavis** (existing page, no link) is a separate small follow-up.

## Notes
- Obscure merchants (Carla, Crowned Skin, The Tight Spot, Panda Office, FragranceShop, VY Jewelry) were web-verified so intros are accurate. No em dashes.
- Category tags mirror comparable existing stores; most default to `online_shopping`.

## Verification
- `npm run build:stores` → **932 stores / 463 affiliate links**; all 56 carry `affiliate.network: cj`.
- All 56 return **200** with their CJ link in the CTA and correct category ranking. Screenshot confirmed (FOREO).