### PR TITLE
perf(web): self-host Inter/Inter Tight via next/font

### DIFF
--- a/apps/web-next/next.config.mjs
+++ b/apps/web-next/next.config.mjs
@@ -13,8 +13,9 @@ const withBundleAnalyzer = bundleAnalyzer({
 // Third parties inventoried: PostHog (us.i.posthog.com / us-assets.i.posthog.com),
 // Firebase Auth (apis.google.com,
 // gstatic, *.googleapis.com, creditodds.firebaseapp.com, accounts.google.com),
-// Google Fonts, Highcharts (bundled — no external origin), the card-image CDN/S3,
-// Google profile photos, and the API origin.
+// Highcharts (bundled — no external origin), the card-image CDN/S3,
+// Google profile photos, and the API origin. Fonts are self-hosted via
+// next/font, so no Google Fonts origins are needed.
 const DEFAULT_API_ORIGIN = 'https://d2ojrhbh2dincr.cloudfront.net';
 // Normalize to a bare origin — a CSP host-source must not carry a path (the env
 // var may include one, e.g. an API Gateway ".../Prod" URL in some environments).
@@ -32,10 +33,10 @@ const contentSecurityPolicy = [
   `frame-ancestors 'none'`,
   `form-action 'self'`,
   `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://www.gstatic.com https://us-assets.i.posthog.com`,
-  `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
-  `font-src 'self' data: https://fonts.gstatic.com`,
+  `style-src 'self' 'unsafe-inline'`,
+  `font-src 'self' data:`,
   `img-src 'self' data: blob: https://d3ay3etzd1512y.cloudfront.net https://credit-card-data-site.s3.us-east-2.amazonaws.com https://*.googleusercontent.com`,
-  `connect-src 'self' ${API_ORIGIN} https://*.googleapis.com https://us.i.posthog.com https://us-assets.i.posthog.com https://fonts.gstatic.com https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.us.sentry.io`,
+  `connect-src 'self' ${API_ORIGIN} https://*.googleapis.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.us.sentry.io`,
   `frame-src 'self' https://creditodds.firebaseapp.com https://accounts.google.com https://apis.google.com`,
   `worker-src 'self' blob:`,
   `manifest-src 'self'`,

--- a/apps/web-next/src/app/articles/author/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/author/[slug]/page.tsx
@@ -117,7 +117,7 @@ export default async function AuthorPage({ params }: Props) {
               padding: '80px 0',
               textAlign: 'center',
               color: 'var(--muted)',
-              fontFamily: "'Inter', sans-serif",
+              fontFamily: "var(--font-inter), sans-serif",
               fontSize: 13,
             }}
           >

--- a/apps/web-next/src/app/articles/category/[tag]/page.tsx
+++ b/apps/web-next/src/app/articles/category/[tag]/page.tsx
@@ -111,7 +111,7 @@ export default async function CategoryPage({ params }: Props) {
               padding: '80px 0',
               textAlign: 'center',
               color: 'var(--muted)',
-              fontFamily: "'Inter', sans-serif",
+              fontFamily: "var(--font-inter), sans-serif",
               fontSize: 13,
             }}
           >

--- a/apps/web-next/src/app/articles/page.tsx
+++ b/apps/web-next/src/app/articles/page.tsx
@@ -82,7 +82,7 @@ export default async function ArticlesPage() {
               padding: '80px 0',
               textAlign: 'center',
               color: 'var(--muted)',
-              fontFamily: "'Inter', sans-serif",
+              fontFamily: "var(--font-inter), sans-serif",
               fontSize: 13,
             }}
           >

--- a/apps/web-next/src/app/bank/[name]/page.tsx
+++ b/apps/web-next/src/app/bank/[name]/page.tsx
@@ -132,7 +132,7 @@ export default async function BankPage({ params }: BankPageProps) {
                     <span
                       className="text-xs text-gray-500"
                       style={{
-                        fontFamily: "'Inter', sans-serif",
+                        fontFamily: "var(--font-inter), sans-serif",
                       }}
                     >
                       {new Date(news.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}

--- a/apps/web-next/src/app/best/BestV2Client.tsx
+++ b/apps/web-next/src/app/best/BestV2Client.tsx
@@ -103,7 +103,7 @@ export default function BestV2Client({
               padding: '80px 0',
               textAlign: 'center',
               color: 'var(--muted)',
-              fontFamily: "'Inter', sans-serif",
+              fontFamily: "var(--font-inter), sans-serif",
               fontSize: 13,
             }}
           >

--- a/apps/web-next/src/app/compare/page.tsx
+++ b/apps/web-next/src/app/compare/page.tsx
@@ -136,7 +136,7 @@ export default async function ComparePage() {
               style={{
                 padding: '48px 0',
                 color: 'var(--muted)',
-                fontFamily: "'Inter', sans-serif",
+                fontFamily: "var(--font-inter), sans-serif",
                 fontSize: 13,
               }}
             >

--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -566,7 +566,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
               padding: '80px 0',
               textAlign: 'center',
               color: 'var(--muted)',
-              fontFamily: "'Inter', sans-serif",
+              fontFamily: "var(--font-inter), sans-serif",
               fontSize: 13,
             }}
           >

--- a/apps/web-next/src/app/globals.css
+++ b/apps/web-next/src/app/globals.css
@@ -63,7 +63,7 @@ body {
   border: 1px solid #ddd7ec;
   border-left-width: 4px;
   color: #1a1330;
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-family: var(--font-inter), ui-sans-serif, system-ui, -apple-system, sans-serif;
   font-size: 14px;
   font-weight: 500;
   padding: 10px 14px;

--- a/apps/web-next/src/app/landing-v3.css
+++ b/apps/web-next/src/app/landing-v3.css
@@ -29,7 +29,7 @@
   margin-bottom: 40px;
 }
 .landing-v3 .hero-c h1 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.04em;
   font-size: clamp(48px, 6vw, 88px);
@@ -93,7 +93,7 @@
   flex: 1;
   border: 0;
   outline: 0;
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.012em;
   font-size: 22px;
@@ -253,7 +253,7 @@
   font-weight: 600;
 }
 .landing-v3 .lane-hd h3 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.018em;
   font-size: 28px;
