### PR TITLE
cards: rename Princess Cruises Rewards Visa -> Princess Rewards Visa (blocked on migration 053)

### DIFF
--- a/apps/api/migrations/053_rename_princess_cruises_rewards_visa.sql
+++ b/apps/api/migrations/053_rename_princess_cruises_rewards_visa.sql
@@ -1,0 +1,9 @@
+-- Barclays rebrand: Princess Cruises Rewards Visa -> Princess Rewards Visa.
+-- The live apply page (cards.barclaycardus.com/credit-card/b2e0e09c-...) titles
+-- the product "PRINCESS REWARDS VISA" and no longer contains the string
+-- "Princess Cruises Rewards" anywhere.
+--
+-- Must run BEFORE the renamed cards.json reaches the sync: update-cards-github.js
+-- links rows by card_name, so a rename that lands in the CDN first would create a
+-- second row and strand this card's ratings, stats and CardWire history.
+UPDATE cards SET card_name = 'Princess Rewards Visa' WHERE card_name = 'Princess Cruises Rewards Visa';

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -1,10 +1,12 @@
-name: "Princess Cruises Rewards Visa"
+name: "Princess Rewards Visa"
+previous_names:
+  - "Princess Cruises Rewards Visa"
 bank: "Barclays"
 slug: "princess-cruises-rewards-visa-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/credit-card/b2e0e09c-e93c-43be-8758-57d22bb39ec1
 our_take: >
-  The Princess Cruises Rewards Visa is a niche card designed for loyal
+  The Princess Rewards Visa is a niche card designed for loyal
   Princess Cruises passengers, offering 2 points per dollar on purchases made
   with the cruise line. With no annual fee and a 20,000-point signup bonus
   after spending $1,000 in the first 3 months, it's a low-cost way to earn


### PR DESCRIPTION
> **Draft on purpose.** Do not merge until migration `053` has run against production. See the runbook below.

Reconstruction of the closed #1745, unchanged in substance.

## Evidence

Barclays dropped "Cruises" from the product name. Re-rendered from the live apply page:

```
name mentions:                       PRINCESS ® REWARDS VISA
"Princess Cruises Rewards" present:  false
```

## What is in this PR

| File | Change |
|---|---|
| `data/cards/princess-cruises-rewards-visa-card.yaml` | `name` -> "Princess Rewards Visa", old name into `previous_names`, `our_take` prose updated |
| `apps/api/migrations/053_rename_princess_cruises_rewards_visa.sql` | single-statement `UPDATE cards SET card_name = ...` |

The **slug is unchanged** — slugs are permanent here, as with `chase-freedom-student` still serving Chase Freedom Rise.

Verified against current `main`: the diff is only the rename, and `053` is still an unused migration number (`052s` is the highest on main).

## Why it is blocked

`update-cards-github.js` matches DB rows **by `card_name`**:

```js
existingByName[card.card_name] = card;      // lookup by name
...
SELECT MAX(card_id) ... INSERT INTO cards   // no match -> new row
```

Merge this before the migration and the sync inserts a **second** Princess row, stranding this card's ratings, `card_stats` and CardWire history on the orphan. That is precisely the damage the 051/052 dedupe series just finished cleaning up.

## Runbook

`RunMigrationHandler` is intentionally not wired (`template.yml`, near the `RunMigrationFunction` comment block). It reads an arbitrary file path from its invoke payload, so it must not sit deployed.

**Preferred — local, no OIDC, nothing passes through `main`:**

```bash
# 1. wire: uncomment the RunMigrationFunction block in apps/api/template.yml
#    (leave it WITHOUT esbuild Metadata — the handler fs-reads loose migration files)
cd apps/api && sam build && sam deploy

# 2. run it
aws lambda invoke --region us-east-1 \
  --function-name "$(aws lambda list-functions --region us-east-1 \
      --query "Functions[?contains(FunctionName,'RunMigration')].FunctionName" --output text)" \
  --payload '{"migration":"053_rename_princess_cruises_rewards_visa.sql"}' \
  --cli-binary-format raw-in-base64-out /dev/stdout

#    expect affectedRows: 1 — anything else, stop
# 3. unwire: re-comment the block, then `sam build && sam deploy` again
```

**Via CI:** the deploy role's OIDC trust is scoped to `repo:CreditOdds/creditodds:ref:refs/heads/main`, so a branch dispatch fails at the credentials step (confirmed on 2026-07-21). Going through CI means merging the temp wiring to `main` and reverting it, which briefly leaves the arbitrary-file-path Lambda deployed.

## When the migration has run

Mark this ready for review and merge. `build-cards` then syncs the renamed card against the already-updated row, and the card page picks up its "Previously" subtitle.

`npm run build:cards` -> 182 cards, `OK: Princess Rewards Visa`.