### PR TITLE
feat: auto-generate our_take editorial copy twice a month

### DIFF
--- a/.github/workflows/refresh-our-takes.yml
+++ b/.github/workflows/refresh-our-takes.yml
@@ -74,7 +74,7 @@ jobs:
         run: node scripts/refresh-our-takes.js
 
       - name: Upload preview batch (preview mode)
-        if: steps.mode.outputs.mode == 'preview'
+        if: always() && steps.mode.outputs.mode == 'preview'
         uses: actions/upload-artifact@v4
         with:
           name: our-takes-preview

--- a/.github/workflows/refresh-our-takes.yml
+++ b/.github/workflows/refresh-our-takes.yml
@@ -3,13 +3,22 @@ name: Refresh Our Takes
 # Twice a month, a few hours after Refresh Best Pages (0 12 1,15), regenerate
 # every card's `our_take` editorial paragraph with an OpenAI writer and commit
 # the changes straight to main. A GITHUB_TOKEN push does not cascade into other
-# workflows, so the final step explicitly dispatches Build and Deploy Cards to
+# workflows, so the publish step explicitly dispatches Build and Deploy Cards to
 # push the refreshed cards.json to S3/CDN.
+#
+# A manual run defaults to PREVIEW mode: it generates the whole batch and uploads
+# it as an artifact (our-takes-dryrun.json) without touching main, so a run can
+# be reviewed before anything goes live. Scheduled runs always publish.
 
 on:
   schedule:
     - cron: '0 16 1,15 * *'  # 1st & 15th of each month, 16:00 UTC
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview only: generate + upload the batch as an artifact, do not commit to main'
+        type: boolean
+        default: true
 
 permissions:
   contents: write   # commit + push the refreshed YAML to main
@@ -36,6 +45,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Determine mode
+        id: mode
+        run: |
+          # Publish only on the schedule, or an explicit non-dry-run dispatch from main.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            MODE=publish
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+            && [ "${{ inputs.dry_run }}" = "false" ] \
+            && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            MODE=publish
+          else
+            MODE=preview
+          fi
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "Running in $MODE mode."
+
       - name: Build fresh inputs (cards.json + best.json)
         run: |
           npm run build:cards
@@ -45,12 +70,23 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_TAKE_MODEL: gpt-4o
+          OUR_TAKE_DRY_RUN: ${{ steps.mode.outputs.mode == 'preview' && '1' || '0' }}
         run: node scripts/refresh-our-takes.js
 
-      - name: Validate cards still build
+      - name: Upload preview batch (preview mode)
+        if: steps.mode.outputs.mode == 'preview'
+        uses: actions/upload-artifact@v4
+        with:
+          name: our-takes-preview
+          path: our-takes-dryrun.json
+          if-no-files-found: warn
+
+      - name: Validate cards still build (publish mode)
+        if: steps.mode.outputs.mode == 'publish'
         run: npm run build:cards
 
-      - name: Commit refreshed takes to main and deploy
+      - name: Commit refreshed takes to main and deploy (publish mode)
+        if: steps.mode.outputs.mode == 'publish'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/refresh-our-takes.yml
+++ b/.github/workflows/refresh-our-takes.yml
@@ -1,0 +1,69 @@
+name: Refresh Our Takes
+
+# Twice a month, a few hours after Refresh Best Pages (0 12 1,15), regenerate
+# every card's `our_take` editorial paragraph with an OpenAI writer and commit
+# the changes straight to main. A GITHUB_TOKEN push does not cascade into other
+# workflows, so the final step explicitly dispatches Build and Deploy Cards to
+# push the refreshed cards.json to S3/CDN.
+
+on:
+  schedule:
+    - cron: '0 16 1,15 * *'  # 1st & 15th of each month, 16:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write   # commit + push the refreshed YAML to main
+  actions: write    # dispatch the Build and Deploy Cards workflow
+
+concurrency:
+  group: refresh-our-takes
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build fresh inputs (cards.json + best.json)
+        run: |
+          npm run build:cards
+          npm run build:best
+
+      - name: Regenerate our_take editorial copy
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_TAKE_MODEL: gpt-4o
+        run: node scripts/refresh-our-takes.js
+
+      - name: Validate cards still build
+        run: npm run build:cards
+
+      - name: Commit refreshed takes to main and deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # best.json is tracked and gets rebuilt above; we only commit card YAML.
+          git checkout -- data/best.json 2>/dev/null || true
+          if [ -z "$(git status --porcelain data/cards/)" ]; then
+            echo "No take changes this run."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/cards/
+          git commit -m "chore: refresh our_take editorial copy ($(date +%Y-%m-%d))"
+          git push origin HEAD:main
+          echo "Pushed refreshed takes to main; dispatching Build and Deploy Cards..."
+          gh workflow run build-cards.yml --ref main

