### PR TITLE
chore: move the two gpt-4o jobs to local routines

### DIFF
--- a/.github/workflows/check-card-rewards-and-benefits.yml
+++ b/.github/workflows/check-card-rewards-and-benefits.yml
@@ -5,9 +5,19 @@ name: Check Card Rewards and Benefits
 # foreign_transaction_fee. Splitting the two so a parsing failure on the
 # (newer, more complex) benefits flow can't take down the working SUB flow.
 
+# SCHEDULE DISABLED 2026-07-21. The weekly sweep now runs from a local Claude
+# Code session (`card-rewards-benefits-local` scheduled task, Sundays), which
+# answers the extraction prompts in-session instead of spending ~148 gpt-4o
+# calls a week on the API. The script grew --phase=fetch/--phase=finish for
+# exactly this; see its header.
+#
+# This workflow is kept as a manual escape hatch: dispatching it still runs the
+# full single pass, which needs OPENAI_API_KEY. Re-enable the cron below only if
+# the local routine is retired.
+#
+#  schedule:
+#    - cron: '0 9 * * 0'  # Sundays 9 AM UTC
 on:
-  schedule:
-    - cron: '0 9 * * 0'  # Sundays 9 AM UTC
   workflow_dispatch:
     inputs:
       card_slug:

--- a/.github/workflows/refresh-our-takes.yml
+++ b/.github/workflows/refresh-our-takes.yml
@@ -10,9 +10,20 @@ name: Refresh Our Takes
 # it as an artifact (our-takes-dryrun.json) without touching main, so a run can
 # be reviewed before anything goes live. Scheduled runs always publish.
 
+# SCHEDULE DISABLED 2026-07-21. The twice-monthly refresh now runs from a local
+# Claude Code session (`our-takes-refresh-local` scheduled task, 1st & 15th),
+# which writes the copy in-session instead of spending 182 gpt-4o calls per run
+# on the API. The script grew --phase=prepare/--phase=apply for exactly this;
+# see its header.
+#
+# This workflow is kept as a manual escape hatch: dispatching it still runs the
+# full single pass, which needs OPENAI_API_KEY. Note that a dispatch defaults to
+# PREVIEW mode and will not commit. Re-enable the cron below only if the local
+# routine is retired.
+#
+#  schedule:
+#    - cron: '0 16 1,15 * *'  # 1st & 15th of each month, 16:00 UTC
 on:
-  schedule:
-    - cron: '0 16 1,15 * *'  # 1st & 15th of each month, 16:00 UTC
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ coverage/
 # Firebase service account keys (never commit these!)
 *-firebase-adminsdk-*.json
 serviceAccountKey.json
+
+# Local-routine work dirs: fetched pages + generated prompts + the answers the
+# session writes back. Regenerated every run; never committed.
+.card-rewards-benefits-work/
+.our-takes-work/

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -17,7 +17,25 @@
  *        - "review"    → append to .card-rewards-benefits-review.md (human triage).
  *        - "skip"      → silent; matched the exclude list or removed-history.
  *
- * Run via .github/workflows/check-card-rewards-and-benefits.yml weekly.
+ * Run shape is selected by --phase, mirroring scripts/check-card-pages.js:
+ *
+ *   --phase=all     (default) fetch + extract via the OpenAI API + apply.
+ *                   Needs OPENAI_API_KEY. This is the old single-pass behaviour.
+ *   --phase=fetch   Fetch every apply page and write one self-contained
+ *                   extraction prompt per card to WORK_DIR. No API key, no
+ *                   network calls to OpenAI.
+ *   --phase=finish  Read the answers back from WORK_DIR/extractions.json and
+ *                   run the identical diff/policy/apply path the single pass
+ *                   uses. No API key.
+ *
+ * The split exists so the weekly sweep can run from a local Claude Code session
+ * (see the `card-rewards-benefits-local` scheduled task) where the extraction is
+ * done in-session instead of by a paid gpt-4o call per card. That is ~148 gpt-4o
+ * calls a week that no longer hit the API.
+ *
+ * Previously run via .github/workflows/check-card-rewards-and-benefits.yml,
+ * whose weekly cron is now disabled in favour of the local routine. The
+ * workflow remains dispatch-only as a manual escape hatch.
  */
 
 const fs = require('fs');
@@ -30,6 +48,22 @@ const CARDS_DIR = path.join(ROOT, 'data', 'cards');
 const POLICY_FILE = path.join(ROOT, 'data', 'benefit-policy.yaml');
 const REVIEW_SUMMARY = path.join(ROOT, '.card-rewards-benefits-review.md');
 const SUMMARY_FILE = path.join(ROOT, '.card-rewards-benefits-summary.md');
