### PR TITLE
Hide APR changes from Card Wire UI (still tracked)

### DIFF
--- a/apps/api/src/handlers/card-wire.js
+++ b/apps/api/src/handlers/card-wire.js
@@ -51,7 +51,7 @@ exports.CardWireHandler = async (event) => {
          FROM card_wire cw
          JOIN cards c ON c.card_id = cw.card_id
          WHERE cw.card_id = ?
-           AND cw.field != 'reward_top_rate'
+           AND cw.field NOT IN ('reward_top_rate', 'apr_min', 'apr_max', 'intro_apr_purchase_months', 'intro_apr_bt_months')
          ORDER BY cw.changed_at DESC
          LIMIT ?`,
         [parseInt(cardId, 10), limit]
@@ -62,7 +62,7 @@ exports.CardWireHandler = async (event) => {
                 cw.field, cw.old_value, cw.new_value, cw.unit, cw.changed_at
          FROM card_wire cw
          JOIN cards c ON c.card_id = cw.card_id
-         WHERE cw.field != 'reward_top_rate'
+         WHERE cw.field NOT IN ('reward_top_rate', 'apr_min', 'apr_max', 'intro_apr_purchase_months', 'intro_apr_bt_months')
          ORDER BY cw.changed_at DESC
          LIMIT ?`,
         [limit]

--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -23,7 +23,8 @@ const FILTERS: { key: FilterKey; label: string }[] = [
   { key: 'all', label: 'All' },
   { key: 'fee', label: 'Annual fee' },
   { key: 'bonus', label: 'Sign-up bonus' },
-  { key: 'apr', label: 'APR' },
+  // 'apr' tab hidden while the card-wire API suppresses apr_min/apr_max and
+  // intro-APR rows (still tracked in card_wire); restore the entry to re-enable.
   { key: 'apps', label: 'Applications' },
 ];
 
@@ -237,7 +238,7 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap, bankM
             </h1>
             <p className="wire-snapshot-sub">
               A chronological feed of every credit-card change we track — annual
-              fees, sign-up bonuses, APR shifts, and application status.
+              fees, sign-up bonuses, and application status.
             </p>
           </div>
           <a

--- a/apps/web-next/src/app/card-wire/page.tsx
+++ b/apps/web-next/src/app/card-wire/page.tsx
@@ -5,7 +5,7 @@ import CardWireV2Client from './CardWireV2Client';
 
 export const metadata: Metadata = {
   title: 'Card Wire - Credit Card Updates & Changes',
-  description: 'A live feed of credit card changes — annual fee updates, sign-up bonus changes, reward rate shifts, and APR adjustments across all major cards.',
+  description: 'A live feed of credit card changes — annual fee updates, sign-up bonus changes, reward rate shifts, and application status across all major cards.',
   openGraph: {
     title: 'Card Wire | CreditOdds',
     description: 'Live feed of credit card changes — fees, bonuses, rates, and more.',


### PR DESCRIPTION
Today's full-card audit (#1696) corrected APRs on ~35 cards in one sync, flooding the Card Wire feed (50 changes dated Jul 16, mostly APR MIN/MAX rows).

- **API** (`card-wire.js`): extend the existing `reward_top_rate` suppression to `apr_min`, `apr_max`, `intro_apr_purchase_months`, `intro_apr_bt_months` in both queries (all-cards feed and per-card history). Rows are **still written** to `card_wire` by `update-cards-github` — this only hides them from the feed.
- **UI** (`CardWireV2Client.tsx`): remove the APR filter tab (would be empty); labels and formatting logic kept so re-enabling is a one-line revert. Page subtitle and SEO description no longer promise APR shifts.

Verified locally against the prod API: APR tab gone, page renders clean, no console errors. Merging auto-deploys both sides (deploy-api.yml + frontend webhook); the feed clears once the API deploy lands and the 300s CloudFront/ISR caches roll.