### PR TITLE
Auto: Chase Freedom Flex rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -79,3 +79,8 @@ benefits:
     frequency: "per_claim"
     category: "other"
     enrollment_required: false
+  - name: "DashPass Complimentary Membership"
+    description: "6 months of complimentary DashPass on DoorDash and Caviar, plus $10 off one non-restaurant DoorDash order each quarter while enrolled."
+    frequency: "one_time"
+    category: "dining"
+    enrollment_required: true


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Chase Freedom Flex**.

**Apply link (verify against this):** https://creditcards.chase.com/cash-back-credit-cards/freedom/flex

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
