### PR TITLE
news listing: show all-time view count on story rows

### DIFF
--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -12,6 +12,9 @@ const NEWS_IMG_CDN = 'https://d3ay3etzd1512y.cloudfront.net/news_images';
 
 interface NewsV2ClientProps {
   items: NewsItem[];
+  /** All-time views keyed by news id. Rendered only above a floor, matching
+   * the detail pages. */
+  viewCounts: Record<string, number>;
 }
 
 type FilterKey = 'all' | NewsTag;
@@ -65,8 +68,9 @@ function readTimeFor(item: NewsItem): string {
   return `${Math.max(1, Math.round(words / 220))} min`;
 }
 
-export default function NewsV2Client({ items }: NewsV2ClientProps) {
+export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
   const [filter, setFilter] = useState<FilterKey>('all');
+  const viewsOf = (item: NewsItem) => viewCounts[item.id] ?? 0;
 
   const filtered = useMemo(() => {
     if (filter === 'all') return items;
@@ -161,6 +165,12 @@ export default function NewsV2Client({ items }: NewsV2ClientProps) {
                   <span>{formatDate(featured.date)}</span>
                   <span>·</span>
                   <span>{readTimeFor(featured)} read</span>
+                  {viewsOf(featured) > 100 && (
+                    <>
+                      <span>·</span>
+                      <span>{viewsOf(featured).toLocaleString('en-US')} views</span>
+                    </>
+                  )}
                 </div>
                 <h2 className="feat-title">{featured.title}</h2>
                 <p className="feat-excerpt">{featured.summary}</p>
@@ -174,6 +184,9 @@ export default function NewsV2Client({ items }: NewsV2ClientProps) {
                   <div className="ni-meta">
                     <span className="news-tag">{TAG_DISPLAY[primaryTag(item)]}</span>
                     <span>{formatDateShort(item.date)}</span>
+                    {viewsOf(item) > 100 && (
+                      <span>{viewsOf(item).toLocaleString('en-US')} views</span>
+                    )}
                   </div>
                   <h3 className="ni-title">{item.title}</h3>
                   <p className="ni-excerpt">{item.summary}</p>
@@ -189,6 +202,9 @@ export default function NewsV2Client({ items }: NewsV2ClientProps) {
                 <div className="ni-meta">
                   <span className="news-tag">{TAG_DISPLAY[primaryTag(item)]}</span>
                   <span>{formatDateShort(item.date)}</span>
+                  {viewsOf(item) > 100 && (
+                    <span>{viewsOf(item).toLocaleString('en-US')} views</span>
+                  )}
                 </div>
                 <h3 className="ni-title">{item.title}</h3>
                 <p className="ni-excerpt">{item.summary}</p>
@@ -228,6 +244,7 @@ export default function NewsV2Client({ items }: NewsV2ClientProps) {
                 <div className="nc-body">
                   <div className="nc-meta">
                     {TAG_DISPLAY[primaryTag(item)]} · {formatDateShort(item.date)}
+                    {viewsOf(item) > 100 && <> · {viewsOf(item).toLocaleString('en-US')} views</>}
                   </div>
                   <h3 className="nc-title">{item.title}</h3>
                 </div>

--- a/apps/web-next/src/app/news/page.tsx
+++ b/apps/web-next/src/app/news/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { getNews } from "@/lib/news";
+import { getContentViewCounts } from "@/lib/api";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import NewsV2Client from "./NewsV2Client";
 
@@ -21,7 +22,12 @@ export const metadata: Metadata = {
 export const revalidate = 300;
 
 export default async function NewsPage() {
-  const newsItems = await getNews();
+  const [newsItems, viewCounts] = await Promise.all([
+    getNews(),
+    // All-time views per item, shown only above a floor (same rule as the
+    // detail pages).
+    getContentViewCounts(0).catch(() => null),
+  ]);
 
   const collectionJsonLd = {
     "@context": "https://schema.org",
@@ -51,7 +57,7 @@ export default async function NewsPage() {
           { name: 'Card News', url: 'https://creditodds.com/news' },
         ]}
       />
-      <NewsV2Client items={newsItems} />
+      <NewsV2Client items={newsItems} viewCounts={viewCounts?.news ?? {}} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
Completes the view-count rollout (#1755 detail pages, #1759 landing lane): /news now shows the all-time count on its story rows — featured meta row, top-stories list, and secondary cards — hidden at 100 views or fewer so the number matches the detail page on click-through.

Counts come from the same cached `getContentViewCounts(0)` call, fetched in the server component and passed to `NewsV2Client`.

## Testing
- Verified live on a local dev server against prod counts: under the Discontinued filter, the Kroger story row renders `Discontinued · May 12 · 610 views` and the Attune secondary card renders `Discontinued · Jun 16 · 162 views`; all sub-100 items show nothing.
- `tsc --noEmit` and `eslint --max-warnings=0` clean.