### PR TITLE
Test Wells Fargo Reflect affiliate link

### DIFF
--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -147,7 +147,11 @@ export default async function BestDetailPage({ params }: Props) {
       </section>
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>
-        <BestRankingViews cards={enrichedCards} panel={page.panel} />
+        <BestRankingViews
+          cards={enrichedCards}
+          panel={page.panel}
+          bestPageSlug={page.slug}
+        />
 
         <Link
           href="/best"

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -33,7 +33,7 @@ import CardyComparePopup from "@/components/ui/CardyComparePopup";
 import { CreditCardSchema, BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { categoryLabels, CategoryIcon } from "@/lib/cardDisplayUtils";
-import { withApplySource } from "@/lib/applyLink";
+import { resolveApplyLink, withApplySource } from "@/lib/applyLink";
 import posthog from "posthog-js";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import CardRecordsTable from "./CardRecordsTable";
@@ -262,6 +262,35 @@ function SubmitParamWatcher({ slug, onTrigger }: { slug: string; onTrigger: () =
     }
   }, [searchParams, authState.isAuthenticated, slug, router, onTrigger]);
   return null;
+}
+
+function DirectApplyLink({
+  cardSlug,
+  defaultUrl,
+  onClick,
+}: {
+  cardSlug: string;
+  defaultUrl: string;
+  onClick: () => void;
+}) {
+  const searchParams = useSearchParams();
+  const href = resolveApplyLink({
+    cardSlug,
+    defaultUrl,
+    source: searchParams.get('from'),
+  });
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={onClick}
+      className="cj-apply-btn"
+    >
+      Apply now
+    </a>
+  );
 }
 
 export default function CardClient({
@@ -631,15 +660,25 @@ export default function CardClient({
       {card.accepting_applications ? (
         <>
           {(card.special_apply_link || card.apply_link) && (
-            <a
-              href={withApplySource(card.special_apply_link || card.apply_link!)}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => handleCardApplyClick("direct")}
-              className="cj-apply-btn"
+            <Suspense
+              fallback={(
+                <a
+                  href={withApplySource(card.special_apply_link || card.apply_link!)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => handleCardApplyClick("direct")}
+                  className="cj-apply-btn"
+                >
+                  Apply now
+                </a>
+              )}
             >
-              Apply now
-            </a>
+              <DirectApplyLink
+                cardSlug={card.slug}
+                defaultUrl={card.special_apply_link || card.apply_link!}
+                onClick={() => handleCardApplyClick("direct")}
+              />
+            </Suspense>
           )}
           {randomReferralUrl && (
             <a

--- a/apps/web-next/src/components/best/ApplyButtons.tsx
+++ b/apps/web-next/src/components/best/ApplyButtons.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link';
 
 interface ApplyButtonsProps {
-  slug: string;
+  href: string;
 }
 
-export function ApplyButtons({ slug }: ApplyButtonsProps) {
+export function ApplyButtons({ href }: ApplyButtonsProps) {
   return (
     <Link
-      href={`/card/${slug}`}
+      href={href}
       className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 transition-colors"
     >
       View Card Details

--- a/apps/web-next/src/components/best/BestCardList.tsx
+++ b/apps/web-next/src/components/best/BestCardList.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Card } from '@/lib/api';
 import { BestPageCard, BestPanel } from '@/lib/best';
 import { ApplyButtons } from './ApplyButtons';
+import { bestCardDetailHref } from '@/lib/applyLink';
 import {
   formatEstimatedValue,
   formatBonusValue,
@@ -20,6 +21,7 @@ interface BestCardListProps {
   panel?: BestPanel;
   /** 'consensus', a model key, or undefined when no panel is available. */
   activeView?: string;
+  bestPageSlug: string;
 }
 
 /**
@@ -63,7 +65,7 @@ function RankChange({ currentRank, previousRank }: { currentRank: number; previo
   );
 }
 
-export function BestCardList({ cards, activeView }: BestCardListProps) {
+export function BestCardList({ cards, activeView, bestPageSlug }: BestCardListProps) {
   const isConsensus = !activeView || activeView === 'consensus';
   return (
     <div className="space-y-6">
@@ -71,6 +73,7 @@ export function BestCardList({ cards, activeView }: BestCardListProps) {
         const { card } = entry;
         const rank = index + 1;
         const topRewards = (card.rewards || []).slice(0, 3);
+        const cardHref = bestCardDetailHref(card.slug, bestPageSlug);
 
         return (
           <div
@@ -82,7 +85,7 @@ export function BestCardList({ cards, activeView }: BestCardListProps) {
               <span className="flex items-center justify-center w-8 h-8 rounded-full bg-indigo-600 text-white text-sm font-bold flex-shrink-0">
                 {rank}
               </span>
-              <Link href={`/card/${card.slug}`} className="text-lg font-bold text-gray-900 hover:text-indigo-600 transition-colors">
+              <Link href={cardHref} className="text-lg font-bold text-gray-900 hover:text-indigo-600 transition-colors">
                 {card.card_name}
               </Link>
               {isConsensus && entry.badge && (
@@ -100,7 +103,7 @@ export function BestCardList({ cards, activeView }: BestCardListProps) {
               <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
                 {/* Card image */}
                 <div className="flex-shrink-0">
-                  <Link href={`/card/${card.slug}`}>
+                  <Link href={cardHref}>
                     <CardImage
                       cardImageLink={card.card_image_link}
                       alt={card.card_name}
@@ -184,7 +187,7 @@ export function BestCardList({ cards, activeView }: BestCardListProps) {
                   )}
 
                   {/* Card details link */}
-                  <ApplyButtons slug={card.slug} />
+                  <ApplyButtons href={cardHref} />
                 </div>
               </div>
             </div>

--- a/apps/web-next/src/components/best/BestComparisonTable.tsx
+++ b/apps/web-next/src/components/best/BestComparisonTable.tsx
@@ -2,6 +2,7 @@ import CardImage from '@/components/ui/CardImage';
 import Link from 'next/link';
 import { Card } from '@/lib/api';
 import { BestPageCard } from '@/lib/best';
+import { bestCardDetailHref } from '@/lib/applyLink';
 import {
   formatAnnualFee,
   formatBonusValue,
@@ -16,6 +17,7 @@ interface EnrichedCard extends BestPageCard {
 
 interface BestComparisonTableProps {
   cards: EnrichedCard[];
+  bestPageSlug: string;
 }
 
 function getTopRewardLabel(card: Card): string {
@@ -71,7 +73,7 @@ function RankChangeSmall({ currentRank, previousRank }: { currentRank: number; p
   );
 }
 
-export function BestComparisonTable({ cards }: BestComparisonTableProps) {
+export function BestComparisonTable({ cards, bestPageSlug }: BestComparisonTableProps) {
   if (cards.length === 0) return null;
 
   // Determine which columns to show based on data
@@ -108,6 +110,7 @@ export function BestComparisonTable({ cards }: BestComparisonTableProps) {
           <tbody className="divide-y divide-gray-200">
             {cards.map((entry, index) => {
               const { card } = entry;
+              const cardHref = bestCardDetailHref(card.slug, bestPageSlug);
               return (
                 <tr key={card.slug} className="hover:bg-gray-50 transition-colors">
                   <td className="px-4 py-3 whitespace-nowrap">
@@ -120,7 +123,7 @@ export function BestComparisonTable({ cards }: BestComparisonTableProps) {
                   </td>
                   <td className="px-4 py-3 align-top">
                     <div className="flex items-start gap-3 min-w-0">
-                      <Link href={`/card/${card.slug}`} className="flex-shrink-0">
+                      <Link href={cardHref} className="flex-shrink-0">
                         <CardImage
                           cardImageLink={card.card_image_link}
                           alt={card.card_name}
@@ -131,7 +134,7 @@ export function BestComparisonTable({ cards }: BestComparisonTableProps) {
                       </Link>
                       <div className="min-w-0">
                         <Link
-                          href={`/card/${card.slug}`}
+                          href={cardHref}
                           className="block text-sm font-medium text-indigo-600 hover:text-indigo-900 break-words leading-snug"
                         >
                           {card.card_name}

--- a/apps/web-next/src/components/best/BestRankingViews.tsx
+++ b/apps/web-next/src/components/best/BestRankingViews.tsx
@@ -12,11 +12,12 @@ type EnrichedCard = BestPageCard & { card: Card };
 interface BestRankingViewsProps {
   cards: EnrichedCard[];
   panel?: BestPanel;
+  bestPageSlug: string;
 }
 
 const CONSENSUS = 'consensus';
 
-export function BestRankingViews({ cards, panel }: BestRankingViewsProps) {
+export function BestRankingViews({ cards, panel, bestPageSlug }: BestRankingViewsProps) {
   const models = panel?.models ?? [];
   // Only offer per-model views when we have a real panel (2+ models) and the
   // cards actually carry per-model ranks.
@@ -82,8 +83,13 @@ export function BestRankingViews({ cards, panel }: BestRankingViewsProps) {
         </div>
       )}
 
-      <BestComparisonTable cards={ordered} />
-      <BestCardList cards={ordered} panel={panel} activeView={hasPanel ? view : undefined} />
+      <BestComparisonTable cards={ordered} bestPageSlug={bestPageSlug} />
+      <BestCardList
+        cards={ordered}
+        panel={panel}
+        activeView={hasPanel ? view : undefined}
+        bestPageSlug={bestPageSlug}
+      />
     </>
   );
 }

--- a/apps/web-next/src/lib/applyLink.test.ts
+++ b/apps/web-next/src/lib/applyLink.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REFLECT_TEST_APPLY_LINK,
+  bestCardDetailHref,
+  resolveApplyLink,
+} from './applyLink';
+
+const DEFAULT_REFLECT_URL = 'https://creditcards.wellsfargo.com/reflect-visa-credit-card';
+
+describe('Wells Fargo Reflect best-page apply-link test', () => {
+  it('marks only the Reflect link on the targeted best page', () => {
+    expect(bestCardDetailHref('wells-fargo-reflect', 'best-0-apr-cards')).toBe(
+      '/card/wells-fargo-reflect?from=best-0-apr-cards',
+    );
+    expect(bestCardDetailHref('wells-fargo-reflect', 'best-balance-transfer-cards')).toBe(
+      '/card/wells-fargo-reflect',
+    );
+    expect(bestCardDetailHref('chase-slate-edge', 'best-0-apr-cards')).toBe(
+      '/card/chase-slate-edge',
+    );
+  });
+
+  it('uses the exact Acclaim link for the targeted cohort during the test', () => {
+    expect(resolveApplyLink({
+      cardSlug: 'wells-fargo-reflect',
+      defaultUrl: DEFAULT_REFLECT_URL,
+      source: 'best-0-apr-cards',
+      now: new Date('2026-07-15T12:00:00.000Z'),
+    })).toBe(REFLECT_TEST_APPLY_LINK);
+  });
+
+  it('keeps the regular link for direct and unrelated traffic', () => {
+    const direct = resolveApplyLink({
+      cardSlug: 'wells-fargo-reflect',
+      defaultUrl: DEFAULT_REFLECT_URL,
+      source: null,
+      now: new Date('2026-07-15T12:00:00.000Z'),
+    });
+
+    expect(direct).toContain('creditcards.wellsfargo.com/reflect-visa-credit-card');
+    expect(direct).toContain('utm_source=creditodds');
+  });
+
+  it('automatically expires the override after seven days', () => {
+    const expired = resolveApplyLink({
+      cardSlug: 'wells-fargo-reflect',
+      defaultUrl: DEFAULT_REFLECT_URL,
+      source: 'best-0-apr-cards',
+      now: new Date('2026-07-21T02:40:00.000Z'),
+    });
+
+    expect(expired).toContain('creditcards.wellsfargo.com/reflect-visa-credit-card');
+    expect(expired).not.toBe(REFLECT_TEST_APPLY_LINK);
+  });
+});

--- a/apps/web-next/src/lib/applyLink.ts
+++ b/apps/web-next/src/lib/applyLink.ts
@@ -1,6 +1,15 @@
 const UTM_SOURCE = 'creditodds';
 const UTM_MEDIUM = 'referral';
 
+export const REFLECT_TEST_SOURCE = 'best-0-apr-cards';
+export const REFLECT_TEST_CARD_SLUG = 'wells-fargo-reflect';
+export const REFLECT_TEST_APPLY_LINK =
+  'https://track.acclaimnetwork.com/apn/click?b2s=302211&SUBID=PARAM&praff=5747';
+
+// Exactly seven days from the test launch (July 13 at 10:40 p.m. ET).
+export const REFLECT_TEST_START = new Date('2026-07-14T02:40:00.000Z');
+export const REFLECT_TEST_END = new Date('2026-07-21T02:40:00.000Z');
+
 export function withApplySource(url: string | undefined | null): string | undefined {
   if (!url) return undefined;
 
@@ -18,4 +27,43 @@ export function withApplySource(url: string | undefined | null): string | undefi
   } catch {
     return url;
   }
+}
+
+export function bestCardDetailHref(cardSlug: string, bestPageSlug: string): string {
+  const path = `/card/${cardSlug}`;
+  if (
+    cardSlug !== REFLECT_TEST_CARD_SLUG ||
+    bestPageSlug !== REFLECT_TEST_SOURCE
+  ) {
+    return path;
+  }
+
+  return `${path}?from=${REFLECT_TEST_SOURCE}`;
+}
+
+interface ResolveApplyLinkOptions {
+  cardSlug: string;
+  defaultUrl: string | undefined | null;
+  source: string | undefined | null;
+  now?: Date;
+}
+
+export function resolveApplyLink({
+  cardSlug,
+  defaultUrl,
+  source,
+  now = new Date(),
+}: ResolveApplyLinkOptions): string | undefined {
+  if (
+    cardSlug === REFLECT_TEST_CARD_SLUG &&
+    source === REFLECT_TEST_SOURCE &&
+    now >= REFLECT_TEST_START &&
+    now < REFLECT_TEST_END
+  ) {
+    // Preserve the Acclaim URL exactly as supplied; its tracking parameters
+    // replace CreditOdds' usual UTM decoration for this test cohort.
+    return REFLECT_TEST_APPLY_LINK;
+  }
+
+  return withApplySource(defaultUrl);
 }


### PR DESCRIPTION
## What changed

- preserve the `/best/best-0-apr-cards` origin when visitors open Wells Fargo Reflect
- use the exact Acclaim tracking URL for that cohort without adding CreditOdds referral parameters
- retain the regular Wells Fargo URL for every other source
- expire the override automatically after exactly seven days

## Validation

- `npm test -w @creditodds/web-next` (63 tests)
- `npm run lint -w @creditodds/web-next`
- `npm run build -w @creditodds/web-next`
- `git diff --check`