### PR TITLE
sentry: drop Firebase installations/app-offline unhandled rejections

### DIFF
--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -69,6 +69,29 @@ describe("isBenignClientError", () => {
     ).toBe(true);
   });
 
+  it("drops Firebase Installations app-offline noise", () => {
+    // FirebaseError shape: name "FirebaseError", code "installations/app-offline".
+    expect(
+      isBenignClientError({
+        name: "FirebaseError",
+        code: "installations/app-offline",
+        message:
+          "Installations: Could not process request. Application offline. (installations/app-offline).",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps other FirebaseErrors", () => {
+    expect(
+      isBenignClientError({
+        name: "FirebaseError",
+        code: "installations/request-failed",
+        message:
+          "Installations: Create Installation request failed with error (installations/request-failed).",
+      }),
+    ).toBe(false);
+  });
+
   it("keeps unrelated UnknownErrors", () => {
     expect(
       isBenignClientError(

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -17,6 +17,12 @@
 // page to try again" — name/code don't match the AbortError gate below, so
 // that signature is matched unconditionally. The page itself is unaffected.
 //
+// Firebase Installations also rejects with "installations/app-offline" when
+// navigator.onLine is false during Analytics init. getAnalytics() never awaits
+// that internal registration promise, so a visitor who loses connectivity
+// mid-load produces an unhandled rejection even though the (already rendered)
+// page is fine. Only their device being offline triggers it — not actionable.
+//
 // Mobile Safari can also surface WebExtension content-script messaging failures
 // as page-level unhandled rejections even though the page never calls the
 // extension API. These are user-extension/WebKit noise, not app failures.
@@ -33,6 +39,7 @@ const BENIGN_CLIENT_SIGNATURES = [
 const BENIGN_ANY_ERROR_SIGNATURES = [
   'Invalid call to runtime.sendMessage(). Tab not found.',
   'Connection to Indexed Database server lost',
+  'installations/app-offline',
 ];
 
 // DOMException.ABORT_ERR — the numeric code carried by AbortErrors.


### PR DESCRIPTION
## What

Adds `installations/app-offline` to the benign client-error signatures in `benignClientError.ts`, so Sentry stops reporting it (issue CREDITODDS-JAVASCRIPT-NEXTJS-W, seen on `/news/:id` in Edge on 2026-07-23).

## Why it's noise

Firebase Installations checks `navigator.onLine` during Analytics init and rejects with `installations/app-offline` when the visitor's device is offline. `getAnalytics()` never awaits that internal registration promise, so the rejection surfaces as an unhandled rejection. The page had already rendered fine (breadcrumbs show Firebase init succeeding first); only the visitor losing connectivity triggers it, so there is nothing actionable on our side.

The signature is matched on the error code embedded in the message, so other FirebaseErrors (e.g. `installations/request-failed`) still reach Sentry, covered by a test.

## Testing

`npx vitest run src/lib/benignClientError.test.ts`: 14/14 pass (2 new tests: positive match on the real FirebaseError shape, negative on other Installations errors).