### PR TITLE
Stop counting capped % rebates as free statement credits

### DIFF
--- a/apps/web-next/src/lib/cardDisplayUtils.test.ts
+++ b/apps/web-next/src/lib/cardDisplayUtils.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatBenefitValue,
+  amortizedAnnualValue,
+  isMonetaryBenefit,
+  spendableValue,
+} from './cardDisplayUtils';
+
+// `value_unit: "percent"` marks a benefit whose value is a RATE — a 20%
+// inflight rebate, a 10% concessions rebate. formatBenefitValue had no
+// percent branch, so it fell through to the dollar case and rendered
+// "20%" as "$20" on every surface (card page, compare, wallet).
+// Confirmed live on the Delta SkyMiles Blue page before the fix.
+describe('formatBenefitValue', () => {
+  it('renders a percent benefit as a rate, not dollars', () => {
+    expect(
+      formatBenefitValue({ name: 'x', value: 20, value_unit: 'percent', frequency: 'per_purchase' } as never)
+    ).toBe('20%');
+  });
+
+  it('does not divide a percent rate down by frequency', () => {
+    // A rate applies per purchase; dividing it by 12 would be meaningless.
+    expect(
+      formatBenefitValue({ name: 'x', value: 10, value_unit: 'percent', frequency: 'monthly' } as never)
+    ).toBe('10%');
+  });
+
+  it('still renders dollars, points and miles as before', () => {
+    expect(formatBenefitValue({ name: 'x', value: 250, frequency: 'annual' } as never)).toBe('$250');
+    expect(formatBenefitValue({ name: 'x', value: 240, frequency: 'monthly' } as never)).toBe('$20');
+    expect(
+      formatBenefitValue({ name: 'x', value: 5000, value_unit: 'points', frequency: 'annual' } as never)
+    ).toBe('5,000 points');
+    expect(
+      formatBenefitValue({ name: 'x', value: 10000, value_unit: 'miles', frequency: 'annual' } as never)
+    ).toBe('10,000 miles');
+  });
+});
+
+// A capped percentage rebate is not free money: "10% back up to $250" needs
+// $2,500 of spend to realise $250. Modelling it as `value: 250` in USD put
+// it in the "Statement credits" table and summed it into Total annual value
+// as though it were a giveaway. Modelled as a percent it contributes 0.
+describe('percent benefits never inflate annual value', () => {
+  const rebate = { name: 'Venue Collection', value: 10, value_unit: 'percent', frequency: 'annual' } as never;
+
+  it('is not treated as a monetary benefit', () => {
+    expect(isMonetaryBenefit(rebate)).toBe(false);
+  });
+
+  it('contributes nothing to the annual credits rollup', () => {
+    expect(amortizedAnnualValue(rebate)).toBe(0);
+  });
+
+  it('a real dollar credit still contributes', () => {
+    expect(
+      amortizedAnnualValue({ name: 'Hotel Credit', value: 250, frequency: 'annual' } as never)
+    ).toBe(250);
+  });
+});
+
+describe('spendableValue', () => {
+  it('splits a dollar total across its cycle', () => {
+    expect(spendableValue({ name: 'x', value: 240, frequency: 'monthly' } as never)).toBe(20);
+    expect(spendableValue({ name: 'x', value: 200, frequency: 'quarterly' } as never)).toBe(50);
+  });
+});

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -176,6 +176,10 @@ export function spendableValue(benefit: CardBenefit): number {
 }
 
 export function formatBenefitValue(benefit: CardBenefit): string {
+  // `percent` is a RATE, not an amount, so it must not be divided down by
+  // frequency the way a dollar total is — a 20% inflight rebate is 20% on
+  // every purchase, not 20/12 of anything. Read `value` directly.
+  if (benefit.value_unit === 'percent') return `${benefit.value.toLocaleString()}%`;
   const v = spendableValue(benefit).toLocaleString();
   if (benefit.value_unit === 'points') return `${v} points`;
   if (benefit.value_unit === 'miles') return `${v} miles`;

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -49,7 +49,8 @@ benefits:
     category: "security"
     enrollment_required: true
   - name: "American Express Venue Collection"
-    value: 250
+    value: 10
+    value_unit: "percent"
     description: "10% back on qualifying concessions purchases at select stadiums and arenas up to $250 per calendar year, plus access to dedicated entrances or fast lanes."
     frequency: "annual"
     category: "entertainment"

--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -51,7 +51,8 @@ benefits:
     category: "statement_credit"
     enrollment_required: false
   - name: "Amex Venue Collection"
-    value: 250
+    value: 10
+    value_unit: "percent"
     description: "10% back on qualifying concessions purchases at select stadiums and arenas up to $250 per calendar year."
     frequency: "annual"
     category: "entertainment"

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -55,7 +55,8 @@ benefits:
     category: "hotel"
     enrollment_required: false
   - name: "American Express Venue Collection"
-    value: 250
+    value: 10
+    value_unit: "percent"
     description: "Enhanced experience at select stadiums and arenas with dedicated entrances and 10% back on qualifying concessions purchases up to $250 per calendar year."
     frequency: "annual"
     category: "entertainment"

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -91,7 +91,8 @@ benefits:
     category: "hotel"
     enrollment_required: false
   - name: "American Express Venue Collection"
-    value: 250
+    value: 10
+    value_unit: "percent"
     description: "10% back on food and beverage concessions purchases at Amex Venue Collection stadiums and arenas, up to $250 per calendar year"
     frequency: "annual"
     category: "entertainment"

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -77,7 +77,8 @@ benefits:
     frequency: "ongoing"
     category: "hotel"
   - name: "American Express Venue Collection"
-    value: 250
+    value: 10
+    value_unit: "percent"
     description: "10% back on food and beverage concessions purchases at Amex Venue Collection stadiums and arenas, up to $250 per calendar year"
     frequency: "annual"
     category: "entertainment"

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -65,7 +65,8 @@ benefits:
     frequency: "ongoing"
     category: "hotel"
   - name: "American Express Venue Collection"
-    value: 250
+    value: 10
+    value_unit: "percent"
     description: "10% back on food and beverage concessions purchases at Amex Venue Collection stadiums and arenas, up to $250 per calendar year"
     frequency: "annual"
     category: "entertainment"


### PR DESCRIPTION
Reported: Hilton Honors shows "American Express Venue Collection — \$250 /yr" under **Statement credits**, but that benefit is *10% back up to \$250*. You only see \$250 if you spend \$2,500 on stadium concessions. Statement credits are money you get for free; this isn't that.

That's right, and digging in turned up a second, wider defect underneath it.

## Defect 1 — `percent` benefits render as dollars

`formatBenefitValue` handles `points` and `miles`, then falls through to `$${v}`. There is no `percent` branch, so a benefit with `value_unit: "percent"` prints its rate as a dollar figure.

Confirmed live on Delta SkyMiles Blue before this fix — its **20%** inflight rebate displays as **"$20"**. This affects **34 benefits** across the corpus and every surface that formats a benefit (card page, compare, wallet, CardBenefits).

## Defect 2 — a capped rebate typed as dollars

Amex Venue Collection is a 10% rebate capped at \$250/yr, modeled as `value: 250` with no unit — i.e. as USD. That is indistinguishable from a real \$250 credit, so it landed in the Statement credits table and was summed into **Total annual value**. Six cards carried it.

The corpus already has the right convention: 34 rebates use `value_unit: percent`. These six were the outliers.

**Total annual value, before → after:**

| Card | Before | After |
|---|---|---|
| Hilton Honors | \$250 | **\$0** |
| Delta SkyMiles Blue | \$250 | **\$0** |
| Hilton Honors Surpass | \$450 | \$200 |
| Amex Green | \$469 | \$219 |
| Delta SkyMiles Gold | \$370 | \$120 |
| Hilton Honors Aspire | \$1,069 | \$819 |

The two fixes are coupled: converting the data without the `percent` branch would have rendered these as **"$10"**, which is worse than the bug being fixed.

## Scope

`amortizedAnnualValue` already gates on `isMonetaryBenefit` (which excludes `percent`), so percent benefits contributed 0 to every rollup already. The totals above were wrong purely because these six were typed as dollars. Benefit values do not feed `/best-card-for` ranking, so no ranking changed.

## Not from the weekly checker

Neither defect came from this week's run. The Venue Collection rows were added by #1696 (the July full-card sync); the `formatBenefitValue` gap is older still.

## Verification

New `cardDisplayUtils.test.ts` — 7 tests covering the percent branch, that a rate is not divided down by frequency, that dollars/points/miles are unchanged, and that a percent benefit contributes 0 to the annual rollup while a real dollar credit still contributes. Full web-next suite: **81 passed**. `build:cards` builds all 184 cards.

## Left alone deliberately

Three benefits are *discounts requiring a discretionary purchase*, which overstate value in a softer way and are a separate judgment call — Alaska Lounge+ "\$100 off a membership" (×2 cards) and Hawaiian's "\$100 companion discount". Genuine fixed credits like AT&T's \$10/mo bill discount and the Disney Bundle \$7/mo credit are correctly modeled and untouched.

Separately: percent benefits still appear under a heading called "Statement credits", which is the wrong label for a rebate rate even now that the value renders correctly. That's a UI-copy change affecting all 34, worth doing on its own.