### PR TITLE
Ink Business Cash: add structured expires to the Lyft promo

### DIFF
--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -49,6 +49,7 @@ rewards:
     value: 5
     unit: percent
     note: "On Lyft rides through September 30, 2027 (limited-time promo)"
+    expires: "2027-09-30"
   - category: everything_else
     value: 1
     unit: percent


### PR DESCRIPTION
Completes the `expires` backfill from #1648 for the third Lyft card. Ink Cash's `transit` line landed in #1645 *after* #1648 was branched, so it's caught up here.

All three Ink Lyft rewards now carry `expires: 2027-09-30` — verified in cards.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)