### PR TITLE
card-page-check: run the nightly check locally, extraction in-session

### DIFF
--- a/.github/workflows/check-card-pages.yml
+++ b/.github/workflows/check-card-pages.yml
@@ -1,8 +1,13 @@
 name: Check Card Pages
 
+# The nightly schedule moved to a LOCAL scheduled task
+# (`card-page-check-local`, daily 7 AM ET) that runs scripts/check-card-pages-local.sh
+# with CARD_PAGE_EXTRACTOR=claude. The extraction now bills against the Claude
+# subscription instead of the OpenAI API, which is where ~$82/mo of this job's
+# cost was going. The cron is disabled rather than deleted so this workflow can
+# still be dispatched manually if OpenAI credit is restored — that path is
+# unchanged and still uses gpt-4o.
 on:
-  schedule:
-    - cron: '0 11 * * *'  # Daily at 11 AM UTC / 7 AM ET
   workflow_dispatch:
     inputs:
       card_slug:

--- a/.github/workflows/check-card-pages.yml
+++ b/.github/workflows/check-card-pages.yml
@@ -1,12 +1,14 @@
 name: Check Card Pages
 
-# The nightly schedule moved to a LOCAL scheduled task
-# (`card-page-check-local`, daily 7 AM ET) that runs scripts/check-card-pages-local.sh
-# with CARD_PAGE_EXTRACTOR=claude. The extraction now bills against the Claude
-# subscription instead of the OpenAI API, which is where ~$82/mo of this job's
-# cost was going. The cron is disabled rather than deleted so this workflow can
-# still be dispatched manually if OpenAI credit is restored — that path is
-# unchanged and still uses gpt-4o.
+# The nightly schedule moved to a LOCAL scheduled task (`card-page-check-local`,
+# daily 7 AM). That task runs the check in two phases —
+# `--phase=fetch` then `--phase=finish` — and performs the extraction itself
+# inside the Claude Code session, so no OpenAI key and no CLI token is involved.
+# That is where ~$82/mo of this job's cost was going.
+#
+# The cron is disabled rather than deleted so this workflow can still be
+# dispatched manually if OpenAI credit is restored. That path runs the original
+# single pass (`--phase=all`) on gpt-4o and is unchanged.
 on:
   workflow_dispatch:
     inputs:

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage/
 # Workflow artifacts
 .apply-link-check-result.json
 .issue-body.md
+.card-page-check-work/
 .card-page-check-summary.md
 .card-page-check-stale.md
 # NB: .github/card-page-check-state.json is deliberately NOT ignored — the

--- a/scripts/check-card-pages-local.sh
+++ b/scripts/check-card-pages-local.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Local counterpart to .github/workflows/check-card-pages.yml.
+#
+# Runs the nightly card-page check with the Claude CLI as the extractor instead
+# of gpt-4o, then reproduces the steps the workflow performs around the script:
+# validate, persist skip state, open a PR, and report cards that have gone
+# unverified. The script itself is unchanged between the two paths — only
+# CARD_PAGE_EXTRACTOR differs — so a local run and a CI run produce the same
+# artifacts.
+#
+# Prerequisite: `claude setup-token` (one time) so the CLI can run headless.
+#
+# Usage:  scripts/check-card-pages-local.sh [card-slug]
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+STATE_FILE=".github/card-page-check-state.json"
+SUMMARY_FILE=".card-page-check-summary.md"
+STALE_FILE=".card-page-check-stale.md"
+
+export CARD_PAGE_EXTRACTOR=claude
+export CARD_SLUG="${1:-}"
+
+# The check writes into data/cards/, so it needs that path clean — otherwise a
+# PR would sweep up whatever the user happened to be editing. Only data/cards/
+# is checked; unrelated work elsewhere in the tree is none of this run's
+# business and is left alone.
+if [ -n "$(git status --porcelain data/cards/)" ]; then
+  echo "ERROR: data/cards/ has uncommitted changes. Commit or stash them first." >&2
+  exit 1
+fi
+
+ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+# Always land back on the branch the user was on, however this exits.
+trap 'git checkout -q "$ORIGINAL_BRANCH" 2>/dev/null || true' EXIT
+
+git fetch -q origin main
+git checkout -q main
+git pull -q --ff-only origin main
+
+rm -f "$SUMMARY_FILE" "$STALE_FILE"
+
+echo "=== Running card page check (extractor: claude) ==="
+SCRIPT_STATUS=0
+node scripts/check-card-pages.js || SCRIPT_STATUS=$?
+
+# A preflight failure means nothing ran — no state to persist, no PR to open.
+# Bail before the reporting steps so an auth problem doesn't masquerade as a
+# clean night with zero changes.
+if [ "$SCRIPT_STATUS" -ne 0 ] && [ ! -f "$STATE_FILE" ]; then
+  echo "Check script failed before producing state — aborting." >&2
+  exit "$SCRIPT_STATUS"
+fi
+
+if [ -n "$(git status --porcelain data/cards/)" ]; then
+  echo "=== Validating updated card data ==="
+  if ! npm run build:cards; then
+    echo "ERROR: card validation failed — reverting changes." >&2
+    git checkout -- data/cards/
+    exit 1
+  fi
+  # build:cards regenerates cards.json, which is never committed from a card PR.
+  git checkout -- data/cards.json 2>/dev/null || true
+fi
+
+# Skip counters must survive the run even when nothing else does — a card that
+# is quietly rotting produces no PR, and the counter is the only thing that
+# eventually notices. Pushed through the contents API rather than a local
+# commit for the same reason CI does it: the card edits are sitting uncommitted
+# in the working tree for the PR step below, and a commit/stash dance here
+# risks eating them.
+if [ -n "$(git status --porcelain "$STATE_FILE")" ]; then
+  echo "=== Persisting skip-tracking state ==="
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+  SHA="$(gh api "repos/${REPO}/contents/${STATE_FILE}?ref=main" --jq '.sha' 2>/dev/null || true)"
+  ARGS=(-X PUT "repos/${REPO}/contents/${STATE_FILE}"
+    -f message='chore: update card-page skip-tracking state [skip ci]'
+    -f branch=main
+    -f content="$(base64 < "$STATE_FILE" | tr -d '\n')")
+  [ -n "$SHA" ] && ARGS+=(-f sha="$SHA")
+  gh api "${ARGS[@]}" --jq '.commit.sha' | sed 's/^/Committed state as /'
+  # Drop the local copy now that main owns it, so the PR branch below doesn't
+  # carry a duplicate of the same change.
+  git checkout -- "$STATE_FILE"
+fi
+
+PR_URL=""
+if [ -n "$(git status --porcelain data/cards/)" ]; then
+  echo "=== Opening PR ==="
+  SLUG="${CARD_SLUG:-all}"
+  BRANCH="card-page-check-${SLUG}-$(date +%Y-%m-%d-%H%M%S)"
+  git checkout -q -b "$BRANCH"
+  git add data/cards/
+  git commit -q -m "Card page check — $(date +%Y-%m-%d)"
+  git push -q -u origin "$BRANCH"
+
+  TITLE="Card Page Check $(date +%Y-%m-%d)"
+  if [ -f "$SUMMARY_FILE" ]; then
+    PR_URL=$(gh pr create --title "$TITLE" --body-file "$SUMMARY_FILE")
+  else
+    PR_URL=$(gh pr create --title "$TITLE" --body "Card page check. Please review changes to card YAML files.")
+  fi
+  echo "PR: $PR_URL"
+else
+  echo "No changes detected."
+fi
+
+# Same contract as the workflow: a card unverified for several runs running is a
+# data-integrity problem, so it gets an issue and a non-zero exit rather than
+# another quiet green.
+if [ -f "$STALE_FILE" ]; then
+  COUNT=$(grep -c '^| \[' "$STALE_FILE" || true)
+  TITLE="Cards unverified for several runs — ${COUNT:-?} card(s)"
+  gh label create "card-page-stale" \
+    --description "Cards the daily page check has failed to verify for several runs running" \
+    --color "b60205" 2>/dev/null || true
+  EXISTING=$(gh issue list --state open --label "card-page-stale" --limit 1 --json number --jq '.[0].number // empty')
+  if [ -n "$EXISTING" ]; then
+    gh issue edit "$EXISTING" --title "$TITLE" --body-file "$STALE_FILE"
+  else
+    gh issue create --title "$TITLE" --label "card-page-stale" --body-file "$STALE_FILE"
+  fi
+  echo "ERROR: cards have gone unverified for several consecutive runs." >&2
+  cat "$STALE_FILE"
+  exit 1
+fi
+
+EXISTING=$(gh issue list --state open --label "card-page-stale" --limit 1 --json number --jq '.[0].number // empty')
+if [ -n "$EXISTING" ]; then
+  gh issue close "$EXISTING" --comment "All cards verified on $(date -u +%Y-%m-%dT%H:%M:%SZ). Closing automatically."
+fi
+echo "Every card was verified against its live page."