@@ -443,7 +443,7 @@
   color: var(--accent);
 }
 .landing-v3 .ed-plate-cat {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.02em;
   font-size: clamp(26px, 3.6vw, 36px);
@@ -456,7 +456,7 @@
   padding: 13px 18px 15px;
 }
 .landing-v3 .ed-lead-bd h4 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.014em;
   font-size: 18.5px;
@@ -524,7 +524,7 @@
   margin-bottom: 6px;
 }
 .landing-v3 .ed-row h5 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.01em;
   font-size: 15px;
@@ -567,7 +567,7 @@
   font-weight: 600;
 }
 .landing-v3 .lnk h4 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 15px;
   letter-spacing: -0.005em;
@@ -642,7 +642,7 @@
   padding-right: 24px;
 }
 .landing-v3 .fb .sec-num {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   letter-spacing: 0.16em;
   color: var(--muted);
@@ -651,7 +651,7 @@
   margin-bottom: 14px;
 }
 .landing-v3 .fb h3 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.022em;
   font-size: 32px;
@@ -869,7 +869,7 @@
   color: #fff;
 }
 .landing-v3 .final-c h2 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.035em;
   font-size: clamp(48px, 6vw, 88px);

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -22,7 +22,7 @@
 
   background: var(--paper);
   color: var(--ink);
-  font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-feature-settings: 'ss01', 'cv11';
   font-variant-numeric: tabular-nums;
   -webkit-font-smoothing: antialiased;
@@ -34,11 +34,11 @@
 }
 
 .landing-v2 .serif {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   letter-spacing: -0.02em;
 }
 .landing-v2 .mono {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-feature-settings: 'tnum';
 }
 
@@ -113,7 +113,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   color: var(--muted);
   padding: 6px 10px;
@@ -219,7 +219,7 @@
   font-weight: 600;
 }
 .landing-v2 h1.hero-title {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-weight: 500;
   letter-spacing: -0.035em;
   font-size: clamp(46px, 5.6vw, 82px);
@@ -247,7 +247,7 @@
   flex-wrap: wrap;
 }
 .landing-v2 .hero-cta .note {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 12px;
   color: var(--muted);
 }
@@ -271,7 +271,7 @@
   border-top: 1px dashed var(--line-2);
 }
 .landing-v2 .hero-stats .stat .n {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 32px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -281,7 +281,7 @@
   gap: 4px;
 }
 .landing-v2 .hero-stats .stat .n .sup {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 13px;
   color: var(--accent);
   font-weight: 500;
@@ -338,7 +338,7 @@
   background: var(--paper);
   font-size: 15px;
   color: var(--ink);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   outline: none;
   transition: border-color 0.15s ease, background 0.15s ease;
 }
@@ -412,7 +412,7 @@
   text-overflow: ellipsis;
 }
 .landing-v2 .selected-card-sub {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
   margin-top: 3px;
@@ -469,11 +469,11 @@
 .landing-v2 .card-opt .issuer {
   font-size: 12px;
   color: var(--muted);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
 }
 .landing-v2 .card-opt .records {
   margin-left: auto;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
   white-space: nowrap;
@@ -500,7 +500,7 @@
   padding: 10px 12px;
 }
 .landing-v2 .field .val {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 15px;
   font-weight: 500;
   color: var(--ink);
@@ -586,7 +586,7 @@
   text-align: center;
 }
 .landing-v2 .odds-ring .pct {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 30px;
   font-weight: 500;
   color: var(--ink);
@@ -600,7 +600,7 @@
   margin-top: 4px;
 }
 .landing-v2 .result .meta .verdict {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 20px;
   font-weight: 500;
   color: var(--ink);
@@ -632,7 +632,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10.5px;
 }
 .landing-v2 .dist-bar .seg {
@@ -657,7 +657,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
 }
@@ -679,7 +679,7 @@
   cursor: pointer;
   background: var(--accent);
   color: #fff;
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 13px;
   font-weight: 600;
   letter-spacing: -0.005em;
@@ -712,7 +712,7 @@
   gap: 48px;
   white-space: nowrap;
   animation: landing-ticker 60s linear infinite;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 12.5px;
 }
 .landing-v2 .ticker-item {
@@ -766,7 +766,7 @@
   color: var(--muted);
 }
 .landing-v2 h2.sec-title {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-weight: 500;
   letter-spacing: -0.025em;
   font-size: clamp(36px, 4.2vw, 58px);
@@ -813,7 +813,7 @@
   margin-bottom: 18px;
 }
 .landing-v2 .step h3 {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 26px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -832,7 +832,7 @@
   background: var(--card);
   border-radius: 10px;
   padding: 14px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   color: var(--ink-2);
 }
@@ -891,7 +891,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   color: var(--muted);
 }
@@ -942,12 +942,12 @@
   color: var(--ink);
 }
 .landing-v2 .rec .meta-user .d {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
 }
 .landing-v2 .rec .num {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 12.5px;
   color: var(--ink-2);
   text-align: right;
@@ -955,7 +955,7 @@
 .landing-v2 .rec .num .l {
   display: block;
   font-size: 12px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   color: var(--muted);
 }
 .landing-v2 .rec .status-chip {
@@ -1013,7 +1013,7 @@
   line-height: 1.2;
 }
 .landing-v2 .w-card .w-iss {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10px;
   color: var(--muted);
 }
@@ -1021,7 +1021,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10.5px;
 }
 .landing-v2 .w-card .w-rows .k {
@@ -1081,7 +1081,7 @@
   color: var(--ink);
 }
 .landing-v2 .ref-meta .ref-code {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
 }
