### PR TITLE
cards: accept the 12 verified reward rows from review issue #1743

### DIFF
--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -13,7 +13,11 @@ rewards:
   - category: "amazon"
     value: 5
     unit: "percent"
-    note: "Amazon, Whole Foods Market, Shopbop, Chase Travel (Prime members); 3% without Prime"
+    note: "Amazon, Whole Foods Market, Shopbop (Prime members); 3% without Prime"
+  - category: "travel_portal"
+    value: 5
+    unit: "percent"
+    note: "Chase Travel purchases with an eligible Prime membership; 3% without Prime"
   - category: "dining"
     value: 2
     unit: "percent"

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -48,6 +48,10 @@ rewards:
     unit: points_per_dollar
     note: "On Lyft rides (after linking your Lyft account)"
     merchant_gate: [lyft]
+  - category: rent
+    value: 1.25
+    unit: points_per_dollar
+    note: "Up to 1.25x on rent and mortgage payments with no transaction fee, when the housing-only rewards track is selected. The exact multiplier is set each billing cycle from your everyday spend relative to the housing payment; on the Bilt Cash track housing earns up to 1x instead."
   - category: everything_else
     value: 1
     unit: points_per_dollar

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -64,6 +64,10 @@ rewards:
     unit: "points_per_dollar"
     note: "On Lyft rides (after linking your Lyft account)"
     merchant_gate: [lyft]
+  - category: "rent"
+    value: 1.25
+    unit: "points_per_dollar"
+    note: "Up to 1.25x on rent and mortgage payments with no transaction fee, when the housing-only rewards track is selected. The exact multiplier is set each billing cycle from your everyday spend relative to the housing payment; on the Bilt Cash track housing earns up to 1x instead."
   - category: "everything_else"
     value: 1
     unit: "points_per_dollar"

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -76,6 +76,10 @@ rewards:
     unit: points_per_dollar
     note: "On Lyft rides (after linking your Lyft account)"
     merchant_gate: [lyft]
+  - category: rent
+    value: 1.25
+    unit: points_per_dollar
+    note: "Up to 1.25x on rent and mortgage payments with no transaction fee, when the housing-only rewards track is selected. The exact multiplier is set each billing cycle from your everyday spend relative to the housing payment; on the Bilt Cash track housing earns up to 1x instead."
   - category: everything_else
     value: 2
     unit: points_per_dollar

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -9,6 +9,19 @@ card_referral_link: "https://www.referyourchasecard.com/20r"
 annual_fee: 0
 reward_type: "cashback"
 rewards:
+  - category: dining
+    value: 3
+    unit: percent
+    note: "Dining at restaurants, including takeout and eligible delivery, on up to $6,000 spent in the first 6 months from account opening; 1.5% thereafter"
+    spend_cap: 6000
+    cap_period: lifetime
+    rate_after_cap: 1.5
+  - category: transit
+    value: 2
+    unit: percent
+    note: "On qualifying Lyft rides through September 30, 2027 (limited-time promo; 0.5% on top of the 1.5% base rate)"
+    expires: "2027-09-30"
+    merchant_gate: [lyft]
   - category: everything_else
     value: 1.5
     unit: percent

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -19,6 +19,12 @@ rewards:
   - category: drugstores
     value: 3
     unit: percent
+  - category: transit
+    value: 2
+    unit: percent
+    note: "On qualifying Lyft rides through September 30, 2027 (limited-time promo; 0.5% on top of the 1.5% base rate)"
+    expires: "2027-09-30"
+    merchant_gate: [lyft]
   - category: everything_else
     value: 1.5
     unit: percent

--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -53,6 +53,10 @@ rewards:
   - category: dining
     value: 5
     unit: points_per_dollar
+  - category: office_supplies
+    value: 5
+    unit: points_per_dollar
+    note: "Office supply stores"
   - category: everything_else
     value: 3
     unit: points_per_dollar

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -70,6 +70,18 @@ rewards:
     value: 2
     unit: "points_per_dollar"
     note: "All other travel worldwide"
