### PR TITLE
Bilt lineup: add Lyft earning + fix Blue dining rate

### DIFF
--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -26,7 +26,7 @@ benefits:
     category: "other"
   - name: "Bilt Dining"
     value: 0
-    description: "Earn up to 3x points at participating Bilt Dining restaurants (limited network, not all restaurants)"
+    description: "Earn up to 4x points at participating Bilt Dining restaurants (limited network, not all restaurants)"
     frequency: "ongoing"
     category: "dining"
     enrollment_required: false
@@ -42,6 +42,10 @@ rewards:
     value: 2
     unit: points_per_dollar
     note: "Flights booked through Bilt Travel"
+  - category: transit
+    value: 3
+    unit: points_per_dollar
+    note: "On Lyft rides (after linking your Lyft account)"
   - category: everything_else
     value: 1
     unit: points_per_dollar

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -39,7 +39,7 @@ rewards:
     eligible_categories:
       - "dining"
       - "groceries"
-    note: "Choose dining (default) or groceries as your 3x category annually (cap applies when groceries is selected)"
+    note: "Choose dining (default) or groceries as your 3x category annually (cap applies when groceries is selected). Earn up to 6x at participating Bilt Dining restaurants (limited network) when Dining is the selected category."
     spend_cap: 25000
     cap_period: annual
     rate_after_cap: 1
@@ -54,6 +54,11 @@ rewards:
   - category: "travel"
     value: 2
     unit: "points_per_dollar"
+    note: "Other travel not booked through Bilt Travel"
+  - category: "transit"
+    value: 3
+    unit: "points_per_dollar"
+    note: "On Lyft rides (after linking your Lyft account)"
   - category: "everything_else"
     value: 1
     unit: "points_per_dollar"

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -66,6 +66,10 @@ rewards:
     value: 3
     unit: points_per_dollar
     note: "Flights booked through Bilt Travel"
+  - category: transit
+    value: 4
+    unit: points_per_dollar
+    note: "On Lyft rides (after linking your Lyft account)"
   - category: everything_else
     value: 2
     unit: points_per_dollar


### PR DESCRIPTION
The one genuinely valuable find from the #1636 rewards review. Verified against the **live Bilt card page** (Playwright-rendered — DoC and the checker both understated it; the live page is authoritative per the Wyndham lesson).

## What was wrong
All three cards were **missing the Lyft earning category**, and Blue's Bilt Dining rate was stale.

| Card | Live page | Fix |
|------|-----------|-----|
| **Blue** | 4X Bilt dining, 3X Lyft, 3X hotels/2X flights (Bilt Travel), 1X else | add `transit 3x` (Lyft); Bilt Dining benefit **3x → 4x** |
| **Obsidian** | 4X hotels, 3X dining/grocery (up to 6X at Bilt dining partners), 3X flights, 2X other travel, 3X Lyft | add `transit 3x` (Lyft); note the 6x partner boost. (`travel 2x` was already present) |
| **Palladium** | 5X Bilt dining, 4X hotels, 3X flights, 4X Lyft, 2X everyday | add `transit 4x` (Lyft) |

## Deliberate choices
- **Lyft as `transit` + Lyft-only note**, matching the Ink convention — and **no `expires`**: it's an ongoing Bilt partnership, not a time-limited promo like the Chase Lyft 5%.
- **Bilt Dining stays a benefit** (a limited 20k-restaurant partner network), not a generic `dining` reward that would overstate it — same reasoning as the Apple Card's merchant-gated rewards.
- The `hotels_portal`/`flights_portal` rates, the 3x category choice, base rates, and the Palladium 5x dining benefit were all **confirmed correct** and left unchanged.

`build:cards` clean (182 cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)