### PR TITLE
Add article: U.S. Bank Cash+ Explained (Card Explained series)

### DIFF
--- a/.github/workflows/content-agent.yml
+++ b/.github/workflows/content-agent.yml
@@ -1,0 +1,65 @@
+name: Content Intelligence Agent
+
+# Watches competitor accounts and turns notable card developments into decisions
+# about OUR own content (article / tweet / skip), with fact-checking. Defaults to
+# shadow (reports to Slack, posts/publishes nothing) until the CONTENT_AGENT_MODE
+# repo variable is set to 'live'. Restarted after the X API billing lapse that
+# forced the 2026-07-06 decommission (#1581) was resolved.
+
+on:
+  schedule:
+    - cron: '15 * * * *' # hourly, offset from other content crons
+  workflow_dispatch:
+    inputs:
+      reset:
+        description: 'Ignore saved state and re-scan recent tweets'
+        required: false
+        default: false
+        type: boolean
+
+# contents/pull-requests/actions write: the news path commits a YAML via an
+# auto-PR, self-merges it, and dispatches build-news.yml.
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: content-agent
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
+          aws-region: us-east-2
+      - name: Run content agent
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SOCIAL_API_URL: ${{ secrets.SOCIAL_API_URL }}
+          SOCIAL_API_KEY: ${{ secrets.SOCIAL_API_KEY }}
+          CONTENT_AGENT_STATE_S3: s3://${{ secrets.S3_BUCKET_NAME }}/content-agent/state.json
+          # Defaults to shadow; flip the CONTENT_AGENT_MODE repo variable to 'live'
+          # only after reviewing a stretch of shadow Slack reports.
+          CONTENT_AGENT_MODE: ${{ vars.CONTENT_AGENT_MODE || 'shadow' }}
+          CONTENT_AGENT_KILL: ${{ vars.CONTENT_AGENT_KILL || '' }}
+          CONTENT_AGENT_RESET: ${{ github.event.inputs.reset }}
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/content-agent/run.js

