### PR TITLE
card-page-check: unblock pnc.com, keep amazon.com with a warning

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -263,14 +263,27 @@ function knownBlockedReason(url) {
   try {
     const u = new URL(url);
     const host = u.hostname.replace(/^www\./, '');
-    if (host === 'pnc.com') return 'pnc.com bot mitigation blocks automated fetches (HTTP/2 reset + HTTP/1.1 black-hole)';
+    // pnc.com was listed here until 2026-07-21. The block was written when this
+    // job ran in GitHub Actions, and it was really about the runner's datacenter
+    // IP, not about pnc.com in general. Now that the check runs locally (see the
+    // `card-page-check-local` scheduled task) all four PNC cards fetch fine:
+    // 10.5k-12.7k chars of real product page, verified per card before removal.
+    // Re-add it if the check ever moves back into CI.
+
     // amazon.com serves an automation interstitial ("Click the button below to
-    // continue shopping") instead of card terms. This permanently skips the
-    // Amazon Store card, whose only apply_link is an amazon.com listing with no
-    // scrapeable issuer equivalent (Synchrony has no public product page). The
-    // Amazon Prime card also carries an amazon.com special_apply_link, but
-    // checkUrlFor() routes its check to the scrapeable Chase apply_link instead,
-    // so this entry does not blind Prime.
+    // continue shopping") instead of card terms. Re-verified from a residential
+    // IP on 2026-07-21 and it STILL does: the Amazon Store apply_link returned
+    // 154 chars of interstitial. It is inconsistent rather than fixed — one
+    // fetch returned 18k chars of product page, but with no offer language in
+    // it — so the entry stays.
+    //
+    // This entry is also load-bearing for a card it does not name. Amazon Prime
+    // carries an amazon.com `special_apply_link`, and checkUrlFor() only skips a
+    // special_apply_link when knownBlockedReason() flags its host. Drop this
+    // entry and Prime silently stops being checked against its scrapeable Chase
+    // apply_link and starts being checked against a 153-char interstitial.
+    // Measured, not theorised. If you remove this, give Prime an explicit
+    // `page_check_url` pointing at the Chase page first.
     if (host === 'amazon.com') return 'amazon.com serves an automation interstitial ("Continue shopping") instead of card terms';
   } catch { /* malformed URL — let the normal fetch path handle it */ }
   return null;


### PR DESCRIPTION
## pnc.com — removed

The rule described pnc.com as permanently bot-blocked. That was true of **GitHub Actions' datacenter IPs**, not of pnc.com in general, and this check moved to a local routine on 2026-07-21.

Verified each card individually before removing the rule:

```
pnc-cash-rewards     Fetched 10566 chars
pnc-cash-unlimited   Fetched 10541 chars
pnc-secured          Fetched 11657 chars
pnc-spend-wise       Fetched 12732 chars
```

Four cards go from permanently unverified to verified every run. Re-add the rule if this check ever moves back into CI.

## amazon.com — stays, and I was wrong to suggest otherwise

I flagged this list as stale on the strength of the rewards-and-benefits run, which fetched Amazon fine. Re-testing here **expecting to remove it**, the Amazon Store apply_link still returns:

```
154 bytes: "Amazon.com Click the button below to continue shopping ..."
```

It is **inconsistent rather than fixed** — one fetch returned 18k chars of product page, but with no offer language in it. Either way it does not yield card terms, so the entry is correct.

## The part worth reading

The amazon.com entry is **load-bearing for a card it does not name**.

Amazon Prime carries an amazon.com `special_apply_link`, and `checkUrlFor()` only skips a `special_apply_link` when `knownBlockedReason()` flags its host. Remove the entry and Prime silently stops being checked against its scrapeable Chase page:

```
with rule removed:  URL: https://www.amazon.com/dp/BT00LN946S (special_apply_link)
                    Fetched 153 chars     ← "Continue shopping" interstitial

with rule kept:     URL: https://creditcards.chase.com/cash-back-credit-cards/amazon-prime-rewards
                    Fetched 18000 chars   ← real terms
```

Measured while testing this change, not theorised. A 153-char page extracts to nulls, which this pipeline reads as "no changes" — so the damage would have been an invisible false pass on a live card, not a loud failure.

The comment now records this, including the instruction to give Prime an explicit `page_check_url` **before** anyone removes the entry.

## Verification

- `knownBlockedReason()` classifier: pnc allowed, amazon Prime special blocked, amazon Store blocked, Chase Prime allowed
- Prime end-to-end routes to Chase and fetches 18000 chars
- Amazon Store remains a clean, visible known-block skip rather than a silent gap
- `scripts/check-card-pages.test.js` passes