### PR TITLE
Add rumor news: Chase Freedom Flex to drop foreign transaction fees Sept 20, 2026

### DIFF
--- a/data/news/2026-07-15-chase-freedom-flex-no-ftf-rumor.yaml
+++ b/data/news/2026-07-15-chase-freedom-flex-no-ftf-rumor.yaml
@@ -1,0 +1,56 @@
+id: "chase-freedom-flex-no-ftf-rumor"
+date: "2026-07-15"
+title: "Rumor: Chase Freedom Flex to Drop Foreign Transaction Fees on September 20, 2026"
+summary: "Unconfirmed: a cardholder on r/CreditCards says a July 15 email from Chase states the no-annual-fee Freedom Flex will stop charging foreign transaction fees starting September 20, 2026. The same email reportedly repeats that cell phone protection ends that day. Chase has not published the fee change publicly, so treat the FTF removal as a rumor until it appears in the card's terms."
+tags:
+  - "rumor"
+  - "fee-change"
+  - "benefit-change"
+bank: "Chase"
+card_slug: "chase-freedom-flex"
+card_name: "Chase Freedom Flex"
+source: "r/CreditCards"
+source_url: "https://www.reddit.com/r/CreditCards/comments/1ux5f6v/chase_freedom_flex_no_ftf_starting_sept_20_2026/"
+body: |
+  **This is an unconfirmed report.** The foreign transaction fee change below comes from a single cardholder relaying an email, not from a Chase page or the card's official terms. We are covering it because it is specific, dated, and lines up with a change Chase has already documented. Treat it as a rumor until Chase publishes it.
+
+  ## What the report says
+
+  In a [thread on r/CreditCards](https://www.reddit.com/r/CreditCards/comments/1ux5f6v/chase_freedom_flex_no_ftf_starting_sept_20_2026/), a cardholder says they received an email from Chase at 9:02 a.m. ET on July 15, 2026 covering two changes to the **Chase Freedom Flex**:
+
+  - **No foreign transaction fees starting September 20, 2026.** This is the new, unverified claim.
+  - **Cell phone protection going away September 20, 2026.** This part is already confirmed (more below).
+
+  The Freedom Flex currently charges a **3% foreign transaction fee** on purchases made outside the United States. If the report holds, that fee would disappear on September 20, 2026, making the card usable abroad without the surcharge that has long steered international spend to other cards.
+
+  ## Why this one is plausible
+
+  Two things make this more than idle speculation:
+
+  1. **The date matches a known change.** Chase has already confirmed, through its updated [Guide to Benefits](https://www.chasebenefits.com/K113-022/pdf/BGC11539.pdf), that cell phone protection on the Freedom Flex is discontinued on September 20, 2026. An email bundling both changes on the same effective date fits a single scheduled terms update. (See our earlier coverage: [Chase Freedom Flex Loses Cell Phone Protection](/news/chase-freedom-flex-cell-phone-protection-ending).)
+  2. **It is a giveaway, not a takeaway.** Dropping a foreign transaction fee is a benefit to cardholders. Issuers rarely see rumors invented in their favor, and the detail (a precise date, tied to a real update) is more specific than typical wishful posting.
+
+  That said, none of this is confirmation. A forwarded email quoted secondhand is not the same as the change appearing in Chase's published pricing and terms.
+
+  ## What is actually confirmed
+
+  Only the cell phone protection change is confirmed. Per the current Guide to Benefits, cell phone protection covers eligible losses through **September 19, 2026** and is **discontinued September 20, 2026**. That benefit reimbursed damage or theft (the lesser of repair or replacement cost, less a $50 deductible, up to $800 per claim, two claims per 12 months) when the full monthly phone bill was charged to the card.
+
+  The foreign transaction fee removal is **not** reflected in Chase's public terms as of this writing.
+
+  ## What it would mean for cardholders
+
+  If the fee removal is real, it meaningfully changes how the Freedom Flex fits in a wallet:
+
+  - **A no-annual-fee card usable abroad.** The 3% surcharge is the main reason people leave the Freedom Flex at home when traveling internationally. Removing it lets the card's 5% rotating and 3% dining and drugstore categories earn overseas without a penalty on top.
+  - **It softens the cell phone protection loss.** The Freedom Flex loses a perk on the same day it (reportedly) gains one. For anyone who valued the card mostly for its rotating categories rather than the phone coverage, that trade could be a net positive.
+  - **It narrows the gap to travel cards.** A no-fee card with no foreign transaction fees competes more directly with cards people carry specifically for overseas spend.
+
+  ## How to verify before you rely on it
+
+  Do not change your travel plans on the strength of a rumor. Before September 20, confirm the fee change yourself:
+
+  - Check the **pricing and terms** and the **Guide to Benefits** on your own Chase account or the [Freedom Flex product page](https://creditcards.chase.com/cash-back-credit-cards/freedom/flex) for an updated foreign transaction fee line.
+  - Watch for a **Change in Terms** notice in your Chase secure inbox or mailed disclosures, which is how issuers are required to communicate pricing changes.
+
+  We will update this story the moment Chase's published terms confirm (or contradict) the foreign transaction fee change.


### PR DESCRIPTION
Adds a rumor-labeled news article covering the r/CreditCards report that the Chase Freedom Flex will stop charging foreign transaction fees starting September 20, 2026.

- Tagged `rumor` + `fee-change` + `benefit-change`; title and body both flag it as unconfirmed.
- Cross-links the already-confirmed cell phone protection change (same effective date) and the Chase Guide to Benefits.
- `card_slug: chase-freedom-flex` drives the AI hero image to composite the real Freedom Flex card art (verified: card_image_links resolves, art is HTTP 200 on CDN, sync-news-images dry-run reports 1 card ref).