### PR TITLE
card-page-check: diff signup_bonus.type through a cash/cashback alias

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -446,7 +446,7 @@ Extract the following fields and return ONLY valid JSON — no markdown fences, 
   "annual_fee": <number or null>,
   "signup_bonus": {
     "value": <number or null>,
-    "type": <"points"|"miles"|"cashback"|"free_nights" or null>,
+    "type": <"points"|"miles"|"cash"|"cashback"|"free_nights" or null>,
     "spend_requirement": <number or null>,
     "timeframe_months": <number or null>,
     "authorized_user_bonus": <number or null>,
@@ -462,7 +462,7 @@ Extract the following fields and return ONLY valid JSON — no markdown fences, 
 Rules:
 - annual_fee: the ongoing annual fee, NOT an introductory/$0 first year rate. If the card says "$0 intro annual fee" but $99 after, use 99. Use 0 only if the card truly has no annual fee. null if not stated at all.
 - signup_bonus.value: raw number only (e.g. 60000 for "60,000 points", or 3 for "3 free night awards"). null if absent.
-- signup_bonus.type: use "free_nights" when the bonus is free hotel night awards (e.g. Marriott free night certificates).
+- signup_bonus.type: the unit the bonus is denominated in. Use "free_nights" when the bonus is free hotel night awards (e.g. Marriott free night certificates). "cash" and "cashback" both mean a dollar-denominated bonus and are treated as identical — return either. Report the unit the page ACTUALLY advertises today; do not copy the current YAML type if the page contradicts it.
 - SIGNUP BONUS SCOPE: All signup_bonus fields refer ONLY to the one-time welcome/new-cardmember offer earned during the initial signup window. NEVER capture recurring/ongoing rewards in any signup_bonus field — including: anniversary bonuses, "each calendar year" bonuses, "every account year" bonuses, annual spend bonuses earned year after year, statement credits that reset annually, or cardmember-anniversary point awards. Those are ongoing benefits, not signup bonuses. If the offer is described with phrases like "each year", "every year", "annually", "each calendar year", "each anniversary", "every account anniversary" → it is NOT a signup bonus and must be excluded from value, spend_requirement, timeframe_months, AND bonus_note.
 - TIMEFRAME UNITS: signup_bonus.timeframe_months must be expressed in whole MONTHS, never raw days. Issuer pages often state the window in days (e.g. "within the first 90 days", "in the first 180 days") — convert to months: 90 days → 3, 120 days → 4, 150 days → 5, 180 days → 6, 270 days → 9, 365 days → 12. A welcome-offer window is essentially never longer than ~18 months, so NEVER return a value above 18 — if you computed one, you returned days by mistake and must convert it to months.
 - TIERED BONUSES: Many cards have one-time tiered signup bonuses (e.g., "earn 70,000 miles after $3,000 in 6 months, plus an additional 20,000 miles after an additional $2,000 in 6 months", or "3 free nights after $3,000 in 3 months, plus 1 more after $4,000 total in 4 months"). When the welcome offer is tiered, use the HEADLINE-MAX convention:
@@ -599,6 +599,21 @@ function needsBrowserRetry(extracted, currentSignupBonus) {
 function normalizeTimeframeMonths(v) {
   if (typeof v === 'number' && v > 24) return Math.round(v / 30);
   return v;
+}
+
+// The extraction prompt and the YAML convention spell dollar-denominated
+// bonuses differently: the prompt's enum says "cashback", YAML says "cash" (36
+// cards). They denote the same unit, so collapse them to one canonical form
+// before comparing — otherwise every cash-back card would propose a phantom
+// cash → cashback change on every run. The remaining values (points, miles,
+// free_nights) are shared by both vocabularies and pass through untouched.
+const BONUS_TYPE_ALIASES = { cashback: 'cash' };
+
+function normalizeBonusType(type) {
+  if (type == null) return null;
+  const t = String(type).trim().toLowerCase();
+  if (!t) return null;
+  return BONUS_TYPE_ALIASES[t] ?? t;
 }
 
 // A tiered note carries the tier amounts it describes ("70,000 miles ... an
@@ -870,6 +885,60 @@ function detectChanges(card, extracted, now = new Date(), suppressions = [], pag
           });
         }
       }
