### PR TITLE
card-page-check: drop dead EXTRACTION_SCHEMA, base card PR on origin/main

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -390,38 +390,6 @@ async function closeBrowser() {
 
 // ─── Extraction ───────────────────────────────────────────────────────────────
 
-// The JSON contract both backends must satisfy. OpenAI gets it as
-// `response_format: json_object` plus the shape spelled out in the prompt;
-// the Claude CLI gets it as a real `--json-schema`, which is strictly
-// stronger — malformed output is rejected before it ever reaches us.
-const EXTRACTION_SCHEMA = {
-  type: 'object',
-  properties: {
-    annual_fee: { type: ['number', 'null'] },
-    signup_bonus: {
-      type: 'object',
-      properties: {
-        value: { type: ['number', 'null'] },
-        type: { type: ['string', 'null'], enum: ['points', 'miles', 'cashback', 'free_nights', null] },
-        spend_requirement: { type: ['number', 'null'] },
-        timeframe_months: { type: ['number', 'null'] },
-        authorized_user_bonus: { type: ['number', 'null'] },
-        bonus_note: { type: ['string', 'null'] },
-        offer_is_tiered: { type: ['boolean', 'null'] },
-      },
-      required: ['value', 'type', 'spend_requirement', 'timeframe_months'],
-    },
-    apr: {
-      type: 'object',
-      properties: {
-        purchase_intro_months: { type: ['number', 'null'] },
-        balance_transfer_intro_months: { type: ['number', 'null'] },
-      },
-    },
-  },
-  required: ['annual_fee', 'signup_bonus'],
-};
-
 function buildExtractionPrompt(cardName, bankName, applyLink, pageContent, currentSignupBonus) {
   const cur = currentSignupBonus || {};
   const currentContext = `Current YAML values (for unit context — DO NOT copy these, extract fresh from the page):


### PR DESCRIPTION
Two small follow-ups to #1704, both found while running the first full local check.

## 1. `EXTRACTION_SCHEMA` is dead code

It was only ever consumed by the `claude -p` CLI backend, which #1704 removed in favour of in-session extraction. Nothing references it. Verified with `grep -c EXTRACTION_SCHEMA` → 0 after removal.

## 2. The publish script based the card PR on `HEAD`, not `main`

`scripts/check-card-pages-publish.sh` created the card branch from whatever `HEAD` happened to be. In CI that is always `main`, so it was invisible there — but a local run may well be on a feature branch, and branching off `HEAD` sweeps that branch's unrelated commits into a PR that is supposed to contain nothing but card YAML.

Now explicitly `git checkout -b "$BRANCH" origin/main`. The uncommitted `data/cards/` edits carry across cleanly because they are the only modified paths.

This was not hypothetical — the first full run was driven from the #1704 feature branch, and without this fix [#1708](https://github.com/CreditOdds/creditodds/pull/1708) would have carried the entire phase-split changeset. With it, that PR is exactly one file, `+2/-2`.

## Test plan

- [x] `node --check` and `bash -n` pass
- [x] No remaining `EXTRACTION_SCHEMA` references
- [x] Proven in the real run: #1708 contains only `data/cards/the-business-platinum-card-from-american-express.yaml`, based on `main`