### PR TITLE
card-page-check: make Amazon Prime & Rakuten verifiable without moving apply buttons

### DIFF
--- a/data/cards/rakuten-american-express.yaml
+++ b/data/cards/rakuten-american-express.yaml
@@ -3,6 +3,13 @@ bank: "American Express"
 slug: "rakuten-american-express"
 accepting_applications: true
 apply_link: https://www.rakuten.com/american-express-card
+# Checker-only: rakuten.com renders this card's page inside a cross-origin iframe
+# served from rakuten.imprint.co (Imprint issues the card), so a fetch of
+# apply_link strips to ~523 chars of accessibility boilerplate. Point the page
+# check at the framed document directly; the Apply button still uses apply_link.
+# NOTE: this path is a dated campaign slug and will rotate — when the check skips
+# Rakuten with an HTTP 404, re-read the iframe src on apply_link and update it.
+page_check_url: https://rakuten.imprint.co/cham-july-2026
 category: "cashback"
 image: "rakuten-american-express.png"
 annual_fee: 0

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -88,6 +88,11 @@
       "format": "uri",
       "description": "Targeted offer URL — used for the Apply button and for signup-bonus extraction by check-card-pages.js when set. Falls back to apply_link. Use when the card's headline SUB lives on a different page than the generic marketing page (e.g. Fidelity's /go/ offer pages)."
     },