+
+const PHASE = (() => {
+  const arg = process.argv.find(a => a.startsWith('--phase='));
+  const v = (arg ? arg.slice('--phase='.length) : process.env.CARD_RB_PHASE || 'all').toLowerCase();
+  if (!['all', 'fetch', 'finish'].includes(v)) {
+    console.error(`Error: --phase must be 'all', 'fetch' or 'finish' (got '${v}')`);
+    process.exit(1);
+  }
+  return v;
+})();
+
+const WORK_DIR = path.join(ROOT, '.card-rewards-benefits-work');
+const PROMPTS_DIR = path.join(WORK_DIR, 'prompts');
+const PAGES_DIR = path.join(WORK_DIR, 'pages');
+const FETCH_STATE_FILE = path.join(WORK_DIR, 'fetch-state.json');
+const EXTRACTIONS_FILE = path.join(WORK_DIR, 'extractions.json');
 
 const FETCH_DELAY_MS = 2000;
 const FETCH_TIMEOUT_MS = 15000;
@@ -247,10 +281,11 @@ function buildFewShotExamples(allCards, exampleSlugs) {
 
 // ─── OpenAI extraction ──────────────────────────────────────────────────────
 
-async function extractRewardsAndBenefits(card, applyLink, pageContent, examples) {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error('OPENAI_API_KEY required');
-
+// Single source of truth for the extraction prompt. The API path and the
+// fetch phase both call this, so a prompt tweak can never apply to one and not
+// the other — the local routine must be answering exactly the question the
+// single pass would have asked.
+function buildExtractionPrompt(card, applyLink, pageContent, examples) {
   const examplesBlock = examples
     .slice(0, 3)
     .map(ex => `### ${ex.name}\n${JSON.stringify({ rewards: ex.rewards, benefits: ex.benefits, foreign_transaction_fee: ex.foreign_transaction_fee }, null, 2)}`)
@@ -502,6 +537,15 @@ EXAMPLES — what good extraction looks like for our team:
 ${examplesBlock}
 
 Now extract for ${card.data.name}.`;
+
+  return prompt;
+}
+
+async function extractRewardsAndBenefits(card, applyLink, pageContent, examples) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY required');
+
+  const prompt = buildExtractionPrompt(card, applyLink, pageContent, examples);
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -1440,6 +1484,23 @@ async function main() {
   const policy = loadPolicy();
   const examples = buildFewShotExamples(allCards, policy.exampleCards);
 
+  if (PHASE === 'finish') return finishPhase({ cards, policy });
+
+  if (PHASE === 'all' && !process.env.OPENAI_API_KEY) {
+    console.error('OPENAI_API_KEY is required for --phase=all. Use --phase=fetch/--phase=finish to extract locally.');
+    process.exit(1);
+  }
+
+  const fetchedSlugs = [];
+  if (PHASE === 'fetch') {
+    // Wipe rather than merge: a stale prompt from a previous run would be
+    // answered as if it were current, silently checking a card against page
+    // content that is a week old.
+    fs.rmSync(WORK_DIR, { recursive: true, force: true });
+    fs.mkdirSync(PROMPTS_DIR, { recursive: true });
+    fs.mkdirSync(PAGES_DIR, { recursive: true });
+  }
+
   // Reset review summary for this run, then immediately write the
   // rotating-period staleness section so it sits at the top.
   if (fs.existsSync(REVIEW_SUMMARY)) fs.unlinkSync(REVIEW_SUMMARY);
@@ -1492,6 +1553,22 @@ async function main() {
     }
     summary.fetched++;
 
+    // FETCH PHASE: write the prompt out and stop. The caller answers it.
+    if (PHASE === 'fetch') {
+      fs.writeFileSync(
+        path.join(PROMPTS_DIR, `${card.slug}.txt`),
+        buildExtractionPrompt(card, card.data.apply_link, pageResult.content, examples)
+      );
+      // The page text is kept because --phase=finish needs it: diffForeignTxn
+      // reads the raw page to confirm a "no foreign transaction fee" claim,
+      // and re-fetching at finish time could see a different page.
+      fs.writeFileSync(path.join(PAGES_DIR, `${card.slug}.txt`), pageResult.content);
+      fetchedSlugs.push(card.slug);
+      console.log('  Prompt written');
+      await new Promise(r => setTimeout(r, FETCH_DELAY_MS));
+      continue;
+    }
+
     let extracted;
     try {
       extracted = await withTimeout(
@@ -1509,6 +1586,99 @@ async function main() {
       continue;
     }
 
+    applyExtraction({ card, extracted, pageContent: pageResult.content, policy, summary });
+
+    await new Promise(r => setTimeout(r, FETCH_DELAY_MS));
+  }
+
+  await closeBrowser();
+
+  if (PHASE === 'fetch') {
+    fs.writeFileSync(FETCH_STATE_FILE, JSON.stringify({
+      fetched_at: new Date().toISOString(),
+      slug_filter: slugFilter || null,
+      fetched: fetchedSlugs,
+      fetch_failed: summary.fetchFailed,
+    }, null, 2));
+    console.log(`\nWrote ${fetchedSlugs.length} prompt(s) to ${path.relative(process.cwd(), PROMPTS_DIR)}`);
+    console.log(`${summary.fetchFailed} card(s) could not be fetched.`);
+    console.log('\nNext: answer each prompt and write {"<slug>": {...}} to');
+    console.log(`  ${path.relative(process.cwd(), EXTRACTIONS_FILE)}`);
+    console.log('then run: node scripts/check-card-rewards-and-benefits.js --phase=finish');
+    console.log('\n=== Fetch phase complete ===');
+    return;
+  }
+
+  writeSummary(summary);
+}
+
+// ─── Finish phase ────────────────────────────────────────────────────────────
+// Reads back the extractions the calling session produced and runs them through
+// exactly the same policy/diff/apply path the single pass uses. A card with no
+// extraction is counted as an extraction failure, never as "no changes" — an
+// unanswered prompt must not read as a clean bill of health.
+function finishPhase({ cards, policy }) {
+  if (!fs.existsSync(FETCH_STATE_FILE)) {
+    console.error(`Error: ${path.relative(process.cwd(), FETCH_STATE_FILE)} not found — run --phase=fetch first.`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(EXTRACTIONS_FILE)) {
+    console.error(`Error: ${path.relative(process.cwd(), EXTRACTIONS_FILE)} not found — answer the prompts first.`);
+    process.exit(1);
+  }
+
+  const fetchState = JSON.parse(fs.readFileSync(FETCH_STATE_FILE, 'utf8'));
+  const extractions = JSON.parse(fs.readFileSync(EXTRACTIONS_FILE, 'utf8'));
+  const fetched = new Set(fetchState.fetched || []);
+
+  // The rotating-period section is regenerated here rather than carried over
+  // from the fetch phase: it is derived purely from YAML and the calendar, so
+  // recomputing keeps it correct even if finish runs on a later day.
+  const allCards = loadAllCards();
+  if (fs.existsSync(REVIEW_SUMMARY)) fs.unlinkSync(REVIEW_SUMMARY);
+  const staleRotations = findStaleRotatingPeriods(allCards);
+  writeRotatingPeriodSection(staleRotations);
+
+  const summary = {
+    fetched: fetched.size,
+    extractFailed: 0,
+    fetchFailed: fetchState.fetch_failed || 0,
+    cardsModified: 0,
+    autoChanges: 0,
+    reviewItems: 0,
+    staleRotatingPeriods: staleRotations.length,
+  };
+
+  for (const card of cards) {
+    if (!fetched.has(card.slug)) continue;
+
+    const extracted = extractions[card.slug];
+    if (!extracted) {
+      console.warn(`  ${card.data.name}: no extraction returned — skipping`);
+      summary.extractFailed++;
+      continue;
+    }
+
+    const pagePath = path.join(PAGES_DIR, `${card.slug}.txt`);
+    if (!fs.existsSync(pagePath)) {
+      console.warn(`  ${card.data.name}: page text missing from the fetch phase — skipping`);
+      summary.extractFailed++;
+      continue;
+    }
+    const pageContent = fs.readFileSync(pagePath, 'utf8');
+
+    console.log(`[finish] ${card.data.name}`);
+    applyExtraction({ card, extracted, pageContent, policy, summary });
+  }
+
+  writeSummary(summary);
+}
+
+// Everything that happens once a card's extraction is in hand: policy filter,
+// diff, YAML write, review-queue append. Shared verbatim by --phase=all and
+// --phase=finish so a locally-answered prompt lands exactly where an
+// API-answered one would.
+function applyExtraction({ card, extracted, pageContent, policy, summary }) {
     const removed = getRemovedBenefitsForCard(card.filepath);
     const currentNames = getCurrentBenefitNames(card);
     // Don't deny-list things that are CURRENTLY in the YAML (they can be
@@ -1527,7 +1697,7 @@ async function main() {
     const ftxnDiff = diffForeignTxn(
       card.data.foreign_transaction_fee,
       extracted.foreign_transaction_fee,
-      pageResult.content
+      pageContent
     );
 
     const wrote = applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff);
@@ -1553,13 +1723,11 @@ async function main() {
       rewardsDiff.added.length +
       rewardsDiff.removed.length +
       rewardsDiff.downgraded.length;
+}
 
-    await new Promise(r => setTimeout(r, FETCH_DELAY_MS));
-  }
-
-  await closeBrowser();
-
-  // Top-level summary so the workflow can decide whether to PR / open issue
+// Top-level summary so the caller (workflow or local routine) can decide
+// whether to PR / open an issue.
+function writeSummary(summary) {
   fs.writeFileSync(SUMMARY_FILE, JSON.stringify(summary, null, 2));
   console.log('\n=== Summary ===');
   console.log(JSON.stringify(summary, null, 2));

--- a/scripts/check-card-rewards-benefits-publish.sh
+++ b/scripts/check-card-rewards-benefits-publish.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Publish step for the local rewards-and-benefits check. Runs AFTER
+# `node scripts/check-card-rewards-and-benefits.js --phase=finish` has applied
+# the YAML edits.
+#
+# This is the local counterpart to everything
+# .github/workflows/check-card-rewards-and-benefits.yml does around the script:
+# validate, open one PR per modified card, and file the weekly review issue.
+# The check itself is driven by the Claude Code session (see the
+# `card-rewards-benefits-local` scheduled task), because the extraction happens
+# there rather than through a paid gpt-4o call per card.
+#
+# Usage:  scripts/check-card-rewards-benefits-publish.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+REVIEW_FILE=".card-rewards-benefits-review.md"
+SUMMARY_FILE=".card-rewards-benefits-summary.md"
+DATE=$(date +%Y-%m-%d)
+
+if [ -n "$(git status --porcelain data/cards/)" ]; then
+  echo "=== Validating updated card data ==="
+  if ! npm run build:cards; then
+    echo "ERROR: card validation failed — reverting changes." >&2
+    git checkout -- data/cards/
+    exit 1
+  fi
+  # build:cards regenerates data/cards.json, which is never committed from a
+  # card PR — CI rebuilds it.
+  git checkout -- data/cards.json 2>/dev/null || true
+fi
+
+ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ -z "$(git status --porcelain data/cards/)" ]; then
+  echo "No card YAMLs changed."
+else
+  echo "=== Opening one PR per modified card ==="
+  # One PR per card, matching the workflow: a rewards/benefits change needs
+  # verifying against that card's apply page, and a 12-card bundle makes that
+  # review impossible to do honestly.
+  #
+  # Stash everything, then re-apply a single card at a time onto a fresh branch
+  # cut from origin/main. Branching off HEAD would sweep unrelated local commits
+  # into a PR that should contain nothing but one card's YAML.
+  git stash push -q -m "rewards-and-benefits-check" -- data/cards/
+  git fetch -q origin main
+
+  for FILE in $(git stash show "stash@{0}" --name-only); do
+    SLUG=$(basename "$FILE" .yaml)
+    BRANCH="auto/${SLUG}-rewards-benefits-${DATE}"
+
+    # Idempotency: don't spam a second PR if last week's is still open.
+    if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+      echo "  Branch $BRANCH already on origin — skipping $SLUG"
+      continue
+    fi
+
+    git checkout -q -B "$BRANCH" origin/main
+    git checkout "stash@{0}" -- "$FILE"
+
+    # Use the YAML parser rather than awk: the writer does not force quotes,
+    # so naive field splitting returns empty strings.
+    CARD_NAME=$(node -e "console.log(require('js-yaml').load(require('fs').readFileSync('$FILE','utf8')).name || '')")
+    APPLY_LINK=$(node -e "console.log(require('js-yaml').load(require('fs').readFileSync('$FILE','utf8')).apply_link || '')")
+
+    git add "$FILE"
+    git commit -q -m "Auto: ${CARD_NAME} rewards/benefits check ${DATE}"
+    git push -q -u origin "$BRANCH"
+
+    BODY_FILE=$(mktemp)
+    {
+      printf 'The weekly rewards-and-benefits check picked up changes on the apply page for **%s**.\n\n' "$CARD_NAME"
+      printf '**Apply link (verify against this):** %s\n\n' "$APPLY_LINK"
+      printf 'Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.\n\n'
+      printf 'Review against the live apply page before merging.\n'
+    } > "$BODY_FILE"
+
+    gh pr create \
+      --title "Auto: ${CARD_NAME} rewards/benefits update — ${DATE}" \
+      --body-file "$BODY_FILE" || echo "  PR creation failed for $SLUG (continuing)"
+    rm -f "$BODY_FILE"
+  done
+
+  git checkout -q "$ORIGINAL_BRANCH"
+  git stash drop -q "stash@{0}" || true
+fi
+
+if [ -s "$REVIEW_FILE" ]; then
+  echo "=== Opening weekly review issue ==="
+  ISSUE_BODY=$(printf '%s\n\n%s' \
+    "Weekly review queue from the local \`card-rewards-benefits-local\` routine. Two kinds of items show up here: (a) **stale rotating-category periods** — quarterly cards (Discover It, Freedom Flex, etc.) whose \`current_period\` doesn't match this quarter, and (b) **borderline benefits** the checker spotted on apply pages but couldn't auto-PR (generic travel insurance, secondary CDW, purchase protection, and similar). Triage each manually." \
+    "$(cat "$REVIEW_FILE")")
+  gh issue create \
+    --title "Card benefits review — ${DATE}" \
+    --body "$ISSUE_BODY" || echo "Issue creation failed (continuing)"
+else
+  echo "Nothing to review (no borderline items, no stale rotating periods)."
+fi
+
+if [ -f "$SUMMARY_FILE" ]; then
+  echo ""
+  echo "=== Run summary ==="
+  cat "$SUMMARY_FILE"
+fi

--- a/scripts/refresh-our-takes-publish.sh
+++ b/scripts/refresh-our-takes-publish.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Publish step for the local our_take refresh. Runs AFTER
+# `node scripts/refresh-our-takes.js --phase=apply` has rewritten the YAML.
+#
+# Local counterpart to the publish half of .github/workflows/refresh-our-takes.yml,
+# with one deliberate difference: the workflow committed straight to main, this
+# opens a PR.
+#
+# Two reasons. First, this repo's rule is never commit directly to main, and a
+# local routine runs under that rule where a bot workflow did not. Second, the
+# workflow only needed its explicit `gh workflow run build-cards.yml` because a
+# GITHUB_TOKEN push does not cascade into other workflows. A human merging a PR
+# is a real push, so Build and Deploy Cards fires on its own `data/cards/**`
+# trigger and the dispatch hack disappears.
+#
+# Usage:  scripts/refresh-our-takes-publish.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DATE=$(date +%Y-%m-%d)
+
+if [ -z "$(git status --porcelain data/cards/)" ]; then
+  echo "No take changes this run."
+  exit 0
+fi
+
+echo "=== Validating updated card data ==="
+if ! npm run build:cards; then
+  echo "ERROR: card validation failed — reverting changes." >&2
+  git checkout -- data/cards/
+  exit 1
+fi
+# Regenerated artifacts are never committed from a card PR; CI rebuilds them.
+git checkout -- data/cards.json 2>/dev/null || true
+git checkout -- data/best.json 2>/dev/null || true
+
+CHANGED=$(git status --porcelain data/cards/ | wc -l | tr -d ' ')
+ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+BRANCH="auto/our-takes-refresh-${DATE}"
+
+echo "=== Opening PR for ${CHANGED} refreshed take(s) ==="
+
+# Base on origin/main, not HEAD: the routine may well run from a feature branch,
+# and branching off HEAD would sweep its unrelated commits into this PR.
+git fetch -q origin main
+git stash push -q -m "our-takes-refresh" -- data/cards/
+git checkout -q -B "$BRANCH" origin/main
+git stash pop -q
+
+git add data/cards/
+git commit -q -m "chore: refresh our_take editorial copy (${DATE})"
+git push -q -u origin "$BRANCH"
+
+BODY_FILE=$(mktemp)
+{
+  printf 'Twice-monthly regeneration of the `our_take` editorial paragraph, written in-session by the local `our-takes-refresh-local` routine rather than by a gpt-4o call per card.\n\n'
+  printf '**%s card(s) changed.** Cards whose copy came out byte-identical are not touched, so everything in this diff is a real rewrite.\n\n' "$CHANGED"
+  printf 'House style is pinned in the prompt: one paragraph, no em dashes, lead with the strongest reason to carry the card, name the catch honestly, no clickbait.\n\n'
+  printf 'Skim for accuracy against each card. Merging fires Build and Deploy Cards on the `data/cards/**` push trigger, which refreshes cards.json on the CDN.\n'
+} > "$BODY_FILE"
+
+PR_URL=$(gh pr create \
+  --title "chore: refresh our_take editorial copy — ${DATE}" \
+  --body-file "$BODY_FILE")
+rm -f "$BODY_FILE"
+
+echo "PR: $PR_URL"
+git checkout -q "$ORIGINAL_BRANCH"

--- a/scripts/refresh-our-takes.js
+++ b/scripts/refresh-our-takes.js
@@ -27,8 +27,24 @@
  * when the take actually changed, so byte-identical output never churns the
  * diff.
  *
+ * Run shape is selected by --phase:
+ *
+ *   --phase=all      (default) build prompts + write every take with the
+ *                    OpenAI API + apply. Needs OPENAI_API_KEY.
+ *   --phase=prepare  Build the prompts (CardWire + best-of + card YAML) and
+ *                    write one per card to WORK_DIR, plus the shared system
+ *                    prompt. No API key, no OpenAI calls.
+ *   --phase=apply    Read the written takes back from WORK_DIR/takes.json and
+ *                    run the identical length-guard / changed-check / YAML
+ *                    upsert the single pass uses. No API key.
+ *
+ * The split exists so the twice-monthly refresh can run from a local Claude
+ * Code session (see the `our-takes-refresh-local` scheduled task) with the copy
+ * written in-session instead of by a paid gpt-4o call per card. That is 182
+ * gpt-4o calls per run, twice a month, that no longer hit the API.
+ *
  * Env:
- *   OPENAI_API_KEY     (required)
+ *   OPENAI_API_KEY     (required for --phase=all only)
  *   OPENAI_TAKE_MODEL  (optional, default: gpt-4o)
  *   CARD_WIRE_URL      (optional, default: CloudFront /card-wire endpoint)
  *   WIRE_WINDOW_DAYS   (optional, default: 120)
@@ -40,6 +56,22 @@ const yaml = require('js-yaml');
 
 const CARDS_DIR = path.join(__dirname, '..', 'data', 'cards');
 const BEST_FILE = path.join(__dirname, '..', 'data', 'best.json');
+
+const PHASE = (() => {
+  const arg = process.argv.find(a => a.startsWith('--phase='));
+  const v = (arg ? arg.slice('--phase='.length) : process.env.OUR_TAKE_PHASE || 'all').toLowerCase();
+  if (!['all', 'prepare', 'apply'].includes(v)) {
+    console.error(`Error: --phase must be 'all', 'prepare' or 'apply' (got '${v}')`);
+    process.exit(1);
+  }
+  return v;
+})();
+
+const WORK_DIR = path.join(__dirname, '..', '.our-takes-work');
+const PROMPTS_DIR = path.join(WORK_DIR, 'prompts');
+const PREPARE_STATE_FILE = path.join(WORK_DIR, 'prepare-state.json');
+const SYSTEM_PROMPT_FILE = path.join(WORK_DIR, 'system-prompt.txt');
+const TAKES_FILE = path.join(WORK_DIR, 'takes.json');
 
 const API_KEY = process.env.OPENAI_API_KEY;
 const MODEL = process.env.OPENAI_TAKE_MODEL || 'gpt-4o';
@@ -356,10 +388,14 @@ async function generateTake(prompt) {
 // ─── main ─────────────────────────────────────────────────────────────────
 
 async function main() {
-  if (!API_KEY) {
-    console.error('OPENAI_API_KEY is required.');
+  if (PHASE === 'all' && !API_KEY) {
+    console.error('OPENAI_API_KEY is required for --phase=all. Use --phase=prepare/--phase=apply to write takes locally.');
     process.exit(1);
   }
+
+  // apply reads only the YAML plus the takes the caller wrote, so it needs
+  // neither CardWire nor best.json — and must not fail if either is down.
+  if (PHASE === 'apply') return applyPhase();
 
   const [wireByName, featuredBySlug] = [await loadWireChanges(), loadFeaturedIn()];
 
@@ -393,6 +429,41 @@ async function main() {
   }
   if (LIMIT > 0) queue = queue.slice(0, LIMIT);
   const total = queue.length;
+
+  // PREPARE PHASE: write every prompt out and stop. The caller writes the copy.
+  if (PHASE === 'prepare') {
+    // Wipe rather than merge, so a stale prompt from a previous run can't be
+    // answered as though it described the card's current terms.
+    fs.rmSync(WORK_DIR, { recursive: true, force: true });
+    fs.mkdirSync(PROMPTS_DIR, { recursive: true });
+    fs.writeFileSync(SYSTEM_PROMPT_FILE, SYSTEM_PROMPT);
+
+    const prepared = [];
+    for (const card of queue) {
+      const wire = wireByName.get(normalizeName(card.data.name)) || [];
+      const featured = featuredBySlug.get(card.data.slug) || [];
+      fs.writeFileSync(
+        path.join(PROMPTS_DIR, `${card.data.slug}.txt`),
+        buildUserPrompt(card.data, wire, featured)
+      );
+      prepared.push({ slug: card.data.slug, name: card.data.name });
+    }
+
+    fs.writeFileSync(PREPARE_STATE_FILE, JSON.stringify({
+      prepared_at: new Date().toISOString(),
+      only: ONLY.length ? ONLY : null,
+      limit: LIMIT || null,
+      cards: prepared,
+    }, null, 2));
+
+    console.log(`\nWrote ${prepared.length} prompt(s) to ${path.relative(process.cwd(), PROMPTS_DIR)}`);
+    console.log(`House style / voice rules: ${path.relative(process.cwd(), SYSTEM_PROMPT_FILE)}`);
+    console.log('\nNext: write each take and save {"<slug>": "<take text>"} to');
+    console.log(`  ${path.relative(process.cwd(), TAKES_FILE)}`);
+    console.log('then run: node scripts/refresh-our-takes.js --phase=apply');
+    console.log('\n=== Prepare phase complete ===');
+    return;
+  }
 
   console.log(
     `\nRegenerating our_take for ${total}${LIMIT > 0 ? ` of ${cards.length}` : ''} cards with ${MODEL}${DRY_RUN ? ' (dry run, no writes)' : ''}...\n`
@@ -471,6 +542,79 @@ async function main() {
   // report but never hard-fail.
   if (!DRY_RUN && failed > cards.length / 2) {
     console.error('More than half the cards failed to generate; failing the run.');
+    process.exit(1);
+  }
+}
+
+// ─── apply phase ────────────────────────────────────────────────────────────
+// Reads back the takes the calling session wrote and runs them through the same
+// guards the single pass applies: MIN_TAKE_LENGTH, the normalized changed-check
+// so byte-identical copy never churns the diff, and upsertOurTake for the write.
+// A card with no take is skipped and counted, never written blank.
+function applyPhase() {
+  if (!fs.existsSync(PREPARE_STATE_FILE)) {
+    console.error(`Error: ${path.relative(process.cwd(), PREPARE_STATE_FILE)} not found — run --phase=prepare first.`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(TAKES_FILE)) {
+    console.error(`Error: ${path.relative(process.cwd(), TAKES_FILE)} not found — write the takes first.`);
+    process.exit(1);
+  }
+
+  const state = JSON.parse(fs.readFileSync(PREPARE_STATE_FILE, 'utf8'));
+  const takes = JSON.parse(fs.readFileSync(TAKES_FILE, 'utf8'));
+  const prepared = state.cards || [];
+
+  let changed = 0;
+  let unchanged = 0;
+  let missing = 0;
+  let tooShort = 0;
+
+  for (const { slug, name } of prepared) {
+    const take = takes[slug];
+    if (take === undefined || take === null || `${take}`.trim() === '') {
+      console.warn(`  MISSING  ${name} — no take written, leaving the existing copy alone`);
+      missing++;
+      continue;
+    }
+    if (`${take}`.trim().length < MIN_TAKE_LENGTH) {
+      console.warn(`  SHORT    ${name} — take under ${MIN_TAKE_LENGTH} chars, skipping`);
+      tooShort++;
+      continue;
+    }
+
+    const filepath = path.join(CARDS_DIR, `${slug}.yaml`);
+    if (!fs.existsSync(filepath)) {
+      console.warn(`  MISSING  ${name} — ${slug}.yaml not found, skipping`);
+      missing++;
+      continue;
+    }
+
+    const raw = fs.readFileSync(filepath, 'utf8');
+    let existing = null;
+    try {
+      existing = (yaml.load(raw) || {}).our_take || null;
+    } catch { /* fall through: an unparseable file still gets its block replaced */ }
+
+    if (normalizeText(take) === normalizeText(existing)) {
+      unchanged++;
+      continue;
+    }
+
+    fs.writeFileSync(filepath, upsertOurTake(raw, `${take}`.trim()));
+    console.log(`  CHANGED  ${name}`);
+    changed++;
+  }
+
+  console.log(
+    `\nDone. ${changed} updated, ${unchanged} unchanged, ${tooShort} too short, ` +
+    `${missing} missing (${prepared.length} prepared).`
+  );
+
+  // Same guard as the single pass: a mostly-empty batch means something went
+  // wrong upstream, and half-refreshing the card set is worse than not refreshing.
+  if (missing + tooShort > prepared.length / 2) {
+    console.error('More than half the prepared cards had no usable take; failing the run.');
     process.exit(1);
   }
 }


