### PR TITLE
content-agent: prioritize structural card news, deprioritize limited-time offers

### DIFF
--- a/scripts/content-agent/triage.js
+++ b/scripts/content-agent/triage.js
@@ -29,19 +29,29 @@ async function triage(tweet) {
 watch competitor accounts to spot card developments worth covering with our OWN
 original content. Classify each tweet.
 
-CreditOdds covers credit cards AND the surrounding points/miles ecosystem that card
-holders care about: transfer partners, and airline/hotel loyalty program changes
-(especially DEVALUATIONS and award-chart changes) are IN SCOPE — treat them as tweet
-or article material, not skip.
+WHAT WE MOST WANT TO COVER — durable CARD NEWS. Prioritize these; they are the point:
+- A card being discontinued, shut down, killed off, or closed to new applicants.
+- A new card launching, or a major refresh/relaunch of an existing card.
+- Material changes to a card's ongoing benefits, earning/rewards structure, or annual fee.
+- Major loyalty-program devaluations, award-chart changes, or transfer-partner changes
+  (IN SCOPE — cardholders care about the points/miles ecosystem too).
+
+WHAT WE WANT MUCH LESS OF — deprioritize hard:
+- Limited-time / promotional sign-up bonus offers, elevated-offer alerts, and short-lived
+  deals. These are NOT our focus. Default them to "skip". Only rescue one to "tweet" if it
+  is genuinely exceptional AND broadly relevant (e.g. a record-high offer on a mainstream
+  card), and even then keep it rare. A routine "bonus is up to X for a limited time" is skip.
+- Small perks, single data points, one-off anecdotes.
 
 decision:
-- "article": a substantial, evergreen development where we can add real value (new card
-  launch, meaningful sign-up bonus change, benefit/earning change, an award-program
-  DEVALUATION, transfer-partner change, major policy/rule change). Medium bar: genuinely
-  notable, not trivial.
-- "tweet": timely and notable but thin (a limited-time offer, a small perk, a smaller
-  devaluation, a single data point) — worth an original post but not a full article.
-- "skip": not card/points relevant, off-brand, or on the never-act list.
+- "tweet": a real, publishable development from the CARD NEWS list above (discontinuation,
+  new card, benefit/rewards/fee change, major devaluation/transfer change). This becomes a
+  published news page, so the bar is genuine notability — not a promo, not trivia.
+- "article": reserved for broad, long-form explainer or roundup topics we would write as a
+  full article. Use sparingly. For a concrete single development, prefer "tweet" over
+  "article" so it actually gets published.
+- "skip": not card/points relevant, off-brand, on the never-act list, OR a limited-time /
+  promotional offer that isn't exceptional.
 
 ${AVOID_RULES}
 


### PR DESCRIPTION
## Why

Per feedback, the bot should post about **durable card news** (a card shut down, a new card launching, big changes to a card's benefits/rewards) and **much less about limited-time offers**.

The triage was skewed the wrong way: the `"tweet"` decision — which is what `run.js` turns into a **published news page** — was literally defined as *"a limited-time offer, a small perk, a single data point"*, while substantial developments were labeled `"article"` (report-only). So the publish path favored exactly the low-value items. Card **shutdowns weren't listed anywhere** as newsworthy.

## Change (triage prompt only)

- **Publishing bucket (`tweet`) is now structural card news:** discontinuation/shutdown, new-card launch, material benefit/rewards/annual-fee changes, major loyalty devaluations/transfer-partner changes.
- **Limited-time / promotional offers default to `skip`** unless genuinely exceptional and broadly relevant (rare).
- **`article`** narrowed to long-form explainer/roundup topics; concrete single developments prefer `tweet` so they publish.

## Verification

`node --check` + module load pass. Behavior is LLM-driven; since content-agent runs in **shadow**, the shifted mix will show in the Slack reports before anything publishes — a live shadow run is the real test.

## One thing to consider next (not in this PR)

Now that high-stakes items like *"card X was discontinued"* flow through the `tweet` publish gate (confidence ≥ 0.70, **no primary-source requirement**) rather than the stricter `article` gate (≥ 0.80 **+ primary source**), a wrong "card is dead" post is more brand-damaging than a wrong offer post. Worth deciding whether the publish gate should require primary-source corroboration for structural claims before going live. Happy to do that as a follow-up.