--- a/scripts/refresh-our-takes.js
+++ b/scripts/refresh-our-takes.js
@@ -61,6 +61,9 @@ const MIN_TAKE_LENGTH = 60; // guard against a truncated / empty generation
 const DRY_RUN = process.env.OUR_TAKE_DRY_RUN === '1';
 const DRY_RUN_FILE = path.join(__dirname, '..', 'our-takes-dryrun.json');
 
+// Cap the number of cards processed (0 = all). Handy for a quick sample preview.
+const LIMIT = Number(process.env.OUR_TAKE_LIMIT || 0);
+
 // CardWire stores raw field keys; translate to something the writer reads cleanly.
 const WIRE_FIELD_LABELS = {
   accepting_applications: 'Accepting new applications',
@@ -355,16 +358,20 @@ async function main() {
     })
     .filter(Boolean);
 
+  const queue = LIMIT > 0 ? cards.slice(0, LIMIT) : cards;
+  const total = queue.length;
+
   console.log(
-    `\nRegenerating our_take for ${cards.length} cards with ${MODEL}${DRY_RUN ? ' (dry run, no writes)' : ''}...\n`
+    `\nRegenerating our_take for ${total}${LIMIT > 0 ? ` of ${cards.length}` : ''} cards with ${MODEL}${DRY_RUN ? ' (dry run, no writes)' : ''}...\n`
   );
 
   let changed = 0;
   let unchanged = 0;
   let failed = 0;
+  let processed = 0;
   const previews = [];
 
