### PR TITLE
cards: fix the value_unit schema drift and the credits it was zeroing out

### DIFF
--- a/data/cards/jetblue-premier-card.yaml
+++ b/data/cards/jetblue-premier-card.yaml
@@ -56,7 +56,6 @@ our_take: >
 benefits:
   - name: "TrueBlue Travel Statement Credits"
     value: 300
-    value_unit: "dollars"
     description: "Up to $300 in statement credits on TrueBlue Travel purchases (hotels, car rentals, cruises and more) per calendar year"
     frequency: "annual"
     category: "statement_credit"
@@ -80,7 +79,6 @@ benefits:
     enrollment_required: false
   - name: "Companion Pass Statement Credits"
     value: 2000
-    value_unit: "dollars"
     description: "Up to $500 companion pass statement credit after $15,000 in eligible purchases in a calendar year, plus an additional up to $1,500 companion pass statement credit after $75,000 in eligible purchases in a calendar year"
     frequency: "annual"
     category: "travel"
@@ -97,7 +95,6 @@ benefits:
     enrollment_required: true
   - name: "Global Entry or TSA PreCheck Credit"
     value: 120
-    value_unit: "dollars"
     description: "Up to $120 application fee statement credit for Global Entry or TSA PreCheck every 4 years"
     frequency: "multi_year"
     frequency_years: 4

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -253,8 +253,8 @@
           },
           "value_unit": {
             "type": "string",
-            "enum": ["dollars", "percent", "points", "miles"],
-            "description": "Unit of `value` when it is not a flat dollar amount. Defaults to dollars."
+            "enum": ["usd", "percent", "points", "miles"],
+            "description": "Unit of `value` when it is not a flat dollar amount. OMIT for plain dollar amounts — that is the convention every consumer expects (isMonetaryBenefit treats an absent unit as dollars) and what check-card-rewards-and-benefits.js writes back, so an explicit \"usd\" would be stripped on the next regeneration and churn the review queue."
           },
           "value_per_cycle": {
             "type": "number",

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -205,6 +205,22 @@ function validateCard(card, schema, categoryIds, storeSlugs) {
   // StubHub credit → [stubhub, viagogo]). Every slug must resolve to a real
   // store, or the credit would point at a 404 and never render.
   if (card.benefits) {
+    // Validate benefit value_unit. Nothing checked this before, which let three
+    // JetBlue Premier credits sit on `value_unit: "dollars"` — not a unit any
+    // consumer knows. isMonetaryBenefit only accepts an absent unit or "usd", so
+    // those credits were treated as non-monetary and amortizedAnnualValue
+    // returned 0 for each, understating the card's Total Annual Credits by
+    // $2,330 against a $499 annual fee.
+    const validUnits = schema.properties.benefits.items.properties.value_unit.enum;
+    for (const benefit of card.benefits) {
+      if (benefit.value_unit !== undefined && !validUnits.includes(benefit.value_unit)) {
+        errors.push(
+          `Invalid value_unit for benefit "${benefit.name}": ${benefit.value_unit} ` +
+          `(must be one of ${validUnits.join(', ')}, or omitted for plain dollar amounts)`
+        );
+      }
+    }
+
     for (const benefit of card.benefits) {
       if (benefit.merchants === undefined) continue;
       if (!Array.isArray(benefit.merchants)) {


### PR DESCRIPTION
Follow-up to #1800. The drift turned out to be doing real damage, not just sitting there.

## The drift

`schema.json` declared the benefit `value_unit` enum as `["dollars", "percent", "points", "miles"]`. No consumer has ever known `"dollars"`:

| Consumer | Expects |
|---|---|
| `isMonetaryBenefit` (`cardDisplayUtils.tsx:152`) | absent or `"usd"` |
| `CardClient.tsx:417` | absent or `"usd"` |
| `check-card-rewards-and-benefits.js:1569` | writes the field only when **not** `"usd"` |
| `CardBenefit.value_unit` TS type | `usd \| points \| miles \| percent` |

## What it was costing

Three **JetBlue Premier** credits were authored on `value_unit: "dollars"`. `isMonetaryBenefit` returned false for all three, so `amortizedAnnualValue` returned 0 for each:

| Benefit | Value | Counted |
|---|---|---|
| TrueBlue Travel Statement Credits | $300/yr | $0 |
| Companion Pass Statement Credits | $2,000/yr | $0 |
| Global Entry / TSA PreCheck | $120 / 4yr | $0 |

The card displayed **$0 Total Annual Credits against a $499 annual fee**. Correct total is **$2,330**. Verified against the built `cards.json` using the same amortization logic the app runs.

## The fix

**1. Drop the three `value_unit` lines** from `jetblue-premier-card.yaml`. Removing is correct rather than rewriting to `"usd"` — the writer emits the field only when it is not `"usd"`, so an explicit `"usd"` would be stripped on the next regeneration and churn the weekly review queue.

**2. Correct the schema enum** to `["usd", "percent", "points", "miles"]`, and say in the description to omit it for plain dollar amounts.

**3. Validate benefit `value_unit` in `build-cards.js`.** Nothing checked it before, which is why both this and the missing `percent` that broke production in #1800 went unnoticed. Confirmed the guard fails the build on `"dollars"`:

```
ERROR: Invalid value_unit for benefit "TrueBlue Travel Statement Credits": dollars
(must be one of usd, percent, points, miles, or omitted for plain dollar amounts)
```

## Validation

`npm run build:cards` clean (184 cards). `cardDisplayUtils` tests pass (7/7). No YAML now carries an out-of-enum unit: 40 `percent`, 21 `points`, 2 `miles`, rest omitted. Regenerated `cards.json` not committed.
