### PR TITLE
articles listing: show all-time view count on article cards

### DIFF
--- a/apps/web-next/src/app/articles/author/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/author/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getArticles, getUniqueAuthors, generateAuthorSlug } from "@/lib/articles";
+import { getContentViewCounts } from "@/lib/api";
 import { ArticleCard } from "@/components/articles/ArticleCard";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
@@ -42,7 +43,11 @@ export const revalidate = 300;
 
 export default async function AuthorPage({ params }: Props) {
   const { slug } = await params;
-  const allArticles = await getArticles();
+  const [allArticles, viewCountsRes] = await Promise.all([
+    getArticles(),
+    getContentViewCounts(0).catch(() => null),
+  ]);
+  const viewCounts = viewCountsRes?.article ?? {};
   const authors = getUniqueAuthors(allArticles);
   const author = authors.find(a => a.slug === slug);
   if (!author) notFound();
@@ -108,7 +113,11 @@ export default async function AuthorPage({ params }: Props) {
         {articles.length > 0 ? (
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {articles.map((article) => (
-              <ArticleCard key={article.id} article={article} />
+              <ArticleCard
+                key={article.id}
+                article={article}
+                viewCount={viewCounts[article.slug] ?? 0}
+              />
             ))}
           </div>
         ) : (

--- a/apps/web-next/src/app/articles/category/[tag]/page.tsx
+++ b/apps/web-next/src/app/articles/category/[tag]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getArticlesByTag, tagLabels, tagDescriptions, ArticleTag } from "@/lib/articles";
+import { getContentViewCounts } from "@/lib/api";
 import { ArticleCard } from "@/components/articles/ArticleCard";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
@@ -47,7 +48,11 @@ export default async function CategoryPage({ params }: Props) {
   const { tag } = await params;
   if (!VALID_TAGS.includes(tag as ArticleTag)) notFound();
 
-  const articles = await getArticlesByTag(tag as ArticleTag);
+  const [articles, viewCountsRes] = await Promise.all([
+    getArticlesByTag(tag as ArticleTag),
+    getContentViewCounts(0).catch(() => null),
+  ]);
+  const viewCounts = viewCountsRes?.article ?? {};
   const tagLabel = stripEmoji(tagLabels[tag as ArticleTag]);
   const tagDescription = tagDescriptions[tag as ArticleTag];
 
@@ -102,7 +107,11 @@ export default async function CategoryPage({ params }: Props) {
         {articles.length > 0 ? (
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {articles.map((article) => (
-              <ArticleCard key={article.id} article={article} />
+              <ArticleCard
+                key={article.id}
+                article={article}
+                viewCount={viewCounts[article.slug] ?? 0}
+              />
             ))}
           </div>
         ) : (

--- a/apps/web-next/src/app/articles/page.tsx
+++ b/apps/web-next/src/app/articles/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { getArticles } from "@/lib/articles";
+import { getContentViewCounts } from "@/lib/api";
 import { ArticlesListClient } from "@/components/articles/ArticlesListClient";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
@@ -22,7 +23,12 @@ export const metadata: Metadata = {
 export const revalidate = 300;
 
 export default async function ArticlesPage() {
-  const articles = await getArticles();
+  const [articles, viewCounts] = await Promise.all([
+    getArticles(),
+    // All-time views per article, shown only above a floor (same rule as the
+    // detail pages).
+    getContentViewCounts(0).catch(() => null),
+  ]);
 
   const collectionJsonLd = {
     "@context": "https://schema.org",
@@ -75,7 +81,7 @@ export default async function ArticlesPage() {
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 80 }}>
         {articles.length > 0 ? (
-          <ArticlesListClient articles={articles} />
+          <ArticlesListClient articles={articles} viewCounts={viewCounts?.article ?? {}} />
         ) : (
           <div
             style={{

--- a/apps/web-next/src/components/articles/ArticleCard.tsx
+++ b/apps/web-next/src/components/articles/ArticleCard.tsx
@@ -21,9 +21,11 @@ function TagBadge({ tag }: { tag: ArticleTag }) {
 
 interface ArticleCardProps {
   article: Article;
+  /** All-time views; rendered only above a floor, matching the detail pages. */
+  viewCount?: number;
 }
 
-export function ArticleCard({ article }: ArticleCardProps) {
+export function ArticleCard({ article, viewCount = 0 }: ArticleCardProps) {
   const imageUrl = article.image
     ? `https://d3ay3etzd1512y.cloudfront.net/article_images/${article.image}`
     : null;
@@ -82,7 +84,10 @@ export function ArticleCard({ article }: ArticleCardProps) {
             <span className="text-gray-300">|</span>
             <span>{formatDate(article.date)}</span>
           </div>
-          <span>{article.reading_time} min read</span>
+          <span>
+            {article.reading_time} min read
+            {viewCount > 100 && <> · {viewCount.toLocaleString('en-US')} views</>}
+          </span>
         </div>
       </div>
     </Link>

--- a/apps/web-next/src/components/articles/ArticlesListClient.tsx
+++ b/apps/web-next/src/components/articles/ArticlesListClient.tsx
@@ -11,9 +11,11 @@ const ARTICLES_PER_PAGE = 9;
 interface ArticlesListClientProps {
   articles: Article[];
   initialTag?: ArticleTag;
+  /** All-time views keyed by article slug. Shown only above a floor. */
+  viewCounts?: Record<string, number>;
 }
 
-export function ArticlesListClient({ articles, initialTag }: ArticlesListClientProps) {
+export function ArticlesListClient({ articles, initialTag, viewCounts = {} }: ArticlesListClientProps) {
   const [selectedTags, setSelectedTags] = useState<ArticleTag[]>(
     initialTag ? [initialTag] : []
   );
@@ -63,7 +65,11 @@ export function ArticlesListClient({ articles, initialTag }: ArticlesListClientP
         <>
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {paginatedArticles.map((article) => (
-              <ArticleCard key={article.id} article={article} />
+              <ArticleCard
+                key={article.id}
+                article={article}
+                viewCount={viewCounts[article.slug] ?? 0}
+              />
             ))}
           </div>
 


### PR DESCRIPTION
## Summary
Extends the view-count rollout (#1755 detail pages, #1759 landing, #1760 news listing) to the articles surfaces: `ArticleCard` now shows the all-time view count next to the read time, hidden at 100 views or fewer as everywhere else. Counts are threaded through the /articles index (via `ArticlesListClient`), category pages, and author pages, all fetching the same cached `getContentViewCounts(0)`.

No article is over the floor yet (top is `credit-limit-increases` at 75), so nothing visibly changes on deploy; counts appear as articles cross 100.

## Testing
- Verified on a local dev server against prod counts: no counts render at the real threshold (correct, all articles are sub-100); positive path exercised by temporarily lowering the floor locally, which rendered `10 min read · 18 views` style metas, then restoring it.
- /articles, category, and author pages all render 200; `tsc --noEmit` and `eslint --max-warnings=0` clean.