### PR TITLE
No news for SUB changes + fix Record Rejected News detached-HEAD push

### DIFF
--- a/.github/workflows/reject-news.yml
+++ b/.github/workflows/reject-news.yml
@@ -23,6 +23,12 @@ jobs:
     steps:
       - name: Checkout default branch
         uses: actions/checkout@v6
+        with:
+          # On pull_request events a bare checkout gives the PR's merge ref —
+          # a DETACHED HEAD — so the plain `git push` below dies with
+          # "fatal: You are not currently on a branch" (run #957, the first
+          # time the reject path ever fired). Pin to main explicitly.
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -48,7 +54,9 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add data/news-rejected.yaml
             git commit -m "Record rejected news from PR #${PR_NUMBER}"
-            git push
+            # Other bots (card-page check state, content agent) also push to
+            # main; rebase-retry once instead of failing on a stale ref.
+            git push || (git pull --rebase origin main && git push)
           else
             echo "No rejected news to record"
           fi

--- a/data/news-rejected.yaml
+++ b/data/news-rejected.yaml
@@ -22,3 +22,9 @@
   source_url: "https://www.usnews.com/info/blogs/press-room/articles/2026-03-10/u-s-news-world-report-debuts-2026-credit-card-awards"
   rejected_at: "2026-03-11"
   pr: 247
+- id: "chase-sapphire-preferred-100k-bonus-back"
+  title: "Chase Sapphire Preferred's 100K Bonus Is Back"
+  source_url: "https://thepointsguy.com/news/chase-sapphire-preferred-2026-new-benefits-100k-live/"
+  date_rejected: "2026-07-14"
+  reason: "Signup-bonus change on an existing card — SUB moves (elevated/reduced/returning offers) are covered by CardWire and the weekly sign-up bonus changes post, never as news articles. Recorded manually: the Record Rejected News run for this PR failed on a detached-HEAD push (run #957)."
+  pr: 1680

--- a/scripts/auto-news-from-reddit.js
+++ b/scripts/auto-news-from-reddit.js
@@ -239,14 +239,14 @@ Below are top-level comments from today's thread. Your job is to identify which 
 
 ## NEWSWORTHY items (include)
 - New card launches, relaunches, or discontinuations
-- Sign-up bonus changes (elevated offer, reduced offer, public→targeted)
 - Annual fee changes
 - Benefit changes (lounge access, credits added/removed)
 - Transfer partner changes, rate changes
 - Policy changes (referral caps, application rules, approval logic)
-- Time-limited offers that are broadly useful (expires in >=3 days, publicly available)
+- Time-limited offers that are broadly useful (expires in >=3 days, publicly available) — EXCEPT signup-bonus offers, see below
 
 ## NOT NEWSWORTHY (skip)
+- Sign-up bonus changes on existing cards (elevated, reduced, returning, or public→targeted offers) — CreditOdds covers every SUB move in the CardWire / weekly sign-up bonus changes posts, never as news. A brand-new card launch is still newsworthy even if the coverage leads with its launch bonus.
 - Single-person data points ("I got approved for X", "I got a targeted offer")
 - General questions, speculation, or subjective opinions
 - Off-topic discussion, subreddit drama

