### PR TITLE
Gate Disney Inspire/Premier streaming rate to Disney+, Hulu, ESPN+

### DIFF
--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -59,6 +59,7 @@ rewards:
     value: 10
     unit: percent
     note: "Disney+, Hulu, and ESPN+ purchases"
+    merchant_gate: [disney-plus, hulu, espn-plus]
   - category: gas
     value: 3
     unit: percent

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -10,6 +10,7 @@ rewards:
     value: 5
     unit: percent
     note: "Disney+, Hulu, and ESPN+ purchases"
+    merchant_gate: [disney-plus, hulu, espn-plus]
   - category: entertainment
     value: 2
     unit: percent


### PR DESCRIPTION
## Problem

The Disney Inspire's 10% (and Disney Premier's 5%) streaming reward only applies to purchases billed directly by Disney+, Hulu, and ESPN+, but both were modeled as the generic `streaming` category with the restriction only in the display `note`. The ranker matches by category, so the Inspire ranked #1 on all 12 non-Disney streaming store pages, e.g. [/best-card-for/audible](https://creditodds.com/best-card-for/audible), where the card actually earns 1%. Affected pages: Audible, Netflix, Spotify, Apple Music, Max, Peacock, Paramount+, YouTube TV, Fubo, Philo, NBA League Pass, NFL+.

It also over-credited both cards in the /best-card-for-me quiz, which valued the Inspire at 10% of a user's entire streaming budget.

## Fix

Add `merchant_gate: [disney-plus, hulu, espn-plus]` to the streaming reward on both cards, the same pattern ~30 airline/hotel co-brands already use (United Explorer's gated 3x airlines, etc.). All ranker consumers (store ranking, wallet picks, next-card quiz, best-card-for-me valuation) already handle the field, so this is data-only.

The base Disney Visa has no streaming reward and is unaffected.

## Verification

`npm run build:cards` passes (182 cards). Ran the store ranker against the rebuilt data:

| Store | Before | After |
|---|---|---|
| Audible | Disney Inspire 10% #1 | Blue Cash Preferred 6% #1, Disney cards absent |
| Netflix | Disney Inspire 10% #1 | Blue Cash Preferred 6% #1, Disney cards absent |
| Disney+ | Disney Inspire #1 | Disney Inspire #1 (unchanged, correct) |
| Hulu | Disney Inspire #1 | Disney Inspire #1 (unchanged, correct) |