### PR TITLE
fix(web-next): stop fetchWithRetry hanging forever on a 5xx

### DIFF
--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -166,11 +166,20 @@ export default async function CardPage({ params }: CardPageProps) {
     // Fetch all data in parallel — chain getCard → getCardRatings together
     // so ratings fetches concurrently with graphs/news/articles instead of after them all
     const [cardWithRatingsAndWire, graphData, records, allNews, allArticles, allCards, comparePartners, bestPages] = await Promise.all([
-      getCard(slug).then(async (card) => ({
-        card,
-        ratings: await getCardRatings(card.card_name, card.db_card_id ?? card.card_id).catch(() => ({ count: 0, average: null })),
-        wire: await getCardWire(Number(card.card_id)).catch(() => [] as CardWireEntry[]),
-      })),
+      getCard(slug).then(async (card) => {
+        // card_id is the numeric DB id once a card has been synced to the
+        // database, but falls back to the slug for a brand-new card that hasn't
+        // synced yet. Skip card-wire in that case — there are no wire entries
+        // for an unsynced card, and asking for card_id=NaN 500s the API.
+        const wireId = Number(card.card_id);
+        return {
+          card,
+          ratings: await getCardRatings(card.card_name, card.db_card_id ?? card.card_id).catch(() => ({ count: 0, average: null })),
+          wire: Number.isInteger(wireId)
+            ? await getCardWire(wireId).catch(() => [] as CardWireEntry[])
+            : ([] as CardWireEntry[]),
+        };
+      }),
       getCardGraphs(slug).catch(() => [] as GraphData[]),
       getCardRecords(slug).catch(() => [] as CardRecord[]),
       getNews().catch(() => [] as NewsItem[]),

--- a/apps/web-next/src/lib/fetchWithRetry.test.ts
+++ b/apps/web-next/src/lib/fetchWithRetry.test.ts
@@ -63,6 +63,42 @@ describe("fetchWithRetry", () => {
     expect(await out.json()).toEqual({ ok: true });
   });
 
+  it("retries a 5xx whose body can never be cancelled or read", async () => {
+    // Under Next.js's patched fetch the response is one branch of a tee'd
+    // stream, and a branch's cancel() only settles once both branches are
+    // cancelled — which Next never does. Discarding the failed body must not be
+    // able to block the retry loop, or a real 5xx hangs the whole SSR render.
+    const neverSettles = () => new Promise<never>(() => {});
+    const stuck = {
+      status: 503,
+      statusText: "Service Unavailable",
+      headers: new Headers(),
+      body: { cancel: neverSettles },
+      arrayBuffer: neverSettles,
+    } as unknown as Response;
+    const good = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const fetchMock = vi.fn().mockResolvedValueOnce(stuck).mockResolvedValue(good);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await fetchWithRetry("https://x.test", undefined, { backoffMs: 0 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(await out.json()).toEqual({ ok: true });
+  }, 2000);
+
+  it("returns the 5xx to the caller once retries are exhausted", async () => {
+    // A fresh Response per call, as real fetch gives — the retried attempts
+    // discard their bodies, so a single shared Response would be unusable.
+    const fetchMock = vi.fn(async () => new Response("upstream boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await fetchWithRetry("https://x.test", undefined, { retries: 2, backoffMs: 0 });
+
+    expect(out.status).toBe(500);
+    expect(await out.text()).toBe("upstream boom");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("does not retry a 4xx", async () => {
     const fetchMock = vi.fn().mockResolvedValue(res(404));
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/web-next/src/lib/fetchWithRetry.ts
+++ b/apps/web-next/src/lib/fetchWithRetry.ts
@@ -37,6 +37,24 @@ const backoffFor = (attempt: number, backoffMs: number) => {
 // Statuses that the Response constructor requires to have a null body.
 const NULL_BODY_STATUSES = new Set([204, 205, 304]);
 
+// Drain the body of a response we're about to throw away, so the underlying
+// socket goes back to the pool instead of waiting on the GC.
+//
+// Deliberately NOT awaited, and deliberately not `res.body.cancel()`. Under
+// Next.js's patched fetch the response handed to us is one branch of a tee'd
+// stream (Next reads the other branch into the fetch cache — see
+// next/dist/server/lib/clone-response.js). Per the ReadableStream tee contract,
+// a branch's cancel() promise only settles once BOTH branches are cancelled or
+// the source ends; Next never cancels its branch, so `await res.body.cancel()`
+// can hang forever. Verified 2026-07-27: a 500 from /card-wire during a
+// /card/[name] render never retried — the SSR request sat open until the client
+// disconnected 90s later, which is the exact opposite of what this wrapper is
+// for. Not awaiting means the retry loop can't be blocked by the discarded
+// response no matter how its body behaves.
+function discardBody(res: Response): void {
+  void res.arrayBuffer().catch(() => {});
+}
+
 export async function fetchWithRetry(
   input: string | URL,
   init?: RequestInit,
@@ -52,7 +70,7 @@ export async function fetchWithRetry(
 
       // Retry transient upstream failures (5xx), but never client errors (4xx).
       if (res.status >= 500 && attempt < retries) {
-        await res.body?.cancel();
+        discardBody(res);
         await delay(backoffFor(attempt, backoffMs));
         continue;
       }


### PR DESCRIPTION
## The bug

`fetchWithRetry` never retries a 5xx — it hangs until the request times out. The 5xx branch does:

```ts
if (res.status >= 500 && attempt < retries) {
  await res.body?.cancel();
  ...
}
```

and that `cancel()` promise never settles under Next.js's patched fetch.

## Why

It's the `ReadableStream` tee contract, not anything undici-specific.

Next hands the caller **one branch of a tee'd body**: `next/dist/server/lib/clone-response.js` does `original.body.tee()` and returns branch 2 to us while Next reads branch 1 into the fetch cache (`patch-fetch.js:147` for the cache-set path, `:869` for the foreground-revalidate path a stale `revalidate: 300` entry takes). Per spec, a branch's `cancel()` promise only settles once **both** branches are cancelled, or the source ends. Next never cancels its branch, so we wait forever.

## Repro

Found while adding a card that hadn't synced to the DB yet. On `/card/<slug>` the page calls `getCardWire(Number(card.card_id))`; for an unsynced card `card_id` is still the slug, so the URL becomes `/card-wire?card_id=NaN&limit=20`, which the API answers 500 in ~0.2s (confirmed with curl). The SSR render then never completes.

Reproduced on the dev server with a scratch route calling `fetchWithRetry` against that exact URL with `next: { revalidate: 300 }`:

```
GET /repro-hang 200 in 90s (compile: 259ms, render: 90s)
```

The render finished only when curl's 90s timeout dropped the connection. After the fix, same route:

```
settled status=500 in 905ms
```

Three attempts plus backoff, then the 500 handed back to the caller.

## The fix

- **`fetchWithRetry.ts`** — replaces the cancel with a `discardBody()` that reads and drops the body, and is deliberately **not awaited**, so the retry loop can't be blocked by the discarded response however its body behaves. Reasoning and the tee mechanism are in the comment above it.
- **`card/[name]/page.tsx`** — guards the call site that produced the 500: skip `getCardWire` when `Number(card.card_id)` isn't an integer. An unsynced card has no wire entries anyway.

## Impact beyond dev

Any genuine 5xx from `api.creditodds.com` would hang an ISR render for the full timeout instead of retrying.

## Tests

Two added to the existing `fetchWithRetry.test.ts`:

- a 5xx whose `body.cancel()` and `arrayBuffer()` both never settle (the Next tee shape) must still retry and return the good response;
- a persistent 5xx returns its body to the caller once retries are exhausted.

The first isn't vacuous — reverting the one line to `await res.body?.cancel()` makes it fail on timeout.

Full suite: 74 passed across 10 files. `tsc --noEmit` clean. A normal card page still renders its Card Wire section (200 in 2.6s).
