### PR TITLE
Record three declined auto benefits, and make review-declined.yaml gate the auto path

### DIFF
--- a/data/review-declined.yaml
+++ b/data/review-declined.yaml
@@ -19,6 +19,13 @@
 # quiet permanently. Delete an entry to let it surface again (e.g. when an
 # issuer actually changes something and you want a fresh look).
 #
+# `benefits` entries also suppress the AUTO path, not just the review queue.
+# An auto-tier benefit whose PR you close unmerged is otherwise invisible to
+# every other guard: nothing lands in the YAML, so there's no removed `name:`
+# line for getRemovedBenefitsForCard to find in git history, and the branch
+# name carries the run date so the idempotency check never matches. Without
+# an entry here it comes back as a fresh PR every week.
+#
 # Matching is exact on slug + category (rewards) or slug + name (benefits),
 # except for `benefits_global`, which matches a benefit name on every card.
 
@@ -75,7 +82,13 @@ rewards_removed:
   - { slug: robinhood-gold-card, category: travel_portal }
 
 # Benefit names declined on a specific card.
-benefits: []
+benefits:
+  - { slug: chase-ihg-one-rewards-premier-business, name: "Points Purchase Discount",
+      why: "a discount on BUYING points carries no wallet value — below the small-benefits threshold (PR #1775)" }
+  - { slug: navy-federal-more-rewards-american-express, name: "Booking.com Hotel Discount",
+      why: "an Amex network offers-platform promotion, not a card benefit; rotating 'up to 30% / select properties' copy (PR #1771)" }
+  - { slug: robinhood-platinum, name: "Eight Sleep Credit",
+      why: "dated promo ('valid through 9/15') and benefits have no `expires` field, so nothing would flag it once lapsed (PR #1772)" }
 
 # Benefit names declined on EVERY card. Prefer benefit-policy.yaml's
 # `exclude` list for anything the team will never want; this is for names

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -2068,6 +2068,17 @@ function applyExtraction({ card, extracted, pageContent, policy, summary, shared
       removed,
       card.data.signup_bonus
     );
+    // A benefit declined in review-declined.yaml must not come back through
+    // the AUTO path either. Until now isDeclined only filtered the review
+    // queue, so an auto-tier benefit whose PR a human closed unmerged
+    // recurred every week forever: closing without merging leaves no removed
+    // `name:` line in git history, so getRemovedBenefitsForCard can't see it,
+    // and the dated branch name differs each run so the idempotency check
+    // never fires. (2026-07-26: IHG points-purchase discount, Navy Federal
+    // Booking.com discount, Robinhood Eight Sleep credit.)
+    benefitsDiff.auto = benefitsDiff.auto.filter(
+      b => !isDeclined('benefit', card.slug, b.name)
+    );
     const ftxnDiff = diffForeignTxn(
       card.data.foreign_transaction_fee,
       extracted.foreign_transaction_fee,


### PR DESCRIPTION
Follow-up to the 2026-07-26 weekly rewards-and-benefits run.

## Declines

Three auto-tier benefits reviewed and declined; their PRs are closed unmerged.

| Card | Benefit | Why |
|---|---|---|
| IHG One Rewards Premier Business | Points Purchase Discount | a discount on *buying* points carries no wallet value, below the small-benefits threshold ([#1775](https://github.com/CreditOdds/creditodds/pull/1775)) |
| Navy Federal More Rewards Amex | Booking.com Hotel Discount | an Amex network offers-platform promotion, not a card benefit; rotating "up to 30% / select properties" copy ([#1771](https://github.com/CreditOdds/creditodds/pull/1771)) |
| Robinhood Platinum | Eight Sleep Credit | dated promo ("valid through 9/15") and benefits have no `expires` field, so nothing flags it once lapsed ([#1772](https://github.com/CreditOdds/creditodds/pull/1772)) |

## The recording would not have worked on its own

`isDeclined` was only called inside `appendReviewEntries`, so it filtered the **review queue** and nothing else. The **auto** path that produced these three PRs never consulted it.

An auto-tier benefit whose PR a human closes unmerged is invisible to every other guard:

- nothing lands in the card YAML, so there is no removed `name:` line for `getRemovedBenefitsForCard` to find in git history;
- the branch is `auto/<slug>-rewards-benefits-<date>`, so next week's date produces a new branch and the `git ls-remote` idempotency check never matches.

All three would have come back as fresh PRs on the next run, indefinitely. `benefitsDiff.auto` is now filtered through `isDeclined` too, and the file header documents that `benefits` entries gate both paths.

## Verification

`isDeclined('benefit', …)` returns true for all three, false for a kept benefit on the same card and for the same name on a different card. Existing suite passes.