### PR TITLE
bilt: add the Obsidian $200 Bilt Cash welcome offer

### DIFF
--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -75,3 +75,9 @@ apr:
   regular:
     min: 26.74
     max: 34.74
+signup_bonus:
+  value: 200
+  type: "cash"
+  spend_requirement: 0
+  timeframe_months: 0
+  note: "$200 in Bilt Cash deposited upon approval; no minimum spend required"


### PR DESCRIPTION
## What

Adds the missing welcome offer to Bilt Obsidian. Verified against the live `bilt.com/card` page, whose FAQ states it outright:

> The Bilt Obsidian Card welcome offer is $200 in Bilt Cash upon approval, with no minimum spend required to receive it.

Uses the existing upon-approval convention (`spend_requirement: 0`, `timeframe_months: 0`, structure in `note`) already established by the Amazon Prime Rewards, Amazon Business Prime, and REI Co-op gift-card bonuses.

## Why only one card changed

This started from the nightly check reporting missing bonuses on **both** Blue and Obsidian. Verifying against the live page showed only one of those was real:

| Card | Nightly check proposed | Live page | Action |
|---|---|---|---|
| Blue | $100 Bilt Cash | **No welcome offer exists** | none |
| Obsidian | $200 Bilt Cash | $200 on approval, no spend | **added** |
| Palladium | (not flagged) | $300 Bilt Cash + 50k + Gold after $4k/90d | already correct |

The Blue figure was a misread. The page has welcome-offer FAQ entries for Obsidian and Palladium but **none for Blue**, and every `$100` on the page is either the annual Bilt Travel Hotel credit or the Bilt Cash year-end rollover cap ("up to $100 carries over to the next year"). One of those got mistaken for a signup bonus.

Palladium was checked and already matches the live page exactly, so it is untouched.

## Related gap

The reason this needed a manual fix at all: `detectChanges()` never proposes a `signup_bonus` for a card that doesn't already have one, so a card *gaining* a welcome offer is invisible to the nightly job. Verified:

```js
// card with no signup_bonus, extractor proposes one:
detectChanges(card, extracted, ...)  // => []
```

Obsidian's offer would have gone unnoticed indefinitely. Worth fixing separately — this PR only corrects the data.

## Test plan

- [x] `npm run build:cards` passes (182 cards)
- [x] Built output confirms `bilt-obsidian` carries the bonus, `bilt-blue` stays `null`, `bilt-palladium` unchanged
- [x] `data/cards.json` not committed (gitignored; CI rebuilds)

## Unrelated observation

`apply_link` on all three Bilt cards is `https://www.biltrewards.com/card/apply`, which now redirects to `https://www.bilt.com/card`. Still resolves, so not fixed here.