### PR TITLE
ci: stop hero-image generation from blocking news and article publishing

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -54,7 +54,13 @@ jobs:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2
 
+      # Non-blocking, same rationale as build-news.yml: a hero image is
+      # decoration, the article is the product, and every step below this one is
+      # sequential — so letting image generation fail the job takes the S3
+      # upload, the Amplify rebuild and the social post down with it.
       - name: Sync article hero images (generate missing via OpenAI)
+        id: hero-images
+        continue-on-error: true
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           S3_IMAGES_BUCKET_NAME: ${{ secrets.S3_IMAGES_BUCKET_NAME }}
@@ -66,6 +72,18 @@ jobs:
             ARGS="--force ${{ inputs.force_regenerate_slug }}"
           fi
           node scripts/sync-article-images.js $ARGS
+
+      - name: Flag hero-image failure
+        if: steps.hero-images.outcome == 'failure'
+        run: |
+          echo "::warning title=Hero images failed::sync-article-images.js failed; articles are publishing without new hero images. Check the OpenAI balance and the step log above."
+          {
+            echo "### ⚠️ Hero images failed"
+            echo ""
+            echo "\`sync-article-images.js\` did not complete. Articles still published, but any new one may be missing its hero image."
+            echo ""
+            echo "Re-run this workflow once the cause is fixed to backfill; S3 is the source of truth, so existing images are not regenerated."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload articles.json to S3
         run: aws s3 cp data/articles.json s3://${{ secrets.S3_BUCKET_NAME }}/articles.json --content-type application/json --cache-control "max-age=300"

--- a/.github/workflows/build-news.yml
+++ b/.github/workflows/build-news.yml
@@ -52,11 +52,38 @@ jobs:
           role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
           aws-region: us-east-2
 
+      # Non-blocking on purpose. A hero image is decoration; the article is the
+      # product. This step is not allowed to decide whether news ships.
+      #
+      # It blocked publishing twice on 2026-07-21 — once when the OpenAI balance
+      # ran out, once on a bad parameter — and because every later step is
+      # sequential, `Upload news.json to S3`, the Amplify rebuild, the social
+      # queue and IndexNow were all skipped. The article existed on main and was
+      # invisible on the site, which is a worse outcome than an article with a
+      # missing image.
+      #
+      # A failure here is still surfaced: the next step annotates the run and
+      # `image_status` marks the job so a silent image outage cannot masquerade
+      # as a clean deploy.
       - name: Sync news hero images (generate missing via OpenAI)
+        id: hero-images
+        continue-on-error: true
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           S3_IMAGES_BUCKET_NAME: ${{ secrets.S3_IMAGES_BUCKET_NAME }}
         run: node scripts/sync-news-images.js
+
+      - name: Flag hero-image failure
+        if: steps.hero-images.outcome == 'failure'
+        run: |
+          echo "::warning title=Hero images failed::sync-news-images.js failed; news is publishing without new hero images. Check the OpenAI balance and the step log above."
+          {
+            echo "### ⚠️ Hero images failed"
+            echo ""
+            echo "\`sync-news-images.js\` did not complete. News still published, but any new item may be missing its hero image (used on the news page, the OG card, and the social post)."
+            echo ""
+            echo "Re-run this workflow once the cause is fixed to backfill; S3 is the source of truth, so images that already exist are not regenerated."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload news.json to S3
         run: aws s3 cp data/news.json s3://${{ secrets.S3_BUCKET_NAME }}/news.json --content-type application/json --cache-control "max-age=300"


### PR DESCRIPTION
## The problem

A hero image is decoration. The article is the product. But image generation was allowed to fail the job, and every step below it is sequential — so one failed OpenAI call took down the entire publish:

```
6. ✅ Build news.json
8. ❌ Sync news hero images (OpenAI)
9. ⏭️  Upload news.json to S3       ← never ran
12. ⏭️  Trigger Amplify rebuild
14. ⏭️  Queue social
15. ⏭️  Notify IndexNow
```

This cost a real publish **twice on 2026-07-21**: first when the OpenAI balance ran out, then after the top-up when a bad parameter (`input_fidelity` on a model that rejects it) failed the step. Both times the U.S. Bank Shopper article was merged to `main` and **invisible on the site** — strictly worse than an article with a missing image.

## The fix

Both image steps become `continue-on-error: true`, with a following step that fires on `steps.hero-images.outcome == 'failure'` and emits:

- a `::warning` annotation on the run, and
- a `$GITHUB_STEP_SUMMARY` block explaining what is missing and how to backfill

So the failure stays **loud** — it just no longer decides whether news ships. A silent image outage cannot masquerade as a clean deploy.

## Why backfilling is safe

`sync-news-images.js` treats **S3 as the source of truth**: if the object already exists it stamps the field and skips generation. Re-running the workflow after fixing the cause regenerates only what is genuinely missing, at no extra cost for images that already landed.

## Also fixed

`build-articles.yml` had the identical shape — same blocking image step, same sequential steps below it. Fixed the same way rather than waiting for it to bite.

## Validation

Both workflow files parse as YAML, and step order is unchanged apart from the inserted flag step.