### PR TITLE
post-best-rankings: name the merchant a gated rate is limited to

### DIFF
--- a/scripts/post-best-rankings.js
+++ b/scripts/post-best-rankings.js
@@ -230,11 +230,95 @@ function formatRate(reward) {
   return isPercent ? `${display}%` : `${display}x`;
 }
 
+// A reward carrying `merchant_specific: true` or a non-empty `merchant_gate`
+// applies only at the merchants it names, not across its whole spending
+// category — the category is just the bucket the rate lives in. Labeling the
+// Hilton Aspire's Hilton-only 14x as "14x HOTELS" overstates the card, the same
+// way the Intuit Business tweet claimed "5% on online shopping".
+//
+// Gated rates are still worth showing: on a co-brand card the gated rate IS the
+// headline. So the rate keeps its place and gets relabeled with the brand it is
+// gated to ("14x HILTON"). A gated rate we cannot name a brand for — a bare
+// `merchant_specific: true` with no `merchant_gate`, e.g. the Apple Card's 3% —
+// has no truthful short label, so it is dropped and the next-best rate shows.
+function isMerchantGated(reward) {
+  return reward.merchant_specific === true
+    || (Array.isArray(reward.merchant_gate) && reward.merchant_gate.length > 0);
+}
+
+function hasNamedMerchants(reward) {
+  return Array.isArray(reward.merchant_gate) && reward.merchant_gate.length > 0;
+}
+
+// Store display names, keyed by the slug used in `merchant_gate`. Every gate
+// slug is validated against data/stores/ by audit-store-rankings.js, so a
+// lookup miss means the store file was renamed; fall back to the slug itself
+// rather than dropping a real rate.
+const STORES_DIR = path.join(__dirname, '..', 'data', 'stores');
+
+let storeNameCache = null;
+
+function loadStoreNames() {
+  if (storeNameCache) return storeNameCache;
+  storeNameCache = {};
+  try {
+    for (const file of fs.readdirSync(STORES_DIR)) {
+      if (!/\.ya?ml$/.test(file)) continue;
+      const slug = file.replace(/\.ya?ml$/, '');
+      const store = yaml.load(fs.readFileSync(path.join(STORES_DIR, file), 'utf8'));
+      if (store && store.name) storeNameCache[slug] = String(store.name);
+    }
+  } catch (err) {
+    console.warn(`  Warning: could not read store names (${err.message}); falling back to slugs`);
+  }
+  return storeNameCache;
+}
+
+// Labels sit in a narrow right-aligned column at 10px mono, so they have to
+// stay short. Drop trailing words before truncating: "AMERICAN AIRLINES" reads
+// fine as "AMERICAN", where a hard cut would give "AMERICAN AIRLIN…".
+const MAX_LABEL_CHARS = 16;
+
+function fitLabel(label) {
+  if (label.length <= MAX_LABEL_CHARS) return label;
+  const words = label.split(' ');
+  while (words.length > 1) {
+    words.pop();
+    const shorter = words.join(' ');
+    if (shorter.length <= MAX_LABEL_CHARS) return shorter;
+  }
+  return `${label.slice(0, MAX_LABEL_CHARS - 1)}…`;
+}
+
+// One gate → the brand ("HILTON"). Several → "SELECT <CATEGORY>"
+// ("SELECT AIRLINES"), since two brand names never fit the column.
+function gatedLabel(reward, fallbackLabel) {
+  const gates = reward.merchant_gate || [];
+  if (gates.length === 1) {
+    const names = loadStoreNames();
+    return fitLabel((names[gates[0]] || gates[0].replace(/-/g, ' ')).toUpperCase());
+  }
+  const category = REWARD_LABELS[reward.category] || fallbackLabel || String(reward.category).toUpperCase();
+  return fitLabel(`SELECT ${category}`);
+}
+
+// Builds the stat block for a reward, naming the merchant limit when the rate
+// carries one. Returns null when the reward cannot be labeled truthfully, which
+// tells the caller to fall through to its next option.
+function rewardStat(reward, fallbackLabel) {
+  if (!reward) return null;
+  const label = isMerchantGated(reward)
+    ? gatedLabel(reward, fallbackLabel)
+    : (REWARD_LABELS[reward.category] || fallbackLabel || String(reward.category).toUpperCase());
+  return label ? { value: formatRate(reward), label } : null;
+}
+
 function findTopReward(rewards, preferredCategories) {
   if (!rewards || !rewards.length) return null;
-  const pool = preferredCategories
+  const pool = (preferredCategories
     ? rewards.filter(r => preferredCategories.includes(r.category))
-    : rewards.filter(r => r.category !== 'everything_else');
+    : rewards.filter(r => r.category !== 'everything_else')
+  ).filter(r => !isMerchantGated(r) || hasNamedMerchants(r));
   if (!pool.length) return null;
   return [...pool].sort((a, b) => Number(b.value) - Number(a.value))[0];
 }
