### PR TITLE
Auto: Robinhood Platinum rewards/benefits update — 2026-07-26

### DIFF
--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -77,6 +77,12 @@ benefits:
     frequency: "semi_annual"
     category: "travel"
     enrollment_required: false
+  - name: "Eight Sleep Credit"
+    value: 1000
+    description: "Up to a $1,000 one-time credit toward the Eight Sleep Pod and Base, valid through 9/15."
+    frequency: "one_time"
+    category: "shopping"
+    enrollment_required: false
 tags:
   - premium
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Robinhood Platinum**.

**Apply link (verify against this):** https://robinhood.com/us/en/creditcard/platinum/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
