### PR TITLE
card page: grey out "Highest bonus on record" for cards not accepting applications

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1674,25 +1674,35 @@ export default function CardClient({
           {wireEntries.length > 0 && (
             <div className="cj-rail-block cj-wire-rail">
               <div className="cj-rail-label">Card wire</div>
-              {highestSub && (
-                <div
-                  className={`cj-wire-high${highestSub.isCurrent ? "" : " cj-wire-high-stale"}`}
-                >
-                  <span className="cj-wire-high-label">
-                    Highest bonus on record
-                  </span>
-                  <span className="cj-wire-high-val">{highestSub.label}</span>
-                  {highestSub.isCurrent ? (
-                    <span className="cj-wire-high-now">Live now</span>
-                  ) : (
-                    highestSub.asOf && (
-                      <span className="cj-wire-high-date">
-                        last offered {highestSub.asOf}
+              {highestSub &&
+                (() => {
+                  // A no-longer-accepting card can't have a "live" bonus, even
+                  // if its stored value still matches the record — grey it out.
+                  const liveNow =
+                    highestSub.isCurrent &&
+                    card.accepting_applications !== false;
+                  return (
+                    <div
+                      className={`cj-wire-high${liveNow ? "" : " cj-wire-high-stale"}`}
+                    >
+                      <span className="cj-wire-high-label">
+                        Highest bonus on record
                       </span>
-                    )
-                  )}
-                </div>
-              )}
+                      <span className="cj-wire-high-val">
+                        {highestSub.label}
+                      </span>
+                      {liveNow ? (
+                        <span className="cj-wire-high-now">Live now</span>
+                      ) : (
+                        highestSub.asOf && (
+                          <span className="cj-wire-high-date">
+                            last offered {highestSub.asOf}
+                          </span>
+                        )
+                      )}
+                    </div>
+                  );
+                })()}
               <ul className="cj-wire-rail-list">
                 {wireEntries.map((w) => {
                   const dir = wireDirection(w.field, w.old_value, w.new_value);


### PR DESCRIPTION
When a card is no longer accepting applications, the "Highest bonus on record" callout in the Card wire rail should not advertise a live offer.

Previously the green **"Live now"** badge showed whenever the stored bonus equaled the all-time record (`highestSub.isCurrent`), regardless of whether the card still accepts applications. So a discontinued card whose last known bonus happened to be its record still read as "Live now".

This gates the badge on `card.accepting_applications`:

```tsx
const liveNow = highestSub.isCurrent && card.accepting_applications !== false;
```

When a card is not accepting applications, the callout now renders greyed (`cj-wire-high-stale`) with no "Live now" badge (falling back to the "last offered" date if present).

Verified locally on Citi Custom Cash (not accepting, record == current): callout renders `cj-wire-high cj-wire-high-stale` with no "Live now" badge.