### PR TITLE
Auto: World of Hyatt Business rewards/benefits update — 2026-07-21

### DIFF
--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -27,6 +27,12 @@ benefits:
     description: "After spending $50,000 in a calendar year, get 10% of redeemed points back on up to 200,000 points redeemed per year"
     frequency: "annual"
     category: "hotel"
+  - name: "DoorDash DashPass Membership"
+    value: 120
+    description: "12 months of complimentary DashPass when the membership is first activated with the card between 02/01/2025 and 12/31/2027"
+    frequency: "annual"
+    category: "dining"
+    enrollment_required: true
 tags:
   - hotel
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **World of Hyatt Business**.

**Apply link (verify against this):** https://creditcards.chase.com/business-credit-cards/world-of-hyatt/hyatt-business-card

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
