### PR TITLE
Stop describing merchant-gated reward rates as category-wide

### DIFF
--- a/scripts/post-new-card.js
+++ b/scripts/post-new-card.js
@@ -93,8 +93,13 @@ function isMerchantGated(reward) {
     || (Array.isArray(reward.merchant_gate) && reward.merchant_gate.length > 0);
 }
 
+// The schema's only units are `percent` and `points_per_dollar` — the bare
+// `points` this used to check is not a value any card carries, so every points
+// and miles card fed the model raw "5points_per_dollar on travel portal".
 function formatRate(reward) {
-  const unit = reward.unit === 'percent' ? '%' : (reward.unit === 'points' ? 'x' : (reward.unit || ''));
+  const unit = reward.unit === 'percent'
+    ? '%'
+    : (reward.unit === 'points_per_dollar' || reward.unit === 'points' ? 'x' : (reward.unit || ''));
   return `${reward.value}${unit}`;
 }
 

--- a/scripts/post-new-card.js
+++ b/scripts/post-new-card.js
@@ -80,18 +80,68 @@ function formatFee(fee) {
   return n === 0 ? '$0' : `$${n.toLocaleString()}`;
 }
 
+// A reward carrying `merchant_specific: true` or a non-empty `merchant_gate`
+// does NOT apply to its whole spending category — the category is just the
+// bucket the rate lives in. Feeding "5% online_shopping" to the model for the
+// Intuit Business card produced "5% rewards on online shopping", when the 5%
+// only covers Intuit's own products and the card's real headline rate is a flat
+// 2%. So gated rates are quarantined into their own labeled section with the
+// scope text from the reward's `note`, and a rate with no `note` is dropped
+// outright (there is nothing truthful to say about its scope).
+function isMerchantGated(reward) {
+  return reward.merchant_specific === true
+    || (Array.isArray(reward.merchant_gate) && reward.merchant_gate.length > 0);
+}
+
+function formatRate(reward) {
+  const unit = reward.unit === 'percent' ? '%' : (reward.unit === 'points' ? 'x' : (reward.unit || ''));
+  return `${reward.value}${unit}`;
+}
+
+function categoryLabel(category) {
+  return String(category).replace(/_/g, ' ');
+}
+
+const MAX_NOTE_CHARS = 140;
+
+function truncateNote(note) {
+  const clean = String(note).trim().replace(/\s+/g, ' ');
+  return clean.length > MAX_NOTE_CHARS ? `${clean.slice(0, MAX_NOTE_CHARS - 1)}…` : clean;
+}
+
+// Returns { ungated, gated } summary strings, either of which may be null.
+// `ungated` covers rates the copy may state plainly (including the flat
+// everything_else rate, which is often the card's true headline number and was
+// previously filtered out entirely).
 function summarizeRewards(rewards) {
-  if (!Array.isArray(rewards) || rewards.length === 0) return null;
-  const top = rewards
-    .filter(r => r && r.value && r.category && r.category !== 'everything_else')
-    .sort((a, b) => Number(b.value) - Number(a.value))
+  if (!Array.isArray(rewards) || rewards.length === 0) return { ungated: null, gated: null };
+
+  const valid = rewards.filter(r => r && r.value && r.category);
+  const byValueDesc = (a, b) => Number(b.value) - Number(a.value);
+  const isBonusCategory = r => r.category !== 'everything_else';
+
+  const ungatedParts = valid
+    .filter(r => isBonusCategory(r) && !isMerchantGated(r))
+    .sort(byValueDesc)
     .slice(0, 3)
-    .map(r => {
-      const unit = r.unit === 'percent' ? '%' : (r.unit === 'points' ? 'x' : (r.unit || ''));
-      const cat = String(r.category).replace(/_/g, ' ');
-      return `${r.value}${unit} ${cat}`;
-    });
-  return top.length > 0 ? top.join(', ') : null;
+    .map(r => `${formatRate(r)} on ${categoryLabel(r.category)}`);
+
+  const flat = valid.find(r => r.category === 'everything_else');
+  if (flat) {
+    ungatedParts.push(
+      `${formatRate(flat)} on ${ungatedParts.length > 0 ? 'everything else' : 'every purchase'}`
+    );
+  }
+
+  const gatedParts = valid
+    .filter(r => isBonusCategory(r) && isMerchantGated(r) && r.note)
+    .sort(byValueDesc)
+    .map(r => `${formatRate(r)} in the ${categoryLabel(r.category)} category, limited to: ${truncateNote(r.note)}`);
+
+  return {
+    ungated: ungatedParts.length > 0 ? ungatedParts.join(', ') : null,
+    gated: gatedParts.length > 0 ? gatedParts.join('; ') : null,
+  };
 }
 
 function summarizeSignupBonus(bonus) {
@@ -113,8 +163,14 @@ function buildCardSummary(card) {
   if (fee !== null) parts.push(`Annual fee: ${fee}`);
   const sub = summarizeSignupBonus(card.signup_bonus);
   if (sub) parts.push(`Sign-up bonus: ${sub}`);
-  const rewards = summarizeRewards(card.rewards);
-  if (rewards) parts.push(`Top rewards: ${rewards}`);
+  const { ungated, gated } = summarizeRewards(card.rewards);
+  if (ungated) parts.push(`Top rewards, each applying to the whole category named: ${ungated}`);
+  if (gated) {
+    parts.push(
+      'Merchant-limited rates, which apply ONLY at the merchants named and NOT to the '
+      + `whole category: ${gated}`
+    );
+  }
   return parts.join('. ');
 }
 
@@ -134,6 +190,9 @@ Rules:
 - Open with a plain statement that the card is now listed, e.g. "Now on CreditOdds: ..." or "The ${card.name} has been added to CreditOdds"
 - Max 200 characters (shorter is better)
 - State the most notable facts plainly (sign-up bonus, top reward rate, or annual fee) — facts only, no editorializing
+- Rates under "Top rewards" apply to the whole category and can be stated plainly, e.g. "3% on dining"
+- Rates under "Merchant-limited rates" apply ONLY at the merchants named after "limited to". Either name that limit in the tweet (e.g. "5% on Intuit products") or leave the rate out entirely and use a top reward instead. Never write a merchant-limited rate as if it covered its whole category
+- Never repeat the labels from the details above ("merchant-limited", "top rewards", "applies to the whole category") in the tweet. Name the merchants directly instead
 - No exclamation points, no all-caps words, no rhetorical questions
 - No filler words, no "excited to announce", no "stay tuned"
 - No hashtags
@@ -263,7 +322,16 @@ async function main() {
   console.log('=== Done ===');
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  isMerchantGated,
+  summarizeRewards,
+  summarizeSignupBonus,
+  buildCardSummary,
+};

--- a/scripts/post-new-card.test.js
+++ b/scripts/post-new-card.test.js
@@ -1,0 +1,173 @@
+// Smoke tests for the reward summarizer in post-new-card.js.
+//
+// Guards the merchant-gate bug: a rate carrying `merchant_specific: true` or a
+// non-empty `merchant_gate` covers only the merchants in its `note`, not the
+// whole spending category. The Intuit Business card's Intuit-products-only 5%
+// was fed to the model as plain "5% online_shopping" and came back as "5%
+// rewards on online shopping", which is wrong twice over: the 5% is not
+// category-wide, and the card's real headline rate is the flat 2% that the old
+// everything_else filter dropped from the summary entirely.
+//
+// Run: `node scripts/post-new-card.test.js`. Exits non-zero if any assertion fails.
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const {
+  isMerchantGated,
+  summarizeRewards,
+  buildCardSummary,
+} = require('./post-new-card.js');
+
+const CARDS_DIR = path.join(__dirname, '..', 'data', 'cards');
+
+function loadCard(slug) {
+  return yaml.load(fs.readFileSync(path.join(CARDS_DIR, `${slug}.yaml`), 'utf8'));
+}
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+console.log('isMerchantGated');
+
+test('merchant_specific: true is gated', () => {
+  assert.equal(isMerchantGated({ category: 'online_shopping', merchant_specific: true }), true);
+});
+
+test('non-empty merchant_gate is gated', () => {
+  assert.equal(isMerchantGated({ category: 'transit', merchant_gate: ['lyft'] }), true);
+});
+
+test('empty merchant_gate is not gated', () => {
+  assert.equal(isMerchantGated({ category: 'transit', merchant_gate: [] }), false);
+});
+
+test('a plain category rate is not gated', () => {
+  assert.equal(isMerchantGated({ category: 'dining', value: 3, unit: 'percent' }), false);
+});
+
+console.log('\nsummarizeRewards');
+
+test('a gated rate never lands in the ungated line', () => {
+  const { ungated, gated } = summarizeRewards([
+    { category: 'online_shopping', value: 5, unit: 'percent', merchant_specific: true, note: 'Intuit products' },
+    { category: 'everything_else', value: 2, unit: 'percent' },
+  ]);
+  assert.ok(!/online shopping/.test(ungated), `gated category leaked into ungated: ${ungated}`);
+  assert.equal(ungated, '2% on every purchase');
+  assert.match(gated, /^5% in the online shopping category, limited to: Intuit products$/);
+});
+
+test('the flat everything_else rate survives as the headline', () => {
+  // The old summarizer filtered everything_else out, so a card whose only
+  // ungated rate is the flat one had no truthful rate left to quote.
+  const { ungated } = summarizeRewards([{ category: 'everything_else', value: 2, unit: 'percent' }]);
+  assert.equal(ungated, '2% on every purchase');
+});
+
+test('everything_else reads as "everything else" alongside bonus categories', () => {
+  const { ungated } = summarizeRewards([
+    { category: 'dining', value: 3, unit: 'percent' },
+    { category: 'everything_else', value: 1, unit: 'percent' },
+  ]);
+  assert.equal(ungated, '3% on dining, 1% on everything else');
+});
+
+test('a gated rate with no note is dropped, not guessed at', () => {
+  const { ungated, gated } = summarizeRewards([
+    { category: 'airlines', value: 3, unit: 'points', merchant_gate: ['united-airlines'] },
+    { category: 'everything_else', value: 1, unit: 'points' },
+  ]);
+  assert.equal(gated, null);
+  assert.ok(!/airlines/.test(ungated), `unscopable gated rate leaked: ${ungated}`);
+});
+
+test('ungated bonus categories are capped at the top three by value', () => {
+  const { ungated } = summarizeRewards([
+    { category: 'dining', value: 4, unit: 'percent' },
+    { category: 'gas', value: 3, unit: 'percent' },
+    { category: 'groceries', value: 5, unit: 'percent' },
+    { category: 'transit', value: 2, unit: 'percent' },
+  ]);
+  assert.equal(ungated, '5% on groceries, 4% on dining, 3% on gas');
+});
+
+test('long notes are truncated so one reward cannot swamp the prompt', () => {
+  const { gated } = summarizeRewards([
+    { category: 'online_shopping', value: 5, unit: 'percent', merchant_specific: true, note: 'x'.repeat(400) },
+  ]);
+  assert.ok(gated.length < 220, `note not truncated: ${gated.length} chars`);
+  assert.ok(gated.endsWith('…'));
+});
+
+test('empty or missing rewards yield no lines', () => {
+  assert.deepEqual(summarizeRewards([]), { ungated: null, gated: null });
+  assert.deepEqual(summarizeRewards(undefined), { ungated: null, gated: null });
+});
+
+console.log('\nbuildCardSummary against real card YAML');
+
+test('intuit-business leads with the flat 2%, quarantines the Intuit-only 5%', () => {
+  const summary = buildCardSummary(loadCard('intuit-business'));
+  assert.match(summary, /whole category named: 2% on every purchase/);
+  assert.match(summary, /Merchant-limited rates[^.]*5% in the online shopping category, limited to: Intuit products/);
+  // The exact wording that shipped wrong: 5% presented as a category-wide rate.
+  assert.ok(
+    !/whole category named:[^.]*online shopping/.test(summary),
+    `Intuit 5% still presented as a category rate:\n${summary}`
+  );
+});
+
+test('apple-card scopes the 3% to its merchant list', () => {
+  const summary = buildCardSummary(loadCard('apple-card'));
+  assert.match(summary, /Merchant-limited rates[^.]*3% in the online shopping category, limited to: Apple purchases/);
+  assert.ok(
+    !/whole category named:[^.]*online shopping/.test(summary),
+    `Apple 3% still presented as a category rate:\n${summary}`
+  );
+});
+
+test('chase-ink-business-unlimited scopes the Lyft 5% out of transit', () => {
+  const summary = buildCardSummary(loadCard('chase-ink-business-unlimited'));
+  assert.match(summary, /whole category named: 1\.5% on every purchase/);
+  assert.match(summary, /Merchant-limited rates[^.]*5% in the transit category, limited to: On Lyft rides/);
+  assert.ok(
+    !/whole category named:[^.]*transit/.test(summary),
+    `Ink Lyft 5% still presented as a category rate:\n${summary}`
+  );
+});
+
+test('no card in data/cards puts a gated rate in the ungated line', () => {
+  const offenders = [];
+  for (const file of fs.readdirSync(CARDS_DIR).filter(f => f.endsWith('.yaml'))) {
+    const card = yaml.load(fs.readFileSync(path.join(CARDS_DIR, file), 'utf8'));
+    const gatedCategories = (card.rewards || [])
+      .filter(r => r && r.value && r.category && isMerchantGated(r))
+      .map(r => String(r.category).replace(/_/g, ' '));
+    if (gatedCategories.length === 0) continue;
+
+    const { ungated } = summarizeRewards(card.rewards);
+    if (!ungated) continue;
+    // A gated category may still appear if the card ALSO has an ungated rate in
+    // that same category, which is legitimate; compare against the gated rate's
+    // own value to catch only the real leaks.
+    for (const r of card.rewards.filter(x => x && x.value && isMerchantGated(x))) {
+      const label = `${r.value}${r.unit === 'percent' ? '%' : 'x'} on ${String(r.category).replace(/_/g, ' ')}`;
+      if (ungated.includes(label)) offenders.push(`${file}: "${label}"`);
+    }
+  }
+  assert.deepEqual(offenders, [], `gated rates leaked into ungated copy:\n${offenders.join('\n')}`);
+});
+
+console.log(failures === 0 ? '\nAll tests passed.' : `\n${failures} test(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/post-new-card.test.js
+++ b/scripts/post-new-card.test.js
@@ -110,6 +110,32 @@ test('long notes are truncated so one reward cannot swamp the prompt', () => {
   assert.ok(gated.endsWith('…'));
 });
 
+test('points_per_dollar renders as x, the only unit points cards actually use', () => {
+  // `points_per_dollar` is one of the schema's two units (the other is
+  // `percent`); a bare `points` is not a value any card carries. Rendering the
+  // raw unit fed the model "5points_per_dollar on travel portal".
+  const { ungated, gated } = summarizeRewards([
+    { category: 'travel_portal', value: 5, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+    { category: 'transit', value: 5, unit: 'points_per_dollar', merchant_gate: ['lyft'], note: 'On Lyft rides' },
+  ]);
+  assert.equal(ungated, '5x on travel portal, 1x on everything else');
+  assert.match(gated, /^5x in the transit category/);
+});
+
+test('no card in data/cards renders a raw unit string', () => {
+  for (const file of fs.readdirSync(CARDS_DIR).filter(f => f.endsWith('.yaml'))) {
+    const card = yaml.load(fs.readFileSync(path.join(CARDS_DIR, file), 'utf8'));
+    const { ungated, gated } = summarizeRewards(card.rewards);
+    for (const line of [ungated, gated]) {
+      assert.ok(
+        !/points_per_dollar/.test(line || ''),
+        `${file} leaked a raw unit into the prompt: ${line}`
+      );
+    }
+  }
+});
+
 test('empty or missing rewards yield no lines', () => {
   assert.deepEqual(summarizeRewards([]), { ungated: null, gated: null });
   assert.deepEqual(summarizeRewards(undefined), { ungated: null, gated: null });

--- a/scripts/refresh-best-pages.js
+++ b/scripts/refresh-best-pages.js
@@ -114,12 +114,24 @@ function getCardContext(card) {
     };
   }
   if (card.rewards) {
-    ctx.rewards = card.rewards.map(r => ({
-      category: r.category,
-      value: r.value,
-      unit: r.unit,
-      description: r.description,
-    }));
+    ctx.rewards = card.rewards.map(r => {
+      const out = { category: r.category, value: r.value, unit: r.unit };
+      // The scope of a rate lives in `note` ("Intuit products and services
+      // including QuickBooks...", "On Lyft rides through September 30, 2027").
+      // This used to read `r.description`, a field no card has ever set and
+      // that build-cards.js does not emit, so all 278 notes were silently
+      // dropped and every rate reached the panel stripped of its scope.
+      if (r.note) out.note = r.note;
+      // `merchant_specific` / `merchant_gate` mean the rate applies only at the
+      // merchants named in the note, not across its category — a card earning
+      // 5% "online_shopping" at one merchant is not a 5% online shopping card.
+      // Passed through so the guidelines can tell the panel to discount them.
+      if (r.merchant_specific === true) out.merchant_specific = true;
+      if (Array.isArray(r.merchant_gate) && r.merchant_gate.length > 0) {
+        out.merchant_gate = r.merchant_gate;
+      }
+      return out;
+    });
   }
   if (card.apr) ctx.apr = card.apr;
   if (card.intro_apr) ctx.intro_apr = card.intro_apr;
@@ -228,6 +240,7 @@ const SHARED_GUIDELINES = `RANKING GUIDELINES:
 - A high annual fee is justified only if the rewards and perks clearly offset it.
 - Category relevance matters: for a "Best Cash Back" page a card's cash back rates matter most; for "Best Travel" transfer partners, travel perks, and portal multipliers matter most.
 - Consider the full picture: a card with a slightly lower bonus but much better ongoing rewards may deserve a higher rank.
+- A reward marked "merchant_specific": true or carrying a "merchant_gate" list earns its rate ONLY at the merchants named in its "note", not across the category it is filed under. Weigh it as the narrow perk it is, and judge everyday earning on the ungated rates (including "everything_else"). A card whose only high rate is gated is not a high-earning card in that category.
 
 RULES:
 - Rank ALL provided cards. Do NOT add, remove, or invent cards.
@@ -275,6 +288,7 @@ YOUR TASK:
 RULES:
 - Keep the cards array in the EXACT order provided. Do NOT reorder, add, or remove cards.
 - ONLY use facts from card_data. Never invent or assume numbers.
+- A reward marked "merchant_specific": true or carrying a "merchant_gate" list applies ONLY at the merchants named in its "note". If you mention such a rate, name that limit (e.g. "5% on Intuit products", "5% on Lyft rides"). Never write it as if it covered the whole category it is filed under, and prefer an ungated rate when one makes the point.
 - If a signup_bonus value is a string like "4 Free Night Awards", use it as-is.
 - Match the existing concise, factual, comparative editorial tone. No hype words like "incredible", "amazing", or "unbeatable". Do not use em dashes.
 - Do not mention CreditOdds or link to anything.
@@ -728,7 +742,16 @@ async function main() {
   console.log('\n=== Complete ===');
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  getCardContext,
+  buildCardsWithData,
+  buildVoterPrompt,
+  buildWriterPrompt,
+};

--- a/scripts/refresh-best-pages.test.js
+++ b/scripts/refresh-best-pages.test.js
@@ -1,0 +1,117 @@
+// Smoke tests for the card context handed to the /best ranking panel.
+//
+// getCardContext used to map rewards to {category, value, unit, description}.
+// No card has ever set `reward.description` and build-cards.js does not emit
+// it, so the field was always undefined: all 278 reward `note`s and every
+// merchant_specific / merchant_gate flag were silently dropped, and the panel
+// ranked (and the writer described) gated rates as if they were category-wide.
+//
+// Run: `node scripts/refresh-best-pages.test.js`. Exits non-zero on failure.
+// Requires data/cards.json — run `npm run build:cards` first if it is missing.
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { getCardContext, buildVoterPrompt, buildWriterPrompt } = require('./refresh-best-pages.js');
+
+const CARDS_FILE = path.join(__dirname, '..', 'data', 'cards.json');
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+console.log('getCardContext');
+
+test('a reward note reaches the panel', () => {
+  const ctx = getCardContext({
+    name: 'X', rewards: [{ category: 'groceries', value: 3, unit: 'points_per_dollar', note: 'Online grocery purchases only' }],
+  });
+  assert.equal(ctx.rewards[0].note, 'Online grocery purchases only');
+});
+
+test('merchant_specific is flagged', () => {
+  const ctx = getCardContext({
+    name: 'X', rewards: [{ category: 'online_shopping', value: 5, unit: 'percent', note: 'Intuit products', merchant_specific: true }],
+  });
+  assert.equal(ctx.rewards[0].merchant_specific, true);
+});
+
+test('a non-empty merchant_gate is passed through', () => {
+  const ctx = getCardContext({
+    name: 'X', rewards: [{ category: 'transit', value: 5, unit: 'percent', note: 'On Lyft rides', merchant_gate: ['lyft'] }],
+  });
+  assert.deepEqual(ctx.rewards[0].merchant_gate, ['lyft']);
+});
+
+test('absent scope fields are omitted rather than sent as undefined keys', () => {
+  const ctx = getCardContext({ name: 'X', rewards: [{ category: 'dining', value: 4, unit: 'percent' }] });
+  assert.deepEqual(Object.keys(ctx.rewards[0]), ['category', 'value', 'unit']);
+  // An empty gate list is not a gate.
+  const empty = getCardContext({ name: 'X', rewards: [{ category: 'dining', value: 4, unit: 'percent', merchant_gate: [] }] });
+  assert.equal('merchant_gate' in empty.rewards[0], false);
+});
+
+test('the dead `description` field is gone', () => {
+  const ctx = getCardContext({
+    name: 'X', rewards: [{ category: 'dining', value: 4, unit: 'percent', description: 'should not be read' }],
+  });
+  assert.equal('description' in ctx.rewards[0], false);
+});
+
+console.log('\nprompts');
+
+test('both prompts explain what a gate means', () => {
+  const page = { data: { title: 'Best X', description: 'd', cards: [], intro: '' } };
+  for (const [label, prompt] of [['voter', buildVoterPrompt(page, [])], ['writer', buildWriterPrompt(page, [])]]) {
+    assert.match(prompt, /merchant_specific/, `${label} prompt does not mention merchant_specific`);
+    assert.match(prompt, /merchant_gate/, `${label} prompt does not mention merchant_gate`);
+  }
+});
+
+console.log('\nagainst built cards.json');
+
+if (!fs.existsSync(CARDS_FILE)) {
+  console.log('  skip (data/cards.json missing; run `npm run build:cards`)');
+} else {
+  const cards = JSON.parse(fs.readFileSync(CARDS_FILE, 'utf8')).cards;
+
+  test('no reward in cards.json sets `description` (the field the old code read)', () => {
+    const offenders = cards
+      .filter(c => (c.rewards || []).some(r => r && r.description !== undefined))
+      .map(c => c.slug);
+    assert.deepEqual(offenders, []);
+  });
+
+  test('every gated reward reaches the panel with both its flag and its scope', () => {
+    const missing = [];
+    for (const card of cards) {
+      const ctx = getCardContext(card);
+      for (const r of ctx.rewards || []) {
+        const gated = r.merchant_specific === true || (r.merchant_gate && r.merchant_gate.length > 0);
+        if (gated && !r.note) missing.push(`${card.slug}: ${r.value} ${r.category}`);
+      }
+    }
+    // A gated rate with no note gives the panel a flag it cannot interpret.
+    // If this ever fails, the card YAML needs a note, not a code change.
+    assert.deepEqual(missing, [], `gated rewards with no scope note:\n${missing.join('\n')}`);
+  });
+
+  test('notes and gates actually survive for a known-gated card', () => {
+    const csp = cards.find(c => c.slug === 'chase-sapphire-preferred');
+    assert.ok(csp, 'chase-sapphire-preferred missing from cards.json');
+    const groceries = getCardContext(csp).rewards.find(r => r.category === 'groceries');
+    assert.equal(groceries.merchant_specific, true);
+    assert.match(groceries.note, /Online grocery purchases only/);
+  });
+}
+
+console.log(failures === 0 ? '\nAll tests passed.' : `\n${failures} test(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Two LLM copy generators read card rewards by `category` alone, so a rate limited to specific merchants came back out as a category-wide claim. 97 rewards across 72 cards carry a gate today.

---

## 1. `post-new-card.js` — the tweet that shipped wrong

The Intuit Business announcement went out as *"...and 5% rewards on online shopping"*. Wrong twice over: that 5% is Intuit products only (`merchant_specific: true`, scope in the reward's `note`), and the card's actual headline rate is the flat 2%. The queued post had to be hand-edited before it published.

`summarizeRewards` never looked at `merchant_specific` / `merchant_gate`, and it filtered out `everything_else`, so the truthful flat rate was never even a candidate.

It now returns `{ungated, gated}`:

- **Ungated** rates the copy may state plainly, with `everything_else` included (rendered "every purchase" or "everything else" depending on whether bonus categories exist).
- **Gated** rates quarantined into a separate labeled prompt line carrying the reward's `note` as scope. A gated rate with no `note` is dropped, since there is nothing truthful to say about its scope.

Prompt rules spell out the distinction and stop the model echoing the section labels back as jargon (it did that on the first pass, writing "Merchant-limited rate: 3%...").

**Verified** with `--dry-run` against the three cards that exercise every path:

| card | before | after |
|---|---|---|
| `intuit-business` | 5% rewards on online shopping | 2% on every purchase and 5% on Intuit products including QuickBooks and TurboTax |
| `apple-card` | (3% online shopping) | Earn 3% on Apple purchases and select merchants via Apple Pay |
| `chase-ink-business-unlimited` | (5% transit) | 1.5% on every purchase. 5% on Lyft rides through September 30, 2027 |

---

## 2. `refresh-best-pages.js` — reading a field that does not exist

`getCardContext` mapped rewards to `{category, value, unit, description}`. **No card has ever set `reward.description`** and `build-cards.js` does not emit it. The cards.json reward keys are:

```
cap_period, category, choices, current_categories, current_period,
eligible_categories, expires, merchant_gate, merchant_specific, mode,
note, rate_after_cap, spend_cap, unit, value
```

So that key was always `undefined`: all 278 reward `note`s were dropped and the panel ranked every rate with its scope stripped.

Now passes `note` plus `merchant_specific` / `merchant_gate` when set, omitted otherwise to keep the prompt payload lean. Across the 7 best pages that is **159 of 357 rewards** gaining a note the panel could not previously see, and **55** newly flagged as gated.

Both prompts gain a rule for the flags, since the fields are useless if the models do not know what they mean. The voter is told to judge everyday earning on ungated rates; the writer is told to name the limit or use an ungated rate instead. The writer rule matters because it is instructed to write highlights from `card_data` reward rates, and those land in published /best copy.

**Verified** with a live read-only `gpt-4o-mini` vote on `best-dining-grocery-cards`, same page and model, old context vs new:

```
 7. blue-cash-everyday-card   (+3)
 8. chase-freedom-flex        (-1)
10. chase-freedom-unlimited   (-2)
```

The right direction: CSP's 3x groceries is *"Online grocery purchases only (excluding Target, Walmart, and wholesale clubs)"* and Freedom Unlimited's 5x transit is Lyft-only, while Blue Cash Everyday's 3% groceries is ungated. Top 6 unchanged. Single sample at `temperature: 0.2`, so indicative rather than a fixed delta.

---

## Tests

```bash
node scripts/post-new-card.test.js && node scripts/refresh-best-pages.test.js
```

25 assertions. Both sweep real card data: `post-new-card` asserts no card in `data/cards` puts a gated rate in the ungated line; `refresh-best-pages` asserts no reward in cards.json sets `description` and that every gated reward carries a scope note. Helpers are exported behind the repo's `require.main === module` guard.

## Scope notes

- **`post-card-wire.js` is clean** and untouched. It never reads `rewards`, only wire fields (`signup_bonus_value`, `annual_fee`, APR).
- **The news path `post-social.js` is clean** and untouched. It prompts from the news/article YAML's `title` and `summary` plus card names; no reward data reaches the model.
- **`post-best-rankings.js` is still affected** and deliberately left for its own PR. `findTopReward` ignores gating, so 56 cards would render a gated rate as their ranking-image stat. The co-brand cases want a *relabel* to the brand ("14x HILTON" for Hilton Aspire) rather than a removal, which is a visual design call, not a port of this patch.
- Separately noticed while confirming the cards.json shape: `spend_cap` / `rate_after_cap` / `cap_period` are also not passed to the ranking panel, so a capped 5% is weighed as uncapped. Not addressed here.