### PR TITLE
cards: fix stale Disney Inspire SUB breakdown ($400 -> $300 eGift)

### DIFF
--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -82,7 +82,7 @@ signup_bonus:
   type: "cash"
   spend_requirement: 1000
   timeframe_months: 3
-  note: "$400 Disney eGift Card upon approval + $200 statement credit after spending $1,000 in first 3 months"
+  note: "$300 Disney eGift Card upon approval + $200 statement credit after spending $1,000 in first 3 months"
 apr:
   regular:
     min: 18.24
@@ -90,7 +90,7 @@ apr:
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/inspire
 foreign_transaction_fee: false
 our_take: >
-  The Inspire is the top Disney card, with a $149 fee buying a $400 Disney eGift
+  The Inspire is the top Disney card, with a $149 fee buying a $300 Disney eGift
   card up front, 10% back on Disney+/Hulu/ESPN+, and 3% on Disney purchases.
   But the earn rates are mediocre for a fee card (most spend lands at 1-2%), and
   the park-ticket, resort, and streaming credits all require Disney spending to


### PR DESCRIPTION
## What

`data/cards/disney-inspire-visa.yaml` carried a signup bonus breakdown that was both stale and internally inconsistent:

```yaml
value: 500
note: "$400 Disney eGift Card upon approval + $200 statement credit after spending $1,000 in first 3 months"
```

$400 + $200 = $600, but the headline `value` is 500.

## Verification

Chase's live apply page (https://creditcards.chase.com/rewards-credit-cards/disney/inspire), fetched 2026-07-19:

> NEW CARDMEMBER OFFER $500 Offer — Get a $300 Disney Gift Card eGift to use today upon approval + earn a $200 statement credit after you spend $1,000 on purchases in the first 3 months from account opening.

$300 + $200 = $500, which matches the stored `value`. So the headline number was right all along and only the breakdown was wrong.

The other two Disney cards were re-verified against their live pages in the same pass and need no change:

| Card | Live page | Stored YAML |
|---|---|---|
| Disney Inspire | $300 + $200 = $500 | note said $400 — **fixed** |
| Disney Premier | $200 + $100 = $300 | matches |
| Disney Visa | $100 + $50 = $150 | matches |

## Changes

- `signup_bonus.note` → `$300 Disney eGift Card upon approval + ...`, matching the phrasing style already used in `disney-premier-visa-card.yaml` and `disney-visa-card.yaml`.
- `our_take` → "a $149 fee buying a **$300** Disney eGift card up front".

`npm run build:cards` passes (182 cards). `data/cards.json` is gitignored, so nothing generated is committed.

## Why the nightly checker never flagged this

`scripts/check-card-pages.js` only proposes a `signup_bonus.note` change when `signup_bonus.value` also changed in the same run. The headline value here is still 500 and has been correct the whole time, so the stale note was suppressed on every single run — indefinitely. Same failure shape as #1711 (`signup_bonus.type` never diffed at all): a field that is checked only conditionally on another field is, in practice, not checked. Worth fixing separately; filed as a follow-up.