+  - category: "transit"
+    value: 5
+    unit: "points_per_dollar"
+    note: "On Lyft rides through September 30, 2027 (limited-time promo)"
+    expires: "2027-09-30"
+    merchant_gate: [lyft]
+  - category: "sporting_goods"
+    value: 5
+    unit: "points_per_dollar"
+    note: "Eligible Peloton equipment and accessory purchases over $150 through December 31, 2027 (limited-time promo)"
+    expires: "2027-12-31"
+    merchant_specific: true
   - category: "everything_else"
     value: 1
     unit: "points_per_dollar"

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -114,6 +114,18 @@ rewards:
   - category: dining
     value: 3
     unit: points_per_dollar
+  - category: transit
+    value: 5
+    unit: points_per_dollar
+    note: "On Lyft rides through September 30, 2027 (limited-time promo)"
+    expires: "2027-09-30"
+    merchant_gate: [lyft]
+  - category: sporting_goods
+    value: 10
+    unit: points_per_dollar
+    note: "Eligible Peloton equipment and accessory purchases over $150, on up to $5,000 in purchases, through December 31, 2027 (limited-time promo)"
+    expires: "2027-12-31"
+    merchant_specific: true
   - category: everything_else
     value: 1
     unit: points_per_dollar


### PR DESCRIPTION
Triage of the 2026-07-21 card benefits review queue (#1743). **12 of 64 items held up against the live issuer pages.** The other 52 were detector false positives: all 30 reward removals, 7 of 19 additions, and all 15 borderline benefits.

## Accepted

| Card | Row | Verified against |
|---|---|---|
| Chase Sapphire Preferred | `transit` 5x Lyft | "5X on Lyft through 09/30/2027" |
| Chase Sapphire Preferred | `sporting_goods` 5x Peloton | "5X on Peloton equipment/accessories over $150" |
| Chase Sapphire Reserve | `transit` 5x Lyft | "5x total on Lyft rides" |
| Chase Sapphire Reserve | `sporting_goods` 10x Peloton | "10x on Peloton over $150, up to $5,000" |
| Chase Freedom Unlimited | `transit` 2% Lyft | "2% on qualifying Lyft (0.5% on top of base 1.5%)" |
| Chase Freedom Rise | `transit` 2% Lyft | same wording |
| Chase Freedom Rise | `dining` 3% intro | "3% on dining on up to $6,000 in the first 6 months" |
| IHG One Rewards Premier Business | `office_supplies` 5x | 5x list explicitly names office supply stores |
| Prime Visa | `travel_portal` 5% | "5% at Amazon.com **and on Chase Travel purchases**" |
| Bilt Blue / Obsidian / Palladium | `rent` 1.25x | "up to 1.25X on rent and mortgage when housing-only rewards are selected" |

## Judgment calls

- **Peloton category.** The queue proposed `gyms_fitness` for the Reserve and `sporting_goods` for the Preferred, for the same purchase. Both use `sporting_goods` here since it is equipment, not a gym membership.
- **Gating.** Lyft rows carry `merchant_gate: [lyft]` and `expires`, matching the three Ink cards. Peloton has no store page, so those rows take `merchant_specific: true` per the merchant-gate convention.
- **Freedom Rise 3% dining is an intro rate**, not permanent, encoded as `spend_cap: 6000` / `cap_period: lifetime` / `rate_after_cap: 1.5`. That card lives in `data/cards/chase-freedom-student.yaml` (stale filename from an old rename) and previously had only `everything_else: 1.5`.
- **Prime Visa** already mentioned Chase Travel inside the `amazon` row's note, so the rate was documented but Chase Travel spend never matched a category. Split into its own `travel_portal` row and trimmed the note.
- **Bilt `rent`** is genuinely "up to" 1.25x and varies per billing cycle and rewards track; the note says so. `rent` was defined in `categories.yaml` but used by no card, so all three Bilt cards were modeling rent at their base rate.

`npm run build:cards` passes clean on all 183 cards. `cards.json` is not committed (CI rebuilds it).

A companion PR fixes the detector patterns that produced the 52 false positives.