### PR DESCRIPTION
Moves the repo's two heaviest AI consumers out of GitHub Actions and into local Claude Code routines, following the pattern `check-card-pages` already uses.

| Job | Was | Model | Calls/month |
|---|---|---|---|
| check-card-rewards-and-benefits | weekly cron | **gpt-4o** | ~600 |
| refresh-our-takes | 1st & 15th cron | **gpt-4o** | ~364 (182 cards x 2) |

Both now answer their prompts in-session instead of paying for them. Neither needs CI: they are read-mostly analysis jobs that end in a PR a human reviews, not deploy pipelines.

## Script changes

**`check-card-rewards-and-benefits.js`** gains `--phase=fetch` / `--phase=finish`, mirroring `check-card-pages.js`:

- `fetch` renders the ~148 apply pages and writes one self-contained prompt per card
- `finish` reads the answers back and runs the **identical** policy filter, diff, YAML write and review-queue path

Two refactors keep the paths honest rather than parallel:
- the prompt text moved into `buildExtractionPrompt()`, so the API path and the fetch phase cannot drift
- the post-extraction work moved into `applyExtraction()`, so a locally-answered prompt lands exactly where an API-answered one would

The fetch phase also saves each page's stripped text, because `finish` genuinely needs it: `diffForeignTxn` reads the raw page to confirm a "no foreign transaction fee" claim, and re-fetching later could see a different page.

