### PR TITLE
cards: backfill foreign_transaction_fee on the last 4 accepting cards

### DIFF
--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -40,6 +40,7 @@ apr:
     min: 27.49
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/cash-back-secured-credit-card/
+foreign_transaction_fee: true
 our_take: >
   The Bank of America Cash Rewards Secured card is a standout option for those
   looking to build or rebuild credit while earning cash back. With no annual

--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -18,6 +18,7 @@ apr:
     min: 14.99
     max: 25.99
 apply_link: https://www.bankofamerica.com/credit-cards/products/bankamericard-credit-card/
+foreign_transaction_fee: true
 our_take: >
   The BankAmericard stands out with its extended 21-month 0% intro APR on both
   purchases and balance transfers, recently increased from 18 months. This

--- a/data/cards/usaa-rewards.yaml
+++ b/data/cards/usaa-rewards.yaml
@@ -22,6 +22,7 @@ apr:
   regular:
     min: 13.40
     max: 27.40
+foreign_transaction_fee: false
 our_take: >
   The USAA Rewards card offers a straightforward rewards structure with no
   annual fee, making it a practical choice for those who frequently spend on

--- a/data/cards/usaa-secured-visa-platinum.yaml
+++ b/data/cards/usaa-secured-visa-platinum.yaml
@@ -12,6 +12,7 @@ apr:
   regular:
     min: 11.40
     max: 21.40
+foreign_transaction_fee: false
 our_take: >
   The USAA Secured Visa Platinum is a straightforward option for those looking
   to build or rebuild their credit without the burden of an annual fee. With a


### PR DESCRIPTION
Follow-up to #1788. These four were the only accepting cards with `foreign_transaction_fee` absent, so the new "No foreign fee" filter excluded them regardless of their actual terms.

| Card | Value | Basis |
|---|---|---|
| USAA Rewards | `false` | USAA card agreement fee schedule |
| USAA Secured Visa Platinum | `false` | USAA card agreement fee schedule |
| BankAmericard | `true` | Absent from BoA no-FTF card page |
| Bank of America Cash Rewards Secured | `true` | Absent from BoA no-FTF card page |

## USAA

USAA's [combined credit card agreement](https://content.usaa.com/mcontent/static_assets/Media/credit_card_combined_agreement.pdf) (08/2025, doc 138910-0126) has a single fee schedule with no per-product variants, and it lists **"Foreign Transaction: None"**. Section 8 describes currency conversion but imposes no USAA fee. Consistent with the five other USAA cards already in the repo, all `false`, including USAA Secured American Express.

## Bank of America

BoA does not publish the Schumer box at a fetchable URL (the per-card terms links 404 without a session), so this rests on [BoA's own no-foreign-transaction-fee card page](https://www.bankofamerica.com/credit-cards/no-foreign-transaction-fee-credit-cards/), which lists Travel Rewards, Premium Rewards, Premium Rewards Elite, Travel Rewards for Students, Travel Rewards Secured and the Atmos pair. Neither of these two appears on it.

That page agrees with **all seven** BoA cards already carrying a value in the repo. It also lists Travel Rewards Secured as no-FTF while omitting the cash secured card, so BoA distinguishes secured cards individually rather than treating them as a block. Third-party sources put the BoA fee at 3%, which we do not store, only the boolean.

Since this is inference from absence rather than a quoted disclosure, it is the weaker of the two claims here and worth a second look if you have a BoA statement handy.

## Result

All 157 accepting cards now carry the field: 119 `false`, 38 `true`. Validated with `npm run build:cards` (184 cards, no errors); regenerated `cards.json` not committed.