### PR TITLE
sentry: drop bare-Event promise-rejection noise (extension-injected)

### DIFF
--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isBenignClientError } from "./benignClientError";
 
 // Mimics a browser DOMException without depending on the DOM lib in tests.
@@ -127,5 +127,42 @@ describe("isBenignClientError", () => {
   it("handles null/undefined safely", () => {
     expect(isBenignClientError(null)).toBe(false);
     expect(isBenignClientError(undefined)).toBe(false);
+  });
+
+  // "Event `Event` (type=error) captured as promise rejection" — foreign
+  // main-world code (extensions) rejecting with a raw DOM Event. Node has a
+  // global Event, so these use the real constructor.
+  it("drops a bare DOM Event used as a rejection reason", () => {
+    expect(isBenignClientError(new Event("error"))).toBe(true);
+  });
+
+  it("drops bare DOM Events regardless of type", () => {
+    expect(isBenignClientError(new Event("unhandledrejection"))).toBe(true);
+  });
+
+  it("keeps ErrorEvents, which carry a real error payload", () => {
+    // Node has no ErrorEvent; stub one derived from the real Event so both
+    // instanceof checks in the implementation see it.
+    class FakeErrorEvent extends Event {
+      readonly message: string;
+      constructor(type: string, message: string) {
+        super(type);
+        this.message = message;
+      }
+    }
+    vi.stubGlobal("ErrorEvent", FakeErrorEvent);
+    try {
+      expect(
+        isBenignClientError(new FakeErrorEvent("error", "boom")),
+      ).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps an Error whose message merely mentions an Event", () => {
+    expect(isBenignClientError(new Error("Event: something failed"))).toBe(
+      false,
+    );
   });
 });

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -26,6 +26,19 @@
 // Mobile Safari can also surface WebExtension content-script messaging failures
 // as page-level unhandled rejections even though the page never calls the
 // extension API. These are user-extension/WebKit noise, not app failures.
+//
+// A separate shape entirely: an unhandled rejection whose reason is a bare DOM
+// Event (Sentry: "Event `Event` (type=error) captured as promise rejection",
+// CREDITODDS-JAVASCRIPT-NEXTJS-12). Audit of everything shipped on the page
+// (2026-07-26) found no promise that rejects with a raw event — our own code
+// doesn't, and Turbopack's chunk loader rejects with undefined, Next's router
+// wraps chunk failures in real Errors, posthog-js reports loader failures via
+// callbacks, and Firebase rejects DOMExceptions/FirebaseErrors/strings. So an
+// Event-as-rejection-reason can only come from foreign main-world code
+// (browser extensions, injected third-party scripts), and it is inherently
+// unactionable: a bare Event carries no stack, no message, and no URL.
+// ErrorEvent is deliberately NOT matched — it carries a real message/error
+// payload worth reporting.
 const BENIGN_CLIENT_SIGNATURES = [
   'The transaction was aborted',
   'database connection is closing',
@@ -45,7 +58,24 @@ const BENIGN_ANY_ERROR_SIGNATURES = [
 // DOMException.ABORT_ERR — the numeric code carried by AbortErrors.
 const ABORT_ERR_CODE = 20;
 
+// True when the rejection reason is a bare DOM Event (see block comment above).
+// Guarded lookups because this module is also exercised in Node-based tests,
+// where Event exists but ErrorEvent does not.
+function isBareEventRejection(error: unknown): boolean {
+  if (typeof Event === 'undefined' || !(error instanceof Event)) {
+    return false;
+  }
+  if (typeof ErrorEvent !== 'undefined' && error instanceof ErrorEvent) {
+    return false;
+  }
+  return true;
+}
+
 export function isBenignClientError(error: unknown): boolean {
+  if (isBareEventRejection(error)) {
+    return true;
+  }
+
   // Walk the cause chain in case Firebase wraps the original DOMException.
   let current: unknown = error;
   for (let depth = 0; current != null && depth < 5; depth++) {


### PR DESCRIPTION
## Problem

Sentry issue **CREDITODDS-JAVASCRIPT-NEXTJS-12**: unhandled promise rejection on `/news/:id` (Chrome 142 / Mac, production) with value:

> Event `Event` (type=error) captured as promise rejection

The rejection reason is a raw DOM `Event`, not an `Error`, so it carries no stack, no message, and no URL. The existing `benignClientError.ts` filter matches on `name`/`message`/`code` signatures, none of which exist on a bare `Event`, so it sailed through `beforeSend`.

## Root-cause audit

Checked every promise-rejection source actually shipped on that page (app code plus the deployed bundles, including the live Turbopack runtime chunk fetched from creditodds.com):

| Source | Rejects with |
|---|---|
| First-party components (ViewTracker, CardImage, AuthProvider, ...) | no event-shaped rejections at all |
| Turbopack chunk loader (live + local build) | `undefined` (`r.reject()` with no arg) |
| Next router script/prefetch loaders | real `Error`s (E74/E268) |
| posthog-js external-script loader | callbacks, never rejects |
| Firebase auth IDB / loadJS | `DOMException` / `FirebaseError` |
| Firebase util `validateIndexedDBOpenable` | string (and caught by `isSupported`) |
| Firebase analytics gtag inject | no error handler at all |

Nothing we ship rejects with a raw event, so this shape can only originate from foreign main-world code (browser extensions / injected scripts), a well-known Sentry noise signature, and it is unactionable by definition.

## Fix

Extend `isBenignClientError` to drop rejection reasons that are bare `Event` instances. `ErrorEvent` is deliberately excluded: it carries a real `message`/`error` payload and keeps reporting. Guarded for Node-based tests (global `Event` exists there, `ErrorEvent` does not).

## Testing

- 4 new vitest cases (bare `Event` dropped for any type; `ErrorEvent` kept via stubbed global; `Error` merely mentioning Event kept). Suite: 18/18 pass.
- `tsc --noEmit` clean.

Not browser-verifiable in a preview: the triggering rejection is injected by extension code, and the change only affects what Sentry's `beforeSend` drops.