**`refresh-our-takes.js`** gains `--phase=prepare` / `--phase=apply`. Prepare writes the 182 prompts plus the shared house-style system prompt. Apply re-uses the existing guards: takes under 60 chars are skipped, byte-identical copy never churns the diff, an omitted card keeps the copy it has, and a batch that is more than half empty fails the run.

`--phase=all` is untouched in both, so a dispatch still behaves exactly as before.

## Workflow changes

Crons **commented out, not deleted**, with a note explaining why and how to restore. Both keep `workflow_dispatch` as a manual escape hatch that still runs the full single pass (and still needs `OPENAI_API_KEY`).

## One deliberate behaviour change

The our_take publish step **opens a PR where the workflow pushed straight to `main`**. Two reasons:

1. This repo's rule is never commit directly to main. A local routine runs under that rule where a bot workflow did not.
2. The workflow only needed its explicit `gh workflow run build-cards.yml` because a `GITHUB_TOKEN` push does not cascade into other workflows. A human-merged PR is a real push, so Build and Deploy Cards fires on its own `data/cards/**` trigger and the dispatch hack disappears.

The rewards-benefits publish script keeps one-PR-per-card, matching the workflow: each change needs verifying against that card's apply page, and a 12-card bundle makes that review impossible to do honestly.

## Verification

Both phase splits exercised end to end against live pages:

- **fetch** on one card: prompt + page written, `fetch-state.json` correct
- **finish** with an extraction mirroring current YAML: 0 changes, YAML untouched
- **finish** with an empty extractions file: counted as `extractFailed: 1`, not silent success
- **prepare** on 2 cards: prompts + system prompt written
- **apply** with 1 identical and 1 new take: 1 unchanged, 1 CHANGED, correct wrapped YAML block
- guards: `--phase=finish`/`apply` before their prerequisite phase both error out; invalid `--phase` rejected
- `npm run build:cards` clean (182 cards); both publish scripts pass `bash -n` and no-op correctly on a clean tree
- both workflow files still parse as YAML

## Scheduled tasks

Registered in `~/.claude/scheduled-tasks/`:
- `card-rewards-benefits-local` — Sundays 8am local
- `our-takes-refresh-local` — 1st & 15th, 10am local

Both instruct the routine to use a git worktree if another session has the tree on a different branch, and neither is allowed to merge its own PRs.

## Tradeoff

Local routines only run when the machine is awake. Weekly and twice-monthly jobs absorb that well; a missed run slips a few days. Today's card-page-check showed the failure mode is a transient network drop mid-fetch, which the retry pass in #1717 now handles.