### PR TITLE
Triage review issue #1774: decline all three items

### DIFF
--- a/data/review-declined.yaml
+++ b/data/review-declined.yaml
@@ -37,12 +37,16 @@ rewards_added:
       why: "the card's 2x base rate restated; AmexTravel.com is not a separate bonus" }
   - { slug: capital-one-venture-rewards, category: entertainment,
       why: "alias of the existing entertainment_portal row" }
+  - { slug: citi-strata-elite, category: airlines,
+      why: "the existing flights_portal 6x row — cititravel.com only; a bare `airlines` row would claim 6x on direct airline purchases the card does not earn on" }
   - { slug: citi-strata-premier, category: travel,
       why: "YAML splits this into airlines 3x + hotels 3x" }
   - { slug: citi-strata, category: streaming,
       why: "covered by the selected_categories self-select row" }
   - { slug: playstation-visa, category: tv_internet_streaming,
       why: "the existing streaming row already covers cable and internet" }
+  - { slug: united-quest, category: hotels,
+      why: "the existing hotels_portal 5x row — Renowned Hotels via Chase Travel only; a bare `hotels` row would claim 5x on all hotel spend" }
   - { slug: world-of-hyatt-business-credit-card, category: selected_categories,
       why: "the same bucket as the existing top_category row" }
 
@@ -87,6 +91,8 @@ benefits:
       why: "a discount on BUYING points carries no wallet value — below the small-benefits threshold (PR #1775)" }
   - { slug: navy-federal-more-rewards-american-express, name: "Booking.com Hotel Discount",
       why: "an Amex network offers-platform promotion, not a card benefit; rotating 'up to 30% / select properties' copy (PR #1771)" }
+  - { slug: atmos-rewards-business, name: "Travel Accident Insurance",
+      why: "standard network insurance — same class declined in #1636, #1666, #1731, #1743 (issue #1774)" }
   - { slug: robinhood-platinum, name: "Eight Sleep Credit",
       why: "dated promo ('valid through 9/15') and benefits have no `expires` field, so nothing would flag it once lapsed (PR #1772)" }
 


### PR DESCRIPTION
Triage of [#1774](https://github.com/CreditOdds/creditodds/issues/1774). All three declined and recorded so they stop resurfacing.

## Citi Strata Elite — `airlines` 6x → decline

The card already carries `flights_portal: 6`, note *"On air travel booked through Citi Travel"*. The proposal is the same row under a bare category name (*"Air travel booked on cititravel.com"*) — same rate, same mechanic, same portal.

It has **no** `airlines` row, because it doesn't earn 6x on airline purchases made directly with the airline. Adding a generic `airlines: 6x` would claim a rate the card doesn't pay.

## United Quest — `hotels` 5x → decline

Same shape. The card already carries `hotels_portal: 5`, note *"Hotels prepaid through Renowned Hotels and Resorts for United Cardmembers"*; the proposal restates it as bare `hotels`. It has no generic hotels row, so a `hotels: 5x` entry would claim 5x on all hotel spend.

Both of these matter beyond noise: `/best-card-for` ranks purely by effective rate, so a bogus generic row would win categories these cards don't deserve.

## Atmos Rewards Business — Travel Accident Insurance → decline

Standard network insurance, no card-specific value. Same class already declined in #1636, #1666, #1731, and #1743.

## Verification

`isDeclined` returns true for all three and false for the controls (same category on a different card, same benefit name on a different card, and the kept `hotels_portal` row). Suite passes.

## Two systemic gaps this surfaced — not fixed here

**1. `data/benefit-policy.yaml` documents a migration that only half happened.** The `borderline:` block's comment says the standard insurance names *"were moved OUT of this list and into `exclude` above"* — but 8 are still in `borderline` and absent from `exclude`: Extended Warranty, Travel Accident Insurance, Travel & Emergency Assistance, Roadside Assistance, Return Protection, Emergency Evacuation, Emergency Medical, Price Protection. Others in the same class (Trip Cancellation, Auto Rental Coverage, Purchase Protection, Lost Luggage, Baggage Delay) did make it into `exclude`. That partial move is why Travel Accident Insurance reached this week's queue at all, and the comment itself warns *"Leaving an item borderline means re-litigating it every single week."* The per-card decline above only silences it for Atmos.

**2. Bare `hotels` / `airlines` are not aliases of the portal rows.** `PORTAL_ALIAS_GROUP` covers `travel_portal`, `hotels_car_portal`, `hotels_portal`, `car_rentals_portal`, `flights_portal` — but not the plain categories, and `isBroaderThan("hotels", "hotels_portal")` is false. So a portal row restated under its bare name is never auto-suppressed, and lands in the queue for a human every week, per card. Both items above are instances of exactly this.