### PR TITLE
Weekly signup bonus changes Reddit draft on Mondays

### DIFF
--- a/.github/workflows/weekly-sub-changes-reddit.yml
+++ b/.github/workflows/weekly-sub-changes-reddit.yml
@@ -1,0 +1,26 @@
+name: Weekly Sign-up Bonus Changes Reddit Draft
+
+on:
+  schedule:
+    # Every Monday at 3pm UTC (11am ET during DST / 10am ET otherwise).
+    # Nothing auto-publishes: this drops a pending-manual Reddit draft into
+    # the Social Posting Service UI, so blackout windows don't apply.
+    - cron: '0 15 * * 1'
+  workflow_dispatch: {}
+
+jobs:
+  draft-reddit-sub-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 18
+
+      # No npm ci: the script only uses Node built-ins and repo-local requires.
+      - name: Create weekly sign-up bonus changes Reddit draft
+        env:
+          SOCIAL_API_URL: ${{ secrets.SOCIAL_API_URL }}
+          SOCIAL_API_KEY: ${{ secrets.SOCIAL_API_KEY }}
+        run: node scripts/post-weekly-sub-changes-reddit.js

--- a/scripts/lib/weekly-sub-changes.js
+++ b/scripts/lib/weekly-sub-changes.js
@@ -1,0 +1,181 @@
+/**
+ * Shared logic for the weekly sign-up bonus change roundups.
+ *
+ * Pulls the past 7 days of `signup_bonus_value` rows from the card wire and
+ * collapses each card down to a single net change. Consumed by
+ * post-weekly-sub-changes.js (X/Facebook/LinkedIn, Thursdays) and
+ * post-weekly-sub-changes-reddit.js (manual Reddit draft, Mondays).
+ */
+
+const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
+const CARD_WIRE_URL = 'https://creditodds.com/card-wire';
+
+// The endpoint caps `limit` at 200 and returns newest-first. A typical week
+// carries well under 20 rows, so 200 covers the window with wide margin.
+const FETCH_LIMIT = 200;
+const WINDOW_DAYS = 7;
+
+/**
+ * Rough cash value of one unit, used only to rank changes against each other —
+ * never displayed. Ranking by percent instead would let a $10 -> $0 store-card
+ * gift card (a 100% drop) outrank a 185,000 -> 140,000 point devaluation (24%),
+ * and would divide by zero whenever a bonus starts at 0.
+ */
+const UNIT_VALUE_USD = {
+  cash: 1,
+  cashback: 1,
+  points: 0.015,
+  miles: 0.013,
+  free_nights: 150,
+};
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(url, options, { maxRetries = 3, baseDelay = 2000 } = {}) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, options);
+    if (response.ok || (response.status < 500 && response.status !== 429)) {
+      return response;
+    }
+    if (attempt < maxRetries) {
+      const delay = baseDelay * Math.pow(2, attempt);
+      console.log(`  Retrying in ${delay / 1000}s (attempt ${attempt + 1}/${maxRetries}, status ${response.status})...`);
+      await sleep(delay);
+    } else {
+      return response;
+    }
+  }
+}
+
+/**
+ * Card names carry the issuer suffix in the DB ("... American Express"), which
+ * eats scarce space without adding information next to the card name.
+ */
+function shortenCardName(name) {
+  return String(name)
+    .replace(/\s+American Express$/i, '')
+    .replace(/\s+Credit Card$/i, '')
+    .trim();
+}
+
+/**
+ * Mirrors the user-facing convention: cash bonuses render as dollars, free
+ * nights keep their unit (a bare "2" would be meaningless), and points/miles
+ * render as a plain grouped number.
+ */
+function formatBonus(value, unit) {
+  const num = parseFloat(value);
+  if (Number.isNaN(num)) return String(value);
+  if (unit === 'cash' || unit === 'cashback') return `$${num.toLocaleString('en-US')}`;
+  if (unit === 'free_nights') return `${num.toLocaleString('en-US')} night${num === 1 ? '' : 's'}`;
+  return num.toLocaleString('en-US');
+}
+
+async function fetchRecentSubChanges() {
+  // Bust the CloudFront cache (s-maxage=300) so the run never reads a
+  // response written before the morning's card sync.
+  const res = await fetchWithRetry(`${API_BASE}/card-wire?limit=${FETCH_LIMIT}&_=${Date.now()}`);
+  if (!res.ok) throw new Error(`Failed to fetch card wire: ${res.status}`);
+  const { changes } = await res.json();
+
+  if (changes.length >= FETCH_LIMIT) {
+    console.log(`  Warning: hit the ${FETCH_LIMIT}-row fetch cap — the oldest changes in the window may be missing.`);
+  }
+
+  const cutoff = Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  return changes.filter(
+    c => c.field === 'signup_bonus_value' && new Date(c.changed_at).getTime() >= cutoff
+  );
+}
+
+/**
+ * A card can move more than once in a week (or flip units mid-week). Collapse
+ * each card to one net change: oldest old_value -> newest new_value, using
+ * only the rows that share the card's most recent unit, since values in
+ * different units aren't comparable. Cards that net out flat are dropped.
+ */
+function collapsePerCard(rows) {
+  const byCard = new Map();
+  for (const row of rows) {
+    if (!byCard.has(row.card_id)) byCard.set(row.card_id, []);
+    byCard.get(row.card_id).push(row);
+  }
+
+  const collapsed = [];
+  for (const cardRows of byCard.values()) {
+    cardRows.sort((a, b) => new Date(a.changed_at) - new Date(b.changed_at));
+
+    const latest = cardRows[cardRows.length - 1];
+    const sameUnit = cardRows.filter(r => r.unit === latest.unit);
+    const first = sameUnit[0];
+
+    const oldNum = parseFloat(first.old_value);
+    const newNum = parseFloat(latest.new_value);
+    if (Number.isNaN(oldNum) || Number.isNaN(newNum) || oldNum === newNum) continue;
+
+    // A value of 0 is real data: it means the public sees no bonus amount.
+    // Cards that simply have no bonus omit `signup_bonus` entirely, so a 0 here
+    // is always a deliberate statement about the public offer, and a move to or
+    // from it is a genuine change worth reporting.
+    collapsed.push({
+      cardName: shortenCardName(latest.card_name),
+      unit: latest.unit,
+      oldValue: first.old_value,
+      newValue: latest.new_value,
+      oldNum,
+      newNum,
+      // Approximate cash value of the swing, so changes rank against each other
+      // across units. Ordering only — never shown in the post.
+      weight: Math.abs(newNum - oldNum) * (UNIT_VALUE_USD[latest.unit] ?? 0.015),
+      changedAt: latest.changed_at,
+    });
+  }
+  return collapsed;
+}
+
+function buildCardWireLink(utmSource, campaign) {
+  const url = new URL(CARD_WIRE_URL);
+  url.searchParams.set('utm_source', utmSource);
+  url.searchParams.set('utm_medium', 'social');
+  url.searchParams.set('utm_campaign', campaign);
+  url.searchParams.set('utm_content', `weekly-${new Date().toISOString().slice(0, 10)}`);
+  return url.toString();
+}
+
+/**
+ * POST an arbitrary body to the Social Posting Service queue endpoint.
+ */
+async function queueSocialPost(body) {
+  const apiUrl = process.env.SOCIAL_API_URL;
+  const apiKey = process.env.SOCIAL_API_KEY;
+  if (!apiUrl || !apiKey) throw new Error('SOCIAL_API_URL and SOCIAL_API_KEY are required');
+
+  const response = await fetchWithRetry(`${apiUrl}/social/queue`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Queue API error: ${response.status} - ${errorText}`);
+  }
+
+  return response.json();
+}
+
+module.exports = {
+  WINDOW_DAYS,
+  fetchWithRetry,
+  shortenCardName,
+  formatBonus,
+  fetchRecentSubChanges,
+  collapsePerCard,
+  buildCardWireLink,
+  queueSocialPost,
+};

--- a/scripts/post-weekly-sub-changes-reddit.js
+++ b/scripts/post-weekly-sub-changes-reddit.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * Weekly Sign-up Bonus Changes — Reddit draft for r/creditodds
+ *
+ * Monday counterpart to post-weekly-sub-changes.js (which tweets a truncated
+ * roundup on Thursdays). Reddit has no length pressure, so this renders the
+ * FULL week of net changes and sends it to the Social Posting Service
+ * targeted at the manual `reddit` platform.
+ *
+ * Nothing is auto-published to Reddit: the service's reddit module just
+ * records a pre-filled reddit.com submit URL as a `pending_manual` result.
+ * The post shows up in the service UI with a "Post now" link that opens
+ * Reddit's composer with title and body already filled in.
+ *
+ * `publish_now: true` runs that synchronously, so this works even while the
+ * service's scheduler rule is disabled.
+ *
+ * The first line of text_content becomes the Reddit title (the service's
+ * reddit module splits on the first newline); the rest is the selftext body.
+ *
+ * Usage: node scripts/post-weekly-sub-changes-reddit.js [--dry-run]
+ *
+ * Env vars: SOCIAL_API_URL, SOCIAL_API_KEY
+ */
+
+const {
+  WINDOW_DAYS,
+  formatBonus,
+  fetchRecentSubChanges,
+  collapsePerCard,
+  buildCardWireLink,
+  queueSocialPost,
+} = require('./lib/weekly-sub-changes');
+
+/**
+ * With no card-name column label next to it, a bare "75,000" is ambiguous, so
+ * points and miles spell out their unit (dollars and free nights already
+ * carry theirs).
+ */
+function formatBonusWithUnit(value, unit) {
+  const base = formatBonus(value, unit);
+  if (unit === 'points') return `${base} points`;
+  if (unit === 'miles') return `${base} miles`;
+  return base;
+}
+
+/**
+ * Deliberately markdown-free: Reddit's submit page opens in the rich-text
+ * editor, which takes the pre-filled text literally — `**` and `|` table
+ * syntax would post as visible asterisks and pipes. Plain lines read
+ * correctly in both the rich-text and markdown editors.
+ */
+function renderLines(changes) {
+  return changes
+    .map(c => `${c.cardName}: ${formatBonusWithUnit(c.oldValue, c.unit)} → ${formatBonusWithUnit(c.newValue, c.unit)}`)
+    .join('\n');
+}
+
+function formatShortDate(date) {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+}
+
+/**
+ * First line is the Reddit title; the service appends the CardWire link to
+ * the body, so the body's closing line introduces it.
+ */
+function buildPostText(increases, decreases) {
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const title = `Weekly Sign Up Bonus Changes (${formatShortDate(windowStart)} to ${formatShortDate(now)})`;
+
+  const sections = [];
+  if (increases.length > 0) {
+    sections.push(`Increases:\n\n${renderLines(increases)}`);
+  }
+  if (decreases.length > 0) {
+    sections.push(`Decreases:\n\n${renderLines(decreases)}`);
+  }
+  sections.push(
+    'Values are the publicly visible offers we track. Full change history on CardWire:'
+  );
+
+  return `${title}\n\n${sections.join('\n\n')}`;
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+
+  console.log('=== Weekly Sign-up Bonus Changes (Reddit) ===\n');
+
+  const rows = await fetchRecentSubChanges();
+  console.log(`Found ${rows.length} sign-up bonus row(s) in the last ${WINDOW_DAYS} days.`);
+
+  const collapsed = collapsePerCard(rows);
+  if (collapsed.length === 0) {
+    console.log('No net sign-up bonus changes this week — skipping post.');
+    return;
+  }
+
+  const byWeight = (a, b) => b.weight - a.weight;
+  const increases = collapsed.filter(c => c.newNum > c.oldNum).sort(byWeight);
+  const decreases = collapsed.filter(c => c.newNum < c.oldNum).sort(byWeight);
+  console.log(`  ${increases.length} increase(s), ${decreases.length} decrease(s)`);
+
+  const text = buildPostText(increases, decreases);
+  // utm_source gets rewritten to the platform name at publish time anyway;
+  // set it to reddit so a dry-run prints the real link.
+  const linkUrl = buildCardWireLink('reddit', 'weekly-sub-changes-reddit');
+  const dateStamp = new Date().toISOString().slice(0, 10);
+
+  console.log(`\nPost text:\n\n${text}`);
+  console.log(`\nLink (appended to body): ${linkUrl}`);
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Skipping queue.');
+    return;
+  }
+
+  console.log('\nSending to Social Posting Service (publish_now, reddit only)...');
+  const result = await queueSocialPost({
+    text_content: text,
+    link_url: linkUrl,
+    source_type: 'weekly-sub-changes',
+    source_id: `weekly-sub-reddit-${dateStamp}`,
+    platforms: ['reddit'],
+    publish_now: true,
+    // A rerun on the same day (workflow retry, manual dispatch) must not
+    // create a second pending-manual chore in the UI.
+    idempotency_key: `weekly-sub-reddit-${dateStamp}`,
+  });
+
+  console.log(`Post #${result.id} status: ${result.status}`);
+  const redditResult = (result.results || []).find(r => r.platform === 'reddit');
+  if (redditResult?.postUrl) {
+    console.log(`\nPre-filled Reddit submit URL (also in the service UI under History):\n${redditResult.postUrl}`);
+  }
+  if (result.status !== 'posted' && !result.deduped) {
+    throw new Error(`Expected status 'posted', got '${result.status}' (${JSON.stringify(result.results)})`);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/post-weekly-sub-changes.js
+++ b/scripts/post-weekly-sub-changes.js
@@ -19,53 +19,20 @@
  * Env vars: SOCIAL_API_URL, SOCIAL_API_KEY
  */
 
-const API_BASE = 'https://d2ojrhbh2dincr.cloudfront.net';
-const CARD_WIRE_URL = 'https://creditodds.com/card-wire';
-
-// The endpoint caps `limit` at 200 and returns newest-first. A typical week
-// carries well under 20 rows, so 200 covers the window with wide margin.
-const FETCH_LIMIT = 200;
-const WINDOW_DAYS = 7;
+const {
+  WINDOW_DAYS,
+  formatBonus,
+  fetchRecentSubChanges,
+  collapsePerCard,
+  buildCardWireLink,
+  queueSocialPost,
+} = require('./lib/weekly-sub-changes');
 
 // X counts most non-Latin glyphs (our arrows/emoji) as 2 characters. Stay
 // under the 280 ceiling with room for a trailing "+N more" line.
 const TWEET_MAX = 274;
 
 const HEADER = 'Weekly Sign Up Bonus Changes from CardWire';
-
-/**
- * Rough cash value of one unit, used only to rank changes against each other —
- * never displayed. Ranking by percent instead would let a $10 -> $0 store-card
- * gift card (a 100% drop) outrank a 185,000 -> 140,000 point devaluation (24%),
- * and would divide by zero whenever a bonus starts at 0.
- */
-const UNIT_VALUE_USD = {
-  cash: 1,
-  cashback: 1,
-  points: 0.015,
-  miles: 0.013,
-  free_nights: 150,
-};
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-async function fetchWithRetry(url, options, { maxRetries = 3, baseDelay = 2000 } = {}) {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await fetch(url, options);
-    if (response.ok || (response.status < 500 && response.status !== 429)) {
-      return response;
-    }
-    if (attempt < maxRetries) {
-      const delay = baseDelay * Math.pow(2, attempt);
-      console.log(`  Retrying in ${delay / 1000}s (attempt ${attempt + 1}/${maxRetries}, status ${response.status})...`);
-      await sleep(delay);
-    } else {
-      return response;
-    }
-  }
-}
 
 /**
  * Approximates X's weighted character count: code points in the Basic Latin /
@@ -77,92 +44,6 @@ function tweetLength(text) {
     total += ch.codePointAt(0) <= 0x00ff ? 1 : 2;
   }
   return total;
-}
-
-/**
- * Card names carry the issuer suffix in the DB ("... American Express"), which
- * eats scarce tweet budget without adding information next to the card name.
- */
-function shortenCardName(name) {
-  return String(name)
-    .replace(/\s+American Express$/i, '')
-    .replace(/\s+Credit Card$/i, '')
-    .trim();
-}
-
-/**
- * Mirrors the user-facing convention: cash bonuses render as dollars, free
- * nights keep their unit (a bare "2" would be meaningless), and points/miles
- * render as a plain grouped number.
- */
-function formatBonus(value, unit) {
-  const num = parseFloat(value);
-  if (Number.isNaN(num)) return String(value);
-  if (unit === 'cash' || unit === 'cashback') return `$${num.toLocaleString('en-US')}`;
-  if (unit === 'free_nights') return `${num.toLocaleString('en-US')} night${num === 1 ? '' : 's'}`;
-  return num.toLocaleString('en-US');
-}
-
-async function fetchRecentSubChanges() {
-  // Bust the CloudFront cache (s-maxage=300) so a Thursday run never reads a
-  // response written before the morning's card sync.
-  const res = await fetchWithRetry(`${API_BASE}/card-wire?limit=${FETCH_LIMIT}&_=${Date.now()}`);
-  if (!res.ok) throw new Error(`Failed to fetch card wire: ${res.status}`);
-  const { changes } = await res.json();
-
-  if (changes.length >= FETCH_LIMIT) {
-    console.log(`  Warning: hit the ${FETCH_LIMIT}-row fetch cap — the oldest changes in the window may be missing.`);
-  }
-
-  const cutoff = Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000;
-  return changes.filter(
-    c => c.field === 'signup_bonus_value' && new Date(c.changed_at).getTime() >= cutoff
-  );
-}
-
-/**
- * A card can move more than once in a week (or flip units mid-week). Collapse
- * each card to one net change: oldest old_value -> newest new_value, using
- * only the rows that share the card's most recent unit, since values in
- * different units aren't comparable. Cards that net out flat are dropped.
- */
-function collapsePerCard(rows) {
-  const byCard = new Map();
-  for (const row of rows) {
-    if (!byCard.has(row.card_id)) byCard.set(row.card_id, []);
-    byCard.get(row.card_id).push(row);
-  }
-
-  const collapsed = [];
-  for (const cardRows of byCard.values()) {
-    cardRows.sort((a, b) => new Date(a.changed_at) - new Date(b.changed_at));
-
-    const latest = cardRows[cardRows.length - 1];
-    const sameUnit = cardRows.filter(r => r.unit === latest.unit);
-    const first = sameUnit[0];
-
-    const oldNum = parseFloat(first.old_value);
-    const newNum = parseFloat(latest.new_value);
-    if (Number.isNaN(oldNum) || Number.isNaN(newNum) || oldNum === newNum) continue;
-
-    // A value of 0 is real data: it means the public sees no bonus amount.
-    // Cards that simply have no bonus omit `signup_bonus` entirely, so a 0 here
-    // is always a deliberate statement about the public offer, and a move to or
-    // from it is a genuine change worth reporting.
-    collapsed.push({
-      cardName: shortenCardName(latest.card_name),
-      unit: latest.unit,
-      oldValue: first.old_value,
-      newValue: latest.new_value,
-      oldNum,
-      newNum,
-      // Approximate cash value of the swing, so changes rank against each other
-      // across units. Ordering only — never shown in the post.
-      weight: Math.abs(newNum - oldNum) * (UNIT_VALUE_USD[latest.unit] ?? 0.015),
-      changedAt: latest.changed_at,
-    });
-  }
-  return collapsed;
 }
 
 function renderLine(change) {
@@ -226,44 +107,15 @@ function buildPostText(increases, decreases) {
   return { text: render(totalItems - shown), shown, total: totalItems };
 }
 
-function buildLinkUrl() {
-  const url = new URL(CARD_WIRE_URL);
-  url.searchParams.set('utm_source', 'twitter');
-  url.searchParams.set('utm_medium', 'social');
-  url.searchParams.set('utm_campaign', 'weekly-sub-changes');
-  url.searchParams.set('utm_content', `weekly-${new Date().toISOString().slice(0, 10)}`);
-  return url.toString();
-}
-
 async function queuePost(textContent, linkUrl, sourceId) {
-  const apiUrl = process.env.SOCIAL_API_URL;
-  const apiKey = process.env.SOCIAL_API_KEY;
-  if (!apiUrl || !apiKey) throw new Error('SOCIAL_API_URL and SOCIAL_API_KEY are required');
-
   // No `platforms` key: fan out to every connected account (X/@CreditOdds,
   // Facebook, LinkedIn), matching post-weekly-top-cards.js.
-  const body = {
+  return queueSocialPost({
     text_content: textContent,
     link_url: linkUrl,
     source_type: 'weekly-sub-changes',
     source_id: sourceId,
-  };
-
-  const response = await fetchWithRetry(`${apiUrl}/social/queue`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-    },
-    body: JSON.stringify(body),
   });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Queue API error: ${response.status} - ${errorText}`);
-  }
-
-  return response.json();
 }
 
 async function main() {
@@ -291,7 +143,7 @@ async function main() {
   }
 
   const { text, shown, total } = buildPostText(increases, decreases);
-  const linkUrl = buildLinkUrl();
+  const linkUrl = buildCardWireLink('twitter', 'weekly-sub-changes');
   const sourceId = `weekly-sub-${new Date().toISOString().slice(0, 10)}`;
 
   console.log(`\nPost text (${tweetLength(text)} weighted chars, ${shown}/${total} shown):\n`);


### PR DESCRIPTION
## What

Monday counterpart to the Thursday weekly SUB changes tweet, targeted at r/creditodds via the Social Posting Service's manual Reddit flow.

- `scripts/lib/weekly-sub-changes.js`: card-wire fetch/collapse logic extracted from `post-weekly-sub-changes.js` (no behavior change to the Thursday post; dry-run output verified identical).
- `scripts/post-weekly-sub-changes-reddit.js`: renders the FULL week of net changes (Reddit has no length pressure) and sends it with `platforms: ["reddit"]` + `publish_now: true` + a per-day idempotency key. `publish_now` runs synchronously, so it works even while the service scheduler rule is disabled.
- `.github/workflows/weekly-sub-changes-reddit.yml`: Mondays 15:00 UTC + manual dispatch. Uses the existing `SOCIAL_API_URL`/`SOCIAL_API_KEY` secrets.

Nothing auto-publishes to Reddit: the service records a pre-filled `reddit.com/r/creditodds/submit` URL as a `pending_manual` result, and the post shows in the service UI's History with a "Post now" link that opens Reddit's composer with title and body filled in.

The body is plain text on purpose. Reddit's submit page opens in the rich-text editor, which takes pre-filled text literally, so markdown tables/bold would post as visible asterisks and pipes (verified against the live composer).

## Depends on

CreditOdds/social-posting-service PR reinstating the manual reddit platform (module + migration 008) — until that is deployed and the reddit account row re-activated, this workflow's queue call fails with "No active platforms".