### PR TITLE
Auto: Atlas rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/atlas-card.yaml
+++ b/data/cards/atlas-card.yaml
@@ -115,6 +115,12 @@ benefits:
     description: "21g mirror-finished steel card, CNC-milled and laser-engraved with cardholder's preferred first name"
     frequency: "ongoing"
     category: "other"
+  - name: "Slate Shared Membership"
+    value: 595
+    description: "Complimentary one-year Slate Shared Membership ($595 value) plus $395 off every seat between New York, the Hamptons, Nantucket, and South Florida"
+    frequency: "one_time"
+    category: "travel"
+    enrollment_required: true
 tags:
   - premium
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Atlas**.

**Apply link (verify against this):** https://atlascard.com/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
