### PR TITLE
Ink Business Cash: add 5% Lyft transit reward

### DIFF
--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -45,6 +45,10 @@ rewards:
     spend_cap: 25000
     cap_period: annual
     rate_after_cap: 1
+  - category: transit
+    value: 5
+    unit: percent
+    note: "On Lyft rides through September 30, 2027 (limited-time promo)"
   - category: everything_else
     value: 1
     unit: percent


### PR DESCRIPTION
Chase's page shows Ink Business Cash earns **5% total cash back on Lyft rides through September 30, 2027**. We had this category on Ink Business Preferred and Ink Business Unlimited but **not** on Cash — an internal inconsistency surfaced by the 2026-07-10 rewards/benefits review (#1636).

Adds `transit: 5%` matching the siblings' note convention (specifies Lyft + the promo end date). `build:cards` clean.

Follow-up (separate PR): a structured `expires` field so these promos self-manage instead of living as free-text end dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)