@@ -1093,7 +1093,7 @@
   margin-left: 0;
 }
 .landing-v2 .ref-stats .big {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 22px;
   color: var(--ink);
   line-height: 1;
@@ -1113,12 +1113,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 12px;
   font-weight: 500;
 }
 .landing-v2 .ref-earnings .amt {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 20px;
   font-weight: 500;
 }
@@ -1140,7 +1140,7 @@
   padding: 28px 24px;
 }
 .landing-v2 .proof-cell .pn {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-weight: 500;
   font-size: 44px;
   letter-spacing: -0.025em;
@@ -1148,7 +1148,7 @@
   line-height: 1;
 }
 .landing-v2 .proof-cell .pn .sup {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 14px;
   color: var(--muted);
   font-weight: 400;
@@ -1168,7 +1168,7 @@
   text-align: center;
 }
 .landing-v2 .final h2 {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-weight: 500;
   letter-spacing: -0.03em;
   font-size: clamp(46px, 6vw, 96px);
@@ -1229,7 +1229,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   color: var(--muted-2);
 }
@@ -1352,7 +1352,7 @@
   }
 }
 .landing-v2 .page-title {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-weight: 500;
   letter-spacing: -0.035em;
   font-size: clamp(36px, 4.2vw, 58px);
@@ -1514,7 +1514,7 @@
   color: var(--ink);
 }
 .landing-v2 .filter-chip .ct {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
 }
@@ -1672,7 +1672,7 @@
   text-overflow: ellipsis;
 }
 .landing-v2 .issuer-count {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
 }
@@ -1746,7 +1746,7 @@
   letter-spacing: -0.01em;
 }
 .landing-v2 .cc-iss {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
   margin-top: 3px;
@@ -1760,7 +1760,7 @@
   gap: 2px;
 }
 .landing-v2 .cc-odds .pct {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 24px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -1779,14 +1779,14 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   border-top: 1px dashed var(--line);
   padding-top: 12px;
 }
 .landing-v2 .cc-rows .k {
   color: var(--muted);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
 }
 .landing-v2 .cc-rows .v {
   color: var(--ink);
@@ -1808,7 +1808,7 @@
   gap: 10px;
   padding-top: 10px;
   border-top: 1px solid var(--line);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
 }
@@ -1917,7 +1917,7 @@
 }
 .landing-v2 .card-table td.num {
   text-align: right;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 13px;
   font-weight: 500;
   white-space: nowrap;
@@ -1968,14 +1968,14 @@
   color: var(--accent);
 }
 .landing-v2 .ct-iss {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
   margin-top: 2px;
 }
 .landing-v2 .ct-sub {
   display: block;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10.5px;
   color: var(--muted);
   font-weight: 400;
@@ -1983,7 +1983,7 @@
 }
 .landing-v2 .bonus-sub {
   display: block;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10.5px;
   color: var(--muted);
   font-weight: 400;
@@ -1991,7 +1991,7 @@
 }
 .landing-v2 .ct-odds {
   color: var(--accent);
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -2024,13 +2024,13 @@
   flex-shrink: 0;
 }
 .landing-v2 .ct-top-reward-rate {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-weight: 600;
   color: var(--ink);
   font-size: 13px;
 }
 .landing-v2 .ct-top-reward-label {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   color: var(--muted);
   font-size: 12px;
 }
@@ -2040,7 +2040,7 @@
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--ink-2);
 }
@@ -2179,7 +2179,7 @@
   font-weight: 600;
 }
 .landing-v2 .feat-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 32px;
   font-weight: 500;
   letter-spacing: -0.025em;
@@ -2226,7 +2226,7 @@
   border: 1px solid var(--line);
 }
 .landing-v2 .news-item .ni-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 18px;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -2302,7 +2302,7 @@
   margin-bottom: 10px;
 }
 .landing-v2 .news-card .nc-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 18px;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -2763,7 +2763,7 @@
   padding: 6px 0 16px;
 }
 .landing-v2.wire-v2 .wire-snapshot .cj-snapshot-h1 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 32px;
   letter-spacing: -0.03em;
@@ -3045,7 +3045,7 @@
   padding: 80px 0;
   text-align: center;
   color: var(--muted);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 13px;
   border: 1px solid var(--line-2);
   background: var(--paper-2);
@@ -3077,7 +3077,7 @@
   background: var(--paper-2);
   border-top: 1px solid var(--line);
   border-bottom: 1px dashed var(--line-2);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   font-weight: 500;
   color: var(--muted);
@@ -3164,7 +3164,7 @@
   background: var(--paper);
   border: 1px solid var(--line);
   border-radius: 2px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
 }
 
 .landing-v2.wire-v2 .wire-card {
@@ -3194,7 +3194,7 @@
 .landing-v2.wire-v2 .wire-card-name {
   font-weight: 500;
   color: var(--ink);
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 14px;
   letter-spacing: -0.005em;
   white-space: nowrap;
@@ -3252,7 +3252,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 12.5px;
   min-width: 0;
 }
@@ -3281,7 +3281,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 0 8px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   color: var(--muted);
 }
@@ -3365,7 +3365,7 @@
   background: var(--paper-2);
 }
 .landing-v2 .best-promo .bp-kicker {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -3373,7 +3373,7 @@
   color: var(--accent);
 }
 .landing-v2 .best-promo .bp-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 20px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -3428,7 +3428,7 @@
   margin-bottom: 6px;
 }
 .landing-v2 .bhs .v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.015em;
@@ -3437,7 +3437,7 @@
 .landing-v2 .bhs .v.accent {
   font-size: 14px;
   color: var(--accent);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-weight: 500;
 }
 .landing-v2 .bhs .v.accent a {
@@ -3493,7 +3493,7 @@
   flex: 1;
 }
 .landing-v2 .best-body .best-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -3605,7 +3605,7 @@
   margin-bottom: 10px;
 }
 .landing-v2 .best-method h3 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -3661,7 +3661,7 @@
   display: flex;
   align-items: center;
   gap: 14px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   flex-wrap: wrap;
 }
@@ -3706,7 +3706,7 @@
   flex-wrap: wrap;
 }
 .landing-v2.profile-v2 .cj-snapshot-h1 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 28px !important;
   letter-spacing: -0.03em;