+    }
+
+    // signup_bonus.type — the unit the bonus is denominated in. Left undiffed
+    // until now, silently: a bonus converting from cashback to points, or from
+    // free nights to points, never surfaced in a check PR. That silence was
+    // half-deliberate (a naive diff proposes cash → cashback on all 36 cash-back
+    // cards, forever, because the prompt's enum and the YAML convention spell
+    // the same unit differently) but it was never written down, and it
+    // suppressed real changes along with the phantom ones. normalizeBonusType
+    // collapses the cash/cashback pair so only genuine unit switches survive.
+    //
+    // Unit switches are not hypothetical — Marriott Bonvoy Boundless moved from
+    // free nights to points, and card-wire carries a purpose-built guard for
+    // that exact transition (apps/api/src/handlers/update-cards-github.js).
+    //
+    // The unit is load-bearing in three places downstream, which is what made
+    // the silence expensive: card_wire stamps every signup_bonus_value row with
+    // it and refuses to diff across units (so a stale type lets it compare
+    // "3" free nights against "125,000" points as a numeric jump), /compare
+    // reads cash/cashback as dollars and everything else as points, and
+    // cardDisplayUtils suppresses the dollar estimate for free_nights.
+    //
+    // Guards, mirroring the rest of this block:
+    //   - the page must actually render an offer, so a JS-gated page can't flip
+    //     a card's unit off an echoed or guessed currency (same gate as
+    //     pageSaysFlat above)
+    //   - a concrete extracted value is required, as further evidence the
+    //     extractor read a real offer instead of inferring a currency from the
+    //     card's branding
+    //   - a run suppressed as tiered skips type too: if the offer parse isn't
+    //     trusted enough to move value, it isn't trusted to rewrite the unit
+    //
+    // Known ambiguity: the Avios trio (British Airways / Iberia / Aer Lingus)
+    // stores "miles" while the issuer pages say "Avios", so the extractor can
+    // land on either side of points/miles. That surfaces as a reviewable row in
+    // the PR, not an auto-merge; add `signup_bonus.type` to a card's
+    // check_ignore if one proves recurring.
+    const proposedType = normalizeBonusType(sb.type);
+    if (
+      !skipAsTieredBonus &&
+      proposedType !== null &&
+      sb.value != null &&
+      cur.type != null &&
+      proposedType !== normalizeBonusType(cur.type) &&
+      pageShowsSignupOffer(pageContent) &&
+      !ignoreFields.has('signup_bonus.type')
+    ) {
+      changes.push({
+        field: 'signup_bonus.type',
+        old_value: cur.type,
+        // Canonical spelling, so an extractor "cashback" never lands in YAML
+        // beside the 36 cards that say "cash".
+        new_value: proposedType,
+      });
     }
 
     // Authorized user bonus → generate templated note if detected and card has none.
