### PR TITLE
Profile: finish "record" to "data point" rename in remaining copy

### DIFF
--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -398,7 +398,7 @@ export default function ProfileClient() {
   };
 
   const handleDeleteRecord = async (recordId: number) => {
-    if (!confirm("Delete this record?")) return;
+    if (!confirm("Delete this data point?")) return;
     setDeletingRecordId(recordId);
     try {
       const token = await getToken();
@@ -409,7 +409,7 @@ export default function ProfileClient() {
       setRecords(records.filter(r => r.record_id !== recordId));
     } catch (e) {
       console.error("Error deleting record:", e);
-      alert("Failed to delete record. Please try again.");
+      alert("Failed to delete data point. Please try again.");
     } finally { setDeletingRecordId(null); }
   };
 
@@ -540,7 +540,7 @@ export default function ProfileClient() {
                 </div>
               </div>
               <div className="cj-readoff-cell">
-                <div className="cj-readoff-k">Records</div>
+                <div className="cj-readoff-k">Data points</div>
                 <div className="cj-readoff-v">{records.length}</div>
                 <div className="cj-readoff-foot">
                   {(() => {
@@ -1214,7 +1214,7 @@ function CardsTab(props: CardsTabProps) {
                   <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{walletDisplayNames.get(c.id) ?? c.card_name}</span>
                   <span className="cj-cw-marks">
                     {hasRecord && (
-                      <span className="cj-cw-mark" title="record submitted" aria-label="record submitted">
+                      <span className="cj-cw-mark" title="data point submitted" aria-label="data point submitted">
                         <DocumentTextIcon style={{ width: 11, height: 11 }} />
                       </span>
                     )}
@@ -1293,9 +1293,9 @@ function CardsTab(props: CardsTabProps) {
                       </button>
                     )}
                     <button type="button" className="cj-wd-cta" onClick={() => onSubmitRecord(c)}>
-                      {hasRecord ? '+ submit another record' : '+ submit a record'}
+                      {hasRecord ? '+ submit another data point' : '+ submit a data point'}
                     </button>
-                    {hasRecord && <span className="cj-wd-done">✓ record submitted</span>}
+                    {hasRecord && <span className="cj-wd-done">✓ data point submitted</span>}
                     {!hasReferral && (
                       <button type="button" className="cj-wd-cta" onClick={onAddReferral}>
                         + add referral link
@@ -1406,8 +1406,8 @@ function ApplicationsTab(props: ApplicationsTabProps) {
                     type="button"
                     onClick={() => onEditRecord(r.record_id)}
                     className="cj-tape-action-btn"
-                    aria-label="Edit record"
-                    title="Edit record"
+                    aria-label="Edit data point"
+                    title="Edit data point"
                   >
                     <PencilIcon className="cj-tape-action-icon" />
                   </button>
@@ -1416,8 +1416,8 @@ function ApplicationsTab(props: ApplicationsTabProps) {
                     onClick={() => onDeleteRecord(r.record_id)}
                     disabled={deletingRecordId === r.record_id}
                     className="cj-tape-action-btn cj-tape-action-btn-danger"
-                    aria-label="Delete record"
-                    title="Delete record"
+                    aria-label="Delete data point"
+                    title="Delete data point"
                   >
                     {deletingRecordId === r.record_id ? (
                       <span className="cj-tape-action-spinner">…</span>
@@ -1527,7 +1527,7 @@ function ReferralsTab(props: ReferralsTabProps) {
                     className="cj-inline-cta"
                     onClick={() => onReplace(cardIdStr)}
                     disabled={!eligible}
-                    title={eligible ? '' : 'You no longer hold this card in your wallet or records, so a new referral cannot be submitted.'}
+                    title={eligible ? '' : 'You no longer hold this card in your wallet or data points, so a new referral cannot be submitted.'}
                   >
                     {eligible ? 'add replacement' : 'card not held'}
                   </button>
@@ -1599,7 +1599,7 @@ function ReferralsTab(props: ReferralsTabProps) {
                   Submit your first referral →
                 </button>
               </>
-            : <><b>No eligible cards yet.</b> Add a card to your wallet or submit a record to add a referral link.</>}
+            : <><b>No eligible cards yet.</b> Add a card to your wallet or submit a data point to add a referral link.</>}
         </div>
       )}
 

--- a/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
@@ -108,7 +108,7 @@ export default function SubmitRecordCardPicker({
 
                 <div className="p-6">
                   <h3 className="text-lg font-semibold text-gray-900 mb-1">
-                    Submit a record
+                    Submit a data point
                   </h3>
                   <p className="text-sm text-gray-500 mb-4">
                     Pick any card you applied for, approved or denied.

--- a/apps/web-next/src/components/forms/SubmitRecordModal.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordModal.tsx
@@ -345,7 +345,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
 
         if (isEditMode && editRecord) {
           await updateRecord(editRecord.record_id, payload, token);
-          toast.success("Your record was updated.", { position: "top-right", autoClose: 4000 });
+          toast.success("Your data point was updated.", { position: "top-right", autoClose: 4000 });
           onSuccess?.();
           handleClose();
           return;
@@ -365,7 +365,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
 
         if (!response.ok) {
           const errorText = await response.text();
-          throw new Error(errorText || 'Failed to submit record');
+          throw new Error(errorText || 'Failed to submit data point');
         }
 
         // Auto-add card to wallet if not already there (silent — don't block on failure)
@@ -385,7 +385,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
           result: values.result,
           credit_score: values.credit_score,
         });
-        toast.success("Your record was submitted successfully!", {
+        toast.success("Your data point was submitted successfully!", {
           position: "top-right",
           autoClose: 5000,
         });
@@ -403,7 +403,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
         handleClose();
       } catch (error) {
         console.error("Error submitting record:", error);
-        toast.error(error instanceof Error ? error.message : (isEditMode ? "Failed to update record" : "Failed to submit record"));
+        toast.error(error instanceof Error ? error.message : (isEditMode ? "Failed to update data point" : "Failed to submit data point"));
       } finally {
         setSubmitting(false);
       }
@@ -432,7 +432,7 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
           <div className="cj-modal-card cj-modal-card-bounded">
             <div className="cj-modal-head">
               <span className="cj-status-dot" />
-              <span className="cj-modal-title">{isEditMode ? 'edit record' : 'submit record'}</span>
+              <span className="cj-modal-title">{isEditMode ? 'edit data point' : 'submit data point'}</span>
               <button type="button" className="cj-modal-close" onClick={handleModalClose} aria-label="Close">
                 <XMarkIcon style={{ width: 16, height: 16 }} />
               </button>
@@ -457,10 +457,10 @@ export default function SubmitRecordModal({ show, handleClose, card, onSuccess, 
                       </div>
                     </div>
                     {isEditMode ? (
-                      <p style={{ fontSize: 11.5, color: 'var(--muted)', marginTop: 8 }}>Editing your existing record.</p>
+                      <p style={{ fontSize: 11.5, color: 'var(--muted)', marginTop: 8 }}>Editing your existing data point.</p>
                     ) : existingRecordCount > 0 ? (
                       <p style={{ fontSize: 11.5, color: 'var(--muted)', marginTop: 8 }}>
-                        You&apos;ve submitted {existingRecordCount} record{existingRecordCount === 1 ? '' : 's'} for this card. Add another if you reapplied or your situation changed.
+                        You&apos;ve submitted {existingRecordCount} data point{existingRecordCount === 1 ? '' : 's'} for this card. Add another if you reapplied or your situation changed.
                       </p>
                     ) : null}
                   </div>


### PR DESCRIPTION
Follow-up to #1802 — sweeps the remaining user-facing "record" wording:

- Snapshot stat label "Records" -> "Data points"
- Cards tab: "+ submit a/another record" -> data point, "record submitted" check/tooltip
- Applications tab: edit/delete button tooltips + delete confirm/alert
- Referrals tab: ineligible-card tooltip and empty-state copy
- Card picker modal heading "Submit a record" -> "Submit a data point"
- Submit modal: title, toasts, error messages, "You've submitted N data points" hint

Left alone: code identifiers, PostHog event names, "Bankruptcy or public record" (credit term), and wallet history's "Nothing recorded yet" (different sense).