### PR TITLE
Add permanent store-ranking audit script + wire gate validation into build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "sync:news-images": "node scripts/sync-news-images.js",
     "build:articles": "node scripts/build-articles.js",
     "build:best": "node scripts/build-best.js",
-    "build:stores": "node scripts/build-stores.js",
+    "build:stores": "node scripts/build-stores.js && node scripts/audit-store-rankings.js --validate-only",
+ "audit:store-rankings": "node scripts/audit-store-rankings.js",
     "start:web-next": "npm run dev -w @creditodds/web-next",
     "dev:web-next": "npm run dev -w @creditodds/web-next",
     "lint": "npm run lint --workspaces --if-present"

--- a/scripts/audit-store-rankings.js
+++ b/scripts/audit-store-rankings.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+//
+// audit-store-rankings.js — run the production store ranker over every store
+// page and audit the results. Two jobs:
+//
+//   1. REPORT: run rankCards() over all stores, dedupe every category-match
+//      reward that surfaces in any top-10, and print each one (card, reason,
+//      note, effective rate, how many stores it hits + sample stores), sorted
+//      by effective rate. This is the lens for catching a merchant-limited
+//      rate polluting generic category pages — a "5x transit" that is really
+//      Lyft-only will show up hitting 30 transit stores instead of 1.
+//
+//   2. VALIDATE: cross-check the data that the ranker trusts —
+//        - every merchant_gate slug must be a real store
+//        - a gated reward's category must be one of the gate-target store's
+//          categories (else the gate is dead: it can never surface anywhere)
+//        - every co_brand_cards / also_earns slug must be a real card
+//      Exits 1 if any validation fails, so it can gate a build or CI run.
+//
+// This is the permanent version of the throwaway harness written during the
+// PR #1701 review, which caught the Lyft / Aeroplan / AT&T / Atmos dead-gate
+// and generic-category pollution bugs plus the phone-category taxonomy drift.
+//
+// Run: node scripts/audit-store-rankings.js
+//   --validate-only   skip the report, run validation only (for CI/build)
+
+const path = require("path");
+
+const CARDS_FILE = path.join(__dirname, "..", "data", "cards.json");
+const STORES_FILE = path.join(
+  __dirname,
+  "..",
+  "apps",
+  "api",
+  "src",
+  "lib",
+  "ranker",
+  "stores.json"
+);
+const { rankCards } = require(path.join(
+  __dirname,
+  "..",
+  "apps",
+  "api",
+  "src",
+  "lib",
+  "ranker",
+  "storeRanking.js"
+));
+
+const TOP_N = 10;
+const SAMPLE_LIMIT = 6;
+
+function loadCards() {
+  const data = require(CARDS_FILE);
+  return data.cards || data;
+}
+
+function loadStores() {
+  const data = require(STORES_FILE);
+  return data.stores || data;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function validate(cards, stores) {
+  const cardSlugs = new Set(cards.map((c) => c.slug));
+  const storesBySlug = new Map(stores.map((s) => [s.slug, s]));
+  const errors = [];
+
+  for (const card of cards) {
+    for (const r of card.rewards || []) {
+      if (!r.merchant_gate || r.merchant_gate.length === 0) continue;
+      for (const gateSlug of r.merchant_gate) {
+        const store = storesBySlug.get(gateSlug);
+        if (!store) {
+          errors.push(
+            `${card.slug}: merchant_gate references "${gateSlug}", which is not a store slug`
+          );
+          continue;
+        }
+        // A gate is only useful if the gated reward's category is one the
+        // target store actually carries — otherwise the reward can never
+        // match there and the rate is silently unreachable everywhere.
+        if (!(store.categories || []).includes(r.category)) {
+          errors.push(
+            `${card.slug}: reward "${r.category}" is gated to "${gateSlug}", ` +
+              `but that store's categories are [${(store.categories || []).join(", ")}] ` +
+              `— the gate is dead, this reward can never surface`
+          );
+        }
+      }
+    }
+  }
+
+  for (const store of stores) {
+    for (const slug of store.co_brand_cards || []) {
+      if (!cardSlugs.has(slug)) {
+        errors.push(
+          `store ${store.slug}: co_brand_cards references "${slug}", which is not a card slug`
+        );
+      }
+    }
+    for (const entry of store.also_earns || []) {
+      if (!cardSlugs.has(entry.card)) {
+        errors.push(
+          `store ${store.slug}: also_earns references "${entry.card}", which is not a card slug`
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+function buildReport(cards, stores) {
+  // Dedupe every category-source pick that lands in a top-10, keyed by the
+  // card + the human reason + note (which together identify the underlying
+  // reward). Track effective rate and which stores it surfaces on.
+  const rewards = new Map();
+
+  for (const store of stores) {
+    const picks = rankCards(store, cards, { maxPicks: TOP_N });
+    for (const pick of picks) {
+      if (pick.source !== "category") continue;
+      const key = `${pick.card.slug}||${pick.reason}||${pick.note || ""}`;
+      let entry = rewards.get(key);
+      if (!entry) {
+        entry = {
+          card: pick.card.card_name || pick.card.slug,
+          slug: pick.card.slug,
+          reason: pick.reason,
+          note: pick.note || "",
+          effectiveRate: pick.effectiveRate,
+          stores: [],
+        };
+        rewards.set(key, entry);
+      }
+      entry.stores.push(store.name);
+    }
+  }
+
+  return [...rewards.values()].sort(
+    (a, b) => b.effectiveRate - a.effectiveRate
+  );
+}
+
+function printReport(report) {
+  console.log(
+    `Category-match rewards surfacing in any top-${TOP_N} (deduped, ${report.length} total)`
+  );
+  console.log("Sorted by effective rate. High store counts on a generic");
+  console.log("category are the smell for a merchant-limited rate.\n");
+
+  for (const r of report) {
+    const rate = r.effectiveRate.toFixed(2).replace(/\.00$/, "");
+    const samples = r.stores.slice(0, SAMPLE_LIMIT).join(", ");
+    const more =
+      r.stores.length > SAMPLE_LIMIT
+        ? `, +${r.stores.length - SAMPLE_LIMIT} more`
+        : "";
+    console.log(`${rate}% ${r.card}`);
+    console.log(`  reason: ${r.reason}`);
+    if (r.note) console.log(`  note:   ${r.note}`);
+    console.log(`  stores: ${r.stores.length} (${samples}${more})`);
+    console.log("");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const validateOnly = process.argv.includes("--validate-only");
+  const cards = loadCards();
+  const stores = loadStores();
+
+  if (!validateOnly) {
+    const report = buildReport(cards, stores);
+    printReport(report);
+  }
+
+  const errors = validate(cards, stores);
+  if (errors.length > 0) {
+    console.error(`\nVALIDATION FAILED — ${errors.length} error(s):`);
+    for (const e of errors) console.error(`  ✗ ${e}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `Validation passed: ${cards.length} cards, ${stores.length} stores, ` +
+      `all merchant_gate / co_brand_cards / also_earns references resolve.`
+  );
+}
+
+main();


### PR DESCRIPTION
## What

Adds `scripts/audit-store-rankings.js` — the permanent version of the throwaway harness written during the [#1701](https://github.com/CreditOdds/creditodds/pull/1701) review (which caught the Lyft/Aeroplan/AT&T/Atmos dead gates, the Costco gas rate, and the phone-category taxonomy drift). Run with `node scripts/audit-store-rankings.js` (or `npm run audit:store-rankings`).

### Report
Runs the production `rankCards()` over all 957 stores, dedupes every category-match reward that surfaces in any top-10, and prints each one — card, reason, note, effective rate, store count + sample stores — sorted by effective rate. A high store count on a *generic* category is the smell for a merchant-limited rate polluting pages it shouldn't reach.

### Validation (`--validate-only`)
Cross-checks the data the ranker trusts, exiting `1` on any failure:
- every `merchant_gate` slug must be a real store,
- a gated reward's category must be one the gate-target store actually carries (otherwise the gate is *dead* — the reward can never surface anywhere),
- every `co_brand_cards` / `also_earns` slug must be a real card.

### Build wiring
`build:stores` now runs `node scripts/build-stores.js && node scripts/audit-store-rankings.js --validate-only`, so a dead gate fails the build fast (cards.json already exists at that point in CI). The report itself is not wired in — only the validation.

## Verification
- `node scripts/audit-store-rankings.js` → full report, 131 deduped rewards, validation passes.
- `--validate-only` → passes on current data (182 cards, 957 stores).
- Negative test: injecting a bad `merchant_gate` slug and a wrong-category gate both surface as errors and exit 1.
- `npm run build:stores` passes end-to-end with the validation appended; no store-data churn beyond the regenerated `generated_at` timestamp (reverted).