@@ -3757,7 +3757,7 @@
   color: var(--muted);
 }
 .landing-v2.profile-v2 .cj-readoff-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 19px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -3766,7 +3766,7 @@
   color: var(--ink);
 }
 .landing-v2.profile-v2 .cj-readoff-foot {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   color: var(--muted);
   margin-top: 5px;
@@ -3932,7 +3932,7 @@
 .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-name {
   font-weight: 500;
   color: var(--ink);
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 14px;
   letter-spacing: -0.005em;
   white-space: nowrap;
@@ -4054,7 +4054,7 @@
 .landing-v2.profile-v2 .cj-wallet-detail .cj-wd-v {
   font-size: 14px;
   color: var(--ink);
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.005em;
   line-height: 1.2;
@@ -4141,7 +4141,7 @@
   padding: 9px 14px;
   border-top: 1px solid var(--line);
   align-items: center;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 12px;
   gap: 10px;
   color: inherit;
@@ -4153,7 +4153,7 @@
 .landing-v2.profile-v2 .cj-tape-event .cj-tape-field {
   font-weight: 500;
   color: var(--ink);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 13px;
 }
 .landing-v2.profile-v2 .cj-tape-event .cj-tape-detail {
@@ -4404,13 +4404,13 @@
 .landing-v2.profile-v2 .cj-table tbody tr:first-child { border-top: 0; }
 .landing-v2.profile-v2 .cj-cell-primary { font-weight: 500; }
 .landing-v2.profile-v2 .cj-cell-detail {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10.5px;
   color: var(--muted);
   margin-top: 1px;
 }
 .landing-v2.profile-v2 .cj-eff-pct {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 15px;
   font-weight: 500;
   color: var(--accent);
@@ -4458,7 +4458,7 @@
 }
 .landing-v2.profile-v2 .cj-settings-list:first-of-type { border-top: 1px solid var(--line); }
 .landing-v2.profile-v2 .cj-settings-k { color: var(--muted); font-weight: 500; }
-.landing-v2.profile-v2 .cj-settings-v { color: var(--ink); font-family: 'Inter', sans-serif; }
+.landing-v2.profile-v2 .cj-settings-v { color: var(--ink); font-family: var(--font-inter), sans-serif; }
 .landing-v2.profile-v2 .cj-settings-edit {
   font-size: 11.5px;
   color: var(--accent);
@@ -4562,7 +4562,7 @@
   font-size: 11px;
 }
 .landing-v2.profile-v2 .cj-rail-row-date {
-  font-family: 'Inter', monospace;
+  font-family: var(--font-inter), monospace;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--muted);
@@ -4618,14 +4618,14 @@
   color: var(--muted-2);
 }
 .landing-v2.profile-v2 .cj-apply-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.02em;
   margin-top: 4px;
 }
 .landing-v2.profile-v2 .cj-apply-sub {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted-2);
   margin-top: 2px;
@@ -4725,7 +4725,7 @@
 }
 .landing-v2.profile-v2 .cj-bch-desktop-banner-text { min-width: 0; }
 .landing-v2.profile-v2 .cj-bch-desktop-banner-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 18px;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -4741,7 +4741,7 @@
   font-weight: 400;
 }
 .landing-v2.profile-v2 .cj-bch-desktop-banner-pill {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -4864,7 +4864,7 @@
   .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-name {
     grid-area: name;
     align-self: start;
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 19px;
     font-weight: 500;
     letter-spacing: -0.015em;
@@ -4891,7 +4891,7 @@
   .landing-v2.profile-v2 .cj-wallet-crow .cj-cw-fee {
     grid-area: fee;
     align-self: start;
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 18px;
     font-weight: 500;
     letter-spacing: -0.01em;
@@ -5025,7 +5025,7 @@
     letter-spacing: 0.08em;
   }
   .landing-v2.profile-v2 .cj-mob-wallet-v {
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 28px;
     font-weight: 500;
     letter-spacing: -0.025em;
@@ -5085,7 +5085,7 @@
     font-weight: 600;
   }
   .landing-v2.profile-v2 .cj-mob-snap-v {
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 20px;
     font-weight: 500;
     letter-spacing: -0.015em;
@@ -5103,7 +5103,7 @@
     gap: 12px;
   }
   .landing-v2.profile-v2 .cj-mob-section-h h2 {
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 22px;
     font-weight: 500;
     letter-spacing: -0.02em;
@@ -5296,7 +5296,7 @@
     margin-top: 4px;
   }
   .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-tape-field {
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 20px;
     font-weight: 500;
     letter-spacing: -0.015em;
@@ -5309,7 +5309,7 @@
     border-top: 1px solid var(--line);
   }
   .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-best .cj-bch-card-text .cj-cell-primary {
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 17px;
     font-weight: 500;
     letter-spacing: -0.01em;
@@ -5324,7 +5324,7 @@
   }
   /* Earn rate — large purple */
   .landing-v2.profile-v2 .cj-tape-bch .cj-bch-row .cj-bch-earn .cj-bch-earn-val {
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 24px !important;
     font-weight: 500;
     letter-spacing: -0.02em;
@@ -5419,7 +5419,7 @@
   .landing-v2.profile-v2 .cj-mob-more { padding-top: 4px; }
   .landing-v2.profile-v2 .cj-mob-more-h {
     display: block;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-inter), sans-serif;
     font-size: 11.5px;
     color: var(--muted);
     text-transform: uppercase;
@@ -5457,7 +5457,7 @@
     font-weight: 600;
   }
   .landing-v2.profile-v2 .cj-mob-news-h {
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 28px;
     font-weight: 500;
     letter-spacing: -0.025em;
@@ -5541,7 +5541,7 @@
   .landing-v2.profile-v2 .cj-mob-news-tag--benefit-change,
   .landing-v2.profile-v2 .cj-mob-news-tag--new-card { color: #0f8a5f; }
   .landing-v2.profile-v2 .cj-mob-news-title {
-    font-family: 'Inter Tight', sans-serif;
+    font-family: var(--font-inter-tight), sans-serif;
     font-size: 17px;
     font-weight: 500;
     letter-spacing: -0.01em;
@@ -5657,7 +5657,7 @@
   gap: 8px;
 }
 .landing-v2.profile-v2 .cj-rule-name {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -5687,7 +5687,7 @@
   gap: 6px;
 }
 .landing-v2.profile-v2 .cj-rule-num-current {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 32px;
   font-weight: 500;
   letter-spacing: -0.025em;
@@ -5855,7 +5855,7 @@
   background: var(--paper-2);
 }
 .landing-v2.profile-v2 .cj-modal-card-name {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -6060,7 +6060,7 @@
   height: 36px;
 }
 .landing-v2.profile-v2 .cj-modal-list-name {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 13.5px;
   font-weight: 500;
   color: var(--ink);
@@ -6218,7 +6218,7 @@
   max-width: 720px;
   margin: 0 auto;
   padding: 40px 0 96px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 17px;
   line-height: 1.65;
   color: var(--ink-2);
@@ -6237,7 +6237,7 @@
   margin-top: 36px;
 }
 .landing-v2 .page-body h2 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.02em;
   font-size: 28px;
@@ -6246,7 +6246,7 @@
   margin: 36px 0 14px;
 }
 .landing-v2 .page-body h3 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.015em;
   font-size: 22px;
@@ -6665,7 +6665,7 @@
   font-weight: 600;
 }
 .landing-v2 .article-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   letter-spacing: -0.025em;
   font-size: clamp(32px, 4vw, 52px);
@@ -6760,7 +6760,7 @@
 .landing-v2.card-journal {
   background: var(--paper);
   color: var(--ink);
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: var(--font-inter), system-ui, sans-serif;
 }
 .landing-v2 .cj-terminal {
   background: var(--ink);
@@ -6771,7 +6771,7 @@
   display: flex;
   align-items: center;
   gap: 14px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   flex-wrap: wrap;
 }
@@ -6860,7 +6860,7 @@
   min-width: 170px;
   box-shadow: 0 8px 24px -8px rgba(26, 19, 48, 0.25);
   z-index: 20;
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: var(--font-inter), system-ui, sans-serif;
   text-transform: none;
   letter-spacing: 0;
 }
@@ -6905,7 +6905,7 @@
 }
 .landing-v2 .cj-intro-apr-rows b { color: var(--accent); font-weight: 600; }
 .landing-v2 .cj-intro-apr-then {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
   margin-top: 2px;
@@ -6952,7 +6952,7 @@
 }
 .landing-v2 .cj-toc-link:hover { color: var(--ink); background: var(--paper-2); }
 .landing-v2 .cj-toc-link .cj-toc-num {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10px;
   color: var(--muted);
   width: 18px;
@@ -6969,7 +6969,7 @@
   margin-bottom: 6px;
 }
 .landing-v2 .cj-toc-block-big {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 28px;
   font-weight: 500;
   letter-spacing: -0.025em;
@@ -6977,7 +6977,7 @@
   line-height: 1;
 }
 .landing-v2 .cj-toc-block-sub {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10.5px;
   color: var(--muted);
   margin-top: 4px;
@@ -7003,7 +7003,7 @@
   color: var(--muted);
 }
 .landing-v2 .cj-section-h1 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 44px;
   letter-spacing: -0.03em;