--- a/data/articles/us-bank-cash-plus-explained.yaml
+++ b/data/articles/us-bank-cash-plus-explained.yaml
@@ -1,0 +1,110 @@
+id: "us-bank-cash-plus-explained"
+slug: "us-bank-cash-plus-explained"
+title: "U.S. Bank Cash+ Explained: What Counts as Ground Transportation (and What Doesn't)"
+date: "2026-07-11"
+author: "CreditOdds"
+estimated_value: "$300-500/year"
+summary: "The Cash+ 5% Ground Transportation category covers Uber, Lyft, and Citi Bike, but not Uber Eats. Here is how the card works and how to pick categories."
+tags:
+  - guide
+  - analysis
+related_cards:
+  - us-bank-cash-plus-visa-signature
+  - citi-custom-cash
+seo_title: "U.S. Bank Cash+ Explained: Uber, Lyft, Citi Bike | CreditOdds"
+seo_description: "How the U.S. Bank Cash+ works: the 5% Ground Transportation category covers Uber, Lyft, and Citi Bike, but Uber Eats codes as Restaurants at 2%."
+image: "us-bank-cash-plus-explained.png"
+image_alt: "A rideshare car, a bike-share bicycle, and a food-delivery bag sorted into cash-back category buckets"
+social_title: "Cash+ Explained: Rides Count, Uber Eats Doesn't"
+content: |
+  This is the first in our *Card Explained* series, where we take one card, put it under real-world use, and show exactly how the rewards land. We are starting with the U.S. Bank Cash+ Visa Signature, because it is one of the most flexible no-annual-fee 5% cards out there, and because it has a quirk that trips up almost everyone: the difference between a ride and a meal delivered by the same app.
+
+  ## The card in one paragraph
+
+  The [U.S. Bank Cash+](/card/us-bank-cash-plus-visa-signature) has no annual fee and earns on a three-tier structure that you partly control:
+
+  - **5% cash back** on **two categories you choose** each quarter, on up to **$2,000 in combined purchases** per quarter
+  - **2% cash back** on **one everyday category you choose** (groceries, gas and EV charging, or restaurants), with no cap
+  - **1% cash back** on everything else, and on your 5% spend after you pass the $2,000 quarterly cap
+
+  There is also a 5% rate on prepaid travel booked through the U.S. Bank Travel Rewards Center. The catch that comes with all this flexibility: you have to re-select your categories every quarter, and anything you forget to select earns just 1%.
+
+  ## The star of the show: Ground Transportation
+
+  One of the twelve categories you can pick for your 5% is **Ground Transportation**. This is the category that makes the Cash+ interesting for anyone who lives in a city and does not drive much.
+
+  Here is what actually codes as Ground Transportation, confirmed from real posted transactions:
+
+  | Merchant | What it is | Category it hit | Earn rate |
+  |----------|-----------|-----------------|-----------|
+  | Uber | Rideshare | Ground Transportation | 5% |
+  | Lyft | Rideshare | Ground Transportation | 5% |
+  | Citi Bike | Bike share | Ground Transportation | 5% |
+  | Uber Eats | Food delivery | Restaurants | 2% |
+
+  So a single quarter of city commuting on rideshare and bike share, with Ground Transportation selected as a 5% category, earns 5% across all of it. Rideshare, taxis, and bike-share docks like Citi Bike, Divvy, and Bluebikes all fall under the same transportation coding. That is a genuinely strong rate for spend that most cards treat as ordinary.
+
+  ## The gotcha: Uber Eats is not transportation
+
+  Here is the part almost nobody gets right. **Uber Eats does not count as Ground Transportation, even though it is Uber.**
+
+  The card does not reward based on the app you opened. It rewards based on the **merchant category** the charge carries. An Uber *ride* codes as transportation. An Uber *Eats* order codes as a restaurant or food-delivery merchant. Same brand, same app icon, two completely different buckets.
+
+  You can see it clearly in a real statement:
+
+  - `Uber  $105.55  Earn rate 5%  (Ground Transportation)`
+  - `Uber Eats  $21.84  Earn rate 2%  (Restaurants)`
+  - `Uber Eats  $24.87  Earn rate 2%  (Restaurants)`
+
+  Notice the Uber Eats charges earned 2%, not 5%, and only because the cardholder also selected **Restaurants** as their 2% everyday category. Had they picked groceries or gas for the 2% slot instead, those Uber Eats orders would have dropped all the way to 1%.
+
+  The same logic applies to DoorDash, Grubhub, and other delivery services: they code as restaurants or food delivery, not as transportation. If you want your food delivery to earn more than 1%, the 2% Restaurants pick is where it belongs, not the 5% Ground Transportation pick.
+
+  ## How to actually pick your categories
+
+  The Cash+ rewards planning, not spending. Two decisions drive most of the value.
+
+  ### Your two 5% categories
+
+  You get to choose two from a list of twelve:
+
+  - Fast food
+  - Home utilities
+  - TV, internet, and streaming
+  - Department stores
+  - Cell phone providers
+  - Electronics stores
+  - Sporting goods
+  - Furniture stores
+  - Movie theaters
+  - Ground transportation
+  - Gyms and fitness centers
+  - Select clothing stores
+
+  The two that quietly stand out are **Home utilities** and **Cell phone providers**, because 5% on a power bill or a phone bill is rare and shows up every single month. **Ground Transportation** joins that tier if you are a heavy rideshare or bike-share user. In the real dashboard we looked at, the cardholder ran Cell Phone Providers and Ground Transportation as their two 5% picks and had already spent over $1,000 in transportation for the quarter.
+
+  Remember the shared cap: the $2,000 limit is **combined** across both 5% categories per quarter, not $2,000 each. Once you cross it, everything drops to 1% for the rest of the quarter.
+
+  ### Your one 2% category
+
+  You pick one of: **groceries and grocery delivery**, **gas and EV charging**, or **restaurants**. This one has no cap, so it is the home for a category you spend on constantly but heavily. If food delivery is a big part of your life, Restaurants here is what rescues those Uber Eats and DoorDash orders from the 1% pile.
+
+  ## A quick value example
+
+  Take the transportation spend from the real statement: roughly $530 toward the 5% cap in a quarter, mostly Uber, Lyft, and Citi Bike.
+
+  - At **5%** (Ground Transportation selected): about **$26** back on that spend
+  - At **1%** (category not selected): about **$5** back
+
+  That is a $21 swing on one quarter of rides, from one checkbox. Annualize a steady rideshare and bike-share habit across a full year and the Ground Transportation pick alone is often worth $200 to $400, before you even count the second 5% category and the 2% everyday pick.
+
+  ## Two things that will cost you if you forget
+
+  1. **Re-select every quarter.** Selections lock for the current quarter, and there is a window (roughly mid-quarter to late in the quarter) to set the next one. Miss it, and unchosen spend earns 1%. Put a recurring calendar reminder near the start of each quarter.
+  2. **Watch the merchant category, not the brand.** Uber Eats, warehouse clubs, and supercenters routinely code differently than people expect. When in doubt, run a small test charge and check the earn rate on the pending transaction before you route big spend to it.
+
+  ## The bottom line
+
+  The U.S. Bank Cash+ rewards people who are willing to manage it. Pick Ground Transportation and you get a rare 5% on Uber, Lyft, and Citi Bike. Pick Restaurants as your 2% and you at least catch Uber Eats and other delivery at 2%. Just do not expect the app's name to decide the rate: on this card, a ride and a burrito ordered from the same Uber account land in two different reward buckets, and knowing which is which is most of the game.
+
+  Want to see how the Cash+ stacks up against other flexible-category cards like the [Citi Custom Cash](/card/citi-custom-cash)? Compare them side by side and check current approval odds on their card pages.


### PR DESCRIPTION
Adds the first article in a new **Card Explained** series (one per card), starting with the U.S. Bank Cash+ Visa Signature.

## The hook
Built around a real-world quirk visible in an actual Cash+ statement: the **Ground Transportation** 5% category covers **Uber, Lyft, and Citi Bike**, but **Uber Eats does not** — it codes as *Restaurants*, so it only earns the chosen 2% everyday category (or 1%). Same Uber account, two different reward buckets. The piece uses the app-name-vs-merchant-category distinction as the teaching moment.

## What it covers
- The full 5% / 2% / 1% structure and the $0 annual fee
- All 12 eligible 5% categories, with Home utilities, Cell phone, and Ground Transportation called out as the standouts
- The $2,000 **combined** quarterly cap across both 5% picks
- The 2% everyday category as the right home for food delivery
- A value example drawn from the real dashboard numbers (~$530 transportation spend → ~$26 at 5% vs ~$5 at 1%)
- Quarterly re-selection reminder and a 'watch the merchant category, not the brand' rule

## Details
- New file: `data/articles/us-bank-cash-plus-explained.yaml`
- Tags: `guide`, `analysis`; `related_cards`: us-bank-cash-plus-visa-signature, citi-custom-cash
- Validates via `build-articles.js` (6 min read); no em dashes in copy; inline card links use the correct `/card/<slug>` route
- `data/articles.json` intentionally not committed (CI regenerates and uploads it; the tracked copy is already stale by design). Hero + social images are auto-generated in CI from the `image`/`social_title` fields.