### PR TITLE
Write reward cap fields, and stop reading extractor silence as a cap removal

### DIFF
--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -1018,6 +1018,18 @@ function diffRewards(current, proposed, opts = {}) {
   //      different slices of the same issuer-travel-portal mechanic. If
   //      the YAML has one and the LLM proposes a sibling, treat as match
   //      rather than added/removed.
+  // A cap field counts as changed only when the PROPOSAL states it.
+  // spend_cap / cap_period / rate_after_cap are optional in the extraction
+  // prompt, so an apply page that doesn't restate a cap yields undefined.
+  // That is silence, not evidence the issuer removed the cap — comparing it
+  // straight (`c.spend_cap !== p.spend_cap`) turned every such silence into a
+  // phantom `changed` entry the writer then couldn't express, which is what
+  // inflated the 2026-07-26 run to 18 cards modified against 5 real edits.
+  // A genuine cap REMOVAL is indistinguishable from silence here, so it is
+  // deliberately not auto-applied.
+  const capFieldsDiffer = (c, p) =>
+    CAP_FIELDS.some(f => p[f] !== undefined && p[f] !== null && c[f] !== p[f]);
+
   const noteMentionsCap = (r) =>
     typeof r?.note === 'string' &&
     /(\bfirst\s+\$\d|\bup\s+to\s+\$\d|\bcap\b|then\s+\d+\s*(x|%)|combined\b|when you\s+(buy|pay))/i.test(r.note);
@@ -1128,12 +1140,7 @@ function diffRewards(current, proposed, opts = {}) {
       // instead of auto-PRing it. (Capped/composed everything_else downgrades
       // are already skipped silently by the guard above.)
       downgraded.push({ from: c, to: p });
-    } else if (
-      c.value !== p.value ||
-      c.spend_cap !== p.spend_cap ||
-      c.cap_period !== p.cap_period ||
-      c.rate_after_cap !== p.rate_after_cap
-    ) {
+    } else if (c.value !== p.value || capFieldsDiffer(c, p)) {
       changed.push({ from: c, to: p });
     }
   }
