### PR TITLE
Profile: rename missed "record submitted" hint in card picker

### DIFF
--- a/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
+++ b/apps/web-next/src/components/forms/SubmitRecordCardPicker.tsx
@@ -131,7 +131,7 @@ export default function SubmitRecordCardPicker({
                       {filtered.slice(0, 25).map((card) => {
                         const inWallet = walletCardNames?.has(card.card_name);
                         const hasRecord = recordedCardNames.has(card.card_name);
-                        const meta = [card.bank, inWallet && 'in your wallet', hasRecord && 'record submitted']
+                        const meta = [card.bank, inWallet && 'in your wallet', hasRecord && 'data point submitted']
                           .filter(Boolean)
                           .join(' · ');
                         return (


### PR DESCRIPTION
One string missed by #1803: the per-card meta line in the submit-a-data-point card picker still said "record submitted"; now "data point submitted".