### PR TITLE
Close two gaps that regenerate the same review items every week

### DIFF
--- a/data/benefit-policy.yaml
+++ b/data/benefit-policy.yaml
@@ -105,6 +105,20 @@ exclude:
   - "Rental Car Insurance"
   - "Car Rental Insurance"
   - "Purchase Protection"
+  # The rest of the same class. These were left behind when the block above
+  # was moved out of `borderline`, so they kept regenerating a weekly
+  # manual-decision item (Atmos Rewards Business "Travel Accident Insurance"
+  # in issue #1774) despite the same reasoning applying to all of them.
+  - "Travel Accident Insurance"
+  - "Travel & Emergency Assistance"
+  - "Travel and Emergency Assistance"
+  - "Extended Warranty"
+  - "Extended Warranty Protection"
+  - "Return Protection"
+  - "Price Protection"
+  - "Roadside Assistance"
+  - "Emergency Evacuation"
+  - "Emergency Medical"
   - "Lost Luggage Reimbursement"
   - "Lost Baggage Reimbursement"
   - "Lost Baggage"
@@ -230,21 +244,22 @@ exclude:
 # the team has gone both ways on. We log them in the summary so a human can
 # decide on a case-by-case basis whether they belong on a given card.
 # ────────────────────────────────────────────────────────────────────────────
-borderline:
-  # NOTE — the standard travel/purchase insurance names were moved OUT of
-  # this list and into `exclude` above. They were declined in four
-  # consecutive review issues (#1636, #1666, #1731, #1743) and were the
-  # entire "borderline benefits" bucket in #1743's queue. Leaving an item
-  # borderline means re-litigating it every single week; if the team decides
-  # to start modeling insurance coverage, move them back here in one edit.
-  - "Extended Warranty"
-  - "Travel Accident Insurance"
-  - "Travel & Emergency Assistance"
-  - "Roadside Assistance"
-  - "Return Protection"
-  - "Emergency Evacuation"
-  - "Emergency Medical"
-  - "Price Protection"
+borderline: []
+  # Deliberately empty.
+  #
+  # This list used to hold the standard travel/purchase insurance names, and
+  # its note claimed they had all been moved into `exclude` above. Eight had
+  # not been: Extended Warranty, Travel Accident Insurance, Travel & Emergency
+  # Assistance, Roadside Assistance, Return Protection, Emergency Evacuation,
+  # Emergency Medical, Price Protection. So the note read as done while the
+  # queue kept regenerating them — Atmos Rewards Business "Travel Accident
+  # Insurance" in issue #1774 was one. They are now all in `exclude`, and the
+  # migration this note described is actually finished.
+  #
+  # Leaving an item borderline means re-litigating it every single week, so
+  # add one only when the team genuinely wants a recurring manual decision.
+  # If the team decides to start modeling insurance coverage, move the names
+  # back here in one edit.
 
 # ────────────────────────────────────────────────────────────────────────────
 # 3. Auto-PR — anything not matched above is eligible for an auto-PR.

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -870,6 +870,15 @@ const BROADER_THAN = new Map([
     'travel_portal', 'hotels_portal', 'flights_portal',
     'car_rentals_portal', 'hotels_car_portal',
   ])],
+  // One rung finer than `travel` above. A card that earns a portal-only rate
+  // has its apply page describe it in plain words ("air travel booked on
+  // cititravel.com"), which the extractor renders as the bare category. With
+  // only the `travel` rung present, that bare row was never recognised as the
+  // portal row restated, so it reached the review queue every week, per card
+  // — Citi Strata Elite `airlines` 6x and United Quest `hotels` 5x in #1774.
+  ['hotels', new Set(['hotels_portal', 'hotels_car_portal'])],
+  ['airlines', new Set(['flights_portal'])],
+  ['car_rentals', new Set(['car_rentals_portal', 'hotels_car_portal'])],
   ['transit', new Set(['ground_transportation'])],
   ['online_shopping', new Set(['amazon'])],
 ]);

