### PR TITLE
United Explorer: rename to "Reduced Mileage Awards"

### DIFF
--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -91,7 +91,7 @@ benefits:
     frequency: "per_purchase"
     category: "statement_credit"
     enrollment_required: false
-  - name: "10% Award Flight Discount"
+  - name: "Reduced Mileage Awards"
     value: 10
     value_unit: "percent"
     description: "Save 10% or more on the miles needed when booking award flights on United or United Express"


### PR DESCRIPTION
Follow-up to #1784, which renamed this benefit to "10% Award Flight Discount".

That name tokenized **identically** to the card's existing "Award Flight Discount":

```
"Award Flight Discount"      → {award, flight, discount}
"10% Award Flight Discount"  → {award, flight, discount}
```

`tokenizeBenefitName` strips `%` as punctuation and filters tokens of 2 characters or fewer, so `10%` — the only thing distinguishing the two names — disappears entirely. `looksLikeSameBenefit` saw 3 shared tokens against a threshold of 2 and treated them as the same benefit.

Consequence: if United ever changed one of the two (the \$20,000 threshold, or the 10% rate), a proposal describing that change could dedupe against the other and be dropped as already-known, without reaching a PR or the review queue.

"Reduced Mileage Awards" is United's own terminology and shares only `{award}` with the existing name — one token, no subset relationship, both sets larger than 2, so no match.

Verified: `looksLikeSameBenefit("Award Flight Discount", "Reduced Mileage Awards")` is `false`. `build:cards` passes.