### PR TITLE
Fix: stop counting no-op reward rewrites as auto changes

### DIFF
--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -1587,7 +1587,14 @@ function editRewardValue(text, categoryId, newValue) {
   for (let i = 0; i < Math.min(lines.length, 8); i++) {
     const valM = lines[i].match(/^(\s*)value:\s*[\d.]+(\s*)$/);
     if (valM) {
-      lines[i] = `${valM[1]}value: ${newValue}${valM[2]}`;
+      const newLine = `${valM[1]}value: ${newValue}${valM[2]}`;
+      // A rewrite to the identical line is not a change. diffRewards also
+      // reports `changed` for cap-field-only diffs (spend_cap, cap_period,
+      // rate_after_cap), which this function does not write — returning
+      // `true` there inflated cardsModified/autoChanges with edits that
+      // never reached the file.
+      if (lines[i] === newLine) return { text, changed: false };
+      lines[i] = newLine;
       const newAfter = lines.join('\n');
       return { text: text.slice(0, m.index + m[0].length) + newAfter, changed: true };
     }
@@ -1660,9 +1667,15 @@ function appendBenefits(text, newBenefits) {
   return { text: `${trimmed}\nbenefits:\n${blocks}\n`, changed: true };
 }
 
+// Returns { wrote, rewardEdits, benefitEdits, ftxnEdit } so the caller counts
+// what actually reached the file rather than what was proposed. `rewardEdits`
+// can be shorter than `rewardsDiff.changed` — see editRewardValue.
 function applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff) {
   let text = card.content;
   let modified = false;
+  const rewardEdits = [];
+  let benefitEdits = 0;
+  let ftxnEdit = false;
 
   // FTF — single-line edit or insert
   if (ftxnDiff && ftxnDiff.to !== undefined) {
@@ -1670,6 +1683,7 @@ function applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff) {
     if (r.changed) {
       text = r.text;
       modified = true;
+      ftxnEdit = true;
     }
   }
 
@@ -1680,6 +1694,7 @@ function applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff) {
     if (r.changed) {
       text = r.text;
       modified = true;
+      rewardEdits.push(to);
     }
   }
 
@@ -1689,12 +1704,13 @@ function applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff) {
     if (r.changed) {
       text = r.text;
       modified = true;
+      benefitEdits = benefitsDiff.auto.length;
     }
   }
 
-  if (!modified) return false;
+  if (!modified) return { wrote: false, rewardEdits: [], benefitEdits: 0, ftxnEdit: false };
   fs.writeFileSync(card.filepath, text);
-  return true;
+  return { wrote: true, rewardEdits, benefitEdits, ftxnEdit };
 }
 
 // ─── Review-queue formatting ────────────────────────────────────────────────
@@ -1870,6 +1886,10 @@ async function main() {
     // enough to trust for removals. A rising count means the scrapers are
     // degrading, and is worth acting on before the queue goes quiet.
     untrustedExtractions: 0,
+    // Reward diffs that passed the filters but that the writer cannot express
+    // in YAML today (cap-field-only changes). Non-zero means real signal is
+    // being dropped, not that nothing changed.
+    unwrittenRewardDiffs: 0,
     staleRotatingPeriods: staleRotations.length,
   };
 
@@ -2006,6 +2026,10 @@ function finishPhase({ cards, policy, sharedUrls }) {
     // enough to trust for removals. A rising count means the scrapers are
     // degrading, and is worth acting on before the queue goes quiet.
     untrustedExtractions: 0,
+    // Reward diffs that passed the filters but that the writer cannot express
+    // in YAML today (cap-field-only changes). Non-zero means real signal is
+    // being dropped, not that nothing changed.
+    unwrittenRewardDiffs: 0,
     staleRotatingPeriods: staleRotations.length,
   };
 
