### PR TITLE
card-page-check: self-heal a rotated page_check_url via the content iframe

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -1466,9 +1466,13 @@ async function main() {
   //
   // Shared with the network-error retry pass so a retried card produces exactly
   // the artifacts it would have produced on the first attempt.
-  const writeFetchArtifacts = async (card, { pageContent, usedBrowser, browserFirstValid, prevBrowserFirst }) => {
+  // `apply_link` is passed in rather than recomputed from checkUrlFor(card):
+  // the iframe self-heal may have re-pointed it at a freshly-derived URL after
+  // the stored page_check_url 404'd, and the prompt must name the URL the
+  // content actually came from. Recomputing here would silently label healed
+  // content with the dead URL.
+  const writeFetchArtifacts = async (card, { apply_link, pageContent, usedBrowser, browserFirstValid, prevBrowserFirst }) => {
     const { name, bank } = card.data;
-    const apply_link = checkUrlFor(card);
 
     if (!usedBrowser && !pageShowsSignupOffer(pageContent)) {
       console.log('  No offer language in simple fetch — re-fetching with browser');
@@ -1543,7 +1547,9 @@ async function main() {
 
     try {
       await withTimeout((async () => {
-        const fetchResult = await fetchCardPage(apply_link, browserFirstValid);
+        // `let`, not `const`: the iframe self-heal below reassigns this when it
+        // recovers a card whose stored page_check_url has rotated to a 404.
+        let fetchResult = await fetchCardPage(apply_link, browserFirstValid);
         lastHostHit.set(host, Date.now());
 
         // Iframe self-heal: the primary fetch failed (typically a 404 from a
@@ -1580,7 +1586,7 @@ async function main() {
 
         // FETCH_PHASE stops here — see writeFetchArtifacts.
         if (PHASE === 'fetch') {
-          await writeFetchArtifacts(card, { pageContent, usedBrowser, browserFirstValid, prevBrowserFirst });
+          await writeFetchArtifacts(card, { apply_link, pageContent, usedBrowser, browserFirstValid, prevBrowserFirst });
           return;
         }
 
@@ -1731,6 +1737,7 @@ async function main() {
               return;
             }
             await writeFetchArtifacts(card, {
+              apply_link,
               pageContent: fetchResult.content,
               usedBrowser: fetchResult.usedBrowser,
               browserFirstValid,

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -405,6 +405,64 @@ async function fetchWithBrowser(url) {
   }
 }
 
+// Self-heal for cards whose terms render inside a cross-origin iframe on their
+// marketing page (e.g. Rakuten → rakuten.imprint.co). We store that iframe URL
+// in page_check_url, but issuers serve it from a dated campaign slug that
+// rotates (cham-july-2026 → …), so the stored URL eventually 404s. When that
+// happens, load the parent page and re-derive the current iframe URL at runtime
+// — the check keeps verifying across rotations instead of going dark until a
+// human bumps the slug. Returns the largest visible cross-origin http(s) iframe
+// src, or null if the page has no such frame (the common case — most pages don't
+// nest their terms, so this returns null cheaply and the card just skips).
+// Timeouts are tighter than fetchWithBrowser so this fits inside the per-card
+// budget even after the primary fetch already spent some of it.
+async function resolveContentIframe(url) {
+  const browser = await getBrowser();
+  if (!browser) return null;
+
+  let context;
+  try {
+    context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      viewport: { width: 1280, height: 800 },
+      locale: 'en-US',
+    });
+    const page = await context.newPage();
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    if (response && response.status() >= 400) { await context.close(); return null; }
+    await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+    await page.waitForTimeout(2000);
+
+    // Pick the largest visibly-rendered iframe with a cross-origin http(s) src.
+    // The size gate (≥ 400×300) filters out the 0×0 tracking pixels (DoubleClick,
+    // analytics) these pages are littered with, leaving the content frame.
+    const src = await page.evaluate((parentHref) => {
+      let parentHost = '';
+      try { parentHost = new URL(parentHref).hostname.replace(/^www\./, ''); } catch { /* ignore */ }
+      let best = null, bestArea = 0;
+      for (const f of document.querySelectorAll('iframe')) {
+        const s = f.src || '';
+        if (!/^https?:\/\//i.test(s)) continue;
+        let host;
+        try { host = new URL(s).hostname.replace(/^www\./, ''); } catch { continue; }
+        if (host === parentHost) continue; // same-origin frame is not the swapped-in issuer page
+        const area = f.offsetWidth * f.offsetHeight;
+        if (area >= 400 * 300 && area > bestArea) { bestArea = area; best = s; }
+      }
+      return best;
+    }, url);
+
+    await context.close();
+    return src || null;
+  } catch (err) {
+    // Non-fatal: the card falls through to its normal skip, but say why so a
+    // failed re-derivation isn't indistinguishable from "page has no iframe".
+    console.warn(`  Iframe re-derivation failed: ${err.message.split('\n')[0]}`);
+    if (context) await context.close().catch(() => {});
+    return null;
+  }
+}
+
 async function closeBrowser() {
   if (_browser) {
     await _browser.close();
@@ -1354,7 +1412,9 @@ async function main() {
     }
 
     const { name, bank } = card.data;
-    const apply_link = checkUrlFor(card);
+    // `let`, not `const`: the iframe self-heal below may re-point this at a
+    // freshly-derived URL when a stored page_check_url has rotated to a 404.
+    let apply_link = checkUrlFor(card);
     // Label the URL by which field actually supplied it — checkUrlFor may skip a
     // bot-walled special_apply_link, so keying the tag off its mere presence lies.
     const urlSource =
@@ -1400,6 +1460,31 @@ async function main() {
           fetchResult = await fetchPageContent(apply_link);
         }
         lastHostHit.set(host, Date.now());
+
+        // Iframe self-heal: the primary fetch failed (typically a 404 from a
+        // rotated page_check_url slug, or an issuer page that renders its terms
+        // in a cross-origin iframe). Before skipping, load the card's own
+        // apply_link and re-derive the current content-iframe URL, then fetch
+        // that. Only runs on failure, so a card that was going to skip either
+        // recovers or skips as before — it can never regress a healthy card.
+        if (!fetchResult && card.data.apply_link && card.data.apply_link !== apply_link) {
+          console.log(`  Primary fetch failed (${lastFetchError || 'no content'}) — re-deriving content iframe from apply_link`);
+          const iframeUrl = await resolveContentIframe(card.data.apply_link);
+          lastHostHit.set(hostOf(card.data.apply_link), Date.now());
+          if (iframeUrl && iframeUrl !== apply_link) {
+            console.log(`  Found content iframe: ${iframeUrl}`);
+            const healedContent = await fetchWithBrowser(iframeUrl);
+            lastHostHit.set(hostOf(iframeUrl), Date.now());
+            if (healedContent) {
+              fetchResult = { content: healedContent, usedBrowser: true };
+              if (iframeUrl !== card.data.page_check_url) {
+                console.log(`  NOTE: page_check_url is stale — update the YAML to: ${iframeUrl}`);
+              }
+              apply_link = iframeUrl; // downstream prompt/extraction use the healed URL
+            }
+          }
+        }
+
         if (!fetchResult) {
           console.log('  Skipped (could not fetch page)\n');
           recordSkip(card, lastFetchError || 'could not fetch page');


### PR DESCRIPTION
## Problem

Rakuten's `page_check_url` points at `rakuten.imprint.co`, which serves the card from a **dated campaign slug** (`cham-july-2026`) that rotates. When it rotates, the stored URL 404s and the card-page check goes dark on that card until a human notices and bumps the slug.

That is exactly the failure mode that just hid a stale Rakuten SUB ($200/$2,000 vs. the live $100/$1,000) for four consecutive runs — a blocked fetch is indistinguishable from "no changes."

## Fix

On a **failed** primary fetch, load the card's own `apply_link` and re-derive the current content-iframe URL, then fetch that. The check now survives slug rotations on its own, and logs the fresh URL so the YAML hint can be bumped at leisure rather than urgently.

```
Primary fetch failed (HTTP 404) — re-deriving content iframe from apply_link
Found content iframe: https://rakuten.imprint.co/cham-july-2026
NOTE: page_check_url is stale — update the YAML to: https://rakuten.imprint.co/cham-july-2026
```

## Why this can't regress a healthy card

The fallback runs **only** when both are true:
1. the primary fetch already failed (the card was headed for a skip anyway), and
2. `checkUrlFor()` returned a URL different from `apply_link` — i.e. the card actually has a `page_check_url` / `special_apply_link` override.

So cards that fetch normally do zero extra work, and cards failing for unrelated reasons (the Bank of America / Bilt timeouts) are untouched because their check URL *is* their `apply_link`. A card that would have skipped either recovers or skips exactly as before.

Iframe selection takes the largest visibly-rendered cross-origin `http(s)` frame (≥ 400×300), which skips the 0×0 DoubleClick/analytics pixels these pages are littered with.

## Verification

Pointed `page_check_url` at a deliberately dead slug and ran the real checker:

| Step | Result |
|---|---|
| Primary fetch of dead slug | `HTTP 404` |
| Re-derive from `apply_link` | found `rakuten.imprint.co/cham-july-2026` |
| Fetch healed URL | 3245 chars, live `$100 / $1000 / 90 days` terms |
| Outcome | prompt written — **verified instead of skipped** |

Then reverted the slug and confirmed no behavior change on healthy Rakuten (direct fetch, no fallback), Amazon Prime (Chase fallback), Chase Sapphire Preferred (normal), and Amazon Store (clean known-block skip).

No card YAML changes in this PR.