--- a/scripts/check-card-pages-publish.sh
+++ b/scripts/check-card-pages-publish.sh
@@ -56,7 +56,14 @@ if [ -n "$(git status --porcelain data/cards/)" ]; then
   echo "=== Opening PR ==="
   SLUG="${CARD_SLUG:-all}"
   BRANCH="card-page-check-${SLUG}-$(date +%Y-%m-%d-%H%M%S)"
-  git checkout -q -b "$BRANCH"
+  # Explicitly base the card PR on origin/main, not on whatever HEAD happens to
+  # be. In CI those are the same thing, but locally the check may well have been
+  # run from a feature branch — and branching off HEAD there would sweep that
+  # branch's unrelated commits into a PR that is supposed to contain nothing but
+  # card YAML. The uncommitted data/cards/ edits carry across cleanly because
+  # they are the only modified paths.
+  git fetch -q origin main
+  git checkout -q -b "$BRANCH" origin/main
   git add data/cards/
   git commit -q -m "Card page check — $(date +%Y-%m-%d)"
   git push -q -u origin "$BRANCH"

--- a/scripts/check-card-pages-publish.sh
+++ b/scripts/check-card-pages-publish.sh
@@ -1,17 +1,14 @@
 #!/usr/bin/env bash
 #
-# Local counterpart to .github/workflows/check-card-pages.yml.
+# Publish step for the local card-page check. Runs AFTER
+# `node scripts/check-card-pages.js --phase=finish` has applied the YAML edits.
 #
-# Runs the nightly card-page check with the Claude CLI as the extractor instead
-# of gpt-4o, then reproduces the steps the workflow performs around the script:
-# validate, persist skip state, open a PR, and report cards that have gone
-# unverified. The script itself is unchanged between the two paths — only
-# CARD_PAGE_EXTRACTOR differs — so a local run and a CI run produce the same
-# artifacts.
+# This is the local counterpart to everything .github/workflows/check-card-pages.yml
+# does around the script: validate, persist skip state, open a PR, and file the
+# stale-card issue. The check itself is driven by the Claude Code session (see the
+# `card-page-check-local` scheduled task), because the extraction happens there.
 #
-# Prerequisite: `claude setup-token` (one time) so the CLI can run headless.
-#
-# Usage:  scripts/check-card-pages-local.sh [card-slug]
+# Usage:  scripts/check-card-pages-publish.sh [card-slug]
 
 set -euo pipefail
 
@@ -20,40 +17,7 @@ cd "$(dirname "$0")/.."
 STATE_FILE=".github/card-page-check-state.json"
 SUMMARY_FILE=".card-page-check-summary.md"
 STALE_FILE=".card-page-check-stale.md"
-
-export CARD_PAGE_EXTRACTOR=claude
-export CARD_SLUG="${1:-}"
-
-# The check writes into data/cards/, so it needs that path clean — otherwise a
-# PR would sweep up whatever the user happened to be editing. Only data/cards/
-# is checked; unrelated work elsewhere in the tree is none of this run's
-# business and is left alone.
-if [ -n "$(git status --porcelain data/cards/)" ]; then
-  echo "ERROR: data/cards/ has uncommitted changes. Commit or stash them first." >&2
-  exit 1
-fi
-
-ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-# Always land back on the branch the user was on, however this exits.
-trap 'git checkout -q "$ORIGINAL_BRANCH" 2>/dev/null || true' EXIT
-
-git fetch -q origin main
-git checkout -q main
-git pull -q --ff-only origin main
-
-rm -f "$SUMMARY_FILE" "$STALE_FILE"
-
-echo "=== Running card page check (extractor: claude) ==="
-SCRIPT_STATUS=0
-node scripts/check-card-pages.js || SCRIPT_STATUS=$?
-
-# A preflight failure means nothing ran — no state to persist, no PR to open.
-# Bail before the reporting steps so an auth problem doesn't masquerade as a
-# clean night with zero changes.
-if [ "$SCRIPT_STATUS" -ne 0 ] && [ ! -f "$STATE_FILE" ]; then
-  echo "Check script failed before producing state — aborting." >&2
-  exit "$SCRIPT_STATUS"
-fi
+CARD_SLUG="${1:-}"
 
 if [ -n "$(git status --porcelain data/cards/)" ]; then
   echo "=== Validating updated card data ==="
