### PR TITLE
landing: show all-time view count on editorial lane items

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -67,6 +67,7 @@ interface LandingClientProps {
   bestPages: LandingBestPage[];
   trendingViews: Record<number, number>;
   editorialViews: EditorialViewCounts;
+  allTimeEditorialViews: EditorialViewCounts;
 }
 
 const TOOL_LINKS: { name: string; value: string; href: string; logo: string }[] = [
@@ -473,16 +474,20 @@ type EditorialItem = {
   image?: string;
   ts: number;
   views: number;
+  /** All-time views, shown only above a floor. Ranking still uses 7-day `views`. */
+  allTimeViews: number;
 };
 
 function NewsLane({
   news,
   articles,
   editorialViews,
+  allTimeEditorialViews,
 }: {
   news: LandingNewsItem[];
   articles: LandingArticle[];
   editorialViews: EditorialViewCounts;
+  allTimeEditorialViews: EditorialViewCounts;
 }) {
   const items = useMemo<EditorialItem[]>(() => {
     const toTs = (d: string) => {
@@ -498,6 +503,7 @@ function NewsLane({
       cardImages: a.cardImages,
       ts: toTs(a.date),
       views: editorialViews.article[a.slug] ?? 0,
+      allTimeViews: allTimeEditorialViews.article[a.slug] ?? 0,
     }));
     const fromNews: EditorialItem[] = news.map((n) => ({
       href: `/news/${n.id}`,
@@ -509,13 +515,14 @@ function NewsLane({
       image: n.newsImage ? `${NEWS_IMG_CDN}/${n.newsImage}` : undefined,
       ts: toTs(n.date),
       views: editorialViews.news[n.id] ?? 0,
+      allTimeViews: allTimeEditorialViews.news[n.id] ?? 0,
     }));
     // Rank by most-viewed this week; tiebreak (and cold-start fallback when
     // there's no view data yet) by newest first. lead = items[0], digest = rest.
     return [...fromArticles, ...fromNews]
       .sort((a, b) => b.views - a.views || b.ts - a.ts)
       .slice(0, 5);
-  }, [news, articles, editorialViews]);
+  }, [news, articles, editorialViews, allTimeEditorialViews]);
 
   if (items.length === 0) return null;
 
@@ -586,6 +593,9 @@ function NewsLane({
                 {lead.tag}
               </span>
               <span>{lead.date}</span>
+              {lead.allTimeViews > 100 && (
+                <span>{lead.allTimeViews.toLocaleString('en-US')} views</span>
+              )}
             </div>
             <h4>{lead.title}</h4>
             {lead.summary && <p className="dek">{lead.summary}</p>}
@@ -599,6 +609,9 @@ function NewsLane({
                   {it.tag}
                 </span>
                 <span>{it.date}</span>
+                {it.allTimeViews > 100 && (
+                  <span>{it.allTimeViews.toLocaleString('en-US')} views</span>
+                )}
               </div>
               <h5>{it.title}</h5>
             </Link>
@@ -792,6 +805,7 @@ export default function LandingClient({
   bestPages,
   trendingViews,
   editorialViews,
+  allTimeEditorialViews,
 }: LandingClientProps) {
   return (
     <div className="landing-v2 landing-v3">
@@ -800,7 +814,12 @@ export default function LandingClient({
         <div className="wrap">
           <PopularLane cards={initialCards} trendingViews={trendingViews} />
           <BestForLane bestPages={bestPages} />
-          <NewsLane news={news} articles={articles} editorialViews={editorialViews} />
+          <NewsLane
+            news={news}
+            articles={articles}
+            editorialViews={editorialViews}
+            allTimeEditorialViews={allTimeEditorialViews}
+          />
         </div>
       </section>
       <FooterBlocks cards={initialCards} />

--- a/apps/web-next/src/app/page.tsx
+++ b/apps/web-next/src/app/page.tsx
@@ -107,13 +107,14 @@ function slimNews(news: NewsItem[], cardImageBySlug: Map<string, string | undefi
 }
 
 export default async function LandingPage() {
-  const [cards, news, articles, bestPages, trendingViews, editorialViews] = await Promise.all([
+  const [cards, news, articles, bestPages, trendingViews, editorialViews, allTimeEditorialViews] = await Promise.all([
     getAllCards(),
     getNews(),
     getArticles(),
     getBestPages(),
     getCardViewCounts('trending').catch(() => ({}) as Record<number, number>),
     getContentViewCounts(7).catch(() => ({ article: {}, news: {} }) as EditorialViewCounts),
+    getContentViewCounts(0).catch(() => ({ article: {}, news: {} }) as EditorialViewCounts),
   ]);
 
   const slimmedCards: LandingCard[] = cards.map(slimCard);
@@ -145,6 +146,7 @@ export default async function LandingPage() {
       bestPages={slimmedBest}
       trendingViews={trendingViews}
       editorialViews={editorialViews}
+      allTimeEditorialViews={allTimeEditorialViews}
     />
   );
 }


### PR DESCRIPTION
## Summary
Follow-up to #1755: the landing page's Lane 03 (Editorial) now shows the same all-time view count next to its items — in the lead card's meta row and on each digest row — under the same rule: hidden at 100 views or fewer, so the number matches what the visitor sees after clicking through.

- Lane ranking is unchanged (still 7-day views); this adds a second `getContentViewCounts(0)` fetch of the same cached endpoint, threaded through `LandingClient` as `allTimeEditorialViews`.

## Testing
- Verified on a local dev server against prod counts: an over-threshold news item shows `News · Jul 24 · 606 views` in the lane meta row; all current sub-100 items (24 views and below) show nothing.
- `tsc --noEmit` and `eslint --max-warnings=0` clean.