### PR TITLE
card-page-check: 150m budget, multi-slug scoping, pulled-card detector

### DIFF
--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -2,7 +2,7 @@ name: "American Express Green"
 bank: "American Express"
 slug: "american-express-green-card"
 image: "amex_green_card.png"
-accepting_applications: true
+accepting_applications: false
 apply_link: https://www.americanexpress.com/us/credit-cards/card/green/
 foreign_transaction_fee: false
 our_take: >

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -116,9 +116,12 @@ const PER_CARD_TIMEOUT_MS = Number(process.env.CARD_PAGE_PER_CARD_TIMEOUT_MS || 
 // The 'fetch' phase gets a larger budget: it runs locally with no job cap, and
 // it browser-renders far more pages than the single pass does (see FETCH_PHASE
 // note in the card loop), which is slower but removes the need for a second
-// extraction round trip.
+// extraction round trip. At the measured ~45s/card pace, 90 min ran out of clock
+// around card ~121 of 147 and stranded the alphabetical tail (US Bank, Wells
+// Fargo, Wyndham) unchecked every run; 150 min covers the full catalog plus the
+// network-error retry round with headroom. Still overridable via env.
 const SCRIPT_TIMEOUT_MS = Number(
-  process.env.CARD_PAGE_SCRIPT_TIMEOUT_MS || (PHASE === 'fetch' ? 90 * 60 * 1000 : 30 * 60 * 1000)
+  process.env.CARD_PAGE_SCRIPT_TIMEOUT_MS || (PHASE === 'fetch' ? 150 * 60 * 1000 : 30 * 60 * 1000)
 );
 // Max stripped page text handed to the extractor. Sized so nav-heavy issuer
 // pages still include the card terms — e.g. business.bankofamerica.com leads
@@ -218,7 +221,13 @@ function filterCardsForCheck(allCards, slugFilter) {
     c => c.data.accepting_applications !== false && checkUrlFor(c)
   );
   if (slugFilter) {
-    cards = cards.filter(c => c.slug === slugFilter);
+    // CARD_SLUG accepts a single slug or a comma-separated list, so a run can be
+    // scoped to just the cards a previous run skipped (recovery pass) without
+    // re-fetching the whole catalog.
+    const wanted = new Set(
+      slugFilter.split(',').map(s => s.trim()).filter(Boolean)
+    );
+    cards = cards.filter(c => wanted.has(c.slug));
     if (cards.length === 0) {
       console.warn(`Warning: No active card with apply_link found for slug "${slugFilter}"`);
     }

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -339,6 +339,43 @@ const NETWORK_RETRY_BACKOFFS_MS = (
     : [30 * 1000, 120 * 1000]
 ).filter(ms => Number.isFinite(ms) && ms >= 0);
 
+// A card's dedicated page redirecting UP to a listing/hub — e.g. Amex retiring
+// /us/credit-cards/card/green/ and 301-ing it to /us/credit-cards/ with a plain
+// HTTP 200 — is how an issuer signals a card that has been pulled or paused. The
+// hub renders a full, healthy page about OTHER cards, so the 4xx guard and the
+// content-length guard both miss it and the extractor just yields "no data" —
+// which is indistinguishable from a flaky fetch and only ever bumps the skip
+// counter. Detect the redirect explicitly so a pulled card surfaces as a
+// possible discontinuation on the FIRST run, not after the stale threshold.
+const PULLED_TO_HUB_MARKER = 'redirected to a listing/hub';
+
+function redirectedToAncestor(requestedUrl, finalUrl) {
+  let req, fin;
+  try {
+    req = new URL(requestedUrl);
+    fin = new URL(finalUrl);
+  } catch {
+    return false;
+  }
+  // A cross-host redirect (rebrand, acquisition, marketing domain) is a
+  // different signal with its own false-positive profile — out of scope here.
+  if (req.hostname !== fin.hostname) return false;
+  const norm = p => p.replace(/\/+$/, '').toLowerCase();
+  const reqPath = norm(req.pathname);
+  const finPath = norm(fin.pathname);
+  // No real move: trailing-slash or query-only normalization, or same path.
+  if (!reqPath || finPath === reqPath) return false;
+  // The final path is a strict ancestor of the requested one, at a path-segment
+  // boundary — i.e. the deep card page collapsed to a shallower hub. Deeper or
+  // sibling redirects (e.g. /green → /green/apply, or a rename to another card)
+  // are NOT this signal and pass through untouched.
+  return reqPath.startsWith(finPath + '/');
+}
+
+function pulledToHubReason(finalUrl) {
+  return `${PULLED_TO_HUB_MARKER} (${finalUrl}) — card may no longer be accepting applications; verify the live page and set accepting_applications: false if so`;
+}
+
 async function fetchPageContent(url) {
   // Status from the plain fetch, remembered so that if the browser fallback also
   // fails we report the origin's real complaint ("HTTP 400") rather than the
@@ -365,6 +402,14 @@ async function fetchPageContent(url) {
     simpleStatus = response.status;
 
     if (response.ok) {
+      // A 200 reached only by redirecting up to a hub is a pulled card, not
+      // content — bail before the length check waves the hub page through, and
+      // skip the browser fallback (it would just re-follow the same redirect).
+      if (response.redirected && redirectedToAncestor(url, response.url)) {
+        lastFetchError = pulledToHubReason(response.url);
+        console.warn(`  Simple fetch ${PULLED_TO_HUB_MARKER}: ${url} → ${response.url}`);
+        return null;
+      }
       const contentType = response.headers.get('content-type') || '';
       if (contentType.includes('text/html')) {
         const html = await response.text();
@@ -442,6 +487,16 @@ async function fetchWithBrowser(url) {
     if (status >= 400) {
       lastFetchError = `HTTP ${status}`;
       console.warn(`  Browser fetch returned HTTP ${status} — treating as fetch failure, not content`);
+      await context.close();
+      return null;
+    }
+
+    // Same pulled-card signal as the simple path: a 200 whose final URL has
+    // collapsed up to a listing/hub is a discontinuation, not content.
+    const finalUrl = response ? response.url() : url;
+    if (redirectedToAncestor(url, finalUrl)) {
+      lastFetchError = pulledToHubReason(finalUrl);
+      console.warn(`  Browser fetch ${PULLED_TO_HUB_MARKER}: ${url} → ${finalUrl}`);
       await context.close();
       return null;
     }
@@ -1941,6 +1996,23 @@ async function finalize({ allCards, cardsToCheck, skippedCards, allChanges, allS
   const verified = checkedSlugs.size - skippedCards.length;
   console.log(`Verified ${verified}/${checkedSlugs.size} card(s) against their live page this run.`);
 
+  // A card whose page collapsed to a hub is very likely pulled/paused, and that
+  // is worth a human's eyes THIS run — not after SKIP_ALERT_THRESHOLD runs of a
+  // counter that reads like a flaky fetch. Surface it prominently and distinctly,
+  // decoupled from the stale alarm, with the exact remediation.
+  const possiblyPulled = skippedCards.filter(
+    s => typeof s.reason === 'string' && s.reason.includes(PULLED_TO_HUB_MARKER)
+  );
+  if (possiblyPulled.length > 0) {
+    console.warn(
+      `\n🚫 ${possiblyPulled.length} card(s) may have been PULLED or PAUSED (page ${PULLED_TO_HUB_MARKER} this run):`
+    );
+    for (const s of possiblyPulled) {
+      console.warn(`  - ${s.name}: ${s.reason}\n      ${s.url}`);
+    }
+    console.warn('  → Verify the live page; if the card is gone, set accepting_applications: false so it drops out of the check.\n');
+  }
+
   const stale = staleCardsFrom(nextState);
   if (fs.existsSync(STALE_REPORT_FILE)) fs.unlinkSync(STALE_REPORT_FILE);
   if (stale.length > 0) {
@@ -1992,5 +2064,7 @@ module.exports = {
   updateSkipState,
   staleCardsFrom,
   isTransientNetworkError,
+  redirectedToAncestor,
+  PULLED_TO_HUB_MARKER,
   SKIP_ALERT_THRESHOLD,
 };


### PR DESCRIPTION
## Why

Two problems surfaced by the 2026-07-24 nightly run.

**1. The fetch ran out of clock.** The 90-minute budget stopped the run around card ~121 of 147 (measured ~45s/card), leaving the alphabetical tail — US Bank, Wells Fargo, Wyndham, World of Hyatt, United, Venmo — **never checked**, plus the network-error retry round unreached. Because run order is stable/alphabetical, that same tail is stranded every run and accumulates `consecutive_skips` until it would trip the `card-page-stale` alarm despite nothing being wrong.

**2. A pulled card is invisible.** The Amex Green was quietly paused (rumored refresh) and we only found out by word of mouth. Its apply page — `/us/credit-cards/card/green/` — now **301-redirects to the compare hub `/us/credit-cards/` with a plain HTTP 200**. The hub is a full, healthy page about *other* cards, so the existing 4xx and content-length guards both miss it and the extractor just returns "no data" — indistinguishable from a flaky fetch, only bumping the skip counter.

## Changes

- **Fetch-phase deadline 90m → 150m.** Covers the full 147-card catalog plus the retry round with headroom. CI-bound 30m (single-pass) branch **untouched** (keeps the `timeout-minutes: 45` invariant). Still overridable via `CARD_PAGE_SCRIPT_TIMEOUT_MS`.
- **`CARD_SLUG` accepts a comma-separated list.** Scopes a run to just the cards a prior run skipped (recovery pass) without re-fetching the whole catalog. A single slug still works as before.
- **Pulled-card detector.** `redirectedToAncestor()` flags a 200 whose final URL has collapsed to an ancestor path of the requested one, in **both** the simple-fetch and browser-fetch paths. `finalize()` surfaces these as a distinct **"may have been PULLED or PAUSED"** block on the **first** run, decoupled from the multi-run stale threshold, with the exact remediation. Precise by construction — trailing-slash/query-only, deeper (apply-flow), sibling-rename, non-segment-boundary, and cross-host redirects all pass through untouched (unit-checked, 11/11).
- **Amex Green → `accepting_applications: false`.** Not accepting applications pending the rumored refresh; renders the archived banner, preserves the card's page/ratings/URL for relaunch, and drops it out of the daily check.

## Validation

- Multi-slug path used today to recover the 39 cards the nightly run skipped: scoped fetch (0 skips), extracted, verified **39/39** against live pages, skip counters reset.
- Detector unit-checked against the real Amex Green redirect plus 10 false-positive/edge cases — all pass.
- `npm run build:cards` passes with the Green card flip.

## Follow-ups (not in this PR)

- Card-name-presence detector for issuers who swap content in place *without* redirecting (catches client-side/SPA cases the redirect check can't see).
- Optionally have the publish step open a `card-page-pulled` issue from the finalize block, so a pulled card pages a human even on unattended runs.