### PR TITLE
Add follow-@creditodds callout to news and articles pages

### DIFF
--- a/apps/web-next/src/app/articles/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { ShareButtons } from "@/components/articles/ShareButtons";
 import { RelatedArticles } from "@/components/articles/RelatedArticles";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import { FollowXCallout } from "@/components/landing-v2/FollowXCallout";
 import ViewTracker from "@/components/ViewTracker";
 import { getContentViewCounts } from "@/lib/api";
 import { truncateTitle } from "@/lib/seo";
@@ -241,6 +242,10 @@ export default async function ArticlePage({ params }: Props) {
                 )}
 
                 <RelatedArticles articles={relatedArticles} />
+
+                <div className="article-follow">
+                  <FollowXCallout sub="Don't miss an update" />
+                </div>
               </div>
             </div>
             <aside className="article-sidebar">

--- a/apps/web-next/src/app/articles/author/[slug]/page.tsx
+++ b/apps/web-next/src/app/articles/author/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getContentViewCounts } from "@/lib/api";
 import { ArticleCard } from "@/components/articles/ArticleCard";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import { FollowXCallout } from "@/components/landing-v2/FollowXCallout";
 import "../../../landing.css";
 
 interface Props {
@@ -99,14 +100,17 @@ export default async function AuthorPage({ params }: Props) {
         </div>
       </div>
 
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          Everything by <em>{author.name}.</em>
-        </h1>
-        <p className="page-sub">
-          {author.count} article{author.count !== 1 ? 's' : ''} on credit card strategy,
-          data takes, and card teardowns.
-        </p>
+      <section className="page-hero has-follow wrap">
+        <div>
+          <h1 className="page-title">
+            Everything by <em>{author.name}.</em>
+          </h1>
+          <p className="page-sub">
+            {author.count} article{author.count !== 1 ? 's' : ''} on credit card strategy,
+            data takes, and card teardowns.
+          </p>
+        </div>
+        <FollowXCallout sub="Don't miss an update" />
       </section>
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>

--- a/apps/web-next/src/app/articles/category/[tag]/page.tsx
+++ b/apps/web-next/src/app/articles/category/[tag]/page.tsx
@@ -6,6 +6,7 @@ import { getContentViewCounts } from "@/lib/api";
 import { ArticleCard } from "@/components/articles/ArticleCard";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import { FollowXCallout } from "@/components/landing-v2/FollowXCallout";
 import "../../../landing.css";
 
 interface Props {
@@ -98,9 +99,12 @@ export default async function CategoryPage({ params }: Props) {
         </div>
       </div>
 
-      <section className="page-hero wrap">
-        <h1 className="page-title">{tagLabel} <em>articles.</em></h1>
-        <p className="page-sub">{tagDescription}</p>
+      <section className="page-hero has-follow wrap">
+        <div>
+          <h1 className="page-title">{tagLabel} <em>articles.</em></h1>
+          <p className="page-sub">{tagDescription}</p>
+        </div>
+        <FollowXCallout sub="Don't miss an update" />
       </section>
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>

--- a/apps/web-next/src/app/articles/page.tsx
+++ b/apps/web-next/src/app/articles/page.tsx
@@ -4,6 +4,7 @@ import { getContentViewCounts } from "@/lib/api";
 import { ArticlesListClient } from "@/components/articles/ArticlesListClient";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import { FollowXCallout } from "@/components/landing-v2/FollowXCallout";
 import "../landing.css";
 
 export const metadata: Metadata = {
@@ -69,14 +70,17 @@ export default async function ArticlesPage() {
         </div>
       </div>
 
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          Deeper reads, <em>same data discipline.</em>
-        </h1>
-        <p className="page-sub">
-          Long-form guides, teardowns, and strategies for getting the most out of your
-          credit cards — grounded in the community database, not affiliate marketing.
-        </p>
+      <section className="page-hero has-follow wrap">
+        <div>
+          <h1 className="page-title">
+            Deeper reads, <em>same data discipline.</em>
+          </h1>
+          <p className="page-sub">
+            Long-form guides, teardowns, and strategies for getting the most out of your
+            credit cards — grounded in the community database, not affiliate marketing.
+          </p>
+        </div>
+        <FollowXCallout sub="Don't miss an update" />
       </section>
 
       <div className="wrap" style={{ paddingTop: 24, paddingBottom: 80 }}>

--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
 import { V2Footer } from '@/components/landing-v2/Chrome';
+import { FollowXCallout } from '@/components/landing-v2/FollowXCallout';
 import type { CardWireEntry } from '@/lib/api';
 import '../landing.css';
 
@@ -241,26 +242,7 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap, bankM
               fees, sign-up bonuses, and application status.
             </p>
           </div>
-          <a
-            className="wire-follow"
-            href="https://x.com/creditodds"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <span className="wire-follow-copy">
-              <span className="wire-follow-handle">
-                <svg className="wire-follow-x" viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    fill="currentColor"
-                    d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"
-                  />
-                </svg>
-                @creditodds
-              </span>
-              <span className="wire-follow-sub">Every change, the moment it posts</span>
-            </span>
-            <span className="wire-follow-btn">Follow</span>
-          </a>
+          <FollowXCallout sub="Every change, the moment it posts" />
         </div>
 
         {/* Sticky filter toolbar — segmented control + issuer select + direction */}

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2857,6 +2857,12 @@
   transition: background 0.12s;
 }
 .landing-v2 .x-follow:hover .x-follow-btn { background: var(--accent-deep); }
+@media (max-width: 640px) {
+  .landing-v2 .x-follow {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
 .landing-v2.wire-v2 .wire-snapshot .cj-readoff {
   margin-top: 4px;
 }

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1239,6 +1239,14 @@
   padding-block: 20px 24px;
   border-bottom: 1px solid var(--line);
 }
+/* Hero with an .x-follow callout beside the title (wraps below on mobile) */
+.landing-v2 .page-hero.has-follow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px 32px;
+}
 .landing-v2.check-v2 .page-hero {
   border-bottom: 0;
   padding-block: 20px 8px;
@@ -2794,8 +2802,9 @@
   gap: 16px 32px;
 }
 
-/* Follow @card_wire callout */
-.landing-v2.wire-v2 .wire-follow {
+/* Follow @creditodds callout — shared by the card-wire snapshot, the /news
+   hero, and news article footers (FollowXCallout component). */
+.landing-v2 .x-follow {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
@@ -2808,16 +2817,16 @@
   text-decoration: none;
   transition: border-color 0.12s, box-shadow 0.12s;
 }
-.landing-v2.wire-v2 .wire-follow:hover {
+.landing-v2 .x-follow:hover {
   border-color: var(--muted-2);
   box-shadow: var(--shadow);
 }
-.landing-v2.wire-v2 .wire-follow-copy {
+.landing-v2 .x-follow-copy {
   display: flex;
   flex-direction: column;
   gap: 3px;
 }
-.landing-v2.wire-v2 .wire-follow-handle {
+.landing-v2 .x-follow-handle {
   display: inline-flex;
   align-items: center;
   gap: 7px;
@@ -2825,17 +2834,17 @@
   font-weight: 600;
   color: var(--ink);
 }
-.landing-v2.wire-v2 .wire-follow-x {
+.landing-v2 .x-follow-logo {
   width: 13px;
   height: 13px;
   color: var(--ink);
   flex: 0 0 auto;
 }
-.landing-v2.wire-v2 .wire-follow-sub {
+.landing-v2 .x-follow-sub {
   font-size: 11.5px;
   color: var(--muted);
 }
-.landing-v2.wire-v2 .wire-follow-btn {
+.landing-v2 .x-follow-btn {
   display: inline-flex;
   align-items: center;
   padding: 7px 16px;
@@ -2847,7 +2856,7 @@
   white-space: nowrap;
   transition: background 0.12s;
 }
-.landing-v2.wire-v2 .wire-follow:hover .wire-follow-btn { background: var(--accent-deep); }
+.landing-v2 .x-follow:hover .x-follow-btn { background: var(--accent-deep); }
 .landing-v2.wire-v2 .wire-snapshot .cj-readoff {
   margin-top: 4px;
 }
@@ -6726,6 +6735,9 @@
   border-radius: 14px;
   padding: 32px clamp(20px, 3vw, 48px) 40px;
   box-shadow: var(--shadow-sm);
+}
+.landing-v2 .article-follow {
+  margin-top: 24px;
 }
 .landing-v2 .article-source {
   margin-top: 24px;

--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { V2Footer } from '@/components/landing-v2/Chrome';
+import { FollowXCallout } from '@/components/landing-v2/FollowXCallout';
 import CardImage from '@/components/ui/CardImage';
 import type { NewsItem, NewsTag } from '@/lib/news';
 import '../landing.css';
@@ -97,14 +98,17 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
           <span><span className="cj-status-dot" />{items.length.toLocaleString()} stor{items.length === 1 ? 'y' : 'ies'} · live</span>
         </div>
       </div>
-      <section className="page-hero wrap">
-        <h1 className="page-title">
-          News without the <em>affiliate spin.</em>
-        </h1>
-        <p className="page-sub">
-          Card teardowns, issuer policy shifts, and data takes grounded in the records
-          database. No referral-link chasing.
-        </p>
+      <section className="page-hero has-follow wrap">
+        <div>
+          <h1 className="page-title">
+            News without the <em>affiliate spin.</em>
+          </h1>
+          <p className="page-sub">
+            Card teardowns, issuer policy shifts, and data takes grounded in the records
+            database. No referral-link chasing.
+          </p>
+        </div>
+        <FollowXCallout sub="Don't miss an update" />
       </section>
 
       <div className="wrap">

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -11,6 +11,7 @@ import { RelatedCards } from "@/components/articles/RelatedCards";
 import { RelatedCardInfo } from "@/lib/articles";
 import CardImage from "@/components/ui/CardImage";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import { FollowXCallout } from "@/components/landing-v2/FollowXCallout";
 import ViewTracker from "@/components/ViewTracker";
 import { truncateTitle } from "@/lib/seo";
 import "../../landing.css";
@@ -239,6 +240,10 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
               Source: <span>{item.source}</span>
             </div>
           )}
+
+          <div className="article-follow">
+            <FollowXCallout sub="Don't miss an update" />
+          </div>
         </article>
         <V2Footer />
       </div>

--- a/apps/web-next/src/components/landing-v2/FollowXCallout.tsx
+++ b/apps/web-next/src/components/landing-v2/FollowXCallout.tsx
@@ -1,0 +1,26 @@
+/** Boxed "Follow @creditodds" callout with an X logo and Follow button.
+ * Styled by the .x-follow rules in landing.css; server-safe (no hooks). */
+export function FollowXCallout({ sub }: { sub: string }) {
+  return (
+    <a
+      className="x-follow"
+      href="https://x.com/creditodds"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span className="x-follow-copy">
+        <span className="x-follow-handle">
+          <svg className="x-follow-logo" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              fill="currentColor"
+              d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"
+            />
+          </svg>
+          @creditodds
+        </span>
+        <span className="x-follow-sub">{sub}</span>
+      </span>
+      <span className="x-follow-btn">Follow</span>
+    </a>
+  );
+}


### PR DESCRIPTION
Adds a "Don't miss an update" follow link to the X account across the news and articles sections, matching the callout on the card wire page.

- Extracts the card wire's inline follow markup into a shared `FollowXCallout` component (`components/landing-v2/FollowXCallout.tsx`); the card wire keeps its existing copy.
- CSS classes renamed `wire-follow*` -> `x-follow*` and re-scoped from `.landing-v2.wire-v2` to `.landing-v2` so the callout works on any v2 page. No visual change on the wire.
- `/news` and `/articles` (plus category and author listings): callout sits to the right of the hero title (wraps below on mobile via the new `.page-hero.has-follow` flex rule).
- `/news/[id]`: callout renders at the end of the article, after the source line.
- `/articles/[slug]`: callout renders at the end of the article body, after related articles.

Verified in the dev server on /news, /articles, a news article, an article detail, a category listing, and /card-wire; typecheck and eslint clean.