### PR TITLE
Auto: IHG Rewards Club Traveler rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -55,7 +55,7 @@ tags:
   - rewards
 rewards:
   - category: hotels
-    value: 17
+    value: 5
     unit: points_per_dollar
     note: "Up to 17x total points at IHG hotels"
     merchant_specific: true


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **IHG Rewards Club Traveler**.

**Apply link (verify against this):** https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/traveler

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
