### PR TITLE
cards: repoint Princess Cruises Rewards Visa, SUB spend $500 -> $1,000

### DIFF
--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -2,12 +2,12 @@ name: "Princess Cruises Rewards Visa"
 bank: "Barclays"
 slug: "princess-cruises-rewards-visa-card"
 accepting_applications: true
-apply_link: https://cards.barclaycardus.com/banking/cards/princess-cruises-rewards-visa-card/
+apply_link: https://cards.barclaycardus.com/credit-card/b2e0e09c-e93c-43be-8758-57d22bb39ec1
 our_take: >
   The Princess Cruises Rewards Visa is a niche card designed for loyal
   Princess Cruises passengers, offering 2 points per dollar on purchases made
   with the cruise line. With no annual fee and a 20,000-point signup bonus
-  after spending $500 in the first 3 months, it's a low-cost way to earn
+  after spending $1,000 in the first 3 months, it's a low-cost way to earn
   rewards for your next voyage. However, outside of Princess Cruises
   purchases, the card only earns 1 point per dollar on everything else, which
   is not competitive compared to broader travel cards. The 15-month 0% intro
@@ -31,8 +31,8 @@ rewards:
     unit: points_per_dollar
 signup_bonus:
   value: 20000
-  type: points
-  spend_requirement: 500
+  type: "points"
+  spend_requirement: 1000
   timeframe_months: 3
 apr:
   balance_transfer_intro:


### PR DESCRIPTION
## Why the link was dead

Barclays retired the old product URL. It now redirects to an "Offer Expired" page:

```
/banking/cards/princess-cruises-rewards-visa-card/  ->  200, /banking/offer-expired/
```

Another **soft 404**, same shape as the U.S. Bank Shopper case in #1720: answers `200`, so the checker's status guard passes it through, and the extractor then correctly refuses to read card terms off an expired-offer page. That is why this card sat at six consecutive unverified runs instead of quietly reporting "no changes".

Barclays moved the product to a UUID-style URL, supplied by @melchermaxwell:
`https://cards.barclaycardus.com/credit-card/b2e0e09c-e93c-43be-8758-57d22bb39ec1`

I verified it serves the real card before wiring it in: 200, no redirect, and the page renders as **PRINCESS REWARDS VISA CARD** with live terms.

## What the dead URL was hiding

Repointing and running the checker against the live page surfaced a real change. The application page states:

> Earn 20,000 bonus points, worth $200 in onboard credit after spending $1000 in the first 90 days.

We had **$500**. The spend requirement has doubled. Applied by `--phase=finish`, not by hand:

```
"Princess Cruises Rewards Visa": signup_bonus.spend_requirement 500 -> 1000
```

## Changes

1. `apply_link` repointed to the live URL. This also fixes a dead **Apply** button for users.
2. `signup_bonus.spend_requirement` 500 -> 1000.
3. `our_take` prose corrected, which cited the same stale $500. The checker does not diff prose, so it would have contradicted the card's own data until the next scheduled regeneration.

## What I deliberately did not change

- **`balance_transfer_intro` (15 months, 0%)** left as stored. The page advertises a "Low Intro APR on balance transfers" without stating a term, so I extracted `null` rather than retire a real value on an unstated one.
- **Card name.** The live page titles it "PRINCESS REWARDS VISA CARD"; we store "Princess Cruises Rewards Visa". That may be a rebrand, but a rename needs the `previous_names` pattern plus a DB migration, so it is out of scope here. Flagging it for a decision.

## Validation

- `npm run build:cards` -> 182 cards OK
- Card now verifies cleanly (1/1 this run) and drops off the stale list
- Regenerated `cards.json` not committed; CI rebuilds it
- Skip-state file left untouched; the next scheduled run updates it through its normal path