### PR TITLE
card page: render accepting_applications wire changes as true/false

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -595,6 +595,13 @@ export default function CardClient({
   };
   const formatWireValue = (val: string | null, field: string) => {
     if (val === null) return "N/A";
+    // Booleans arrive from the DB as "1"/"0"; render them as true/false so the
+    // rail reads as a value change rather than an unlabeled number.
+    if (field === "accepting_applications") {
+      if (val === "1" || val === "true") return "true";
+      if (val === "0" || val === "false") return "false";
+      return val;
+    }
     if (field === "annual_fee") return `$${Number(val).toLocaleString()}`;
     if (field === "signup_bonus_value") return Number(val).toLocaleString();
     if (field.startsWith("apr_")) return `${val}%`;


### PR DESCRIPTION
The card page's change-history rail had no formatter for `accepting_applications`, so the raw DB values fell through and the row read:

```
JUL 25 | accepting_applications | 1 → 0
```

It now reads `true → false`.

Verified locally on the Amex Green page (the Jul 25 entry). The `/card-wire` listing page has its own formatter that already renders this field as Accepting / Not accepting and is unchanged.