### PR TITLE
rewards checker: cut the false-positive rate in the weekly review queue

### DIFF
--- a/data/benefit-policy.yaml
+++ b/data/benefit-policy.yaml
@@ -79,6 +79,40 @@ exclude:
   - "Limited Time Offers"
   - "Special Limited-Time Offers"
 
+  # Standard travel/purchase insurance coverage.
+  #
+  # These sat in `borderline` for months, which meant every apply page that
+  # mentions them regenerated the same manual-decision item every week. They
+  # were declined in four consecutive review issues (#1636, #1666, #1731,
+  # #1743) and made up the ENTIRE borderline bucket of #1743's queue (15 of
+  # 15 items). The reason they keep getting declined is structural: the
+  # benefit model is built on a concrete annual dollar value, and insurance
+  # coverage has an expected value of roughly zero in a typical year. A
+  # "$10,000 trip cancellation" line would be modeled as $10,000 of value.
+  #
+  # This only stops the checker from PROPOSING them. Cards that already
+  # carry these benefits keep them.
+  - "Trip Cancellation/Interruption Insurance"
+  - "Trip Cancellation"
+  - "Trip Interruption Insurance"
+  - "Trip Delay Reimbursement"
+  - "Trip Delay Insurance"
+  - "Auto Rental Coverage"
+  - "Auto Rental Collision Damage Waiver"
+  - "Primary Auto Rental Coverage"
+  - "Car Rental Loss & Damage Insurance"
+  - "Worldwide Car Rental Insurance"
+  - "Rental Car Insurance"
+  - "Car Rental Insurance"
+  - "Purchase Protection"
+  - "Lost Luggage Reimbursement"
+  - "Lost Baggage Reimbursement"
+  - "Lost Baggage"
+  - "Baggage Delay Insurance"
+  - "Baggage Insurance Plan"
+  - "Global Assist Hotline"
+  - "Premium Global Assist Hotline"
+
   # Generic business-card platform features (not card-differentiators)
   - "Free Employee Cards"
   - "Employee Cards"
@@ -197,32 +231,20 @@ exclude:
 # decide on a case-by-case basis whether they belong on a given card.
 # ────────────────────────────────────────────────────────────────────────────
 borderline:
-  - "Trip Cancellation/Interruption Insurance"
-  - "Trip Cancellation"
-  - "Trip Interruption Insurance"
-  - "Trip Delay Reimbursement"
-  - "Trip Delay Insurance"
-  - "Auto Rental Coverage"
-  - "Auto Rental Collision Damage Waiver"
-  - "Car Rental Loss & Damage Insurance"
-  - "Worldwide Car Rental Insurance"
-  - "Purchase Protection"
+  # NOTE — the standard travel/purchase insurance names were moved OUT of
+  # this list and into `exclude` above. They were declined in four
+  # consecutive review issues (#1636, #1666, #1731, #1743) and were the
+  # entire "borderline benefits" bucket in #1743's queue. Leaving an item
+  # borderline means re-litigating it every single week; if the team decides
+  # to start modeling insurance coverage, move them back here in one edit.
   - "Extended Warranty"
-  - "Lost Luggage Reimbursement"
-  - "Lost Baggage Reimbursement"
-  - "Lost Baggage"
-  - "Baggage Delay Insurance"
-  - "Baggage Insurance Plan"
   - "Travel Accident Insurance"
   - "Travel & Emergency Assistance"
-  - "Global Assist Hotline"
   - "Roadside Assistance"
   - "Return Protection"
   - "Emergency Evacuation"
   - "Emergency Medical"
   - "Price Protection"
-  - "Rental Car Insurance"
-  - "Car Rental Insurance"
 
 # ────────────────────────────────────────────────────────────────────────────
 # 3. Auto-PR — anything not matched above is eligible for an auto-PR.

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -14,7 +14,14 @@ rewards:
     value: 3
     unit: percent
     choices: 1
-    note: "3% in choice category; cap is combined with groceries/wholesale-club row"
+    eligible_categories:
+      - gas
+      - online_shopping
+      - dining
+      - travel
+      - drugstores
+      - home_improvement
+    note: "3% in choice category (gas, online shopping, dining, travel, drugstores, home improvement); cap is combined with groceries/wholesale-club row"
     spend_cap: 2500
     cap_period: quarterly
     rate_after_cap: 1

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -15,6 +15,13 @@ rewards:
     value: 3
     unit: percent
     choices: 1
+    eligible_categories:
+      - gas
+      - online_shopping
+      - dining
+      - travel
+      - drugstores
+      - home_improvement
     note: "3% in choice category (gas, online shopping, dining, travel, drugstores, home improvement); cap is combined with groceries/wholesale-club row"
     spend_cap: 2500
     cap_period: quarterly

--- a/data/cards/citi-strata.yaml
+++ b/data/cards/citi-strata.yaml
@@ -28,7 +28,12 @@ rewards:
     value: 3
     unit: points_per_dollar
     choices: 1
-    note: "3x on one eligible self-select category of your choice"
+    eligible_categories:
+      - streaming
+      - gyms_fitness
+      - entertainment
+      - pet_supplies
+    note: "3x on one eligible self-select category of your choice: Select Streaming Services (the default), Fitness Clubs, Live Entertainment, Cosmetic Stores/Barber Shops/Hair Salons, or Pet Supply Stores. Changeable once per calendar quarter."
   - category: dining
     value: 2
     unit: points_per_dollar

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -49,7 +49,16 @@ rewards:
     value: 2
     unit: points_per_dollar
     mode: auto_top_spend
-    note: "Automatically in your top three spend categories each quarter"
+    eligible_categories:
+      - dining
+      - shipping
+      - airlines
+      - transit
+      - car_rentals
+      - gas
+      - tv_internet_streaming
+      - phone
+    note: "Automatically 2x total in your top three spend categories each calendar quarter, from dining, shipping, airline tickets bought directly with the airline, local transit and commuting, social media and search engine advertising, car rental agencies, gas stations, and internet/cable/phone services"
   - category: gyms_fitness
     value: 2
     unit: points_per_dollar

