### PR TITLE
fix(web): pin date formatting to UTC in hydrated client components (React #418)

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -186,7 +186,10 @@ function formatNewsDate(dateStr: string): string {
   try {
     const d = new Date(dateStr);
     if (isNaN(d.getTime())) return dateStr;
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    // timeZone: 'UTC' keeps SSR and client output identical — date-only
+    // strings parse as UTC midnight, so local-zone formatting shifts the day
+    // for visitors west of UTC and breaks hydration.
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
   } catch {
     return dateStr;
   }

--- a/apps/web-next/src/app/best/BestV2Client.tsx
+++ b/apps/web-next/src/app/best/BestV2Client.tsx
@@ -17,7 +17,9 @@ function formatShortDate(iso?: string): string {
   if (!iso) return '';
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  // timeZone: 'UTC' keeps SSR and client output identical — local-zone
+  // formatting shifts the day for visitors west of UTC and breaks hydration.
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
 }
 
 export default function BestV2Client({

--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -107,10 +107,13 @@ function changeDirection(
 function formatDay(ts: string): string {
   const d = new Date(ts);
   if (Number.isNaN(d.getTime())) return ts;
+  // timeZone: 'UTC' keeps SSR and client output identical — local-zone
+  // formatting shifts the day for visitors west of UTC and breaks hydration.
   return d.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
 }
 
@@ -120,6 +123,7 @@ function formatDayShort(ts: string): string {
   return d.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
   });
 }
 

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -187,10 +187,14 @@ function WireChip({
 
   if (!entry) return null;
 
+  // timeZone: "UTC" on the date formats below keeps SSR and client output
+  // identical — local-zone formatting shifts the day for visitors west of
+  // UTC and breaks hydration.
   const date = new Date(entry.changed_at).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
     year: "2-digit",
+    timeZone: "UTC",
   });
 
   const dir = wireDirection(entry.field, entry.old_value, entry.new_value);
@@ -576,6 +580,7 @@ export default function CardClient({
           : new Date(asOfTs).toLocaleDateString("en-US", {
               month: "short",
               year: "numeric",
+              timeZone: "UTC",
             }),
     };
   }, [card.signup_bonus, wire]);
@@ -1636,7 +1641,7 @@ export default function CardClient({
                 {newsEntries.map((n, i) => {
                   const dateText = new Date(n.date).toLocaleDateString(
                     "en-US",
-                    { year: "numeric", month: "short", day: "numeric" },
+                    { year: "numeric", month: "short", day: "numeric", timeZone: "UTC" },
                   );
                   const tag = n.tags[0] as NewsTag | undefined;
                   return (
@@ -1685,6 +1690,7 @@ export default function CardClient({
                         year: "numeric",
                         month: "short",
                         day: "numeric",
+                        timeZone: "UTC",
                       })
                     : "";
                   return (
@@ -1742,7 +1748,7 @@ export default function CardClient({
                   const dirClass = dir ? ` cj-wire-${dir}` : "";
                   const date = new Date(w.changed_at).toLocaleDateString(
                     "en-US",
-                    { month: "short", day: "numeric" },
+                    { month: "short", day: "numeric", timeZone: "UTC" },
                   );
                   return (
                     <li key={w.id} className="cj-wire-rail-row">

--- a/apps/web-next/src/app/card/[name]/CardRecordsTable.tsx
+++ b/apps/web-next/src/app/card/[name]/CardRecordsTable.tsx
@@ -10,7 +10,9 @@ function formatMonth(dateStr: string | null): string {
   if (!dateStr) return '—';
   const d = new Date(dateStr);
   if (Number.isNaN(d.getTime())) return '—';
-  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
+  // timeZone: 'UTC' keeps SSR and client output identical — local-zone
+  // formatting shifts the day for visitors west of UTC and breaks hydration.
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', timeZone: 'UTC' });
 }
 
 function formatInquiries(r: CardRecord): string {

--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -43,13 +43,16 @@ const TAG_DISPLAY: Record<NewsTag, string> = {
 function formatDate(iso: string) {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  // timeZone: 'UTC' keeps SSR and client output identical — date-only strings
+  // parse as UTC midnight, so local-zone formatting shifts the day for
+  // visitors west of UTC and breaks hydration.
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
 }
 
 function formatDateShort(iso: string) {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
 }
 
 function primaryTag(item: NewsItem): NewsTag {

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -858,7 +858,7 @@ export default function ProfileClient() {
                   <li key={n.id} className="cj-rail-row">
                     <div className="cj-rail-row-meta">
                       <span className="cj-rail-row-date">
-                        {new Date(n.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                        {new Date(n.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })}
                       </span>
                       {n.tags?.[0] && (
                         <span className={`cj-news-tag cj-news-tag--${n.tags[0]}`}>
@@ -1863,7 +1863,7 @@ function MobileNewsView({ relevantNews, walletCardsCount }: { relevantNews: News
               </span>
               <div>
                 <div className="cj-mob-news-meta">
-                  <span>{new Date(n.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+                  <span>{new Date(n.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })}</span>
                   <span style={{ color: 'var(--muted-2)' }}>·</span>
                   {n.tags?.[0] && (
                     <span className={`cj-mob-news-tag cj-mob-news-tag--${n.tags[0]}`}>

--- a/apps/web-next/src/components/news/NewsTable.tsx
+++ b/apps/web-next/src/components/news/NewsTable.tsx
@@ -11,10 +11,14 @@ const PAGE_SIZE = 15;
 
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
+  // timeZone: 'UTC' keeps SSR and client output identical — date-only strings
+  // parse as UTC midnight, so local-zone formatting shifts the day for
+  // visitors west of UTC and breaks hydration.
   return date.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
   });
 }
 

--- a/apps/web-next/src/components/tools/PaginatedNewsList.tsx
+++ b/apps/web-next/src/components/tools/PaginatedNewsList.tsx
@@ -34,7 +34,7 @@ export default function PaginatedNewsList({
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0">
                 <p className="text-xs text-gray-500">
-                  {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                  {new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}
                 </p>
                 <p className="text-sm font-medium text-gray-900 mt-1">
                   {item.body ? (


### PR DESCRIPTION
## Problem

PostHog issue [019f3de2](https://us.posthog.com/error_tracking/019f3de2-821b-7232-8e9b-354c450419e7): minified React error #418 (hydration failed: server-rendered **text** didn't match the client).

Date-only strings like news dates (`"2026-07-09"`) parse as **UTC midnight**, and `toLocaleDateString('en-US', ...)` formats in the runtime's local zone. The server (UTC on Amplify) renders "Jul 9" while every browser west of UTC renders "Jul 8" during hydration of the same markup — a guaranteed text-node mismatch for essentially all US visitors, on every page that shows these dates.

Reproduced locally by running the dev server with `TZ=UTC`:

| | SSR HTML | Client (America/New_York) |
|---|---|---|
| Before | Jul 9, Jun 30, Jul 7, May 2 | **Jul 8, Jun 29, Jul 6, May 1** + PostHog `$exception` |
| After | Jul 9, Jun 30, Jul 7, May 2 | Jul 9, Jun 30, Jul 7, May 2 — no exception |

## Fix

Add `timeZone: 'UTC'` to every `toLocaleDateString` call in client components whose output appears in server-rendered HTML, mirroring the existing `formatExpiresDate` fix in CardClient (which documented this exact day-slip pitfall):

- LandingClient (editorial lane news/article dates)
- NewsV2Client, NewsTable, PaginatedNewsList
- CardWireV2Client (day group headers, last-update stamp)
- CardClient (wire chips, "as of", news/article/wire rails)
- CardRecordsTable (approval months)
- BestV2Client (last refresh / updated dates)
- ProfileClient news dates (render post-mount, fixed for display correctness — a Jul 9 item showed "Jul 8" for US users)

Server components and post-fetch admin timestamps are untouched (no hydration surface).

Verified: eslint zero warnings, `tsc --noEmit` clean, landing / news / card-wire / best / card pages load with no hydration exception under `TZ=UTC` SSR.