### PR TITLE
docs: bring READMEs up to date with the current stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CreditOdds
 
-CreditOdds is a platform that helps users understand their credit card approval odds based on real user-submitted data points.
+CreditOdds is a platform that helps users understand their credit card approval odds based on real user-submitted data points, track the cards in their wallet, and find the best card for any purchase.
 
 ## Project Structure
 
@@ -9,50 +9,67 @@ This is a monorepo containing all CreditOdds applications and shared code:
 ```
 creditodds/
 ├── apps/
-│   ├── api/                 # AWS Lambda serverless API
-│   ├── functions/           # Firebase Cloud Functions
-│   ├── ios/                 # Native iOS app (SwiftUI)
+│   ├── api/                 # AWS SAM serverless API (Lambda, Node.js 22)
+│   ├── functions/           # Firebase Cloud Functions (new-signup Slack notification)
+│   ├── ios/                 # Native iOS app (SwiftUI, XcodeGen)
 │   └── web-next/            # Next.js 16 frontend application
 ├── packages/
 │   └── shared/              # Shared utilities and validation schemas
-├── data/
-│   ├── articles/            # Long-form article content (Markdown)
-│   ├── best/                # "Best cards" category pages (Markdown)
-│   ├── cards/               # Credit card data (YAML files)
+├── data/                    # Content source of truth (YAML/Markdown → built JSON)
+│   ├── articles/            # Long-form article content (+ drafts/ for scheduled posts)
+│   ├── best/                # "Best cards" category pages
+│   ├── cards/               # Credit card definitions (one YAML per card)
 │   │   └── images/          # Card images for PR submissions
-│   ├── news/                # News articles (Markdown)
-│   ├── social-pages/        # Social page metadata (YAML)
-│   ├── stores/              # Store / merchant data (YAML)
-│   └── valuations/          # Points & miles valuation history (YAML)
-├── docs/                    # Project documentation
-├── scripts/                 # Build and utility scripts
+│   ├── news/                # News articles
+│   ├── social-pages/        # Social page metadata
+│   ├── stores/              # Store / merchant data for best-card-for pages
+│   └── valuations/          # Points & miles valuation history
+├── docs/                    # Project documentation (e.g. adding-cards.md)
+├── infra/                   # Standalone CloudFormation (VPC / networking)
+├── scripts/                 # Build, content-automation, QA, and social scripts
 └── .github/
-    └── workflows/           # GitHub Actions for CI/CD
+    └── workflows/           # GitHub Actions for CI/CD and automation
 ```
 
 ## Tech Stack
 
 ### Frontend (`apps/web-next`)
-- Next.js 16 with App Router
-- TypeScript
-- Tailwind CSS
-- Highcharts for data visualization
+- Next.js 16 with App Router, built with Turbopack
+- TypeScript, Tailwind CSS
+- Highcharts for data visualization (code-split, client-only)
 - Firebase Authentication (Google Sign-in, Email Magic Links)
-- Server-Side Rendering (SSR) and Static Site Generation (SSG) for SEO
+- SSR/SSG with ISR (most pages revalidate every 5 minutes)
+- Sentry error monitoring, PostHog analytics (proxied through `/ingest`), Web Vitals reporting
+- Security headers (HSTS, X-Frame-Options, Permissions-Policy) plus a report-only CSP
+- SEO: per-page JSON-LD, ~40 OpenGraph image routes, sitemap + Google News sitemap, a prebuild SEO gate (`scripts/check-seo.mjs`)
+- Tests with Vitest; ESLint with zero-warning policy
 - Deployed on AWS Amplify
 
 ### Backend (`apps/api`)
