### PR TITLE
Capitalize Best Cards labels

### DIFF
--- a/apps/web-next/src/app/best/[slug]/page.tsx
+++ b/apps/web-next/src/app/best/[slug]/page.tsx
@@ -87,7 +87,7 @@ export default async function BestDetailPage({ params }: Props) {
 
       <div className="cj-terminal">
         <nav className="cj-crumbs" aria-label="Breadcrumb">
-          <Link href="/best" className="cj-crumb">Best cards</Link>
+          <Link href="/best" className="cj-crumb">Best Cards</Link>
           <span className="cj-sep">/</span>
           <span className="cj-crumb cj-crumb-current" aria-current="page">{page.title}</span>
         </nav>

--- a/apps/web-next/src/components/landing-v2/Chrome.tsx
+++ b/apps/web-next/src/components/landing-v2/Chrome.tsx
@@ -87,7 +87,7 @@ export function V2Footer() {
           <div>
             <h4>Content</h4>
             <Link href="/articles">Articles</Link>
-            <Link href="/best">Best cards</Link>
+            <Link href="/best">Best Cards</Link>
             <Link href="/best-card-for">Best card by store</Link>
             <Link href="/best-card-for-me">Best card for me</Link>
             <Link href="/news">Card news</Link>


### PR DESCRIPTION
## What changed

- capitalize the `/best` breadcrumb label as “Best Cards”
- apply the same capitalization to the footer navigation label

## Why

The destination name should use consistent title casing everywhere it appears in site navigation.

## Validation

- `npm run lint -w @creditodds/web-next`
- `git diff --check`