--- a/data/review-declined.yaml
+++ b/data/review-declined.yaml
@@ -1,0 +1,83 @@
+# Declined items from the weekly card-rewards-and-benefits review queue.
+#
+# WHY THIS FILE EXISTS
+#
+# The checker already refuses to re-add a benefit a human deleted from a card:
+# `getRemovedBenefitsForCard` walks the YAML's git history for removed
+# `name:` lines. But that only remembers proposals that once LANDED. A
+# proposal a human looked at in the review issue and declined never touched
+# the YAML, so it has no history to find and comes back every single week,
+# forever.
+#
+# Measured on issue #1743: 27 of its 51 distinct lines (53%) had already
+# appeared in #1636, #1666, or #1731 and been triaged away.
+#
+# HOW TO USE IT
+#
+# When you close a review issue, add whatever you decided against here. The
+# checker filters the review queue against this file, so a declined item goes
+# quiet permanently. Delete an entry to let it surface again (e.g. when an
+# issuer actually changes something and you want a fresh look).
+#
+# Matching is exact on slug + category (rewards) or slug + name (benefits),
+# except for `benefits_global`, which matches a benefit name on every card.
+
+# Reward categories proposed as NEW that we decided not to add.
+rewards_added:
+  - { slug: aaa-daily-advantage-visa-signature, category: travel,
+      why: "Travel Advantage's row bleeding over — both AAA cards share one apply URL" }
+  - { slug: blue-business-plus-credit-card-from-american-express, category: travel_portal,
+      why: "the card's 2x base rate restated; AmexTravel.com is not a separate bonus" }
+  - { slug: capital-one-venture-rewards, category: entertainment,
+      why: "alias of the existing entertainment_portal row" }
+  - { slug: citi-strata-premier, category: travel,
+      why: "YAML splits this into airlines 3x + hotels 3x" }
+  - { slug: citi-strata, category: streaming,
+      why: "covered by the selected_categories self-select row" }
+  - { slug: playstation-visa, category: tv_internet_streaming,
+      why: "the existing streaming row already covers cable and internet" }
+  - { slug: world-of-hyatt-business-credit-card, category: selected_categories,
+      why: "the same bucket as the existing top_category row" }
+
+# Reward categories flagged as present in YAML but not on the apply page.
+# Every entry below was verified still live on the issuer's page; the
+# detector could not read the earn table (JS-rendered or bot-blocked).
+rewards_removed:
+  - { slug: aaa-daily-advantage-visa-signature, category: ev_charging }
+  - { slug: aaa-travel-advantage-visa-signature, category: ev_charging }
+  - { slug: atmos-rewards-business, category: ev_charging }
+  - { slug: capital-one-quicksilver-secured, category: hotels_car_portal }
+  - { slug: capital-one-quicksilver, category: hotels_car_portal }
+  - { slug: capital-one-quicksilverone, category: hotels_car_portal }
+  - { slug: capital-one-savor-student, category: hotels_car_portal }
+  - { slug: capital-one-venture-rewards, category: entertainment_portal }
+  - { slug: capital-one-venture-x, category: hotels_car_portal }
+  - { slug: capital-one-venture-x, category: flights_portal }
+  - { slug: capital-one-venture-x, category: entertainment_portal }
+  - { slug: capital-one-venture-x, category: everything_else }
+  - { slug: capital-one-ventureone-rewards, category: hotels_car_portal }
+  - { slug: capital-one-ventureone-rewards, category: everything_else }
+  - { slug: citi-strata-premier, category: airlines }
+  - { slug: citi-strata-premier, category: hotels }
+  - { slug: citibusiness-aadvantage-platinum-select-maste, category: car_rentals }
+  - { slug: citibusiness-aadvantage-platinum-select-maste, category: phone }
+  - { slug: costco-anywhere-visa-business-card-by-citi, category: wholesale_clubs }
+  - { slug: costco-anywhere-visa-card-by-citi, category: wholesale_clubs }
+  - { slug: hawaiian-airlines-business-mastercard, category: airlines }
+  - { slug: hawaiian-airlines-business-mastercard, category: gas }
+  - { slug: hawaiian-airlines-business-mastercard, category: dining }
+  - { slug: hawaiian-airlines-business-mastercard, category: office_supplies }
+  - { slug: hawaiian-airlines-business-mastercard, category: everything_else }
+  - { slug: marriott-bonvoy-boundless-credit-card, category: hotels }
+  - { slug: marriott-bonvoy-boundless-credit-card, category: travel }
+  - { slug: marriott-bonvoy-brilliant-american-express, category: hotels }
+  - { slug: playstation-visa, category: streaming }
+  - { slug: robinhood-gold-card, category: travel_portal }
+
+# Benefit names declined on a specific card.
+benefits: []
+
+# Benefit names declined on EVERY card. Prefer benefit-policy.yaml's
+# `exclude` list for anything the team will never want; this is for names
+# that are merely not worth re-litigating each week.
+benefits_global: []

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -150,6 +150,27 @@ function validateCard(card, schema, categoryIds, storeSlugs) {
       if (reward.choices !== undefined && (typeof reward.choices !== 'number' || reward.choices < 1 || !Number.isInteger(reward.choices))) {
         errors.push(`Invalid reward choices for ${reward.category}: must be a positive integer`);
       }
+      // Meta-rows stand in for a BUCKET of eligible categories. The rewards
+      // checker suppresses "new category" noise by reading that bucket list
+      // (see collectMetaCoveredCategories in check-card-rewards-and-benefits.js),
+      // so a meta-row without one silently disables the suppression and floods
+      // the weekly review queue with duplicates of what the row already covers.
+      // Four cards were in that state when issue #1743 was triaged.
+      const META_COVERED_FIELD = {
+        rotating: 'current_categories',
+        top_category: 'eligible_categories',
+        selected_categories: 'eligible_categories',
+      };
+      const coveredField = META_COVERED_FIELD[reward.category];
+      if (coveredField) {
+        const covered = reward[coveredField];
+        if (!Array.isArray(covered) || covered.length === 0) {
+          errors.push(
+            `${reward.category} row must list the categories it covers in \`${coveredField}\` ` +
+            `(the rewards checker uses it to suppress duplicate proposals)`
+          );
+        }
+      }
       // Cap fields. spend_cap is the dollar threshold; cap_period is the
       // window over which it resets; rate_after_cap is the rate earned on
       // spend above the cap (defaults to 1 if unspecified).

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -10,9 +10,15 @@
  * Pipeline (per active card with apply_link):
  *   1. Fetch the apply page (simple fetch → Playwright fallback).
  *   2. Ask Claude Haiku to extract { rewards[], benefits[], foreign_transaction_fee }.
- *   3. Filter the proposal through `data/benefit-policy.yaml` and the card's
- *      git history (skip benefits previously removed from this card).
- *   4. Three-tier routing:
+ *   3. Gate on extraction trust: an extraction that returned nothing, missed
+ *      the card's base rate, or matched under half its existing categories
+ *      cannot support a "the issuer removed this" claim, so its removals and
+ *      value rewrites are dropped. See assessExtractionTrust.
+ *   4. Filter the proposal through `data/benefit-policy.yaml`, the card's git
+ *      history (skip benefits previously removed from this card), and
+ *      `data/review-declined.yaml` (skip anything a human already declined in
+ *      a past review issue).
+ *   5. Three-tier routing:
  *        - "auto-PR"   → write changes to the YAML; PR is opened by the workflow.
  *        - "review"    → append to .card-rewards-benefits-review.md (human triage).
  *        - "skip"      → silent; matched the exclude list or removed-history.
@@ -46,6 +52,7 @@ const yaml = require('js-yaml');
 const ROOT = path.join(__dirname, '..');
 const CARDS_DIR = path.join(ROOT, 'data', 'cards');
 const POLICY_FILE = path.join(ROOT, 'data', 'benefit-policy.yaml');
+const DECLINED_FILE = path.join(ROOT, 'data', 'review-declined.yaml');
 const REVIEW_SUMMARY = path.join(ROOT, '.card-rewards-benefits-review.md');
 const SUMMARY_FILE = path.join(ROOT, '.card-rewards-benefits-summary.md');
 
@@ -114,6 +121,30 @@ function loadAllCards() {
   return cards;
 }
 
+// Several cards legitimately share one apply page: the three Bilt cards, both
+// AAA Visa Signatures, and both Navy Federal Cash Rewards cards. The extractor
+// sees every card's earn table on that one page and has no reliable way to
+// attribute rows, so it proposes the sibling's rates as new (#1743: AAA Daily
+// Advantage got AAA Travel Advantage's `travel` 3%) and reports genuine rows
+// as missing. Build the map once so both the prompt and the diff can adapt.
+function buildSharedUrlMap(cards) {
+  const byUrl = new Map();
+  for (const c of cards) {
+    const url = c.data.apply_link;
+    if (!url) continue;
+    if (!byUrl.has(url)) byUrl.set(url, []);
+    byUrl.get(url).push(c);
+  }
+  const shared = new Map();
+  for (const [, group] of byUrl) {
+    if (group.length < 2) continue;
+    for (const c of group) {
+      shared.set(c.slug, group.filter(o => o.slug !== c.slug).map(o => o.data.name));
+    }
+  }
+  return shared;
+}
+
 function filterCardsForCheck(allCards, slugFilter) {
   let cards = allCards.filter(
     c => c.data.accepting_applications !== false && c.data.apply_link
@@ -174,6 +205,62 @@ function loadPolicy() {
   };
 }
 
+// ─── Declined-review memory ─────────────────────────────────────────────────
+//
+// `getRemovedBenefitsForCard` only remembers proposals that once landed in a
+// card's YAML and were later deleted. A proposal a human declined in the
+// review issue never touched the YAML, so it has no git history and recurs
+// every week forever. 27 of issue #1743's 51 distinct lines had already been
+// triaged away in #1636 / #1666 / #1731.
+//
+// data/review-declined.yaml closes that loop. See the file header for the
+// shape and for how to retire an entry.
+let _declined = null;
+function loadDeclined() {
+  if (_declined) return _declined;
+  const empty = {
+    rewardsAdded: new Set(),
+    rewardsRemoved: new Set(),
+    benefits: new Set(),
+    benefitsGlobal: new Set(),
+  };
+  try {
+    const raw = yaml.load(fs.readFileSync(DECLINED_FILE, 'utf8')) || {};
+    const key = (slug, v) => `${slug}::${String(v).toLowerCase()}`;
+    for (const e of raw.rewards_added || []) {
+      if (e?.slug && e?.category) empty.rewardsAdded.add(key(e.slug, e.category));
+    }
+    for (const e of raw.rewards_removed || []) {
+      if (e?.slug && e?.category) empty.rewardsRemoved.add(key(e.slug, e.category));
+    }
+    for (const e of raw.benefits || []) {
+      if (e?.slug && e?.name) empty.benefits.add(key(e.slug, e.name));
+    }
+    for (const n of raw.benefits_global || []) {
+      if (n) empty.benefitsGlobal.add(String(n).toLowerCase());
+    }
+  } catch (err) {
+    // A missing or malformed file must not silently disable the filter —
+    // say so, then carry on with an empty set.
+    if (err.code !== 'ENOENT') {
+      console.warn(`Warning: could not read ${path.basename(DECLINED_FILE)}: ${err.message}`);
+    }
+  }
+  _declined = empty;
+  return _declined;
+}
+
+function isDeclined(kind, slug, value) {
+  const d = loadDeclined();
+  const k = `${slug}::${String(value).toLowerCase()}`;
+  if (kind === 'reward_added') return d.rewardsAdded.has(k);
+  if (kind === 'reward_removed') return d.rewardsRemoved.has(k);
+  if (kind === 'benefit') {
+    return d.benefits.has(k) || d.benefitsGlobal.has(String(value).toLowerCase());
+  }
+  return false;
+}
+
 function classifyBenefit(name, policy, removedFromThisCard) {
   const lower = name.toLowerCase();
   if (removedFromThisCard.has(name)) return 'removed_history';
@@ -222,6 +309,29 @@ async function closeBrowser() {
   }
 }
 
+// Does this page text actually contain an earn table?
+//
+// The old floor was `stripped.length >= 200`, which any bot-block page,
+// cookie wall, or JS shell clears. That let unreadable pages through as if
+// they were readable, and an extraction against chrome-only text returns
+// nothing — which the diff then reported as "the issuer removed every
+// category." Capital One and Citi render their earn tables client-side;
+// Barclays returns 403 outright.
+//
+// Require several rate-shaped tokens ("5%", "3X", "2 points per $1") before
+// treating a fetch as usable. Three is deliberately low: a card with one
+// bonus category plus a base rate still clears it, while a nav-and-footer
+// shell does not.
+const MIN_RATE_TOKENS = 3;
+
+function hasRewardEvidence(text) {
+  if (!text || typeof text !== 'string') return false;
+  const matches = text.match(
+    /\d+(?:\.\d+)?\s*(?:%|[xX]\b|(?:points?|miles?|cash\s*back)\s+(?:per|back|on|for))/g
+  );
+  return Boolean(matches && matches.length >= MIN_RATE_TOKENS);
+}
+
 async function fetchPageContent(url) {
   // Simple fetch first
   try {
@@ -243,8 +353,14 @@ async function fetchPageContent(url) {
       if (ct.includes('text/html')) {
         const html = await response.text();
         const stripped = stripHtml(html);
-        if (stripped.length >= 200) return { content: stripped, usedBrowser: false };
+        // Only accept the cheap path when the text actually carries an earn
+        // table; otherwise fall through to the browser, which can render one.
+        if (stripped.length >= 200 && hasRewardEvidence(stripped)) {
+          return { content: stripped, usedBrowser: false };
+        }
       }
+    } else {
+      console.warn(`  Simple fetch returned HTTP ${response.status} — falling back to browser`);
     }
   } catch (err) {
     console.warn(`  Simple fetch failed: ${err.message} — falling back to browser`);
@@ -259,11 +375,33 @@ async function fetchPageContent(url) {
       userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
     });
     const page = await context.newPage();
-    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
-    await page.waitForTimeout(3000);
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    if (response && response.status() >= 400) {
+      console.warn(`  Browser fetch got HTTP ${response.status()} — treating as unfetchable`);
+      return null;
+    }
+    // Wait for the earn table to render rather than a flat 3s: issuer pages
+    // that hydrate their rewards client-side routinely take longer, and the
+    // ones that don't shouldn't pay the full wait.
+    try {
+      await page.waitForFunction(
+        () => /\d+(?:\.\d+)?\s*(?:%|[xX]\b)/.test(document.body?.innerText || ''),
+        { timeout: 8000 }
+      );
+    } catch {
+      // No rate text appeared; fall through and let the evidence check below
+      // make the call on whatever did render.
+    }
+    await page.waitForTimeout(1000);
     const html = await page.content();
     const stripped = stripHtml(html);
     if (stripped.length < 200) return null;
+    // A rendered page with no earn table is not usable input. Returning it
+    // anyway is what produced the all-rows-removed reports in #1743.
+    if (!hasRewardEvidence(stripped)) {
+      console.warn(`  Rendered page has no earn-rate text — treating as unfetchable`);
+      return null;
+    }
     return { content: stripped, usedBrowser: true };
   } catch (err) {
     console.warn(`  Browser fetch error: ${err.message}`);
@@ -296,7 +434,7 @@ function buildFewShotExamples(allCards, exampleSlugs) {
 // fetch phase both call this, so a prompt tweak can never apply to one and not
 // the other — the local routine must be answering exactly the question the
 // single pass would have asked.
-function buildExtractionPrompt(card, applyLink, pageContent, examples) {
+function buildExtractionPrompt(card, applyLink, pageContent, examples, sharedUrlWith = []) {
   const examplesBlock = examples
     .slice(0, 3)
     .map(ex => `### ${ex.name}\n${JSON.stringify({ rewards: ex.rewards, benefits: ex.benefits, foreign_transaction_fee: ex.foreign_transaction_fee }, null, 2)}`)
@@ -309,11 +447,21 @@ function buildExtractionPrompt(card, applyLink, pageContent, examples) {
     ? `\nCurrent benefits[] (DO NOT propose anything semantically equivalent):\n${JSON.stringify(card.data.benefits, null, 2)}\n`
     : '';
 
+  const sharedBlock = sharedUrlWith.length > 0
+    ? `
+⚠️ SHARED PAGE — this URL also describes ${sharedUrlWith.length} other card(s): ${sharedUrlWith.join(', ')}.
+Extract ONLY the rows that belong to ${card.data.name}. When the page states a
+rate without making clear which of these cards it applies to, OMIT it rather
+than guessing. Returning fewer rows is correct here; a rate copied from a
+sibling card is a false positive that reaches production.
+`
+    : '';
+
   const prompt = `You are extracting earn rates and benefits from a credit card's apply page.
 
 Card: ${card.data.name} (${card.data.bank})
 Source URL: ${applyLink}
-${subBlock}${existingBenefitsBlock}
+${sharedBlock}${subBlock}${existingBenefitsBlock}
 Page content:
 ${pageContent}
 
@@ -552,11 +700,11 @@ Now extract for ${card.data.name}.`;
   return prompt;
 }
 
-async function extractRewardsAndBenefits(card, applyLink, pageContent, examples) {
+async function extractRewardsAndBenefits(card, applyLink, pageContent, examples, sharedUrlWith = []) {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error('OPENAI_API_KEY required');
 
-  const prompt = buildExtractionPrompt(card, applyLink, pageContent, examples);
+  const prompt = buildExtractionPrompt(card, applyLink, pageContent, examples, sharedUrlWith);
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -686,6 +834,62 @@ const PORTAL_ALIAS_GROUP = new Set([
   'flights_portal',
 ]);
 
+// Alias groups — sets of category ids that encode the same spend in
+// different slices. If the YAML uses one member and the extractor proposes
+// a sibling, that is a naming difference, not a change. Applied
+// symmetrically to both the added and removed sides of the diff.
+//
+// The portal family is the original case. The rest were all confirmed
+// false-positive generators in review issue #1743:
+//   entertainment ↔ entertainment_portal — Capital One Venture's
+//     `entertainment_portal` row re-proposed as bare `entertainment`.
+//   streaming ↔ tv_internet_streaming — PlayStation Visa's `streaming`
+//     row (which already covers "streaming, cable, and internet") flagged
+//     removed while `tv_internet_streaming` was proposed as new.
+//   gas ↔ ev_charging — issuers advertise "gas stations and EV charging"
+//     as one line, so the extractor emits a single `gas` row and every
+//     card that splits the two orphans its `ev_charging` row every week
+//     (AAA Daily Advantage, AAA Travel Advantage, Atmos Rewards Business).
+const CATEGORY_ALIAS_GROUPS = [
+  PORTAL_ALIAS_GROUP,
+  new Set(['entertainment', 'entertainment_portal']),
+  new Set(['streaming', 'tv_internet_streaming']),
+  new Set(['gas', 'ev_charging']),
+];
+
+// Broad → narrow containment. A card that splits a broad category into
+// narrower rows (Citi Strata Premier stores `airlines` 3x + `hotels` 3x)
+// gets the broad row proposed as "new" every run, because the apply page
+// says "3x on air travel and other hotel purchases". Suppress a proposed
+// broad row when the YAML already carries any of its narrow members, and
+// suppress a narrow YAML row from the removed list when the proposal
+// carries its broad parent.
+const BROADER_THAN = new Map([
+  ['travel', new Set([
+    'airlines', 'hotels', 'car_rentals', 'vacation_rentals', 'transit',
+    'travel_portal', 'hotels_portal', 'flights_portal',
+    'car_rentals_portal', 'hotels_car_portal',
+  ])],
+  ['transit', new Set(['ground_transportation'])],
+  ['online_shopping', new Set(['amazon'])],
+]);
+
+// All ids in the same alias group as `cat` (excluding itself).
+function aliasSiblings(cat) {
+  const out = new Set();
+  for (const group of CATEGORY_ALIAS_GROUPS) {
+    if (!group.has(cat)) continue;
+    for (const member of group) if (member !== cat) out.add(member);
+  }
+  return out;
+}
+
+// True when `broad` is a strictly broader encoding of `narrow`.
+function isBroaderThan(broad, narrow) {
+  const narrowSet = BROADER_THAN.get(broad);
+  return Boolean(narrowSet && narrowSet.has(narrow));
+}
+
 // Extract the set of category ids covered by a card's meta-rows
 // (rotating / top_category / selected_categories). Returns null when the
 // card has no meta-rows, so callers can short-circuit.
@@ -709,7 +913,65 @@ function collectMetaCoveredCategories(currentRewards) {
   return hasMeta ? covered : null;
 }
 
-function diffRewards(current, proposed) {
+// ─── Extraction trust floor ─────────────────────────────────────────────────
+//
+// The single largest source of false positives in the weekly queue: a failed
+// extraction is structurally indistinguishable from "the issuer removed these
+// categories." An empty `proposed` array walks straight through the removed
+// loop and reports every row the card has as missing from the page.
+//
+// Issue #1743 shipped three cards in exactly that state — Capital One Venture X
+// (4 of 4 rows flagged), VentureOne (2 of 2), and Hawaiian Airlines Business
+// (5 of 5, including `everything_else`). None had changed; the pages either
+// render their earn tables in JS or bot-block the scraper outright (Barclays
+// returns 403). That is 11 of the issue's 30 removals from three cards.
+//
+// A removal claim requires evidence the page's earn table was actually read.
+// We only trust the extraction enough to report removals when:
+//   1. it returned at least one reward, AND
+//   2. it found a base rate if the card has one (essentially every card does;
+//      an extractor that missed `everything_else` did not read the table), AND
+//   3. it matched at least half the categories already in the YAML, counting
+//      alias and meta equivalences.
+//
+// Additions are held to a lower bar and still surface: those need only that
+// the page said something, and a genuinely new category is exactly the thing
+// no amount of YAML-side evidence can confirm.
+function assessExtractionTrust(current, proposed) {
+  const cur = (current || []).filter(r => r && r.category);
+  const prop = (proposed || []).filter(r => r && r.category);
+  if (cur.length === 0) return { trusted: true, reason: null };
+  if (prop.length === 0) {
+    return { trusted: false, reason: 'extractor returned no rewards at all' };
+  }
+
+  const proposedCats = new Set(prop.map(r => r.category));
+  if (cur.some(r => r.category === 'everything_else') && !proposedCats.has('everything_else')) {
+    return { trusted: false, reason: 'extractor found no base rate (everything_else)' };
+  }
+
+  const matched = cur.filter(r => {
+    if (proposedCats.has(r.category)) return true;
+    // Meta-rows never appear on apply pages by name, so they can't be
+    // "matched" — don't let them drag the ratio down.
+    if (META_CATEGORIES.has(r.category)) return true;
+    for (const sib of aliasSiblings(r.category)) if (proposedCats.has(sib)) return true;
+    for (const p of proposedCats) if (isBroaderThan(p, r.category)) return true;
+    return false;
+  }).length;
+
+  if (matched / cur.length < 0.5) {
+    return {
+      trusted: false,
+      reason: `extractor matched only ${matched} of ${cur.length} existing categories`,
+    };
+  }
+  return { trusted: true, reason: null };
+}
+
+// `opts.suppressRemovals` is set by the caller for cards whose apply_link is
+// shared with another card — see SHARED-URL handling in main().
+function diffRewards(current, proposed, opts = {}) {
   // Returns { added, removed, changed } by category id.
   //
   // Reward-rate change is gated by FOUR guards. All four are silent
@@ -788,11 +1050,31 @@ function diffRewards(current, proposed) {
   // the LLM proposes a new `dining` row, suppress the "added" flag.
   const metaCoveredCategories = collectMetaCoveredCategories(current) || new Set();
 
-  // Suppression set B: when the YAML has any portal-family row and the
-  // LLM proposes a sibling portal row (or vice versa), the two are
-  // equivalent enough that we don't want to flag either side.
-  const yamlHasPortalRow = [...cur.keys()].some(c => PORTAL_ALIAS_GROUP.has(c));
-  const proposalHasPortalRow = [...prop.keys()].some(c => PORTAL_ALIAS_GROUP.has(c));
+  // Suppression set B: when the YAML has a row in the same alias group as
+  // a proposed row (or vice versa), the two are equivalent encodings of the
+  // same spend and neither side should be flagged.
+  const yamlHasAliasOf = cat => [...cur.keys()].some(c => aliasSiblings(cat).has(c));
+  const proposalHasAliasOf = cat => [...prop.keys()].some(c => aliasSiblings(cat).has(c));
+
+  // Suppression set C: broad/narrow splits. A proposed broad row is noise
+  // when the YAML already carries any of its narrow members; a narrow YAML
+  // row isn't "removed" when the proposal carries its broad parent.
+  const yamlHasNarrowerThan = broad => [...cur.keys()].some(c => isBroaderThan(broad, c));
+  const proposalHasBroaderThan = narrow => [...prop.keys()].some(c => isBroaderThan(c, narrow));
+
+  // Suppression set D: the card's own base rate restated under a category
+  // name. Amex Blue Business Plus earns 2x on everything, so its apply page's
+  // "2X on AmexTravel.com" line gets extracted as a new `travel_portal` 2x
+  // row every run. If a proposed rate equals the base rate in the same unit,
+  // it carries no information the base row doesn't already have.
+  const baseRow = cur.get('everything_else');
+  const isBaseRateRestated = p =>
+    Boolean(baseRow) && p.unit === baseRow.unit && p.value === baseRow.value;
+
+  // Meta-rows in the YAML mean the card models a bucket. A proposal that
+  // names a meta id itself (World of Hyatt Business: YAML `top_category`,
+  // proposal `selected_categories`) is the same bucket under another name.
+  const yamlHasMetaRow = [...cur.keys()].some(c => META_CATEGORIES.has(c));
 
   const added = [];
   const removed = [];
@@ -804,9 +1086,16 @@ function diffRewards(current, proposed) {
       // Suppress proposals already covered by a meta-row (rotating /
       // top_category / selected_categories).
       if (metaCoveredCategories.has(cat)) continue;
-      // Suppress portal-sibling proposals when YAML already has any
-      // portal-family row encoding the same earn mechanic.
-      if (PORTAL_ALIAS_GROUP.has(cat) && yamlHasPortalRow) continue;
+      // A proposal that names a meta id itself, when the YAML already
+      // models the same bucket under a different meta id.
+      if (META_CATEGORIES.has(cat) && yamlHasMetaRow) continue;
+      // Suppress alias-sibling proposals when YAML already has a row
+      // encoding the same earn mechanic under another slice.
+      if (yamlHasAliasOf(cat)) continue;
+      // Suppress a broad proposal when the YAML splits it into narrow rows.
+      if (yamlHasNarrowerThan(cat)) continue;
+      // Suppress the base rate restated under a category name.
+      if (isBaseRateRestated(p)) continue;
       added.push(p);
     } else if (c.unit !== p.unit) {
       // Unit mismatch — skip; almost always an LLM misread.
@@ -848,19 +1137,42 @@ function diffRewards(current, proposed) {
       changed.push({ from: c, to: p });
     }
   }
+  // Removals are only reported when the extraction is trustworthy enough to
+  // stand as evidence of absence, and never for cards whose apply page also
+  // describes a sibling card (the extractor can't be held to knowing which
+  // rows belong to which).
+  const trust = assessExtractionTrust(current, proposed);
+  const reportRemovals = trust.trusted && !opts.suppressRemovals;
+
   for (const [cat, c] of cur) {
+    if (!reportRemovals) break;
     if (prop.has(cat)) continue;
     // Meta-rows (rotating / top_category / selected_categories) never
     // appear on apply pages — the page lists the underlying eligible
     // categories. Don't flag the meta-row itself as "removed".
     if (META_CATEGORIES.has(cat)) continue;
-    // Portal-family rows: when the proposal includes any sibling portal
-    // category, treat as matched (the LLM picked a different slice of
-    // the same mechanic).
-    if (PORTAL_ALIAS_GROUP.has(cat) && proposalHasPortalRow) continue;
+    // Alias-family rows: when the proposal includes any sibling category,
+    // treat as matched (the LLM picked a different slice of the same
+    // mechanic).
+    if (proposalHasAliasOf(cat)) continue;
+    // A narrow YAML row isn't missing when the proposal carries its broad
+    // parent (page says "3x travel", YAML splits airlines + hotels).
+    if (proposalHasBroaderThan(cat)) continue;
     removed.push(c);
   }
-  return { added, removed, changed, downgraded };
+
+  // Neither a base-rate cut nor a value rewrite claimed by an untrusted
+  // extraction is a finding. `changed` auto-PRs, so an extraction we don't
+  // trust to say what's absent shouldn't get to silently rewrite what's
+  // present either.
+  return {
+    added,
+    removed,
+    changed: trust.trusted ? changed : [],
+    downgraded: trust.trusted ? downgraded : [],
+    trust,
+    removalsSuppressed: !reportRemovals,
+  };
 }
 
 // Tokenize a benefit name into meaningful words for fuzzy duplicate detection.
@@ -1387,15 +1699,27 @@ function applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff) {
 
 // ─── Review-queue formatting ────────────────────────────────────────────────
 
-function appendReviewEntries(cardName, applyLink, reviewItems, rewardsDiff, ftxnDiff) {
-  const downgraded = rewardsDiff.downgraded || [];
+function appendReviewEntries(card, reviewItems, rewardsDiff, ftxnDiff) {
+  const cardName = card.data.name;
+  const applyLink = card.data.apply_link;
+  const slug = card.slug;
+
+  // Everything the team has already looked at and declined stays out of the
+  // queue. See data/review-declined.yaml.
+  const added = rewardsDiff.added.filter(r => !isDeclined('reward_added', slug, r.category));
+  const removed = rewardsDiff.removed.filter(r => !isDeclined('reward_removed', slug, r.category));
+  const downgraded = (rewardsDiff.downgraded || []).filter(
+    d => !isDeclined('reward_removed', slug, d.to.category)
+  );
+  const benefits = reviewItems.filter(b => !isDeclined('benefit', slug, b.name));
+
   if (
-    reviewItems.length === 0 &&
-    rewardsDiff.added.length === 0 &&
-    rewardsDiff.removed.length === 0 &&
+    benefits.length === 0 &&
+    added.length === 0 &&
+    removed.length === 0 &&
     downgraded.length === 0
   ) {
-    return;
+    return 0;
   }
   const lines = [];
   lines.push(`\n## ${cardName}`);
@@ -1408,26 +1732,31 @@ function appendReviewEntries(cardName, applyLink, reviewItems, rewardsDiff, ftxn
       lines.push(`- \`${to.category}\`: ${from.value}${u} → ${to.value}${u} (the extractor frequently misreads flat base rates as 1 — confirm the cut is real)`);
     }
   }
-  if (rewardsDiff.added.length > 0) {
+  if (added.length > 0) {
     lines.push(`### New reward category proposed (needs human routing)`);
-    for (const r of rewardsDiff.added) {
+    for (const r of added) {
       lines.push(`- \`${r.category}\`: ${r.value}${r.unit === 'percent' ? '%' : 'x'}${r.note ? ` — ${r.note}` : ''}`);
     }
   }
-  if (rewardsDiff.removed.length > 0) {
+  if (removed.length > 0) {
     lines.push(`### Reward category present in YAML but not on apply page`);
-    for (const r of rewardsDiff.removed) {
+    for (const r of removed) {
       lines.push(`- \`${r.category}\`: ${r.value}${r.unit === 'percent' ? '%' : 'x'} (verify before removing)`);
     }
   }
-  if (reviewItems.length > 0) {
+  if (benefits.length > 0) {
     lines.push(`### Borderline benefits proposed (manual decision)`);
-    for (const b of reviewItems) {
+    for (const b of benefits) {
       lines.push(`- **${b.name}** — ${b.description}`);
     }
   }
+  lines.push(
+    `\n<sub>Declined an item? Add it to \`data/review-declined.yaml\` ` +
+    `(slug \`${slug}\`) so it stops coming back every week.</sub>`
+  );
 
   fs.appendFileSync(REVIEW_SUMMARY, lines.join('\n') + '\n');
+  return added.length + removed.length + downgraded.length + benefits.length;
 }
 
 // ─── Rotating-period staleness check ────────────────────────────────────────
@@ -1494,8 +1823,11 @@ async function main() {
   const cards = filterCardsForCheck(allCards, slugFilter);
   const policy = loadPolicy();
   const examples = buildFewShotExamples(allCards, policy.exampleCards);
+  // Keyed on every card, not just the filtered set, so a --slug run still
+  // knows its page is shared.
+  const sharedUrls = buildSharedUrlMap(allCards.filter(c => c.data.apply_link));
 
-  if (PHASE === 'finish') return finishPhase({ cards, policy });
+  if (PHASE === 'finish') return finishPhase({ cards, policy, sharedUrls });
 
   if (PHASE === 'all' && !process.env.OPENAI_API_KEY) {
     console.error('OPENAI_API_KEY is required for --phase=all. Use --phase=fetch/--phase=finish to extract locally.');
@@ -1534,6 +1866,10 @@ async function main() {
     cardsModified: 0,
     autoChanges: 0,
     reviewItems: 0,
+    // Cards whose page could be fetched but whose extraction wasn't complete
+    // enough to trust for removals. A rising count means the scrapers are
+    // degrading, and is worth acting on before the queue goes quiet.
+    untrustedExtractions: 0,
     staleRotatingPeriods: staleRotations.length,
   };
 
@@ -1568,7 +1904,10 @@ async function main() {
     if (PHASE === 'fetch') {
       fs.writeFileSync(
         path.join(PROMPTS_DIR, `${card.slug}.txt`),
-        buildExtractionPrompt(card, card.data.apply_link, pageResult.content, examples)
+        buildExtractionPrompt(
+          card, card.data.apply_link, pageResult.content, examples,
+          sharedUrls.get(card.slug) || []
+        )
       );
       // The page text is kept because --phase=finish needs it: diffForeignTxn
       // reads the raw page to confirm a "no foreign transaction fee" claim,
@@ -1583,7 +1922,10 @@ async function main() {
     let extracted;
     try {
       extracted = await withTimeout(
-        extractRewardsAndBenefits(card, card.data.apply_link, pageResult.content, examples),
+        extractRewardsAndBenefits(
+          card, card.data.apply_link, pageResult.content, examples,
+          sharedUrls.get(card.slug) || []
+        ),
         PER_CARD_TIMEOUT_MS,
         `extract ${card.data.name}`
       );
@@ -1597,7 +1939,10 @@ async function main() {
       continue;
     }
 
-    applyExtraction({ card, extracted, pageContent: pageResult.content, policy, summary });
+    applyExtraction({
+      card, extracted, pageContent: pageResult.content, policy, summary,
+      sharedUrlWith: sharedUrls.get(card.slug) || [],
+    });
 
     await new Promise(r => setTimeout(r, FETCH_DELAY_MS));
   }
@@ -1628,7 +1973,7 @@ async function main() {
 // exactly the same policy/diff/apply path the single pass uses. A card with no
 // extraction is counted as an extraction failure, never as "no changes" — an
 // unanswered prompt must not read as a clean bill of health.
-function finishPhase({ cards, policy }) {
+function finishPhase({ cards, policy, sharedUrls }) {
   if (!fs.existsSync(FETCH_STATE_FILE)) {
     console.error(`Error: ${path.relative(process.cwd(), FETCH_STATE_FILE)} not found — run --phase=fetch first.`);
     process.exit(1);
@@ -1657,6 +2002,10 @@ function finishPhase({ cards, policy }) {
     cardsModified: 0,
     autoChanges: 0,
     reviewItems: 0,
+    // Cards whose page could be fetched but whose extraction wasn't complete
+    // enough to trust for removals. A rising count means the scrapers are
+    // degrading, and is worth acting on before the queue goes quiet.
+    untrustedExtractions: 0,
     staleRotatingPeriods: staleRotations.length,
   };
 
@@ -1679,7 +2028,10 @@ function finishPhase({ cards, policy }) {
     const pageContent = fs.readFileSync(pagePath, 'utf8');
 
     console.log(`[finish] ${card.data.name}`);
-    applyExtraction({ card, extracted, pageContent, policy, summary });
+    applyExtraction({
+      card, extracted, pageContent, policy, summary,
+      sharedUrlWith: sharedUrls.get(card.slug) || [],
+    });
   }
 
   writeSummary(summary);
@@ -1689,7 +2041,7 @@ function finishPhase({ cards, policy }) {
 // diff, YAML write, review-queue append. Shared verbatim by --phase=all and
 // --phase=finish so a locally-answered prompt lands exactly where an
 // API-answered one would.
-function applyExtraction({ card, extracted, pageContent, policy, summary }) {
+function applyExtraction({ card, extracted, pageContent, policy, summary, sharedUrlWith }) {
     const removed = getRemovedBenefitsForCard(card.filepath);
     const currentNames = getCurrentBenefitNames(card);
     // Don't deny-list things that are CURRENTLY in the YAML (they can be
@@ -1697,7 +2049,18 @@ function applyExtraction({ card, extracted, pageContent, policy, summary }) {
     for (const name of currentNames) removed.delete(name);
 
     const normalizedRewards = normalizeRewardsUnits(extracted.rewards);
-    const rewardsDiff = diffRewards(card.data.rewards, normalizedRewards);
+    const sharedUrl = Array.isArray(sharedUrlWith) && sharedUrlWith.length > 0;
+    const rewardsDiff = diffRewards(card.data.rewards, normalizedRewards, {
+      // When several cards share one apply page, absence of a row from the
+      // extraction says nothing — the extractor may simply have attributed
+      // it to the sibling card. (Confirmed in #1743: AAA Travel Advantage's
+      // `travel` 3% row was proposed as new for AAA Daily Advantage.)
+      suppressRemovals: sharedUrl,
+    });
+    if (!rewardsDiff.trust.trusted) {
+      console.warn(`  ⚠️  ${card.data.name}: untrusted extraction (${rewardsDiff.trust.reason}) — reward diff suppressed`);
+      summary.untrustedExtractions = (summary.untrustedExtractions || 0) + 1;
+    }
     const benefitsDiff = diffBenefits(
       card.data.benefits,
       extracted.benefits,
@@ -1728,12 +2091,7 @@ function applyExtraction({ card, extracted, pageContent, policy, summary }) {
       }
     }
 
-    appendReviewEntries(card.data.name, card.data.apply_link, benefitsDiff.review, rewardsDiff, ftxnDiff);
-    summary.reviewItems +=
-      benefitsDiff.review.length +
-      rewardsDiff.added.length +
-      rewardsDiff.removed.length +
-      rewardsDiff.downgraded.length;
+    summary.reviewItems += appendReviewEntries(card, benefitsDiff.review, rewardsDiff, ftxnDiff);
 }
 
 // Top-level summary so the caller (workflow or local routine) can decide
@@ -1764,6 +2122,15 @@ module.exports = {
   looksLikeSameByDescription,
   looksLikeSameBenefit,
   collectMetaCoveredCategories,
+  assessExtractionTrust,
+  hasRewardEvidence,
+  isDeclined,
+  loadDeclined,
+  buildSharedUrlMap,
+  aliasSiblings,
+  isBroaderThan,
   META_CATEGORIES,
   PORTAL_ALIAS_GROUP,
+  CATEGORY_ALIAS_GROUPS,
+  BROADER_THAN,
 };

--- a/scripts/check-card-rewards-and-benefits.test.js
+++ b/scripts/check-card-rewards-and-benefits.test.js
@@ -19,6 +19,11 @@ const {
   looksLikeSameByDescription,
   looksLikeSameBenefit,
   collectMetaCoveredCategories,
+  assessExtractionTrust,
+  hasRewardEvidence,
+  buildSharedUrlMap,
+  isDeclined,
+  loadDeclined,
 } = require('./check-card-rewards-and-benefits');
 
 const NOOP_POLICY = { exclude: [], borderline: [], exampleCards: [] };
@@ -464,6 +469,280 @@ test('diffBenefits: description-fuzzy duplicate is skipped when names diverge', 
     diff.skipped[0].tier === 'duplicate_description' || diff.skipped[0].tier === 'duplicate_fuzzy',
     `expected description/fuzzy dedup, got ${diff.skipped[0].tier}`
   );
+});
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regressions from review issue #1743. Every case below is a real item that
+// reached the human queue on 2026-07-21 and should not have.
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log('\nExtraction trust floor (#1743):');
+
+test('empty extraction reports no removals (Hawaiian Airlines Business: 5 of 5 rows flagged)', () => {
+  const current = [
+    { category: 'airlines', value: 3, unit: 'points_per_dollar' },
+    { category: 'gas', value: 2, unit: 'points_per_dollar' },
+    { category: 'dining', value: 2, unit: 'points_per_dollar' },
+    { category: 'office_supplies', value: 2, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+  ];
+  const diff = diffRewards(current, []);
+  assert.equal(diff.removed.length, 0, 'an empty extraction is not evidence of absence');
+  assert.equal(diff.trust.trusted, false);
+});
+
+test('extraction missing the base rate is untrusted (Venture X: 4 of 4 rows flagged)', () => {
+  const current = [
+    { category: 'hotels_car_portal', value: 10, unit: 'points_per_dollar' },
+    { category: 'flights_portal', value: 5, unit: 'points_per_dollar' },
+    { category: 'entertainment_portal', value: 5, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 2, unit: 'points_per_dollar' },
+  ];
+  // Page shell rendered one stray rate and nothing else.
+  const proposed = [{ category: 'hotels_car_portal', value: 10, unit: 'points_per_dollar' }];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.trust.trusted, false, 'no everything_else means the table was not read');
+  assert.equal(diff.removed.length, 0);
+});
+
+test('a complete extraction still reports a genuine removal', () => {
+  const current = [
+    { category: 'dining', value: 3, unit: 'percent' },
+    { category: 'gas', value: 2, unit: 'percent' },
+    { category: 'everything_else', value: 1, unit: 'percent' },
+  ];
+  const proposed = [
+    { category: 'dining', value: 3, unit: 'percent' },
+    { category: 'everything_else', value: 1, unit: 'percent' },
+  ];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.trust.trusted, true);
+  assert.equal(diff.removed.length, 1);
+  assert.equal(diff.removed[0].category, 'gas');
+});
+
+test('untrusted extraction also suppresses value rewrites and base-rate cuts', () => {
+  const current = [
+    { category: 'dining', value: 3, unit: 'percent' },
+    { category: 'gas', value: 2, unit: 'percent' },
+    { category: 'everything_else', value: 1.5, unit: 'percent' },
+  ];
+  const proposed = [{ category: 'dining', value: 1, unit: 'percent' }];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.changed.length, 0, 'must not auto-PR a value from an unread page');
+  assert.equal(diff.downgraded.length, 0);
+});
+
+console.log('\nAlias groups (#1743):');
+
+test('gas/ev_charging: page merges them, split YAML row is not flagged removed', () => {
+  // AAA Daily Advantage, AAA Travel Advantage, Atmos Rewards Business.
+  const current = [
+    { category: 'gas', value: 3, unit: 'percent' },
+    { category: 'ev_charging', value: 3, unit: 'percent' },
+    { category: 'everything_else', value: 1, unit: 'percent' },
+  ];
+  const proposed = [
+    { category: 'gas', value: 3, unit: 'percent', note: 'Gas stations and EV charging' },
+    { category: 'everything_else', value: 1, unit: 'percent' },
+  ];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.removed.length, 0);
+  assert.equal(diff.added.length, 0);
+});
+
+test('streaming/tv_internet_streaming are the same slice (PlayStation Visa)', () => {
+  const current = [
+    { category: 'streaming', value: 3, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+  ];
+  const proposed = [
+    { category: 'tv_internet_streaming', value: 3, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+  ];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.added.length, 0);
+  assert.equal(diff.removed.length, 0);
+});
+
+test('entertainment_portal is not re-proposed as bare entertainment (C1 Venture)', () => {
+  const current = [
+    { category: 'hotels_car_portal', value: 5, unit: 'points_per_dollar' },
+    { category: 'entertainment_portal', value: 5, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 2, unit: 'points_per_dollar' },
+  ];
+  const proposed = [
+    { category: 'hotels_car_portal', value: 5, unit: 'points_per_dollar' },
+    { category: 'entertainment', value: 5, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 2, unit: 'points_per_dollar' },
+  ];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.added.length, 0);
+  assert.equal(diff.removed.length, 0);
+});
+
+console.log('\nBroad/narrow containment (#1743):');
+
+test('broad `travel` proposal suppressed when YAML splits airlines + hotels (Citi Strata Premier)', () => {
+  const current = [
+    { category: 'airlines', value: 3, unit: 'points_per_dollar' },
+    { category: 'hotels', value: 3, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+  ];
+  const proposed = [
+    { category: 'travel', value: 3, unit: 'points_per_dollar', note: 'Air travel and other hotel purchases' },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+  ];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.added.length, 0, 'travel is the parent of the rows already stored');
+  assert.equal(diff.removed.length, 0, 'airlines/hotels are covered by the broad proposal');
+});
+
+console.log('\nBase-rate restatement + meta-to-meta (#1743):');
+
+test('a proposal equal to everything_else is the base rate restated (Blue Business Plus)', () => {
+  const current = [
+    { category: 'everything_else', value: 2, unit: 'points_per_dollar', spend_cap: 50000 },
+  ];
+  const proposed = [
+    { category: 'everything_else', value: 2, unit: 'points_per_dollar', spend_cap: 50000 },
+    { category: 'travel_portal', value: 2, unit: 'points_per_dollar', note: 'AmexTravel.com purchases' },
+  ];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.added.length, 0);
+});
+
+test('a rate ABOVE the base rate still surfaces', () => {
+  const current = [{ category: 'everything_else', value: 2, unit: 'points_per_dollar' }];
+  const proposed = [
+    { category: 'everything_else', value: 2, unit: 'points_per_dollar' },
+    { category: 'dining', value: 4, unit: 'points_per_dollar' },
+  ];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.added.length, 1);
+  assert.equal(diff.added[0].category, 'dining');
+});
+
+test('meta id proposed against a different meta id in YAML (World of Hyatt Business)', () => {
+  const current = [
+    { category: 'top_category', value: 2, unit: 'points_per_dollar', mode: 'auto_top_spend',
+      eligible_categories: ['dining', 'shipping', 'airlines'] },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+  ];
+  const proposed = [
+    { category: 'selected_categories', value: 2, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+  ];
+  const diff = diffRewards(current, proposed);
+  assert.equal(diff.added.length, 0);
+  assert.equal(diff.removed.length, 0);
+});
+
+console.log('\nShared apply pages (#1743):');
+
+test('buildSharedUrlMap pairs cards that share an apply_link', () => {
+  const cards = [
+    { slug: 'bilt-blue', data: { name: 'Bilt Blue', apply_link: 'https://x/apply' } },
+    { slug: 'bilt-obsidian', data: { name: 'Bilt Obsidian', apply_link: 'https://x/apply' } },
+    { slug: 'other', data: { name: 'Other', apply_link: 'https://y/apply' } },
+  ];
+  const shared = buildSharedUrlMap(cards);
+  assert.deepEqual(shared.get('bilt-blue'), ['Bilt Obsidian']);
+  assert.deepEqual(shared.get('bilt-obsidian'), ['Bilt Blue']);
+  assert.equal(shared.has('other'), false);
+});
+
+test('suppressRemovals drops removals but keeps additions (AAA pair)', () => {
+  const current = [
+    { category: 'gas', value: 5, unit: 'percent' },
+    { category: 'dining', value: 3, unit: 'percent' },
+    { category: 'everything_else', value: 1, unit: 'percent' },
+  ];
+  const proposed = [
+    { category: 'gas', value: 5, unit: 'percent' },
+    { category: 'wholesale_clubs', value: 3, unit: 'percent' },
+    { category: 'everything_else', value: 1, unit: 'percent' },
+  ];
+  const withRemovals = diffRewards(current, proposed);
+  assert.equal(withRemovals.removed.length, 1, 'sanity: dining is removed without the flag');
+
+  const diff = diffRewards(current, proposed, { suppressRemovals: true });
+  assert.equal(diff.removed.length, 0);
+  assert.equal(diff.added.length, 1, 'additions still surface for shared-page cards');
+});
+
+console.log('\nFetch evidence gate (#1743):');
+
+test('hasRewardEvidence rejects a nav-and-footer shell', () => {
+  assert.equal(
+    hasRewardEvidence('Credit Cards Personal Business Rewards Sign In Locations Contact Us Privacy'),
+    false
+  );
+});
+
+test('hasRewardEvidence rejects a bot-block interstitial', () => {
+  assert.equal(
+    hasRewardEvidence('Access Denied You do not have permission to access this page Reference 18.2f'),
+    false
+  );
+});
+
+test('hasRewardEvidence accepts a real earn table', () => {
+  assert.equal(
+    hasRewardEvidence('Earn 5% cash back on travel, 3% on dining and drugstores, and 1.5% on all other purchases'),
+    true
+  );
+});
+
+test('hasRewardEvidence accepts points-per-dollar phrasing', () => {
+  assert.equal(
+    hasRewardEvidence('Earn 10X points on hotels, 5X on flights, and 2X on everything else'),
+    true
+  );
+});
+
+console.log('\nassessExtractionTrust:');
+
+test('cards with no YAML rewards are always trusted (nothing to contradict)', () => {
+  assert.equal(assessExtractionTrust([], []).trusted, true);
+});
+
+test('matching under half the existing categories is untrusted', () => {
+  const current = [
+    { category: 'dining', value: 3, unit: 'percent' },
+    { category: 'gas', value: 3, unit: 'percent' },
+    { category: 'groceries', value: 3, unit: 'percent' },
+    { category: 'everything_else', value: 1, unit: 'percent' },
+  ];
+  const proposed = [{ category: 'everything_else', value: 1, unit: 'percent' }];
+  const t = assessExtractionTrust(current, proposed);
+  assert.equal(t.trusted, false);
+  assert.match(t.reason, /matched only 1 of 4/);
+});
+
+console.log('\nDeclined-review memory (#1743):');
+
+test('review-declined.yaml parses and is non-empty', () => {
+  const d = loadDeclined();
+  assert.ok(d.rewardsAdded.size > 0, 'expected seeded rewards_added entries');
+  assert.ok(d.rewardsRemoved.size > 0, 'expected seeded rewards_removed entries');
+});
+
+test('a declined addition is filtered (AAA Daily Advantage travel)', () => {
+  assert.equal(isDeclined('reward_added', 'aaa-daily-advantage-visa-signature', 'travel'), true);
+});
+
+test('a declined removal is filtered (Venture X everything_else)', () => {
+  assert.equal(isDeclined('reward_removed', 'capital-one-venture-x', 'everything_else'), true);
+});
+
+test('the declined list is scoped per card, not global', () => {
+  assert.equal(isDeclined('reward_added', 'chase-sapphire-preferred', 'travel'), false);
+});
+
+test('added and removed lists do not leak into each other', () => {
+  assert.equal(isDeclined('reward_removed', 'aaa-daily-advantage-visa-signature', 'travel'), false);
 });
 
 console.log('\nDone.\n');


### PR DESCRIPTION
Triaging review issue #1743 found **12 real items out of 64**. Every one of the other 52 traces to a specific detector gap. This PR fixes all seven, ranked by how many items each would have removed from that issue.

Companion PR #1764 lands the 12 accepted YAML rows.

## 1. Extraction trust floor — 11 items

A failed extraction was structurally indistinguishable from "the issuer removed these categories." An empty `proposed` array walked straight through the removed loop and reported every row the card has as missing:

| Card | Rows flagged removed | Actually changed |
|---|---|---|
| Capital One Venture X | 4 of 4 (incl. `everything_else`) | nothing |
| Capital One VentureOne | 2 of 2 (incl. `everything_else`) | nothing |
| Hawaiian Airlines Business | 5 of 5 (incl. `everything_else`) | nothing |

A removal claim now requires evidence the earn table was actually read: a non-empty extraction, the base rate present if the card has one, and at least half the existing categories matched (counting alias and meta equivalences). Untrusted extractions also stop auto-PRing value rewrites, since a page we can't trust to say what is absent shouldn't get to rewrite what is present.

## 2. Declined-review memory — 27 of 51 distinct lines (53%)

`getRemovedBenefitsForCard` only remembers proposals that once **landed** in a card's YAML and were later deleted. A proposal a human declined in the review issue never touched the YAML, so it has no git history and comes back every week forever. Comparing #1743 against #1636 / #1666 / #1731, 27 of its 51 distinct lines had already been triaged away.

New `data/review-declined.yaml` closes the loop, seeded with everything rejected from #1743 (37 entries, all slugs validated against `data/cards/`). Each review-issue section now ends with a one-line pointer telling the triager where to record a decline.

## 3. Fetch-quality gate

The old floor was `stripped.length >= 200`, which any bot-block page, cookie wall, or JS shell clears. That is the root cause of most of the removal bucket: Capital One and Citi render their earn tables client-side, and the Barclays URL for Hawaiian Business returns **403**. Now the fetcher requires rate-shaped tokens (`5%`, `3X`, `2 points per $1`) before accepting a result, surfaces non-2xx explicitly, waits for rate text to render instead of a flat 3s, and returns null when nothing renders rather than passing chrome to the extractor.

## 4. Shared apply pages

Eight cards share three URLs: the three Bilt cards, both AAA Visa Signatures, both Navy Federal Cash Rewards. The extractor sees every card's table on one page and can't attribute rows, which is how AAA Daily Advantage got AAA Travel Advantage's `travel` 3%. The map is built once and used twice: the prompt names the sibling cards and tells the extractor to omit anything it can't attribute, and removals are suppressed for those cards (additions still surface).

## 5. Meta-row suppression completeness

`collectMetaCoveredCategories` reads `eligible_categories` / `current_categories`, but four cards had meta rows with **no such list**, silently no-opping the suppression: Citi Strata, World of Hyatt Business, and both BofA Customized Cash cards. Backfilled, plus a `build-cards` rule so a meta row without its bucket list fails the build instead of quietly disabling a guard. Also suppresses a proposal that names a meta id itself when the YAML models the same bucket under a different meta id (Hyatt `top_category` vs proposed `selected_categories`).

## 6. Generalized alias groups

`PORTAL_ALIAS_GROUP` becomes `CATEGORY_ALIAS_GROUPS`, adding:

- `entertainment` ↔ `entertainment_portal` (C1 Venture)
- `streaming` ↔ `tv_internet_streaming` (PlayStation Visa)
- `gas` ↔ `ev_charging` — issuers advertise these as one line, so every card that splits them orphaned its `ev_charging` row weekly (both AAA cards, Atmos Business)

Plus a `BROADER_THAN` containment map so a broad `travel` proposal doesn't fight a YAML that splits `airlines` + `hotels` (Citi Strata Premier).

## 7. Base-rate restatement guard

A proposed rate equal to the card's `everything_else` rate in the same unit carries no information the base row doesn't. Amex Blue Business Plus's 2x base kept arriving as a new `travel_portal` 2x row.

## Policy change worth a second look

The standard travel and purchase insurance names move from `borderline` to `exclude` in `benefit-policy.yaml`. They were **all 15** of #1743's borderline bucket and were declined in four consecutive issues (#1636, #1666, #1731, #1743). The reason they keep getting declined is structural: the benefit model is built on a concrete annual dollar value, and insurance coverage has an expected value near zero, so a "$10,000 trip cancellation" line would be modeled as $10,000 of value. This only stops the checker from proposing them; cards already carrying these benefits keep them. Easy to revert if you'd rather keep seeing them.

## Testing

27 new regression tests, one per #1743 case, including the three all-rows-flagged cards by name. Full suite 65 passing, `npm run build:cards` clean on all 183 cards.

```bash
node scripts/check-card-rewards-and-benefits.test.js
```