### PR TITLE
Store-pages audit: gate merchant-limited rates, fix Costco gas rate, phone taxonomy

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T15:16:44.495Z",
+  "generated_at": "2026-07-17T14:16:46.619Z",
   "count": 957,
   "stores": [
     {
@@ -367,6 +367,9 @@
     {
       "name": "Air Canada",
       "slug": "air-canada",
+      "co_brand_cards": [
+        "chase-aeroplan"
+      ],
       "categories": [
         "airlines",
         "travel"
@@ -397,7 +400,8 @@
       ],
       "categories": [
         "travel",
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.airalo.com",
       "intro": "Airalo is an eSIM marketplace that sells prepaid mobile data plans for travelers,\nletting a phone connect to a local or regional carrier's network abroad without\nswapping a physical SIM card. It covers plans for well over 100 countries and is\ncommonly used as an alternative to international roaming fees. There is no Airalo\ncredit card, and eSIM purchases typically code as either travel or a phone or\ntelecom service depending on the issuer, so a card that bonuses travel purchases,\nor a flat-rate cashback card, is the reasonable choice when buying a plan.\n",
@@ -453,6 +457,9 @@
       "aliases": [
         "Alaska",
         "Mileage Plan"
+      ],
+      "co_brand_cards": [
+        "atmos-rewards-ascent"
       ],
       "categories": [
         "airlines",
@@ -1145,7 +1152,8 @@
       "name": "AT&T",
       "slug": "atandt",
       "categories": [
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.att.com",
       "intro": "AT&T provides wireless service, fiber internet and TV bundles to millions of US customers. Your monthly bill earns a bonus only on cards that reward wireless or telecom spending, otherwise it lands on the flat rate, and certain cards include cell-phone protection if you charge the bill to them.\n"
@@ -2005,6 +2013,9 @@
       "slug": "british-airways",
       "aliases": [
         "BA"
+      ],
+      "co_brand_cards": [
+        "british-airways-visa-signature-card"
       ],
       "categories": [
         "airlines",
@@ -3107,7 +3118,8 @@
         "Cricket"
       ],
       "categories": [
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.cricketwireless.com",
       "intro": "Cricket Wireless, AT&T's prepaid brand, sells no-contract phone plans and devices. Payments code as a wireless or telecom charge, so they earn extra only on a card with a cell-phone or wireless bonus, otherwise dropping to flat-rate. A bonus here is that some cards add cell-phone protection when you pay the monthly bill with them, which is worth checking before you set autopay.\n"
@@ -4890,6 +4902,7 @@
       ],
       "categories": [
         "cell_phone_providers",
+        "phone",
         "online_shopping"
       ],
       "website": "https://gabb.com",
@@ -5510,7 +5523,8 @@
       ],
       "website": "https://www.hawaiianairlines.com",
       "co_brand_cards": [
-        "hawaiian-airlines-world-elite-mastercard"
+        "hawaiian-airlines-world-elite-mastercard",
+        "atmos-rewards-ascent"
       ],
       "intro": "Hawaiian Airlines is the dominant carrier between the U.S. mainland and Hawaii, plus\ninter-island routes. Tickets code as airfare on every card we track. The co-branded\nHawaiian Airlines World Elite Mastercard offers a discount on round-trip companion\ntickets to Hawaii each year and bonus miles on the airline. With Alaska Airlines'\nacquisition closed, Hawaiian's loyalty program is integrating with Alaska's Mileage\nPlan, so long-term value will increasingly route through Alaska's award chart.\n"
     },
@@ -6097,6 +6111,7 @@
       ],
       "categories": [
         "cell_phone_providers",
+        "phone",
         "online_shopping"
       ],
       "website": "https://www.infimobile.com",
@@ -9241,6 +9256,7 @@
       ],
       "categories": [
         "cell_phone_providers",
+        "phone",
         "online_shopping"
       ],
       "website": "https://www.phone.com",
@@ -11435,7 +11451,8 @@
       "name": "T-Mobile",
       "slug": "t-mobile",
       "categories": [
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.t-mobile.com",
       "intro": "T-Mobile is one of the big three US carriers, offering wireless plans plus home internet. Wireless bills earn extra only on cards with a phone or wireless bonus, otherwise they code at the flat rate, and a handful of cards throw in cell-phone protection when the bill is paid with that card.\n"
@@ -11589,6 +11606,7 @@
       ],
       "categories": [
         "cell_phone_providers",
+        "phone",
         "online_shopping"
       ],
       "website": "https://tello.com",
@@ -12563,7 +12581,8 @@
       "name": "Verizon",
       "slug": "verizon",
       "categories": [
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.verizon.com",
       "intro": "Verizon is the largest US wireless carrier, billing for phone plans, devices and home internet. Wireless and internet charges earn a bonus only on cards that specifically reward phone or internet bills, otherwise they fall to a flat rate, though some cards add cell-phone protection when you pay the bill with them.\n"

--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -14,6 +14,7 @@ rewards:
     value: 3
     unit: points_per_dollar
     note: "Aer Lingus, British Airways, and Iberia flights"
+    merchant_gate: [british-airways]
   - category: hotels
     value: 2
     unit: points_per_dollar

--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -15,6 +15,8 @@ rewards:
   - category: airlines
     value: 3
     unit: points_per_dollar
+    note: "Alaska and Hawaiian Airlines purchases"
+    merchant_gate: [alaska-airlines, hawaiian-airlines]
   - category: gas
     value: 2
     unit: points_per_dollar

--- a/data/cards/att-points-plus-from-citi.yaml
+++ b/data/cards/att-points-plus-from-citi.yaml
@@ -34,6 +34,7 @@ rewards:
     value: 2
     unit: points_per_dollar
     note: "AT&T products, services, and bill payments"
+    merchant_gate: [atandt]
   - category: everything_else
     value: 1
     unit: points_per_dollar

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -47,6 +47,7 @@ rewards:
     value: 3
     unit: points_per_dollar
     note: "On Lyft rides (after linking your Lyft account)"
+    merchant_gate: [lyft]
   - category: everything_else
     value: 1
     unit: points_per_dollar

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -63,6 +63,7 @@ rewards:
     value: 3
     unit: "points_per_dollar"
     note: "On Lyft rides (after linking your Lyft account)"
+    merchant_gate: [lyft]
   - category: "everything_else"
     value: 1
     unit: "points_per_dollar"

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -75,6 +75,7 @@ rewards:
     value: 4
     unit: points_per_dollar
     note: "On Lyft rides (after linking your Lyft account)"
+    merchant_gate: [lyft]
   - category: everything_else
     value: 2
     unit: points_per_dollar

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -14,6 +14,7 @@ rewards:
     value: 3
     unit: points_per_dollar
     note: "British Airways, Aer Lingus, and Iberia flights"
+    merchant_gate: [british-airways]
   - category: hotels
     value: 2
     unit: points_per_dollar

--- a/data/cards/chase-aeroplan.yaml
+++ b/data/cards/chase-aeroplan.yaml
@@ -10,6 +10,7 @@ rewards:
     value: 3
     unit: points_per_dollar
     note: "Air Canada direct purchases"
+    merchant_gate: [air-canada]
   - category: dining
     value: 3
     unit: points_per_dollar

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -50,6 +50,7 @@ rewards:
     unit: percent
     note: "On Lyft rides through September 30, 2027 (limited-time promo)"
     expires: "2027-09-30"
+    merchant_gate: [lyft]
   - category: everything_else
     value: 1
     unit: percent

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -24,6 +24,7 @@ rewards:
     unit: points_per_dollar
     note: "On Lyft rides through September 30, 2027 (limited-time promo)"
     expires: "2027-09-30"
+    merchant_gate: [lyft]
   - category: everything_else
     value: 1
     unit: points_per_dollar

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -15,6 +15,7 @@ rewards:
     unit: percent
     note: "On Lyft rides through September 30, 2027 (limited-time promo)"
     expires: "2027-09-30"
+    merchant_gate: [lyft]
   - category: everything_else
     value: 1.5
     unit: percent

--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -11,9 +11,9 @@ tags:
   - business
 rewards:
   - category: gas
-    value: 5
+    value: 4
     unit: percent
-    note: "5% at Costco gas stations. 4% on other eligible gas and EV charging worldwide, first $7,000/year combined."
+    note: "4% on eligible gas and EV charging worldwide (first $7,000/year combined, then 1%); 5% at Costco gas stations."
   - category: dining
     value: 3
     unit: percent

--- a/data/cards/costco-anywhere-visa-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-card-by-citi.yaml
@@ -10,9 +10,9 @@ tags:
   - rewards
 rewards:
   - category: "gas"
-    value: 5
+    value: 4
     unit: "percent"
-    note: "5% at Costco gas stations. 4% on other eligible gas and EV charging worldwide, first $7,000/year combined."
+    note: "4% on eligible gas and EV charging worldwide (first $7,000/year combined, then 1%); 5% at Costco gas stations."
   - category: "dining"
     value: 3
     unit: "percent"

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -67,6 +67,7 @@ rewards:
     value: 3
     unit: percent
     note: "Most U.S. Disney locations"
+    merchant_specific: true
   - category: groceries
     value: 2
     unit: percent

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -14,7 +14,8 @@ rewards:
   - category: entertainment
     value: 2
     unit: percent
-    note: "Select Disney purchases, gas stations, and grocery stores"
+    note: "Most U.S. Disney locations"
+    merchant_specific: true
   - category: gas
     value: 2
     unit: percent

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -26,6 +26,7 @@ rewards:
     value: 3
     unit: points_per_dollar
     note: "Iberia, British Airways, and Aer Lingus flights"
+    merchant_gate: [british-airways]
   - category: hotels
     value: 2
     unit: points_per_dollar

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T15:16:44.495Z",
+  "generated_at": "2026-07-17T14:16:46.619Z",
   "count": 957,
   "stores": [
     {
@@ -367,6 +367,9 @@
     {
       "name": "Air Canada",
       "slug": "air-canada",
+      "co_brand_cards": [
+        "chase-aeroplan"
+      ],
       "categories": [
         "airlines",
         "travel"
@@ -397,7 +400,8 @@
       ],
       "categories": [
         "travel",
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.airalo.com",
       "intro": "Airalo is an eSIM marketplace that sells prepaid mobile data plans for travelers,\nletting a phone connect to a local or regional carrier's network abroad without\nswapping a physical SIM card. It covers plans for well over 100 countries and is\ncommonly used as an alternative to international roaming fees. There is no Airalo\ncredit card, and eSIM purchases typically code as either travel or a phone or\ntelecom service depending on the issuer, so a card that bonuses travel purchases,\nor a flat-rate cashback card, is the reasonable choice when buying a plan.\n",
@@ -453,6 +457,9 @@
       "aliases": [
         "Alaska",
         "Mileage Plan"
+      ],
+      "co_brand_cards": [
+        "atmos-rewards-ascent"
       ],
       "categories": [
         "airlines",
@@ -1145,7 +1152,8 @@
       "name": "AT&T",
       "slug": "atandt",
       "categories": [
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.att.com",
       "intro": "AT&T provides wireless service, fiber internet and TV bundles to millions of US customers. Your monthly bill earns a bonus only on cards that reward wireless or telecom spending, otherwise it lands on the flat rate, and certain cards include cell-phone protection if you charge the bill to them.\n"
@@ -2005,6 +2013,9 @@
       "slug": "british-airways",
       "aliases": [
         "BA"
+      ],
+      "co_brand_cards": [
+        "british-airways-visa-signature-card"
       ],
       "categories": [
         "airlines",
@@ -3107,7 +3118,8 @@
         "Cricket"
       ],
       "categories": [
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.cricketwireless.com",
       "intro": "Cricket Wireless, AT&T's prepaid brand, sells no-contract phone plans and devices. Payments code as a wireless or telecom charge, so they earn extra only on a card with a cell-phone or wireless bonus, otherwise dropping to flat-rate. A bonus here is that some cards add cell-phone protection when you pay the monthly bill with them, which is worth checking before you set autopay.\n"
@@ -4890,6 +4902,7 @@
       ],
       "categories": [
         "cell_phone_providers",
+        "phone",
         "online_shopping"
       ],
       "website": "https://gabb.com",
@@ -5510,7 +5523,8 @@
       ],
       "website": "https://www.hawaiianairlines.com",
       "co_brand_cards": [
-        "hawaiian-airlines-world-elite-mastercard"
+        "hawaiian-airlines-world-elite-mastercard",
+        "atmos-rewards-ascent"
       ],
       "intro": "Hawaiian Airlines is the dominant carrier between the U.S. mainland and Hawaii, plus\ninter-island routes. Tickets code as airfare on every card we track. The co-branded\nHawaiian Airlines World Elite Mastercard offers a discount on round-trip companion\ntickets to Hawaii each year and bonus miles on the airline. With Alaska Airlines'\nacquisition closed, Hawaiian's loyalty program is integrating with Alaska's Mileage\nPlan, so long-term value will increasingly route through Alaska's award chart.\n"
     },
@@ -6097,6 +6111,7 @@
       ],
       "categories": [
         "cell_phone_providers",
+        "phone",
         "online_shopping"
       ],
       "website": "https://www.infimobile.com",
@@ -9241,6 +9256,7 @@
       ],
       "categories": [
         "cell_phone_providers",
+        "phone",
         "online_shopping"
       ],
       "website": "https://www.phone.com",
@@ -11435,7 +11451,8 @@
       "name": "T-Mobile",
       "slug": "t-mobile",
       "categories": [
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.t-mobile.com",
       "intro": "T-Mobile is one of the big three US carriers, offering wireless plans plus home internet. Wireless bills earn extra only on cards with a phone or wireless bonus, otherwise they code at the flat rate, and a handful of cards throw in cell-phone protection when the bill is paid with that card.\n"
@@ -11589,6 +11606,7 @@
       ],
       "categories": [
         "cell_phone_providers",
+        "phone",
         "online_shopping"
       ],
       "website": "https://tello.com",
@@ -12563,7 +12581,8 @@
       "name": "Verizon",
       "slug": "verizon",
       "categories": [
-        "cell_phone_providers"
+        "cell_phone_providers",
+        "phone"
       ],
       "website": "https://www.verizon.com",
       "intro": "Verizon is the largest US wireless carrier, billing for phone plans, devices and home internet. Wireless and internet charges earn a bonus only on cards that specifically reward phone or internet bills, otherwise they fall to a flat rate, though some cards add cell-phone protection when you pay the bill with them.\n"

--- a/data/stores/air-canada.yaml
+++ b/data/stores/air-canada.yaml
@@ -1,5 +1,7 @@
 name: "Air Canada"
 slug: "air-canada"
+co_brand_cards:
+  - chase-aeroplan
 categories:
   - airlines
   - travel

--- a/data/stores/airalo.yaml
+++ b/data/stores/airalo.yaml
@@ -5,6 +5,7 @@ aliases:
 categories:
   - travel
   - cell_phone_providers
+  - phone
 website: "https://www.airalo.com"
 intro: |
   Airalo is an eSIM marketplace that sells prepaid mobile data plans for travelers,

--- a/data/stores/alaska-airlines.yaml
+++ b/data/stores/alaska-airlines.yaml
@@ -3,6 +3,8 @@ slug: "alaska-airlines"
 aliases:
   - "Alaska"
   - "Mileage Plan"
+co_brand_cards:
+  - atmos-rewards-ascent
 categories:
   - airlines
   - travel

--- a/data/stores/atandt.yaml
+++ b/data/stores/atandt.yaml
@@ -2,6 +2,7 @@ name: AT&T
 slug: atandt
 categories:
   - cell_phone_providers
+  - phone
 website: https://www.att.com
 intro: |
   AT&T provides wireless service, fiber internet and TV bundles to millions of US customers. Your monthly bill earns a bonus only on cards that reward wireless or telecom spending, otherwise it lands on the flat rate, and certain cards include cell-phone protection if you charge the bill to them.

--- a/data/stores/british-airways.yaml
+++ b/data/stores/british-airways.yaml
@@ -2,6 +2,8 @@ name: "British Airways"
 slug: "british-airways"
 aliases:
   - "BA"
+co_brand_cards:
+  - british-airways-visa-signature-card
 categories:
   - airlines
   - travel

--- a/data/stores/cricket-wireless.yaml
+++ b/data/stores/cricket-wireless.yaml
@@ -4,6 +4,7 @@ aliases:
   - Cricket
 categories:
   - cell_phone_providers
+  - phone
 website: https://www.cricketwireless.com
 intro: |
   Cricket Wireless, AT&T's prepaid brand, sells no-contract phone plans and devices. Payments code as a wireless or telecom charge, so they earn extra only on a card with a cell-phone or wireless bonus, otherwise dropping to flat-rate. A bonus here is that some cards add cell-phone protection when you pay the monthly bill with them, which is worth checking before you set autopay.

--- a/data/stores/gabb-wireless.yaml
+++ b/data/stores/gabb-wireless.yaml
@@ -4,6 +4,7 @@ aliases:
   - "Gabb"
 categories:
   - cell_phone_providers
+  - phone
   - online_shopping
 website: "https://gabb.com"
 intro: |

--- a/data/stores/hawaiian-airlines.yaml
+++ b/data/stores/hawaiian-airlines.yaml
@@ -9,6 +9,7 @@ categories:
 website: "https://www.hawaiianairlines.com"
 co_brand_cards:
   - hawaiian-airlines-world-elite-mastercard
+  - atmos-rewards-ascent
 intro: |
   Hawaiian Airlines is the dominant carrier between the U.S. mainland and Hawaii, plus
   inter-island routes. Tickets code as airfare on every card we track. The co-branded

--- a/data/stores/infimobile.yaml
+++ b/data/stores/infimobile.yaml
@@ -4,6 +4,7 @@ aliases:
   - "Infimobile.com"
 categories:
   - cell_phone_providers
+  - phone
   - online_shopping
 website: "https://www.infimobile.com"
 intro: |

--- a/data/stores/phone-com.yaml
+++ b/data/stores/phone-com.yaml
@@ -4,6 +4,7 @@ aliases:
   - "Phone.com"
 categories:
   - cell_phone_providers
+  - phone
   - online_shopping
 website: "https://www.phone.com"
 intro: |

--- a/data/stores/t-mobile.yaml
+++ b/data/stores/t-mobile.yaml
@@ -2,6 +2,7 @@ name: T-Mobile
 slug: t-mobile
 categories:
   - cell_phone_providers
+  - phone
 website: https://www.t-mobile.com
 intro: |
   T-Mobile is one of the big three US carriers, offering wireless plans plus home internet. Wireless bills earn extra only on cards with a phone or wireless bonus, otherwise they code at the flat rate, and a handful of cards throw in cell-phone protection when the bill is paid with that card.

--- a/data/stores/tello.yaml
+++ b/data/stores/tello.yaml
@@ -4,6 +4,7 @@ aliases:
   - "Tello Mobile"
 categories:
   - cell_phone_providers
+  - phone
   - online_shopping
 website: "https://tello.com"
 intro: |

--- a/data/stores/verizon.yaml
+++ b/data/stores/verizon.yaml
@@ -2,6 +2,7 @@ name: Verizon
 slug: verizon
 categories:
   - cell_phone_providers
+  - phone
 website: https://www.verizon.com
 intro: |
   Verizon is the largest US wireless carrier, billing for phone plans, devices and home internet. Wireless and internet charges earn a bonus only on cards that specifically reward phone or internet bills, otherwise they fall to a flat rate, though some cards add cell-phone protection when you pay the bill with them.


### PR DESCRIPTION
## Context

Follow-up to #1700 (Disney streaming gate). Ran the production ranker (`storeRanking.js`) over **all 957 store pages**, deduped every reward surfacing in a top-10, audited each against real card terms, and cross-validated every `merchant_gate` / `co_brand_cards` / `also_earns` slug. Portal-only rates (Amex/Citi/Bilt/Robinhood portals) were all already modeled correctly via `_portal` categories; the bugs were all merchant-limited rates in generic categories.

## Merchant-limited rates now gated

| Cards | Rate | Was polluting | Fix |
|---|---|---|---|
| Ink Business Cash / Unlimited / Preferred | 5%/5x transit (Lyft-only promo) | Amtrak, **Uber**, Greyhound, FlixBus | `merchant_gate: [lyft]` |
| Bilt Blue / Obsidian / Palladium | 3x-4x transit (Lyft-only, link required) | same transit pages | `merchant_gate: [lyft]` |
| Aeroplan | 3x airlines (Air Canada direct only) | 25 airline pages (Lufthansa, ANA, Emirates...) | `merchant_gate: [air-canada]` |
| Aer Lingus / British Airways / Iberia Visa Signature | 3x airlines (IAG airlines only) | airline pages below the fold + wallet picks | `merchant_gate: [british-airways]` (only IAG store page that exists) |
| AT&T Points Plus | 2x phone (AT&T bills only) | Mint Mobile, Straight Talk, Visible | `merchant_gate: [atandt]` |
| Atmos Rewards Ascent | 3x airlines (un-noted; Alaska/Hawaiian only — BofA co-brand) | ANA, Cathay, Emirates, Lufthansa | note + `merchant_gate: [alaska-airlines, hawaiian-airlines]` + co-brand listing on both store pages |
| Disney Inspire / Premier | 3%/2% entertainment (Disney locations only) | AMC, Fandango, Eventbrite + 19 more | `merchant_specific: true` (no Disney-parks store exists to gate to) |

## Rate accuracy

- **Costco Anywhere Visa + Business**: showed "5% on gas" on 30 generic gas pages (7-Eleven, BP, Arco...), but 5% is Costco-pumps-only — everywhere else is 4% (first $7k/yr). Now `value: 4` with the note leading with the generic rate.

## Taxonomy fixes the audit's validator surfaced

- **9 carrier stores** (AT&T, Verizon, T-Mobile, Cricket, Airalo, Gabb, Infimobile, Phone.com, Tello) had only `cell_phone_providers` while Mint/Straight Talk/Visible also had `phone` — so phone-services rates like Ink Cash's 5% never surfaced on the big carrier pages. Added `phone` to all of them (Ink Cash now correctly #1 on Verizon).
- **air-canada / british-airways** were the only airline brand pages with no `co_brand_cards`; their own cards fell below top-10 once gated. Added them (matches the Delta/United/JetBlue/AA/Southwest pattern).

## What was checked and found clean

- All `booked directly` airline/hotel rates (Platinum, CSR, Gold, Brilliant, Hyatt, Delta Plat, Strata Premier, United Explorer, BA-family hotels) — legitimately earned at brand sites
- Broad category rates with scary notes (BCE/Surpass online retail, BCP streaming/groceries, United Quest streaming, PlayStation streaming) — genuinely broad per issuer terms
- Wyndham travel 4x (verified against the #1431 live-data refresh), choice/rotating/top-spend cards (badged conditionals), `also_earns` entries (Apple Card Ace/Walgreens, Shopper Cash retailers, Prime WFM)
- Zero dead slugs across all `merchant_gate` / `co_brand_cards` / `also_earns` references

## Verification

`build:cards` + `build:stores` pass; re-ran the full 957-store harness after the change: validation errors 0, every gated rate now surfaces only on its brand page(s), and spot-checked pages (Air Canada, British Airways, Alaska, Hawaiian, Verizon, AMC, Uber, Amtrak, Disney+) all rank correctly. Both generated `stores.json` copies committed per convention (#1684).