@@ -1573,6 +1580,98 @@ function renderBenefitBlock(b, indent = '  ') {
 // `- category: <id>` line (allowing optional quotes around the id), then
 // edit the immediately-following `value:` line. We do NOT touch `unit:`
 // because diffRewards already rejected unit-mismatch updates.
+// The cap fields, in the order the hand-written cards keep them: they trail
+// `note:` at the end of a reward row.
+const CAP_FIELDS = ['spend_cap', 'cap_period', 'rate_after_cap'];
+
+// Locate one reward row's line range.
+//
+// Only TOP-LEVEL rows count. A rotating row nests its eligible categories
+// under `current_categories:`, so `- category: "gas"` can appear twice in one
+// file at different depths — once as a real reward row and once inside the
+// rotating bucket. Matching the wrong one would write a cap onto a nested
+// descriptor. We take the indent of the first `- category:` under `rewards:`
+// as the canonical row indent and ignore anything deeper.
+function findRewardBlock(text, categoryId) {
+  const lines = text.split('\n');
+  const rewardsAt = lines.findIndex(l => /^rewards:\s*$/.test(l));
+  if (rewardsAt === -1) return null;
+
+  let rowIndent = null;
+  for (let i = rewardsAt + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i])) break; // left the rewards block
+    const m = lines[i].match(/^(\s*)-\s*category:/);
+    if (m) { rowIndent = m[1].length; break; }
+  }
+  if (rowIndent === null) return null;
+
+  const escaped = categoryId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const catRe = new RegExp(String.raw`^ {${rowIndent}}-\s*category:\s*"?${escaped}"?\s*$`);
+
+  for (let i = rewardsAt + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i])) break;
+    if (!catRe.test(lines[i])) continue;
+    // The row runs until the next line at or left of the row indent.
+    let end = i + 1;
+    while (end < lines.length) {
+      if (lines[end].trim() === '') { end++; continue; }
+      if (lines[end].match(/^\s*/)[0].length <= rowIndent) break;
+      end++;
+    }
+    return { lines, start: i, end, rowIndent, fieldIndent: rowIndent + 2 };
+  }
+  return null;
+}
+
+// Write the cap fields a proposal actually states onto a reward row: edit in
+// place when the field is already there, otherwise append in convention order.
+//
+// Fields the proposal leaves undefined are NOT touched, and never deleted.
+// `spend_cap` / `cap_period` / `rate_after_cap` are optional in the extraction
+// prompt, so a page that simply doesn't restate a cap yields undefined — which
+// is silence, not evidence the issuer dropped the cap. Treating it as a
+// deletion would strip real caps off ~45 reward rows.
+function editRewardCapFields(text, categoryId, to) {
+  const stated = CAP_FIELDS.filter(f => to[f] !== undefined && to[f] !== null);
+  if (stated.length === 0) return { text, changed: false, fields: [] };
+
+  const block = findRewardBlock(text, categoryId);
+  if (!block) return { text, changed: false, fields: [] };
+
+  const { lines, start, end, fieldIndent } = block;
+  const pad = ' '.repeat(fieldIndent);
+  const written = [];
+  let blockEnd = end;
+
+  for (const field of stated) {
+    // Only match the row's OWN fields, at exactly its field indent — never a
+    // nested descriptor's.
+    const re = new RegExp(String.raw`^ {${fieldIndent}}${field}:\s*(.*)$`);
+    const newLine = `${pad}${field}: ${to[field]}`;
+    let found = false;
+
+    for (let i = start + 1; i < blockEnd; i++) {
+      if (!re.test(lines[i])) continue;
+      found = true;
+      if (lines[i] !== newLine) {
+        lines[i] = newLine;
+        written.push(field);
+      }
+      break;
+    }
+
+    if (!found) {
+      // Append at the end of the row, which is where these live by convention.
+      lines.splice(blockEnd, 0, newLine);
+      blockEnd++;
+      written.push(field);
+    }
+  }
+
+  if (written.length === 0) return { text, changed: false, fields: [] };
+  return { text: lines.join('\n'), changed: true, fields: written };
+}
+
 function editRewardValue(text, categoryId, newValue) {
   // Match: `  - category: airlines` or `  - category: "airlines"` (with any leading indent).
   const catRe = new RegExp(
@@ -1687,12 +1786,25 @@ function applyChangesToYaml(card, rewardsDiff, benefitsDiff, ftxnDiff) {
     }
   }
 
-  // Rewards — overwrite the `value:` line for changed categories only.
-  // (Unit changes are rejected upstream by diffRewards.)
+  // Rewards — overwrite the `value:` line and any cap fields the proposal
+  // states, for changed categories only. (Unit changes are rejected upstream
+  // by diffRewards.)
   for (const { to } of rewardsDiff.changed) {
-    const r = editRewardValue(text, to.category, to.value);
-    if (r.changed) {
-      text = r.text;
+    let touched = false;
+
+    const v = editRewardValue(text, to.category, to.value);
+    if (v.changed) {
+      text = v.text;
+      touched = true;
+    }
+
+    const caps = editRewardCapFields(text, to.category, to);
+    if (caps.changed) {
+      text = caps.text;
+      touched = true;
+    }
+
+    if (touched) {
       modified = true;
       rewardEdits.push(to);
     }
@@ -2152,6 +2264,8 @@ if (require.main === module) {
 }
 
 module.exports = {
+  editRewardCapFields,
+  findRewardBlock,
   editRewardValue,
   diffRewards,
   diffBenefits,

--- a/scripts/check-card-rewards-and-benefits.test.js
+++ b/scripts/check-card-rewards-and-benefits.test.js
@@ -12,6 +12,7 @@
 const assert = require('node:assert/strict');
 const {
   editRewardValue,
+  editRewardCapFields,
   diffRewards,
   diffBenefits,
   diffForeignTxn,
@@ -788,6 +789,104 @@ test('a category absent from the YAML is not a change', () => {
   const r = editRewardValue(REWARD_YAML, 'dining', 4);
   assert.equal(r.changed, false);
   assert.equal(r.text, REWARD_YAML);
+});
+
+// ─── editRewardCapFields ────────────────────────────────────────────────────
+//
+// spend_cap / cap_period / rate_after_cap were diffed but never written. The
+// writer must express them without ever reading extractor silence as a cap
+// deletion, and without touching the nested rows a rotating bucket carries
+// under `current_categories:`.
+console.log('\neditRewardCapFields:');
+
+const CAPPED_YAML = [
+  'name: Test',
+  'rewards:',
+  '  - category: rotating',
+  '    value: 5',
+  '    unit: percent',
+  '    current_categories:',
+  '      - category: "gas"',
+  '        note: "Gas stations"',
+  '    spend_cap: 1500',
+  '    cap_period: quarterly',
+  '    rate_after_cap: 1',
+  '  - category: everything_else',
+  '    value: 1',
+  '',
+].join('\n');
+
+const UNCAPPED_YAML = [
+  'name: Test',
+  'rewards:',
+  '  - category: dining',
+  '    value: 3',
+  '    unit: percent',
+  '  - category: everything_else',
+  '    value: 1',
+  '',
+].join('\n');
+
+test('a stated cap change is written to the right row', () => {
+  const r = editRewardCapFields(CAPPED_YAML, 'rotating', { spend_cap: 2000 });
+  assert.equal(r.changed, true);
+  assert.deepEqual(r.fields, ['spend_cap']);
+  assert.match(r.text, /^ {4}spend_cap: 2000$/m);
+  assert.equal((r.text.match(/spend_cap:/g) || []).length, 1);
+});
+
+test('a proposal that states no cap fields writes nothing', () => {
+  const r = editRewardCapFields(CAPPED_YAML, 'rotating', { value: 5 });
+  assert.equal(r.changed, false);
+  assert.equal(r.text, CAPPED_YAML);
+});
+
+test('cap fields identical to the YAML are not a change', () => {
+  const r = editRewardCapFields(CAPPED_YAML, 'rotating', {
+    spend_cap: 1500, cap_period: 'quarterly', rate_after_cap: 1,
+  });
+  assert.equal(r.changed, false);
+  assert.equal(r.text, CAPPED_YAML);
+});
+
+test('a category that exists only as a nested rotating row is not writable', () => {
+  const r = editRewardCapFields(CAPPED_YAML, 'gas', { spend_cap: 999 });
+  assert.equal(r.changed, false);
+  assert.equal(r.text, CAPPED_YAML);
+});
+
+test('missing cap fields are appended in convention order after the row', () => {
+  const r = editRewardCapFields(UNCAPPED_YAML, 'dining', {
+    spend_cap: 6000, cap_period: 'annual', rate_after_cap: 1,
+  });
+  assert.equal(r.changed, true);
+  assert.deepEqual(r.fields, ['spend_cap', 'cap_period', 'rate_after_cap']);
+  assert.match(
+    r.text,
+    /- category: dining\n {4}value: 3\n {4}unit: percent\n {4}spend_cap: 6000\n {4}cap_period: annual\n {4}rate_after_cap: 1\n {2}- category: everything_else/
+  );
+});
+
+// The diff side of the same defect: an optional field the extractor didn't
+// mention must not read as a cap removal.
+console.log('\ncap-field diffing:');
+
+const CAPPED_ROW = [{
+  category: 'groceries', value: 6, unit: 'percent',
+  spend_cap: 6000, cap_period: 'annual', rate_after_cap: 1,
+}];
+
+test('extractor silence on cap fields is not a change', () => {
+  const d = diffRewards(CAPPED_ROW, [{ category: 'groceries', value: 6, unit: 'percent' }]);
+  assert.equal(d.changed.length, 0);
+});
+
+test('a stated cap change is a change', () => {
+  const d = diffRewards(CAPPED_ROW, [
+    { category: 'groceries', value: 6, unit: 'percent', spend_cap: 7000 },
+  ]);
+  assert.equal(d.changed.length, 1);
+  assert.equal(d.changed[0].to.spend_cap, 7000);
 });
 
 console.log('\nDone.\n');


### PR DESCRIPTION
Stacked on #1776 — review that one first; this PR targets its branch, so the diff here is only the cap work.

Closes the gap #1776 documented: `spend_cap` / `cap_period` / `rate_after_cap` were diffed but never written, so cap changes were detected and then silently dropped (the two Costco gas rows in the 2026-07-26 run).

## Two halves

**The writer could not express caps.** `applyChangesToYaml` only ever called `editRewardValue`, which rewrites the `value:` line. New `editRewardCapFields` edits a stated cap field in place, or appends it after the row in the order the hand-written cards use (`spend_cap`, `cap_period`, `rate_after_cap`).

**The diff was manufacturing cap changes out of silence.** Cap fields are marked *optional* in the extraction prompt, so an apply page that doesn't restate a cap yields `undefined`. `c.spend_cap !== p.spend_cap` then fired on every capped row whose page was quiet — which is what produced the phantom `changed` entries behind the 18-vs-5 discrepancy. A cap field now counts as changed only when the proposal actually states it.

A naive writer without this second half would have **stripped the caps off all 45 capped reward rows** on the first run.

## The nested-row hazard

A rotating row nests its eligible categories under `current_categories:`, so `- category: "gas"` can appear twice in one file at different depths. `findRewardBlock` takes the indent of the first `- category:` under `rewards:` as the canonical row indent and matches only at that depth, so a nested descriptor is never written to. Covered by a test.

## Not auto-applied

A genuine cap **removal** is indistinguishable from extractor silence, so it is deliberately never auto-applied.

## Verification

Exercised against every reward row in `data/cards` — 45 in-place edits, 527 appends, 572 total. Each result reparsed with `js-yaml`, the target row compared field-by-field, sibling rows and row count asserted unchanged. Zero failures. Seven new unit tests; full suite passes; `build:cards` builds all 183 cards.