### PR TITLE
card-rewards-benefits: raise the page cap 8000 -> 18000 chars

### DIFF
--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -65,6 +65,17 @@ const PAGES_DIR = path.join(WORK_DIR, 'pages');
 const FETCH_STATE_FILE = path.join(WORK_DIR, 'fetch-state.json');
 const EXTRACTIONS_FILE = path.join(WORK_DIR, 'extractions.json');
 
+// Max stripped page text handed to the extractor. This was 8000, which was too
+// small and silently blinded the check to every nav-heavy issuer: the terms sat
+// past the cutoff, so the extractor saw only chrome and returned nothing. The
+// 2026-07-21 run lost 12 cards that way, including ALL SIX Bank of America
+// cards, whose pages lead with ~11k chars of menu before the earn rates appear.
+//
+// 18000 matches MAX_CONTENT_CHARS in the sibling check-card-pages.js, which was
+// sized for exactly this problem. Keep the two in step: they scrape the same
+// pages, and a card the SUB checker can read but this one cannot is a bug.
+const MAX_CONTENT_CHARS = 18000;
+
 const FETCH_DELAY_MS = 2000;
 const FETCH_TIMEOUT_MS = 15000;
 const PER_CARD_TIMEOUT_MS = 90 * 1000;
@@ -185,7 +196,7 @@ function stripHtml(html) {
     .replace(/&[a-z#0-9]+;/gi, ' ')
     .replace(/\s+/g, ' ')
     .trim()
-    .slice(0, 8000); // benefits sections are wordy — give Haiku a bit more
+    .slice(0, MAX_CONTENT_CHARS);
 }
 
 // ─── Page fetching ──────────────────────────────────────────────────────────

--- a/scripts/check-card-rewards-benefits-publish.sh
+++ b/scripts/check-card-rewards-benefits-publish.sh
@@ -33,7 +33,11 @@ if [ -n "$(git status --porcelain data/cards/)" ]; then
   git checkout -- data/cards.json 2>/dev/null || true
 fi
 
-ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+# Remember where to return to. `--abbrev-ref HEAD` yields the literal string
+# "HEAD" on a detached checkout, and `git checkout HEAD` is a no-op that leaves
+# us parked on whichever auto/* branch was created last. Fall back to the commit
+# SHA so a detached worktree lands back where it started.
+ORIGINAL_REF="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
 
 if [ -z "$(git status --porcelain data/cards/)" ]; then
   echo "No card YAMLs changed."
@@ -85,7 +89,7 @@ else
     rm -f "$BODY_FILE"
   done
 
-  git checkout -q "$ORIGINAL_BRANCH"
+  git checkout -q "$ORIGINAL_REF"
   git stash drop -q "stash@{0}" || true
 fi
 


### PR DESCRIPTION
## The bug

`stripHtml()` truncated every apply page to **8000 characters** before handing it to the extractor. Any issuer whose terms sat past that cutoff was invisible: the model saw navigation chrome, found no earn rates, and returned nothing.

The sibling `check-card-pages.js` already uses `MAX_CONTENT_CHARS = 18000`, with a comment naming Bank of America specifically. The two scripts scrape the same pages, so a card the SUB checker can read and this one cannot was always a bug.

Page text went from a uniform ~8000 bytes to a median of ~13000 (max 18186).

## What it recovered, honestly

Less than I predicted. Extraction went **135 -> 137 of 147**. `atlas-card`, `atmos-rewards-business` and `att-points-plus-from-citi` came back; the Bank of America cards did not.

I checked why rather than assuming. **The BoA pages contain no rate text at any length** — no `%`, no "points per", not even the word "earn" in 16KB of fetched content. Their reward tables are client-rendered and never reach the scraper. That is a separate, unsolved problem, and no character cap fixes it.

So this is a real fix worth having (it removes a silent blind spot and aligns the two scripts), but it is not the reason BoA has been missing. I over-attributed on first diagnosis.

## Also fixed

`check-card-rewards-benefits-publish.sh` left a **detached** worktree parked on the last `auto/*` branch: `git rev-parse --abbrev-ref HEAD` returns the literal string `HEAD` when detached, making the restore a no-op. Now uses `git symbolic-ref` with a SHA fallback. Verified: the worktree returns to its original ref after publishing.

## Nothing was corrupted by the bug

Empty extractions route to the **review queue**, not the auto-write path — I verified this against `diffRewards` before running finish. No card ever lost its rewards. The cost was silent non-coverage plus phantom "removed" items inflating the review issue.

## Run comparison

| | Run 1 (8000) | Run 2 (18000) |
|---|---|---|
| extracted | 135/147 | **137/147** |
| cards modified | 6 | **11** |
| auto changes | 27 | 32 |
| review items | 51 | 64 |
| fetch failures | 0 | 0 |

Run 1's six PRs were closed and regenerated against full page content: #1732-#1742. Review issue #1731 closed and superseded by #1743.