--- a/scripts/check-card-rewards-and-benefits.test.js
+++ b/scripts/check-card-rewards-and-benefits.test.js
@@ -10,8 +10,12 @@
 // if any assertion fails.
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yamlLib = require('js-yaml');
 const {
   editRewardValue,
+  isBroaderThan,
   editRewardCapFields,
   diffRewards,
   diffBenefits,
@@ -887,6 +891,92 @@ test('a stated cap change is a change', () => {
   ]);
   assert.equal(d.changed.length, 1);
   assert.equal(d.changed[0].to.spend_cap, 7000);
+});
+
+// ─── Portal rows restated under a bare category name ────────────────────────
+//
+// An apply page describes a portal-only rate in plain words ("air travel
+// booked on cititravel.com"), so the extractor emits the bare category. Only
+// the `travel` rung existed, so `airlines` / `hotels` / `car_rentals` were
+// never recognised as the portal row restated and reached the review queue
+// every week, per card (issue #1774).
+console.log('\nbare-category portal rungs:');
+
+test('a bare category is broader than its portal slice', () => {
+  assert.equal(isBroaderThan('hotels', 'hotels_portal'), true);
+  assert.equal(isBroaderThan('hotels', 'hotels_car_portal'), true);
+  assert.equal(isBroaderThan('airlines', 'flights_portal'), true);
+  assert.equal(isBroaderThan('car_rentals', 'car_rentals_portal'), true);
+  assert.equal(isBroaderThan('car_rentals', 'hotels_car_portal'), true);
+});
+
+test('the relation stays one-way and does not cross travel types', () => {
+  assert.equal(isBroaderThan('hotels_portal', 'hotels'), false);
+  assert.equal(isBroaderThan('airlines', 'hotels_portal'), false);
+  assert.equal(isBroaderThan('hotels', 'airlines'), false);
+});
+
+test('a bare airlines proposal is suppressed when YAML has flights_portal', () => {
+  const current = [
+    { category: 'flights_portal', value: 6, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1.5, unit: 'points_per_dollar' },
+  ];
+  const d = diffRewards(current, [
+    ...current,
+    { category: 'airlines', value: 6, unit: 'points_per_dollar' },
+  ]);
+  assert.equal(d.added.length, 0);
+});
+
+test('a bare hotels proposal is suppressed when YAML has hotels_portal', () => {
+  const current = [
+    { category: 'hotels_portal', value: 5, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1, unit: 'points_per_dollar' },
+  ];
+  const d = diffRewards(current, [
+    ...current,
+    { category: 'hotels', value: 5, unit: 'points_per_dollar' },
+  ]);
+  assert.equal(d.added.length, 0);
+});
+
+test('an unrelated new category is still proposed', () => {
+  const current = [
+    { category: 'flights_portal', value: 6, unit: 'points_per_dollar' },
+    { category: 'everything_else', value: 1.5, unit: 'points_per_dollar' },
+  ];
+  const d = diffRewards(current, [
+    ...current,
+    { category: 'groceries', value: 3, unit: 'points_per_dollar' },
+  ]);
+  assert.equal(d.added.length, 1);
+  assert.equal(d.added[0].category, 'groceries');
+});
+
+// ─── benefit-policy insurance class ─────────────────────────────────────────
+//
+// The `borderline` block's note claimed these had been moved into `exclude`,
+// but eight were left behind, so they kept regenerating a weekly manual
+// decision (issue #1774). Guard the finished migration.
+console.log('\nbenefit-policy insurance class:');
+
+const POLICY_RAW = yamlLib.load(
+  fs.readFileSync(path.join(__dirname, '..', 'data', 'benefit-policy.yaml'), 'utf8')
+);
+
+test('every standard insurance name is excluded, not borderline', () => {
+  const exclude = (POLICY_RAW.exclude || []).map(s => String(s).toLowerCase());
+  for (const name of [
+    'Extended Warranty', 'Travel Accident Insurance', 'Travel & Emergency Assistance',
+    'Roadside Assistance', 'Return Protection', 'Emergency Evacuation',
+    'Emergency Medical', 'Price Protection',
+  ]) {
+    assert.ok(exclude.includes(name.toLowerCase()), `${name} should be in exclude`);
+  }
+});
+
+test('borderline is empty, so nothing is re-litigated weekly by default', () => {
+  assert.deepEqual(POLICY_RAW.borderline || [], []);
 });
 
 console.log('\nDone.\n');


### PR DESCRIPTION
Follow-up to the #1774 triage in #1789. Both gaps caused the checker to re-ask a question that had already been answered.

## 1. `benefit-policy.yaml` — finish the migration its own note described

The `borderline:` block's comment claimed the standard insurance names *"were moved OUT of this list and into `exclude` above"*. Eight never made the trip:

Extended Warranty · Travel Accident Insurance · Travel & Emergency Assistance · Roadside Assistance · Return Protection · Emergency Evacuation · Emergency Medical · Price Protection

Their siblings (Trip Cancellation, Auto Rental Coverage, Purchase Protection, Lost Luggage, Baggage Delay) did. So the note read as finished while the queue kept regenerating the leftovers every week — Atmos Rewards Business "Travel Accident Insurance" in #1774 was one.

All eight now sit in `exclude` alongside the rest of the class, with two spelling variants added (`Travel and Emergency Assistance`, `Extended Warranty Protection`). `borderline` is now empty, and its note describes what the file actually does instead of what someone intended.

This only stops the checker **proposing** them. Cards that already carry these benefits keep them.

## 2. `BROADER_THAN` — add the bare-category rung

`travel` was already registered as broader than every `*_portal` category. One rung finer was missing:

```js
['hotels',      new Set(['hotels_portal', 'hotels_car_portal'])],
['airlines',    new Set(['flights_portal'])],
['car_rentals', new Set(['car_rentals_portal', 'hotels_car_portal'])],
```

An apply page describes a portal-only rate in plain words ("air travel booked on cititravel.com"), so the extractor emits the bare category. Without this rung it was never recognised as the portal row restated, and landed in the queue for a human every week, per card. Citi Strata Elite `airlines` 6x and United Quest `hotels` 5x in #1774 were both instances.

## Verification

Replaying the two real #1774 reward proposals against the actual card YAML now yields **0 added rows** for both, where each previously produced a queue item. All eight insurance names return `auto: 0, review: 0` through `diffBenefits`; a genuine perk ("Annual Hotel Credit") still proposes normally. Nine new tests; full suite passes; `build:cards` builds all 184 cards.

## Trade-off worth naming

Suppressing a bare `hotels` proposal means that if a card ever adds a genuine generic hotels rate *alongside* a portal rate, it would be suppressed rather than surfaced. That risk already exists identically for the `travel` rung directly above it, so this follows the established behaviour rather than introducing a new one — but it is a real false negative, and the `hotels_portal` → `hotels` direction stays false so an actual portal row is never masked by a generic one.