### PR TITLE
fix(ratings): resolve card ratings by numeric card_id, not just name

### DIFF
--- a/apps/api/src/handlers/card-ratings.js
+++ b/apps/api/src/handlers/card-ratings.js
@@ -31,6 +31,25 @@ async function resolveCardId(cardName) {
   return rows.length > 0 ? rows[0].card_id : null;
 }
 
+// Resolve a rating request to a numeric card_id. Prefer an explicit numeric
+// card_id when the caller has one (the web card page and wallet both do): it is
+// stable across card renames, whereas matching on the display name breaks the
+// moment the YAML/CDN name drifts from the DB `cards.card_name` (e.g. a rename
+// whose DB migration never ran). Fall back to resolving the card_name string
+// for legacy/iOS callers that only send a name.
+async function resolveRatingCardId({ cardId, cardName }) {
+  const numericId = Number(cardId);
+  if (Number.isInteger(numericId) && numericId > 0) {
+    const rows = await mysql.query(
+      `SELECT card_id FROM cards WHERE card_id = ? LIMIT 1`,
+      [numericId]
+    );
+    if (rows.length > 0) return rows[0].card_id;
+  }
+  if (cardName) return resolveCardId(cardName);
+  return null;
+}
+
 // GET /ratings?card_name=Chase+Sapphire+Preferred — public, returns avg + count
 
 // Cacheable headers for public GET reads: lets CloudFront/browser cache
@@ -58,16 +77,17 @@ exports.CardRatingsHandler = async (event) => {
     case "GET":
       try {
         const cardName = event.queryStringParameters?.card_name;
-        if (!cardName) {
+        const cardIdParam = event.queryStringParameters?.card_id;
+        if (!cardName && !cardIdParam) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "card_name is required" }),
+            body: JSON.stringify({ error: "card_name or card_id is required" }),
           };
           break;
         }
 