-  await mapPool(cards, CONCURRENCY, async card => {
+  await mapPool(queue, CONCURRENCY, async card => {
     const wire = wireByName.get(normalizeName(card.data.name)) || [];
     const featured = featuredBySlug.get(card.data.slug) || [];
     const prompt = buildUserPrompt(card.data, wire, featured);
@@ -373,18 +380,19 @@ async function main() {
     try {
       take = await generateTake(prompt);
     } catch (err) {
-      console.error(`  FAIL   ${card.data.name}: ${err.message}`);
+      console.error(`  [${++processed}/${total}] FAIL ${card.data.name}: ${err.message}`);
       failed++;
       return;
     }
 
     if (!take || take.length < MIN_TAKE_LENGTH) {
-      console.error(`  FAIL   ${card.data.name}: empty or too-short take.`);
+      console.error(`  [${++processed}/${total}] FAIL ${card.data.name}: empty or too-short take.`);
       failed++;
       return;
     }
 
     const isChanged = normalizeText(take) !== normalizeText(card.data.our_take);
+    console.log(`  [${++processed}/${total}] ${isChanged ? 'CHANGED ' : 'same    '} ${card.data.name}`);
 
     if (DRY_RUN) {
       previews.push({
@@ -405,11 +413,10 @@ async function main() {
 
     fs.writeFileSync(card.filepath, upsertOurTake(card.raw, take));
     changed++;
-    console.log(`  UPDATE ${card.data.name}`);
   });
 
   console.log(
-    `\nDone. ${changed} ${DRY_RUN ? 'would change' : 'updated'}, ${unchanged} unchanged, ${failed} failed (${cards.length} total).`
+    `\nDone. ${changed} ${DRY_RUN ? 'would change' : 'updated'}, ${unchanged} unchanged, ${failed} failed (${total} total).`
   );
 
   if (DRY_RUN) {

--- a/scripts/refresh-our-takes.js
+++ b/scripts/refresh-our-takes.js
@@ -1,0 +1,388 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * refresh-our-takes.js
+ *
+ * Regenerates the `our_take` editorial paragraph for every card in
+ * data/cards/*.yaml using an OpenAI writer model. Runs twice a month (1st &
+ * 15th, a few hours after the Best-pages re-rank) via
+ * .github/workflows/refresh-our-takes.yml, which commits any changed takes
+ * straight to main and then dispatches Build and Deploy Cards to push the new
+ * cards.json to the CDN.
+ *
+ * For each card the writer is given everything we know about it:
+ *   - the full card YAML (rewards, APR/intro offers, signup bonus, benefits,
+ *     fees, tags, category)
+ *   - recent CardWire changes for that card, so a take can note a move such as
+ *     "recently trimmed from 24 to 21 months"
+ *   - which /best pages currently feature the card, at what rank and badge
+ *
+ * House style is pinned in the prompt: no em dashes, one paragraph, lead with
+ * the single strongest reason to carry the card, name the catch honestly, no
+ * clickbait. The two hand-written takes (US Bank Shield, Wells Fargo Reflect)
+ * ride along as few-shot voice exemplars.
+ *
+ * The whole card set is regenerated every run, but a file is only rewritten
+ * when the take actually changed, so byte-identical output never churns the
+ * diff.
+ *
+ * Env:
+ *   OPENAI_API_KEY     (required)
+ *   OPENAI_TAKE_MODEL  (optional, default: gpt-4o)
+ *   CARD_WIRE_URL      (optional, default: CloudFront /card-wire endpoint)
+ *   WIRE_WINDOW_DAYS   (optional, default: 120)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const CARDS_DIR = path.join(__dirname, '..', 'data', 'cards');
+const BEST_FILE = path.join(__dirname, '..', 'data', 'best.json');
+
+const API_KEY = process.env.OPENAI_API_KEY;
+const MODEL = process.env.OPENAI_TAKE_MODEL || 'gpt-4o';
+const CARD_WIRE_URL =
+  process.env.CARD_WIRE_URL || 'https://d2ojrhbh2dincr.cloudfront.net/card-wire';
+const WIRE_WINDOW_DAYS = Number(process.env.WIRE_WINDOW_DAYS || 120);
+const WIRE_FETCH_LIMIT = 500;
+
+const CONCURRENCY = 4;
+const WRAP_WIDTH = 76; // content columns; a 2-space indent lands near the 78 the YAML files use
+const MIN_TAKE_LENGTH = 60; // guard against a truncated / empty generation
+
+// CardWire stores raw field keys; translate to something the writer reads cleanly.
+const WIRE_FIELD_LABELS = {
+  accepting_applications: 'Accepting new applications',
+  annual_fee: 'Annual fee',
+  signup_bonus_value: 'Signup bonus value',
+  apr_min: 'Regular APR (low end)',
+  apr_max: 'Regular APR (high end)',
+  intro_apr_purchase_months: 'Intro 0% APR on purchases (months)',
+  intro_apr_bt_months: 'Intro 0% APR on balance transfers (months)',
+};
+
+const SYSTEM_PROMPT = `You are the senior credit-card editor for CreditOdds. You write the "Our take" paragraph shown on each card's detail page: a short, honest, plain-English verdict that helps a reader decide whether the card belongs in their wallet.
+
+Voice and rules:
+- One paragraph, roughly 4 to 6 sentences.
+- Lead with the single strongest reason to carry the card, then name the real catch or tradeoff honestly.
+- Plain text only: no markdown, no headings, no lists, no links, no surrounding quotes.
+- NEVER use em dashes or en dashes. Use commas, colons, or separate sentences instead. This is a hard rule.
+- No hype or clickbait ("game-changer", "must-have", "insane value"). Stay measured and specific.
+- Anchor claims in the actual numbers from the card data (earn rates, intro APR length, annual fee, signup bonus) rather than vague praise.
+- If the recent-changes list shows a material move (an intro APR window or signup bonus that just dropped or rose, a fee change, or the card no longer accepting applications), work it in naturally, e.g. "recently trimmed from 24 to 21 months".
+- If the card tops a Best-of list, you may note that once and naturally, but never force it.
+- Do not invent benefits, credits, categories, or numbers that are not in the data.
+
+Return ONLY a JSON object of the exact shape {"our_take": "<the paragraph>"}.
+
+Two examples of the target voice:
+
+Example A (US Bank Shield):
+"U.S. Bank recently trimmed the Shield's 0% intro APR from 24 months to 21, but even after the cut it remains one of the longest runways on the market, covering both purchases and balance transfers with no annual fee. That still makes it a strong pick if you're paying down existing debt or financing a large purchase over the next year and a half. The catch is the rewards are thin: outside of 4% cash back on prepaid travel booked through the U.S. Bank Travel Center, there's no everyday earn rate, so once the intro period ends the card has little reason to stay in your wallet. Treat the $20 annual statement credit and cell phone protection as minor extras."
+
+Example B (Wells Fargo Reflect):
+"The Reflect is a pure balance-transfer play: 21 months of 0% intro APR on purchases and qualifying balance transfers, with no annual fee. That long runway makes it a solid choice if your only goal is to pay down existing debt or float a big purchase interest-free for nearly two years. Just be clear-eyed about the tradeoff: this card earns no rewards at all, so there's no cash back or points to keep it relevant once the intro period ends. Cell phone protection when you pay your bill with the card is the lone ongoing perk. Open it for the 0% window, run your payoff plan, and don't expect a reason to keep using it after that."`;
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+function normalizeName(s) {
+  return (s || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function normalizeText(s) {
+  return (s || '').replace(/\s+/g, ' ').trim();
+}
+
+async function fetchWithRetry(url, options = {}, { maxRetries = 3, baseDelay = 1500 } = {}) {
+  let lastErr;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const res = await fetch(url, options);
+      if (res.status === 429 || res.status >= 500) throw new Error(`HTTP ${res.status}`);
+      return res;
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxRetries) {
+        await new Promise(r => setTimeout(r, baseDelay * Math.pow(2, attempt)));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+async function mapPool(items, concurrency, fn) {
+  let cursor = 0;
+  async function worker() {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      await fn(items[idx], idx);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, worker)
+  );
+}
+
+// Fold a take into a `>` block scalar, word-wrapped and 2-space indented to
+// match the surrounding YAML.
+function formatOurTakeBlock(text) {
+  const words = normalizeText(text).split(' ');
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    if (line && line.length + 1 + word.length > WRAP_WIDTH) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = line ? `${line} ${word}` : word;
+    }
+  }
+  if (line) lines.push(line);
+  return ['our_take: >', ...lines.map(l => `  ${l}`)];
+}
+
+// Replace the existing our_take block in the raw YAML text, or insert one after
+// apply_link when the card has none. Everything else stays byte-identical, so
+// diffs stay tight.
+function upsertOurTake(raw, newText) {
+  const lines = raw.split('\n');
+  const block = formatOurTakeBlock(newText);
+  const idx = lines.findIndex(l => /^our_take\s*:/.test(l));
+
+  if (idx !== -1) {
+    // Consume the existing block: the key line plus every indented body line.
+    let end = idx + 1;
+    while (end < lines.length && /^\s+\S/.test(lines[end])) end++;
+    lines.splice(idx, end - idx, ...block);
+    return lines.join('\n');
+  }
+
+  const applyIdx = lines.findIndex(l => /^apply_link\s*:/.test(l));
+  let insertAt = applyIdx !== -1 ? applyIdx + 1 : lines.length;
+  // Don't slip the block below a trailing blank line at EOF.
+  if (insertAt >= lines.length && lines[lines.length - 1] === '') {
+    insertAt = lines.length - 1;
+  }
+  lines.splice(insertAt, 0, ...block);
+  return lines.join('\n');
+}
+
+// ─── external data: CardWire + Best-of ──────────────────────────────────────
+
+async function loadWireChanges() {
+  const byCard = new Map(); // normalizedName -> [change rows within the window]
+  try {
+    const url = `${CARD_WIRE_URL}?limit=${WIRE_FETCH_LIMIT}&_=${Date.now()}`;
+    const res = await fetchWithRetry(url);
+    if (!res.ok) throw new Error(`card-wire ${res.status}`);
+    const { changes = [] } = await res.json();
+    const cutoff = Date.now() - WIRE_WINDOW_DAYS * 86400000;
+    for (const change of changes) {
+      if (new Date(change.changed_at).getTime() < cutoff) continue;
+      const key = normalizeName(change.card_name);
+      if (!byCard.has(key)) byCard.set(key, []);
+      byCard.get(key).push(change);
+    }
+    console.log(
+      `CardWire: ${changes.length} rows fetched, ${byCard.size} cards changed in the last ${WIRE_WINDOW_DAYS} days.`
+    );
+    if (changes.length >= WIRE_FETCH_LIMIT) {
+      console.warn(`  Warning: hit the ${WIRE_FETCH_LIMIT}-row fetch cap; the oldest changes may be missing.`);
+    }
+  } catch (err) {
+    console.warn(`Warning: could not load CardWire changes (${err.message}). Proceeding without change history.`);
+  }
+  return byCard;
+}
+
+function loadFeaturedIn() {
+  const bySlug = new Map(); // slug -> [{ title, rank, badge }]
+  if (!fs.existsSync(BEST_FILE)) {
+    console.warn('Warning: data/best.json not found; skipping Best-of enrichment.');
+    return bySlug;
+  }
+  try {
+    const best = JSON.parse(fs.readFileSync(BEST_FILE, 'utf8'));
+    for (const page of best.pages || []) {
+      (page.cards || []).forEach((card, i) => {
+        if (!card.slug) return;
+        if (!bySlug.has(card.slug)) bySlug.set(card.slug, []);
+        bySlug.get(card.slug).push({ title: page.title, rank: i + 1, badge: card.badge || null });
+      });
+    }
+    console.log(`Best-of: ${bySlug.size} cards featured across ${(best.pages || []).length} pages.`);
+  } catch (err) {
+    console.warn(`Warning: could not parse best.json (${err.message}).`);
+  }
+  return bySlug;
+}
+
+// ─── prompt + generation ─────────────────────────────────────────────────────
+
+function buildUserPrompt(card, wire, featured) {
+  const { our_take, ...rest } = card;
+  const cardYaml = yaml.dump(rest, { lineWidth: 100 }).trim();
+
+  let wireBlock;
+  if (!wire.length) {
+    wireBlock = `None in the last ${WIRE_WINDOW_DAYS} days.`;
+  } else {
+    wireBlock = wire
+      .slice()
+      .sort((a, b) => new Date(a.changed_at) - new Date(b.changed_at))
+      .map(c => {
+        const label = WIRE_FIELD_LABELS[c.field] || c.field;
+        const unit = c.unit ? ` ${c.unit}` : '';
+        const date = new Date(c.changed_at).toISOString().slice(0, 10);
+        return `- ${label}: ${c.old_value} -> ${c.new_value}${unit} (changed ${date})`;
+      })
+      .join('\n');
+  }
+
+  const featBlock = featured.length
+    ? featured
+        .map(f => `- ${f.title}: ranked #${f.rank}${f.badge ? `, badge "${f.badge}"` : ''}`)
+        .join('\n')
+    : 'Not currently featured on any Best-of list.';
+
+  return [
+    'Write the "Our take" paragraph for this card.',
+    '',
+    'CARD DATA (YAML):',
+    cardYaml,
+    '',
+    `RECENT CHANGES (last ${WIRE_WINDOW_DAYS} days, from CardWire):`,
+    wireBlock,
+    '',
+    'FEATURED IN (current Best-of lists):',
+    featBlock,
+  ].join('\n');
+}
+
+async function generateTake(prompt) {
+  const res = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: prompt },
+      ],
+      response_format: { type: 'json_object' },
+      temperature: 0.4,
+      max_tokens: 600,
+    }),
+  });
+  if (!res.ok) throw new Error(`OpenAI API ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  const content = data.choices?.[0]?.message?.content || '{}';
+  const parsed = JSON.parse(content);
+
+  let take = normalizeText(parsed.our_take || '');
+  // Defensive: strip any em/en dashes the model slips in, since they are a hard
+  // house-style violation in user-facing copy.
+  take = take.replace(/\s*[—–]\s*/g, ', ');
+  return take;
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!API_KEY) {
+    console.error('OPENAI_API_KEY is required.');
+    process.exit(1);
+  }
+
+  const [wireByName, featuredBySlug] = [await loadWireChanges(), loadFeaturedIn()];
+
+  const cards = fs
+    .readdirSync(CARDS_DIR)
+    .filter(f => f.endsWith('.yaml'))
+    .map(file => {
+      const filepath = path.join(CARDS_DIR, file);
+      const raw = fs.readFileSync(filepath, 'utf8');
+      let data;
+      try {
+        data = yaml.load(raw);
+      } catch (err) {
+        console.error(`Skip ${file}: YAML parse error (${err.message}).`);
+        return null;
+      }
+      if (!data || !data.name) {
+        console.error(`Skip ${file}: no card name.`);
+        return null;
+      }
+      return { file, filepath, raw, data };
+    })
+    .filter(Boolean);
+
+  console.log(`\nRegenerating our_take for ${cards.length} cards with ${MODEL}...\n`);
+
+  let changed = 0;
+  let unchanged = 0;
+  let failed = 0;
+
+  await mapPool(cards, CONCURRENCY, async card => {
+    const wire = wireByName.get(normalizeName(card.data.name)) || [];
+    const featured = featuredBySlug.get(card.data.slug) || [];
+    const prompt = buildUserPrompt(card.data, wire, featured);
+
+    let take;
+    try {
+      take = await generateTake(prompt);
+    } catch (err) {
+      console.error(`  FAIL   ${card.data.name}: ${err.message}`);
+      failed++;
+      return;
+    }
+
+    if (!take || take.length < MIN_TAKE_LENGTH) {
+      console.error(`  FAIL   ${card.data.name}: empty or too-short take.`);
+      failed++;
+      return;
+    }
+
+    if (normalizeText(take) === normalizeText(card.data.our_take)) {
+      unchanged++;
+      return;
+    }
+
+    fs.writeFileSync(card.filepath, upsertOurTake(card.raw, take));
+    changed++;
+    console.log(`  UPDATE ${card.data.name}`);
+  });
+
+  console.log(
+    `\nDone. ${changed} updated, ${unchanged} unchanged, ${failed} failed (${cards.length} total).`
+  );
+
+  // A large failure rate usually means a bad key or a rate-limit wall; don't
+  // ship a half-refreshed batch.
+  if (failed > cards.length / 2) {
+    console.error('More than half the cards failed to generate; failing the run.');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  normalizeName,
+  normalizeText,
+  formatOurTakeBlock,
+  upsertOurTake,
+  buildUserPrompt,
+  loadFeaturedIn,
+};

--- a/scripts/refresh-our-takes.js
+++ b/scripts/refresh-our-takes.js
@@ -122,26 +122,46 @@ async function rateGate(spacingMs) {
   if (wait > 0) await sleep(wait);
 }
 
-async function fetchWithRetry(url, options = {}, { maxRetries = 10, baseDelay = 2000 } = {}) {
+let loggedRetryReason = false;
+
+async function fetchWithRetry(url, options = {}, { maxRetries = 6, baseDelay = 2000 } = {}) {
   let lastErr;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const res = await fetch(url, options);
-      if ((res.status === 429 || res.status >= 500) && attempt < maxRetries) {
-        // Honor the server's Retry-After when present, else capped exponential backoff.
-        const retryAfter = Number(res.headers.get('retry-after'));
-        const wait =
-          Number.isFinite(retryAfter) && retryAfter > 0
-            ? retryAfter * 1000 + 250
-            : Math.min(baseDelay * Math.pow(2, attempt), 30000);
-        await sleep(wait + Math.floor(Math.random() * 500)); // jitter to desync workers
-        continue;
+      if (res.status === 429 || res.status >= 500) {
+        // Peek at the body to tell a transient rate limit apart from a terminal
+        // quota/billing error, which no amount of retrying will fix.
+        let snippet = '';
+        try {
+          snippet = (await res.clone().text()).slice(0, 300);
+        } catch {
+          /* body unreadable; treat as transient */
+        }
+        const terminal = /insufficient_quota|exceeded your current quota|billing_hard_limit|account_deactivated/i.test(snippet);
+        if (terminal) {
+          console.error(`Non-retryable ${res.status}: ${snippet}`);
+          return res; // let the caller throw with the real message; don't burn retries
+        }
+        if (attempt < maxRetries) {
+          if (!loggedRetryReason) {
+            loggedRetryReason = true;
+            console.warn(`  Rate limited (${res.status}); backing off and retrying. First body: ${snippet.slice(0, 160)}`);
+          }
+          const retryAfter = Number(res.headers.get('retry-after'));
+          const wait =
+            Number.isFinite(retryAfter) && retryAfter > 0
+              ? retryAfter * 1000 + 250
+              : Math.min(baseDelay * Math.pow(2, attempt), 20000);
+          await sleep(wait + Math.floor(Math.random() * 500)); // jitter to desync workers
+          continue;
+        }
       }
       return res;
     } catch (err) {
       lastErr = err;
       if (attempt >= maxRetries) throw lastErr;
-      await sleep(Math.min(baseDelay * Math.pow(2, attempt), 30000));
+      await sleep(Math.min(baseDelay * Math.pow(2, attempt), 20000));
     }
   }
   throw lastErr || new Error('fetchWithRetry: retries exhausted');

--- a/scripts/refresh-our-takes.js
+++ b/scripts/refresh-our-takes.js
@@ -52,6 +52,12 @@ const CONCURRENCY = 4;
 const WRAP_WIDTH = 76; // content columns; a 2-space indent lands near the 78 the YAML files use
 const MIN_TAKE_LENGTH = 60; // guard against a truncated / empty generation
 
+// Preview mode: generate every take but write NOTHING back to the YAML. Instead
+// dump the results to our-takes-dryrun.json and print a few samples, so a run
+// can be reviewed before any take goes live. Set OUR_TAKE_DRY_RUN=1.
+const DRY_RUN = process.env.OUR_TAKE_DRY_RUN === '1';
+const DRY_RUN_FILE = path.join(__dirname, '..', 'our-takes-dryrun.json');
+
 // CardWire stores raw field keys; translate to something the writer reads cleanly.
 const WIRE_FIELD_LABELS = {
   accepting_applications: 'Accepting new applications',
@@ -323,11 +329,14 @@ async function main() {
     })
     .filter(Boolean);
 
-  console.log(`\nRegenerating our_take for ${cards.length} cards with ${MODEL}...\n`);
+  console.log(
+    `\nRegenerating our_take for ${cards.length} cards with ${MODEL}${DRY_RUN ? ' (dry run, no writes)' : ''}...\n`
+  );
 
   let changed = 0;
   let unchanged = 0;
   let failed = 0;
+  const previews = [];
 
   await mapPool(cards, CONCURRENCY, async card => {
     const wire = wireByName.get(normalizeName(card.data.name)) || [];
@@ -349,7 +358,21 @@ async function main() {
       return;
     }
 
-    if (normalizeText(take) === normalizeText(card.data.our_take)) {
+    const isChanged = normalizeText(take) !== normalizeText(card.data.our_take);
+
+    if (DRY_RUN) {
+      previews.push({
+        slug: card.data.slug,
+        name: card.data.name,
+        changed: isChanged,
+        old_take: card.data.our_take || null,
+        new_take: take,
+      });
+      isChanged ? changed++ : unchanged++;
+      return;
+    }
+
+    if (!isChanged) {
       unchanged++;
       return;
     }
@@ -360,8 +383,22 @@ async function main() {
   });
 
   console.log(
-    `\nDone. ${changed} updated, ${unchanged} unchanged, ${failed} failed (${cards.length} total).`
+    `\nDone. ${changed} ${DRY_RUN ? 'would change' : 'updated'}, ${unchanged} unchanged, ${failed} failed (${cards.length} total).`
   );
+
+  if (DRY_RUN) {
+    previews.sort((a, b) => a.name.localeCompare(b.name));
+    fs.writeFileSync(DRY_RUN_FILE, JSON.stringify(previews, null, 2));
+    console.log(`\n[dry run] Wrote ${previews.length} takes to ${DRY_RUN_FILE}. No YAML modified.`);
+
+    const samples = previews.filter(p => p.changed).slice(0, 8);
+    console.log(`\n===== SAMPLE TAKES (${samples.length} of ${changed} changed) =====`);
+    for (const s of samples) {
+      console.log(`\n### ${s.name} (${s.slug})`);
+      console.log(s.new_take);
+    }
+    console.log('\n===== END SAMPLES =====');
+  }
 
   // A large failure rate usually means a bad key or a rate-limit wall; don't
   // ship a half-refreshed batch.

--- a/scripts/refresh-our-takes.js
+++ b/scripts/refresh-our-takes.js
@@ -64,6 +64,12 @@ const DRY_RUN_FILE = path.join(__dirname, '..', 'our-takes-dryrun.json');
 // Cap the number of cards processed (0 = all). Handy for a quick sample preview.
 const LIMIT = Number(process.env.OUR_TAKE_LIMIT || 0);
 
+// Restrict to specific cards by slug or name (comma-separated). For targeted tests.
+const ONLY = (process.env.OUR_TAKE_ONLY || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+
 // CardWire stores raw field keys; translate to something the writer reads cleanly.
 const WIRE_FIELD_LABELS = {
   accepting_applications: 'Accepting new applications',
@@ -378,7 +384,14 @@ async function main() {
     })
     .filter(Boolean);
 
-  const queue = LIMIT > 0 ? cards.slice(0, LIMIT) : cards;
+  let queue = cards;
+  if (ONLY.length) {
+    const want = new Set(ONLY.map(s => s.toLowerCase()));
+    queue = cards.filter(
+      c => want.has((c.data.slug || '').toLowerCase()) || want.has(normalizeName(c.data.name))
+    );
+  }
+  if (LIMIT > 0) queue = queue.slice(0, LIMIT);
   const total = queue.length;
 
   console.log(

--- a/scripts/refresh-our-takes.js
+++ b/scripts/refresh-our-takes.js
@@ -48,7 +48,10 @@ const CARD_WIRE_URL =
 const WIRE_WINDOW_DAYS = Number(process.env.WIRE_WINDOW_DAYS || 120);
 const WIRE_FETCH_LIMIT = 500;
 
-const CONCURRENCY = 4;
+// gpt-4o rate limits are tight, so keep concurrency low and let the request
+// spacing + Retry-After handling below do the real pacing. Both overridable.
+const CONCURRENCY = Number(process.env.OUR_TAKE_CONCURRENCY || 2);
+const REQUEST_SPACING_MS = Number(process.env.OUR_TAKE_SPACING_MS || 350);
 const WRAP_WIDTH = 76; // content columns; a 2-space indent lands near the 78 the YAML files use
 const MIN_TAKE_LENGTH = 60; // guard against a truncated / empty generation
 
@@ -102,21 +105,43 @@ function normalizeText(s) {
   return (s || '').replace(/\s+/g, ' ').trim();
 }
 
-async function fetchWithRetry(url, options = {}, { maxRetries = 3, baseDelay = 1500 } = {}) {
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+// Global request-start spacing so a pool of workers doesn't fire a burst that
+// trips the rate limit on the very first round.
+let nextSlot = 0;
+async function rateGate(spacingMs) {
+  const now = Date.now();
+  const wait = Math.max(0, nextSlot - now);
+  nextSlot = Math.max(now, nextSlot) + spacingMs;
+  if (wait > 0) await sleep(wait);
+}
+
+async function fetchWithRetry(url, options = {}, { maxRetries = 10, baseDelay = 2000 } = {}) {
   let lastErr;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const res = await fetch(url, options);
-      if (res.status === 429 || res.status >= 500) throw new Error(`HTTP ${res.status}`);
+      if ((res.status === 429 || res.status >= 500) && attempt < maxRetries) {
+        // Honor the server's Retry-After when present, else capped exponential backoff.
+        const retryAfter = Number(res.headers.get('retry-after'));
+        const wait =
+          Number.isFinite(retryAfter) && retryAfter > 0
+            ? retryAfter * 1000 + 250
+            : Math.min(baseDelay * Math.pow(2, attempt), 30000);
+        await sleep(wait + Math.floor(Math.random() * 500)); // jitter to desync workers
+        continue;
+      }
       return res;
     } catch (err) {
       lastErr = err;
-      if (attempt < maxRetries) {
-        await new Promise(r => setTimeout(r, baseDelay * Math.pow(2, attempt)));
-      }
+      if (attempt >= maxRetries) throw lastErr;
+      await sleep(Math.min(baseDelay * Math.pow(2, attempt), 30000));
     }
   }
-  throw lastErr;
+  throw lastErr || new Error('fetchWithRetry: retries exhausted');
 }
 
 async function mapPool(items, concurrency, fn) {
@@ -269,6 +294,7 @@ function buildUserPrompt(card, wire, featured) {
 }
 
 async function generateTake(prompt) {
+  await rateGate(REQUEST_SPACING_MS);
   const res = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -401,8 +427,9 @@ async function main() {
   }
 
   // A large failure rate usually means a bad key or a rate-limit wall; don't
-  // ship a half-refreshed batch.
-  if (failed > cards.length / 2) {
+  // ship a half-refreshed batch. In dry run we still want the artifact, so we
+  // report but never hard-fail.
+  if (!DRY_RUN && failed > cards.length / 2) {
     console.error('More than half the cards failed to generate; failing the run.');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
Automates the `our_take` editorial paragraph on every card page. A new **Refresh Our Takes** workflow regenerates all cards' takes with **gpt-4o** on the **1st and 15th** (16:00 UTC, a few hours after `Refresh Best Pages`), commits changes to `main`, and triggers the deploy.

## How it works
- **`scripts/refresh-our-takes.js`** — for each `data/cards/*.yaml`, sends the writer the full card YAML plus two enrichment sources that don't live in the YAML:
  - **Recent CardWire changes** (last 120 days) from the public `/card-wire` endpoint, so a take can say e.g. *"recently trimmed from 24 to 21 months"*. Verified against live data: the Shield's `intro_apr_purchase_months: 24 → 21` row is present and matched.
  - **`/best` featured-in status** (rank + badge) from `best.json`, so a take can note *"our #1 pick for 0% APR"*.
- **House style pinned in the prompt**: no em dashes, one paragraph, lead with the strongest reason to carry, name the catch, no clickbait. The hand-written Shield + Reflect takes ride along as few-shot voice exemplars. Any stray em/en dashes are also stripped defensively.
- **Surgical writes**: only the `our_take` block in each YAML is replaced (byte-identical everywhere else); a file is rewritten only when the take actually changed.

## Deploy path
Config choices from planning: **regenerate all every run**, **auto-commit to `main`**, **gpt-4o**.

Because a `GITHUB_TOKEN` push does **not** cascade into other workflows, the workflow explicitly runs `gh workflow run build-cards.yml` after pushing, which rebuilds `cards.json` → S3/CDN → CloudFront invalidation → Amplify rebuild (the canonical deploy). `our_take` is a CDN-only field (not DB-synced), so the S3 upload is what makes it live; prose-only edits touch no CardWire-tracked field and add no new card files, so no spurious social posts fire.

## Validation
- 22 unit tests on the write/prompt logic (surgical replace preserves all other fields, exactly one `our_take` key, valid YAML round-trip, no em dashes, wire/featured context rendered) — all pass.
- Live read-only probes: `/card-wire` returns 200 and matches the Shield change; `best.json` featured-in map resolves correctly.
- `npm run build:cards` builds clean.
- Live gpt-4o generation runs on the first `workflow_dispatch` (recommend a manual dispatch to eyeball the first batch before it goes live).

## Notes
- First workflow in the repo to commit directly to `main` (all others open PRs); `main` is unprotected so this works. No PAT needed thanks to the explicit dispatch.
- Reuses the existing `OPENAI_API_KEY` secret.
- Heads-up: with regenerate-all, the first run will rewrite the two hand-written Shield/Reflect takes in gpt-4o's voice (the CardWire feed lets it keep the "24→21" point).