### PR TITLE
news listing: fix missing separator before view count in story rows

### DIFF
--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -184,9 +184,9 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
                   <div className="ni-meta">
                     <span className="news-tag">{TAG_DISPLAY[primaryTag(item)]}</span>
                     <span>{formatDateShort(item.date)}</span>
-                    {viewsOf(item) > 100 && (
-                      <span>{viewsOf(item).toLocaleString('en-US')} views</span>
-                    )}
+                    {/* ni-meta is inline (not a flex row), so the separator must be
+                        literal text; a bare span would render flush against the date. */}
+                    {viewsOf(item) > 100 && <> · {viewsOf(item).toLocaleString('en-US')} views</>}
                   </div>
                   <h3 className="ni-title">{item.title}</h3>
                   <p className="ni-excerpt">{item.summary}</p>
@@ -202,9 +202,7 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
                 <div className="ni-meta">
                   <span className="news-tag">{TAG_DISPLAY[primaryTag(item)]}</span>
                   <span>{formatDateShort(item.date)}</span>
-                  {viewsOf(item) > 100 && (
-                    <span>{viewsOf(item).toLocaleString('en-US')} views</span>
-                  )}
+                  {viewsOf(item) > 100 && <> · {viewsOf(item).toLocaleString('en-US')} views</>}
                 </div>
                 <h3 className="ni-title">{item.title}</h3>
                 <p className="ni-excerpt">{item.summary}</p>


### PR DESCRIPTION
## Summary
Fixes a layout bug from #1760: in the /news top-stories and recent-stories rows, the view count rendered flush against the date (`Jun 16164 views`). Unlike `feat-meta` (flex + gap) and `nc-meta` (explicit middot text), `ni-meta` is a plain inline block, so the added span had no spacing. The count is now emitted as literal ` · N views` text, matching the secondary cards.

## Testing
- Verified in the browser on a local dev server with the Discontinued filter: row now renders `Discontinued · May 12 · 634 views`; secondary cards and sub-100 rows unchanged.
- `tsc --noEmit` and `eslint --max-warnings=0` clean.