@@ -62,16 +26,17 @@ if [ -n "$(git status --porcelain data/cards/)" ]; then
     git checkout -- data/cards/
     exit 1
   fi
-  # build:cards regenerates cards.json, which is never committed from a card PR.
+  # build:cards regenerates data/cards.json, which is never committed from a
+  # card PR — CI rebuilds it.
   git checkout -- data/cards.json 2>/dev/null || true
 fi
 
 # Skip counters must survive the run even when nothing else does — a card that
 # is quietly rotting produces no PR, and the counter is the only thing that
-# eventually notices. Pushed through the contents API rather than a local
-# commit for the same reason CI does it: the card edits are sitting uncommitted
-# in the working tree for the PR step below, and a commit/stash dance here
-# risks eating them.
+# eventually notices. Pushed through the contents API rather than a local commit
+# for the same reason CI does it: the card edits are sitting uncommitted in the
+# working tree for the PR step below, and a commit/stash dance here risks
+# eating them.
 if [ -n "$(git status --porcelain "$STATE_FILE")" ]; then
   echo "=== Persisting skip-tracking state ==="
   REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
@@ -82,12 +47,11 @@ if [ -n "$(git status --porcelain "$STATE_FILE")" ]; then
     -f content="$(base64 < "$STATE_FILE" | tr -d '\n')")
   [ -n "$SHA" ] && ARGS+=(-f sha="$SHA")
   gh api "${ARGS[@]}" --jq '.commit.sha' | sed 's/^/Committed state as /'
-  # Drop the local copy now that main owns it, so the PR branch below doesn't
-  # carry a duplicate of the same change.
   git checkout -- "$STATE_FILE"
 fi
 
-PR_URL=""
+ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
 if [ -n "$(git status --porcelain data/cards/)" ]; then
   echo "=== Opening PR ==="
   SLUG="${CARD_SLUG:-all}"
@@ -104,6 +68,7 @@ if [ -n "$(git status --porcelain data/cards/)" ]; then
     PR_URL=$(gh pr create --title "$TITLE" --body "Card page check. Please review changes to card YAML files.")
   fi
   echo "PR: $PR_URL"
+  git checkout -q "$ORIGINAL_BRANCH"
 else
   echo "No changes detected."
 fi

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -7,13 +7,18 @@
  * extracts current terms with an LLM, and creates a PR for human review when
  * changes are detected.
  *
- * Extraction backend is selected by CARD_PAGE_EXTRACTOR:
- *   'openai' (default) — gpt-4o via the API; what workflow_dispatch runs.
- *   'claude'           — the local Claude Code CLI, used by the nightly local
- *                        task (scripts/check-card-pages-local.sh) so the
- *                        inference bills against the subscription rather than
- *                        a metered API.
- * Both share one prompt and one JSON contract; nothing downstream differs.
+ * Run shape is selected by --phase:
+ *   all (default) — fetch + extract in one loop via gpt-4o; what
+ *                   workflow_dispatch runs.
+ *   fetch         — fetch pages and write one extraction prompt per card to
+ *                   .card-page-check-work/, then stop.
+ *   finish        — read the answers back from
+ *                   .card-page-check-work/extractions.json and do the diffing,
+ *                   YAML edits and reporting.
+ *
+ * The fetch/finish split exists so the nightly run can happen inside a Claude
+ * Code session, which answers the prompts itself. That path needs no API key
+ * and no CLI token. All three phases share one prompt and one JSON contract.
  *
  * Only processes cards where:
  *   - accepting_applications !== false
@@ -34,9 +39,7 @@
  */
 
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
-const { execFile } = require('child_process');
 const yaml = require('js-yaml');
 
 const CARDS_DIR = path.join(__dirname, '..', 'data', 'cards');
@@ -72,39 +75,50 @@ const FETCH_DELAY_MS = 2000;
 const BROWSER_FIRST_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 15000;
 
-// ─── Extraction backend ──────────────────────────────────────────────────────
-// 'openai' (default) keeps CI on gpt-4o. 'claude' shells out to the locally
-// authenticated Claude Code CLI instead, moving the per-card inference off a
-// metered API and onto the subscription — the whole point of running this
-// nightly job locally. Nothing else in the script changes: same prompt, same
-// JSON contract, same downstream diffing.
-const EXTRACTOR = (process.env.CARD_PAGE_EXTRACTOR || 'openai').toLowerCase();
-const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
-const CLAUDE_MODEL = process.env.CLAUDE_MODEL || 'claude-sonnet-5';
+// ─── Run phases ──────────────────────────────────────────────────────────────
+// 'all' (default) is the original single pass: fetch and extract each card in
+// one loop, calling gpt-4o. That is what workflow_dispatch still runs.
+//
+// 'fetch' and 'finish' split that pass in two so the extraction step can be
+// performed by the Claude Code session itself rather than by any API this
+// script calls. `fetch` writes one self-contained prompt per card to WORK_DIR;
+// the session answers them and writes extractions.json; `finish` reads those
+// answers back and does the diffing, YAML edits and reporting exactly as the
+// single pass would. No API key and no CLI token are involved on that path —
+// the inference happens inside the already-authenticated session.
+//
+// Everything that must be exact (fetching, change detection, YAML rewriting,
+// skip accounting) stays in this script. Only the extraction, which is the
+// genuinely model-shaped part, moves out.
+const PHASE = (() => {
+  const arg = process.argv.find(a => a.startsWith('--phase='));
+  const v = (arg ? arg.slice('--phase='.length) : process.env.CARD_PAGE_PHASE || 'all').toLowerCase();
+  return v;
+})();
+const WORK_DIR = path.join(__dirname, '..', '.card-page-check-work');
+const PROMPTS_DIR = path.join(WORK_DIR, 'prompts');
+const PAGES_DIR = path.join(WORK_DIR, 'pages');
+const FETCH_STATE_FILE = path.join(WORK_DIR, 'fetch-state.json');
+const EXTRACTIONS_FILE = path.join(WORK_DIR, 'extractions.json');
 
