### PR TITLE
Restore Claude to the best-pages ranking panel

### DIFF
--- a/.github/workflows/refresh-best-pages.yml
+++ b/.github/workflows/refresh-best-pages.yml
@@ -33,6 +33,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: node scripts/refresh-best-pages.js
 
       - name: Validate best.json

--- a/scripts/refresh-best-pages.js
+++ b/scripts/refresh-best-pages.js
@@ -7,7 +7,7 @@
  * a single consensus ranking. For each page:
  *   1. Loads current card list and enriches with live data from cards.json
  *   2. Sends an IDENTICAL ranking prompt to every available voter model
- *      (OpenAI, Gemini) and collects each model's ranked order.
+ *      (OpenAI, Gemini, Claude) and collects each model's ranked order.
  *   3. Aggregates the votes with a Borda count → consensus order.
  *   4. GPT (the "writer") writes the intro + per-card badge/highlight for
  *      the consensus order (prose is never voted on — one editorial voice).
@@ -25,8 +25,10 @@
  * Env:
  *   OPENAI_API_KEY       (required — GPT votes AND writes)
  *   GEMINI_API_KEY       (optional — adds Gemini to the panel)
+ *   ANTHROPIC_API_KEY    (optional — adds Claude to the panel)
  *   OPENAI_RANKING_MODEL (optional, default: gpt-4o-mini)
  *   GEMINI_RANKING_MODEL (optional, default: gemini-2.0-flash)
+ *   RANKING_MODEL        (optional, default: claude-haiku-4-5-20251001)
  */
 
 const fs = require('fs');
@@ -58,6 +60,13 @@ const PANEL = [
     envKey: 'GEMINI_API_KEY',
     model: process.env.GEMINI_RANKING_MODEL || 'gemini-3.5-flash',
     call: callGemini,
+  },
+  {
+    key: 'claude',
+    label: 'Claude',
+    envKey: 'ANTHROPIC_API_KEY',
+    model: process.env.RANKING_MODEL || 'claude-haiku-4-5-20251001',
+    call: callAnthropic,
   },
 ];
 
@@ -126,6 +135,25 @@ function buildCardsWithData(page, cardsLookup) {
 }
 
 // ─── Provider adapters (each returns raw response text) ───────────────────────
+
+async function callAnthropic(model, prompt, apiKey) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 8192,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  if (!res.ok) throw new Error(`Anthropic API ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.content?.[0]?.text || '';
+}
 
 async function callOpenAI(model, prompt, apiKey) {
   const res = await fetch('https://api.openai.com/v1/chat/completions', {


### PR DESCRIPTION
## Problem

You flagged that [#1689](https://github.com/CreditOdds/creditodds/pull/1689) ranked with only **GPT** and **Gemini** — every category showed `Panel: GPT (gpt-4o-mini), Gemini (gemini-3.5-flash)`. Claude was missing.

## Root cause

Not a per-run glitch. [#1498](https://github.com/CreditOdds/creditodds/pull/1498) ("switch LLM scripts from Anthropic to OpenAI", June 29) **removed Claude from the panel entirely** while the Anthropic keys were down: it deleted the `callAnthropic` adapter and the `claude` PANEL entry, and promoted OpenAI to the required writer. The `refresh-best-pages.yml` workflow stopped passing `ANTHROPIC_API_KEY`. So every biweekly refresh since late June has been a 2-model panel.

The `ANTHROPIC_API_KEY` GitHub secret was restored on **2026-07-09**, so the fix is now viable.

## Changes

- `scripts/refresh-best-pages.js`: re-add the `callAnthropic` adapter and a `claude` entry in `PANEL` — as a **non-required voter** (OpenAI stays the writer), so an Anthropic outage degrades gracefully instead of breaking the run. Voter model defaults to `claude-haiku-4-5-20251001`, overridable via `RANKING_MODEL`.
- `.github/workflows/refresh-best-pages.yml`: pass `ANTHROPIC_API_KEY` to the refresh step.

The voter prompt ("Return ONLY valid JSON") and `parseRanking`/`stripFences` path are unchanged — this is the exact setup Claude used as a voter before #1498. The frontend per-model toggle reads the YAML `panel:` block, so Claude reappears there automatically after the next refresh.

## Verifying

`node -c` passes. The next scheduled run (1st/15th) or a manual `workflow_dispatch` will produce a 3-model panel; the PR body should then read `Panel: GPT ..., Gemini ..., Claude ...`.