@@ -7012,7 +7012,7 @@
 }
 @media (min-width: 768px) { .landing-v2 .cj-section-h1 { font-size: 56px; } }
 .landing-v2 .cj-section-h2 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 28px;
   letter-spacing: -0.02em;
@@ -7218,7 +7218,7 @@
   color: var(--muted);
 }
 .landing-v2 .cj-readoff-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 18px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -7227,7 +7227,7 @@
 }
 @media (min-width: 1280px) { .landing-v2 .cj-readoff-v { font-size: 22px; line-height: 1; } }
 .landing-v2 .cj-readoff-foot {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   color: var(--muted);
   margin-top: 5px;
@@ -7306,7 +7306,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   text-align: left;
   white-space: normal;
 }
@@ -7532,7 +7532,7 @@
   width: 100%;
   border-collapse: collapse;
   font-size: 12.5px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   min-width: 720px;
 }
 .landing-v2 .cj-records-table th,
@@ -7635,7 +7635,7 @@
 .landing-v2 .cj-table tbody tr:first-child { border-top: 0; }
 .landing-v2 .cj-cell-primary { font-weight: 500; }
 .landing-v2 .cj-cell-detail {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10.5px;
   color: var(--muted);
   margin-top: 1px;
@@ -7653,9 +7653,9 @@
   font-weight: 400;
   opacity: 0.8;
 }
-.landing-v2 .cj-rate-mono { font-family: 'Inter', sans-serif; font-weight: 600; }
+.landing-v2 .cj-rate-mono { font-family: var(--font-inter), sans-serif; font-weight: 600; }
 .landing-v2 .cj-eff-pct {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 15px;
   font-weight: 500;
   color: var(--accent);
@@ -7674,7 +7674,7 @@
   color: var(--muted-2);
 }
 .landing-v2 .cj-row-total .cj-row-total-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   text-align: right;
@@ -7708,7 +7708,7 @@
   gap: 12px;
   padding: 9px 14px;
   border-top: 1px dashed var(--line);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 12px;
   align-items: baseline;
 }
@@ -7738,7 +7738,7 @@
   flex-wrap: wrap;
 }
 .landing-v2 .cj-odds-meta {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted);
   text-align: right;
@@ -7762,7 +7762,7 @@
   color: var(--muted);
 }
 .landing-v2 .cj-stat-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 30px;
   font-weight: 500;
   letter-spacing: -0.025em;
@@ -7780,7 +7780,7 @@
   grid-template-columns: 88px 1fr 52px;
   gap: 10px;
   align-items: center;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
 }
 .landing-v2 .cj-bar-label { color: var(--muted); }
