### PR TITLE
cards: add a network field and populate 159 of 184 cards

### DIFF
--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -151,6 +151,9 @@ export interface Card {
   annual_fee?: number;
   annual_fee_intro?: { value: number; months: number };
   foreign_transaction_fee?: boolean;
+  // Payment network. Undefined means unknown, not "runs on no network" — match
+  // on an explicit value rather than treating absence as a default.
+  network?: 'visa' | 'mastercard' | 'amex' | 'discover';
   apply_link?: string;
   special_apply_link?: string;
   card_referral_link?: string;

--- a/data/cards/aaa-daily-advantage-visa-signature.yaml
+++ b/data/cards/aaa-daily-advantage-visa-signature.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 apply_link: https://northeast.aaa.com/financial/more-products/aaa-visa-credit-card.html
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "cashback"
 tags:
   - cashback

--- a/data/cards/aaa-travel-advantage-visa-signature.yaml
+++ b/data/cards/aaa-travel-advantage-visa-signature.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 apply_link: https://northeast.aaa.com/financial/more-products/aaa-visa-credit-card.html
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "cashback"
 tags:
   - cashback

--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 image: "aer-lingus.png"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "miles"
 tags:
   - airline

--- a/data/cards/amazon-business-prime-american-express-card.yaml
+++ b/data/cards/amazon-business-prime-american-express-card.yaml
@@ -39,6 +39,7 @@ tags:
   - cashback
   - shopping
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/amazon-business-prime-card/
+network: "amex"
 our_take: >
   The Amazon Business Prime American Express card offers an impressive 5% cash
   back on U.S. purchases at Amazon.com, Amazon Business, AWS, and Whole Foods

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -49,6 +49,7 @@ special_apply_link: https://www.amazon.com/dp/BT00LN946S
 # checker's blocked-host list, which it no longer does.
 page_check_url: https://creditcards.chase.com/cash-back-credit-cards/amazon-prime-rewards
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Amazon Prime Rewards Visa Signature card shines for Amazon Prime members
   with a hefty 5% cash back on purchases at Amazon, Whole Foods Market,

--- a/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
+++ b/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
@@ -30,6 +30,7 @@ apr:
     max: 29.49
 apply_link: https://www.citi.com/credit-cards/aadvantage-mile-up-credit-card
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The American Airlines AAdvantage MileUp Mastercard is a solid choice for
   frequent flyers who want to earn miles without paying an annual fee. With 2

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -88,6 +88,7 @@ tags:
   - premium
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/american-express-business-gold-card-amex/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   Built for businesses with lumpy, varied spend: 4x auto-applies to your top
   two categories each cycle (U.S. advertising, electronics and cloud, dining,

--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -5,6 +5,7 @@ image: "amex_gold_card.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/gold-card/
 foreign_transaction_fee: false
+network: "amex"
 card_referral_link: "https://www.americanexpress.com/en-us/referral/personal/gold-card?ref="
 our_take: >
   The American Express Gold card shines for foodies and travelers alike,

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -5,6 +5,7 @@ image: "amex_green_card.png"
 accepting_applications: false
 apply_link: https://www.americanexpress.com/us/credit-cards/card/green/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The American Express Green card stands out for frequent travelers and diners
   with its 3 points per dollar on travel, transit, and dining purchases,

--- a/data/cards/amex-everyday-credit-card.yaml
+++ b/data/cards/amex-everyday-credit-card.yaml
@@ -6,6 +6,7 @@ accepting_applications: false
 annual_fee: 0
 reward_type: "points"
 apply_link: https://www.americanexpress.com/us/credit-cards/card/amex-everyday/
+network: "amex"
 our_take: >
   The Amex Everyday card is no longer accepting applications, so it won't be
   an option if you're looking to add a new card to your wallet. It previously

--- a/data/cards/amex-everyday-preferred-credit-card.yaml
+++ b/data/cards/amex-everyday-preferred-credit-card.yaml
@@ -6,6 +6,7 @@ image: "everyday-preferred.png"
 annual_fee: 95
 reward_type: "points"
 apply_link: https://www.americanexpress.com/us/credit-cards/card/amex-everyday-preferred/
+network: "amex"
 our_take: >
   The Amex Everyday Preferred card is no longer accepting applications, which
   means it's off the table for new cardholders. For those who already have it,

--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -38,6 +38,7 @@ apr:
     max: 27.74
 apply_link: https://www.apple.com/apple-card/
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The Apple Card stands out for its seamless integration with Apple Pay,
   offering 3% cash back on Apple purchases and select merchants like Nike and

--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 category: "travel"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "visa"
 tags:
   - travel
   - airline

--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -12,6 +12,7 @@ annual_fee: 95
 check_ignore:
   - annual_fee
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Atmos Rewards Business card from Bank of America is a strong contender
   for businesses that frequently book flights with Alaska Airlines, offering 3

--- a/data/cards/atmos-rewards-summit.yaml
+++ b/data/cards/atmos-rewards-summit.yaml
@@ -7,6 +7,7 @@ apply_link: https://www.bankofamerica.com/credit-cards/products/alaska-airlines-
 category: "travel"
 annual_fee: 395
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Atmos Rewards Summit card from Bank of America is designed for frequent
   travelers who can leverage its robust airline perks, including 3 points per

--- a/data/cards/att-points-plus-from-citi.yaml
+++ b/data/cards/att-points-plus-from-citi.yaml
@@ -5,6 +5,7 @@ image: "citi-att-points-plus.png"
 accepting_applications: true
 apply_link: https://www.citi.com/credit-cards/citi-att-pointsplus-credit-card
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The AT&T Points Plus from Citi stands out with its robust rewards structure,
   offering 3 points per dollar on gas and EV charging, and 2 points per dollar

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -41,6 +41,7 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/cash-back-secured-credit-card/
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The Bank of America Cash Rewards Secured card is a standout option for those
   looking to build or rebuild credit while earning cash back. With no annual

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -6,6 +6,7 @@ image: "customized-cash-rewards.png"
 category: "cashback"
 annual_fee: 0
 foreign_transaction_fee: true
+network: "visa"
 reward_type: "cashback"
 tags:
   - cashback

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -6,6 +6,7 @@ image: "premium-rewards.png"
 category: "travel"
 annual_fee: 550
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "points"
 benefits:
   - name: "Lifestyle Credit"

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 category: "travel"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "points"
 benefits:
   - name: "Airline Incidental Credit"

--- a/data/cards/bank-of-america-travel-rewards.yaml
+++ b/data/cards/bank-of-america-travel-rewards.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 category: "travel"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "points"
 signup_bonus:
   value: 25000

--- a/data/cards/bank-of-america-unlimited-cash-rewards.yaml
+++ b/data/cards/bank-of-america-unlimited-cash-rewards.yaml
@@ -6,6 +6,7 @@ category: "cashback"
 image: "unlimited-cash-rewards.png"
 annual_fee: 0
 foreign_transaction_fee: true
+network: "visa"
 reward_type: "cashback"
 tags:
   - cashback

--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -19,6 +19,7 @@ apr:
     max: 25.99
 apply_link: https://www.bankofamerica.com/credit-cards/products/bankamericard-credit-card/
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The BankAmericard stands out with its extended 21-month 0% intro APR on both
   purchases and balance transfers, recently increased from 18 months. This

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -5,6 +5,7 @@ image: "bilt_blue.png"
 accepting_applications: true
 apply_link: https://www.biltrewards.com/card/apply
 foreign_transaction_fee: false
+network: "mastercard"
 annual_fee: 0
 reward_type: "points"
 release_date: "2025-01-15"

--- a/data/cards/bilt-mastercard.yaml
+++ b/data/cards/bilt-mastercard.yaml
@@ -8,6 +8,7 @@ category: "rewards"
 annual_fee: 0
 reward_type: "points"
 release_date: "2022-06-01"
+network: "mastercard"
 our_take: >
   The Bilt Mastercard, issued by Wells Fargo, is no longer accepting
   applications, which limits its availability for new cardholders. With no

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -5,6 +5,7 @@ image: "bilt_obsidian.png"
 accepting_applications: true
 apply_link: https://www.biltrewards.com/card/apply
 foreign_transaction_fee: false
+network: "mastercard"
 annual_fee: 95
 reward_type: "points"
 release_date: "2025-01-15"

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -5,6 +5,7 @@ image: "bilt_palladium.png"
 accepting_applications: true
 apply_link: https://www.biltrewards.com/card/apply
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The Bilt Palladium card stands out with its unique ability to pay rent
   without transaction fees while earning points, a rare feature among premium

--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -30,6 +30,7 @@ tags:
   - cashback
 apply_link: https://www.americanexpress.com/en-us/business/credit-cards/blue-business-cash
 foreign_transaction_fee: true
+network: "amex"
 our_take: >
   The Blue Business Cash Card from American Express offers a straightforward
   2% cash back on all purchases up to $50,000 annually, then 1% thereafter,

--- a/data/cards/blue-business-plus-credit-card-from-american-express.yaml
+++ b/data/cards/blue-business-plus-credit-card-from-american-express.yaml
@@ -30,6 +30,7 @@ tags:
   - rewards
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/american-express-blue-business-plus-credit-card-amex/
 foreign_transaction_fee: true
+network: "amex"
 our_take: >
   The Blue Business Plus from American Express stands out for its
   straightforward rewards structure, offering 2 points per dollar on all

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -5,6 +5,7 @@ image: "amex_blue_cash_everyday.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/blue-cash-everyday/
 foreign_transaction_fee: true
+network: "amex"
 card_referral_link: "https://americanexpress.com/en-us/referral/blue-cash-everyday-credit-card?ref="
 our_take: >
   The Blue Cash Everyday card from American Express is a no-annual-fee option

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -5,6 +5,7 @@ image: "amex_blue_cash_preferred.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/blue-cash-preferred/
 foreign_transaction_fee: true
+network: "amex"
 our_take: >
   The Blue Cash Preferred card from American Express is a standout for
   families and frequent shoppers, offering an impressive 6% cash back on up to

--- a/data/cards/blue-from-american-express.yaml
+++ b/data/cards/blue-from-american-express.yaml
@@ -4,6 +4,7 @@ slug: "blue-from-american-express"
 accepting_applications: false
 annual_fee: 0
 reward_type: "points"
+network: "amex"
 our_take: >
   The Blue card from American Express is no longer accepting applications,
   which means it's off the table for new cardholders. With a $0 annual fee, it

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 image: "british-airways.png"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "miles"
 tags:
   - airline

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -101,6 +101,7 @@ apr:
     max: 28.49
 apply_link: https://www.capitalone.com/credit-cards/venture-x/
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Capital One Venture X Rewards card stands out with a substantial
   75,000-mile signup bonus after spending $4,000 in the first three months,

--- a/data/cards/cash-magnet-card.yaml
+++ b/data/cards/cash-magnet-card.yaml
@@ -11,6 +11,7 @@ rewards:
     unit: "percent"
     note: "1.5% unlimited cash back on all eligible purchases"
 apply_link: https://www.americanexpress.com/us/credit-cards/card/cash-magnet/
+network: "amex"
 our_take: >
   The American Express Cash Magnet card offers a straightforward 1.5%
   unlimited cash back on all eligible purchases, making it a simple choice for

--- a/data/cards/chase-aeroplan.yaml
+++ b/data/cards/chase-aeroplan.yaml
@@ -72,6 +72,7 @@ tags:
   - rewards
 apply_link: https://creditcards.chase.com/travel-credit-cards/aircanada/aeroplan
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The Chase Aeroplan card is a strong contender for frequent Air Canada
   travelers, offering 3 points per dollar on Air Canada purchases, dining, and

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -59,6 +59,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/flex
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The Chase Freedom Flex stands out as the top pick for cash back enthusiasts,
   offering a robust 5% back on quarterly rotating categories like gas

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -31,6 +31,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/rise
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The Chase Freedom Rise offers a straightforward 1.5% cash back on all
   purchases with no annual fee, making it a solid entry-level choice for those

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -45,6 +45,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/unlimited
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The Chase Freedom Unlimited is a versatile cash-back card with no annual
   fee, offering a solid 1.5% back on all purchases and higher rates in

--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -72,6 +72,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/business-credit-cards/IHG/business-premier
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The IHG One Rewards Premier Business card from Chase offers a compelling
   140,000-point signup bonus after spending $4,000 in the first three months,

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -68,6 +68,7 @@ apr:
     max: 24.74
 apply_link: https://creditcards.chase.com/business-credit-cards/ink/cash
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The Ink Business Cash card stands out with its generous 5% cash back on
   office supplies, internet, cable, and phone services, up to a combined

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 category: "business"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "points"
 tags:
   - business

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -47,6 +47,7 @@ our_take: >
   seeking uncomplicated rewards and a strong introductory offer.
 apply_link: https://creditcards.chase.com/business-credit-cards/ink/unlimited
 foreign_transaction_fee: true
+network: "visa"
 benefits:
   - name: "Instacart+ Membership"
     description: "Complimentary three-month Instacart+ membership with a $20 Instacart credit each month"

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -96,6 +96,7 @@ apr:
     max: 27.49
 apply_link: https://creditcards.chase.com/rewards-credit-cards/sapphire/preferred
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Chase Sapphire Preferred stands out with its recently increased signup
   bonus of 100,000 points after spending $5,000 in the first three months,

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -140,6 +140,7 @@ apr:
     max: 27.99
 apply_link: https://creditcards.chase.com/rewards-credit-cards/sapphire/reserve
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Chase Sapphire Reserve is a top-tier choice for luxury travelers,
   offering an array of premium benefits that can offset its hefty $795 annual

--- a/data/cards/chase-slate-edge.yaml
+++ b/data/cards/chase-slate-edge.yaml
@@ -13,6 +13,7 @@ apr:
     max: 28.99
 apply_link: https://creditcards.chase.com/credit-building-credit-cards/edge
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The Slate Edge is a simple no-annual-fee card built around one idea: a built-in incentive
   to lower your APR over time if you pay on time and spend a set amount each year. It no

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -84,6 +84,7 @@ apr:
     max: 29.49
 apply_link: https://www.citi.com/usc/lpaca/aa/aadvantage/exec/ps/index0.html
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The Citi AAdvantage Executive World Elite Mastercard is a strong contender
   for frequent American Airlines flyers, offering full Admirals Club lounge

--- a/data/cards/citi-aadvantage-globe.yaml
+++ b/data/cards/citi-aadvantage-globe.yaml
@@ -93,6 +93,7 @@ apr:
     max: 29.49
 apply_link: https://www.citi.com/credit-cards/citi-aadvantage-globe-mastercard
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The Citi AAdvantage Globe card stands out for frequent American Airlines
   travelers with perks like a free first checked bag and preferred boarding.

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -60,6 +60,7 @@ apr:
     max: 29.49
 apply_link: https://www.citi.com/credit-cards/citi-aadvantage-platinum-select-world-elite-mastercard
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The Citi AAdvantage Platinum Select World Elite Mastercard shines for
   frequent American Airlines flyers, offering a generous 80,000-mile signup

--- a/data/cards/citi-diamond-preferred.yaml
+++ b/data/cards/citi-diamond-preferred.yaml
@@ -19,6 +19,7 @@ apr:
     max: 27.24
 apply_link: https://www.citi.com/credit-cards/citi-diamond-preferred-credit-card
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The Citi Diamond Preferred card stands out for its lengthy 21-month 0% intro
   APR on balance transfers, making it a top choice for those focused on paying

--- a/data/cards/citi-double-cash.yaml
+++ b/data/cards/citi-double-cash.yaml
@@ -31,6 +31,7 @@ apr:
     max: 27.49
 apply_link: https://www.citi.com/credit-cards/citi-double-cash-credit-card
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The Citi Double Cash card stands out for its straightforward cash back
   structure, offering 2% on all purchases: 1% when you buy and an additional

--- a/data/cards/citi-prestige.yaml
+++ b/data/cards/citi-prestige.yaml
@@ -5,6 +5,7 @@ accepting_applications: false
 image: "citi-prestige.png"
 annual_fee: 495
 reward_type: "points"
+network: "mastercard"
 our_take: >
   The Citi Prestige card is no longer accepting applications, which limits its
   appeal to current cardholders who already enjoy its benefits. With a high

--- a/data/cards/citi-rewards.yaml
+++ b/data/cards/citi-rewards.yaml
@@ -5,6 +5,7 @@ accepting_applications: false
 annual_fee: 0
 reward_type: "points"
 image: "citi-rewards-plus.png"
+network: "mastercard"
 our_take: >
   The Citi Rewards+ card is no longer accepting applications, which is a shame
   given its unique rewards structure. With no annual fee, it offered a

--- a/data/cards/citi-secured-mastercard.yaml
+++ b/data/cards/citi-secured-mastercard.yaml
@@ -13,6 +13,7 @@ apr:
     max: 25.99
 apply_link: https://www.citi.com/credit-cards/citi-secured-credit-card
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The Citi Secured Mastercard is a straightforward tool for building or
   rebuilding your credit, with no annual fee to worry about. As a secured

--- a/data/cards/citi-simplicity-card.yaml
+++ b/data/cards/citi-simplicity-card.yaml
@@ -19,6 +19,7 @@ apr:
     max: 28.24
 apply_link: https://www.citi.com/credit-cards/citi-simplicity-credit-card
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The Simplicity is a debt-payoff card: 18 months of 0% intro APR on both
   purchases and balance transfers (transfers must be completed within the first

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -86,6 +86,7 @@ apr:
     max: 28.49
 apply_link: https://www.citi.com/credit-cards/citi-strata-elite-credit-card
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   Citi's run at the premium-travel tier, a $595 card stacked with credits (hotel,
   splurge, Blacklane), Priority Pass, and a strong 75,000-point bonus, and it ranks among

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -51,6 +51,7 @@ apr:
     max: 28.24
 apply_link: https://www.citi.com/credit-cards/citi-strata-premier-credit-card
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The Citi Strata Premier card stands out with its impressive 10 points per
   dollar on hotels, car rentals, and attractions booked through Citi Travel,

--- a/data/cards/citi-strata.yaml
+++ b/data/cards/citi-strata.yaml
@@ -57,6 +57,7 @@ apr:
     max: 28.49
 apply_link: https://www.citi.com/credit-cards/citi-strata-credit-card
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The Citi Strata card stands out with its 5 points per dollar on hotels, car
   rentals, and attractions booked through Citi Travel, making it a strong

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -15,6 +15,7 @@ annual_fee_intro:
   value: 0
   months: 12
 foreign_transaction_fee: false
+network: "mastercard"
 reward_type: "miles"
 our_take: >
   The Citi AAdvantage Business World Elite Mastercard is a solid choice for

--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -38,6 +38,7 @@ apr:
     max: 26.74
 apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-business-card
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   Effectively free if you are already paying for a Costco membership (no separate
   annual fee), and the gas rate is the draw: 5% at Costco gas stations and 4% on

--- a/data/cards/costco-anywhere-visa-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-card-by-citi.yaml
@@ -37,6 +37,7 @@ apr:
     max: 26.74
 apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-card
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Costco Anywhere Visa by Citi stands out for its strong cashback rates,
   especially if you're a frequent Costco shopper or driver. You'll earn 5%

--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -5,6 +5,7 @@ image: "amex_delta_blue_skymiles.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-blue-american-express-card/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Delta SkyMiles Blue American Express card stands out as a no-annual-fee
   option for Delta flyers, offering 2 miles per dollar on Delta purchases and

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -5,6 +5,7 @@ image: "amex_delta_skymiles_gold.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-gold-american-express-card/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Delta SkyMiles Gold American Express card stands out with its generous
   signup bonus of up to 90,000 miles, which requires $5,000 in spending within

--- a/data/cards/delta-skymiles-gold-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-business-american-express-card.yaml
@@ -5,6 +5,7 @@ image: "amex_delta_skymiles_gold_business.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-gold
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Delta SkyMiles Gold Business American Express card stands out with a
   limited-time signup bonus of 90,000 miles after spending $6,000 in the first

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -5,6 +5,7 @@ image: "amex_delta_skymiles_platinum.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-platinum-american-express-card/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Delta SkyMiles Platinum American Express card is a strong contender for
   frequent Delta flyers, offering a generous signup bonus of up to 100,000

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -5,6 +5,7 @@ image: "amex_delta_skymiles_reserve.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-reserve-american-express-card/
 foreign_transaction_fee: false
+network: "amex"
 annual_fee: 650
 reward_type: "miles"
 our_take: >

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -35,6 +35,7 @@ apr:
     max: 26.49
 apply_link: https://www.discover.com/credit-cards/cash-back/it-card.html
 foreign_transaction_fee: false
+network: "discover"
 our_take: >
   The Discover it Cash Back card stands out with its 5% cash back on quarterly
   rotating categories like gas, EV charging, transit, airlines, and

--- a/data/cards/discover-it-for-students-card.yaml
+++ b/data/cards/discover-it-for-students-card.yaml
@@ -32,6 +32,7 @@ apr:
     max: 25.49
 apply_link: https://www.discover.com/credit-cards/student/it-card.html
 foreign_transaction_fee: false
+network: "discover"
 our_take: >
   The Discover it for Students card is a solid starter option with no annual
   fee and a unique Cashback Match feature that doubles your cash back at the

--- a/data/cards/discover-it-gas-and-restaurants.yaml
+++ b/data/cards/discover-it-gas-and-restaurants.yaml
@@ -5,6 +5,7 @@ accepting_applications: false
 image: "discover-it-gas-restaurants.png"
 annual_fee: 0
 reward_type: "cashback"
+network: "discover"
 our_take: >
   The Discover it Gas and Restaurants card is no longer accepting
   applications, which means it's off the table for new cardholders. For those

--- a/data/cards/discover-it-miles.yaml
+++ b/data/cards/discover-it-miles.yaml
@@ -24,6 +24,7 @@ apr:
     max: 26.49
 apply_link: https://www.discover.com/credit-cards/travel/
 foreign_transaction_fee: false
+network: "discover"
 our_take: >
   The Discover it Miles card offers a straightforward rewards structure with
   1.5 miles per dollar on every purchase, making it a solid choice for those

--- a/data/cards/discover-it-secured-credit-card.yaml
+++ b/data/cards/discover-it-secured-credit-card.yaml
@@ -28,6 +28,7 @@ apr:
     max: 26.49
 apply_link: https://www.discover.com/credit-cards/secured-credit-card/
 foreign_transaction_fee: false
+network: "discover"
 our_take: >
   One of the best secured cards for building credit because it earns like a real
   rewards card: 5% on rotating quarterly categories (up to $1,500 in spend,

--- a/data/cards/discover-it-student-chrome-card.yaml
+++ b/data/cards/discover-it-student-chrome-card.yaml
@@ -30,6 +30,7 @@ apr:
     max: 25.49
 apply_link: https://www.discover.com/credit-cards/student/chrome-card.html
 foreign_transaction_fee: false
+network: "discover"
 our_take: >
   A starter card for students who want simple, capped rewards without tracking
   rotating categories: 2% at gas and restaurants on up to $1,000 combined per

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -89,6 +89,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/inspire
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Inspire is the top Disney card, with a $149 fee buying a $300 Disney eGift
   card up front, 10% back on Disney+/Hulu/ESPN+, and 3% on Disney purchases.

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -88,4 +88,5 @@ our_take: >
   for Disney-related expenses.
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/premier
 foreign_transaction_fee: true
+network: "visa"
 

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -22,6 +22,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/rewards
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The Disney Visa from Chase is an attractive option for Disney enthusiasts,
   especially with its recently increased signup bonus of $150. This bonus is

--- a/data/cards/expedia-rewards-card-from-citi.yaml
+++ b/data/cards/expedia-rewards-card-from-citi.yaml
@@ -5,6 +5,7 @@ accepting_applications: false
 image: "citi-expedia-rewards.png"
 annual_fee: 0
 reward_type: "points"
+network: "mastercard"
 our_take: >
   The Expedia Rewards from Citi card is no longer accepting applications,
   which limits its appeal to current cardholders. With no annual fee, it was

--- a/data/cards/expedia-rewards-voyager-card-from-citi.yaml
+++ b/data/cards/expedia-rewards-voyager-card-from-citi.yaml
@@ -5,6 +5,7 @@ accepting_applications: false
 image: "citi-expedia-rewards-voyager.png"
 annual_fee: 0
 reward_type: "points"
+network: "mastercard"
 our_take: >
   The Expedia Rewards Voyager from Citi is no longer accepting applications,
   which limits its relevance for new card seekers. For existing cardholders,

--- a/data/cards/fidelity-rewards-visa-signature.yaml
+++ b/data/cards/fidelity-rewards-visa-signature.yaml
@@ -24,6 +24,7 @@ apply_link: https://www.fidelity.com/spend-save/visa-signature-card
 # only on that landing page and is not advertised on the public apply page, so the bonus
 # was removed with it. Restore both together if Fidelity publishes a new offer page.
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Fidelity Rewards Visa Signature card offers a straightforward 2% cash
   back on all purchases when you deposit the rewards into an eligible Fidelity

--- a/data/cards/gemini-credit.yaml
+++ b/data/cards/gemini-credit.yaml
@@ -33,6 +33,7 @@ apr:
     max: 34.49
 apply_link: https://www.gemini.com/credit-card
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The hook here is that rewards pay out in crypto, with 4% on gas, EV charging, and transit
   (capped at $300 of combined spend per month), 3% dining, 2% groceries, and 1% on everything

--- a/data/cards/graphite-business-cash-unlimited.yaml
+++ b/data/cards/graphite-business-cash-unlimited.yaml
@@ -8,6 +8,7 @@ category: "business"
 annual_fee: 295
 apply_link: "https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/graphite-business-cash-unlimited-card/"
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Graphite Business Cash Unlimited card from American Express offers a
   straightforward 2% cash back on all eligible purchases, making it a reliable

--- a/data/cards/hawaiian-airlines-business-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-business-mastercard.yaml
@@ -7,6 +7,7 @@ category: "business"
 image: "barclays-hawaiian-business.png"
 annual_fee: 99
 foreign_transaction_fee: false
+network: "mastercard"
 reward_type: "miles"
 tags:
   - travel

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -6,6 +6,7 @@ category: "travel"
 image: "barclays-hawaiian.png"
 annual_fee: 99
 foreign_transaction_fee: false
+network: "mastercard"
 reward_type: "miles"
 tags:
   - travel

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -5,6 +5,7 @@ image: "amex_hilton_honors_aspire.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors-aspire/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Hilton Honors American Express Aspire card is a powerhouse for frequent
   Hilton guests, offering a massive 14 points per dollar on eligible Hilton

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -5,6 +5,7 @@ image: "amex_hilton_honors_surpass.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors-surpass/
 foreign_transaction_fee: false
+network: "amex"
 annual_fee: 150
 our_take: >
   The Hilton Honors American Express Surpass card stands out for frequent

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -5,6 +5,7 @@ image: "amex_hilton_honors.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Hilton Honors American Express Card shines with a generous 100,000-point
   signup bonus, recently increased from 80,000, plus a $100 statement credit

--- a/data/cards/hotels-com-rewards-visa.yaml
+++ b/data/cards/hotels-com-rewards-visa.yaml
@@ -5,6 +5,7 @@ accepting_applications: false
 image: "wells-fargo-hotels-com.png"
 annual_fee: 0
 reward_type: null
+network: "visa"
 our_take: >
   The Hotels.com Rewards Visa from Wells Fargo is no longer accepting
   applications, so it won't be an option for new cardholders looking to earn

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -5,6 +5,7 @@ accepting_applications: true
 image: "iberia-plus.png"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "miles"
 our_take: >
   The Iberia Visa Signature card is a compelling choice for frequent flyers of

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -110,6 +110,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/premier
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The IHG One Rewards Premier card shines for frequent IHG travelers with its
   standout benefit of up to 26x points per dollar at IHG hotels. It also

--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -93,6 +93,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/traveler
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The IHG Rewards Club Traveler card is a solid choice for frequent IHG hotel
   guests, offering up to 17x points per dollar spent at IHG properties with no

--- a/data/cards/intuit-business.yaml
+++ b/data/cards/intuit-business.yaml
@@ -34,6 +34,7 @@ apr:
     min: 14.24
     max: 35.24
 foreign_transaction_fee: true
+network: "mastercard"
 apply_link: https://www.intuit.com/credit-card/
 benefits:
   - name: "QuickBooks Sync"

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -7,6 +7,7 @@ category: "business"
 image: "barclays-jetblue-business.png"
 annual_fee: 99
 foreign_transaction_fee: false
+network: "mastercard"
 reward_type: "points"
 tags:
   - travel

--- a/data/cards/jetblue-card.yaml
+++ b/data/cards/jetblue-card.yaml
@@ -4,6 +4,7 @@ slug: "jetblue-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/banking/cards/jetblue-card/
 foreign_transaction_fee: false
+network: "mastercard"
 category: "travel"
 image: "barclays-jetblue.png"
 annual_fee: 0

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -7,6 +7,7 @@ category: "travel"
 image: "barclays-jetblue-plus.png"
 annual_fee: 99
 foreign_transaction_fee: false
+network: "mastercard"
 reward_type: "points"
 our_take: >
   The JetBlue Plus card is a strong contender for frequent JetBlue flyers,

--- a/data/cards/jetblue-premier-card.yaml
+++ b/data/cards/jetblue-premier-card.yaml
@@ -7,6 +7,7 @@ category: "travel"
 image: "jetblue-premier.png"
 annual_fee: 499
 foreign_transaction_fee: false
+network: "mastercard"
 reward_type: "points"
 tags:
   - travel

--- a/data/cards/marriott-bonvoy-bevy-american-express.yaml
+++ b/data/cards/marriott-bonvoy-bevy-american-express.yaml
@@ -5,6 +5,7 @@ image: "marriott-bonvoy-bevy.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy-bevy/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Marriott Bonvoy Bevy American Express card is a strong choice for
   frequent Marriott travelers, offering 6 points per dollar at participating

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -78,6 +78,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/bold
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Marriott Bonvoy Bold card is a solid choice for travelers who frequent
   Marriott properties, offering 3 points per dollar spent at Marriott Bonvoy

--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -86,6 +86,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/boundless
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Marriott Bonvoy Boundless card from Chase is a strong contender for
   frequent Marriott guests, offering 6 points per dollar at Marriott Bonvoy

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -5,6 +5,7 @@ image: "amex_marriott_bonvoy_brilliant.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy-brilliant/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The Marriott Bonvoy Brilliant American Express card is a strong choice for
   frequent Marriott guests, offering 6 points per dollar at Marriott

--- a/data/cards/navy-federal-cash-rewards-plus.yaml
+++ b/data/cards/navy-federal-cash-rewards-plus.yaml
@@ -6,6 +6,7 @@ category: "cashback"
 image: "navy-federal-cash-rewards-plus.png"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "cashback"
 our_take: >
   The Navy Federal cashRewards Plus card stands out for its straightforward

--- a/data/cards/navy-federal-cash-rewards-secured.yaml
+++ b/data/cards/navy-federal-cash-rewards-secured.yaml
@@ -6,6 +6,7 @@ category: "secured"
 image: "navy-federal-cash-rewards-secured.png"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "cashback"
 tags:
   - secured

--- a/data/cards/navy-federal-cash-rewards.yaml
+++ b/data/cards/navy-federal-cash-rewards.yaml
@@ -6,6 +6,7 @@ category: "cashback"
 image: "navy-federal-cash-rewards.png"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "cashback"
 tags:
   - cashback

--- a/data/cards/navy-federal-flagship-rewards.yaml
+++ b/data/cards/navy-federal-flagship-rewards.yaml
@@ -6,6 +6,7 @@ category: "travel"
 image: "navy-federal-flagship-rewards.png"
 annual_fee: 49
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Navy Federal Visa Signature Flagship Travel Rewards card is a strong
   contender for frequent travelers, offering 3 points per dollar on a wide

--- a/data/cards/navy-federal-more-rewards-american-express.yaml
+++ b/data/cards/navy-federal-more-rewards-american-express.yaml
@@ -6,6 +6,7 @@ category: "rewards"
 image: "navy-federal-more-rewards-american-express.png"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "amex"
 reward_type: "points"
 our_take: >
   The Navy Federal More Rewards American Express card stands out for its

--- a/data/cards/nhl-discover-it.yaml
+++ b/data/cards/nhl-discover-it.yaml
@@ -34,6 +34,7 @@ apr:
     max: 26.49
 apply_link: https://www.discover.com/credit-cards/cash-back/nhl-card.html
 foreign_transaction_fee: false
+network: "discover"
 our_take: >
   The NHL Discover it card stands out with its 5% cashback on quarterly
   rotating categories, which currently include gas, EV charging, transit,

--- a/data/cards/paypal-cashback-mastercard.yaml
+++ b/data/cards/paypal-cashback-mastercard.yaml
@@ -24,6 +24,7 @@ apr:
     max: 33.24
 apply_link: https://www.paypal.com/us/digital-wallet/manage-money/paypal-cashback-mastercard
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The PayPal Cashback Mastercard stands out for its simple and effective
   rewards structure: 3% cash back on purchases made through PayPal checkout,

--- a/data/cards/playstation-visa.yaml
+++ b/data/cards/playstation-visa.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 apply_link: https://www.playstation.com/en-us/playstation-credit-card/
 annual_fee: 0
 foreign_transaction_fee: true
+network: "visa"
 reward_type: "points"
 tags:
   - entertainment

--- a/data/cards/pnc-cash-rewards.yaml
+++ b/data/cards/pnc-cash-rewards.yaml
@@ -49,6 +49,7 @@ apr:
     max: 28.49
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-cash-rewards-visa-credit-card.html
 foreign_transaction_fee: true
+network: "visa"
 benefits:
   - name: "Cell Phone Protection"
     value: 0

--- a/data/cards/pnc-cash-unlimited.yaml
+++ b/data/cards/pnc-cash-unlimited.yaml
@@ -6,6 +6,7 @@ category: "cashback"
 image: "pnc-cash-unlimited.png"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "cashback"
 tags:
   - cashback

--- a/data/cards/pnc-secured.yaml
+++ b/data/cards/pnc-secured.yaml
@@ -12,6 +12,7 @@ apr:
     min: 25.49
     max: 25.49
 foreign_transaction_fee: true
+network: "visa"
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-secured-credit-card.html
 our_take: >
   The PNC Secured card is a straightforward option for those looking to build

--- a/data/cards/pnc-spend-wise.yaml
+++ b/data/cards/pnc-spend-wise.yaml
@@ -17,6 +17,7 @@ apr:
     min: 19.49
     max: 27.49
 foreign_transaction_fee: true
+network: "visa"
 benefits:
   - name: "Purchase APR Reduction Program"
     value: 0

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -21,6 +21,7 @@ category: "travel"
 image: "barclays-princess.png"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "points"
 rewards:
   - category: travel

--- a/data/cards/rakuten-american-express.yaml
+++ b/data/cards/rakuten-american-express.yaml
@@ -47,6 +47,7 @@ apr:
     min: 19.74
     max: 33.99
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   This card is built for Rakuten loyalists: 4% on Rakuten.com (up to $10,000 a year)
   and 5% on Rakuten Dining stack on top of the usual cash-back portal, with a $100

--- a/data/cards/rei-co-op-mastercard.yaml
+++ b/data/cards/rei-co-op-mastercard.yaml
@@ -5,6 +5,7 @@ image: "rei-coop.png"
 accepting_applications: true
 apply_link: https://www.capitalone.com/credit-cards/rei/
 foreign_transaction_fee: false
+network: "mastercard"
 annual_fee: 0
 reward_type: "cashback"
 tags:

--- a/data/cards/samsung-galaxy-card.yaml
+++ b/data/cards/samsung-galaxy-card.yaml
@@ -7,6 +7,7 @@ apply_link: https://www.samsung.com/us/samsung-card/
 category: "cashback"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 release_date: "2026-07-20"
 reward_type: "cashback"
 tags:

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -65,6 +65,11 @@
       "type": "boolean",
       "description": "Whether the card charges a foreign transaction fee. true = card charges a foreign transaction fee; false = no foreign transaction fees on international purchases (optional)"
     },
+    "network": {
+      "type": "string",
+      "enum": ["visa", "mastercard", "amex", "discover"],
+      "description": "Payment network the card runs on. OMIT when unknown, when the issuer assigns the network at approval rather than per product (several Capital One products), or for closed-loop store cards that run on no network at all. Absent means unknown, never 'no network', so consumers must match on an explicit value rather than treating a missing field as a default (optional)"
+    },
     "release_date": {
       "type": "string",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}$",

--- a/data/cards/serve-from-american-express.yaml
+++ b/data/cards/serve-from-american-express.yaml
@@ -3,6 +3,7 @@ bank: "American Express"
 slug: "serve-from-american-express"
 accepting_applications: false
 annual_fee: 0
+network: "amex"
 our_take: >
   The Serve card from American Express is no longer accepting applications,
   which limits its availability for new users. With no annual fee, it was a

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -91,6 +91,7 @@ benefits:
       - instacart
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/plus
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Southwest Rapid Rewards Plus card is a solid choice for frequent
   Southwest flyers, with 2 points per dollar on Southwest purchases and a

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -95,6 +95,7 @@ tags:
   - travel
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/premier
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Southwest Rapid Rewards Premier card is a strong choice for frequent
   Southwest flyers, offering 3 points per dollar on Southwest Airlines

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -99,6 +99,7 @@ tags:
   - rewards
 apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/priority
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Southwest Rapid Rewards Priority card is a strong choice for frequent
   Southwest flyers, offering 4 points per dollar on Southwest purchases and a

--- a/data/cards/starbucks-rewards-visa-card.yaml
+++ b/data/cards/starbucks-rewards-visa-card.yaml
@@ -5,6 +5,7 @@ image: "chase-starbucks-rewards.png"
 accepting_applications: false
 annual_fee: 0
 reward_type: null
+network: "visa"
 our_take: >
   The Starbucks Rewards Visa from Chase is no longer accepting applications,
   so if you were considering it for your wallet, you'll need to look

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -160,6 +160,7 @@ tags:
   - premium
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/american-express-business-platinum-credit-card-amex/
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The most loaded business travel card there is: Centurion and Priority Pass
   lounge access, 5x on Amex Travel flights and prepaid hotels, a 200k-point

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -5,6 +5,7 @@ image: "amex_the_platinum_card.png"
 accepting_applications: true
 apply_link: https://www.americanexpress.com/us/credit-cards/card/platinum/
 foreign_transaction_fee: false
+network: "amex"
 card_referral_link: "https://americanexpress.com/en-us/referral/platinum-card?ref="
 our_take: >
   The Platinum Card from American Express stands out with a massive

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -108,6 +108,7 @@ tags:
   - premium
 apply_link: https://creditcards.chase.com/travel-credit-cards/united/club-infinite
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The United Club Infinite card is a premium choice for frequent United
   flyers, offering a strong 5 miles per dollar on United purchases and a

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -104,6 +104,7 @@ tags:
   - rewards
 apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-explorer
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The United Explorer card is a solid choice for frequent United Airlines
   travelers, offering 3 miles per dollar on eligible United purchases and a

--- a/data/cards/united-gateway.yaml
+++ b/data/cards/united-gateway.yaml
@@ -38,6 +38,7 @@ tags:
   - travel
 apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-gateway
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The United Gateway card stands out with its $0 annual fee and a solid
   rewards structure, offering 2 miles per dollar on United purchases, gas, and

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -132,6 +132,7 @@ tags:
   - premium
 apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-quest
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The United Quest card is a strong contender for frequent United Airlines
   travelers, offering 4 miles per dollar on United purchases and a $200 annual

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -64,6 +64,7 @@ apr:
     max: 27.49
 apply_link: https://www.usbank.com/credit-cards/altitude-connect-visa-signature-credit-card.html
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   Unusually generous for a no-annual-fee travel card: 4x on travel and gas, 5x through the
   travel portal, plus a Global Entry credit and a 12-month Priority Pass Select membership,

--- a/data/cards/us-bank-altitude-go-visa-signature.yaml
+++ b/data/cards/us-bank-altitude-go-visa-signature.yaml
@@ -47,6 +47,7 @@ apr:
     max: 27.49
 apply_link: https://www.usbank.com/credit-cards/altitude-go-visa-signature-credit-card.html
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The U.S. Bank Altitude Go Visa Signature card stands out with its impressive
   4 points per dollar on dining, up to $2,000 per quarter, making it a top

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -6,6 +6,7 @@ category: "travel"
 image: "us-bank-altitude-reserve.png"
 annual_fee: 400
 reward_type: "points"
+network: "visa"
 our_take: >
   The U.S. Bank Altitude Reserve Visa Infinite offers a compelling travel
   package with its standout $325 annual travel credit for purchases made via a

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -50,6 +50,7 @@ apr:
     max: 27.99
 apply_link: https://www.usbank.com/credit-cards/cash-plus-visa-signature-credit-card.html
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The U.S. Bank Cash+ Visa Signature card shines with its customizable 5% cash
   back on two categories of your choice each quarter, up to $2,000 in combined

--- a/data/cards/us-bank-secured.yaml
+++ b/data/cards/us-bank-secured.yaml
@@ -23,3 +23,4 @@ apr:
     min: 27.49
     max: 27.49
 foreign_transaction_fee: true
+network: "visa"

--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -25,6 +25,7 @@ apr:
     max: 27.99
 apply_link: https://www.usbank.com/credit-cards/pm/shield-visa-credit-card.html
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   U.S. Bank recently trimmed the Shield's 0% intro APR from 24 months to 21,
   but it still offers one of the longest interest-free periods available,

--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -75,3 +75,4 @@ our_take: >
   spenders who can take full advantage of the rotating categories.
 apply_link: https://www.usbank.com/credit-cards/shopper-cash-rewards-visa-signature-credit-card.html
 foreign_transaction_fee: true
+network: "visa"

--- a/data/cards/us-bank-smartly-visa-signature.yaml
+++ b/data/cards/us-bank-smartly-visa-signature.yaml
@@ -37,3 +37,4 @@ apr:
     min: 18.24
     max: 28.24
 foreign_transaction_fee: true
+network: "visa"

--- a/data/cards/us-bank-split.yaml
+++ b/data/cards/us-bank-split.yaml
@@ -9,6 +9,7 @@ tags:
   - rewards
 apply_link: https://www.usbank.com/credit-cards/offers/split-card-world-mastercard-credit-card.html
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   The U.S. Bank Split card stands out with its unique 3-month interest-free
   payment plans for purchases of $100 or more, allowing for flexibility

--- a/data/cards/usaa-cashback-rewards-plus.yaml
+++ b/data/cards/usaa-cashback-rewards-plus.yaml
@@ -34,6 +34,7 @@ apr:
     min: 15.40
     max: 27.40
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   The USAA Cashback Rewards Plus card offers standout value for military
   families and frequent drivers, with 5% cash back on gas and purchases at

--- a/data/cards/usaa-eagle-navigator.yaml
+++ b/data/cards/usaa-eagle-navigator.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 category: "travel"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "visa"
 tags:
   - travel
   - rewards

--- a/data/cards/usaa-preferred-cash-rewards.yaml
+++ b/data/cards/usaa-preferred-cash-rewards.yaml
@@ -30,3 +30,4 @@ apr:
     min: 15.40
     max: 27.40
 foreign_transaction_fee: false
+network: "visa"

--- a/data/cards/usaa-rate-advantage.yaml
+++ b/data/cards/usaa-rate-advantage.yaml
@@ -16,6 +16,7 @@ apr:
     min: 10.40
     max: 24.40
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   A low-rate card for USAA members who carry a balance: a roughly 20-month 0% intro on transfers and,
   more notably, an ongoing regular APR that starts as low as 10.40%, well below most cards.

--- a/data/cards/usaa-rewards.yaml
+++ b/data/cards/usaa-rewards.yaml
@@ -23,6 +23,7 @@ apr:
     min: 13.40
     max: 27.40
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The USAA Rewards card offers a straightforward rewards structure with no
   annual fee, making it a practical choice for those who frequently spend on

--- a/data/cards/usaa-secured-american-express.yaml
+++ b/data/cards/usaa-secured-american-express.yaml
@@ -13,6 +13,7 @@ apr:
     min: 26.40
     max: 26.40
 foreign_transaction_fee: false
+network: "amex"
 our_take: >
   This is a no-fee secured card for building or rebuilding credit. The 26.40%
   APR is in line with typical secured cards, so treat it as a credit-building

--- a/data/cards/usaa-secured-visa-platinum.yaml
+++ b/data/cards/usaa-secured-visa-platinum.yaml
@@ -13,6 +13,7 @@ apr:
     min: 11.40
     max: 21.40
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The USAA Secured Visa Platinum is a straightforward option for those looking
   to build or rebuild their credit without the burden of an annual fee. With a

--- a/data/cards/venmo-credit-card.yaml
+++ b/data/cards/venmo-credit-card.yaml
@@ -47,6 +47,7 @@ apr:
     max: 30.74
 apply_link: https://venmo.com/about/creditcard
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   A no-fee card that auto-adjusts to your spending: 3% on your top category and 2%
   on your second each statement period, from a list of eight, with 1% on the rest.

--- a/data/cards/wells-fargo-active-cash.yaml
+++ b/data/cards/wells-fargo-active-cash.yaml
@@ -30,6 +30,7 @@ apr:
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/active-cash-credit-card
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The Wells Fargo Active Cash card stands out for its straightforward 2% cash
   back on every purchase, making it an excellent choice for those who prefer a

--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -58,6 +58,7 @@ apr:
     min: 18.49
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/attune-credit-card
+network: "mastercard"
 our_take: >
   The Wells Fargo Attune card offers a robust 4% cash back on a diverse range
   of categories including gyms, entertainment, streaming services, and even

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -61,6 +61,7 @@ apr:
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/autograph-journey-visa-credit-card
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   A strong mid-tier travel card: 5x on hotels, 4x on airlines, and 3x on dining and other
   travel, plus a $50 annual statement credit and no foreign transaction fee for $95. The travel

--- a/data/cards/wells-fargo-autograph.yaml
+++ b/data/cards/wells-fargo-autograph.yaml
@@ -53,6 +53,7 @@ apr:
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/autograph-visa-credit-card
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The Wells Fargo Autograph card stands out with its 3x points on dining,
   travel, gas, transit, and streaming, all with no annual fee, making it a

--- a/data/cards/wells-fargo-cash-wise-visa.yaml
+++ b/data/cards/wells-fargo-cash-wise-visa.yaml
@@ -5,6 +5,7 @@ image: "cash_wise.png"
 accepting_applications: false
 annual_fee: 0
 reward_type: "cashback"
+network: "visa"
 our_take: >
   The Wells Fargo Cash Wise Visa is no longer accepting applications, which
   limits its appeal right out of the gate. For those who already have it, the

--- a/data/cards/wells-fargo-choice-privileges-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-mastercard.yaml
@@ -42,6 +42,7 @@ apr:
     max: 28.49
 apply_link: https://creditcards.wellsfargo.com/choice-hotel-privileges-mastercard
 foreign_transaction_fee: false
+network: "mastercard"
 our_take: >
   The Wells Fargo Choice Privileges Mastercard is a strong contender for
   travelers who frequently stay at Choice Hotels, offering 5 points per dollar

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -6,6 +6,7 @@ accepting_applications: true
 category: "travel"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "mastercard"
 reward_type: "points"
 our_take: >
   The Wells Fargo Choice Privileges Select Mastercard is a compelling option

--- a/data/cards/wells-fargo-propel-american-express.yaml
+++ b/data/cards/wells-fargo-propel-american-express.yaml
@@ -26,6 +26,7 @@ rewards:
   - category: "everything_else"
     value: 1
     unit: "points_per_dollar"
+network: "amex"
 our_take: >
   The Wells Fargo Propel American Express card offers a strong earn rate of 3
   points per dollar on popular categories like dining, travel, transit, gas,

--- a/data/cards/wells-fargo-reflect.yaml
+++ b/data/cards/wells-fargo-reflect.yaml
@@ -19,6 +19,7 @@ apr:
     max: 28.24
 apply_link: https://creditcards.wellsfargo.com/reflect-visa-credit-card
 foreign_transaction_fee: true
+network: "visa"
 our_take: >
   The Wells Fargo Reflect card offers a standout 21-month 0% intro APR on both
   purchases and balance transfers, making it a top choice for those looking to

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -4,6 +4,7 @@ slug: "wells-fargo-signify-business-cash"
 accepting_applications: true
 apply_link: https://creditcards.wellsfargo.com/business-credit-cards/signify-business-cash-credit-card/
 foreign_transaction_fee: true
+network: "mastercard"
 our_take: >
   A clean, no-fee business card built on simplicity: a flat 2% back on every
   purchase with no categories to track and a 12-month 0% intro APR on purchases,

--- a/data/cards/wells-fargo-visa-signature.yaml
+++ b/data/cards/wells-fargo-visa-signature.yaml
@@ -5,6 +5,7 @@ image: "wells_fargo_visa_signature.png"
 accepting_applications: false
 annual_fee: 0
 reward_type: "points"
+network: "visa"
 our_take: >
   The Wells Fargo Visa Signature card is no longer accepting applications,
   which limits its availability to new users. For those who already have it,

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -77,6 +77,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/business-credit-cards/world-of-hyatt/hyatt-business-card
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   Aimed at business owners loyal to Hyatt: up to 9x at Hyatt properties,
   automatic Discoverist status, up to $100 in Hyatt statement credits each

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -73,6 +73,7 @@ apr:
     max: 27.74
 apply_link: https://creditcards.chase.com/travel-credit-cards/world-of-hyatt-credit-card
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The World of Hyatt Credit Card is a strong choice for Hyatt loyalists,
   offering up to 9x points at Hyatt properties when combined with World of

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -17,6 +17,7 @@ category: "business"
 image: "barclays-wyndham-earner-business.png"
 annual_fee: 149
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "points"
 tags:
   - hotel

--- a/data/cards/wyndham-rewards-earner-card.yaml
+++ b/data/cards/wyndham-rewards-earner-card.yaml
@@ -7,6 +7,7 @@ category: "travel"
 image: "barclays-wyndham-earner.png"
 annual_fee: 0
 foreign_transaction_fee: false
+network: "visa"
 our_take: >
   The no-fee entry to Wyndham's lineup: 5x at Hotels by Wyndham, 3x on dining
   and groceries, automatic Gold status, and a 10% discount on award-night

--- a/data/cards/wyndham-rewards-earner-plus-card.yaml
+++ b/data/cards/wyndham-rewards-earner-plus-card.yaml
@@ -7,6 +7,7 @@ category: "travel"
 image: "barclays-wyndham-earner-plus.png"
 annual_fee: 95
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "points"
 tags:
   - hotel

--- a/data/cards/wyndham-rewards-earner-premier-card.yaml
+++ b/data/cards/wyndham-rewards-earner-premier-card.yaml
@@ -7,6 +7,7 @@ category: "travel"
 image: "barclays-wyndham-earner-premier.png"
 annual_fee: 395
 foreign_transaction_fee: false
+network: "visa"
 reward_type: "points"
 tags:
   - hotel

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -96,6 +96,12 @@ function validateCard(card, schema, categoryIds, storeSlugs) {
     errors.push(`Invalid reward_type: ${card.reward_type}`);
   }
 
+  // Validate network enum. Absent is legal and means unknown — see the schema
+  // note. Only an explicitly wrong value is an error.
+  if (card.network !== undefined && !schema.properties.network.enum.includes(card.network)) {
+    errors.push(`Invalid network: ${card.network} (must be one of ${schema.properties.network.enum.join(', ')})`);
+  }
+
   // Validate rewards categories against categories.yaml
   if (card.rewards) {
     const validModes = ['quarterly_rotating', 'user_choice', 'auto_top_spend'];


### PR DESCRIPTION
We were not tracking the payment network anywhere: not in the YAML, not in `schema.json`, not on the `Card` TS type. This adds the field and populates it. **No UI consumes it yet** — the /explore filter is the follow-up, per the ask.

## The field

`network`, optional, enum `visa | mastercard | amex | discover`. Validated in `build-cards.js` (the schema enum is not checked generically, so a bare enum entry would let a typo through — verified the guard rejects `"MasterCard"`). Mirrored on the `Card` type.

**Absent means unknown, not "no network."** Same convention `foreign_transaction_fee` needed: a consumer must match an explicit value rather than treating a missing field as a default. Documented in the schema description.

## Coverage: 159 of 184 (157 active cards → 138 set, 19 unset)

| Network | All | Active |
|---|---|---|
| visa | 78 | 72 |
| mastercard | 43 | 37 |
| amex | 31 | 23 |
| discover | 7 | 6 |
| unset | 25 | 19 |

Sources, in precedence order:
- **65** where the network is in the card's own official name (Visa Signature, World Elite Mastercard, etc.)
- **78** read off the card art in `data/cards/images`. Before trusting this I ran four control cards whose network the name already gives; all four read correctly.
- **16** from a quoted issuer disclosure or Visa's own card directory — Freedom Flex "World Elite Mastercard", Citi Double Cash "is a Mastercard credit card", Apple Card "Mastercard is our global payment network", United trio "Visa Signature Concierge Service", Venture X "Visa Infinite Guide to Benefits" — plus 7 Amex-issued cards that are on Amex by construction.

## The 25 left unset, and why

Not guessed. Leaving them absent is the honest state given the field's semantics.

- **11 Capital One products.** Capital One does not state a network on its product pages (checked Venture, Quicksilver, SavorOne, Platinum — all silent), and it assigns the network at approval for several of these, so any single value would be wrong for some cardholders. Venture X is the one exception and is set, because its page cites the Visa Infinite Guide to Benefits.
- **Navy Federal GO REWARDS / GO BIZ / Platinum, Robinhood Gold + Platinum, Coinbase One, Atlas** — art carries no network mark.
- **Amazon Store** — closed-loop store card, genuinely on no network. Arguably wants its own value rather than absence; flagging rather than deciding.
- **6 archived** — Citi Custom Cash, AT&T Access, United Presidential Plus, three Wells Fargo.

Citi Custom Cash is worth a note: I did not infer it Mastercard despite 10 of 10 Citi cards read from art being Mastercard, because Citi also issues Visa (Costco Anywhere), so the issuer-level pattern is not safe.

## Two findings that contradicted plausible priors

Both came from the card art, and both would have been wrong if assumed:
- **BankAmericard is Mastercard**, not Visa.
- **USAA Cashback Rewards Plus is American Express**, which the name does not say.

## Validation

`npm run build:cards` clean (184 cards), `tsc --noEmit` clean, regenerated `cards.json` not committed.