### PR TITLE
fix(navy-federal): repoint broken apply links (#1642)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,43 @@ functions from production. Recovery required a manual
 `IpHashPepper` (the previous value lived only on the deployer's machine and
 was wiped from the stack when the broken template was applied).
 
+### Data-pipeline workflows: the us-east-1 / us-east-2 region split
+
+The `build-*.yml` data workflows straddle two regions, and this is
+**deliberate, not a bug**:
+
+- **S3 stays in us-east-2.** The data bucket `creditodds-cards-data`
+  (holds `cards.json`, `articles.json`, `news.json`, `best.json`, and
+  `content-agent/state.json`) never migrated. So `aws s3 cp` steps — and
+  the job-level `aws-region: us-east-2` default in `build-articles.yml`,
+  `build-news.yml`, `build-best.yml`, and `content-agent.yml` — are correct.
+- **Lambdas moved to us-east-1** with the rest of the stack (see us-east-1
+  migration below). Any `aws lambda invoke` must pass `--region us-east-1`
+  explicitly. `build-cards.yml` does both: job default `us-east-2` for the
+  S3 upload, `--region us-east-1` on the `creditodds-sync-cards` invoke.
+  `check-referrals.yml` is all us-east-1 (it only invokes Lambdas).
+
+**Gotcha — IAM policy region ARNs (fixed 2026-07-11):** the `Build and Deploy
+Cards` job started failing at the "Sync cards to database" step with
+`AccessDeniedException ... not authorized to perform lambda:InvokeFunction on
+arn:aws:lambda:us-east-1:...:creditodds-sync-cards`. The workflow region was
+right, but the `InvokeSyncCards` inline policy on the **`GitHubActions-CreditOdds`**
+role still pinned its `Resource` to the old `us-east-2` ARN (PR #1617 fixed the
+workflow region refs but missed this policy). Fix was to repoint the ARN:
+
+```
+aws iam put-role-policy --role-name GitHubActions-CreditOdds \
+  --policy-name InvokeSyncCards --policy-document '{"Version":"2012-10-17",
+  "Statement":[{"Sid":"InvokeSyncCards","Effect":"Allow","Action":"lambda:InvokeFunction",
+  "Resource":"arn:aws:lambda:us-east-1:953352003729:function:creditodds-sync-cards"}]}'
+```
+
+While it was broken, `cards.json` still synced to S3/CDN (live site stayed
+current) but the **DB layer** (numeric `card_id`, `card_stats`, and CardWire
+`wire_changes` → social posts) silently stalled. When touching post-migration
+infra, check IAM policy Resource ARNs for stale `us-east-2` regions, not just
+workflow YAML.
+
 ## Database
 
 - MySQL database hosted on AWS (RDS), inside a **private VPC** — not reachable

--- a/data/cards/navy-federal-cash-rewards-plus.yaml
+++ b/data/cards/navy-federal-cash-rewards-plus.yaml
@@ -44,4 +44,4 @@ benefits:
     description: "Rental car collision damage waiver coverage when the rental is paid with the card"
     category: "travel"
     enrollment_required: false
-apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards-alt.html
+apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards.html

--- a/data/cards/navy-federal-cash-rewards.yaml
+++ b/data/cards/navy-federal-cash-rewards.yaml
@@ -44,4 +44,4 @@ our_take: >
   is limited to the military community, but for those who qualify the rock-bottom
   rates and fee structure beat most mainstream cash-back cards, especially if you
   occasionally carry a balance.
-apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards-alt.html
+apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards.html

--- a/data/cards/navy-federal-platinum.yaml
+++ b/data/cards/navy-federal-platinum.yaml
@@ -28,7 +28,7 @@ benefits:
     description: "24/7 travel and emergency assistance services"
     category: "travel"
     enrollment_required: false
-apply_link: https://www.navyfederal.org/loans-cards/credit-cards/platinum-alt.html
+apply_link: https://www.navyfederal.org/loans-cards/credit-cards/platinum.html
 our_take: >
   Built for paying down debt if you qualify for Navy Federal membership: no annual fee, no
   balance transfer fees, and a standard APR as low as 10.24%, well under most issuers. The


### PR DESCRIPTION
Closes #1642.

The apply-link health check flagged 3 broken Navy Federal links (HTTP 404). All three pointed at `-alt.html` page variants that no longer exist.

| Card | Old (404) | New (200) |
|------|-----------|-----------|
| Navy Federal cashRewards | `cash-rewards-alt.html` | `cash-rewards.html` |
| Navy Federal cashRewards Plus | `cash-rewards-alt.html` | `cash-rewards.html` |
| Navy Federal Platinum | `platinum-alt.html` | `platinum.html` |

New URLs verified returning HTTP 200; old ones confirmed 404.