### PR TITLE
feat(rewards): structured expires date for limited-time promo rewards

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -130,6 +130,19 @@ function wireDirection(
   return wentUp ? "pos" : "neg";
 }
 
+// Renders a reward's `expires` ISO date as "Sep 30, 2027". Parsed as UTC (append
+// T00:00:00Z) so the day doesn't slip in negative-offset timezones.
+function formatExpiresDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 // Formats a signup-bonus amount in its natural unit (mirrors the headline
 // `bonusDisplay` logic so the rail's "highest ever" reads the same way).
 function formatBonusValue(value: number, type: string): string {
@@ -1107,6 +1120,11 @@ export default function CardClient({
                               </div>
                               {r.note && (
                                 <div className="cj-cell-detail">{r.note}</div>
+                              )}
+                              {r.expires && (
+                                <div className="cj-cell-detail cj-reward-expires">
+                                  {`Through ${formatExpiresDate(r.expires)}`}
+                                </div>
                               )}
                               {r.spend_cap && (
                                 <div className="cj-cell-detail">

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7640,6 +7640,19 @@
   color: var(--muted);
   margin-top: 1px;
 }
+/* Limited-time promo end date (reward.expires) — a small clock-tagged caption. */
+.landing-v2 .cj-reward-expires {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.landing-v2 .cj-reward-expires::before {
+  content: "\23F1"; /* stopwatch */
+  font-weight: 400;
+  opacity: 0.8;
+}
 .landing-v2 .cj-rate-mono { font-family: 'Inter', sans-serif; font-weight: 600; }
 .landing-v2 .cj-eff-pct {
   font-family: 'Inter Tight', sans-serif;

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -35,6 +35,9 @@ export interface Reward {
   value: number;
   unit: string;
   note?: string;
+  // ISO date (YYYY-MM-DD) a limited-time promo reward stops earning, e.g. the
+  // Chase Lyft 5% through 2027-09-30. Rendered as a "Through <date>" badge.
+  expires?: string;
   mode?: 'quarterly_rotating' | 'user_choice' | 'auto_top_spend';
   eligible_categories?: string[];
   choices?: number;

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -23,6 +23,7 @@ rewards:
     value: 5
     unit: points_per_dollar
     note: "On Lyft rides through September 30, 2027 (limited-time promo)"
+    expires: "2027-09-30"
   - category: everything_else
     value: 1
     unit: points_per_dollar

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -14,6 +14,7 @@ rewards:
     value: 5
     unit: percent
     note: "On Lyft rides through September 30, 2027 (limited-time promo)"
+    expires: "2027-09-30"
   - category: everything_else
     value: 1.5
     unit: percent

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -125,6 +125,11 @@
             "type": "string",
             "description": "Additional context for the reward"
           },
+          "expires": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "ISO date (YYYY-MM-DD) the reward stops earning, for limited-time promos like the Chase Lyft 5%. Structured so the card page can badge it and build-cards can flag it once past — instead of the end date living only in free-text notes."
+          },
           "mode": {
             "type": "string",
             "enum": ["quarterly_rotating", "user_choice", "auto_top_spend"],

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -95,6 +95,15 @@ function validateCard(card, schema, categoryIds) {
       if (reward.note !== undefined && typeof reward.note !== 'string') {
         errors.push(`Invalid reward note for ${reward.category}: must be a string`);
       }
+      if (reward.expires !== undefined) {
+        if (typeof reward.expires !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(reward.expires)) {
+          errors.push(`Invalid reward expires for ${reward.category}: must be an ISO date (YYYY-MM-DD)`);
+        } else if (reward.expires < new Date().toISOString().slice(0, 10)) {
+          // Past its end date but still in the YAML: warn (don't fail the build)
+          // so the stale promo gets pruned instead of silently over-rewarding.
+          console.warn(`  ⚠️  Expired promo reward still in YAML: ${card.name} ${reward.category} ${reward.value}${reward.unit === 'percent' ? '%' : 'x'} expired ${reward.expires} — remove it`);
+        }
+      }
       if (reward.mode !== undefined && !validModes.includes(reward.mode)) {
         errors.push(`Invalid reward mode for ${reward.category}: ${reward.mode} (must be one of ${validModes.join(', ')})`);
       }


### PR DESCRIPTION
Follow-up to #1645. Limited-time promo rewards (the Chase Lyft 5%, and ~9 cards total) bury their end date in **free-text notes**, so nothing flags them once they lapse and they silently keep over-rewarding. This adds a structured per-reward `expires` field.

## Changes
- **schema.json** — `expires` (ISO `YYYY-MM-DD`) on reward categories.
- **build-cards.js** — validates the format; once past the date, **warns** that the stale promo is still in the YAML (non-fatal) so it gets pruned. Otherwise passed through unchanged.
- **Card page** — renders a small `⏱ Through Sep 30, 2027` badge under the reward. `Reward.expires` typed; `formatExpiresDate` parses as UTC so the day can't slip in negative-offset timezones.
- **Backfill** — the two on-main Lyft promos (Ink Preferred, Ink Unlimited). Ink Cash gets the field once #1645 lands.

## Why a per-reward field, not a separate "limited-time" section
The Lyft 5% *is* a transit reward — it must stay in the `transit` category so rideshare wallet-matching still finds it. A per-reward `expires` keeps it there and adds the structure. Same benefit, far less churn.

## Verified
- `build:cards` clean (182 cards); `expires` flows into cards.json for both backfilled cards.
- Expired-warning path fires (tested with a temp past date): `⚠️ Expired promo reward still in YAML: Ink Business Unlimited transit 5% expired 2020-01-01 — remove it`.
- Frontend typecheck clean on touched files.

Future extensions (not in this PR): auto-drop after expiry in build output, extend `expires` to benefits + signup_bonus notes, and have the rewards/benefits checker auto-flag expired promos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)