### PR TITLE
Auto: Marriott Bonvoy Brilliant American Express rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -91,6 +91,12 @@ benefits:
     frequency: "annual"
     category: "hotel"
     enrollment_required: false
+  - name: "Cell Phone Protection"
+    value: 800
+    description: "Reimburses repair or replacement costs up to $800 per claim (2 approved claims per 12 months, $50 deductible) when the prior month's wireless bill was paid with the Card."
+    frequency: "per_claim"
+    category: "telecom"
+    enrollment_required: false
 tags:
   - hotel
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Marriott Bonvoy Brilliant American Express**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy-brilliant/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
