### PR TITLE
fix(card): unbreak Amplify build — empty alt on Further reading thumbnail

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1709,7 +1709,7 @@ export default function CardClient({
                         {a.image ? (
                           <img
                             src={`https://d3ay3etzd1512y.cloudfront.net/article_images/${a.image}`}
-                            alt=""
+                            alt={a.title}
                             loading="lazy"
                           />
                         ) : (


### PR DESCRIPTION
## Problem
Production Amplify builds on `main` have been **failing since job 1308** (last success). The `prebuild` SEO gate (`scripts/check-seo.mjs`) rejects empty `alt` attributes:

```
Empty alt attribute (Bing flags as missing alt):
src/app/card/[name]/CardClient.tsx:1712: alt=""
```

Introduced by the Further reading thumbnails feature (#1649). The image sits in an `aria-hidden` container so it was marked decorative with `alt=""`, but the SEO check forbids empty alt regardless. Result: **creditodds.com has not deployed any of the last 3 merges** (Amplify jobs 1309/1310/1311 all failed).

## Fix
Use the article title as the alt text: `alt={a.title}`.

## Verification
`node scripts/check-seo.mjs` → `SEO check passed.` (exit 0)

Once merged, this unblocks the Amplify production deploy.