--- a/scripts/auto-news-update.js
+++ b/scripts/auto-news-update.js
@@ -113,10 +113,11 @@ function buildSearchQueries() {
   const year = now.getFullYear();
   const month = now.toLocaleString('default', { month: 'long' });
 
-  // Generic credit card news queries — use month+year to avoid old results
+  // Generic credit card news queries — use month+year to avoid old results.
+  // No bonus-change query: SUB moves are CardWire territory, never news (the
+  // prompt rejects them), so hunting for them only wastes a search slot.
   const queries = [
     `credit card news ${month} ${year}`,
-    `credit card bonus change ${month} ${year}`,
     `credit card annual fee change ${month} ${year}`,
     `new credit card launch ${month} ${year}`,
   ];
@@ -398,6 +399,7 @@ ${[...existingNewsIds, ...rejectedNewsIds].filter(Boolean).join(', ') || 'None'}
 - Generic credit card advice articles
 - **CRITICAL — NEVER INCLUDE**: Settlements, lawsuits, class actions, regulatory fines, or enforcement actions where a credit card issuer, bank, or network (Visa/Mastercard/Amex/Discover) is the defendant or accused party. We partner with these companies and surfacing negative legal coverage damages those relationships. This applies even if cardholders are eligible for payouts. Examples to reject: "Capital One $X million settlement," "Chase agrees to pay $X to settle," "Bank of America class action," "Visa/Mastercard antitrust settlement."
 - Lobbying, regulatory advocacy, or capital-rule debates (e.g. Basel proposals, banks pushing back on regulators) — these have no direct, actionable impact on cardholders this week.
+- **CRITICAL — NEVER INCLUDE**: Signup-bonus (welcome offer) changes on existing cards — elevated offers, reduced offers, returning offers ("Card X's 100K bonus is back"), or limited-time SUB promotions. CreditOdds already covers every SUB move in the dedicated CardWire / weekly sign-up bonus changes posts, so a news article duplicates that coverage (this is why "Chase Sapphire Preferred's 100K Bonus Is Back" was rejected on PR #1680). A brand-new card LAUNCH is still news even when the coverage leads with its launch bonus — the launch is the story, not the bonus.
 - **CRITICAL — NEVER INCLUDE**: Politically slanted, partisan, or politician-centered stories. Reject anything framed around a political figure (president, cabinet officials, members of Congress, governors, candidates), a party, an administration, or a partisan critique — even if it mentions credit cards. CreditOdds is a non-political product and any political slant alienates a meaningful share of our audience and partners. Examples to reject: "[Politician] says Americans' card spending is soaring," "[Administration] policy hurts cardholders," "Democrats/Republicans push card legislation," election or campaign-related framing. Macroeconomic context (inflation, interest rates, consumer debt levels) is fine ONLY when reported as neutral data without political framing or quoted political commentary.
 - **CRITICAL**: Old news being re-reported. If a card was launched, a benefit changed, or a policy was updated more than a week ago, it is NOT news even if a new article was just published about it. Check the actual event date, not just the article publication date.
 - **CRITICAL**: News about the same topic as existing items above, even if worded differently. If we already posted about a card's fee change, benefit update, or policy change this month, do NOT post about it again even if there's a new article about the same thing.
@@ -784,7 +786,6 @@ async function main() {
   // Google News RSS
   console.log('\n--- Google News RSS ---');
   const googleQueries = [
-    'credit card bonus change',
     'credit card new launch',
     'credit card annual fee',
     'credit card benefit update',
@@ -815,7 +816,7 @@ async function main() {
     console.log('\n--- xAI X/Twitter Search ---');
     const xQueries = [
       'credit card news announcement',
-      'credit card bonus change new card launch',
+      'new credit card launch',
     ];
 
     for (const query of xQueries) {


### PR DESCRIPTION
Follow-up to [Record Rejected News run #957](https://github.com/CreditOdds/creditodds/actions/runs/29332893430), which failed when [PR #1680](https://github.com/CreditOdds/creditodds/pull/1680) ("Auto News Update 2026-07-14" — the Sapphire Preferred 100K story) was closed with `news:reject`.

## 1. Fix the workflow (root cause of #957)
On `pull_request` events a bare `actions/checkout` checks out the PR's **merge ref — a detached HEAD** — despite the step being named "Checkout default branch". The commit succeeded but `git push` died with `fatal: You are not currently on a branch` (exit 128). This was the first time the reject path ever executed, so the bug was latent since the workflow was written. Checkout now pins `ref: main`, and the push rebase-retries once since other bots (card-page check state, content agent) also push to main.

## 2. Recover the lost rejection record
The #957 failure meant the rejection never reached `data/news-rejected.yaml`, so the pipeline could have re-proposed the same story. The entry is added manually with the real reason instead of the script's generic one.

## 3. Make the policy categorical: SUB changes are never news
The story was rejected because signup-bonus moves are covered by CardWire / the weekly sign-up bonus changes post — that's a category, not a one-off. Following the repo's existing pattern (the settlements and political rules in the prompt, both born from PR #1092 rejections):

- **`auto-news-update.js` prompt**: new CRITICAL never-include rule — SUB changes on existing cards (elevated / reduced / returning / limited-time offers) are rejected; a brand-new card **launch** is still news even when coverage leads with its launch bonus.
- **Search queries**: dropped the three `bonus change` queries (Brave, Google News RSS, xAI) that existed specifically to hunt SUB stories the prompt now rejects.
- **`auto-news-from-reddit.js`**: moved "Sign-up bonus changes" from NEWSWORTHY to skip with the same CardWire rationale (script isn't wired to a workflow today, but keeps the editorial policy consistent if it ever is).

## Verification
- `node --check` passes on both scripts; workflow YAML and `news-rejected.yaml` parse cleanly.
- The new rejected entry round-trips through `loadRejectedNews()` (id, CardWire reason, `pr: 1680`), so it lands in the model's do-not-re-suggest context on the next run.