@@ -1645,6 +1714,7 @@ module.exports = {
   detectChanges,
   applyChanges,
   needsBrowserRetry,
+  normalizeBonusType,
   pageShowsSignupOffer,
   updateSkipState,
   staleCardsFrom,

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -15,6 +15,7 @@ const assert = require('node:assert/strict');
 const {
   detectChanges,
   needsBrowserRetry,
+  normalizeBonusType,
   pageShowsSignupOffer,
   updateSkipState,
   staleCardsFrom,
@@ -544,6 +545,128 @@ test('a normal months value (≤24) is left untouched', () => {
   });
   const ch = changes.find(c => c.field === 'signup_bonus.timeframe_months');
   assert.equal(ch.new_value, 4);
+});
+
+console.log('');
+// ─── signup_bonus.type: unit switches, through the cash/cashback alias ──────
+
+// type went undiffed entirely until this section existed, so a bonus converting
+// from cashback to points (or free nights to points, as Marriott Bonvoy
+// Boundless actually did) never surfaced. The blocker was vocabulary: the
+// extraction prompt says "cashback", YAML says "cash" on 36 cards, so a naive
+// diff proposes a phantom change on every cash-back card. normalizeBonusType
+// collapses that pair; everything else compares straight.
+
+// A page whose offer body actually rendered — pageShowsSignupOffer gates the
+// type diff, so the JS-gated case has to be tested separately.
+const OFFER_PAGE =
+  'Earn 60,000 bonus points after you spend $4,000 on purchases in the first 3 months from account opening.';
+
+function typedCard(type, extra = {}) {
+  return {
+    data: {
+      name: 'Type Test',
+      signup_bonus: { value: 60000, type, spend_requirement: 4000, timeframe_months: 3, note: null, ...extra },
+    },
+  };
+}
+
+function typedExtract(type, extra = {}) {
+  return {
+    signup_bonus: { value: 60000, type, spend_requirement: 4000, timeframe_months: 3, ...extra },
+  };
+}
+
+function typeChange(card, extracted, page = OFFER_PAGE) {
+  return detectChanges(card, extracted, new Date(), [], page).find(c => c.field === 'signup_bonus.type');
+}
+
+console.log('\nsignup_bonus.type normalization:');
+
+test('cash → cashback is NOT a change (the phantom that kept type undiffed)', () => {
+  assert.equal(typeChange(typedCard('cash'), typedExtract('cashback')), undefined);
+});
+
+test('cashback → cash is NOT a change either (alias is symmetric)', () => {
+  assert.equal(typeChange(typedCard('cashback'), typedExtract('cash')), undefined);
+});
+
+test('the alias is case- and whitespace-insensitive', () => {
+  assert.equal(typeChange(typedCard('cash'), typedExtract('  CashBack ')), undefined);
+});
+
+test('normalizeBonusType collapses only the cash pair', () => {
+  assert.equal(normalizeBonusType('cashback'), 'cash');
+  assert.equal(normalizeBonusType('cash'), 'cash');
+  assert.equal(normalizeBonusType('points'), 'points');
+  assert.equal(normalizeBonusType('miles'), 'miles');
+  assert.equal(normalizeBonusType('free_nights'), 'free_nights');
+  assert.equal(normalizeBonusType(null), null);
+  assert.equal(normalizeBonusType('   '), null);
+});
+
+console.log('\nsignup_bonus.type genuine unit switches:');
+
+test('cash → points surfaces as a real change', () => {
+  const ch = typeChange(typedCard('cash'), typedExtract('points'));
+  assert.deepEqual([ch.old_value, ch.new_value], ['cash', 'points']);
+});
+
+test('points → miles surfaces as a real change', () => {
+  const ch = typeChange(typedCard('points'), typedExtract('miles'));
+  assert.deepEqual([ch.old_value, ch.new_value], ['points', 'miles']);
+});
+
+test('free nights → points surfaces (the Marriott Bonvoy Boundless transition)', () => {
+  const ch = typeChange(typedCard('free_nights', { value: 3 }), typedExtract('points', { value: 125000 }));
+  assert.deepEqual([ch.old_value, ch.new_value], ['free_nights', 'points']);
+});
+
+test('a points → cashback switch is written in the YAML spelling ("cash", not "cashback")', () => {
+  const ch = typeChange(typedCard('points'), typedExtract('cashback'));
+  assert.equal(ch.new_value, 'cash');
+});
+
+console.log('\nsignup_bonus.type guards:');
+
+test('a JS-gated page (offer never rendered) cannot flip the unit', () => {
+  assert.equal(typeChange(typedCard('points'), typedExtract('cash'), 'Rewards Terms apply. Member FDIC.'), undefined);
+});
+
+test('a null extracted type never erases a real one', () => {
+  assert.equal(typeChange(typedCard('points'), typedExtract(null)), undefined);
+});
+
+test('a null extracted value blocks the flip (no concrete offer was read)', () => {
+  assert.equal(typeChange(typedCard('points'), typedExtract('cash', { value: null })), undefined);
+});
+
+test('a card with no stored type is never given one', () => {
+  const card = typedCard('points');
+  delete card.data.signup_bonus.type;
+  assert.equal(typeChange(card, typedExtract('miles')), undefined);
+});
+
+test('check_ignore on signup_bonus.type suppresses the flip', () => {
+  const card = typedCard('miles');
+  card.data.check_ignore = ['signup_bonus.type'];
+  assert.equal(typeChange(card, typedExtract('points')), undefined);
+});
+
+test('a run suppressed as tiered skips type along with value', () => {
+  const card = typedCard('points', {
+    value: 90000,
+    note: 'Earn 70,000 points after you spend $3,000, plus an additional 20,000 points after $2,000 more.',
+  });
+  // Base-tier misparse: value collapses to a named tier AND the unit flips.
+  // Neither is trusted — the offer parse itself is in doubt.
+  const changes = detectChanges(card, typedExtract('miles', { value: 70000 }), new Date(), [], OFFER_PAGE);
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('legacy two-arg calls (no pageContent) still diff type', () => {
+  const changes = detectChanges(typedCard('cash'), typedExtract('points'));
+  assert.ok(changes.some(c => c.field === 'signup_bonus.type'));
 });
 
 console.log('');


### PR DESCRIPTION
## The gap

`detectChanges()` in `scripts/check-card-pages.js` never compared `signup_bonus.type`. `value`, `spend_requirement` and `timeframe_months` were all diffed; the unit was silently skipped. Confirmed against the real signature before changing anything:

```
cash   -> cashback    : []
cash   -> points      : []
points -> miles       : []
points -> free_nights : []
miles  -> points      : []
```

So a card converting from cashback to points would never surface in a card-page-check PR.

## Why it was skipped, and why that wasn't good enough

The skip was half-deliberate, as suspected. The extraction prompt's enum offers `cashback`; the YAML convention is `cash` (36 cards). A naive diff would therefore propose a phantom `cash → cashback` row on every cash-back card, on every run. That is a real problem worth avoiding — but it was never written down, and avoiding it by skipping the field also suppressed genuine unit switches.

**Unit switches are not hypothetical.** `apps/api/src/handlers/update-cards-github.js:72` documents one that already happened:

> When the unit itself changes (e.g. Marriott Bonvoy Boundless switched from free nights to points), the old->new numbers aren't comparable, so skip the diff entirely

That guard exists specifically for this transition — and it can only ever fire if the YAML type actually updates, which required this diff to exist.

## Why it's worth diffing rather than documenting the skip

The unit is load-bearing in three downstream consumers, so a stale `type` doesn't just go unnoticed, it actively mis-values the card:

| Consumer | Behavior | Effect of a stale type |
|---|---|---|
| `update-cards-github.js:78` | stamps every `signup_bonus_value` card_wire row with the unit, and refuses to diff across units | the cross-unit guard never fires, so card_wire compares `3` free nights against `125,000` points as a numeric jump |
| `CompareClient.tsx:393` | reads `cash`/`cashback` as dollars, everything else as points | a converted bonus is valued in the wrong currency |
| `cardDisplayUtils.tsx:296` | returns `null` (no dollar estimate) for `free_nights` | a free-nights bonus gets a bogus dollar estimate |

Given card_wire SUB increases can fire social posts, a stale unit is a plausible path to a wrong public post.

## The change

- **`normalizeBonusType()`** collapses `cashback → cash` (case- and whitespace-insensitive). `points` / `miles` / `free_nights` are shared by both vocabularies and pass through untouched. Only genuine unit switches survive the diff.
- **Canonical spelling on write** — a real `points → cashback` switch is proposed as `cash`, so `cashback` never lands in YAML beside the 36 cards that say `cash`.
- **Guarded like the rest of the `signup_bonus` block:**
  - the page must actually render an offer (`pageShowsSignupOffer`), so a JS-gated page can't flip a card's unit off an echoed or guessed currency — the same gate `pageSaysFlat` already uses
  - a concrete extracted `value` is required, as further evidence the extractor read a real offer rather than inferring a currency from the card's branding
  - a run suppressed as tiered skips `type` too: if the offer parse isn't trusted enough to move `value`, it isn't trusted to rewrite the unit
  - `check_ignore` works per card
- **Prompt widened** to accept `"cash"` alongside `"cashback"`, so the extractor's natural echo of the current YAML value (shown to it in `currentContext`) isn't in tension with the enum. Also tells it to report the unit the page advertises rather than copying the stored type.

## Known ambiguity

The Avios trio (British Airways / Iberia / Aer Lingus) stores `miles` while the issuer pages say "Avios", so the extractor could land on either side of points/miles. These surface as a reviewable row in a human-reviewed PR, not an auto-merge, and `check_ignore: [signup_bonus.type]` is the per-card escape hatch. Documented in the code comment.

## Testing

17 new tests in `scripts/check-card-pages.test.js` covering normalization (both directions, case/whitespace), genuine switches (including the real Boundless free-nights → points transition), canonical write spelling, and every guard. Full suite green — **74 passing, 0 failures**.

The apply path was also verified end-to-end against a real card file: `applyChanges` writes `type: "cash"` correctly, preserving quoting and the rest of the block.

Note: `EXTRACTION_SCHEMA` (line 397) carries the same enum but is dead code — unreferenced at HEAD, and already being removed on the unmerged `fix/card-page-check-cleanup` branch. Left untouched here to avoid conflicting with that PR.