### PR TITLE
feat(stores): surface merchant statement credits on /best-card-for pages

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { rankCards, formatRate, labelForCategory } from "@/lib/storeRanking";
 import { BreadcrumbSchema, FAQSchema, CollectionPageSchema } from "@/components/seo/JsonLd";
 import CardImage from "@/components/ui/CardImage";
 import { V2Footer } from "@/components/landing-v2/Chrome";
-import { PencilSquareIcon, ExclamationTriangleIcon, CalendarDaysIcon } from "@heroicons/react/24/outline";
+import { PencilSquareIcon, ExclamationTriangleIcon, CalendarDaysIcon, BanknotesIcon } from "@heroicons/react/24/outline";
 import StorePersonalRow from "./StorePersonalRow";
 import StoreAffiliateCta from "./StoreAffiliateCta";
 import StoreVisitTracker from "./StoreVisitTracker";
@@ -76,6 +76,24 @@ function tagLabelForCategory(id: string): string {
     || id.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
+// Cadence suffix for a credit amount. A benefit's `value` is always the annual
+// rollup (see CardBenefit in lib/api.ts — value_per_cycle holds the per-cycle
+// figure), so every recurring frequency renders "/yr"; a $10/month credit is
+// stored as value: 120 and shows "$120/yr", not "$120/mo".
+const CREDIT_FREQUENCY_SUFFIX: Record<string, string> = {
+  annual: '/yr',
+  semi_annual: '/yr',
+  quarterly: '/yr',
+  monthly: '/yr',
+  multi_year: '',
+  ongoing: '',
+};
+
+function creditAmountLabel(value: number, frequency: string): string {
+  if (!value || value <= 0) return '';
+  return `$${value.toLocaleString()}${CREDIT_FREQUENCY_SUFFIX[frequency] ?? ''}`;
+}
+
 export default async function BestCardForStorePage({ params }: PageProps) {
   const { slug } = await params;
   const [store, allCards, allStores, generatedAt] = await Promise.all([
@@ -89,6 +107,39 @@ export default async function BestCardForStorePage({ params }: PageProps) {
   const picks = rankCards(store, allCards, { maxPicks: 20 });
   const usingFallback = picks.length > 0 && picks.every(p => p.source === 'flat_rate');
   const pageUrl = `https://creditodds.com/best-card-for/${store.slug}`;
+
+  // Merchant credits & perks: cards whose benefit is tagged with this store
+  // slug. These are fixed capped dollar amounts or complimentary memberships
+  // (e.g. CSR's $300/yr StubHub credit, a free DashPass at DoorDash), not earn
+  // rates, so they can't be ranked into `picks` by effective % — they get their
+  // own block. Sort by value, highest first.
+  const merchantCredits = allCards
+    .filter(c => c.accepting_applications !== false)
+    .flatMap(c =>
+      (c.benefits ?? [])
+        .filter(b => Array.isArray(b.merchants) && b.merchants.includes(store.slug))
+        .map(b => ({ card: c, benefit: b })),
+    )
+    .sort((a, b) => (b.benefit.value ?? 0) - (a.benefit.value ?? 0));
+
+  // Split into monetary credits (rendered as full rows) and value-0
+  // complimentary memberships (collapsed into a compact chip list). Popular
+  // merchants like DoorDash carry ~17 near-identical "free DashPass" perks —
+  // a wall of identical rows buries the actual dollar credits, so the perks
+  // become chips beneath the credits that matter.
+  const dollarCredits = merchantCredits.filter(mc => (mc.benefit.value ?? 0) > 0);
+  // Perk-only chips: value-0 complimentary memberships. Dedupe to one chip per
+  // card, and drop any card that already has a dollar credit above (e.g.
+  // Robinhood Platinum's $250 credit already names its free DashPass — no need
+  // to also chip it as a bare membership).
+  const dollarCreditSlugs = new Set(dollarCredits.map(mc => mc.card.slug));
+  const perkMemberships = Array.from(
+    new Map(
+      merchantCredits
+        .filter(mc => (mc.benefit.value ?? 0) <= 0 && !dollarCreditSlugs.has(mc.card.slug))
+        .map(mc => [mc.card.slug, mc]),
+    ).values(),
+  );
 
   // Rank related stores by category overlap so the most-similar stores win.
   // A store sharing both [hotels, travel] with Best Western beats one that
@@ -173,6 +224,77 @@ export default async function BestCardForStorePage({ params }: PageProps) {
             affiliate={store.affiliate}
             topPickName={picks[0]?.card.card_name}
           />
+        )}
+
+        {merchantCredits.length > 0 && (
+          <section className="store-credits" aria-labelledby="store-credits-title">
+            <div className="store-credits-head">
+              <BanknotesIcon className="store-credits-head-icon" aria-hidden="true" />
+              <h2 id="store-credits-title" className="store-credits-title">
+                Credits &amp; perks at {store.name}
+              </h2>
+            </div>
+            <p className="store-credits-sub">
+              These cards include a statement credit or complimentary membership you can use at{' '}
+              {store.name}, on top of whatever you earn on the purchase. Weigh these alongside the
+              ranked picks below.
+            </p>
+            {dollarCredits.length > 0 && (
+              <ul className="store-credits-list">
+                {dollarCredits.map(({ card, benefit }) => {
+                  const amount = creditAmountLabel(benefit.value, benefit.frequency);
+                  return (
+                    <li key={`${card.slug}-${benefit.name}`} className="store-credit">
+                      <Link
+                        href={`/card/${card.slug}`}
+                        className="store-credit-image"
+                        aria-hidden="true"
+                        tabIndex={-1}
+                      >
+                        <CardImage
+                          cardImageLink={card.card_image_link}
+                          alt={card.card_name}
+                          width={64}
+                          height={40}
+                          style={{ width: 64, height: 40, objectFit: 'contain' }}
+                        />
+                      </Link>
+                      <div className="store-credit-body">
+                        <div className="store-credit-name-row">
+                          <Link href={`/card/${card.slug}`} className="store-credit-name">
+                            {card.card_name}
+                          </Link>
+                          {benefit.enrollment_required && (
+                            <span className="store-credit-flag">Enrollment required</span>
+                          )}
+                        </div>
+                        <div className="store-credit-bank">{card.bank}</div>
+                        <div className="store-credit-desc">{benefit.description}</div>
+                      </div>
+                      {amount && <div className="store-credit-amount">{amount}</div>}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            {perkMemberships.length > 0 && (
+              <div className="store-credits-perks">
+                <div className="store-credits-perks-label">
+                  {dollarCredits.length > 0 ? 'Also comes with' : 'Comes with'} a complimentary{' '}
+                  membership at {store.name}:
+                </div>
+                <ul className="store-credits-perk-chips">
+                  {perkMemberships.map(({ card }) => (
+                    <li key={card.slug}>
+                      <Link href={`/card/${card.slug}`} className="store-credits-perk-chip">
+                        {card.card_name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
         )}
 
         {usingFallback && (

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -8302,6 +8302,175 @@
   font-size: 15px;
 }
 
+/* ---------- Merchant statement-credit callout (above the ranked picks) ----------
+   Statement credits are fixed capped dollar amounts, not earn rates, so they
+   render in their own accent-tinted block instead of competing in the % list. */
+.landing-v2.store-v2 .store-credits {
+  margin-bottom: 28px;
+  padding: 18px 18px 20px;
+  background: var(--accent-2);
+  border: 1px solid color-mix(in oklab, var(--accent) 22%, transparent);
+  border-radius: 6px;
+}
+.landing-v2.store-v2 .store-credits-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.landing-v2.store-v2 .store-credits-head-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.landing-v2.store-v2 .store-credits-title {
+  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin: 0;
+}
+.landing-v2.store-v2 .store-credits-sub {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--muted);
+  margin: 0 0 16px;
+}
+.landing-v2.store-v2 .store-credits-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+.landing-v2.store-v2 .store-credit {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: var(--shadow-sm);
+  min-width: 0;
+}
+.landing-v2.store-v2 .store-credit-image {
+  flex-shrink: 0;
+  width: 64px;
+  height: 40px;
+  display: block;
+}
+.landing-v2.store-v2 .store-credit-body {
+  flex: 1;
+  min-width: 0;
+}
+.landing-v2.store-v2 .store-credit-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.landing-v2.store-v2 .store-credit-name {
+  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+  text-decoration: none;
+}
+.landing-v2.store-v2 .store-credit-name:hover {
+  color: var(--accent);
+}
+.landing-v2.store-v2 .store-credit-flag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--gold);
+  background: color-mix(in oklab, var(--gold) 10%, var(--paper));
+  border: 1px solid color-mix(in oklab, var(--gold) 30%, transparent);
+  padding: 2px 7px;
+  border-radius: 999px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.landing-v2.store-v2 .store-credit-bank {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin-top: 1px;
+}
+.landing-v2.store-v2 .store-credit-desc {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  margin-top: 6px;
+}
+.landing-v2.store-v2 .store-credit-amount {
+  flex-shrink: 0;
+  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  padding-top: 1px;
+}
+/* Compact chip list for value-0 complimentary memberships (e.g. free DashPass
+   across ~17 cards), so they don't bury the dollar credits above. */
+.landing-v2.store-v2 .store-credits-perks {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid color-mix(in oklab, var(--accent) 15%, transparent);
+}
+.landing-v2.store-v2 .store-credits-perks-label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.landing-v2.store-v2 .store-credits-perk-chips {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.landing-v2.store-v2 .store-credits-perk-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  padding: 5px 11px;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: border-color 0.12s, color 0.12s;
+}
+.landing-v2.store-v2 .store-credits-perk-chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+@media (max-width: 640px) {
+  .landing-v2.store-v2 .store-credit {
+    padding: 12px;
+    gap: 10px;
+  }
+  .landing-v2.store-v2 .store-credit-image {
+    width: 52px;
+    height: 33px;
+  }
+  .landing-v2.store-v2 .store-credit-amount {
+    font-size: 17px;
+  }
+}
+
 /* ---------- Personal "From your wallet" row (above the picks list) ---------- */
 .landing-v2.store-v2 .store-personal-row {
   margin-bottom: 20px;

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -120,6 +120,13 @@ export interface CardBenefit {
   value_per_cycle?: number;
   category: 'dining' | 'dining_travel' | 'travel' | 'hotel' | 'entertainment' | 'shopping' | 'fitness' | 'lounge' | 'security' | 'gas' | 'streaming' | 'grocery' | 'rideshare' | 'car_rental' | 'other';
   enrollment_required?: boolean;
+  // Store slugs (from data/stores/) this credit applies at. A statement credit
+  // is a fixed capped dollar amount, not an earn rate, so it can't be honestly
+  // ranked into the rate-sorted picks list. Instead, /best-card-for/<slug>
+  // renders a dedicated "Statement credits" block listing every card whose
+  // benefit `merchants` includes that store slug (e.g. the CSR StubHub credit
+  // carries merchants: ["stubhub", "viagogo"]). build-cards validates each slug.
+  merchants?: string[];
 }
 
 export interface Card {

--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -55,6 +55,8 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "Baggage Delay Insurance"
     description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -41,6 +41,9 @@ benefits:
     frequency: "monthly"
     category: "other"
     enrollment_required: true
+    merchants:
+      - fedex-office
+      - grubhub
   - name: "ChatGPT Credits"
     value: 300
     description: "$300 in annual ChatGPT credits for AI-powered productivity tools"
@@ -54,6 +57,8 @@ benefits:
     frequency: "monthly"
     category: "shopping"
     enrollment_required: true
+    merchants:
+      - walmart
   - name: "Squarespace Credit"
     value: 150
     description: "Up to $150 back annually in statement credits for U.S. purchases with Squarespace."

--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -21,18 +21,29 @@ benefits:
     frequency: "monthly"
     category: "rideshare"
     enrollment_required: true
+    merchants:
+      - uber
+      - uber-eats
   - name: "Dining Credit"
     value: 120
     description: "$10/month in statement credits at Grubhub, The Cheesecake Factory, Goldbelly, Wine.com, and Five Guys"
     frequency: "monthly"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - grubhub
+      - cheesecake-factory
+      - goldbelly
+      - winecom
+      - five-guys
   - name: "Dunkin' Credit"
     value: 84
     description: "Up to $7/month in statement credits on eligible purchases at U.S. Dunkin' locations"
     frequency: "monthly"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - dunkin
   - name: "Resy Credit"
     value: 100
     description: "Up to $50 semiannually at U.S. Resy restaurants and other eligible Resy purchases"

--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -57,6 +57,9 @@ benefits:
     frequency: "one_time"
     category: "rideshare"
     enrollment_required: true
+    merchants:
+      - uber
+      - uber-eats
   - name: "Hertz Car Rental Benefits"
     value: 5
     value_unit: "percent"

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -59,6 +59,10 @@ benefits:
     frequency: "annual"
     category: "streaming"
     enrollment_required: true
+    merchants:
+      - disney-plus
+      - hulu
+      - espn-plus
   - name: "Purchase Protection"
     description: "Coverage up to $50,000 per calendar year (maximum $1,000 per purchase) for stolen or accidentally damaged covered purchases within 90 days"
     category: "protection"

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -56,6 +56,10 @@ benefits:
     frequency: "monthly"
     category: "streaming"
     enrollment_required: true
+    merchants:
+      - disney-plus
+      - hulu
+      - espn-plus
   - name: "Purchase Protection"
     description: "Coverage up to $1,000 per covered purchase and $50,000 per account per calendar year if a charged item is stolen or accidentally damaged within 90 days"
     category: "protection"

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -53,6 +53,8 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "Baggage Delay Insurance"
     description: "Reimbursement up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -28,6 +28,8 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "Automatic Payment Statement Credit"
     value: 25
     description: "Earn a $25 statement credit when you sign up for automatic payments within the first three months of opening your account and remain enrolled for at least 90 days."

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -52,3 +52,5 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -79,3 +79,5 @@ benefits:
     frequency: "one_time"
     category: "shopping"
     enrollment_required: true
+    merchants:
+      - instacart

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -61,4 +61,6 @@ benefits:
     frequency: "monthly"
     category: "rewards"
     enrollment_required: true
+    merchants:
+      - doordash
 apply_link: https://creditcards.chase.com/business-credit-cards/ink/business-preferred

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -44,3 +44,5 @@ benefits:
     frequency: "one_time"
     category: "shopping"
     enrollment_required: true
+    merchants:
+      - instacart

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -30,6 +30,8 @@ benefits:
     frequency: "monthly"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
 tags:
   - travel
   - dining

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -61,24 +61,33 @@ benefits:
     frequency: "annual"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "DoorDash Promos"
     value: 300
     description: "Up to $25 per month ($5 restaurant promo + two $10 grocery/retail promos) to spend on DoorDash through December 31, 2027."
     frequency: "annual"
     category: "dining"
     enrollment_required: false
+    merchants:
+      - doordash
   - name: "StubHub Credits"
     value: 300
     description: "Up to $150 in statement credits from January–June and July–December for StubHub and viagogo purchases, maximum $300 annually through December 31, 2027."
     frequency: "annual"
     category: "entertainment"
     enrollment_required: true
+    merchants:
+      - stubhub
+      - viagogo
   - name: "Lyft Credits"
     value: 120
     description: "Up to $10 in monthly in-app credits for Lyft rides through September 30, 2027."
     frequency: "annual"
     category: "rideshare"
     enrollment_required: false
+    merchants:
+      - lyft
   - name: "Peloton Credits"
     value: 120
     description: "Up to $10 in statement credits per month on eligible Peloton memberships, maximum $120 annually through December 31, 2027."

--- a/data/cards/chase-slate-edge.yaml
+++ b/data/cards/chase-slate-edge.yaml
@@ -29,3 +29,5 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -33,12 +33,16 @@ benefits:
     frequency: "annual"
     category: "rideshare"
     enrollment_required: true
+    merchants:
+      - lyft
   - name: "Grubhub Statement Credit"
     value: 120
     description: "Up to $120 annual statement credit on eligible Grubhub purchases ($10 per monthly billing statement)"
     frequency: "annual"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - grubhub
   - name: "Avis and Budget Car Rental Credit"
     value: 120
     description: "Up to $120 annual statement credit for eligible prepaid car rentals booked directly on avis.com or budget.com"

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -24,6 +24,8 @@ benefits:
     frequency: "annual"
     category: "fitness"
     enrollment_required: true
+    merchants:
+      - equinox
   - name: "Global Entry / TSA PreCheck Credit"
     value: 100
     description: "Statement credit for Global Entry or TSA PreCheck application fee"
@@ -41,6 +43,9 @@ benefits:
     frequency: "annual"
     category: "statement_credit"
     enrollment_required: false
+    merchants:
+      - best-buy
+      - american-airlines
   - name: "Annual Blacklane Credit"
     value: 200
     description: "Up to $200 annual statement credit when booking with Blacklane premium chauffeur service ($100 Jan-Jun, $100 Jul-Dec)."

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -36,6 +36,8 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "Purchase Protection"
     description: "Covers eligible new purchases against damage or theft for 120 days from date of purchase up to $500 per item"
     category: "protection"

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -54,6 +54,8 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "Baggage Delay Insurance"
     description: "Reimbursement up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -51,12 +51,16 @@ benefits:
     frequency: "annual"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "DoorDash Quarterly Discount"
     value: 10
     description: "Up to $10 off quarterly on non-restaurant DoorDash orders through Dec 31, 2027."
     frequency: "quarterly"
     category: "dining"
     enrollment_required: false
+    merchants:
+      - doordash
 tags:
   - hotel
   - travel

--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -33,12 +33,16 @@ benefits:
     frequency: "annual"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "Instacart Credit"
     value: 120
     description: "Receive a $10 Instacart credit monthly (up to $120 annually) plus a complimentary 3-month Instacart+ membership; benefits end 12/31/27."
     frequency: "annual"
     category: "shopping"
     enrollment_required: true
+    merchants:
+      - instacart
 tags:
   - hotel
   - travel

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -22,6 +22,8 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
 tags:
   - hotel
   - travel

--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -33,6 +33,8 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
 tags:
   - hotel
   - travel

--- a/data/cards/pnc-spend-wise.yaml
+++ b/data/cards/pnc-spend-wise.yaml
@@ -27,6 +27,10 @@ benefits:
     description: "Up to $25 in annual credits for eligible Spotify, Netflix, and Disney+ purchases"
     frequency: "annual"
     category: "streaming"
+    merchants:
+      - spotify
+      - netflix
+      - disney-plus
   - name: "Price Protection"
     value: 0
     description: "Reimbursement for the price difference (up to $1,000) if an eligible item drops in price within 60 days of purchase"

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -22,6 +22,8 @@ benefits:
     description: "$250 annual DoorDash credit plus complimentary DashPass membership"
     frequency: "annual"
     category: "dining"
+    merchants:
+      - doordash
   - name: "Autonomous Ride Credit"
     value: 250
     description: "$250 annual credit for eligible autonomous ride purchases"
@@ -59,6 +61,8 @@ benefits:
     frequency: "ongoing"
     category: "dining"
     enrollment_required: false
+    merchants:
+      - doordash
   - name: "Global Entry or TSA PreCheck"
     value: 100
     description: "Application fee credit for Global Entry or TSA PreCheck."

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -264,6 +264,11 @@
           "enrollment_required": {
             "type": "boolean",
             "description": "Whether the cardholder must enroll or activate to receive the benefit"
+          },
+          "merchants": {
+            "type": "array",
+            "items": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+            "description": "Store slugs (from data/stores/) this credit applies at. Surfaces the card in a 'Statement credits' block on each of those /best-card-for/<slug> pages. Statement credits are fixed capped dollar amounts, not earn rates, so they get their own section instead of competing in the rate-ranked list. Use for merchant-linked credits like the CSR StubHub credit (merchants: [stubhub, viagogo]). Every slug must exist as a store; build-cards fails otherwise."
           }
         }
       },

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -74,6 +74,8 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "No Foreign Transaction Fees"
     description: "No foreign transaction fees on purchases made outside the US"
     frequency: "per_purchase"
@@ -85,6 +87,8 @@ benefits:
     frequency: "annual"
     category: "groceries"
     enrollment_required: true
+    merchants:
+      - instacart
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/plus
 our_take: >
   The cheapest way into the Southwest card lineup at $99, and it still delivers the parts

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -70,12 +70,16 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "Instacart Credits"
     value: 120
     description: "Up to $120 in Instacart credits annually with $0 delivery fees and 3 months complimentary Instacart+."
     frequency: "annual"
     category: "groceries"
     enrollment_required: true
+    merchants:
+      - instacart
 tags:
   - airline
   - travel

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -71,6 +71,8 @@ benefits:
     frequency: "one_time"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
   - name: "First Checked Bag Free"
     value: 90
     description: "First checked bag free for cardholder and up to 8 additional passengers in the same reservation (up to $90 round trip)"
@@ -83,6 +85,8 @@ benefits:
     frequency: "annual"
     category: "groceries"
     enrollment_required: true
+    merchants:
+      - instacart
   - name: "A-List Status TQPs"
     description: "Earn 2,500 tier qualifying points for every $5,000 spent in purchases annually toward A-List status"
     frequency: "annual"

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -43,6 +43,8 @@ benefits:
     frequency: "annual"
     category: "shopping"
     enrollment_required: true
+    merchants:
+      - dell
   - name: "Hilton for Business Credit"
     value: 200
     description: "Up to $50 per quarter on eligible purchases made directly with Hilton portfolio properties"

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -40,6 +40,9 @@ benefits:
     frequency: "monthly"
     category: "dining_travel"
     enrollment_required: true
+    merchants:
+      - uber
+      - uber-eats
   - name: "Airline Fee Credit"
     value: 200
     description: "Select one qualifying airline per year for incidental fee credits like baggage and seat upgrades"
@@ -58,6 +61,9 @@ benefits:
     frequency: "monthly"
     category: "rideshare"
     enrollment_required: true
+    merchants:
+      - uber
+      - uber-eats
   - name: "Digital Entertainment Credit"
     value: 300
     value_per_cycle: 25
@@ -65,6 +71,13 @@ benefits:
     frequency: "monthly"
     category: "streaming"
     enrollment_required: true
+    merchants:
+      - disney-plus
+      - espn-plus
+      - hulu
+      - paramount-plus
+      - peacock
+      - youtube-tv
   - name: "CLEAR Plus Credit"
     value: 209
     description: "Statement credit for CLEAR Plus airport security membership"
@@ -78,12 +91,16 @@ benefits:
     frequency: "monthly"
     category: "shopping"
     enrollment_required: true
+    merchants:
+      - walmart
   - name: "Saks Fifth Avenue Credit"
     value: 100
     description: "$50 semiannually (Jan–Jun and Jul–Dec) at Saks Fifth Avenue"
     frequency: "semi_annual"
     category: "shopping"
     enrollment_required: true
+    merchants:
+      - saks-fifth-avenue
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120
     description: "Up to $120 statement credit for Global Entry or TSA PreCheck application fee"
@@ -97,12 +114,16 @@ benefits:
     frequency: "monthly"
     category: "fitness"
     enrollment_required: true
+    merchants:
+      - equinox
   - name: "Lululemon Credit"
     value: 300
     description: "$75 per quarter toward purchases at Lululemon"
     frequency: "quarterly"
     category: "shopping"
     enrollment_required: true
+    merchants:
+      - lululemon
   - name: "Global Dining Access by Resy"
     value: 0
     description: "Priority reservations and special access at select restaurants nationwide"

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -78,6 +78,8 @@ benefits:
     description: "Two $10 Instacart credits each month through 12/31/27"
     frequency: "monthly"
     category: "groceries"
+    merchants:
+      - instacart
   - name: "JSX Credit"
     value: 200
     description: "Up to $200 each anniversary year on flights purchased directly with JSX"

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -77,6 +77,8 @@ benefits:
     description: "$10 monthly Instacart credit through 12/31/27"
     frequency: "monthly"
     category: "groceries"
+    merchants:
+      - instacart
   - name: "JSX Credit"
     value: 100
     description: "Up to $100 each anniversary year on flights purchased directly with JSX"

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -104,6 +104,8 @@ benefits:
     frequency: "annual"
     category: "groceries"
     enrollment_required: true
+    merchants:
+      - instacart
   - name: "JSX Flight Credit"
     value: 150
     description: "Up to $150 in statement credits each anniversary year on flights purchased directly through JSX"

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -26,6 +26,8 @@ benefits:
     frequency: "annual"
     category: "dining"
     enrollment_required: true
+    merchants:
+      - doordash
 tags:
   - hotel
   - travel

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -8,10 +8,27 @@ const CARDS_DIR = path.join(__dirname, '..', 'data', 'cards');
 const OUTPUT_FILE = path.join(__dirname, '..', 'data', 'cards.json');
 const SCHEMA_FILE = path.join(CARDS_DIR, 'schema.json');
 const CATEGORIES_FILE = path.join(__dirname, '..', 'data', 'categories.yaml');
+const STORES_DIR = path.join(__dirname, '..', 'data', 'stores');
 
 function loadSchema() {
   const schemaContent = fs.readFileSync(SCHEMA_FILE, 'utf8');
   return JSON.parse(schemaContent);
+}
+
+// Set of valid store slugs, so we can validate that a benefit's `merchants`
+// list points at real /best-card-for/<slug> pages. Store files are named
+// <slug>.yaml (the on-page "Edit this page" link and routing both assume
+// filename === slug), so the directory listing is the canonical slug set —
+// no YAML parse needed. Returns an empty set if the directory is absent, in
+// which case merchant validation is skipped (build stays resilient).
+function loadStoreSlugs() {
+  if (!fs.existsSync(STORES_DIR)) return new Set();
+  return new Set(
+    fs
+      .readdirSync(STORES_DIR)
+      .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'))
+      .map(f => f.replace(/\.ya?ml$/, '')),
+  );
 }
 
 function loadCategories() {
@@ -20,7 +37,7 @@ function loadCategories() {
   return data.categories;
 }
 
-function validateCard(card, schema, categoryIds) {
+function validateCard(card, schema, categoryIds, storeSlugs) {
   const errors = [];
 
   // Check required fields
@@ -156,6 +173,27 @@ function validateCard(card, schema, categoryIds) {
     }
   }
 
+  // Validate benefit merchant links. A benefit's `merchants` array ties a
+  // statement credit to specific /best-card-for/<slug> pages (e.g. the CSR
+  // StubHub credit → [stubhub, viagogo]). Every slug must resolve to a real
+  // store, or the credit would point at a 404 and never render.
+  if (card.benefits) {
+    for (const benefit of card.benefits) {
+      if (benefit.merchants === undefined) continue;
+      if (!Array.isArray(benefit.merchants)) {
+        errors.push(`Invalid merchants for benefit "${benefit.name}": must be an array of store slugs`);
+        continue;
+      }
+      for (const slug of benefit.merchants) {
+        if (typeof slug !== 'string' || !/^[a-z0-9-]+$/.test(slug)) {
+          errors.push(`Invalid merchant slug for benefit "${benefit.name}": ${slug} (lowercase, hyphens only)`);
+        } else if (storeSlugs.size > 0 && !storeSlugs.has(slug)) {
+          errors.push(`Unknown merchant slug for benefit "${benefit.name}": ${slug} (no data/stores/${slug}.yaml)`);
+        }
+      }
+    }
+  }
+
   // Validate APR
   if (card.apr) {
     if (typeof card.apr !== 'object' || Array.isArray(card.apr)) {
@@ -237,6 +275,7 @@ function buildCards() {
   const schema = loadSchema();
   const categories = loadCategories();
   const categoryIds = new Set(categories.map(c => c.id));
+  const storeSlugs = loadStoreSlugs();
   const cards = [];
   const cardsWithFiles = [];
   const errors = [];
@@ -255,7 +294,7 @@ function buildCards() {
       const card = yaml.load(content);
 
       // Validate the card
-      const validationErrors = validateCard(card, schema, categoryIds);
+      const validationErrors = validateCard(card, schema, categoryIds, storeSlugs);
       if (validationErrors.length > 0) {
         errors.push({ file, errors: validationErrors });
         console.log(`  ERROR: ${validationErrors.join(', ')}`);


### PR DESCRIPTION
## Problem

The Chase Sapphire Reserve gives a $300/yr StubHub credit, but it didn't appear anywhere on `/best-card-for/stubhub`. Two reasons:

1. The store ranker (`storeRanking.js`) only reads `rewards[]`, `co_brand_cards`, and store `also_earns[]` — it never looks at a card's `benefits[]`, where statement credits live.
2. Nothing linked a benefit to a merchant (the StubHub connection was only English prose in the description).

And it's genuinely tricky: a statement credit is a **fixed, capped dollar amount**, not a percentage that scales with spend, so it can't be honestly sorted into the effective-% ranked list.

## Approach

A structured link plus a **dedicated section**, not a hack into the ranking.

- **New data field** — optional `benefits[].merchants: [store-slug]` (schema + `CardBenefit` type). `build-cards.js` validates every slug against `data/stores/` and **hard-fails on an unknown one**, so a credit can never point at a 404 store page.
- **New store-page block** — `/best-card-for/<slug>` renders a "Credits & perks at {merchant}" callout above the ranked picks, in two tiers:
  - Dollar credits as full rows, sorted by annual value (amounts render `/yr` since `value` is the annual rollup — a $10/mo credit is `value: 120` → `$120/yr`)
  - Value-0 complimentary memberships (free DashPass, etc.) collapsed into a compact chip list, deduped so a card with both a $ credit and a free membership shows only once

## Catalog sweep

Tagged **34 cards / 54 benefit tags / 29 store pages**. Every multi-merchant tag was checked against the benefit's own description text. Busiest pages: doordash (22), instacart (9), uber/uber-eats (4 each), disney-plus (4).

## Verification

- `/best-card-for/stubhub` → CSR `$300/yr` credit renders
- `/best-card-for/doordash` → two-tier layout (5 credits + 15 membership chips), no dupes, `$120/yr` not `/mo`
- `/best-card-for/target` → no credits section, ranked picks intact (no regression)
- `npm run build:cards` clean (182 cards) incl. negative test for unknown slug; `tsc --noEmit` clean

## Follow-up (not in this PR)

15 merchants have credits already tagged-worthy but no store page yet — `clear`, `resy`, `apple-tv-plus`, `nyt`, `wsj`, `peloton`, `caviar`, `live-nation`, and a few Amex Business ones. Adding any of those store pages auto-surfaces the credits.