### PR TITLE
fix(web): make eslint pass with zero warnings

### DIFF
--- a/apps/web-next/eslint.config.mjs
+++ b/apps/web-next/eslint.config.mjs
@@ -1,10 +1,12 @@
 import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 import nextTypescript from "eslint-config-next/typescript";
 
-export default [
+const config = [
   ...nextCoreWebVitals,
   ...nextTypescript,
   {
     ignores: ["coverage/**"],
   },
 ];
+
+export default config;

--- a/apps/web-next/src/app/(auth)/login/page.tsx
+++ b/apps/web-next/src/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, Suspense } from "react";
+import { useState, useEffect, useCallback, Suspense } from "react";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { XCircleIcon, CheckCircleIcon, EnvelopeIcon } from "@heroicons/react/24/solid";
@@ -25,7 +25,7 @@ function LoginPageInner() {
   const { authState, signInWithGoogle, sendEmailLink } = useAuth();
 
   // Build redirect URL from query params
-  const getRedirectUrl = () => {
+  const getRedirectUrl = useCallback(() => {
     const redirect = searchParams.get('redirect');
     // Only allow same-origin relative paths. Reject absolute and
     // protocol-relative URLs (https://evil.com, //evil.com, /\evil.com) so a
@@ -46,14 +46,14 @@ function LoginPageInner() {
     });
     const qs = params.toString();
     return qs ? `${redirect}?${qs}` : redirect;
-  };
+  }, [searchParams]);
 
   // Redirect if already authenticated
   useEffect(() => {
     if (authState.isAuthenticated) {
       router.push(getRedirectUrl());
     }
-  }, [authState.isAuthenticated, router, searchParams]);
+  }, [authState.isAuthenticated, router, getRedirectUrl]);
 
   const handleGoogleSignIn = async () => {
     setErrorMessage("");

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import CardImage from "@/components/ui/CardImage";
 import { useAuth } from "@/auth/AuthProvider";
@@ -87,6 +87,10 @@ export default function AdminPage() {
   const [searchesTotal, setSearchesTotal] = useState(0);
   const [graphData, setGraphData] = useState<AdminGraphsData | null>(null);
   const [graphDays, setGraphDays] = useState(30);
+  // Mirror of graphDays for loadData: keeps loadData's identity stable so the
+  // auth effect that depends on it doesn't re-run a full reload when the graph
+  // period changes (loadGraphs alone handles that).
+  const graphDaysRef = useRef(30);
   const [userLookupId, setUserLookupId] = useState('');
 
   // UI states for condensed tabs
@@ -97,22 +101,6 @@ export default function AdminPage() {
   const [processingId, setProcessingId] = useState<number | null>(null);
 
   const isAdmin = authState.user && ADMIN_USER_IDS.includes(authState.user.uid);
-
-  useEffect(() => {
-    if (!authState.isLoading && !authState.isAuthenticated) {
-      router.replace("/login");
-      return;
-    }
-
-    if (authState.isAuthenticated && !isAdmin) {
-      router.replace("/");
-      return;
-    }
-
-    if (authState.isAuthenticated && isAdmin) {
-      loadData();
-    }
-  }, [authState.isAuthenticated, authState.isLoading, isAdmin, router]);
 
   const loadGraphs = async (days: number) => {
     try {
@@ -126,11 +114,12 @@ export default function AdminPage() {
   };
 
   const handleGraphDaysChange = (days: number) => {
+    graphDaysRef.current = days;
     setGraphDays(days);
     loadGraphs(days);
   };
 
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -147,7 +136,7 @@ export default function AdminPage() {
         getAdminReferrals(token),
         getAdminAuditLog(token),
         getAdminSearches(token),
-        getAdminGraphs(token, graphDays).catch(() => null)
+        getAdminGraphs(token, graphDaysRef.current).catch(() => null)
       ]);
 
       setStats(statsData);
@@ -166,7 +155,23 @@ export default function AdminPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [getToken]);
+
+  useEffect(() => {
+    if (!authState.isLoading && !authState.isAuthenticated) {
+      router.replace("/login");
+      return;
+    }
+
+    if (authState.isAuthenticated && !isAdmin) {
+      router.replace("/");
+      return;
+    }
+
+    if (authState.isAuthenticated && isAdmin) {
+      loadData();
+    }
+  }, [authState.isAuthenticated, authState.isLoading, isAdmin, router, loadData]);
 
   const handleDeleteRecord = async (recordId: number) => {
     if (!confirm("Are you sure you want to delete this record?")) return;
@@ -619,27 +624,30 @@ interface ApplyClickRow {
 function ApplyClicksTab() {
   const { cards } = useCardCatalog();
   const [periodDays, setPeriodDays] = useState(30);
-  const [breakdown, setBreakdown] = useState<Record<number, CardApplyClickBreakdown>>({});
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  // Loading/error/data are derived from the last settled fetch, keyed by the
+  // period it was for — no synchronous loading-flag setState in the effect.
+  const [fetched, setFetched] = useState<{
+    period: number;
+    breakdown: Record<number, CardApplyClickBreakdown>;
+    error: string | null;
+  } | null>(null);
   const [sortKey, setSortKey] = useState<ApplyClickSortKey>('total');
+
+  const settled = fetched !== null && fetched.period === periodDays ? fetched : null;
+  const loading = settled === null;
+  const breakdown = settled && !settled.error ? settled.breakdown : {};
+  const loadError = settled ? settled.error : null;
 
   useEffect(() => {
     let isMounted = true;
-    setLoading(true);
-    setLoadError(null);
     getCardApplyClicksBreakdown(periodDays)
       .then((data) => {
         if (!isMounted) return;
-        setBreakdown(data);
+        setFetched({ period: periodDays, breakdown: data, error: null });
       })
       .catch(() => {
         if (!isMounted) return;
-        setLoadError('Failed to load apply click data');
-        setBreakdown({});
-      })
-      .finally(() => {
-        if (isMounted) setLoading(false);
+        setFetched({ period: periodDays, breakdown: {}, error: 'Failed to load apply click data' });
       });
     return () => {
       isMounted = false;
@@ -818,27 +826,29 @@ function pct(n: number): string {
 function ApplyOutcomesTab() {
   const { cards } = useCardCatalog();
   const [periodDays, setPeriodDays] = useState(30);
-  const [breakdown, setBreakdown] = useState<Record<number, ApplyOutcomeBreakdown>>({});
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  // Same derived-loading pattern as CardApplyClicksTab above.
+  const [fetched, setFetched] = useState<{
+    period: number;
+    breakdown: Record<number, ApplyOutcomeBreakdown>;
+    error: string | null;
+  } | null>(null);
   const [sortKey, setSortKey] = useState<ApplyOutcomeSortKey>('total');
+
+  const settled = fetched !== null && fetched.period === periodDays ? fetched : null;
+  const loading = settled === null;
+  const breakdown = settled && !settled.error ? settled.breakdown : {};
+  const loadError = settled ? settled.error : null;
 
   useEffect(() => {
     let isMounted = true;
-    setLoading(true);
-    setLoadError(null);
     getApplyOutcomesBreakdown(periodDays)
       .then((data) => {
         if (!isMounted) return;
-        setBreakdown(data);
+        setFetched({ period: periodDays, breakdown: data, error: null });
       })
       .catch(() => {
         if (!isMounted) return;
-        setLoadError('Failed to load apply outcome data');
-        setBreakdown({});
-      })
-      .finally(() => {
-        if (isMounted) setLoading(false);
+        setFetched({ period: periodDays, breakdown: {}, error: 'Failed to load apply outcome data' });
       });
     return () => {
       isMounted = false;
@@ -1022,15 +1032,21 @@ interface StoreTrafficRow extends StorePageEventStat {
 
 function StoreTrafficTab({ getToken }: { getToken: () => Promise<string | null> }) {
   const [periodDays, setPeriodDays] = useState(30);
-  const [stats, setStats] = useState<StorePageEventStat[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  // Same derived-loading pattern as CardApplyClicksTab above.
+  const [fetched, setFetched] = useState<{
+    period: number;
+    stats: StorePageEventStat[];
+    error: string | null;
+  } | null>(null);
   const [sortKey, setSortKey] = useState<StoreTrafficSortKey>('visits');
+
+  const settled = fetched !== null && fetched.period === periodDays ? fetched : null;
+  const loading = settled === null;
+  const stats = settled && !settled.error ? settled.stats : [];
+  const loadError = settled ? settled.error : null;
 
   useEffect(() => {
     let isMounted = true;
-    setLoading(true);
-    setLoadError(null);
     getToken()
       .then((token) => {
         if (!token) throw new Error('no token');
@@ -1038,15 +1054,11 @@ function StoreTrafficTab({ getToken }: { getToken: () => Promise<string | null> 
       })
       .then((data) => {
         if (!isMounted) return;
-        setStats(data);
+        setFetched({ period: periodDays, stats: data, error: null });
       })
       .catch(() => {
         if (!isMounted) return;
-        setLoadError('Failed to load store traffic data');
-        setStats([]);
-      })
-      .finally(() => {
-        if (isMounted) setLoading(false);
+        setFetched({ period: periodDays, stats: [], error: 'Failed to load store traffic data' });
       });
     return () => {
       isMounted = false;
@@ -1485,15 +1497,10 @@ function UserLookupTab({
   const [lookupLoading, setLookupLoading] = useState(false);
   const [lookupError, setLookupError] = useState('');
 
-  useEffect(() => {
-    if (initialUserId) {
-      setUserId(initialUserId);
-      doLookup(initialUserId);
-    }
-  }, [initialUserId]);
-
-  const doLookup = async (uid?: string) => {
-    const lookupId = uid || userId;
+  // Stable lookup runner (doesn't close over the userId input state) so the
+  // initialUserId effect can list it as a dependency without re-firing on
+  // every keystroke in the UID field.
+  const runLookup = useCallback(async (lookupId: string) => {
     if (!lookupId.trim()) return;
 
     setLookupLoading(true);
@@ -1513,7 +1520,16 @@ function UserLookupTab({
     } finally {
       setLookupLoading(false);
     }
-  };
+  }, [getToken]);
+
+  useEffect(() => {
+    if (initialUserId) {
+      setUserId(initialUserId);
+      runLookup(initialUserId);
+    }
+  }, [initialUserId, runLookup]);
+
+  const doLookup = () => runLookup(userId);
 
   return (
     <>

--- a/apps/web-next/src/app/api/og/compare/route.tsx
+++ b/apps/web-next/src/app/api/og/compare/route.tsx
@@ -80,9 +80,12 @@ export async function GET(request: Request) {
                   gap: 16,
                 }}
               >
-                {/* Card image or placeholder */}
+                {/* Card image or placeholder. Plain <img> is required: this JSX
+                    is rendered by satori into a static OG image, not by the DOM. */}
                 {card!.card_image_link ? (
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
+                    alt={card!.card_name}
                     src={`${CDN_BASE}/${card!.card_image_link}`}
                     width={280}
                     height={176}

--- a/apps/web-next/src/app/articles/[slug]/opengraph-image.tsx
+++ b/apps/web-next/src/app/articles/[slug]/opengraph-image.tsx
@@ -156,7 +156,6 @@ export default async function OGImage({ params }: Props) {
                 overflow: 'hidden',
               }}
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={articleImageUrl}
                 alt={article.title}

--- a/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
+++ b/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
@@ -18,8 +18,8 @@ function getTopReward(rewards: Reward[] | undefined): Reward | null {
 export default function BankCardsTable({ cards, trendingViews }: BankCardsTableProps) {
   const [showArchived, setShowArchived] = useState(false);
 
-  // Count active and archived cards
-  const { activeCount, archivedCount } = useMemo(() => {
+  // Count archived cards (the active count isn't currently displayed)
+  const { archivedCount } = useMemo(() => {
     let active = 0;
     let archived = 0;
     cards.forEach(card => {

--- a/apps/web-next/src/app/best-card-for/[slug]/StorePersonalRow.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/StorePersonalRow.tsx
@@ -61,7 +61,7 @@ export default function StorePersonalRow({ store }: Props) {
           <div className="store-personal-row-eyebrow">Your wallet</div>
           <div className="store-personal-row-cta-line">
             <Link href="/register" className="store-personal-row-cta-link">Sign up free</Link>{' '}
-            and we'll show you the best card you already own to use at {store.name}.
+            and we&apos;ll show you the best card you already own to use at {store.name}.
           </div>
         </div>
       </div>
@@ -91,11 +91,11 @@ export default function StorePersonalRow({ store }: Props) {
               <>
                 Add cards to{' '}
                 <Link href="/profile" className="store-personal-row-cta-link">your wallet</Link>{' '}
-                and we'll surface your best pick for {store.name} here.
+                and we&apos;ll surface your best pick for {store.name} here.
               </>
             ) : (
               <>
-                Couldn't load your wallet. <Link href="/profile" className="store-personal-row-cta-link">View your wallet</Link>.
+                Couldn&apos;t load your wallet. <Link href="/profile" className="store-personal-row-cta-link">View your wallet</Link>.
               </>
             )}
           </div>

--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -301,13 +301,13 @@ export default async function BestCardForStorePage({ params }: PageProps) {
           <div className="store-banner">
             <b>Honest answer:</b> no card we track gives a category bonus on{' '}
             {store.categories.map(labelForCategory).join(' or ')} purchases. Your best
-            move is a strong flat-rate cashback card — these are the ones we'd pick.
+            move is a strong flat-rate cashback card — these are the ones we&apos;d pick.
           </div>
         )}
 
         {picks.length === 0 ? (
           <p className="store-empty">
-            We don't have a strong recommendation for {store.name} yet. Check back as we
+            We don&apos;t have a strong recommendation for {store.name} yet. Check back as we
             add more cards.
           </p>
         ) : (

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -23,7 +23,7 @@ import {
   CardWireEntry,
 } from "@/lib/api";
 import { getValuationDetails } from "@/lib/valuations";
-import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, frequencyLabel, isMonetaryBenefit } from "@/lib/cardDisplayUtils";
+import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, frequencyLabel } from "@/lib/cardDisplayUtils";
 import { NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { Article } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -388,8 +388,6 @@ export default function CardClient({
 
   const acceptedBuckets = bucketize(chartOne[0] || [], FICO_BUCKETS);
   const rejectedBuckets = bucketize(chartOne[1] || [], FICO_BUCKETS);
-  const totalRecordsFromChart =
-    (chartOne[0]?.length || 0) + (chartOne[1]?.length || 0);
   const maxBucketTotal = Math.max(
     1,
     ...FICO_BUCKETS.map(
@@ -463,14 +461,12 @@ export default function CardClient({
   }, [card, sortedRewards]);
 
   // Headline: split on last space so the closing word can take the accent color.
-  const { headlineMain, headlineAccent } = useMemo(() => {
-    const words = card.card_name.trim().split(/\s+/);
-    if (words.length < 2) return { headlineMain: "", headlineAccent: card.card_name };
-    return {
-      headlineMain: words.slice(0, -1).join(" "),
-      headlineAccent: words[words.length - 1],
-    };
-  }, [card.card_name]);
+  // Plain computation (cheap string split) — was a useMemo the React Compiler
+  // couldn't preserve.
+  const headlineWords = card.card_name.trim().split(/\s+/);
+  const headlineMain = headlineWords.length < 2 ? "" : headlineWords.slice(0, -1).join(" ");
+  const headlineAccent =
+    headlineWords.length < 2 ? card.card_name : headlineWords[headlineWords.length - 1];
 
   const bonusDisplay = useMemo(() => {
     const sb = card.signup_bonus;
@@ -500,13 +496,6 @@ export default function CardClient({
   }, [card.card_name, card.signup_bonus]);
 
   const ourTake = card.our_take?.trim() || null;
-
-  const approvalRate =
-    card.approved_count !== undefined &&
-    card.total_records &&
-    card.total_records > 0
-      ? Math.round((card.approved_count / card.total_records) * 100)
-      : null;
 
   const creditLength = (() => {
     const v = card.approved_median_length_credit;

--- a/apps/web-next/src/app/card/[name]/opengraph-image.tsx
+++ b/apps/web-next/src/app/card/[name]/opengraph-image.tsx
@@ -101,7 +101,6 @@ export default async function OGImage({ params }: Props) {
                     '0 0 0 1px rgba(255,255,255,0.12), 0 30px 80px rgba(0,0,0,0.5), 0 0 60px rgba(109,63,232,0.25)',
                 }}
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={cardImageUrl}
                   alt={card.card_name}

--- a/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
+++ b/apps/web-next/src/app/check-odds/CheckOddsClient.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import CardImage from "@/components/ui/CardImage";
 import { useAuth } from "@/auth/AuthProvider";
-import { checkOdds, CheckOddsCard, CheckOddsResponse, getWallet, WalletCard } from "@/lib/api";
+import { checkOdds, CheckOddsResponse, getWallet, WalletCard } from "@/lib/api";
 import { calculateApplicationRules, RuleResult } from "@/lib/applicationRules";
 import { cardMatchesSearch } from "@/lib/searchAliases";
 import posthog from "posthog-js";
@@ -146,7 +146,7 @@ export default function CheckOddsClient() {
   const filteredCards = useMemo(() => {
     if (!results) return [];
 
-    let filtered = results.cards.filter(card =>
+    const filtered = results.cards.filter(card =>
       cardMatchesSearch(card.card_name, card.bank, search)
     );
 
@@ -457,7 +457,6 @@ export default function CheckOddsClient() {
 }
 
 function MedianIndicator({
-  value,
   median,
   isAbove,
   isCurrency,
@@ -511,21 +510,6 @@ function MobileIndicator({
   return (
     <span className={isAbove ? 'text-green-700' : 'text-red-700'}>
       {label} {isAbove ? '\u2191' : '\u2193'} {formatted}
-    </span>
-  );
-}
-
-function MatchBadge({ score }: { score: number }) {
-  const colors = {
-    3: 'bg-green-100 text-green-800',
-    2: 'bg-lime-100 text-lime-800',
-    1: 'bg-amber-100 text-amber-800',
-    0: 'bg-red-100 text-red-800',
-  };
-
-  return (
-    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ${colors[score as keyof typeof colors] || colors[0]}`}>
-      {score}/3
     </span>
   );
 }

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -19,7 +19,6 @@ import {
   CategoryIcon,
   formatBonusValue,
   formatEstimatedValue,
-  formatBonusRequirement,
   formatAnnualFee,
   formatRewardWithUsdEquivalent,
   formatRewardCapCaveat,

--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -218,14 +218,6 @@ function topReward(card: Card): Reward | null {
   return pick?.reward ?? null;
 }
 
-function formatTopReward(card: Card): string {
-  const top = topReward(card);
-  if (!top) return '—';
-  const rate = top.unit === 'percent' ? `${top.value}%` : `${top.value}x`;
-  const label = categoryLabels[top.category] || top.category;
-  return `${rate} ${label}`;
-}
-
 function rewardTypeLabel(card: Card): string {
   switch (card.reward_type) {
     case 'cashback':
@@ -282,6 +274,10 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
 
   useEffect(() => {
     const q = new URLSearchParams(window.location.search).get('q');
+    // One-time sync from the URL after hydration; the query string isn't
+    // available during SSR, so seeding it in the useState initializer would
+    // cause a hydration mismatch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (q) setQuery(q);
   }, []);
   const [sort, setSort] = useState<SortKey>('trending');

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -838,7 +838,7 @@ export default function ProfileClient() {
                 {upcomingRenewals.map((r) => (
                   <li key={r.name} className="cj-rail-row">
                     <div className="cj-rail-row-meta">
-                      <span className="cj-rail-row-date">{r.renewal.split(' ')[0]} '{r.renewal.split(' ')[1].slice(2)}</span>
+                      <span className="cj-rail-row-date">{r.renewal.split(' ')[0]} &apos;{r.renewal.split(' ')[1].slice(2)}</span>
                       <span className="cj-rail-row-field">{r.name.replace(/ Card$/, '')}</span>
                     </div>
                     <div className="cj-rail-row-detail">

--- a/apps/web-next/src/app/profile/ProfileLoader.tsx
+++ b/apps/web-next/src/app/profile/ProfileLoader.tsx
@@ -46,6 +46,9 @@ function LoaderDeal({ caption }: { caption: string }) {
 export default function ProfileLoader() {
   const [variant, setVariant] = useState<'riffle' | 'deal'>('riffle');
   useEffect(() => {
+    // Randomizing in the useState initializer would make the server and client
+    // pick different variants and mismatch on hydration; settle it post-mount.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setVariant(Math.random() < 0.5 ? 'riffle' : 'deal');
   }, []);
   return variant === 'riffle' ? (

--- a/apps/web-next/src/auth/AuthProvider.tsx
+++ b/apps/web-next/src/auth/AuthProvider.tsx
@@ -52,6 +52,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const auth = getFirebaseAuth();
     if (!auth) {
       console.warn('Firebase auth not available');
+      // Firebase is unavailable (missing env): there is no auth system to
+      // subscribe to, so settle the auth state once instead of loading forever.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setAuthState({ isAuthenticated: false, isLoading: false, user: null });
       return;
     }

--- a/apps/web-next/src/components/best/BestCardList.tsx
+++ b/apps/web-next/src/components/best/BestCardList.tsx
@@ -4,7 +4,6 @@ import { Card } from '@/lib/api';
 import { BestPageCard, BestPanel } from '@/lib/best';
 import { ApplyButtons } from './ApplyButtons';
 import {
-  getCentsPerPoint,
   formatEstimatedValue,
   formatBonusValue,
   formatBonusRequirement,

--- a/apps/web-next/src/components/charts/ScatterPlot.tsx
+++ b/apps/web-next/src/components/charts/ScatterPlot.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+/* eslint-disable react-hooks/unsupported-syntax --
+   Highcharts axis/tooltip formatter callbacks receive their context as `this`
+   (that's the Highcharts API), which the React Compiler can't analyze. The
+   compiler simply skips this component; the chart itself is unaffected. */
+
 import { useMemo, useEffect } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";

--- a/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { Dialog, DialogPanel, Transition, TransitionChild } from "@headlessui/react";
 import { XMarkIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import CardImage from "@/components/ui/CardImage";
@@ -39,9 +39,14 @@ export default function SubmitRecordCardPicker({
 }: SubmitRecordCardPickerProps) {
   const [search, setSearch] = useState("");
 
-  useEffect(() => {
+  // Reset the search box when the picker closes, using the adjust-state-during-
+  // render pattern (https://react.dev/learn/you-might-not-need-an-effect) instead
+  // of an effect, so the cleared state is visible on the very next render.
+  const [prevShow, setPrevShow] = useState(show);
+  if (prevShow !== show) {
+    setPrevShow(show);
     if (!show) setSearch("");
-  }, [show]);
+  }
 
   const eligible = useMemo(() => {
     const inWallet = walletCardNames ?? new Set<string>();

--- a/apps/web-next/src/components/forms/SubmitRecordModal.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordModal.tsx
@@ -161,7 +161,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
   }, [storageKey]);
 
   // Save form data to localStorage (#7)
-  const saveFormData = useCallback((values: typeof formik.values) => {
+  const saveFormData = useCallback((values: unknown) => {
     if (typeof window === 'undefined') return;
     try {
       localStorage.setItem(storageKey, JSON.stringify(values));

--- a/apps/web-next/src/components/tools/ValuationChartInner.tsx
+++ b/apps/web-next/src/components/tools/ValuationChartInner.tsx
@@ -162,7 +162,7 @@ export default function ValuationChart({ programName, unit, dataPoints }: Valuat
       <div className="flex flex-col gap-1 mb-4">
         <h2 className="text-lg font-semibold text-gray-900">{programName} valuation, by year</h2>
         <p className="text-sm text-gray-600">
-          High, low, and median cents-per-{unit} across major published valuations. Each gray dot is one source's published number for that year — click a dot to view the source.
+          High, low, and median cents-per-{unit} across major published valuations. Each gray dot is one source&apos;s published number for that year — click a dot to view the source.
         </p>
       </div>
 
@@ -194,7 +194,7 @@ export default function ValuationChart({ programName, unit, dataPoints }: Valuat
       </div>
 
       <p className="mt-4 text-xs text-gray-500">
-        {sourceCount > 0 ? `Sources: ${sourceList}.` : ''} Only directly cited values from each source's published page or article are included.
+        {sourceCount > 0 ? `Sources: ${sourceList}.` : ''} Only directly cited values from each source&apos;s published page or article are included.
       </p>
     </div>
   );

--- a/apps/web-next/src/components/ui/CardSelect.tsx
+++ b/apps/web-next/src/components/ui/CardSelect.tsx
@@ -30,6 +30,10 @@ export default function CardSelect({ allCards }: CardSelectProps) {
         const recentCards = recentNames
           .map(name => allCards.find(c => c.card_name === name))
           .filter((c): c is Card => c !== undefined);
+        // One-time sync from localStorage after hydration; reading it during
+        // render or a useState initializer would mismatch the server-rendered
+        // empty state.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setRecentSearches(recentCards);
       }
     } catch {

--- a/apps/web-next/src/components/ui/CardyComparePopup.tsx
+++ b/apps/web-next/src/components/ui/CardyComparePopup.tsx
@@ -56,6 +56,9 @@ export default function CardyComparePopup({ currentSlug, currentName, currentIma
     if (priorUniques.length === 0) return;
 
     const prev = priorUniques[priorUniques.length - 1];
+    // One-time sync from localStorage visit history after hydration; it isn't
+    // readable during SSR, so it can't be a useState initializer w/o mismatch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPreviousCard(prev);
 
     const timer = setTimeout(() => {

--- a/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
+++ b/apps/web-next/src/components/wallet/EditWalletCardModal.tsx
@@ -54,7 +54,7 @@ const months = [
   { value: 10, label: 'October' }, { value: 11, label: 'November' }, { value: 12, label: 'December' },
 ];
 
-export default function EditWalletCardModal({ show, card, cardSlug, annualFee, displayName, lastProductChange, onClose, onSuccess, onRequestProductChange, onRequestCloseCard }: EditWalletCardModalProps) {
+export default function EditWalletCardModal({ show, card, cardSlug, displayName, lastProductChange, onClose, onSuccess, onRequestProductChange, onRequestCloseCard }: EditWalletCardModalProps) {
   const { getToken } = useAuth();
   const [acquiredMonth, setAcquiredMonth] = useState<number | undefined>();
   const [acquiredYear, setAcquiredYear] = useState<number | undefined>();

--- a/apps/web-next/src/lib/storeRanking.ts
+++ b/apps/web-next/src/lib/storeRanking.ts
@@ -11,7 +11,6 @@
 
 import type { Card, WalletCardSelection } from '@/lib/api';
 import type { Store } from '@/lib/stores';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 import * as ranker from '@ranker/storeRanking';
 
 export type MatchMode =

--- a/apps/web-next/tailwind.config.ts
+++ b/apps/web-next/tailwind.config.ts
@@ -1,4 +1,7 @@
 import type { Config } from "tailwindcss";
+import typography from "@tailwindcss/typography";
+import forms from "@tailwindcss/forms";
+import aspectRatio from "@tailwindcss/aspect-ratio";
 
 const config: Config = {
   content: [
@@ -15,11 +18,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [
-    require("@tailwindcss/typography"),
-    require("@tailwindcss/forms"),
-    require("@tailwindcss/aspect-ratio"),
-  ],
+  plugins: [typography, forms, aspectRatio],
 };
 
 export default config;


### PR DESCRIPTION
## Summary

`npm run lint` (`eslint . --max-warnings=0`) had been failing on unmodified `main` — 44 problems (22 errors, 22 warnings), mostly from the react-hooks v6 React Compiler rules. This PR fixes all of them; lint now exits clean.

### set-state-in-effect (9 sites)
- **Admin tabs** (apply clicks, apply outcomes, store traffic): the sync `setLoading(true)` before each fetch is gone — loading/error/data are now **derived** from the last settled fetch, keyed by the period it was for. Same UI states, no cascading render.
- **SubmitRecordCardPicker**: search reset on close now uses the documented [adjust-state-during-render pattern](https://react.dev/learn/you-might-not-need-an-effect) instead of an effect.
- **5 hydration-safe syncs** (Explore `?q=` seed, ProfileLoader random variant, AuthProvider no-Firebase fallback, CardSelect + CardyComparePopup localStorage reads): targeted `eslint-disable` with a justification comment each — these read browser-only state that can't move into a `useState` initializer without an SSR hydration mismatch, so a restructure would change behavior.

### exhaustive-deps (4)
- `getRedirectUrl` (login) and `loadData` (admin) wrapped in `useCallback` and added to deps. `loadData` reads `graphDays` through a ref so changing the graph period doesn't refire the auth effect into a full reload.
- Admin UserLookupTab: lookup logic extracted to a stable `runLookup(uid)` so the `initialUserId` effect can list it without re-firing on every keystroke in the UID field.
- `saveFormData` types its param `unknown` instead of `typeof formik.values`.

### React Compiler diagnostics
- CardClient's headline `useMemo` (compiler couldn't preserve it) is now a plain string computation.
- ScatterPlot: file-level `react-hooks/unsupported-syntax` disable — Highcharts formatter callbacks receive context as `this` by API design.

### Mechanical
8 unescaped apostrophes → `&apos;`; `prefer-const`; tailwind config `require()` → ESM imports; named export in `eslint.config.mjs`; 11 unused vars/imports removed (including the dead `MatchBadge` component); 3 stale disable directives removed; `og/compare` `<img>` gains a real `alt` plus a justified `no-img-element` disable (satori-rendered JSX, not DOM).

## Verification
- `npm run lint`: clean, zero warnings
- `npm test`: 53/53 pass
- Production build: succeeds, 448 pages (the 9 'Ecmascript file had an error' Edge-runtime warnings are pre-existing in `src/lib/api.ts`, untouched here)
- Browser-checked on the dev server: `/explore?q=sapphire` seeds the search box and filters (4 rows), card page headline + Highcharts scatter render, `/check-odds` renders, no React console errors