### PR TITLE
cards: fix stale Rakuten Amex SUB ($200/$2000 -> $100/$1000)

### DIFF
--- a/data/cards/rakuten-american-express.yaml
+++ b/data/cards/rakuten-american-express.yaml
@@ -38,9 +38,9 @@ rewards:
     value: 1
     unit: "percent"
 signup_bonus:
-  value: 200
+  value: 100
   type: "cash"
-  spend_requirement: 2000
+  spend_requirement: 1000
   timeframe_months: 3
 apr:
   regular:
@@ -49,7 +49,7 @@ apr:
 foreign_transaction_fee: false
 our_take: >
   This card is built for Rakuten loyalists: 4% on Rakuten.com (up to $10,000 a year)
-  and 5% on Rakuten Dining stack on top of the usual cash-back portal, with a $200
+  and 5% on Rakuten Dining stack on top of the usual cash-back portal, with a $100
   signup bonus, all for no annual fee.
   Off the Rakuten ecosystem the rates are ordinary (2% groceries and dining, 1% on
   everything else), so a flat 2% card like the Active Cash will beat it for general


### PR DESCRIPTION
Corrects the Rakuten American Express signup bonus, which was overstated.

- **Stored (stale):** $200 for $2,000 spend in 3 months
- **Live offer:** $100 for $1,000 spend in the first 90 days

This drift was invisible until [#1714](https://github.com/CreditOdds/creditodds/pull/1714), because the card-page check couldn't read `rakuten.com` — the terms render inside a cross-origin `rakuten.imprint.co` iframe. With `page_check_url` now pointing the check at the framed document, the live offer reads _"Get a $100 bonus when you spend $1000 in the first 90 days"_, verified directly against the Imprint page.

Updates `signup_bonus.value` (200 → 100), `signup_bonus.spend_requirement` (2000 → 1000), and the matching `our_take` copy. `timeframe_months` stays 3 (90 days). `npm run build:cards` passes.