### PR TITLE
seo: serve a Disallow-all robots.txt from the API domain

### DIFF
--- a/apps/api/src/handlers/robots.js
+++ b/apps/api/src/handlers/robots.js
@@ -1,0 +1,26 @@
+// Serves robots.txt for api.creditodds.com.
+//
+// The API domain has no static origin, so every unmatched path fell through to
+// API Gateway's stock 403 ("Missing Authentication Token") — /robots.txt
+// included. With no fetchable robots.txt, crawlers had no directive for the
+// subdomain and were free to walk all of it; Search Console reported the 403 on
+// the root. /cards alone is ~368 KB of JSON, so letting a crawler enumerate
+// endpoints is real wasted bandwidth on both sides.
+//
+// This is a data plane, not content. Disallow everything.
+const BODY = ["User-agent: *", "Disallow: /", ""].join("\n");
+
+exports.RobotsHandler = async (event) => {
+  console.info("received:", event.httpMethod, event.path);
+
+  return {
+    statusCode: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      // The body is a constant, so cache it hard rather than waking a Lambda
+      // every time a crawler re-checks.
+      "Cache-Control": "public, max-age=86400, s-maxage=86400",
+    },
+    body: BODY,
+  };
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -135,6 +135,38 @@ Resources:
               Header: Authorization
               ReauthorizeEvery: 300
 
+  # Serves /robots.txt so crawlers have a directive for api.creditodds.com.
+  # Without it every path on the domain — robots.txt included — returned API
+  # Gateway's default 403, which is what Search Console flagged on the root.
+  # Inherits the Globals VpcConfig it does not need; not worth an override to
+  # save a cold start on a route crawlers hit about once a day.
+  RobotsFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/robots.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
+    Properties:
+      Handler: src/handlers/robots.RobotsHandler
+      Runtime: nodejs22.x
+      MemorySize: 128
+      Timeout: 5
+      Description: Returns a Disallow-all robots.txt for the API domain
+      Events:
+        CreditCardOddsAPI:
+          Type: Api
+          Properties:
+            Auth:
+              Authorizer: NONE
+            Path: /robots.txt
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+
   AllCardsFunction:
     Type: AWS::Serverless::Function
     Metadata:


### PR DESCRIPTION
Search Console reported *"Blocked due to access forbidden (403)"* for a single URL, `https://api.creditodds.com/` (first detected 7/11/26).

## The 403 itself is benign

```
$ curl -i https://api.creditodds.com/
403  {"message":"Missing Authentication Token"}
```

Misleading wording, but that's API Gateway's stock response for a path matching **no route**. Nothing is meant to live at the API root, and nothing is broken. On its own this row needed no fix.

## The finding underneath it

`/robots.txt` returns the same 403, so crawlers have **no directive at all** for `api.creditodds.com` and nothing discourages them from enumerating the 96 routes behind it. `/cards` is a public 200 and — per the comment already in `template.yml` — ~368 KB raw. An enumerating crawler is real wasted bandwidth on both sides.

Googlebot has only tried `/` so far, so this is insurance rather than an active fire.

## Change

A small public `GET /robots.txt` route returning `Disallow: /` for the whole API domain.

- `Authorizer: NONE` so it's reachable without a Firebase token (the API sets a `DefaultAuthorizer`).
- Inherits the `Globals` `VpcConfig` it has no use for. Not worth a brittle override to save a cold start on a route crawlers hit about once a day.
- `Cache-Control: max-age=86400` — the body is a constant, so don't wake a Lambda on every re-check.

This is **per-origin** and does not touch `creditodds.com`'s own robots.txt, which still welcomes search and AI crawlers to the content pages. The reasoning is that crawlers should be reading the rendered pages, not the raw JSON behind them. Easy to relax if we'd rather expose the API to AI crawlers specifically.

Once deployed, Googlebot fetches robots.txt, stops crawling the subdomain, and the reported 403 ages out of the index report on its own.

## Verification

- Handler returns `200 text/plain; charset=utf-8` with body `User-agent: *\nDisallow: /\n`
- `sam validate --lint` passes

## ⚠️ Merging triggers a production API deploy

This touches `apps/api/**`, so merging runs `sam build && sam deploy` via `deploy-api.yml`. Additive only — one new Lambda and one new route, no existing resource modified — but it is a real deploy against the live stack.