@@ -7798,7 +7798,7 @@
 .landing-v2 .cj-bar-legend {
   display: flex;
   gap: 14px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10.5px;
   color: var(--muted);
   margin-top: 10px;
@@ -7829,7 +7829,7 @@
   padding: 9px 14px;
   border-top: 1px solid var(--line);
   align-items: center;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 12px;
   gap: 10px;
 }
@@ -7839,7 +7839,7 @@
 .landing-v2 .cj-tape-event .cj-tape-field {
   font-weight: 500;
   color: var(--ink);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 13px;
 }
 .landing-v2 .cj-tape-event .cj-tape-change {
@@ -7864,7 +7864,7 @@
   margin-top: 3px;
   color: var(--muted);
   font-size: 11.5px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
 }
 .landing-v2 .cj-tape.cj-tape-reading .cj-tape-row:hover .cj-tape-event .cj-tape-field {
   color: var(--accent);
@@ -7899,7 +7899,7 @@
     display: inline;
     color: var(--muted);
     font-size: 11.5px;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-inter), sans-serif;
   }
 }
 
@@ -7953,20 +7953,20 @@
   color: var(--muted-2);
 }
 .landing-v2 .cj-apply-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.02em;
   margin-top: 4px;
 }
 .landing-v2 .cj-apply-sub {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted-2);
   margin-top: 2px;
 }
 .landing-v2 .cj-apply-note {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   color: var(--muted-2);
   margin-top: 8px;
@@ -8034,7 +8034,7 @@
 }
 .landing-v2 .cj-apply-btn-referral-bonus {
   position: relative;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -8054,7 +8054,7 @@
   padding: 12px;
   border: 1px dashed var(--muted);
   color: var(--muted-2);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11px;
   text-align: center;
   margin-top: 14px;
@@ -8077,7 +8077,7 @@
   display: flex;
   gap: 8px;
   margin-bottom: 3px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10px;
 }
 .landing-v2 .cj-news-tag { color: var(--accent); font-weight: 600; }
@@ -8109,13 +8109,13 @@
 .landing-v2 .cj-sim-img img { max-width: 100%; max-height: 100%; object-fit: contain; }
 .landing-v2 .cj-sim-name { font-size: 12.5px; font-weight: 500; line-height: 1.2; }
 .landing-v2 .cj-sim-meta {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 10px;
   color: var(--muted);
   margin-top: 2px;
 }
 .landing-v2 .cj-sim-rate {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 14px;
   font-weight: 500;
   color: var(--accent);
@@ -8129,14 +8129,14 @@
   padding: 10px 0;
 }
 .landing-v2 .cj-sim-vs {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 11px;
   font-weight: 500;
   font-style: italic;
   color: var(--muted);
 }
 .landing-v2 .cj-sim-arrow {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 14px;
   color: var(--muted);
   opacity: 0;
@@ -8192,7 +8192,7 @@
   flex-shrink: 0;
 }
 .landing-v2 .cj-rating-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.015em;
@@ -8325,7 +8325,7 @@
   flex-shrink: 0;
 }
 .landing-v2.store-v2 .store-credits-title {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 18px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -8373,7 +8373,7 @@
   flex-wrap: wrap;
 }
 .landing-v2.store-v2 .store-credit-name {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 16px;
   font-weight: 600;
   letter-spacing: -0.015em;
@@ -8411,7 +8411,7 @@
 }
 .landing-v2.store-v2 .store-credit-amount {
   flex-shrink: 0;
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -8480,7 +8480,7 @@
   border-radius: 4px;
 }
 .landing-v2.store-v2 .store-personal-row-eyebrow {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.06em;
@@ -8583,7 +8583,7 @@
   font-variant-numeric: tabular-nums;
 }
 .landing-v2.store-v2 .store-personal-row-rate-primary {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 14px;
   font-weight: 600;
   color: var(--accent);
@@ -8781,7 +8781,7 @@
   flex-wrap: wrap;
 }
 .landing-v2.store-v2 .store-pick-name {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 16px;
   font-weight: 600;
   letter-spacing: -0.015em;
@@ -8910,7 +8910,7 @@
   line-height: 1.45;
 }
 .landing-v2.store-v2 .store-pick-rate {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 18px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -8968,7 +8968,7 @@
   min-width: 0;
 }
 .landing-v2.store-v2 .store-affiliate-title {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -9058,7 +9058,7 @@
   margin-top: 40px;
 }
 .landing-v2.store-v2 .store-faq-title {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -9086,7 +9086,7 @@
   border-top: 1px solid var(--line);
 }
 .landing-v2.store-v2 .store-related-title {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -9154,7 +9154,7 @@
   margin-top: 0;
 }
 .landing-v2.store-v2 .store-index-heading {
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -9178,7 +9178,7 @@
 .landing-v2.store-v2 .store-index-link {
   display: block;
   padding: 8px 0;
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -9218,7 +9218,7 @@
   width: 100%;
 }
 .pl-caption {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 14px;
   font-weight: 500;
   letter-spacing: -0.005em;
@@ -9377,7 +9377,7 @@
   display: flex;
   align-items: center;
   gap: 14px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   flex-wrap: wrap;
 }
@@ -9440,7 +9440,7 @@
   flex-wrap: wrap;
 }
 .landing-v2.admin-v2 .av-snapshot-h1 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 28px;
   letter-spacing: -0.03em;
@@ -9530,7 +9530,7 @@
 }
 .landing-v2.admin-v2 .av-readoff-cell.av-hl .av-readoff-k { color: #92722a; }
 .landing-v2.admin-v2 .av-readoff-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -9541,7 +9541,7 @@
 .landing-v2.admin-v2 .av-readoff-v.av-accent { color: var(--accent); }
 .landing-v2.admin-v2 .av-readoff-v.av-warn { color: var(--warn); }
 .landing-v2.admin-v2 .av-readoff-foot {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   color: var(--muted);
   margin-top: 5px;
@@ -9620,7 +9620,7 @@
   flex-wrap: wrap;
 }
 .landing-v2.admin-v2 .av-section-h {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 18px;
   font-weight: 500;
   letter-spacing: -0.015em;
@@ -9787,7 +9787,7 @@
   box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent);
 }
 .landing-v2.admin-v2 .av-input::placeholder { color: var(--muted-2); }
