### PR TITLE
news-images: gate input_fidelity on model support, default gpt-image-1.5

### DIFF
--- a/scripts/sync-news-images.js
+++ b/scripts/sync-news-images.js
@@ -31,8 +31,9 @@
  *   --only <id>        Process just this one id (handy for previews).
  *   --limit <n>        Stop after generating <n> images this run (backfill in batches).
  *   --quality <q>      Image quality: low | medium | high (default medium).
- *   --model <m>        Image model (default gpt-image-1-mini). Use gpt-image-1,
- *                      gpt-image-1.5 or gpt-image-2 for a one-off flagship render.
+ *   --model <m>        Image model (default gpt-image-1.5). gpt-image-1 and
+ *                      gpt-image-1.5 accept input_fidelity: high; gpt-image-2 is
+ *                      always high fidelity; gpt-image-1-mini has none.
  *   --dry-run          Log what would happen, but don't call OpenAI or S3.
  */
 
@@ -59,19 +60,35 @@ const forceIds = new Set(
 );
 const onlyId = argVal('--only');
 const limit = argVal('--limit') ? parseInt(argVal('--limit'), 10) : Infinity;
-// Defaults chosen for cost. gpt-image-1 at high/1536x1024 is $0.25 per image,
-// the most expensive combination OpenAI sells for that model, and every
-// successor now undercuts it (gpt-image-1.5 ~$0.20, gpt-image-2 ~$0.165).
-// gpt-image-1-mini supports the same /images/edits endpoint with reference
-// images, the same sizes, and the same three quality tiers, at $0.019 for
-// medium/1536x1024 — a ~92% cut with the pipeline unchanged. Matches the
-// quality tier sync-article-images.js has always used.
+// Defaults chosen for cost, subject to one hard constraint: the edits path
+// MUST keep `input_fidelity: high`. That parameter is the reason the real card
+// art survives the edit instead of being redrawn from scratch, which is the
+// entire point of compositing actual card PNGs rather than describing them.
 //
-// Both are overridable per run (--model, --quality) so a hero image that
-// genuinely needs the flagship can have it without changing the default for
-// the other ~99% of generations.
-const model = argVal('--model') || 'gpt-image-1-mini';
+// Not every model accepts it (see NO_INPUT_FIDELITY below), so the cheapest
+// model is not automatically the right one:
+//
+//   gpt-image-1     $0.25  medium→high tiers, input_fidelity OK  (previous default)
+//   gpt-image-1.5   ~$0.032 at medium/1536x1024, input_fidelity OK
+//   gpt-image-2     ~$0.041 at medium, always high fidelity, REJECTS the param
+//   gpt-image-1-mini $0.019 at medium, no input_fidelity at all
+//
+// gpt-image-1.5 at medium is the cheapest option that still takes explicit
+// high input fidelity: ~87% off the old per-image cost with the card-faithful
+// behaviour unchanged. mini is cheaper still but cannot hold the card art, so
+// it is not a safe default for this pipeline.
+//
+// Both overridable per run (--model, --quality) for a one-off flagship render.
+const model = argVal('--model') || 'gpt-image-1.5';
 const quality = argVal('--quality') || 'medium';
+
+// Models that reject `input_fidelity` outright. gpt-image-2 processes every
+// image input at high fidelity automatically and 400s if the parameter is sent
+// at all; gpt-image-1-mini does not support it in any form. Sending it blindly
+// is what broke the first switch to mini, so the support check lives here
+// rather than being implied by whichever model happens to be the default.
+const NO_INPUT_FIDELITY = new Set(['gpt-image-1-mini', 'gpt-image-2']);
+const supportsInputFidelity = !NO_INPUT_FIDELITY.has(model);
 
 const bucket = process.env.S3_IMAGES_BUCKET_NAME;
 const openaiKey = process.env.OPENAI_API_KEY;
@@ -178,7 +195,7 @@ async function callOpenAIEdit(prompt, cards) {
   form.append('prompt', prompt);
   form.append('size', '1536x1024');
   form.append('quality', quality);
-  form.append('input_fidelity', 'high');
+  if (supportsInputFidelity) form.append('input_fidelity', 'high');
   form.append('n', '1');
   for (const c of cards) {
     form.append('image[]', new Blob([c.buf], { type: 'image/png' }), c.filename);
@@ -299,7 +316,10 @@ async function main() {
   // Logged every run so the CI output records what a given batch of images
   // actually cost. An accidental `--quality high` is a ~5x bill and is
   // otherwise invisible after the fact.
-  log(`model: ${model} | quality: ${quality} | size: 1536x1024`);
+  log(
+    `model: ${model} | quality: ${quality} | size: 1536x1024 | ` +
+    `input_fidelity: ${supportsInputFidelity ? 'high' : 'not supported by this model'}`
+  );
 
   const results = { generated: [], stamped: [], skipped: 0, failed: [] };
   let generatedThisRun = 0;


### PR DESCRIPTION
## What broke

My #1722 switch to `gpt-image-1-mini` broke generation outright:

```
OpenAI HTTP 400: input_fidelity 'high' is not supported for gpt-image-1-mini.
```

This is my error. `--dry-run` never calls the API, so a rejected parameter is invisible until a real request. I flagged the change as unverified and it failed on the first live run.

It also blocked the whole news deploy. The image step is not `continue-on-error`, so `Upload news.json to S3`, `Amplify rebuild`, social and IndexNow were all skipped, and the U.S. Bank Shopper article never went live.

## Why not just drop input_fidelity

`input_fidelity: high` is the reason the real card PNGs survive the edit instead of being redrawn from scratch. It is the entire point of compositing actual card art rather than describing it. Removing it to keep mini would have quietly gutted the feature to save two cents an image, and the damage would have shown up as subtly wrong card art in published hero images.

## Which models actually accept it

Verified against the live API, not from docs:

| Model | `input_fidelity: high` | medium @ 1536x1024 |
|---|---|---|
| gpt-image-1 (original) | accepted | $0.25 at high |
| **gpt-image-1.5** | **accepted, returned an image** | **~$0.032** |
| gpt-image-2 | **400**, always high fidelity, must omit | ~$0.041 |
| gpt-image-1-mini | **400**, unsupported | $0.019 |

## The fix

Default to **`gpt-image-1.5` at medium**: ~$0.032/image against the old $0.25, still **~87% off**, with card fidelity intact.

The real defect was sending `input_fidelity` unconditionally, so the fix is a support check rather than swapping one hardcoded model for another:

```js
const NO_INPUT_FIDELITY = new Set(['gpt-image-1-mini', 'gpt-image-2']);
const supportsInputFidelity = !NO_INPUT_FIDELITY.has(model);
...
if (supportsInputFidelity) form.append('input_fidelity', 'high');
```

`--model gpt-image-2` and `--model gpt-image-1-mini` now both work instead of 400ing, and the startup log states whether fidelity is in effect:

```
model: gpt-image-1.5    | quality: medium | input_fidelity: high
model: gpt-image-1-mini | quality: medium | input_fidelity: not supported by this model
model: gpt-image-2      | quality: medium | input_fidelity: not supported by this model
```

## Revised savings

| | Full 86-item backfill | Per new article |
|---|---|---|
| Before | $21.50 | $0.25 |
| After | **$2.75** | **$0.032** |

Slightly less than the $1.63 I projected for mini, which was never actually achievable on this pipeline.

## Follow-up worth doing separately

The image step has now blocked publishing twice. A missing hero image is a worse-looking article; a failed step means **no article at all**. Making that step non-fatal would decouple the two. Not included here because it is a judgment call about whether an image-less article should go live.