### PR TITLE
feat(card): redesign Further reading rows with article thumbnails

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1669,7 +1669,7 @@ export default function CardClient({
               </h2>
               <div className="cj-tape cj-tape-reading">
                 <div className="cj-tape-head">
-                  <div className="cj-tape-by">By</div>
+                  <div className="cj-tape-thumb-head" aria-hidden="true"></div>
                   <div>Title</div>
                   <div className="cj-tape-res">Read</div>
                 </div>
@@ -1687,11 +1687,23 @@ export default function CardClient({
                       href={`/articles/${a.slug}`}
                       className="cj-tape-row"
                     >
-                      <div className="cj-tape-when cj-tape-by">{a.author}</div>
+                      <div className="cj-tape-thumb" aria-hidden="true">
+                        {a.image ? (
+                          <img
+                            src={`https://d3ay3etzd1512y.cloudfront.net/article_images/${a.image}`}
+                            alt=""
+                            loading="lazy"
+                          />
+                        ) : (
+                          <span className="cj-tape-thumb-fallback">
+                            {a.title.charAt(0).toUpperCase()}
+                          </span>
+                        )}
+                      </div>
                       <div className="cj-tape-event">
                         <span className="cj-tape-field">{a.title}</span>
                         {articleDateText && (
-                          <span className="cj-tape-mob-date">
+                          <span className="cj-tape-meta">
                             {articleDateText}
                           </span>
                         )}

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7841,21 +7841,66 @@
 .landing-v2 .cj-tape-mob-date,
 .landing-v2 .cj-tape-mob-meta { display: none; }
 
+/* Reading tape: article thumbnail + title/date, no author column */
+.landing-v2 .cj-tape.cj-tape-reading .cj-tape-head,
+.landing-v2 .cj-tape.cj-tape-reading .cj-tape-row {
+  grid-template-columns: 64px 1fr 72px;
+}
+.landing-v2 .cj-tape.cj-tape-reading .cj-tape-row {
+  padding-block: 11px;
+}
+.landing-v2 .cj-tape-thumb {
+  width: 64px;
+  height: 44px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--line-2);
+  background: var(--paper-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.landing-v2 .cj-tape-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.landing-v2 .cj-tape-thumb-fallback {
+  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+  color: #fff;
+  background: linear-gradient(135deg, var(--accent) 0%, #7c3aed 100%);
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.landing-v2 .cj-tape.cj-tape-reading .cj-tape-event .cj-tape-meta {
+  display: block;
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 11.5px;
+  font-family: 'Inter', sans-serif;
+}
+.landing-v2 .cj-tape.cj-tape-reading .cj-tape-row:hover .cj-tape-event .cj-tape-field {
+  color: var(--accent);
+}
+
 @media (max-width: 640px) {
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-head,
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-row {
-    grid-template-columns: 1fr;
+    grid-template-columns: 56px 1fr;
   }
-  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-by,
+  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-thumb-head,
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-res {
     display: none;
   }
-  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-event .cj-tape-mob-date {
-    display: block;
-    margin-top: 4px;
-    color: var(--muted);
-    font-size: 11.5px;
-    font-family: 'Inter', sans-serif;
+  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-thumb {
+    width: 56px;
+    height: 42px;
   }
 
   /* News tape: collapse to a single column on mobile, render date + tag under the title */


### PR DESCRIPTION
## What

Redesigns the **Further reading** section on card pages ([`CardClient.tsx`](apps/web-next/src/app/card/[name]/CardClient.tsx), `#reading`).

- **Removes the "By" column** — it was almost always "By CreditOdds", so it added noise without value.
- **Adds an article thumbnail** to each row to make it more clickable:
  - Renders the article image when set (64×44, rounded, `object-fit: cover`).
  - Falls back to a branded purple gradient tile with the title's initial when there's no image (only 2 of 26 articles have images today, so this is the common case).
- **Surfaces the article date** as a meta line under the title on all viewports (was mobile-only).
- Adds a purple title hover state.

## Responsive
On mobile the thumbnail stays visible (56px), the read-time column collapses, and the date sits under the title.

## Scope / safety
All CSS is scoped to `.cj-tape-reading`, so the News wire tape (which shares `.cj-tape`) is unaffected. Verified on desktop and mobile via computed styles + DOM; no console errors from the change.

## Follow-up idea
Once more articles have `image` set the thumbnails will really shine. A per-tag colored/labeled fallback (instead of the initial) could be a nice next step.