### PR TITLE
explore: add a "No foreign fee" filter

### DIFF
--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -288,6 +288,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
   const [feeBucket, setFeeBucket] = useState<FeeBucket>('all');
   const [selectedBanks, setSelectedBanks] = useState<Set<string>>(new Set());
   const [businessOnly, setBusinessOnly] = useState(false);
+  const [noForeignFeeOnly, setNoForeignFeeOnly] = useState(false);
 
   function handleColSort(col: SortKey) {
     const defaultDir: SortDir = col === 'fee' ? 'asc' : 'desc';
@@ -310,6 +311,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
     feeBucket !== 'all' ||
     selectedBanks.size > 0 ||
     businessOnly ||
+    noForeignFeeOnly ||
     includeArchived;
 
   function clearFilters() {
@@ -318,6 +320,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
     setFeeBucket('all');
     setSelectedBanks(new Set());
     setBusinessOnly(false);
+    setNoForeignFeeOnly(false);
     setIncludeArchived(false);
   }
 
@@ -339,6 +342,10 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
       if (!includeArchived && !c.accepting_applications) return false;
       if (businessOnly && cardCategory(c) !== 'Business') return false;
       if (rewardType !== 'all' && c.reward_type !== rewardType) return false;
+      // Strict `=== false`: the field is optional, and a handful of cards omit
+      // it entirely. Those are unknown, not fee-free, so they stay out rather
+      // than being advertised as no-FTF on missing data.
+      if (noForeignFeeOnly && c.foreign_transaction_fee !== false) return false;
       if (!feeMatchesBucket(c.annual_fee, feeBucket)) return false;
       if (selectedBanks.size > 0 && !selectedBanks.has(c.bank)) return false;
       if (q && !cardMatchesSearch(c.card_name, c.bank, q)) return false;
@@ -385,7 +392,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
       });
     }
     return sorted;
-  }, [cards, query, sort, sortDir, includeArchived, trendingViews, rewardType, feeBucket, selectedBanks, businessOnly]);
+  }, [cards, query, sort, sortDir, includeArchived, trendingViews, rewardType, feeBucket, selectedBanks, businessOnly, noForeignFeeOnly]);
 
   return (
     <div className="landing-v2 explore-v2">
@@ -536,6 +543,13 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
                 onClick={() => setBusinessOnly((v) => !v)}
               >
                 Business only
+              </button>
+              <button
+                type="button"
+                className={'filter-chip ' + (noForeignFeeOnly ? 'active' : '')}
+                onClick={() => setNoForeignFeeOnly((v) => !v)}
+              >
+                No foreign fee
               </button>
               <button
                 type="button"

--- a/apps/web-next/src/app/explore/page.tsx
+++ b/apps/web-next/src/app/explore/page.tsx
@@ -22,6 +22,7 @@ function slimForExplore(c: Card): Card {
     approved_count: c.approved_count,
     rejected_count: c.rejected_count,
     annual_fee: c.annual_fee,
+    foreign_transaction_fee: c.foreign_transaction_fee,
     reward_type: c.reward_type,
     category: c.category,
     tags: c.tags,


### PR DESCRIPTION
Adds a "No foreign fee" toggle to the Show row on /explore, alongside "Business only" and "Archived".

## Behavior

| State | Rows |
|---|---|
| No filters | 157 |
| No foreign fee | 117 |
| No foreign fee + Archived | 118 |
| After Clear filters | 157 |

Verified in the browser against a local dev server; the counts match the YAML directly.

## Two notes for review

**The predicate is a strict `=== false`, not a falsy test.** `foreign_transaction_fee` is optional and four currently-accepting cards omit it (BankAmericard, USAA Rewards, Bank of America Cash Rewards Secured, USAA Secured Visa Platinum). A falsy test would list those as fee-free based on missing data, so they stay out until the field is filled in. Worth a separate pass to backfill those four.

**`slimForExplore` needed the field added.** That function whitelists what gets serialized to the client, and `foreign_transaction_fee` was not in it, so the filter initially matched zero cards. Caught during browser verification, not typecheck, since the field is optional and `undefined` is well-typed. Anything else added to this filter bar will need the same one-line addition.

## Scope

Only this one filter, per the request. The wider list of candidates we discussed (0% intro APR, reward category, credit-score tier, card-type tags) is not included here.