### PR TITLE
cards: rename Princess Cruises Rewards Visa -> Princess Rewards Visa

### DIFF
--- a/apps/api/migrations/053_rename_princess_cruises_rewards_visa.sql
+++ b/apps/api/migrations/053_rename_princess_cruises_rewards_visa.sql
@@ -1,0 +1,9 @@
+-- Barclays rebrand: Princess Cruises Rewards Visa -> Princess Rewards Visa.
+-- The live apply page (cards.barclaycardus.com/credit-card/b2e0e09c-...) titles
+-- the product "PRINCESS REWARDS VISA" and no longer contains the string
+-- "Princess Cruises Rewards" anywhere.
+--
+-- Must run BEFORE the renamed cards.json reaches the sync: update-cards-github.js
+-- links rows by card_name, so a rename that lands in the CDN first would create a
+-- second row and strand this card's ratings, stats and CardWire history.
+UPDATE cards SET card_name = 'Princess Rewards Visa' WHERE card_name = 'Princess Cruises Rewards Visa';

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -1,10 +1,12 @@
-name: "Princess Cruises Rewards Visa"
+name: "Princess Rewards Visa"
+previous_names:
+  - "Princess Cruises Rewards Visa"
 bank: "Barclays"
 slug: "princess-cruises-rewards-visa-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/credit-card/b2e0e09c-e93c-43be-8758-57d22bb39ec1
 our_take: >
-  The Princess Cruises Rewards Visa is a niche card designed for loyal
+  The Princess Rewards Visa is a niche card designed for loyal
   Princess Cruises passengers, offering 2 points per dollar on purchases made
   with the cruise line. With no annual fee and a 20,000-point signup bonus
   after spending $1,000 in the first 3 months, it's a low-cost way to earn


### PR DESCRIPTION
## Evidence

Barclays dropped "Cruises" from the product name. I re-rendered the live apply page to confirm rather than trusting this morning's cached fetch:

```
title:            Secure Credit Card Application - Barclays
name mentions:    PRINCESS ® REWARDS VISA
"Princess Cruises Rewards" present:  false
```

The old string appears nowhere on the page.

## Changes

1. `name` -> `"Princess Rewards Visa"`, with the old name kept in **`previous_names`** so the card page renders its "Previously" subtitle and inbound links still resolve.
2. **Migration `053_rename_princess_cruises_rewards_visa.sql`** repoints `cards.card_name`. Single statement, per convention.
3. `our_take` prose updated — the checker does not diff prose, so it would otherwise have kept the old name until the next scheduled regeneration.

The **slug is unchanged**. Slugs are permanent here; `chase-freedom-student` still serves Chase Freedom Rise for the same reason.

## Ordering matters — read before merging

`update-cards-github.js` links rows to the DB **by `card_name`**. If a renamed `cards.json` reaches the CDN before the migration runs, the sync will not find a matching row, will **insert a second one**, and this card's ratings, `card_stats` and CardWire history stay attached to the orphaned original.

That is the exact failure mode behind the duplicate-rows cleanup in the 051/052 migration series.

**So: run migration 053 first (wire `RunMigrationHandler`, deploy, invoke, unwire), then merge this PR.** Merging first is recoverable but requires another dedupe pass.

## Validation

`npm run build:cards` -> 182 cards, `OK: Princess Rewards Visa`. Regenerated `cards.json` not committed; CI rebuilds it.