@@ -2074,15 +2098,29 @@ function applyExtraction({ card, extracted, pageContent, policy, summary, shared
       pageContent
     );
 
-    const wrote = applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff);
-    if (wrote) {
+    const applied = applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff);
+    if (applied.wrote) {
       summary.cardsModified++;
       summary.autoChanges +=
-        rewardsDiff.changed.length + benefitsDiff.auto.length + (ftxnDiff ? 1 : 0);
+        applied.rewardEdits.length + applied.benefitEdits + (applied.ftxnEdit ? 1 : 0);
       console.log(
-        `  [auto] ${rewardsDiff.changed.length} reward change(s), ${benefitsDiff.auto.length} new benefit(s), ` +
-        `FTF ${ftxnDiff ? `${ftxnDiff.from}→${ftxnDiff.to}` : 'unchanged'}`
+        `  [auto] ${applied.rewardEdits.length} reward change(s), ${applied.benefitEdits} new benefit(s), ` +
+        `FTF ${applied.ftxnEdit ? `${ftxnDiff.from}→${ftxnDiff.to}` : 'unchanged'}`
       );
+    }
+
+    // A `changed` entry the writer could not apply is a cap-field-only diff
+    // (spend_cap / cap_period / rate_after_cap). Nothing writes those today,
+    // so say so out loud instead of letting it vanish into the auto count.
+    const droppedRewardEdits = rewardsDiff.changed.length - applied.rewardEdits.length;
+    if (droppedRewardEdits > 0) {
+      const appliedSet = new Set(applied.rewardEdits);
+      const cats = rewardsDiff.changed
+        .filter(c => !appliedSet.has(c.to))
+        .map(c => c.to.category)
+        .join(', ');
+      console.log(`  [skip] ${droppedRewardEdits} reward diff(s) not written (cap fields only): ${cats}`);
+      summary.unwrittenRewardDiffs = (summary.unwrittenRewardDiffs || 0) + droppedRewardEdits;
     }
 
     if (rewardsDiff.downgraded.length > 0) {
@@ -2114,6 +2152,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  editRewardValue,
   diffRewards,
   diffBenefits,
   diffForeignTxn,

--- a/scripts/check-card-rewards-and-benefits.test.js
+++ b/scripts/check-card-rewards-and-benefits.test.js
@@ -11,6 +11,7 @@
 
 const assert = require('node:assert/strict');
 const {
+  editRewardValue,
   diffRewards,
   diffBenefits,
   diffForeignTxn,
@@ -743,6 +744,50 @@ test('the declined list is scoped per card, not global', () => {
 
 test('added and removed lists do not leak into each other', () => {
   assert.equal(isDeclined('reward_removed', 'aaa-daily-advantage-visa-signature', 'travel'), false);
+});
+
+// ─── editRewardValue ────────────────────────────────────────────────────────
+//
+// diffRewards reports `changed` for cap-field-only diffs (spend_cap,
+// cap_period, rate_after_cap), which this writer does not express. It must
+// report changed:false there, or those non-edits inflate cardsModified and
+// autoChanges with writes that never reach the file (2026-07-26 run:
+// 18 cards modified reported, 5 actually changed).
+console.log('\neditRewardValue:');
+
+const REWARD_YAML = [
+  'name: Test',
+  'rewards:',
+  '  - category: gas',
+  '    value: 5',
+  '    spend_cap: 6000',
+  '  - category: everything_else',
+  '    value: 1',
+  '',
+].join('\n');
+
+test('rewriting a value line to the same number is not a change', () => {
+  const r = editRewardValue(REWARD_YAML, 'gas', 5);
+  assert.equal(r.changed, false);
+  assert.equal(r.text, REWARD_YAML);
+});
+
+test('a real value change is applied and reported', () => {
+  const r = editRewardValue(REWARD_YAML, 'gas', 3);
+  assert.equal(r.changed, true);
+  assert.match(r.text, /- category: gas\n {4}value: 3\n/);
+});
+
+test('the base rate is subject to the same no-op check', () => {
+  const r = editRewardValue(REWARD_YAML, 'everything_else', 1);
+  assert.equal(r.changed, false);
+  assert.equal(r.text, REWARD_YAML);
+});
+
+test('a category absent from the YAML is not a change', () => {
+  const r = editRewardValue(REWARD_YAML, 'dining', 4);
+  assert.equal(r.changed, false);
+  assert.equal(r.text, REWARD_YAML);
 });
 
 console.log('\nDone.\n');


### PR DESCRIPTION
`editRewardValue` rewrote the `value:` line and returned `changed: true` even when the new number equalled the old one.

`diffRewards` pushes to `changed` when `value` **or** `spend_cap` / `cap_period` / `rate_after_cap` differ, but `applyChangesToYaml` only ever calls `editRewardValue(text, to.category, to.value)`, which touches the `value:` line alone. A cap-field-only diff therefore rewrote the line to the identical string and was counted as an applied change.

In the 2026-07-26 weekly run this reported `cardsModified: 18` / `autoChanges: 24` while only 5 YAMLs actually differed, and all 5 were benefit additions — every reward edit it claimed had been a no-op.

## Changes

- `editRewardValue` returns `changed: false` when the rewritten line is identical.
- `applyChangesToYaml` returns what it actually applied (`rewardEdits`, `benefitEdits`, `ftxnEdit`); the caller counts and logs that instead of the proposed diff.
- Reward diffs the writer cannot express are logged as `[skip] ... (cap fields only)` and counted in a new `unwrittenRewardDiffs` summary field, so they are visibly dropped rather than silently folded into the auto count.

## Not fixed here

Cap-field changes still are not written to YAML — nothing in the writer expresses `spend_cap` / `cap_period` / `rate_after_cap`. This PR only stops them being *reported* as applied. The new counter makes the gap measurable.

## Tests

Four cases added to `scripts/check-card-rewards-and-benefits.test.js` covering the no-op rewrite, a real value change, the base-rate path, and a missing category. Full suite passes.