### PR TITLE
Auto: The Platinum Card rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -185,6 +185,11 @@ benefits:
     frequency: "annual"
     category: "lounge"
     enrollment_required: false
+  - name: "Leaders Club Sterling Status"
+    description: "Complimentary Leaders Club Sterling Status from The Leading Hotels of the World, including a 5% Leaders Club points bonus on qualifying stays."
+    frequency: "ongoing"
+    category: "hotel"
+    enrollment_required: false
 tags:
   - travel
   - premium


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **The Platinum Card**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/platinum/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
