### PR TITLE
Remove Approval rate by FICO score bar chart from card pages

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -89,24 +89,6 @@ function getStableReferralIndex(cardKey: string, referralCount: number): number 
 
 const MIN_DATA_POINTS_FOR_CHARTS = 5;
 
-const FICO_BUCKETS: { label: string; min: number; max: number }[] = [
-  { label: "790+", min: 790, max: 850 },
-  { label: "760–789", min: 760, max: 789 },
-  { label: "730–759", min: 730, max: 759 },
-  { label: "700–729", min: 700, max: 729 },
-  { label: "670–699", min: 670, max: 699 },
-  { label: "< 670", min: 0, max: 669 },
-];
-
-function bucketize(
-  pairs: [number, number][],
-  buckets: { min: number; max: number }[],
-): number[] {
-  return buckets.map(
-    (b) => pairs.filter((p) => p[0] >= b.min && p[0] <= b.max).length,
-  );
-}
-
 // Returns 'pos' (good for the cardholder), 'neg' (worse), or null.
 // `annual_fee`, `apr_min`, `apr_max` are inverted — lower is better.
 function wireDirection(
@@ -417,15 +399,6 @@ export default function CardClient({
   );
   const hasChartThree = chartThree.some(
     (s) => Array.isArray(s) && s.length > 0,
-  );
-
-  const acceptedBuckets = bucketize(chartOne[0] || [], FICO_BUCKETS);
-  const rejectedBuckets = bucketize(chartOne[1] || [], FICO_BUCKETS);
-  const maxBucketTotal = Math.max(
-    1,
-    ...FICO_BUCKETS.map(
-      (_, i) => acceptedBuckets[i] + rejectedBuckets[i],
-    ),
   );
 
   const sortedRewards = useMemo<Reward[]>(
@@ -1414,70 +1387,6 @@ export default function CardClient({
                   <div className="cj-stat">
                     <div className="cj-stat-k">Credit history</div>
                     <div className="cj-stat-v">{creditLength ?? "—"}</div>
-                  </div>
-                </div>
-
-                <div style={{ marginTop: 24 }}>
-                  <div className="cj-table-label">
-                    Approval rate by FICO score
-                  </div>
-                  <div className="cj-bars">
-                    {FICO_BUCKETS.map((b, i) => {
-                      const a = acceptedBuckets[i];
-                      const r = rejectedBuckets[i];
-                      const total = a + r;
-                      const aPct =
-                        total > 0 ? (a / maxBucketTotal) * 100 : 0;
-                      const rPct =
-                        total > 0 ? (r / maxBucketTotal) * 100 : 0;
-                      const rate =
-                        total > 0 ? Math.round((a / total) * 100) : null;
-                      return (
-                        <div key={b.label} className="cj-bar-row">
-                          <span className="cj-bar-label">{b.label}</span>
-                          {total > 0 ? (
-                            <span className="cj-bar-track">
-                              <span
-                                className="cj-bar-app"
-                                style={{ width: `${aPct}%` }}
-                              />
-                              <span
-                                className="cj-bar-den"
-                                style={{ width: `${rPct}%` }}
-                              />
-                            </span>
-                          ) : (
-                            <span className="cj-bar-track">
-                              <span
-                                className="cj-bar-empty"
-                                style={{ padding: "0 6px", fontSize: 10 }}
-                              >
-                                no data
-                              </span>
-                            </span>
-                          )}
-                          <span className="cj-bar-n">
-                            {rate !== null ? `${rate}%` : "—"}
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  <div className="cj-bar-legend">
-                    <span>
-                      <span
-                        className="cj-bar-legend-swatch"
-                        style={{ background: "var(--accent)" }}
-                      />
-                      Approved
-                    </span>
-                    <span>
-                      <span
-                        className="cj-bar-legend-swatch"
-                        style={{ background: "var(--warn)", opacity: 0.4 }}
-                      />
-                      Denied
-                    </span>
                   </div>
                 </div>
 

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7770,46 +7770,6 @@
   line-height: 1;
 }
 
-.landing-v2 .cj-bars {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-}
-.landing-v2 .cj-bar-row {
-  display: grid;
-  grid-template-columns: 88px 1fr 52px;
-  gap: 10px;
-  align-items: center;
-  font-family: var(--font-inter), sans-serif;
-  font-size: 11px;
-}
-.landing-v2 .cj-bar-label { color: var(--muted); }
-.landing-v2 .cj-bar-track {
-  height: 14px;
-  background: var(--line);
-  border-radius: 2px;
-  overflow: hidden;
-  display: flex;
-}
-.landing-v2 .cj-bar-app { background: var(--accent); }
-.landing-v2 .cj-bar-den { background: var(--warn); opacity: 0.4; }
-.landing-v2 .cj-bar-n { text-align: right; color: var(--ink); }
-.landing-v2 .cj-bar-empty { color: var(--muted-2); font-style: italic; }
-.landing-v2 .cj-bar-legend {
-  display: flex;
-  gap: 14px;
-  font-family: var(--font-inter), sans-serif;
-  font-size: 10.5px;
-  color: var(--muted);
-  margin-top: 10px;
-}
-.landing-v2 .cj-bar-legend-swatch {
-  display: inline-block;
-  width: 10px; height: 10px;
-  vertical-align: middle;
-  margin-right: 5px;
-}
-
 .landing-v2 .cj-tape {
   border: 1px solid var(--line-2);
 }

--- a/docs/removed-fico-approval-chart.md
+++ b/docs/removed-fico-approval-chart.md
@@ -1,0 +1,84 @@
+# Removed: "Approval rate by FICO score" bar chart (card pages)
+
+Removed 2026-07-14. This note documents how the chart worked so it can be
+restored if we bring it back. To restore, revert the removal PR (branch
+`remove/fico-approval-bar-chart`) or reimplement from the description below.
+
+## What it was
+
+A horizontal stacked bar chart on every card page (`/card/[name]`, rendered by
+`apps/web-next/src/app/card/[name]/CardClient.tsx`), shown in the "Charts" tab
+of the approval-odds section, between the Median FICO / Median income / Credit
+history stat strip and the scatter-plot tabs (Credit Score vs Income, etc.).
+
+It grouped self-reported application records into six FICO buckets and showed,
+per bucket, the approved vs denied split plus the approval percentage.
+
+## Data source
+
+No dedicated API. It reused `graphData[0]` (called `chartOne` in the
+component), the same series that feeds the "Credit Score vs Income" scatter
+plot:
+
+- `chartOne[0]` = accepted applications, as `[creditScore, income]` pairs
+- `chartOne[1]` = rejected applications, same shape
+
+Only index `[0]` of each pair (the credit score) was used; income was ignored.
+`graphData` comes into `CardClient` as a prop from the card page's server
+fetch, so removing the chart required no backend or data-pipeline changes.
+
+## Rendering logic (all in CardClient.tsx, removed in this change)
+
+1. **Buckets** — module-level constant:
+
+   ```ts
+   const FICO_BUCKETS = [
+     { label: "790+",    min: 790, max: 850 },
+     { label: "760–789", min: 760, max: 789 },
+     { label: "730–759", min: 730, max: 759 },
+     { label: "700–729", min: 700, max: 729 },
+     { label: "670–699", min: 670, max: 699 },
+     { label: "< 670",   min: 0,   max: 669 },
+   ];
+   ```
+
+2. **Bucketize helper** — counted pairs whose score fell in each bucket:
+
+   ```ts
+   function bucketize(pairs: [number, number][], buckets) {
+     return buckets.map(
+       (b) => pairs.filter((p) => p[0] >= b.min && p[0] <= b.max).length,
+     );
+   }
+   ```
+
+3. **Computed values** (in the component body's "Computed" section):
+   `acceptedBuckets = bucketize(chartOne[0] || [], FICO_BUCKETS)`,
+   `rejectedBuckets = bucketize(chartOne[1] || [], FICO_BUCKETS)`, and
+   `maxBucketTotal = max(1, max over buckets of accepted + rejected)`.
+
+4. **Bar math** — each row's approved segment width was
+   `(accepted / maxBucketTotal) * 100`% and the denied segment
+   `(rejected / maxBucketTotal) * 100`%, so bar length was proportional to
+   sample size across rows (the fullest bucket set the scale) while the
+   color split showed the approve/deny ratio within the bucket. The
+   right-hand number was `round(accepted / total * 100)`% for the bucket, or
+   an em dash for empty buckets ("no data" shown inside the empty track).
+
+5. **Legend** — Approved swatch `var(--accent)` (purple), Denied swatch
+   `var(--warn)` at 0.4 opacity, matching the scatter plots' accept/reject
+   coloring.
+
+6. **Visibility gate** — the whole odds section (this chart included) only
+   rendered when `card.total_records >= 5` (`MIN_DATA_POINTS_FOR_CHARTS`) and
+   `card.approved_count > 0`. Records missing a credit score simply fell out
+   of every bucket.
+
+## Markup and CSS
+
+JSX used a `cj-table-label` heading ("Approval rate by FICO score") above a
+`cj-bars` grid of `cj-bar-row`s (3-column grid: 88px label / flexible track /
+52px percentage), each with a `cj-bar-track` containing `cj-bar-app` and
+`cj-bar-den` spans, then a `cj-bar-legend`. The `.landing-v2 .cj-bar*` rules
+lived in `apps/web-next/src/app/landing.css` (removed in this change;
+`cj-table-label`, `cj-stat-strip`, etc. remain — they're shared).


### PR DESCRIPTION
Removes the horizontal FICO-bucket bar chart from the card page approval-odds section (Charts tab).

## What's removed
- The "Approval rate by FICO score" JSX block in `CardClient.tsx`
- Its `FICO_BUCKETS` constant, `bucketize()` helper, and the derived `acceptedBuckets`/`rejectedBuckets`/`maxBucketTotal` values
- The now-unused `.landing-v2 .cj-bar*` rules in `landing.css`

## What stays
- The Median FICO / Median income / Credit history stat strip
- All three scatter plots (they use the same `graphData` source, which is untouched)
- The Charts / Raw data tabs

## Restoration note
`docs/removed-fico-approval-chart.md` documents the data source, bucket math, and markup so the chart can be reinstated later.

## Verification
Typecheck passes; verified on local dev (`/card/chase-sapphire-preferred`, n=12): chart heading and `.cj-bars` DOM gone, stat strip and scatter tabs render, no console errors.