### PR TITLE
Self-heal article image field when its S3 object is missing

### DIFF
--- a/scripts/sync-article-images.js
+++ b/scripts/sync-article-images.js
@@ -386,8 +386,19 @@ async function syncVariant(variantName, articles, results) {
     if (!slug) continue;
 
     const force = forceAll || forceSlugs.has(slug);
-    const userSet = article[variant.field] && !force;
-    if (userSet) continue;
+
+    // A manually-set image / social_image is only respected if the file it
+    // points at actually exists on S3. If the field is set but that object is
+    // missing (e.g. an author named the field expecting CI to generate it), we
+    // fall through and generate rather than silently serving a broken image.
+    // --force always regenerates.
+    const userValue = article[variant.field];
+    if (userValue && !force) {
+      if (s3HasObject(`${S3_PREFIX}/${userValue}`)) continue;
+      log(
+        `${variant.field} set to "${userValue}" for ${slug} but missing on S3 — generating instead of skipping`
+      );
+    }
 
     const expected = variant.filenameFor(slug);
     const key = variant.keyFor(slug);


### PR DESCRIPTION
## Background
Follow-up to the U.S. Bank Cash+ Explained hero-image incident. That article set `image: "us-bank-cash-plus-explained.png"`, but the file was never generated and 403'd on the CDN (the social image was fine). We fixed the live image by force-regenerating; this PR removes the footgun so it can't recur.

## Root cause
`scripts/sync-article-images.js` treated **any** set `image` / `social_image` field as a manually-supplied file and skipped generation before ever checking S3:

```js
const userSet = article[variant.field] && !force;
if (userSet) continue;   // skips even if the referenced file does not exist
```

So a field set with no corresponding S3 object yields a silently broken image.

## Change
Respect a set field **only if the file it points at actually exists on S3**; otherwise fall through and generate the default image:

```js
const userValue = article[variant.field];
if (userValue && !force) {
  if (s3HasObject(`${S3_PREFIX}/${userValue}`)) continue;
  log(`${variant.field} set to "${userValue}" ... missing on S3 — generating instead of skipping`);
}
```

## Behavior matrix
| `image`/`social_image` | File on S3 | Before | After |
|---|---|---|---|
| set | exists | respected (skip) | respected (skip) — unchanged |
| set | **missing** | **skip → broken 403** | **generate default** ✅ |
| unset | exists | stamp existing | unchanged |
| unset | missing | generate | unchanged |
| any | any + `--force` | regenerate | regenerate — unchanged |

Note: when a *custom-named* image is set but missing, self-heal generates the default `<slug>.png` and stamps that filename (a working default beats a broken custom reference). `--force` behavior is unchanged.

## Testing
`node --check` passes. No behavior change for the common paths (unset field, or set field whose file exists); the only new path is set-but-missing, which now generates instead of 403-ing.