+    "page_check_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Checker-only override for check-card-pages.js — the page whose live terms should be verified. NOT rendered as the Apply button (unlike apply_link / special_apply_link). Use when the SUB lives on a page the Apply button shouldn't point at, e.g. a card whose marketing page renders its terms inside a cross-origin iframe (Rakuten → rakuten.imprint.co)."
+    },
     "card_referral_link": {
       "type": "string",
       "format": "uri",

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -193,8 +193,24 @@ function loadAllCards() {
 // the generic apply_link — so we treat it as the source of truth for this
 // script. The rewards/benefits check (which reads structural earn rates and
 // perks) still uses apply_link; see check-card-rewards-and-benefits.js.
+//
+// Two escape hatches keep this from checking an unfetchable page while leaving
+// the card's user-facing Apply button untouched (the frontend renders
+// `special_apply_link || apply_link` as the button href — see CardClient.tsx):
+//   1. `page_check_url` (checker-only, never rendered) overrides everything.
+//      Use it when the SUB lives on a page the Apply button shouldn't point at —
+//      e.g. Rakuten, whose marketing page renders the card inside a cross-origin
+//      Imprint iframe that a fetch of apply_link can't see into.
+//   2. A `special_apply_link` on a knownBlockedReason() host is skipped in favor
+//      of apply_link, so a bot-walled targeted-offer URL doesn't blind the check
+//      when the generic page is still scrapeable — e.g. Amazon Prime, whose
+//      amazon.com/dp offer page is an interstitial but whose Chase apply_link
+//      states the same $150 SUB.
 function checkUrlFor(card) {
-  return card.data.special_apply_link || card.data.apply_link;
+  const { page_check_url, special_apply_link, apply_link } = card.data;
+  if (page_check_url) return page_check_url;
+  if (special_apply_link && !knownBlockedReason(special_apply_link)) return special_apply_link;
+  return apply_link || special_apply_link;
 }
 
 function filterCardsForCheck(allCards, slugFilter) {
@@ -248,6 +264,14 @@ function knownBlockedReason(url) {
     const u = new URL(url);
     const host = u.hostname.replace(/^www\./, '');
     if (host === 'pnc.com') return 'pnc.com bot mitigation blocks automated fetches (HTTP/2 reset + HTTP/1.1 black-hole)';
+    // amazon.com serves an automation interstitial ("Click the button below to
+    // continue shopping") instead of card terms. This permanently skips the
+    // Amazon Store card, whose only apply_link is an amazon.com listing with no
+    // scrapeable issuer equivalent (Synchrony has no public product page). The
+    // Amazon Prime card also carries an amazon.com special_apply_link, but
+    // checkUrlFor() routes its check to the scrapeable Chase apply_link instead,
+    // so this entry does not blind Prime.
+    if (host === 'amazon.com') return 'amazon.com serves an automation interstitial ("Continue shopping") instead of card terms';
   } catch { /* malformed URL — let the normal fetch path handle it */ }
   return null;
 }
@@ -1331,8 +1355,14 @@ async function main() {
 
     const { name, bank } = card.data;
     const apply_link = checkUrlFor(card);
+    // Label the URL by which field actually supplied it — checkUrlFor may skip a
+    // bot-walled special_apply_link, so keying the tag off its mere presence lies.
+    const urlSource =
+      apply_link === card.data.page_check_url ? ' (page_check_url)'
+      : apply_link === card.data.special_apply_link ? ' (special_apply_link)'
+      : '';
     console.log(`Checking: ${name}`);
-    console.log(`  URL: ${apply_link}${card.data.special_apply_link ? ' (special_apply_link)' : ''}`);
+    console.log(`  URL: ${apply_link}${urlSource}`);
 
     const blockedReason = knownBlockedReason(apply_link);
     if (blockedReason) {


### PR DESCRIPTION
## Problem

Amazon Prime, Amazon Store, and Rakuten had each gone **unverified for 4 consecutive card-page-check runs** ([#1709](https://github.com/CreditOdds/creditodds/issues/1709)). Their check URLs return no usable content:

- **Amazon Prime** — `special_apply_link` (`amazon.com/dp/...`) serves an automation interstitial (_"Click the button below to continue shopping"_), not card terms.
- **Amazon Store** — `apply_link` (`amazon.com/...` listing) is the same interstitial, and Synchrony has no public product page to fall back to.
- **Rakuten** — `apply_link` (`rakuten.com/american-express-card`) renders the card **entirely inside a cross-origin iframe** from `rakuten.imprint.co` (Imprint issues the card), so a fetch of the top document strips to ~523 chars of accessibility boilerplate.

A blocked fetch looks identical to "no changes," so this was silently hiding possibly-stale data.

## Why not just edit the apply links

The frontend renders `special_apply_link || apply_link` as the live **Apply button** (`CardClient.tsx`), so those fields can't be repurposed for the checker without repointing user-facing links. This PR keeps **every apply button byte-for-byte unchanged**.

## Changes

- **`checkUrlFor()`** — honors a new checker-only `page_check_url` override, and skips a `special_apply_link` on a `knownBlockedReason()` host in favor of `apply_link`. Log label now reflects the URL's actual source.
- **`knownBlockedReason()`** — add `amazon.com`. Permanently and **visibly** skips the Amazon Store card (no scrapeable issuer page exists); Amazon Prime falls through to its scrapeable Chase `apply_link`, which states the same $150 SUB.
- **`schema.json`** — add the `page_check_url` field (checker-only, never rendered).
- **`rakuten-american-express.yaml`** — add `page_check_url` = the Imprint iframe URL. `apply_link` unchanged. (The path is a dated campaign slug and will rotate; a comment documents how to refresh it.)

No card YAML value changes. No apply-button changes.

## Verification (real checker, `--phase=fetch`)

| Card | Before | After |
|---|---|---|
| Amazon Prime | amazon.com interstitial (153 chars) | Chase page, 18000 chars, real $150 / 5% terms |
| Rakuten | rakuten.com boilerplate (523 chars) | imprint.co iframe, real $100 / 4% terms |
| Amazon Store | silent "no content" skip | clean **visible** permanent skip |

`npm run build:cards` passes with the schema addition.

## Follow-up (not in this PR)

With Rakuten now readable, its live offer is **\$100 for \$1,000 in 90 days**, but the YAML still says **\$200 for \$2,000 / 3 months** — a real overstatement that was invisible while the check was blind. Left for the next card-page-check run to catch and PR (only `--phase=finish` writes card YAML, with human review).