### PR TITLE
news/articles: show all-time view count when above 100

### DIFF
--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { RelatedArticles } from "@/components/articles/RelatedArticles";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import ViewTracker from "@/components/ViewTracker";
+import { getContentViewCounts } from "@/lib/api";
 import { truncateTitle } from "@/lib/seo";
 import "../../landing.css";
 
@@ -79,6 +80,12 @@ export default async function ArticlePage({ params }: Props) {
   if (!article) notFound();
 
   const relatedArticles = await getRelatedArticles(article, 3);
+
+  // All-time views, shown only once past a floor so fresh posts don't
+  // advertise low numbers.
+  const viewCounts = await getContentViewCounts(0).catch(() => null);
+  const viewCount = viewCounts?.article[article.slug] ?? 0;
+
   const authorSlug = article.author_slug || generateAuthorSlug(article.author);
   const articleUrl = `https://creditodds.com/articles/${article.slug}`;
 
@@ -168,6 +175,12 @@ export default async function ArticlePage({ params }: Props) {
             )}
             <span>·</span>
             <span>{article.reading_time} min read</span>
+            {viewCount > 100 && (
+              <>
+                <span>·</span>
+                <span>{viewCount.toLocaleString('en-US')} views</span>
+              </>
+            )}
           </div>
 
           {article.estimated_value && (

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { getNews, getNewsItem, tagLabels } from "@/lib/news";
+import { getContentViewCounts } from "@/lib/api";
 import { ArticleContent } from "@/components/articles/ArticleContent";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { ReadingProgressBar } from "@/components/articles/ReadingProgressBar";
@@ -71,6 +72,11 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
   const { id } = await params;
   const item = await getNewsItem(id);
   if (!item) notFound();
+
+  // All-time views, shown only once past a floor so fresh posts don't
+  // advertise low numbers.
+  const viewCounts = await getContentViewCounts(0).catch(() => null);
+  const viewCount = viewCounts?.news[item.id] ?? 0;
 
   const relatedCards: RelatedCardInfo[] = [];
   if (item.card_slugs && item.card_names) {
@@ -165,6 +171,12 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
               <>
                 <span>·</span>
                 <span>{item.bank}</span>
+              </>
+            )}
+            {viewCount > 100 && (
+              <>
+                <span>·</span>
+                <span>{viewCount.toLocaleString('en-US')} views</span>
               </>
             )}
           </div>

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -879,8 +879,9 @@ export async function trackContentView(
   // Fire and forget - don't throw on error
 }
 
-// Get article + news view counts over the trailing `periodDays` window.
-// Used to rank the landing page editorial lane by "top viewed this week".
+// Get article + news view counts over the trailing `periodDays` window
+// (0 = all-time). Used to rank the landing page editorial lane by "top
+// viewed this week" and to show all-time counts on article/news pages.
 export async function getContentViewCounts(periodDays = 7): Promise<EditorialViewCounts> {
   const res = await fetchWithRetry(`${API_BASE}/content-view?period=${periodDays}`, {
     next: { revalidate: 300 },


### PR DESCRIPTION
## Summary
Views on news and article pages have been tracked since #1443 (`content_view_counts` + `/content-view`) but were never shown to visitors. This surfaces the all-time count in the meta row of both detail pages, e.g. `May 11, 2026 · U.S. Bank · 590 views`.

- Counts of 100 or fewer stay hidden so fresh posts don't advertise low numbers.
- Fetched server-side via the existing `getContentViewCounts` helper with `period=0` (all-time), cached with the page's usual 5-minute ISR window.
- No API changes; the GET endpoint already supported all-time aggregation.

Current data: three news items clear the threshold today (590 / 160 / 104); top article is at 74, so article counts appear as they grow.

## Testing
- Verified in the browser on a local dev server against prod counts: 590-view news item shows the count, a 93-view item and a 38-view article show nothing, meta rows otherwise unchanged.
- `tsc --noEmit` and `eslint --max-warnings=0` clean on the changed files.