-- AWS Lambda (Node.js 22)
-- AWS API Gateway with Firebase Token Authorizer
-- AWS SAM for infrastructure
-- MySQL (AWS RDS) for user records
+- AWS SAM stack (`CreditCardOddsAPI`) with ~39 Lambda functions (Node.js 22, esbuild-bundled)
+- AWS API Gateway with a Firebase token authorizer as the default; public read/analytics routes explicitly opt out
+- All functions run inside a private VPC; outbound traffic exits through a single NAT gateway whose Elastic IP is allowlisted by the database security group
+- MySQL (AWS RDS) via a shared `serverless-mysql` connection module (`src/db.js`)
+- Sentry Lambda layer attached to every function
+- One scheduled function: card stats refresh every 5 minutes (EventBridge)
+- Wallet "best card" ranking engine in `apps/api/src/lib/ranker/` (shared with the frontend via the `@ranker` alias)
+- Sequential single-statement SQL migrations in `apps/api/migrations/`
+
+### Other apps
+- **iOS** (`apps/ios`): native SwiftUI app (Wallet / Earn / Settings tabs, card browsing), Firebase Auth, talks to the same API
+- **Firebase Cloud Functions** (`apps/functions`): a single `onUserCreated` trigger that posts new-signup notifications to Slack
 
 ### Infrastructure
-- **Card Data**: GitHub → S3 → CloudFront CDN
-- **Card Images**: GitHub → S3 → CloudFront CDN
-- **User Data**: AWS RDS MySQL
+- **Content data**: YAML/Markdown in `data/` → build scripts → JSON → S3 → CloudFront CDN
+- **Card images**: GitHub → S3 → CloudFront CDN
+- **User data**: AWS RDS MySQL (private VPC; not reachable from local machines)
 - **Authentication**: Firebase (Google, Email Link)
-- **CI/CD**: GitHub Actions
+- **CI/CD & automation**: GitHub Actions (OIDC to AWS, no long-lived keys)
+- **Networking**: `infra/network.yml` defines the VPC, private subnets, single NAT gateway with a static egress IP, and an S3 gateway endpoint
+
+### Region split (deliberate)
+- **Lambdas / API stack**: us-east-1 (co-located with the database)
+- **Content S3 buckets + CloudFront**: us-east-2 (never migrated; workflows default to us-east-2 and pass `--region us-east-1` explicitly for Lambda invokes)
 
 ## Getting Started
 
@@ -60,8 +77,7 @@ creditodds/
 
 - Node.js 22+
 - npm 9+
-- AWS CLI (for API deployment)
-- AWS SAM CLI (for API deployment)
+- AWS CLI and AWS SAM CLI (only for API deployment)
 
 ### Installation
 
