### PR TITLE
Auto: United Explorer rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -91,6 +91,13 @@ benefits:
     frequency: "per_purchase"
     category: "statement_credit"
     enrollment_required: false
+  - name: "Mile Flight Savings"
+    value: 10
+    value_unit: "percent"
+    description: "Save 10% or more when booking flights with miles; Premier members save even more."
+    frequency: "per_flight"
+    category: "rewards"
+    enrollment_required: false
 tags:
   - airline
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **United Explorer**.

**Apply link (verify against this):** https://creditcards.chase.com/travel-credit-cards/united/united-explorer

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