-// A `claude -p` round trip (process spawn + inference) runs several times longer
-// than gpt-4o's ~1.5–3s, so both budgets have to grow with the claude backend or
-// the run truncates itself: cards would trip the per-card timeout, and the whole
-// job would hit its deadline with most of the list unchecked. Locally there is
-// no 45-minute GitHub job cap to stay under, so the ceiling can move.
-const usingClaude = EXTRACTOR === 'claude';
-const PER_CARD_TIMEOUT_MS = Number(
-  process.env.CARD_PAGE_PER_CARD_TIMEOUT_MS || (usingClaude ? 180000 : 60000)
-);
+const PER_CARD_TIMEOUT_MS = Number(process.env.CARD_PAGE_PER_CARD_TIMEOUT_MS || 60000);
 // Overall safety net. Widening the browser-retry condition (needsBrowserRetry)
 // makes every card whose welcome offer is client-side — most of the ~20 Amex
 // cards — pay one extra Playwright fetch (~13s measured) per run, roughly +4 min
 // on a run that already took ~14 min. Raised 20 → 30 min so that added work
 // doesn't silently truncate coverage.
 //
-// On the openai/CI path this MUST stay comfortably below `timeout-minutes` in
-// .github/workflows/check-card-pages.yml (currently 45): the job needs headroom
-// after this deadline to write the skip summary and open the PR. If the two are
-// equal, GitHub hard-kills the job and the graceful exit path never runs.
-// The claude/local path has no such job cap, which is why it gets a far larger
-// budget — it needs one, since each extraction is a process spawn plus inference.
+// On the single-pass/CI path this MUST stay comfortably below `timeout-minutes`
+// in .github/workflows/check-card-pages.yml (currently 45): the job needs
+// headroom after this deadline to write the skip summary and open the PR. If the
+// two are equal, GitHub hard-kills the job and the graceful exit path never runs.
+//
+// The 'fetch' phase gets a larger budget: it runs locally with no job cap, and
+// it browser-renders far more pages than the single pass does (see FETCH_PHASE
+// note in the card loop), which is slower but removes the need for a second
+// extraction round trip.
 const SCRIPT_TIMEOUT_MS = Number(
-  process.env.CARD_PAGE_SCRIPT_TIMEOUT_MS || (usingClaude ? 120 * 60 * 1000 : 30 * 60 * 1000)
+  process.env.CARD_PAGE_SCRIPT_TIMEOUT_MS || (PHASE === 'fetch' ? 90 * 60 * 1000 : 30 * 60 * 1000)
 );
 // Max stripped page text handed to the extractor. Sized so nav-heavy issuer
 // pages still include the card terms — e.g. business.bankofamerica.com leads
@@ -533,74 +547,9 @@ async function extractViaOpenAI(prompt) {
   return parseExtractionJson(data.choices[0]?.message?.content, 'OpenAI');
 }
 
-// Shells out to the locally authenticated Claude Code CLI.
-//
-// `--tools ""` is load-bearing, not tidiness. `pageContent` is untrusted HTML
-// scraped from a third-party issuer site, and it lands verbatim in the prompt.
-// The OpenAI path is inert because that endpoint has no tools at all; a bare
-// `claude -p` does, so a card page carrying injected instructions could
-// otherwise reach Bash/Edit against this repo. Disabling the toolset removes
-// the capability rather than trusting the model to decline.
-//
-// `--bare` skips hooks, LSP and plugin loading — none of which this text-only
-// call needs, and all of which add seconds to a spawn we pay 148 times a night.
-function extractViaClaude(prompt) {
-  return new Promise((resolve, reject) => {
-    const args = [
-      '-p',
-      '--bare',
-      '--tools', '',
-      '--model', CLAUDE_MODEL,
-      '--output-format', 'json',
-      '--json-schema', JSON.stringify(EXTRACTION_SCHEMA),
-    ];
-
-    const child = execFile(
-      CLAUDE_BIN,
-      args,
-      {
-        // Run outside the repo so the CLI picks up no project CLAUDE.md, no
-        // settings, no MCP servers — this call must depend on the prompt alone.
-        cwd: os.tmpdir(),
-        maxBuffer: 10 * 1024 * 1024,
-        timeout: PER_CARD_TIMEOUT_MS,
-      },
-      (err, stdout, stderr) => {
-        // Parse stdout FIRST, even on a non-zero exit. The CLI reports real
-        // failures ("Not logged in", quota) in the envelope's `result` while
-        // also exiting non-zero, and execFile's err.message is just the whole
-        // command line — including the ~700-char schema — which buries the one
-        // string that says what actually went wrong.
-        let envelope = null;
-        try {
-          envelope = JSON.parse(stdout);
-        } catch { /* fall through to the raw-error path below */ }
-
-        if (envelope && envelope.is_error) {
-          return reject(new Error(`claude CLI: ${envelope.result || 'unknown error'}`));
-        }
-
-        if (err) {
-          const detail = (stderr || '').trim().split('\n')[0] || err.message.split('\n')[0];
-          return reject(new Error(`claude CLI failed: ${detail.slice(0, 200)}`));
-        }
-
-        if (!envelope) {
-          return reject(new Error(`claude CLI returned non-JSON: ${stdout.slice(0, 200)}`));
-        }
-
-        resolve(parseExtractionJson(envelope.result, 'Claude'));
-      }
-    );
-
-    child.stdin.on('error', () => {});
-    child.stdin.end(prompt);
-  });
-}
-
 async function extractCardTerms(cardName, bankName, applyLink, pageContent, currentSignupBonus) {
   const prompt = buildExtractionPrompt(cardName, bankName, applyLink, pageContent, currentSignupBonus);
-  return usingClaude ? extractViaClaude(prompt) : extractViaOpenAI(prompt);
+  return extractViaOpenAI(prompt);
 }
 
 // ─── Change detection ─────────────────────────────────────────────────────────
