### PR TITLE
Fix Safari client errors: guard blocked-storage access, filter WebKit IDB noise

### DIFF
--- a/apps/web-next/src/auth/AuthProvider.tsx
+++ b/apps/web-next/src/auth/AuthProvider.tsx
@@ -17,6 +17,33 @@ import posthog from "posthog-js";
 // Key for storing email in localStorage for email link sign-in
 const EMAIL_FOR_SIGN_IN_KEY = 'emailForSignIn';
 
+// localStorage throws SecurityError in Safari when "Block all cookies" is
+// on. The email-link flow works without it — the user just gets prompted
+// for their email again — so storage failures are swallowed.
+function readEmailForSignIn(): string | null {
+  try {
+    return window.localStorage.getItem(EMAIL_FOR_SIGN_IN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function storeEmailForSignIn(email: string) {
+  try {
+    window.localStorage.setItem(EMAIL_FOR_SIGN_IN_KEY, email);
+  } catch {
+    // ignore
+  }
+}
+
+function clearEmailForSignIn() {
+  try {
+    window.localStorage.removeItem(EMAIL_FOR_SIGN_IN_KEY);
+  } catch {
+    // ignore
+  }
+}
+
 interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
@@ -83,7 +110,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (!auth) return;
 
     if (isSignInWithEmailLink(auth, window.location.href)) {
-      let email = window.localStorage.getItem(EMAIL_FOR_SIGN_IN_KEY);
+      let email = readEmailForSignIn();
 
       if (!email) {
         // User opened the link on a different device, prompt for email
@@ -93,7 +120,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (email) {
         signInWithEmailLink(auth, email, window.location.href)
           .then(() => {
-            window.localStorage.removeItem(EMAIL_FOR_SIGN_IN_KEY);
+            clearEmailForSignIn();
             // Clean up the URL
             window.history.replaceState({}, document.title, window.location.pathname);
           })
@@ -119,7 +146,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await sendSignInLinkToEmail(auth, email, actionCodeSettings);
     // Save the email locally to complete sign-in if user opens link on same device
     if (typeof window !== 'undefined') {
-      window.localStorage.setItem(EMAIL_FOR_SIGN_IN_KEY, email);
+      storeEmailForSignIn(email);
     }
   }, []);
 
@@ -131,7 +158,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (isSignInWithEmailLink(auth, window.location.href)) {
       await signInWithEmailLink(auth, email, window.location.href);
-      window.localStorage.removeItem(EMAIL_FOR_SIGN_IN_KEY);
+      clearEmailForSignIn();
       window.history.replaceState({}, document.title, window.location.pathname);
     }
   }, []);

--- a/apps/web-next/src/components/ui/CardyComparePopup.tsx
+++ b/apps/web-next/src/components/ui/CardyComparePopup.tsx
@@ -38,6 +38,17 @@ function writeVisits(visits: VisitedCard[]) {
   }
 }
 
+function popupAlreadyShown(): boolean {
+  try {
+    return sessionStorage.getItem(SHOWN_KEY) === 'true';
+  } catch {
+    // Safari with "Block all cookies" throws SecurityError on any storage
+    // access; without storage we can't cap the popup to once per session,
+    // so never show it (Sentry CREDITODDS-JAVASCRIPT-NEXTJS-V).
+    return true;
+  }
+}
+
 export default function CardyComparePopup({ currentSlug, currentName, currentImage }: CardyComparePopupProps) {
   const [visible, setVisible] = useState(false);
   const [previousCard, setPreviousCard] = useState<VisitedCard | null>(null);
@@ -50,7 +61,7 @@ export default function CardyComparePopup({ currentSlug, currentName, currentIma
     const updated = [...filtered, { slug: currentSlug, name: currentName, image: currentImage ?? null }].slice(-10);
     writeVisits(updated);
 
-    if (sessionStorage.getItem(SHOWN_KEY) === 'true') return;
+    if (popupAlreadyShown()) return;
 
     const priorUniques = filtered;
     if (priorUniques.length === 0) return;

--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -47,6 +47,36 @@ describe("isBenignClientError", () => {
     ).toBe(true);
   });
 
+  it("drops WebKit's IDB-server-connection-lost noise (DOMException shape)", () => {
+    expect(
+      isBenignClientError(
+        domException(
+          "Connection to Indexed Database server lost. Refresh the page to try again",
+          "UnknownError",
+          0,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops WebKit's IDB-server-connection-lost noise (wrapped-message shape)", () => {
+    expect(
+      isBenignClientError(
+        new Error(
+          "UnknownError: Connection to Indexed Database server lost. Refresh the page to try again",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps unrelated UnknownErrors", () => {
+    expect(
+      isBenignClientError(
+        domException("An internal error was encountered.", "UnknownError", 0),
+      ),
+    ).toBe(false);
+  });
+
   it("keeps a real AbortError that isn't IndexedDB-related", () => {
     // e.g. a genuine fetch abort we'd still want to see — bare name only is
     // benign, but a descriptive non-idb abort message is not matched.

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -10,6 +10,13 @@
 // so we drop them in instrumentation-client.ts (mirrors the server-side
 // self-healing-network filter in transientNetworkError.ts).
 //
+// WebKit also drops the page's connection to the IndexedDB server outright
+// when it suspends a backgrounded tab (tab switch, screen lock, memory
+// pressure). On resume, Firebase's internal IDB operations reject with
+// "UnknownError: Connection to Indexed Database server lost. Refresh the
+// page to try again" — name/code don't match the AbortError gate below, so
+// that signature is matched unconditionally. The page itself is unaffected.
+//
 // Mobile Safari can also surface WebExtension content-script messaging failures
 // as page-level unhandled rejections even though the page never calls the
 // extension API. These are user-extension/WebKit noise, not app failures.
@@ -21,8 +28,11 @@ const BENIGN_CLIENT_SIGNATURES = [
   'IndexedDB',
 ];
 
-const BENIGN_EXTENSION_SIGNATURES = [
+// Matched on any error, regardless of name/code (unlike the abort-gated
+// signatures above).
+const BENIGN_ANY_ERROR_SIGNATURES = [
   'Invalid call to runtime.sendMessage(). Tab not found.',
+  'Connection to Indexed Database server lost',
 ];
 
 // DOMException.ABORT_ERR — the numeric code carried by AbortErrors.
@@ -42,7 +52,7 @@ export function isBenignClientError(error: unknown): boolean {
     const message = typeof e.message === 'string' ? e.message : '';
     const isAbort = name === 'AbortError' || e.code === ABORT_ERR_CODE;
 
-    if (BENIGN_EXTENSION_SIGNATURES.some((sig) => message.includes(sig))) {
+    if (BENIGN_ANY_ERROR_SIGNATURES.some((sig) => message.includes(sig))) {
       return true;
     }
 


### PR DESCRIPTION
Fixes the two production Sentry issues reported 2026-07-16.

## 1. `SecurityError: The operation is insecure.` on `/card/:name` (CREDITODDS-JAVASCRIPT-NEXTJS-V)

Safari with **"Block all cookies"** enabled throws `SecurityError` on *any* `sessionStorage`/`localStorage` access, including reads. `CardyComparePopup`'s popup-shown check was the single unguarded storage access on card pages (every other one is try/catch-wrapped), so the mount effect threw during React's commit and crashed the whole card page to `global-error.tsx` for those users. Symbolicated by hand against the deployed chunk: line 2 col 20512 of `33378d83a0d36328.js` lands exactly on that `sessionStorage.getItem`.

Fix: `popupAlreadyShown()` helper with the same try/catch pattern as the component's other accesses. When storage is blocked the popup is treated as already shown (it can't be capped to once-per-session without storage, and with no readable visit history it could never render anyway).

Also guarded the same latent pattern in `AuthProvider`'s email-link flow (read/store/clear of `emailForSignIn`). Degradation there is graceful: without storage the user is simply prompted for their email when completing sign-in.

## 2. `UnknownError: Connection to Indexed Database server lost` (CREDITODDS-JAVASCRIPT-NEXTJS-N)

WebKit kills the page's IndexedDB server connection when it suspends a backgrounded tab (tab switch, screen lock, memory pressure). On resume, Firebase's internal IDB operations reject with this error as an unhandled rejection. The page is unaffected; it's unactionable noise, and it slipped past `benignClientError`'s filter because the IndexedDB signatures there are gated on AbortError (name/code 20) while this shape is `UnknownError`/code 0.

Fix: renamed the unconditional signature list to `BENIGN_ANY_ERROR_SIGNATURES` and added `Connection to Indexed Database server lost` to it. Covers both observed shapes (bare DOMException and wrapped-message Error); added test cases plus a negative case so unrelated UnknownErrors still report.

## Verification

- `npm test` (66 passed, incl. 4 new filter cases), `tsc --noEmit`, `eslint --max-warnings=0` all clean.
- Dev-server repro of the prod crash: patched `sessionStorage.getItem/setItem` to throw `SecurityError: The operation is insecure.` (exactly what Safari does), then client-side navigated to a card page. The page rendered fully, no error boundary, no uncaught errors (only PostHog's own caught storage log). Normal flow re-checked afterwards: popup still appears after visiting a second card and session keys are written.

## Follow-up (not in this PR)

Both events showed `release: HEAD` with minified frames: `SENTRY_AUTH_TOKEN` still isn't set in Amplify, so `withSentryConfig` skips the source-map upload. Setting it would make future stacks readable without manual chunk symbolication.