### PR TITLE
fix: unbreak the production build by adding 'percent' to value_unit

### DIFF
--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -97,7 +97,9 @@ export interface CardAPR {
 export interface CardBenefit {
   name: string;
   value: number;
-  value_unit?: 'usd' | 'points' | 'miles';
+  // 'percent' marks a RATE rather than an amount (a 20% inflight rebate), so
+  // formatBenefitValue reads `value` directly instead of amortizing it.
+  value_unit?: 'usd' | 'points' | 'miles' | 'percent';
   description: string;
   frequency: 'monthly' | 'quarterly' | 'semi_annual' | 'annual' | 'multi_year' | 'ongoing';
   // For frequency: 'multi_year' — number of years between recurrences. Defaults


### PR DESCRIPTION
**main has not deployed since #1796.** Amplify jobs 1432 and 1433 both failed; the site is serving the last good build from 10:31 EDT.

## Failure

Every build dies at the `Running TypeScript` step:

```
./src/lib/cardDisplayUtils.tsx:182:7
Type error: This comparison appears to be unintentional because the types
'"usd" | "points" | "miles" | undefined' and '"percent"' have no overlap.
```

#1796 added a `value_unit === 'percent'` branch to `formatBenefitValue`, plus a test covering it, but did not widen `CardBenefit.value_unit`, which still allowed only `usd | points | miles`. Adding `'percent'` to the union is the entire fix — one line.

## Verified

Ran a real `npm run build` (not just `tsc`), because `tsc` is not what the deploy runs. It compiles and completes route generation. Before the fix it reproduces the exact Amplify error.

## What this is blocking

Two changes are sitting on main undeployed: #1795 / #1797 (the card `network` field and the /explore Network filter) and #1796 itself. The card data reached the CDN fine — that pipeline is independent — so `cards.json` is live while the frontend that renders it is stale.

## Follow-up, deliberately not in this PR

`schema.json` declares the `value_unit` enum as `["dollars", "percent", "points", "miles"]`, but every consumer uses **`usd`**, not `dollars` — `CardClient.tsx:417`, `isMonetaryBenefit`, and the YAML writer in `check-card-rewards-and-benefits.js:1569`. The schema is drifted, and nothing validates benefit `value_unit` at build time, which is why neither this nor the missing `percent` was caught. Worth a separate pass; kept out of here to keep an urgent fix to one line.
