### PR TITLE
Navy Federal: refresh expired SUB offer window to 1/3/2027

### DIFF
--- a/data/cards/navy-federal-cash-rewards-plus.yaml
+++ b/data/cards/navy-federal-cash-rewards-plus.yaml
@@ -33,7 +33,7 @@ signup_bonus:
   type: cash
   spend_requirement: 2500
   timeframe_months: 3
-  note: "Offer valid for accounts opened through 6/30/2026"
+  note: "Offer valid for applications through 1/3/2027"
 apr:
   balance_transfer_intro:
     rate: 1.99

--- a/data/cards/navy-federal-cash-rewards.yaml
+++ b/data/cards/navy-federal-cash-rewards.yaml
@@ -20,7 +20,7 @@ signup_bonus:
   type: cash
   spend_requirement: 2500
   timeframe_months: 3
-  note: "Offer valid for accounts opened through 6/30/2026"
+  note: "Offer valid for applications through 1/3/2027"
 apr:
   balance_transfer_intro:
     rate: 1.99

--- a/data/cards/navy-federal-flagship-rewards.yaml
+++ b/data/cards/navy-federal-flagship-rewards.yaml
@@ -11,8 +11,9 @@ our_take: >
   contender for frequent travelers, offering 3 points per dollar on a wide
   range of travel expenses from airlines to amusement parks. With a modest $49
   annual fee, the card provides solid value, especially when you factor in the
-  35,000-point signup bonus, which is worth $350, plus a free year of Amazon
-  Prime if you spend $3,500 in the first three months. The card also includes
+  35,000-point signup bonus, worth $350 when you spend $3,500 in the first
+  three months, plus a free Amazon Prime annual membership (a $139 value) each
+  year when you pay for it with the card. The card also includes
   valuable travel perks like up to $120 in statement credits for Global Entry
   or TSA PreCheck every four years and a complimentary 3GB GigSky
   international mobile data plan. However, outside of travel, the rewards rate
@@ -38,12 +39,20 @@ signup_bonus:
   type: points
   spend_requirement: 3500
   timeframe_months: 3
-  note: "Worth $350, plus a free year of Amazon Prime (a $139 value) when charged to the card; offer valid for accounts opened through 6/30/2026"
+  note: "Worth $350; offer valid for applications through 1/3/2027"
 apr:
   regular:
     min: 14.74
     max: 18.00
 benefits:
+  - name: "Amazon Prime Membership Credit"
+    value: 139
+    description: "Statement credit covering one Amazon Prime annual membership per year when the membership is paid with the card"
+    frequency: "annual"
+    category: "shopping"
+    enrollment_required: false
+    merchants:
+      - amazon
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120
     description: "Up to $120 in statement credits for Global Entry or TSA PreCheck application fees, once every 4 years"

--- a/data/cards/navy-federal-more-rewards-american-express.yaml
+++ b/data/cards/navy-federal-more-rewards-american-express.yaml
@@ -44,7 +44,7 @@ signup_bonus:
   type: points
   spend_requirement: 2000
   timeframe_months: 3
-  note: "Worth $200; offer valid for accounts opened through 6/30/2026"
+  note: "Worth $200; offer valid for applications through 1/3/2027"
 apr:
   regular:
     min: 14.15


### PR DESCRIPTION
The four Navy Federal signup_bonus notes read "offer valid for accounts opened through 6/30/2026", which is now past. Checked each card's live navyfederal.org page today (2026-07-25): **every offer renewed with identical value and spend requirement** — the disclosures now read "offer valid for accounts applied for between 07/01/2026 and 01/03/2027", so this is a note-only date refresh on all four SUB blocks.

| Card | Bonus | Spend / window | Change |
|---|---|---|---|
| cashRewards Plus | $250 | $2,500 / 90 days | note date only |
| cashRewards | $250 | $2,500 / 90 days | note date only |
| Flagship Rewards | 35,000 pts | $3,500 / 90 days | note date + Prime moved to benefits |
| More Rewards Amex | 20,000 pts | $2,000 / 90 days | note date only |

**Flagship Amazon Prime restructure:** the live page no longer bundles a "free year of Amazon Prime" into the signup offer. It's now a standing card perk — a statement credit covering one Prime **annual** membership per year when the membership is paid with the card (footnote: "Limit of one Amazon statement credit per account, per year"). Moved it out of the signup_bonus note into `benefits` (value 139, frequency annual, `merchants: [amazon]` so it surfaces on the Amazon store page), and updated the one our_take sentence that tied Prime to the $3,500 signup spend.

Also swept the rest of the lineup: no other card YAML carries the 6/30/2026 date, and the remaining Navy Federal cards (GO REWARDS, GO BIZ, Platinum, cashRewards Secured) have no signup_bonus blocks — matches the live pages, which show no bonuses for them.

`npm run build:cards` validates all 183 cards; regenerated cards.json not committed per convention.