### PR TITLE
seo: noindex auth pages, stop crawl discovery of /login?redirect= variants

### DIFF
--- a/apps/web-next/src/app/(auth)/layout.tsx
+++ b/apps/web-next/src/app/(auth)/layout.tsx
@@ -1,5 +1,21 @@
+import type { Metadata } from "next";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import "../landing.css";
+
+// The auth pages are utility screens with no search value. /login in particular
+// is linked as /login?redirect=/card/<slug>?submit=true from every card page, so
+// crawlers discovered one URL per card (~176) that all render identical HTML.
+// Google filed the whole set under "Duplicate without user-selected canonical".
+//
+// noindex lives here rather than in login/page.tsx because that page is a client
+// component, and client components can't export metadata.
+//
+// Deliberately NOT paired with a rel=canonical: noindex plus a canonical sends
+// contradictory signals ("drop this" vs "consolidate this"). We want zero
+// indexation of auth pages, so noindex alone is the decisive, unambiguous fix.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1505,6 +1505,7 @@ export default function CardClient({
                     ) : (
                       <Link
                         href={`/login?redirect=${encodeURIComponent(`/card/${card.slug}?submit=true`)}`}
+                        rel="nofollow"
                         style={{ color: "var(--accent)", fontWeight: 600 }}
                       >
                         Log in to submit a data point →
@@ -1536,6 +1537,7 @@ export default function CardClient({
                 ) : (
                   <Link
                     href={`/login?redirect=${encodeURIComponent(`/card/${card.slug}?submit=true`)}`}
+                    rel="nofollow"
                     style={{ color: "var(--accent)", fontWeight: 600 }}
                   >
                     Log in to submit →
@@ -1564,6 +1566,7 @@ export default function CardClient({
                 ) : (
                   <Link
                     href={`/login?redirect=${encodeURIComponent(`/card/${card.slug}?submit=true`)}`}
+                    rel="nofollow"
                     style={{ color: "var(--accent)", fontWeight: 600 }}
                   >
                     Log in to submit →

--- a/apps/web-next/src/app/robots.ts
+++ b/apps/web-next/src/app/robots.ts
@@ -31,18 +31,30 @@ export default function robots(): MetadataRoute.Robots {
     'YouBot',
   ];
 
+  // NOTE: '/auth/' used to be listed here and never did anything — (auth) is an
+  // App Router route *group*, so it is stripped from the URL and no request path
+  // ever starts with /auth/. The pages it was meant to cover live at /login,
+  // /register and /forgot.
+  //
+  // Do NOT add /login here to "fix" the duplicate-URL reports in Search Console.
+  // /login is deliberately left crawlable so Googlebot can reach it and read the
+  // noindex in app/(auth)/layout.tsx. A Disallow would block the crawl, the
+  // noindex would never be seen, and the already-discovered
+  // /login?redirect=... URLs would stay stuck in the index reports indefinitely.
+  const disallow = ['/profile', '/admin', '/api/'];
+
   return {
     rules: [
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/profile', '/admin', '/api/', '/auth/'],
+        disallow,
       },
       // Explicitly welcome AI crawlers — same allowlist as humans, just signaled clearly
       ...aiCrawlers.map((userAgent) => ({
         userAgent,
         allow: '/',
-        disallow: ['/profile', '/admin', '/api/', '/auth/'],
+        disallow,
       })),
     ],
     sitemap: [`${baseUrl}/sitemap.xml`, `${baseUrl}/news-sitemap.xml`],


### PR DESCRIPTION
Search Console reported **176 pages** under *"Duplicate without user-selected canonical"* (first detected 2/10/26), every one of the shape:

```
https://creditodds.com/login?redirect=/card/<slug>?submit%3Dtrue
```

## Cause

Four things lined up:

1. Every card page links to a **per-card** `/login?redirect=/card/<slug>?submit=true` as a plain crawlable `<Link>`, so Googlebot discovered roughly one variant per card. 176 ≈ the card count.
2. `/login` is a `'use client'` component and so **cannot** export metadata — no robots directive, no canonical.
3. `app/(auth)/layout.tsx` supplied none either, so nothing filled the gap.
4. `robots.ts` disallowed `/auth/`, **which never matched anything** — `(auth)` is an App Router route *group* and is stripped from the URL. `/login` has been fully crawlable the whole time.

Every variant renders identical HTML, so Google clustered them and picked its own canonical.

## Changes

| File | Change |
|---|---|
| `app/(auth)/layout.tsx` | `robots: { index: false, follow: false }` — covers `/login`, `/register`, `/forgot` |
| `card/[name]/CardClient.tsx` | `rel="nofollow"` on all 3 login links, halting discovery of new variants |
| `app/robots.ts` | Drop the dead `/auth/` disallow |

Two deliberate non-changes, both documented in code so they don't get "fixed" later:

- **No `Disallow: /login` in robots.txt.** That's the intuitive fix and it backfires: it blocks the crawl, so Googlebot never reads the `noindex`, and the 176 URLs stay frozen in the report indefinitely.
- **No `rel=canonical` alongside the `noindex`.** The two are contradictory signals ("consolidate this" vs "drop this"). Zero indexation is the goal for auth pages, so `noindex` alone is the decisive fix.

## Verification

Against the dev server:

- `/login` and `/login?redirect=...` both emit `<meta name="robots" content="noindex, nofollow">`
- Card-page links render `rel="nofollow"` in the SSR HTML (what Googlebot actually sees)
- `/`, `/card/*`, `/explore`, `/best` remain free of any robots meta — the `noindex` is correctly scoped to the `(auth)` route group
- `tsc --noEmit` clean

## Expectations

*"Duplicate without user-selected canonical"* is an **excluded** bucket, so these URLs were never competing with real content. This is crawl-budget and report hygiene, not traffic recovery. Expect the count to drain over several weeks as Google re-crawls each URL and sees the `noindex`; **Validate Fix** in GSC once this deploys.

Merging fires the Amplify webhook via `deploy-frontend.yml`.