### PR TITLE
card wire: render accepting_applications as true/false

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -57,8 +57,8 @@ function formatValue(
   if (value === null || value === '') return '—';
   const num = parseFloat(value);
   if (field === 'accepting_applications') {
-    if (value === '1' || value === 'true') return 'Accepting';
-    if (value === '0' || value === 'false') return 'Not accepting';
+    if (value === '1' || value === 'true') return 'true';
+    if (value === '0' || value === 'false') return 'false';
     return value;
   }
   if (field === 'annual_fee') {


### PR DESCRIPTION
Follow-up to #1798. The `/card-wire` feed rendered this field as "Accepting" / "Not accepting" while the card-page rail now reads `true → false`. Same field, two vocabularies — this makes the feed match.

Verified locally on `/card-wire` with the Applications filter: Wells Fargo Attune, Citi Custom Cash, and Amazon Business Prime Amex all read `true → false`.