### PR TITLE
card-page-check: stop skipping amazon.com; block only the browser fetch

### DIFF
--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isBenignClientError } from "./benignClientError";
 
 // Mimics a browser DOMException without depending on the DOM lib in tests.
@@ -127,5 +127,42 @@ describe("isBenignClientError", () => {
   it("handles null/undefined safely", () => {
     expect(isBenignClientError(null)).toBe(false);
     expect(isBenignClientError(undefined)).toBe(false);
+  });
+
+  // "Event `Event` (type=error) captured as promise rejection" — foreign
+  // main-world code (extensions) rejecting with a raw DOM Event. Node has a
+  // global Event, so these use the real constructor.
+  it("drops a bare DOM Event used as a rejection reason", () => {
+    expect(isBenignClientError(new Event("error"))).toBe(true);
+  });
+
+  it("drops bare DOM Events regardless of type", () => {
+    expect(isBenignClientError(new Event("unhandledrejection"))).toBe(true);
+  });
+
+  it("keeps ErrorEvents, which carry a real error payload", () => {
+    // Node has no ErrorEvent; stub one derived from the real Event so both
+    // instanceof checks in the implementation see it.
+    class FakeErrorEvent extends Event {
+      readonly message: string;
+      constructor(type: string, message: string) {
+        super(type);
+        this.message = message;
+      }
+    }
+    vi.stubGlobal("ErrorEvent", FakeErrorEvent);
+    try {
+      expect(
+        isBenignClientError(new FakeErrorEvent("error", "boom")),
+      ).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps an Error whose message merely mentions an Event", () => {
+    expect(isBenignClientError(new Error("Event: something failed"))).toBe(
+      false,
+    );
   });
 });

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -26,6 +26,19 @@
 // Mobile Safari can also surface WebExtension content-script messaging failures
 // as page-level unhandled rejections even though the page never calls the
 // extension API. These are user-extension/WebKit noise, not app failures.
+//
+// A separate shape entirely: an unhandled rejection whose reason is a bare DOM
+// Event (Sentry: "Event `Event` (type=error) captured as promise rejection",
+// CREDITODDS-JAVASCRIPT-NEXTJS-12). Audit of everything shipped on the page
+// (2026-07-26) found no promise that rejects with a raw event — our own code
+// doesn't, and Turbopack's chunk loader rejects with undefined, Next's router
+// wraps chunk failures in real Errors, posthog-js reports loader failures via
+// callbacks, and Firebase rejects DOMExceptions/FirebaseErrors/strings. So an
+// Event-as-rejection-reason can only come from foreign main-world code
+// (browser extensions, injected third-party scripts), and it is inherently
+// unactionable: a bare Event carries no stack, no message, and no URL.
+// ErrorEvent is deliberately NOT matched — it carries a real message/error
+// payload worth reporting.
 const BENIGN_CLIENT_SIGNATURES = [
   'The transaction was aborted',
   'database connection is closing',
@@ -45,7 +58,24 @@ const BENIGN_ANY_ERROR_SIGNATURES = [
 // DOMException.ABORT_ERR — the numeric code carried by AbortErrors.
 const ABORT_ERR_CODE = 20;
 
+// True when the rejection reason is a bare DOM Event (see block comment above).
+// Guarded lookups because this module is also exercised in Node-based tests,
+// where Event exists but ErrorEvent does not.
+function isBareEventRejection(error: unknown): boolean {
+  if (typeof Event === 'undefined' || !(error instanceof Event)) {
+    return false;
+  }
+  if (typeof ErrorEvent !== 'undefined' && error instanceof ErrorEvent) {
+    return false;
+  }
+  return true;
+}
+
 export function isBenignClientError(error: unknown): boolean {
+  if (isBareEventRejection(error)) {
+    return true;
+  }
+
   // Walk the cause chain in case Firebase wraps the original DOMException.
   let current: unknown = error;
   for (let depth = 0; current != null && depth < 5; depth++) {

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -43,6 +43,11 @@ apr:
     max: 27.49
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/amazon-prime-rewards
 special_apply_link: https://www.amazon.com/dp/BT00LN946S
+# Pins the daily page check to the Chase page. The amazon.com special_apply_link
+# gates its terms behind sign-in, so it is the worse of the two sources; this
+# card used to land on Chase only as a side effect of amazon.com sitting in the
+# checker's blocked-host list, which it no longer does.
+page_check_url: https://creditcards.chase.com/cash-back-credit-cards/amazon-prime-rewards
 foreign_transaction_fee: false
 our_take: >
   The Amazon Prime Rewards Visa Signature card shines for Amazon Prime members

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -268,6 +268,38 @@ function stripHtml(html) {
 //
 // (The Atmos cards previously listed here moved to scrapeable Bank of America
 // apply_links; the alaskaair.com SPA that rendered ~20 chars is no longer used.)
+//
+// Currently empty, and that is the healthy state — an entry here means a card is
+// permanently unverified, so each one needs a measurement behind it, not a
+// hunch. Note what a *host* block is and isn't: it must be a failure no fetch
+// mode can get past. A page that only defeats Playwright belongs in
+// BROWSER_BLOCKED_HOSTS below, which keeps the card checked.
+const KNOWN_BLOCKED_HOSTS = new Map();
+
+// Hosts that answer headless Chromium with a bot interstitial but serve a plain
+// HTTP fetch normally. These are NOT skips: the card is still checked, we just
+// never let Playwright near it. Enforced inside fetchWithBrowser() so every
+// caller is covered — the simple-fetch fallback, the fetch phase's
+// no-offer-language re-fetch, the needsBrowserRetry self-heal, and the iframe
+// self-heal alike.
+//
+// This distinction is load-bearing rather than cosmetic. The interstitial is 153
+// chars, comfortably over fetchWithBrowser's 100-char floor, so it does not read
+// as a failed fetch: it would REPLACE good simple-fetch content and set the
+// card's browser_first flag, which sends every later run straight to Playwright
+// and makes the damage permanent.
+const BROWSER_BLOCKED_HOSTS = new Map([
+  ['amazon.com', 'amazon.com answers headless Chromium with a "Continue shopping" interstitial; its plain fetch is fine'],
+]);
+
+function browserBlockedReason(url) {
+  try {
+    return BROWSER_BLOCKED_HOSTS.get(new URL(url).hostname.replace(/^www\./, '')) || null;
+  } catch {
+    return null;
+  }
+}
+
 function knownBlockedReason(url) {
   try {
     const u = new URL(url);
@@ -279,21 +311,29 @@ function knownBlockedReason(url) {
     // 10.5k-12.7k chars of real product page, verified per card before removal.
     // Re-add it if the check ever moves back into CI.
 
-    // amazon.com serves an automation interstitial ("Click the button below to
-    // continue shopping") instead of card terms. Re-verified from a residential
-    // IP on 2026-07-21 and it STILL does: the Amazon Store apply_link returned
-    // 154 chars of interstitial. It is inconsistent rather than fixed — one
-    // fetch returned 18k chars of product page, but with no offer language in
-    // it — so the entry stays.
+    // amazon.com was listed here until 2026-07-26, on the theory that the host
+    // serves an automation interstitial ("Click the button below to continue
+    // shopping") instead of card terms. That attribution was wrong: the
+    // interstitial is a *headless Chromium* response, not a host-level block.
+    // Measured against the Amazon Store apply_link on 2026-07-26, both modes
+    // back to back:
+    //   simple fetch (node fetch + UA header) -> HTTP 200, 64,002 chars of real
+    //     product page (gift card / upon approval / prequalify / APR / 5% back)
+    //   Playwright, this script's exact launch+context config -> HTTP 200,
+    //     153 chars: "Click the button below to continue shopping"
+    // The earlier "154 chars from a residential IP" re-verification was almost
+    // certainly measured through the browser path, which is why the conclusion
+    // landed on the host. amazon.com is now handled by browserBlockedReason()
+    // instead: fetch it, just never with Playwright.
     //
-    // This entry is also load-bearing for a card it does not name. Amazon Prime
-    // carries an amazon.com `special_apply_link`, and checkUrlFor() only skips a
-    // special_apply_link when knownBlockedReason() flags its host. Drop this
-    // entry and Prime silently stops being checked against its scrapeable Chase
-    // apply_link and starts being checked against a 153-char interstitial.
-    // Measured, not theorised. If you remove this, give Prime an explicit
-    // `page_check_url` pointing at the Chase page first.
-    if (host === 'amazon.com') return 'amazon.com serves an automation interstitial ("Continue shopping") instead of card terms';
+    // Amazon Prime used to depend on this entry — it carries an amazon.com
+    // `special_apply_link`, and checkUrlFor() only skips a special_apply_link
+    // when knownBlockedReason() flags its host, so removing the entry would have
+    // re-pointed Prime away from its scrapeable Chase page. Prime now carries an
+    // explicit `page_check_url` for the Chase page, which wins in checkUrlFor()
+    // outright. Any NEW card with an amazon.com special_apply_link needs the
+    // same explicit page_check_url — don't rely on a block entry to steer it.
+    return KNOWN_BLOCKED_HOSTS.get(host) || null;
   } catch { /* malformed URL — let the normal fetch path handle it */ }
   return null;
 }
@@ -462,6 +502,17 @@ async function getBrowser() {
 }
 
 async function fetchWithBrowser(url) {
+  // Refuse before launching: this host hands headless Chromium an interstitial
+  // that is long enough to pass for content. Returning null keeps the caller on
+  // whatever the simple fetch produced and, because usedBrowser stays false,
+  // leaves the card's browser_first flag unset.
+  const browserBlocked = browserBlockedReason(url);
+  if (browserBlocked) {
+    lastFetchError = `browser fetch not attempted: ${browserBlocked}`;
+    console.log(`  Skipping browser fetch: ${browserBlocked}`);
+    return null;
+  }
+
   const browser = await getBrowser();
   if (!browser) { lastFetchError = 'Playwright unavailable'; return null; }
 
@@ -1539,7 +1590,11 @@ async function main() {
   // page reading as "no changes" is exactly the false-verified case the browser
   // retry path exists to prevent.
   const fetchCardPage = async (apply_link, browserFirstValid) => {
-    if (browserFirstValid) {
+    // A browser_first flag on a browser-blocked host would send the card
+    // straight to a fetch that cannot succeed, turning a checkable card into a
+    // guaranteed skip. Stale flags outlive the entry that invalidates them, so
+    // honour the block over the flag.
+    if (browserFirstValid && !browserBlockedReason(apply_link)) {
       console.log('  Known browser-dependent page — skipping simple fetch');
       const content = await fetchWithBrowser(apply_link);
       return content ? { content, usedBrowser: true } : null;


### PR DESCRIPTION
## Why

The Amazon Store card has gone **12 consecutive runs unverified**. The cause was recorded as amazon.com serving an automation interstitial instead of card terms. That attribution was wrong.

Measured both of the script's fetch modes back to back against the card's `apply_link`:

| Mode | Result |
|---|---|
| Simple fetch (node `fetch` + UA header) | **HTTP 200, 64,002 chars** of real product page — gift card, upon approval, prequalify, APR, annual fee, 5% back |
| Playwright, this script's exact launch + context config | **HTTP 200, 153 chars**: "Click the button below to continue shopping" |

The interstitial is a **headless-Chromium** response, not a host-level block. So the card was never actually being blocked: `knownBlockedReason()` short-circuited it before any request went out, which is why the skip was perfectly deterministic across 12 runs instead of intermittent, as a real block would be.

The earlier "154 chars from a residential IP" re-verification in the code comment was almost certainly measured through the browser path, which is how the conclusion landed on the host.

## What changed

Split the two ideas that were conflated in one list:

- `KNOWN_BLOCKED_HOSTS` keeps its old meaning — *no fetch mode works, record a skip*. It is now empty, which is the healthy state.
- `BROWSER_BLOCKED_HOSTS` (new) means *fetch it, just never with Playwright*. Enforced inside `fetchWithBrowser()` so all four call sites are covered at once: the simple-fetch fallback, the fetch phase's no-offer-language re-fetch, the `needsBrowserRetry` self-heal, and the iframe self-heal.

**Enforcing it inside `fetchWithBrowser()` is load-bearing, not tidiness.** The interstitial is 153 chars — comfortably over that function's 100-char floor — so it does not read as a failed fetch. It would *replace* good simple-fetch content and set the card's `browser_first` flag, sending every later run straight to Playwright and making the damage permanent.

The Store card is a live instance of that path, not a hypothetical: its bonus is gated behind sign-in, so `pageShowsSignupOffer()` returns false on the good 64k page and the fetch phase really does reach for the browser. `fetchCardPage()` now also honours the block over a stale `browser_first` flag, since flags outlive the entries around them.

## Amazon Prime

Prime was landing on its scrapeable Chase page only as a side effect of the old block entry — `checkUrlFor()` skips a `special_apply_link` when `knownBlockedReason()` flags its host. Removing the entry without addressing that would have silently re-pointed Prime at `amazon.com/dp/BT00LN946S`, whose terms are gated behind sign-in. It now carries an explicit `page_check_url` for the Chase page, which wins in `checkUrlFor()` outright.

Any new card with an amazon.com `special_apply_link` needs the same explicit `page_check_url` rather than relying on a block entry to steer it.

## Verification

End-to-end scoped run on both cards, fetch through finish:

```
Checking: Amazon Prime Rewards Visa Signature
  URL: https://creditcards.chase.com/cash-back-credit-cards/amazon-prime-rewards (page_check_url)
  Browser fetch succeeded (18000 chars)

Checking: Amazon Store
  Fetched 18000 chars
  No offer language in simple fetch — re-fetching with browser
  Skipping browser fetch: amazon.com answers headless Chromium with a "Continue shopping" interstitial; its plain fetch is fine

Wrote 2 prompt(s); Skipped 0 card(s) before extraction.
Verified 2/2 card(s) against their live page this run.
No changes detected.
```

- `browser_first` set for Prime only — correctly **not** set for the Store card.
- Extraction on the Store page returns a null bonus amount (gated behind sign-in), which does not disturb the stored `value: 0`, so no spurious diff.
- `node --test scripts/check-card-pages.test.js` passes.
- `npm run build:cards` validates; regenerated `data/cards.json` deliberately not committed.

## Note for review

The Store card's welcome offer is only visible after signing in, so its amount stays unverifiable by this checker no matter which fetch mode is used. What this PR fixes is the rest of the card — annual fee, APR, rewards — going unverified along with it, and the skip counter that was climbing on a false premise.