### PR TITLE
United Explorer: rename "Mile Flight Savings" to "10% Award Flight Discount"

### DIFF
--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -91,7 +91,7 @@ benefits:
     frequency: "per_purchase"
     category: "statement_credit"
     enrollment_required: false
-  - name: "Mile Flight Savings"
+  - name: "10% Award Flight Discount"
     value: 10
     value_unit: "percent"
     description: "Save 10% or more on the miles needed when booking award flights on United or United Express"


### PR DESCRIPTION
Follow-up to #1773.

That PR added "Mile Flight Savings" (10% or more off the miles needed on award flights) to a card that already carried "Award Flight Discount" (earn a 10,000-mile award after \$20,000 in annual purchases). They are genuinely different benefits, but the names gave a reader no way to tell them apart on the card page.

One line: `name:` only. No value, description, frequency, or category change.

## One caveat worth recording

`looksLikeSameBenefit("Award Flight Discount", "10% Award Flight Discount")` returns **true** — the rename makes the weekly checker treat the two entries as the same benefit, where it currently sees them as distinct.

No effect on the data as it stands, and no risk of a spurious re-add. The cost is a mild false negative: if United later changes one of the two (say the \$20,000 threshold), a proposal describing it could dedupe against the other and be dropped silently.

If that trade isn't wanted, these alternatives read as clearly and test as distinct against the existing name:

- `10% Off Award Miles`
- `Award Mile Savings`
- `Reduced Mileage Awards`

## Verification

`build:cards` builds all 183 cards; the rendered card shows both benefits with distinguishable names.