### PR TITLE
cards: record Chase Freedom Student as a previous_name for Chase Freedom Rise

### DIFF
--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -1,6 +1,8 @@
 name: "Chase Freedom Rise"
 bank: "Chase"
 slug: "chase-freedom-student"
+previous_names:
+  - "Chase Freedom Student"
 image: "chase-freedom-rise.png"
 accepting_applications: true
 card_referral_link: "https://www.referyourchasecard.com/20r"


### PR DESCRIPTION
The `chase-freedom-student` card was renamed to **Chase Freedom Rise**, but its YAML had no `previous_names` entry (unlike the analogous Citi rebrand, which records its prior name). This adds the history so the card page's "Previously" subtitle reflects the rename.

Surfaced during the daily card-page check: a subagent flagged the prompt as "mislabeled" because the frozen `chase-freedom-student` slug/filename no longer matches the current `name`. The extraction itself was correct — `apply_link` and `name` both point at the live Freedom Rise page. This is metadata-only.

- No `name` change, so no DB migration needed (numeric `card_id` linkage unaffected).
- Validated with `npm run build:cards` (182 cards OK); `cards.json` not committed (CI rebuilds).