-.landing-v2.admin-v2 .av-input-mono { font-family: 'Inter', sans-serif; font-variant-numeric: tabular-nums; }
+.landing-v2.admin-v2 .av-input-mono { font-family: var(--font-inter), sans-serif; font-variant-numeric: tabular-nums; }
 .landing-v2.admin-v2 .av-inputgroup { display: flex; }
 .landing-v2.admin-v2 .av-inputgroup > .av-input {
   border-top-right-radius: 0;
@@ -9932,7 +9932,7 @@
 .landing-v2.admin-v2 .av-thumb.av-thumb-sm { width: 28px; height: 18px; }
 .landing-v2.admin-v2 .av-card-meta { min-width: 0; }
 .landing-v2.admin-v2 .av-card-name {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 13px;
   letter-spacing: -0.005em;
@@ -9949,7 +9949,7 @@
 
 /* Mono fields (IDs, IPs) */
 .landing-v2.admin-v2 .av-mono {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-variant-numeric: tabular-nums;
   font-size: 11.5px;
   color: var(--muted);
@@ -10043,7 +10043,7 @@
 .landing-v2.admin-v2 .av-list-row:hover { background: var(--paper-2); }
 .landing-v2.admin-v2 .av-list-rank {
   color: var(--muted-2);
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-variant-numeric: tabular-nums;
 }
@@ -10128,7 +10128,7 @@
   background: var(--paper-2);
 }
 .landing-v2.admin-v2 .av-panel-h {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 14px;
   font-weight: 600;
   color: var(--ink);
@@ -10170,7 +10170,7 @@
   border-bottom: 1px solid var(--line);
 }
 .landing-v2.admin-v2 .av-modal-h {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 16px;
   font-weight: 500;
   color: var(--ink);
@@ -10395,7 +10395,7 @@
   background: var(--ink);
 }
 .best-for-me-v2 .bcfm-step-title {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 22px;
   letter-spacing: -0.02em;
   color: var(--ink);
@@ -10583,7 +10583,7 @@
   color: var(--muted);
 }
 .best-for-me-v2 .bcfm-spend-total-value {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 20px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
@@ -10788,7 +10788,7 @@
   background: color-mix(in oklab, var(--paper) 80%, transparent);
 }
 .best-for-me-v2 .bcfm-gate-cta h2 {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 24px;
   letter-spacing: -0.02em;
   color: var(--ink);
@@ -10806,7 +10806,7 @@
   margin: 0 auto;
 }
 .best-for-me-v2 .bcfm-results-title {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 28px;
   letter-spacing: -0.03em;
   color: var(--ink);
@@ -10857,7 +10857,7 @@
   object-fit: contain;
 }
 .best-for-me-v2 .bcfm-rec-name {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 17px;
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -10865,7 +10865,7 @@
   margin: 0 0 2px;
 }
 .best-for-me-v2 .bcfm-rec-value {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 22px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
@@ -11005,7 +11005,7 @@
   color: var(--muted);
 }
 .best-for-me-v2 .bcfm-section-h {
-  font-family: 'Inter Tight', 'Inter', sans-serif;
+  font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
   font-size: 18px;
   letter-spacing: -0.01em;
   color: var(--ink);

--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { Inter, Inter_Tight } from "next/font/google";
 import { AuthProvider } from "@/auth/AuthProvider";
 import { UserSettingsProvider } from "@/user-settings/UserSettingsProvider";
 import { ConditionalNavbar } from "@/components/layout/ConditionalChrome";
@@ -8,6 +9,25 @@ import { OrganizationSchema, WebsiteSchema } from "@/components/seo/JsonLd";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import "./globals.css";
+
+// Self-hosted via next/font: same families and the same four static weights
+// the old Google Fonts <link> served, exposed as CSS variables so stylesheets
+// keep their existing font stacks. Weights outside this list (e.g. Tailwind's
+// font-extrabold) must keep resolving to 700, so do not switch these to the
+// variable axis without auditing weight usage.
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-inter",
+});
+
+const interTight = Inter_Tight({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-inter-tight",
+});
 
 export const metadata: Metadata = {
   title: {
@@ -45,20 +65,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${inter.variable} ${interTight.variable}`}>
       <head>
         {/* Preconnect to external domains for faster loading */}
         <link rel="preconnect" href="https://d3ay3etzd1512y.cloudfront.net" />
         <link rel="preconnect" href="https://d2ojrhbh2dincr.cloudfront.net" />
         <link rel="dns-prefetch" href="https://d3ay3etzd1512y.cloudfront.net" />
         <link rel="dns-prefetch" href="https://d2ojrhbh2dincr.cloudfront.net" />
-        {/* Landing v2 fonts */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap"
-          rel="stylesheet"
-        />
       </head>
       <body className="min-h-screen flex flex-col">
         <OrganizationSchema />

--- a/apps/web-next/src/app/not-found.tsx
+++ b/apps/web-next/src/app/not-found.tsx
@@ -20,7 +20,7 @@ export default function NotFound() {
             display: 'flex',
             flexWrap: 'wrap',
             gap: 12,
-            fontFamily: "'Inter', sans-serif",
+            fontFamily: "var(--font-inter), sans-serif",
             fontSize: 12,
           }}
         >

--- a/apps/web-next/src/app/static-pages.css
+++ b/apps/web-next/src/app/static-pages.css
@@ -4,7 +4,7 @@
 .landing-v2.static-v2 {
   background: var(--paper);
   color: var(--ink);
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: var(--font-inter), system-ui, sans-serif;
 }
 
 /* Terminal / breadcrumb bar */
@@ -15,7 +15,7 @@
   display: flex;
   align-items: center;
   gap: 14px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), sans-serif;
   font-size: 11.5px;
   flex-wrap: wrap;
 }
@@ -75,7 +75,7 @@
   margin-bottom: 14px;
 }
 .static-v2 .cj-page-h1 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 64px;
   letter-spacing: -0.03em;
@@ -165,7 +165,7 @@
   color: var(--muted);
 }
 .static-v2 .cj-static-section h2 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 28px;
   letter-spacing: -0.02em;
@@ -174,7 +174,7 @@
   color: var(--ink);
 }
 .static-v2 .cj-static-section h3 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-weight: 500;
   font-size: 17px;
   letter-spacing: -0.005em;
@@ -212,7 +212,7 @@
   padding: 14px 20px;
   border-left: 3px solid var(--accent);
   background: var(--accent-2);
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 17px;
   line-height: 1.45;
   color: var(--ink);
@@ -327,7 +327,7 @@
   color: var(--muted);
 }
 .static-v2 .cj-readoff-v {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -357,7 +357,7 @@
   padding: 18px 18px 20px;
 }
 .static-v2 .cj-step-num {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 30px;
   font-weight: 500;
   letter-spacing: -0.02em;
@@ -365,7 +365,7 @@
   line-height: 1;
 }
 .static-v2 .cj-step-h {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 17px;
   font-weight: 500;
   letter-spacing: -0.005em;
@@ -457,7 +457,7 @@
   margin-bottom: 8px;
 }
 .static-v2 .cj-cta-h {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-inter-tight), sans-serif;
   font-size: 30px;
   font-weight: 500;
   letter-spacing: -0.02em;

--- a/apps/web-next/src/components/charts/ScatterPlot.tsx
+++ b/apps/web-next/src/components/charts/ScatterPlot.tsx
@@ -67,7 +67,7 @@ export default function ScatterPlot({
         margin: 16,
         style: {
           fontFamily:
-            'Inter Tight, Inter, ui-sans-serif, system-ui, sans-serif',
+            'var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif',
           fontSize: "14px",
           fontWeight: "500",
           letterSpacing: "-0.01em",

--- a/apps/web-next/src/components/ui/CardyComparePopup.tsx
+++ b/apps/web-next/src/components/ui/CardyComparePopup.tsx
@@ -98,7 +98,7 @@ export default function CardyComparePopup({ currentSlug, currentName, currentIma
           box-shadow:
             0 1px 0 rgba(26, 19, 48, 0.04),
             0 16px 40px -16px rgba(109, 63, 232, 0.22);
-          font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+          font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
           color: #1a1330;
           animation: cmp-pop-in 220ms ease-out;
         }
@@ -167,7 +167,7 @@ export default function CardyComparePopup({ currentSlug, currentName, currentIma
           overflow: hidden;
         }
         .cmp-name {
-          font-family: 'Inter Tight', 'Inter', sans-serif;
+          font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
           letter-spacing: -0.01em;
           font-size: 13px;
           font-weight: 600;
@@ -189,7 +189,7 @@ export default function CardyComparePopup({ currentSlug, currentName, currentIma
         }
         .cmp-prompt {
           margin: 14px 0 12px;
-          font-family: 'Inter Tight', 'Inter', sans-serif;
+          font-family: var(--font-inter-tight), var(--font-inter), sans-serif;
           letter-spacing: -0.01em;
           font-size: 15px;
           font-weight: 500;

--- a/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
+++ b/apps/web-next/src/components/wallet/ReportMerchantModal.tsx
@@ -137,7 +137,7 @@ export default function ReportMerchantModal({ show, onClose, payload }: ReportMe
                 <CheckIcon style={{ width: 28, height: 28, strokeWidth: 2.5 }} />
               </span>
               <div style={{
-                fontFamily: "'Inter Tight', sans-serif",
+                fontFamily: "var(--font-inter-tight), sans-serif",
                 fontSize: 18,
                 fontWeight: 600,
                 letterSpacing: '-0.01em',


### PR DESCRIPTION
## Summary

Replaces the Google Fonts `<link>` stylesheet with `next/font/google`, self-hosting the exact same fonts.

**Font parity (nothing lost, nothing changed):**
- Same families: Inter Tight + Inter
- Same four static weights (400/500/600/700) the old `<link>` requested — deliberately **not** the variable axis, because the app has three `font-extrabold` (800) usages that today clamp to 700; a variable font would render them as true 800 and change appearance
- Same `display: swap` behavior
- OG-image fonts (`og-utils.tsx`) untouched — satori embeds its own font data

**Mechanics:** the fonts are exposed as `--font-inter` / `--font-inter-tight` CSS variables on `<html>`, and every `font-family` reference (192 across 4 CSS files, plus 13 inline-style/styled-jsx/Highcharts references) now uses the variables with the same fallback stacks. The Google Fonts origins are removed from the report-only CSP (`style-src`, `font-src`, `connect-src`) since nothing loads from them anymore.

**Why:** removes the third-party request chain from first paint (2 preconnects + render-blocking CSS + font fetches from fonts.gstatic.com), serves fonts same-origin with immutable caching, and next/font's metrics-matched fallback faces reduce CLS during swap. Also one less external origin to worry about when the CSP goes enforcing.

## Verification
- Dev-server A/B (stash baseline vs change) with computed-style checks: `h1` resolves `"Inter Tight", "Inter Tight Fallback", sans-serif` (was `"Inter Tight", sans-serif`); body copy resolves Inter identically; the `document.body` system stack is pre-existing (body never used Inter — `.landing-v2` sets it)
- Google Fonts requests: 3 before → **0** after; fonts now load from `/_next/static`
- Landing page screenshot pixel-identical rendering; console clean of font errors
- `npm test`: 53/53 pass. Full production build (incl. the check-seo prebuild gate) succeeds
- `npm run lint` fails identically on unmodified `main` (pre-existing `react-hooks/set-state-in-effect` errors in admin/login pages, unrelated to this diff)