### PR TITLE
Auto: Navy Federal More Rewards American Express rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/navy-federal-more-rewards-american-express.yaml
+++ b/data/cards/navy-federal-more-rewards-american-express.yaml
@@ -58,4 +58,11 @@ benefits:
     description: "Up to 25% off car rentals with rental loss and damage insurance included"
     category: "travel"
     enrollment_required: false
+  - name: "Booking.com Hotel Discount"
+    value: 30
+    value_unit: "percent"
+    description: "Up to 30% off select hotel properties booked through Booking.com on the Amex Benefits platform"
+    frequency: "per_purchase"
+    category: "hotel"
+    enrollment_required: false
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/more-rewards.html


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Navy Federal More Rewards American Express**.

**Apply link (verify against this):** https://www.navyfederal.org/loans-cards/credit-cards/more-rewards.html

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