@@ -268,20 +352,21 @@ function getCategoryStat(card, categorySlug) {
 
   switch (categorySlug) {
     case 'best-travel-cards': {
-      const r = findTopReward(rewards, TRAVEL_LIKE) || findTopReward(rewards);
-      if (r) return { value: formatRate(r), label: REWARD_LABELS[r.category] || r.category.toUpperCase() };
+      const stat = rewardStat(findTopReward(rewards, TRAVEL_LIKE) || findTopReward(rewards));
+      if (stat) return stat;
       break;
     }
     case 'best-airline-cards': {
       const r = findTopReward(rewards, ['airlines', 'flights_portal'])
             || findTopReward(rewards, TRAVEL_LIKE)
             || findTopReward(rewards);
-      if (r) return { value: formatRate(r), label: REWARD_LABELS[r.category] || 'AIRLINES' };
+      const stat = rewardStat(r, 'AIRLINES');
+      if (stat) return stat;
       break;
     }
     case 'best-cash-back-cards': {
-      const r = findTopReward(rewards);
-      if (r) return { value: formatRate(r), label: REWARD_LABELS[r.category] || r.category.toUpperCase() };
+      const stat = rewardStat(findTopReward(rewards));
+      if (stat) return stat;
       // Cards with only `everything_else` (e.g. flat 2%) — show that
       const fallback = (rewards || []).find(x => x.category === 'everything_else');
       if (fallback) return { value: formatRate(fallback), label: 'EVERY PURCHASE' };
@@ -291,7 +376,8 @@ function getCategoryStat(card, categorySlug) {
       const r = findTopReward(rewards, ['dining', 'groceries'])
             || findTopReward(rewards, ['top_category', 'selected_categories'])
             || findTopReward(rewards);
-      if (r) return { value: formatRate(r), label: REWARD_LABELS[r.category] || r.category.toUpperCase() };
+      const stat = rewardStat(r);
+      if (stat) return stat;
       break;
     }
     case 'best-0-apr-cards': {
@@ -306,8 +392,8 @@ function getCategoryStat(card, categorySlug) {
       break;
     }
     case 'best-secured-cards': {
-      const r = findTopReward(rewards);
-      if (r) return { value: formatRate(r), label: REWARD_LABELS[r.category] || r.category.toUpperCase() };
+      const stat = rewardStat(findTopReward(rewards));
+      if (stat) return stat;
       const fallback = (rewards || []).find(x => x.category === 'everything_else');
       if (fallback) return { value: formatRate(fallback), label: 'EVERY PURCHASE' };
       return feeStat(card);
@@ -639,7 +725,19 @@ async function main() {
   console.log(`Queued successfully! Post ID: ${result.id}`);
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  REWARD_LABELS,
+  isMerchantGated,
+  findTopReward,
+  rewardStat,
+  gatedLabel,
+  fitLabel,
+  getCategoryStat,
+};

--- a/scripts/post-best-rankings.test.js
+++ b/scripts/post-best-rankings.test.js
@@ -1,0 +1,191 @@
+// Smoke tests for the ranking-image stat block in post-best-rankings.js.
+//
+// Guards the merchant-gate bug: a rate carrying `merchant_specific: true` or a
+// non-empty `merchant_gate` covers only the merchants it names, not the whole
+// spending category. The stat block used to render the Hilton Aspire's
+// Hilton-only 14x as "14x HOTELS" — the same overstatement that shipped in the
+// Intuit Business tweet as "5% on online shopping".
+//
+// Run: `node scripts/post-best-rankings.test.js`. Exits non-zero on failure.
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const {
+  REWARD_LABELS,
+  isMerchantGated,
+  findTopReward,
+  rewardStat,
+  fitLabel,
+  getCategoryStat,
+} = require('./post-best-rankings.js');
+
+const CARDS_DIR = path.join(__dirname, '..', 'data', 'cards');
+
+const CATEGORIES = [
+  'best-travel-cards',
+  'best-airline-cards',
+  'best-cash-back-cards',
+  'best-dining-grocery-cards',
+  'best-secured-cards',
+];
+
+function loadCard(slug) {
+  return yaml.load(fs.readFileSync(path.join(CARDS_DIR, `${slug}.yaml`), 'utf8'));
+}
+
+function allCards() {
+  return fs.readdirSync(CARDS_DIR)
+    .filter(f => f.endsWith('.yaml'))
+    .map(f => ({ file: f, card: yaml.load(fs.readFileSync(path.join(CARDS_DIR, f), 'utf8')) }));
+}
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+console.log('isMerchantGated');
+
+test('merchant_specific: true is gated', () => {
+  assert.equal(isMerchantGated({ category: 'hotels', merchant_specific: true }), true);
+});
+
+test('a non-empty merchant_gate is gated', () => {
+  assert.equal(isMerchantGated({ category: 'transit', merchant_gate: ['lyft'] }), true);
+});
+
+test('an empty merchant_gate is not gated', () => {
+  assert.equal(isMerchantGated({ category: 'transit', merchant_gate: [] }), false);
+});
+
+console.log('\nfindTopReward');
+
+test('a gated rate with no named merchants is skipped, not labeled', () => {
+  // Apple Card's 3% online_shopping: merchant_specific with no gate slugs, so
+  // there is no brand to name and no truthful short label.
+  const top = findTopReward([
+    { category: 'online_shopping', value: 3, unit: 'percent', merchant_specific: true },
+    { category: 'dining', value: 2, unit: 'percent' },
+  ]);
+  assert.equal(top.category, 'dining');
+});
+
+test('a gated rate with named merchants keeps its place by value', () => {
+  const top = findTopReward([
+    { category: 'hotels', value: 14, unit: 'points_per_dollar', merchant_gate: ['hilton'] },
+    { category: 'dining', value: 7, unit: 'points_per_dollar' },
+  ]);
+  assert.equal(top.category, 'hotels');
+});
+
+test('a card whose only rate is unlabelable yields no reward', () => {
+  const top = findTopReward([
+    { category: 'online_shopping', value: 3, unit: 'percent', merchant_specific: true },
+  ]);
+  assert.equal(top, null);
+});
+
+console.log('\nrewardStat');
+
+test('a single gate is labeled with the store name, not the category', () => {
+  const stat = rewardStat({
+    category: 'hotels', value: 14, unit: 'points_per_dollar', merchant_gate: ['hilton'],
+  });
+  assert.deepEqual(stat, { value: '14x', label: 'HILTON' });
+});
+
+test('several gates read as "SELECT <category>"', () => {
+  const stat = rewardStat({
+    category: 'streaming', value: 10, unit: 'percent',
+    merchant_gate: ['disney-plus', 'hulu', 'espn-plus'],
+  });
+  assert.deepEqual(stat, { value: '10%', label: 'SELECT STREAMING' });
+});
+
+test('an ungated rate keeps its category label', () => {
+  const stat = rewardStat({ category: 'dining', value: 3, unit: 'points_per_dollar' });
+  assert.deepEqual(stat, { value: '3x', label: 'DINING' });
+});
+
+test('an unknown gate slug falls back to the slug, not a category claim', () => {
+  const stat = rewardStat({ category: 'hotels', value: 5, unit: 'percent', merchant_gate: ['some-new-brand'] });
+  assert.equal(stat.label, 'SOME NEW BRAND');
+});
+
+console.log('\nfitLabel');
+
+test('a long label drops trailing words instead of cutting mid-word', () => {
+  assert.equal(fitLabel('AMERICAN AIRLINES'), 'AMERICAN');
+  assert.equal(fitLabel('SOUTHWEST AIRLINES'), 'SOUTHWEST');
+});
+
+test('a label that fits is left alone', () => {
+  assert.equal(fitLabel('UNITED AIRLINES'), 'UNITED AIRLINES');
+  assert.equal(fitLabel('HILTON'), 'HILTON');
+});
+
+console.log('\ngetCategoryStat against real card YAML');
+
+test('Hilton Aspire names Hilton rather than claiming all hotels', () => {
+  const stat = getCategoryStat(loadCard('hilton-honors-american-express-aspire-card'), 'best-travel-cards');
+  assert.deepEqual(stat, { value: '14x', label: 'HILTON' });
+});
+
+test('Ink Business Unlimited names Lyft rather than claiming all transit', () => {
+  const stat = getCategoryStat(loadCard('chase-ink-business-unlimited'), 'best-cash-back-cards');
+  assert.equal(stat.label, 'LYFT');
+});
+
+test('Sapphire Preferred skips its online-only grocery rate', () => {
+  // The 3x groceries is gated to online grocers; dining is the ungated rate.
+  const stat = getCategoryStat(loadCard('chase-sapphire-preferred'), 'best-dining-grocery-cards');
+  assert.equal(stat.label, 'DINING');
+});
+
+test('no card renders a gated rate under a plain category label', () => {
+  for (const { file, card } of allCards()) {
+    const gated = (card.rewards || []).filter(isMerchantGated);
+    if (gated.length === 0) continue;
+    for (const categorySlug of CATEGORIES) {
+      const stat = getCategoryStat(card, categorySlug);
+      if (!stat) continue;
+      for (const reward of gated) {
+        const categoryLabels = [
+          REWARD_LABELS[reward.category],
+          String(reward.category).replace(/_/g, ' ').toUpperCase(),
+        ].filter(Boolean);
+        const sameRate = stat.value === `${reward.value}%` || stat.value === `${reward.value}x`;
+        assert.ok(
+          !(sameRate && categoryLabels.includes(stat.label)),
+          `${file} [${categorySlug}] renders gated ${reward.category} as "${stat.value} ${stat.label}"`
+        );
+      }
+    }
+  }
+});
+
+test('every gated rate that survives selection is labeled by merchant', () => {
+  for (const { file, card } of allCards()) {
+    for (const categorySlug of CATEGORIES) {
+      const rewards = card.rewards || [];
+      const picked = findTopReward(rewards) || null;
+      if (!picked || !isMerchantGated(picked)) continue;
+      assert.ok(
+        Array.isArray(picked.merchant_gate) && picked.merchant_gate.length > 0,
+        `${file} [${categorySlug}] selected an unlabelable gated rate: ${picked.category}`
+      );
+    }
+  }
+});
+
+console.log(failures === 0 ? '\nAll tests passed.' : `\n${failures} test(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Completes the merchant-gate cleanup started in #1787, which fixed the two LLM copy generators and left the ranking images for their own PR.

## The problem

`getCategoryStat` picked the highest-value reward and labeled it with its spending category, ignoring `merchant_specific` / `merchant_gate`. A rate that only earns at one merchant was rendered as a category-wide claim.

The airline list is the clearest case. All five cards earn their top rate only on their own co-brand carrier, and all five rows said `AIRLINES`. The Hilton Aspire's Hilton-only 14x read as `14x HOTELS`.

## The fix

Selection still goes by value. On a co-brand card the gated rate *is* the headline, so it keeps its place and gets relabeled with the brand it's gated to, read from the store's display name in `data/stores/`.

Before and after on `best-airline-cards`:

| card | before | after |
| --- | --- | --- |
| Citi AAdvantage Platinum Select | 2x AIRLINES | 2x AMERICAN |
| JetBlue Plus | 6x AIRLINES | 6x JETBLUE |
| Southwest Rapid Rewards Premier | 3x AIRLINES | 3x SOUTHWEST |
| Southwest Rapid Rewards Priority | 4x AIRLINES | 4x SOUTHWEST |
| British Airways Visa Signature | 3x AIRLINES | 3x BRITISH AIRWAYS |

Two kinds of gated rate can't be labeled this way:

- **No brand to name.** A bare `merchant_specific: true` with no `merchant_gate`, like the Apple Card's 3% "Apple purchases and select merchants via Apple Pay". Dropped from selection so the next-best rate shows (Apple Card falls to `2% DINING`).
- **Several brands.** Two brand names never fit the column, so these read `SELECT AIRLINES` / `SELECT STREAMING` (Atmos Ascent, Disney Inspire).

Labels drop trailing words rather than cutting mid-word: `AMERICAN AIRLINES` (17 chars, over the 16-char column budget) becomes `AMERICAN`, not `AMERICAN AIRLIN…`.

## Verification

```bash
node scripts/post-best-rankings.test.js
```

19 assertions. The last two sweep every card in `data/cards` across all five reward-driven lists and assert no gated rate can surface under a plain category label, and that any gated rate surviving selection has named merchants. I confirmed the sweep is not vacuous by reverting the labeling line: 6 tests fail, including the sweep.

Also rendered the live images with `--dry-run` for `best-travel-cards`, `best-airline-cards`, and `best-cash-back-cards`. Travel and cash-back are unchanged (their current top 5 have no gated top rate), which is the no-regression case; airline is the table above. `BRITISH AIRWAYS` sits well clear of the name column.

## Still open

`spend_cap` / `rate_after_cap` / `cap_period` are not passed to the /best ranking panel, so a capped 5% is weighed as uncapped. Noted in #1787, untouched here.