@@ -1255,29 +1204,20 @@ function writeStaleReport(stale, cardsBySlug) {
 async function main() {
   console.log('=== Check Card Pages ===\n');
 
-  if (!['openai', 'claude'].includes(EXTRACTOR)) {
-    console.error(`Error: CARD_PAGE_EXTRACTOR must be 'openai' or 'claude' (got '${EXTRACTOR}')`);
+  if (!['all', 'fetch', 'finish'].includes(PHASE)) {
+    console.error(`Error: --phase must be 'all', 'fetch' or 'finish' (got '${PHASE}')`);
     process.exit(1);
   }
 
-  if (EXTRACTOR === 'openai' && !process.env.OPENAI_API_KEY) {
+  // Only the single pass talks to OpenAI. The fetch/finish split does its
+  // inference in the calling session, so it must not demand a key.
+  if (PHASE === 'all' && !process.env.OPENAI_API_KEY) {
     console.error('Error: OPENAI_API_KEY environment variable is required');
     process.exit(1);
   }
 
-  // Fail fast on a dead CLI rather than discovering it 148 times. Without this
-  // an unauthenticated CLI turns every card into an "extraction error" skip —
-  // a slow, expensive way to learn the run was never going to work.
-  if (EXTRACTOR === 'claude') {
-    console.log(`Extractor: claude CLI (${CLAUDE_MODEL})`);
-    try {
-      await extractViaClaude('Reply with only this JSON and nothing else: {"annual_fee":0,"signup_bonus":{"value":null,"type":null,"spend_requirement":null,"timeframe_months":null}}');
-    } catch (err) {
-      console.error(`Error: claude CLI preflight failed — ${err.message}`);
-      console.error("Run 'claude setup-token' to authenticate the CLI for headless use.");
-      process.exit(1);
-    }
-  }
+  console.log(`Phase: ${PHASE}\n`);
+  if (PHASE === 'finish') return finishPhase();
 
   const slugFilter = process.env.CARD_SLUG || null;
 
@@ -1297,6 +1237,16 @@ async function main() {
   const allChanges = [];
   const skippedCards = [];
   const allSuppressions = [];
+  const fetchedSlugs = [];
+
+  if (PHASE === 'fetch') {
+    // Wipe rather than merge: a stale prompt left from a previous night would be
+    // answered as if it were current, silently verifying a card against page
+    // content that is a day old.
+    fs.rmSync(WORK_DIR, { recursive: true, force: true });
+    fs.mkdirSync(PROMPTS_DIR, { recursive: true });
+    fs.mkdirSync(PAGES_DIR, { recursive: true });
+  }
 
   // Every path that abandons a card must land here. A skip that isn't recorded is
   // worse than a loud failure: it silently shrinks the verified set while the run
@@ -1388,6 +1338,44 @@ async function main() {
         let { content: pageContent, usedBrowser } = fetchResult;
         console.log(`  Fetched ${pageContent.length} chars`);
 
+        // FETCH_PHASE: write the prompt out and stop — the caller does the
+        // extraction. The single pass decides whether a page needs re-fetching
+        // with the browser by looking at what the extractor returned
+        // (needsBrowserRetry), which is unavailable here because nothing has
+        // been extracted yet. pageShowsSignupOffer is the deterministic stand-in:
+        // a simple-fetch page with no offer language anywhere in it is the same
+        // JS-rendered placeholder case the retry exists to catch. Re-fetching on
+        // that signal keeps the self-heal without needing a second extract/fetch
+        // round trip — at the cost of a wasted browser fetch on cards that
+        // genuinely have no welcome offer, which is time, not accuracy.
+        if (PHASE === 'fetch') {
+          if (!usedBrowser && !pageShowsSignupOffer(pageContent)) {
+            console.log('  No offer language in simple fetch — re-fetching with browser');
+            const browserContent = await fetchWithBrowser(apply_link);
+            lastHostHit.set(host, Date.now());
+            if (browserContent) {
+              pageContent = browserContent;
+              usedBrowser = true;
+            }
+          }
+
+          fs.writeFileSync(
+            path.join(PROMPTS_DIR, `${card.slug}.txt`),
+            buildExtractionPrompt(name, bank, apply_link, pageContent, card.data.signup_bonus)
+          );
+          fs.writeFileSync(path.join(PAGES_DIR, `${card.slug}.txt`), pageContent);
+
+          if (usedBrowser) {
+            browserFirstBySlug.set(
+              card.slug,
+              browserFirstValid ? prevBrowserFirst : new Date().toISOString()
+            );
+          }
+          fetchedSlugs.push(card.slug);
+          console.log('  Prompt written');
+          return;
+        }
+
         // Extract with Claude Haiku
         let extracted;
         try {
@@ -1463,6 +1451,127 @@ async function main() {
     console.log('');
   }
 
+  // FETCH_PHASE ends here. Deliberately does NOT touch the skip counters or the
+  // stale report: nothing has been verified yet, and a card whose prompt was
+  // written but never answered is a skip that only `finish` can see. Recording
+  // success here would let an abandoned run (session closed mid-extraction)
+  // advance the counters as though every card had been checked.
+  if (PHASE === 'fetch') {
+    fs.writeFileSync(FETCH_STATE_FILE, JSON.stringify({
+      fetched_at: new Date().toISOString(),
+      slug_filter: slugFilter,
+      fetched: fetchedSlugs,
+      skipped: skippedCards,
+      browser_first: Object.fromEntries(browserFirstBySlug),
+    }, null, 2));
+
+    await closeBrowser();
+    console.log(`\nWrote ${fetchedSlugs.length} prompt(s) to ${path.relative(process.cwd(), PROMPTS_DIR)}`);
+    console.log(`Skipped ${skippedCards.length} card(s) before extraction.`);
+    console.log('\nNext: answer each prompt and write {"<slug>": {...}} to');
+    console.log(`  ${path.relative(process.cwd(), EXTRACTIONS_FILE)}`);
+    console.log('then run: node scripts/check-card-pages.js --phase=finish');
+    console.log('\n=== Fetch phase complete ===');
+    return;
+  }
+
+  return finalize({
+    allCards, cardsToCheck, skippedCards, allChanges, allSuppressions,
+    slugFilter, prevState, browserFirstBySlug,
+  });
+}
+// ─── Finish phase ────────────────────────────────────────────────────────────
+// Reads back the extractions the calling session produced and runs them through
+// exactly the same detectChanges/applyChanges path the single pass uses. The
+// model's only contribution is the JSON; every judgement about what counts as a
+// change, what gets suppressed and what reaches a human still lives here.
+async function finishPhase() {
+  if (!fs.existsSync(FETCH_STATE_FILE)) {
+    console.error(`Error: ${path.relative(process.cwd(), FETCH_STATE_FILE)} not found — run --phase=fetch first.`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(EXTRACTIONS_FILE)) {
+    console.error(`Error: ${path.relative(process.cwd(), EXTRACTIONS_FILE)} not found — nothing to finish.`);
+    process.exit(1);
+  }
+
+  const fetchState = JSON.parse(fs.readFileSync(FETCH_STATE_FILE, 'utf8'));
+  let extractions;
+  try {
+    extractions = JSON.parse(fs.readFileSync(EXTRACTIONS_FILE, 'utf8'));
+  } catch (err) {
+    console.error(`Error: extractions.json is not valid JSON — ${err.message}`);
+    process.exit(1);
+  }
+
+  const allCards = loadAllCards();
+  const cardsBySlug = new Map(allCards.map(c => [c.slug, c]));
+  const cardsToCheck = filterCardsForCheck(allCards, fetchState.slug_filter || null);
+
+  const allChanges = [];
+  const allSuppressions = [];
+  // Skips recorded during fetch (dead URL, bot-block, timeout) carry straight
+  // through — those cards were never verified, and which phase noticed is
+  // irrelevant to the counter.
+  const skippedCards = [...(fetchState.skipped || [])];
+
+  const now = new Date();
+  for (const slug of fetchState.fetched || []) {
+    const card = cardsBySlug.get(slug);
+    if (!card) continue;  // card deleted between phases
+
+    const extracted = extractions[slug];
+    // A prompt that was written but came back missing, null, or non-object is a
+    // card that did NOT get verified. It must land in skippedCards, not be
+    // quietly treated as "no changes" — that equivalence is the exact failure
+    // this script's skip accounting exists to prevent.
+    if (!extracted || typeof extracted !== 'object') {
+      console.warn(`  ${card.data.name}: no extraction returned — skipping`);
+      skippedCards.push({
+        slug,
+        name: card.data.name,
+        url: checkUrlFor(card),
+        reason: 'no extraction returned for this card',
+        knownBlock: false,
+      });
+      continue;
+    }
+
+    const pageFile = path.join(PAGES_DIR, `${slug}.txt`);
+    const pageContent = fs.existsSync(pageFile) ? fs.readFileSync(pageFile, 'utf8') : null;
+
+    const changes = detectChanges(card, extracted, now, allSuppressions, pageContent);
+    if (changes.length > 0) {
+      console.log(`${card.data.name}: ${changes.length} change(s) detected`);
+      logFetchedText(card.data.name, checkUrlFor(card), true, pageContent || '', extracted);
+      allChanges.push({
+        slug,
+        card_name: card.data.name,
+        apply_link: checkUrlFor(card),
+        changes,
+      });
+    }
+  }
+
+  return finalize({
+    allCards,
+    cardsToCheck,
+    skippedCards,
+    allChanges,
+    allSuppressions,
+    slugFilter: fetchState.slug_filter || null,
+    prevState: loadSkipState(),
+    browserFirstBySlug: new Map(Object.entries(fetchState.browser_first || {})),
+  });
+}
+
+// ─── Shared finalization ─────────────────────────────────────────────────────
+// Everything after the per-card loop: skip reporting, counter persistence, the
+// stale alarm, YAML application and the PR summary. Factored out because the
+// single pass and the finish phase must do this identically — if they drift,
+// one of them silently stops advancing the skip counters that are the only
+// guard against a card rotting unverified.
+async function finalize({ allCards, cardsToCheck, skippedCards, allChanges, allSuppressions, slugFilter, prevState, browserFirstBySlug }) {
   if (skippedCards.length > 0) {
     console.log(`\n⚠️  Skipped ${skippedCards.length} card(s) (NOT checked this run — not the same as unchanged):`);
     for (const s of skippedCards) {

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -4,8 +4,16 @@
  * Check Card Pages Script
  *
  * Fetches the apply page for each active card that has an apply_link,
- * uses Claude Haiku to extract current terms, and creates a PR for
- * human review when changes are detected.
+ * extracts current terms with an LLM, and creates a PR for human review when
+ * changes are detected.
+ *
+ * Extraction backend is selected by CARD_PAGE_EXTRACTOR:
+ *   'openai' (default) — gpt-4o via the API; what workflow_dispatch runs.
+ *   'claude'           — the local Claude Code CLI, used by the nightly local
+ *                        task (scripts/check-card-pages-local.sh) so the
+ *                        inference bills against the subscription rather than
+ *                        a metered API.
+ * Both share one prompt and one JSON contract; nothing downstream differs.
  *
  * Only processes cards where:
  *   - accepting_applications !== false
@@ -26,7 +34,9 @@
  */
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { execFile } = require('child_process');
 const yaml = require('js-yaml');
 
 const CARDS_DIR = path.join(__dirname, '..', 'data', 'cards');
@@ -61,18 +71,41 @@ const FETCH_DELAY_MS = 2000;
 // re-flags itself if still browser-dependent.
 const BROWSER_FIRST_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 15000;
-const PER_CARD_TIMEOUT_MS = 60000;   // 60s max per card (fetch + extraction)
+
+// ─── Extraction backend ──────────────────────────────────────────────────────
+// 'openai' (default) keeps CI on gpt-4o. 'claude' shells out to the locally
+// authenticated Claude Code CLI instead, moving the per-card inference off a
+// metered API and onto the subscription — the whole point of running this
+// nightly job locally. Nothing else in the script changes: same prompt, same
+// JSON contract, same downstream diffing.
+const EXTRACTOR = (process.env.CARD_PAGE_EXTRACTOR || 'openai').toLowerCase();
+const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
+const CLAUDE_MODEL = process.env.CLAUDE_MODEL || 'claude-sonnet-5';
+
+// A `claude -p` round trip (process spawn + inference) runs several times longer
+// than gpt-4o's ~1.5–3s, so both budgets have to grow with the claude backend or
+// the run truncates itself: cards would trip the per-card timeout, and the whole
+// job would hit its deadline with most of the list unchecked. Locally there is
+// no 45-minute GitHub job cap to stay under, so the ceiling can move.
+const usingClaude = EXTRACTOR === 'claude';
+const PER_CARD_TIMEOUT_MS = Number(
+  process.env.CARD_PAGE_PER_CARD_TIMEOUT_MS || (usingClaude ? 180000 : 60000)
+);
 // Overall safety net. Widening the browser-retry condition (needsBrowserRetry)
 // makes every card whose welcome offer is client-side — most of the ~20 Amex
 // cards — pay one extra Playwright fetch (~13s measured) per run, roughly +4 min
 // on a run that already took ~14 min. Raised 20 → 30 min so that added work
 // doesn't silently truncate coverage.
 //
-// MUST stay comfortably below `timeout-minutes` in .github/workflows/check-card-pages.yml
-// (currently 45): the job needs headroom after this deadline to write the skip
-// summary and open the PR. If the two are equal, GitHub hard-kills the job and
-// the graceful exit path never runs.
-const SCRIPT_TIMEOUT_MS = 30 * 60 * 1000; // 30 min overall safety net
+// On the openai/CI path this MUST stay comfortably below `timeout-minutes` in
+// .github/workflows/check-card-pages.yml (currently 45): the job needs headroom
+// after this deadline to write the skip summary and open the PR. If the two are
+// equal, GitHub hard-kills the job and the graceful exit path never runs.
+// The claude/local path has no such job cap, which is why it gets a far larger
+// budget — it needs one, since each extraction is a process spawn plus inference.
+const SCRIPT_TIMEOUT_MS = Number(
+  process.env.CARD_PAGE_SCRIPT_TIMEOUT_MS || (usingClaude ? 120 * 60 * 1000 : 30 * 60 * 1000)
+);
 // Max stripped page text handed to the extractor. Sized so nav-heavy issuer
 // pages still include the card terms — e.g. business.bankofamerica.com leads
 // with ~11k chars of menu chrome and the bonus/spend/timeframe land at ~12k–18k.
@@ -341,12 +374,41 @@ async function closeBrowser() {
   }
 }
 
-// ─── OpenAI extraction ────────────────────────────────────────────────────────
+// ─── Extraction ───────────────────────────────────────────────────────────────
 
-async function extractCardTerms(cardName, bankName, applyLink, pageContent, currentSignupBonus) {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error('OPENAI_API_KEY required');
+// The JSON contract both backends must satisfy. OpenAI gets it as
+// `response_format: json_object` plus the shape spelled out in the prompt;
+// the Claude CLI gets it as a real `--json-schema`, which is strictly
+// stronger — malformed output is rejected before it ever reaches us.
+const EXTRACTION_SCHEMA = {
+  type: 'object',
+  properties: {
+    annual_fee: { type: ['number', 'null'] },
+    signup_bonus: {
+      type: 'object',
+      properties: {
+        value: { type: ['number', 'null'] },
+        type: { type: ['string', 'null'], enum: ['points', 'miles', 'cashback', 'free_nights', null] },
+        spend_requirement: { type: ['number', 'null'] },
+        timeframe_months: { type: ['number', 'null'] },
+        authorized_user_bonus: { type: ['number', 'null'] },
+        bonus_note: { type: ['string', 'null'] },
+        offer_is_tiered: { type: ['boolean', 'null'] },
+      },
+      required: ['value', 'type', 'spend_requirement', 'timeframe_months'],
+    },
+    apr: {
+      type: 'object',
+      properties: {
+        purchase_intro_months: { type: ['number', 'null'] },
+        balance_transfer_intro_months: { type: ['number', 'null'] },
+      },
+    },
+  },
+  required: ['annual_fee', 'signup_bonus'],
+};
 
+function buildExtractionPrompt(cardName, bankName, applyLink, pageContent, currentSignupBonus) {
   const cur = currentSignupBonus || {};
   const currentContext = `Current YAML values (for unit context — DO NOT copy these, extract fresh from the page):
 - signup_bonus.value: ${cur.value ?? 'null'}
@@ -428,6 +490,26 @@ Rules:
 - STRIKETHROUGH TEXT: Text wrapped in [STRIKETHROUGH: ...] is struck through on the page and represents old/expired values. Always ignore strikethrough values and use the non-strikethrough value instead.
 - Return null for any field you cannot determine with confidence.`;
 
+  return prompt;
+}
+
+function parseExtractionJson(text, label) {
+  const cleaned = (text || '{}')
+    .replace(/^```json?\n?/, '')
+    .replace(/\n?```$/, '')
+    .trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch (err) {
+    console.warn(`  Could not parse ${label} response: ${err.message}`);
+    return null;
+  }
+}
+
+async function extractViaOpenAI(prompt) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY required');
+
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -448,17 +530,77 @@ Rules:
   }
 
   const data = await response.json();
-  const text = (data.choices[0]?.message?.content || '{}')
-    .replace(/^```json?\n?/, '')
-    .replace(/\n?```$/, '')
-    .trim();
+  return parseExtractionJson(data.choices[0]?.message?.content, 'OpenAI');
+}
 
-  try {
-    return JSON.parse(text);
-  } catch (err) {
-    console.warn(`  Could not parse OpenAI response: ${err.message}`);
-    return null;
-  }
+// Shells out to the locally authenticated Claude Code CLI.
+//
+// `--tools ""` is load-bearing, not tidiness. `pageContent` is untrusted HTML
+// scraped from a third-party issuer site, and it lands verbatim in the prompt.
+// The OpenAI path is inert because that endpoint has no tools at all; a bare
+// `claude -p` does, so a card page carrying injected instructions could
+// otherwise reach Bash/Edit against this repo. Disabling the toolset removes
+// the capability rather than trusting the model to decline.
+//
+// `--bare` skips hooks, LSP and plugin loading — none of which this text-only
+// call needs, and all of which add seconds to a spawn we pay 148 times a night.
+function extractViaClaude(prompt) {
+  return new Promise((resolve, reject) => {
+    const args = [
+      '-p',
+      '--bare',
+      '--tools', '',
+      '--model', CLAUDE_MODEL,
+      '--output-format', 'json',
+      '--json-schema', JSON.stringify(EXTRACTION_SCHEMA),
+    ];
+
+    const child = execFile(
+      CLAUDE_BIN,
+      args,
+      {
+        // Run outside the repo so the CLI picks up no project CLAUDE.md, no
+        // settings, no MCP servers — this call must depend on the prompt alone.
+        cwd: os.tmpdir(),
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: PER_CARD_TIMEOUT_MS,
+      },
+      (err, stdout, stderr) => {
+        // Parse stdout FIRST, even on a non-zero exit. The CLI reports real
+        // failures ("Not logged in", quota) in the envelope's `result` while
+        // also exiting non-zero, and execFile's err.message is just the whole
+        // command line — including the ~700-char schema — which buries the one
+        // string that says what actually went wrong.
+        let envelope = null;
+        try {
+          envelope = JSON.parse(stdout);
+        } catch { /* fall through to the raw-error path below */ }
+
+        if (envelope && envelope.is_error) {
+          return reject(new Error(`claude CLI: ${envelope.result || 'unknown error'}`));
+        }
+
+        if (err) {
+          const detail = (stderr || '').trim().split('\n')[0] || err.message.split('\n')[0];
+          return reject(new Error(`claude CLI failed: ${detail.slice(0, 200)}`));
+        }
+
+        if (!envelope) {
+          return reject(new Error(`claude CLI returned non-JSON: ${stdout.slice(0, 200)}`));
+        }
+
+        resolve(parseExtractionJson(envelope.result, 'Claude'));
+      }
+    );
+
+    child.stdin.on('error', () => {});
+    child.stdin.end(prompt);
+  });
+}
+
+async function extractCardTerms(cardName, bankName, applyLink, pageContent, currentSignupBonus) {
+  const prompt = buildExtractionPrompt(cardName, bankName, applyLink, pageContent, currentSignupBonus);
+  return usingClaude ? extractViaClaude(prompt) : extractViaOpenAI(prompt);
 }
 
 // ─── Change detection ─────────────────────────────────────────────────────────
@@ -1113,9 +1255,28 @@ function writeStaleReport(stale, cardsBySlug) {
 async function main() {
   console.log('=== Check Card Pages ===\n');
 
-  if (!process.env.OPENAI_API_KEY) {
+  if (!['openai', 'claude'].includes(EXTRACTOR)) {
+    console.error(`Error: CARD_PAGE_EXTRACTOR must be 'openai' or 'claude' (got '${EXTRACTOR}')`);
+    process.exit(1);
+  }
+
+  if (EXTRACTOR === 'openai' && !process.env.OPENAI_API_KEY) {
     console.error('Error: OPENAI_API_KEY environment variable is required');
     process.exit(1);
+  }
+
+  // Fail fast on a dead CLI rather than discovering it 148 times. Without this
+  // an unauthenticated CLI turns every card into an "extraction error" skip —
+  // a slow, expensive way to learn the run was never going to work.
+  if (EXTRACTOR === 'claude') {
+    console.log(`Extractor: claude CLI (${CLAUDE_MODEL})`);
+    try {
+      await extractViaClaude('Reply with only this JSON and nothing else: {"annual_fee":0,"signup_bonus":{"value":null,"type":null,"spend_requirement":null,"timeframe_months":null}}');
+    } catch (err) {
+      console.error(`Error: claude CLI preflight failed — ${err.message}`);
+      console.error("Run 'claude setup-token' to authenticate the CLI for headless use.");
+      process.exit(1);
+    }
   }
 
   const slugFilter = process.env.CARD_SLUG || null;


### PR DESCRIPTION
## Why

The nightly `Check Card Pages` job has been failing on OpenAI `insufficient_quota`. Worth noting how it failed:

| Run | Status | Reality |
|---|---|---|
| 7/18 | ✅ success | 134 of 148 cards failed extraction on 429 |
| 7/19 | ❌ failure | same, plus skip counters crossed the alert threshold |

Quota errors are recorded as *skips*, and `SKIP_ALERT_THRESHOLD = 3` means three consecutive dead runs before the build reddens — so card terms went unverified for a day while CI reported success. That is the silent-false-negative case this job's skip counters exist to catch.

Cost driver: 148 cards × ~6,800 input tokens (2,309-token static prompt + up to 18,000 chars of page text) ≈ **1.0M input tokens/run ≈ $2.74/day ≈ $82/mo** on gpt-4o.

Runner minutes were never the cost — this is a public repo, so Actions is free. Relocating the script alone would have saved nothing and still 429'd; the saving comes entirely from changing *what does the extraction*.

## What

The check splits into phases so the extraction can happen inside the Claude Code session, which is already authenticated. No API key, no CLI token.

| Phase | Does |
|---|---|
| `--phase=fetch` | Fetches every page, writes one self-contained extraction prompt per card to `.card-page-check-work/` |
| *(session)* | Answers the prompts via subagents, writes `extractions.json` |
| `--phase=finish` | Reads the answers back, diffs, applies YAML, reports |
| `--phase=all` | Unchanged single pass on gpt-4o — still what `workflow_dispatch` runs |

Everything that must be exact — fetching, change detection, YAML rewriting, skip accounting — stays in Node. Only the extraction moves out.

### Notable details

- **The browser-retry needed a deterministic stand-in.** The single pass decides whether to re-fetch with Playwright from what the extractor returned (`needsBrowserRetry`), which doesn't exist mid-fetch when nothing has been extracted yet. The fetch phase uses `pageShowsSignupOffer` instead: a simple-fetch page with no offer language anywhere is the same JS-rendered placeholder case. Costs a wasted browser fetch on cards that genuinely have no welcome offer — time, not accuracy.
- **A slug missing from `extractions.json` becomes a recorded skip, never "no changes."** Collapsing those two is the precise failure this script's skip accounting exists to prevent, so the finish phase treats an absent or malformed entry as unverified.
- **The fetch phase does not advance skip counters.** A run abandoned mid-extraction would otherwise mark every card verified without having checked any.
- **`WORK_DIR` is wiped at the start of each fetch**, so a stale prompt can't be answered as though it were current.
- **Post-loop reporting is factored into `finalize()`** and shared by both paths — if they drifted, one would silently stop advancing the counters.

The cron is disabled, not deleted; `workflow_dispatch` still runs gpt-4o if OpenAI credit returns.

## Test plan

- [x] `node --check` and `bash -n` pass
- [x] `--phase=all` with no `OPENAI_API_KEY` still errors — CI path untouched
- [x] Invalid `--phase` rejected at startup
- [x] **End-to-end on `chase-sapphire-preferred`**: fetch wrote the prompt; in-session extraction read $95 / 100,000 pts / $5,000 / 3mo correctly past both a `[STRIKETHROUGH: 75,000]` expired offer and a competing Sapphire *Reserve* offer (100k after $6,000) on the same page; finish confirmed no drift against YAML
- [x] Test run's mutation of `card-page-check-state.json` reverted, work dir gitignored
- [ ] Full 148-card run

## Tradeoffs you're accepting

1. **Local scheduled tasks only run while the app is open.** If it's closed at 7 AM the run happens on next launch. For a job whose purpose is guaranteed daily coverage that's a real downgrade — the skip counters and `card-page-stale` issue still fire, so a gap surfaces rather than passing silently, but later than CI would have caught it.
2. **~1M input tokens per night** flows through subagents. That's meaningful subscription usage, traded against ~$82/mo of API spend.
3. **Extraction consistency is now a fan-out of 19 subagents** rather than one deterministic API call. The prompt is identical, but this is worth watching on the first full run.