### PR TITLE
Auto: American Express Business Gold rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -70,6 +70,12 @@ benefits:
     frequency: "annual"
     category: "statement_credit"
     enrollment_required: true
+  - name: "The Hotel Collection Credit"
+    value: 100
+    description: "$100 credit toward eligible on-property charges plus a room upgrade when available at over 1,300 hotels, on two-night-minimum stays booked through AmexTravel.com."
+    frequency: "per_purchase"
+    category: "hotel"
+    enrollment_required: false
 tags:
   - business
   - rewards


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **American Express Business Gold**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/american-express-business-gold-card-amex/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
