### PR TITLE
refresh-best-pages: show the ranking panel a rate's spend cap

### DIFF
--- a/scripts/refresh-best-pages.js
+++ b/scripts/refresh-best-pages.js
@@ -130,6 +130,17 @@ function getCardContext(card) {
       if (Array.isArray(r.merchant_gate) && r.merchant_gate.length > 0) {
         out.merchant_gate = r.merchant_gate;
       }
+      // A capped rate is not the rate it advertises. Blue Cash Preferred's 6%
+      // groceries stops at $6,000 of spend a year and drops to 1% after, and
+      // Citi Custom Cash's 5% covers $500 a month. Without these the panel
+      // weighed both as if they ran uncapped. `cap_period` and `rate_after_cap`
+      // are sent explicitly at their schema defaults rather than omitted, so
+      // the model never has to guess the window or the post-cap rate.
+      if (typeof r.spend_cap === 'number') {
+        out.spend_cap = r.spend_cap;
+        out.cap_period = r.cap_period || 'annual';
+        out.rate_after_cap = typeof r.rate_after_cap === 'number' ? r.rate_after_cap : 1;
+      }
       return out;
     });
   }
@@ -241,6 +252,7 @@ const SHARED_GUIDELINES = `RANKING GUIDELINES:
 - Category relevance matters: for a "Best Cash Back" page a card's cash back rates matter most; for "Best Travel" transfer partners, travel perks, and portal multipliers matter most.
 - Consider the full picture: a card with a slightly lower bonus but much better ongoing rewards may deserve a higher rank.
 - A reward marked "merchant_specific": true or carrying a "merchant_gate" list earns its rate ONLY at the merchants named in its "note", not across the category it is filed under. Weigh it as the narrow perk it is, and judge everyday earning on the ungated rates (including "everything_else"). A card whose only high rate is gated is not a high-earning card in that category.
+- A reward carrying "spend_cap" earns its headline rate only on the first spend_cap dollars of spend per "cap_period"; everything above that earns "rate_after_cap". Judge it on what the cap is actually worth, not on the headline rate: 6% on the first $6,000 of yearly grocery spend is worth about $360 a year, so it can lose to a lower uncapped rate for anyone who spends past the cap. A tight cap on a card's headline rate makes it weaker than that rate suggests.
 
 RULES:
 - Rank ALL provided cards. Do NOT add, remove, or invent cards.
@@ -289,6 +301,7 @@ RULES:
 - Keep the cards array in the EXACT order provided. Do NOT reorder, add, or remove cards.
 - ONLY use facts from card_data. Never invent or assume numbers.
 - A reward marked "merchant_specific": true or carrying a "merchant_gate" list applies ONLY at the merchants named in its "note". If you mention such a rate, name that limit (e.g. "5% on Intuit products", "5% on Lyft rides"). Never write it as if it covered the whole category it is filed under, and prefer an ungated rate when one makes the point.
+- A reward carrying "spend_cap" earns its headline rate only on the first spend_cap dollars per "cap_period", then drops to "rate_after_cap". If you mention such a rate, state the cap and the window (e.g. "6% at U.S. supermarkets on up to $6,000 a year, then 1%", "5% on your top category on up to $500 a month"). Never present a capped rate as if it ran unlimited.
 - If a signup_bonus value is a string like "4 Free Night Awards", use it as-is.
 - Match the existing concise, factual, comparative editorial tone. No hype words like "incredible", "amazing", or "unbeatable". Do not use em dashes.
 - Do not mention CreditOdds or link to anything.

--- a/scripts/refresh-best-pages.test.js
+++ b/scripts/refresh-best-pages.test.js
@@ -59,6 +59,40 @@ test('absent scope fields are omitted rather than sent as undefined keys', () =>
   assert.equal('merchant_gate' in empty.rewards[0], false);
 });
 
+test('a spend cap reaches the panel with its window and post-cap rate', () => {
+  const ctx = getCardContext({
+    name: 'X',
+    rewards: [{ category: 'top_category', value: 5, unit: 'percent', spend_cap: 500, cap_period: 'monthly', rate_after_cap: 1 }],
+  });
+  assert.equal(ctx.rewards[0].spend_cap, 500);
+  assert.equal(ctx.rewards[0].cap_period, 'monthly');
+  assert.equal(ctx.rewards[0].rate_after_cap, 1);
+});
+
+test('cap_period and rate_after_cap are sent at their schema defaults, not omitted', () => {
+  // The schema defaults cap_period to annual and rate_after_cap to 1. Sending
+  // a bare spend_cap would leave the model guessing both.
+  const ctx = getCardContext({
+    name: 'X', rewards: [{ category: 'groceries', value: 6, unit: 'percent', spend_cap: 6000 }],
+  });
+  assert.equal(ctx.rewards[0].cap_period, 'annual');
+  assert.equal(ctx.rewards[0].rate_after_cap, 1);
+});
+
+test('a rate_after_cap of 0 survives instead of defaulting to 1', () => {
+  const ctx = getCardContext({
+    name: 'X', rewards: [{ category: 'gas', value: 5, unit: 'percent', spend_cap: 6000, rate_after_cap: 0 }],
+  });
+  assert.equal(ctx.rewards[0].rate_after_cap, 0);
+});
+
+test('an uncapped reward carries no cap keys', () => {
+  const ctx = getCardContext({ name: 'X', rewards: [{ category: 'dining', value: 4, unit: 'percent' }] });
+  for (const key of ['spend_cap', 'cap_period', 'rate_after_cap']) {
+    assert.equal(key in ctx.rewards[0], false, `${key} leaked onto an uncapped reward`);
+  }
+});
+
 test('the dead `description` field is gone', () => {
   const ctx = getCardContext({
     name: 'X', rewards: [{ category: 'dining', value: 4, unit: 'percent', description: 'should not be read' }],
@@ -73,6 +107,16 @@ test('both prompts explain what a gate means', () => {
   for (const [label, prompt] of [['voter', buildVoterPrompt(page, [])], ['writer', buildWriterPrompt(page, [])]]) {
     assert.match(prompt, /merchant_specific/, `${label} prompt does not mention merchant_specific`);
     assert.match(prompt, /merchant_gate/, `${label} prompt does not mention merchant_gate`);
+  }
+});
+
+test('both prompts explain what a cap means', () => {
+  // The fields are useless if the models are not told how to read them.
+  const page = { data: { title: 'Best X', description: 'd', cards: [], intro: '' } };
+  for (const [label, prompt] of [['voter', buildVoterPrompt(page, [])], ['writer', buildWriterPrompt(page, [])]]) {
+    assert.match(prompt, /spend_cap/, `${label} prompt does not mention spend_cap`);
+    assert.match(prompt, /cap_period/, `${label} prompt does not mention cap_period`);
+    assert.match(prompt, /rate_after_cap/, `${label} prompt does not mention rate_after_cap`);
   }
 });
 
@@ -102,6 +146,32 @@ if (!fs.existsSync(CARDS_FILE)) {
     // A gated rate with no note gives the panel a flag it cannot interpret.
     // If this ever fails, the card YAML needs a note, not a code change.
     assert.deepEqual(missing, [], `gated rewards with no scope note:\n${missing.join('\n')}`);
+  });
+
+  test('every capped reward reaches the panel with a window and a post-cap rate', () => {
+    const broken = [];
+    for (const card of cards) {
+      const ctx = getCardContext(card);
+      const source = card.rewards || [];
+      for (const [i, r] of (ctx.rewards || []).entries()) {
+        if (typeof source[i].spend_cap !== 'number') continue;
+        if (typeof r.spend_cap !== 'number'
+          || typeof r.cap_period !== 'string'
+          || typeof r.rate_after_cap !== 'number') {
+          broken.push(`${card.slug}: ${r.value} ${r.category}`);
+        }
+      }
+    }
+    assert.deepEqual(broken, [], `capped rewards missing cap context:\n${broken.join('\n')}`);
+  });
+
+  test('a known capped rate arrives capped', () => {
+    const bcp = cards.find(c => c.slug === 'blue-cash-preferred-card');
+    assert.ok(bcp, 'blue-cash-preferred-card missing from cards.json');
+    const groceries = getCardContext(bcp).rewards.find(r => r.category === 'groceries');
+    assert.equal(groceries.spend_cap, 6000);
+    assert.equal(groceries.cap_period, 'annual');
+    assert.equal(groceries.rate_after_cap, 1);
   });
 
   test('notes and gates actually survive for a known-gated card', () => {


### PR DESCRIPTION
Last of the reward-scope gaps opened in #1787 and closed for the ranking images in #1792.

## The problem

`getCardContext` passed each reward's `category`, `value`, `unit`, `note`, and gate flags, but never `spend_cap` / `cap_period` / `rate_after_cap`. Every capped rate reached the ranking panel looking unlimited:

| card | what the panel saw | what the card actually pays |
| --- | --- | --- |
| Blue Cash Preferred | 6% groceries | 6% on the first $6,000 a year, then 1% |
| Citi Custom Cash | 5% top category | 5% on the first $500 a month, then 1% |
| Chase Freedom Flex | 5% rotating | 5% on the first $1,500 a quarter, then 1% |
| Amex Gold | 4x groceries | 4x on the first $25,000 a year, then 1x |

45 capped rewards across 28 cards, 25 of them on cards currently listed on a /best page. Nine are on the dining and grocery list, where the cap is often the whole argument: Blue Cash Preferred's 6% beats Blue Cash Everyday's 3% only up to $6,000 of grocery spend a year.

## The fix

Pass the three fields through. `cap_period` and `rate_after_cap` are sent explicitly at their schema defaults (`annual`, `1`) rather than omitted when the YAML leaves them out, so the model never has to guess the window or the post-cap rate.

```json
{"category":"groceries","value":6,"unit":"percent","note":"U.S. supermarkets",
 "spend_cap":6000,"cap_period":"annual","rate_after_cap":1}
```

Both prompts gain a rule, since the fields are useless if the models don't know how to read them. The voter is told to judge a capped rate on what the cap is worth rather than the headline rate, and that a tight cap can lose to a lower uncapped rate. The writer is told to state the cap and window whenever it quotes one, e.g. "6% at U.S. supermarkets on up to $6,000 a year, then 1%".

## Verification

```bash
node scripts/refresh-best-pages.test.js
```

17 assertions, up from 10. New cases cover the defaults, a `rate_after_cap: 0` surviving instead of being defaulted to 1, uncapped rewards carrying no cap keys, both prompts naming all three fields, and a sweep asserting every capped reward in cards.json arrives with a window and a post-cap rate. Confirmed non-vacuous by deleting the passthrough block: 5 tests fail.

Unlike #1787 I could not run a live vote to show a ranking delta — there is no `OPENAI_API_KEY` on this machine. The change is deterministic in the context payload, which the tests pin, but the effect on actual rankings will first be visible on the next scheduled `refresh-best-pages` run.

## Still open

`expires` is the remaining reward-scope field the panel cannot see, so a limited-time promo rate (the Chase Lyft 5% through September 2027) is weighed as permanent. Same shape of fix; left out here to keep this PR to the caps.