@@ -89,6 +105,8 @@ NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
 NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
 ```
 
+In development the app reads `data/cards.json` and `data/news.json` from the local checkout instead of the CDN, so run the build scripts below at least once.
+
 ### Running Locally
 
 **Start the Next.js application:**
@@ -111,10 +129,11 @@ npm run build:cards
 | `npm run dev:web-next` | Start the Next.js development server (alias) |
 | `npm run build:web-next` | Build the Next.js app for production |
 | `npm run build:cards` | Build cards.json from YAML files |
-| `npm run build:news` | Build news.json from Markdown files |
-| `npm run build:articles` | Build articles.json from Markdown files |
-| `npm run build:best` | Build best.json from Markdown files |
-| `npm run build:stores` | Build stores.json from YAML files |
+| `npm run build:news` | Build news.json from Markdown/YAML files |
+| `npm run build:articles` | Build articles.json from Markdown/YAML files |
+| `npm run build:best` | Build best.json from Markdown/YAML files |
+| `npm run build:stores` | Build stores.json from YAML files (also mirrored into the API bundle) |
+| `npm run sync:news-images` | Generate/sync news hero images |
 | `npm run lint` | Run ESLint across all workspaces |
 
 > **Tests:** the web app uses Vitest (`cd apps/web-next && npm test`). The API
@@ -129,46 +148,33 @@ npm run build:cards
 - **Card Wire**: Live feed of card changes — annual fees, sign-up bonuses, reward rates, APR
 - **Card News**: Curated news and updates about credit cards
 - **Articles**: Long-form guides and analysis
-- **Best Cards**: Ranked lists by category
+- **Best Cards**: Ranked lists by category (multi-model consensus ranking)
+- **Best Card For**: Best card to use at ~900 specific stores/merchants, including statement credits
+- **Best Card For Me**: Personalized next-card quiz ranked by marginal wallet value
 - **Check Odds**: Estimate your approval odds for a specific card
 - **Compare**: Side-by-side credit card comparisons
 - **Card Ratings**: User-submitted 1-5 star ratings on cards
 - **User Submissions**: Submit your credit card application results
 - **Wallet**: Track cards you own, with best-card picks for stores and nearby places
-- **Referral Links**: Share and earn from referral links
-- **Rewards Tools**: 12 points/miles-to-USD converters (Chase UR, Amex MR, Capital One, airline & hotel programs)
+- **Referral Links**: Share and earn from referral links (with automated daily validity checks)
+- **Rewards Tools**: 13 points/miles-to-USD converters (Chase UR, Amex MR, Capital One, airline & hotel programs)
 
 ## Contributing
 
 We welcome contributions! The easiest way to contribute is by adding new credit cards to our database.
 
-**See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed instructions on:**
+**See [CONTRIBUTING.md](./CONTRIBUTING.md) and [docs/adding-cards.md](./docs/adding-cards.md) for detailed instructions on:**
 - Adding new credit cards
 - Submitting card images
 - Code contributions
 
 ## Deployment
 
-### Card Data Deployment
-
-Card data is automatically deployed when changes are merged to `main`:
-
-1. GitHub Action triggers on changes to `data/cards/**`
-2. Builds `cards.json` from YAML files
-3. Uploads to S3 and invalidates CloudFront cache
-4. Triggers database sync via API
-
-### Content Deployment
-
-News, articles, and best-cards pages are also deployed via GitHub Actions on merge to `main`:
-
-- `build-news.yml` — builds and uploads `news.json`
-- `build-articles.yml` — builds and uploads `articles.json`
-- `build-best.yml` — builds and uploads `best.json`
-
-Additional workflows handle automated card updates, card page checks, and scheduled content refreshes.
-
 ### API Deployment
+
+Pushes to `main` touching `apps/api/**` deploy automatically via GitHub Actions
+(`deploy-api.yml`: `sam build && sam deploy`, authenticated with GitHub OIDC).
+Manual deploy still works from a machine with `samconfig.toml`:
 
 ```bash
 cd apps/api
@@ -178,28 +184,75 @@ sam deploy
 
 ### Web Deployment
 
-The Next.js app is deployed automatically via AWS Amplify when changes are merged to `main`.
+The Next.js app builds on AWS Amplify. Amplify's native auto-build is disabled;
+each merge to `main` fires the Amplify webhook exactly once — code pushes via
+`deploy-frontend.yml`, data pushes via the relevant `build-*.yml` workflow.
+
+### Content Data Deployment
+
+Content changes merged to `main` trigger the matching workflow:
+
+1. GitHub Action triggers on changes to `data/<type>/**`
+2. Builds the JSON artifact from YAML/Markdown sources
+3. Uploads to S3 and invalidates CloudFront
+4. Triggers the Amplify webhook (and, for cards, syncs the database via the `creditodds-sync-cards` Lambda)
+
+### Database Migrations
+
+Migrations live in `apps/api/migrations/`, numbered sequentially and
+single-statement only (multi-step changes split into `NNNa_*`, `NNNb_*`).
+The database is inside a private VPC, so migrations run by temporarily wiring
+`RunMigrationHandler` into `template.yml`, deploying, invoking, and unwiring
+(see `apps/api/README.md`).
+
+## Automation (GitHub Actions)
+
+Beyond builds and deploys, the repo runs a substantial automation layer —
+all human-in-the-loop (content changes land as PRs or issues for review):
+
+| Category | Workflows |
+|----------|-----------|
+| Deploys | `deploy-api`, `deploy-frontend` |
+| Data builds | `build-cards`, `build-news`, `build-articles`, `build-best` |
+| Content automation | `auto-news` (2x daily news discovery → PR), `content-agent` (hourly competitor watch), `publish-scheduled-articles` (daily), `refresh-best-pages` (twice monthly LLM re-rank → PR), `bump-best-updated-at`, `reject-news` |
+| Data quality | `check-card-pages` (daily scrape/verify → PR), `check-card-rewards-and-benefits` (weekly → PR), `check-apply-links` (daily → issue), `check-referrals` (daily validation) |
+| Social | `queue-social`, `post-best-rankings`, `post-card-wire-manual`, `reconcile-card-wire` (every 30 min), `weekly-sub-changes`, `weekly-top-cards` |
+
+AWS access from workflows uses GitHub OIDC roles (no stored AWS keys).
+LLM-powered scripts use OpenAI (plus xAI Grok for X/Twitter search in news discovery).
+
+## Monitoring
+
+- **Sentry**: frontend (`@sentry/nextjs`, tunneled through `/monitoring`) and every backend Lambda (Sentry Lambda layer)
+- **PostHog**: product analytics, proxied through the site's `/ingest` rewrite
+- **Web Vitals**: reported from the root layout
 
 ## Architecture
 
 ```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│   GitHub Repo   │────▶│  GitHub Actions  │────▶│  S3 + CloudFront│
-│ (YAML/MD/Images)│     │  (Build/Upload)  │     │ (cards/news/etc)│
-└─────────────────┘     └─────────────────┘     └────────┬────────┘
-                                                         │
-┌─────────────────┐     ┌─────────────────┐              │
-│  Next.js App    │────▶│  Lambda API     │◀─────────────┘
-│  (AWS Amplify)  │     │  + Firebase Auth│
-└────────┬────────┘     └────────┬────────┘
-         │                       │
-         │              ┌────────▼────────┐
-         └─────────────▶│   MySQL (RDS)   │
-          (API calls)   │ (User Records)  │
-                        └─────────────────┘
+┌─────────────────┐     ┌──────────────────┐     ┌──────────────────────┐
+│   GitHub Repo   │────▶│  GitHub Actions   │────▶│    S3 + CloudFront   │
+│ (YAML/MD/Images)│     │ (build + upload,  │     │ cards/news/articles/ │
+└─────────────────┘     │  OIDC to AWS)     │     │ best/stores JSON     │
+                        └────────┬─────────┘     └──────────┬───────────┘
+                                 │ sync-cards Lambda        │
+                                 ▼                          │
+┌─────────────────┐     ┌──────────────────┐                │
+│  Next.js App    │────▶│  API Gateway +    │◀───────────────┘
+│  (AWS Amplify)  │     │  Lambda (SAM,     │
+│  + iOS app      │     │  Firebase auth,   │
+└────────┬────────┘     │  private VPC)     │
+         │              └────────┬─────────┘
+         │                       │ NAT (static EIP)
+         │              ┌────────▼─────────┐
+         └─────────────▶│   MySQL (RDS)    │
+          (API calls)   │  (user records,  │
+                        │  stats, ratings) │
+                        └──────────────────┘
 
-         ┌─────────────────┐
-         │ Firebase Cloud   │
-         │ Functions         │
-         └─────────────────┘
+┌──────────────────┐    ┌───────────────────────┐
+│ Firebase Auth +  │    │ Social Posting Service │
+│ Cloud Functions  │    │ (separate repo/stack)  │
+│ (signup → Slack) │    └───────────────────────┘
+└──────────────────┘
 ```

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -10,7 +10,8 @@ For the full endpoint reference and database schema, see the
 
 ## Layout
 
-- `src/handlers/` — Lambda handlers, one file per route (≈34 handlers)
+- `src/handlers/` — Lambda handlers (~32 files backing ~39 functions; some
+  files, like `admin.js`, back several function resources)
 - `src/lib/` — shared helpers (DB access via `serverless-mysql`, the wallet
   `ranker/`, auth, etc.)
 - `template.yml` — SAM/CloudFormation template defining every function, the


### PR DESCRIPTION
## Summary

Full stack audit found the root README materially stale — it predates the automation layer, the region split, monitoring, and the current deploy paths. This PR is docs-only.

**Root README**
- Documents all 22 GitHub Actions workflows, grouped by category (deploys, data builds, content automation, data quality, social)
- Documents the deliberate region split: Lambdas/API in us-east-1 (next to the DB), content S3 + CloudFront in us-east-2
- Adds Monitoring section (Sentry frontend + Lambda layer, PostHog via /ingest proxy, Web Vitals)
- Adds iOS app and Firebase Cloud Function (signup Slack notify) to the stack description
- Adds VPC/NAT networking model, database migration procedure, and infra/ to the project tree
- Updates deploy docs: deploy-api.yml (OIDC) as the primary API path, Amplify webhook model for the frontend
- Refreshes the feature list (best-card-for stores, best-card-for-me quiz, ratings, 13 tools) and the architecture diagram

**apps/api/README**
- Corrects the stale handler count (~32 handler files backing ~39 Lambda functions)

No intentionally-internal details (IPs, account IDs, SG IDs) were added.