### PR TITLE
perf(card): drop article thumbnails from Further reading

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1687,7 +1687,6 @@ export default function CardClient({
               </h2>
               <div className="cj-tape cj-tape-reading">
                 <div className="cj-tape-head">
-                  <div className="cj-tape-thumb-head" aria-hidden="true"></div>
                   <div>Title</div>
                   <div className="cj-tape-res">Read</div>
                 </div>
@@ -1705,19 +1704,6 @@ export default function CardClient({
                       href={`/articles/${a.slug}`}
                       className="cj-tape-row"
                     >
-                      <div className="cj-tape-thumb" aria-hidden="true">
-                        {a.image ? (
-                          <img
-                            src={`https://d3ay3etzd1512y.cloudfront.net/article_images/${a.image}`}
-                            alt={a.title}
-                            loading="lazy"
-                          />
-                        ) : (
-                          <span className="cj-tape-thumb-fallback">
-                            {a.title.charAt(0).toUpperCase()}
-                          </span>
-                        )}
-                      </div>
                       <div className="cj-tape-event">
                         <span className="cj-tape-field">{a.title}</span>
                         {articleDateText && (

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7854,42 +7854,10 @@
 .landing-v2 .cj-tape-mob-date,
 .landing-v2 .cj-tape-mob-meta { display: none; }
 
-/* Reading tape: article thumbnail + title/date, no author column */
+/* Reading tape: title/date + read time, no author column */
 .landing-v2 .cj-tape.cj-tape-reading .cj-tape-head,
 .landing-v2 .cj-tape.cj-tape-reading .cj-tape-row {
-  grid-template-columns: 64px 1fr 72px;
-}
-.landing-v2 .cj-tape.cj-tape-reading .cj-tape-row {
-  padding-block: 11px;
-}
-.landing-v2 .cj-tape-thumb {
-  width: 64px;
-  height: 44px;
-  border-radius: 8px;
-  overflow: hidden;
-  border: 1px solid var(--line-2);
-  background: var(--paper-2);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.landing-v2 .cj-tape-thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-.landing-v2 .cj-tape-thumb-fallback {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
-  font-weight: 600;
-  font-size: 18px;
-  color: #fff;
-  background: linear-gradient(135deg, var(--accent) 0%, #7c3aed 100%);
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  grid-template-columns: 1fr 72px;
 }
 .landing-v2 .cj-tape.cj-tape-reading .cj-tape-event .cj-tape-meta {
   display: block;
@@ -7905,15 +7873,10 @@
 @media (max-width: 640px) {
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-head,
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-row {
-    grid-template-columns: 56px 1fr;
+    grid-template-columns: 1fr;
   }
-  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-thumb-head,
   .landing-v2 .cj-tape.cj-tape-reading .cj-tape-res {
     display: none;
-  }
-  .landing-v2 .cj-tape.cj-tape-reading .cj-tape-thumb {
-    width: 56px;
-    height: 42px;
   }
 
   /* News tape: collapse to a single column on mobile, render date + tag under the title */


### PR DESCRIPTION
## What

Removes the article thumbnails added in #1649 from the card-page **Further reading** section. The thumbnails trigger image fetches that slow the page load, so this reverts to a lightweight text layout.

- Removes the thumbnail cell and its `<img>` / gradient-fallback markup.
- Collapses the reading grid to `1fr 72px` on desktop, `1fr` on mobile.
- Drops the now-unused `.cj-tape-thumb*` styles.

The **"By" column stays removed** and the article **date meta line stays**, so this keeps the cleanup from #1649 minus the images.

## Verified
Browser check on desktop (`1fr 72px`, 0 images loaded, read time + date shown) and mobile (`1fr`, read column collapsed, date shown).