### PR TITLE
feat(landing): 3D dice icon with hover roll on Approval odds tile

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -701,9 +701,34 @@ function FooterBlocks({ cards }: { cards: LandingCard[] }) {
             </p>
             <div className="tool-mini-grid">
               <Link href="/check-odds" className="tmini odds">
-                <div>
-                  <div className="nm">Approval odds</div>
-                  <div className="v">Real probability · live data</div>
+                <div className="odds-left">
+                  <svg className="odds-dice" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 3 L20 7.5 L12 12 L4 7.5 Z" fill="rgba(255,255,255,0.45)" />
+                    <path d="M12 12 L20 7.5 V16.5 L12 21 Z" fill="rgba(255,255,255,0.22)" />
+                    <path d="M4 7.5 L12 12 V21 L4 16.5 Z" fill="rgba(255,255,255,0.08)" />
+                    <path
+                      d="M12 3 L20 7.5 V16.5 L12 21 L4 16.5 V7.5 Z"
+                      stroke="#fff"
+                      strokeWidth="1.5"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M4 7.5 L12 12 L20 7.5 M12 12 V21"
+                      stroke="#fff"
+                      strokeWidth="1.5"
+                      strokeLinejoin="round"
+                    />
+                    <ellipse cx="12" cy="7.5" rx="1.7" ry="1.05" fill="#fff" />
+                    <ellipse cx="6.3" cy="12.4" rx="0.95" ry="1.15" fill="#fff" />
+                    <ellipse cx="9.7" cy="16.4" rx="0.95" ry="1.15" fill="#fff" />
+                    <ellipse cx="14.3" cy="12.6" rx="0.95" ry="1.15" fill="#fff" />
+                    <ellipse cx="16" cy="14.3" rx="0.95" ry="1.15" fill="#fff" />
+                    <ellipse cx="17.7" cy="16" rx="0.95" ry="1.15" fill="#fff" />
+                  </svg>
+                  <div>
+                    <div className="nm">Approval odds</div>
+                    <div className="v">Real probability · live data</div>
+                  </div>
                 </div>
                 <span style={{ fontSize: 18 }}>→</span>
               </Link>

--- a/apps/web-next/src/app/landing-v3.css
+++ b/apps/web-next/src/app/landing-v3.css
@@ -725,9 +725,47 @@
 .landing-v3 .tmini.odds:hover {
   background: var(--accent-deep);
 }
+.landing-v3 .tmini.odds .odds-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.landing-v3 .odds-dice {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  transform-origin: center;
+}
+.landing-v3 .tmini.odds:hover .odds-dice {
+  animation: dice-roll 0.8s cubic-bezier(0.3, 0.7, 0.4, 1) both;
+}
+@keyframes dice-roll {
+  0% {
+    transform: translateY(0) rotate(0deg);
+  }
+  30% {
+    transform: translateY(-9px) rotate(150deg);
+  }
+  55% {
+    transform: translateY(0) rotate(265deg);
+  }
+  72% {
+    transform: translateY(-4px) rotate(325deg);
+  }
+  88%,
+  100% {
+    transform: translateY(0) rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .landing-v3 .tmini.odds:hover .odds-dice {
+    animation: none;
+  }
+}
 .landing-v3 .tmini.odds .nm {
   color: #fff;
   font-size: 14px;
+  padding-left: 0;
 }
 .landing-v3 .tmini.odds .v {
   color: rgba(255, 255, 255, 0.85);


### PR DESCRIPTION
## Summary
- Fill the empty logo slot on the **Approval odds** tile in the landing page Free calculators grid with an inline white isometric dice SVG (three shaded faces, perspective-squashed pips) matching the v2 line style
- On hover the dice bounces and rolls: a 0.8s 360deg tumble with a big hop and a smaller settle bounce, replaying on each hover
- Respects `prefers-reduced-motion` (static dice, no animation)

## Notes
- Pure inline SVG + CSS, no new assets or JS
- The other tool tiles keep their absolute-positioned 16px logos; the odds tile switches its left side to a flex group so the dice is vertically centered, and drops the now-unneeded 22px text inset

## Test plan
- Verified on local dev server: dice renders white on the purple tile at desktop and mobile widths, no console errors
- Hover starts the `dice-roll` animation; scrubbing the timeline confirms the keyframe transforms (150deg/-9px hop, 265deg landing, 325deg/-4px rebound, rest at 360deg)