-        const cardId = await resolveCardId(cardName);
+        const cardId = await resolveRatingCardId({ cardId: cardIdParam, cardName });
         if (!cardId) {
           await mysql.end();
           response = {
@@ -110,14 +130,14 @@ exports.CardRatingsHandler = async (event) => {
     case "POST":
       try {
         const body = typeof event.body === "string" ? JSON.parse(event.body || "{}") : (event.body || {});
-        const { card_name: cardName, rating } = body;
+        const { card_name: cardName, card_id: cardIdInput, rating } = body;
         const comment = normalizeComment(body.comment);
 
-        if (!cardName || rating === undefined || rating === null) {
+        if ((!cardName && !cardIdInput) || rating === undefined || rating === null) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "card_name and rating are required" }),
+            body: JSON.stringify({ error: "card_name or card_id, and rating, are required" }),
           };
           break;
         }
@@ -131,7 +151,7 @@ exports.CardRatingsHandler = async (event) => {
           break;
         }
 
-        const cardId = await resolveCardId(cardName);
+        const cardId = await resolveRatingCardId({ cardId: cardIdInput, cardName });
         if (!cardId) {
           await mysql.end();
           response = {
@@ -220,16 +240,17 @@ exports.CardRatingsUserHandler = async (event) => {
     case "GET":
       try {
         const cardName = event.queryStringParameters?.card_name;
-        if (!cardName) {
+        const cardIdParam = event.queryStringParameters?.card_id;
+        if (!cardName && !cardIdParam) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "card_name is required" }),
+            body: JSON.stringify({ error: "card_name or card_id is required" }),
           };
           break;
         }
 
-        const cardId = await resolveCardId(cardName);
+        const cardId = await resolveRatingCardId({ cardId: cardIdParam, cardName });
         if (!cardId) {
           await mysql.end();
           response = {
@@ -267,13 +288,13 @@ exports.CardRatingsUserHandler = async (event) => {
     case "POST":
       try {
         const body = typeof event.body === "string" ? JSON.parse(event.body) : event.body;
-        const { card_name: cardName, rating } = body;
+        const { card_name: cardName, card_id: cardIdInput, rating } = body;
 
-        if (!cardName || !rating) {
+        if ((!cardName && !cardIdInput) || !rating) {
           response = {
             statusCode: 400,
             headers: responseHeaders,
-            body: JSON.stringify({ error: "card_name and rating are required" }),
+            body: JSON.stringify({ error: "card_name or card_id, and rating, are required" }),
           };
           break;
         }
@@ -287,7 +308,7 @@ exports.CardRatingsUserHandler = async (event) => {
           break;
         }
 
-        const cardId = await resolveCardId(cardName);
+        const cardId = await resolveRatingCardId({ cardId: cardIdInput, cardName });
         if (!cardId) {
           await mysql.end();
           response = {

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1784,6 +1784,7 @@ export default function CardClient({
 
           <RateCardStars
             cardName={card.card_name}
+            cardId={card.db_card_id ?? card.card_id}
             slug={card.slug}
             cardImageLink={card.card_image_link}
             bank={card.bank}

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -168,7 +168,7 @@ export default async function CardPage({ params }: CardPageProps) {
     const [cardWithRatingsAndWire, graphData, records, allNews, allArticles, allCards, comparePartners, bestPages] = await Promise.all([
       getCard(slug).then(async (card) => ({
         card,
-        ratings: await getCardRatings(card.card_name).catch(() => ({ count: 0, average: null })),
+        ratings: await getCardRatings(card.card_name, card.db_card_id ?? card.card_id).catch(() => ({ count: 0, average: null })),
         wire: await getCardWire(Number(card.card_id)).catch(() => [] as CardWireEntry[]),
       })),
       getCardGraphs(slug).catch(() => [] as GraphData[]),

--- a/apps/web-next/src/components/forms/RateCardStars.tsx
+++ b/apps/web-next/src/components/forms/RateCardStars.tsx
@@ -37,6 +37,9 @@ function StarIcon({ fill = 1, size = 14 }: { fill?: number; size?: number }) {
 
 interface RateCardStarsProps {
   cardName: string;
+  // Numeric DB card_id. Preferred over cardName for resolving the card so
+  // ratings survive card renames; cardName stays the human-readable fallback.
+  cardId?: number | string;
   slug: string;
   cardImageLink?: string;
   bank?: string;
@@ -49,6 +52,7 @@ const storageKey = (slug: string) => `co_card_rating_${slug}`;
 
 export default function RateCardStars({
   cardName,
+  cardId,
   slug,
   cardImageLink,
   bank,
@@ -86,13 +90,13 @@ export default function RateCardStars({
     (async () => {
       const token = await getToken();
       if (!token) return;
-      const rating = await getUserCardRating(cardName, token).catch(() => null);
+      const rating = await getUserCardRating(cardName, token, cardId).catch(() => null);
       if (!cancelled && rating && rating >= 1 && rating <= 5) setMyRating(rating);
     })();
     return () => {
       cancelled = true;
     };
-  }, [authState.isAuthenticated, cardName, getToken]);
+  }, [authState.isAuthenticated, cardName, cardId, getToken]);
 
   // Lock body scroll while the modal is open. Plain overflow:hidden (NOT
   // position:fixed) to avoid the iOS touch-freeze bug.
@@ -123,7 +127,7 @@ export default function RateCardStars({
     setError(null);
     try {
       const token = authState.isAuthenticated ? await getToken() : null;
-      await submitPublicCardRating(cardName, modalRating, comment, token);
+      await submitPublicCardRating(cardName, modalRating, comment, token, cardId);
       setMyRating(modalRating);
       setJustSubmitted(true);
       if (!token) {

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -97,7 +97,7 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, d
         (async () => {
           const token = await getToken();
           if (!token) return;
-          const rating = await getUserCardRating(card.card_name, token);
+          const rating = await getUserCardRating(card.card_name, token, card.card_id);
           setUserRating(rating);
         })();
       }
@@ -145,7 +145,7 @@ export default function EditWalletCardModal({ show, card, cardSlug, annualFee, d
     try {
       const token = await getToken();
       if (!token) return;
-      await submitCardRating(card.card_name, rating, token);
+      await submitCardRating(card.card_name, rating, token, card.card_id);
       setUserRating(rating);
     } catch {
       // Silently fail

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1332,19 +1332,33 @@ export interface CardRatingAggregates {
   average: number | null;
 }
 
-export async function getCardRatings(cardName: string): Promise<CardRatingAggregates> {
-  const res = await fetchWithRetry(`${API_BASE}/ratings?card_name=${encodeURIComponent(cardName)}`, {
-    next: { revalidate: 300 },
-  });
+// Ratings resolve to a card by numeric card_id when one is passed (stable
+// across card renames), falling back to the card_name string otherwise. The web
+// always has the numeric id (from getCard / the wallet), so it passes it; the
+// card_name is kept for legacy/iOS callers and as a human-readable fallback.
+function ratingsCardIdParam(cardId?: number | string): string {
+  return cardId != null && cardId !== '' ? `&card_id=${encodeURIComponent(String(cardId))}` : '';
+}
+
+export async function getCardRatings(cardName: string, cardId?: number | string): Promise<CardRatingAggregates> {
+  const res = await fetchWithRetry(
+    `${API_BASE}/ratings?card_name=${encodeURIComponent(cardName)}${ratingsCardIdParam(cardId)}`,
+    {
+      next: { revalidate: 300 },
+    }
+  );
   if (!res.ok) return { count: 0, average: null };
   return res.json();
 }
 
-export async function getUserCardRating(cardName: string, token: string): Promise<number | null> {
-  const res = await fetch(`${API_BASE}/ratings/me?card_name=${encodeURIComponent(cardName)}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    cache: 'no-store',
-  });
+export async function getUserCardRating(cardName: string, token: string, cardId?: number | string): Promise<number | null> {
+  const res = await fetch(
+    `${API_BASE}/ratings/me?card_name=${encodeURIComponent(cardName)}${ratingsCardIdParam(cardId)}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    }
+  );
   if (!res.ok) return null;
   const data = await res.json();
   return data.rating;
@@ -1356,7 +1370,8 @@ export async function submitPublicCardRating(
   cardName: string,
   rating: number,
   comment?: string,
-  token?: string | null
+  token?: string | null,
+  cardId?: number | string
 ): Promise<void> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
@@ -1365,6 +1380,7 @@ export async function submitPublicCardRating(
     headers,
     body: JSON.stringify({
       card_name: cardName,
+      ...(cardId != null && cardId !== '' ? { card_id: cardId } : {}),
       rating,
       ...(comment?.trim() ? { comment: comment.trim() } : {}),
     }),
@@ -1378,7 +1394,8 @@ export async function submitPublicCardRating(
 export async function submitCardRating(
   cardName: string,
   rating: number,
-  token: string
+  token: string,
+  cardId?: number | string
 ): Promise<void> {
   const res = await fetch(`${API_BASE}/ratings/me`, {
     method: 'POST',
@@ -1386,7 +1403,11 @@ export async function submitCardRating(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ card_name: cardName, rating }),
+    body: JSON.stringify({
+      card_name: cardName,
+      ...(cardId != null && cardId !== '' ? { card_id: cardId } : {}),
+      rating,
+    }),
   });
   if (!res.ok) {
     const errorText = await res.text().catch(() => 'Unknown error');


### PR DESCRIPTION
## Problem

A rating given in the wallet/profile shows up in the wallet but the public card page says **"No ratings yet."** Reported for **US Bank Cash+ Visa Signature**.

Root cause: the ratings endpoints resolved a card via an **exact `cards.card_name` string match** (`resolveCardId`). Two data stores drifted:

- **cards.json / CDN** (drives the public card page) has the current name `US Bank Cash+ Visa Signature`.
- **DB `cards` table** (what ratings resolve against) still has the pre-rename name `U.S. Bank Cash+ Visa Signature` — the rename migration [`036c_rename_us_bank_cash_plus.sql`](apps/api/migrations/036c_rename_us_bank_cash_plus.sql) was **never applied**.

So the public page sends the fresh name → matches no DB row → `count: 0`. The wallet keys ratings off the **numeric `card_id`**, so it kept working. Confirmed live:

| Query | Result |
|---|---|
| `/ratings?card_name=US Bank Cash+ Visa Signature` (public page) | `count: 0` → "No ratings yet" |
| `/ratings?card_name=U.S. Bank Cash+ Visa Signature` (DB/wallet name) | `count: 1, average: 4` ← the stranded rating |

## Fix (hardening)

Resolve ratings by an explicit **numeric `card_id`** when the caller has one (the web card page and wallet both do) — stable across renames — falling back to `card_name` for legacy/iOS callers.

- `card-ratings.js`: new `resolveRatingCardId({cardId, cardName})`; accept `card_id` on GET/POST for both `/ratings` and `/ratings/me`.
- `api.ts`: ratings helpers take an optional `cardId` and send it.
- Card page, `RateCardStars`, and the wallet modal pass the numeric id through.

This immunizes ratings against **all** current and future rename drift, not just this card.

## Still required (separate, operational)

This code un-strands the card once deployed. To also correct the underlying stale DB name, migration **`036c` still needs to be applied** to prod (wire `RunMigrationFunction` → deploy → invoke → unwire). Worth a sweep for other cards affected by the same forgotten-migration pattern (e.g. sibling `036a`/`036b` US Bank Altitude renames).

## Test
- `tsc --noEmit` clean (web-next); `node --check` clean (handler).