### PR TITLE
card-wire: drop reconcile cadence from 30min to 6h

### DIFF
--- a/.github/workflows/reconcile-card-wire.yml
+++ b/.github/workflows/reconcile-card-wire.yml
@@ -24,10 +24,12 @@ name: Reconcile CardWire posts
 
 on:
   schedule:
-    # Every 30 minutes. The happy path already publishes within seconds
+    # Every 6 hours. The happy path already publishes within seconds
     # (social-queue kicks the scheduler for card-wire posts), so this only needs
-    # to bound the worst case for the rare stranded row.
-    - cron: '*/30 * * * *'
+    # to bound the worst case for the rare stranded row. Against a 48h look-back
+    # window a 6h cadence still recovers a stranded row while it is timely news,
+    # and every run in between was a no-op dedupe against the same post ID.
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       hours:


### PR DESCRIPTION
## What

Changes the `Reconcile CardWire posts` schedule from `*/30 * * * *` to `0 */6 * * *`.

## Why

The reconciler re-posts sign-up-bonus increases from the last **48 hours**, relying on `idempotency_key = wire-<slug>-<date>` so anything already tweeted dedupes to a no-op. A 30-minute cron is badly matched to a window that wide: at 6 hours a stranded row is still recovered while it is timely news, well inside the look-back.

Empirically, all 100 runs between 2026-07-11 and 2026-07-18 succeeded and every one was the identical no-op:

```
1 card(s) with a sign-up bonus increase in window
  Already posted (wire-world-of-hyatt-business-credit-card-2026-07-17) - skipped. Post ID: 268
```

That is the correct steady state for a safety net, but it does not need to happen 48x a day. This cuts it to 4x with no loss in coverage.

## What is not changing

The job itself stays. The incident that motivated it (#1622, the 2026-07-10 us-east-2 `ResourceNotFoundException` stranding) was fixed in #1617, but two failure paths it guards are still live: direct invokes of the sync Lambda for backfills, and errors in the post step itself. Both write the `card_wire` row without tweeting.

`workflow_dispatch` with a custom `hours` is untouched for deliberate catch-ups.

## Considered and dropped: rendering the image before the dedupe

`scripts/post-card-wire.js` renders and base64-uploads the card image (~170KB) on every run *before* the social API dedupes it. Skipping that is **not** possible from this repo: `idempotency_key` is only checked inside the `POST /social/queue` handler (`findByIdempotencyKey` in `social-queue.js`), which 405s every other method. `/social/posts` GET is a separate handler and does not filter by key. There is no way to ask whether a key exists without sending the full payload.

Fixing it would mean adding a lookup endpoint to the `social-posting-service` repo plus a manual prod deploy of the stack that publishes to X. At the old 30-minute cadence that was ~48 wasted renders/day and arguably worth it; at 6 hours it is ~4, so it is not. Recorded here in case the cadence ever goes back up.