### PR TITLE
News: Kroger cards officially converting to Smartly Visa

### DIFF
--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -42,6 +42,7 @@ export async function generateMetadata({ params }: NewsDetailPageProps): Promise
       url: `https://creditodds.com/news/${item.id}`,
       type: "article",
       publishedTime: item.date,
+      ...(item.updated ? { modifiedTime: item.updated } : {}),
       ...(item.news_image
         ? {
             images: [
@@ -66,6 +67,9 @@ function formatDate(dateString: string): string {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    // YYYY-MM-DD parses as UTC midnight; format in UTC or the shown day
+    // rolls back one on servers west of Greenwich.
+    timeZone: 'UTC',
   });
 }
 
@@ -104,7 +108,7 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
     headline: item.title,
     description: item.summary,
     datePublished: item.date,
-    dateModified: item.date,
+    dateModified: item.updated ?? item.date,
     url,
     image: item.news_image
       ? `${NEWS_IMG_CDN}/${item.news_image}`
@@ -168,6 +172,14 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
             <time dateTime={item.date}>
               <b>{formatDate(item.date)}</b>
             </time>
+            {item.updated && (
+              <>
+                <span>·</span>
+                <time dateTime={item.updated}>
+                  Updated <b>{formatDate(item.updated)}</b>
+                </time>
+              </>
+            )}
             {item.bank && (
               <>
                 <span>·</span>

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -15,6 +15,8 @@ export type NewsTag =
 export interface NewsItem {
   id: string;
   date: string;
+  /** Date of the last substantive update (YYYY-MM-DD); sorting still uses date. */
+  updated?: string;
   title: string;
   summary: string;
   tags: NewsTag[];

--- a/data/news/2026-05-12-us-bank-kroger-cards-no-longer-accepting-applications.yaml
+++ b/data/news/2026-05-12-us-bank-kroger-cards-no-longer-accepting-applications.yaml
@@ -1,21 +1,33 @@
 id: "us-bank-kroger-cards-no-longer-accepting-applications"
-title: "U.S. Bank Kroger Credit Cards No Longer Accepting New Applications"
-summary: "U.S. Bank has stopped accepting applications for its Kroger co-branded credit cards, with reports indicating the cards have been unavailable for **approximately two weeks**. The exact status of the partnership remains unclear, though customer service representatives have suggested the change may be permanent."
+title: "U.S. Bank Kroger Cards Convert to Smartly Visa"
+summary: "U.S. Bank has confirmed its Kroger partnership is ending. Existing Kroger co-branded cardholders will be automatically converted to the no-annual-fee Smartly Visa Signature, with replacement cards arriving between August and October 2026. Balances, credit limits, and rewards carry over; the 5-cent Kroger fuel discount ends once the new card is activated."
 tags:
   - "discontinued"
   - "policy-change"
 bank: "U.S. Bank"
-source: "Doctor of Credit"
-source_url: "https://www.doctorofcredit.com/u-s-bank-kroger-cards-no-longer-accepting-applications/"
+card_slug: "us-bank-smartly-visa-signature"
+card_name: "Smartly Visa Signature"
+source: "U.S. Bank"
+source_url: "https://www.usbank.com/credit-cards/splash/mysmartlyvisa.html"
 date: "2026-05-12"
+updated: "2026-07-27"
 body: |
-  U.S. Bank's Kroger credit card partnership appears to be winding down. The cards—which include versions of the Kroger cash rewards card—are **no longer accepting new applications**, according to multiple reports from the churning community.
-  
-  **Application availability ceased approximately two weeks ago**, though the exact timeline and reason for the halt remain unconfirmed. Customer service representatives contacted by cardholders have indicated the change may be permanent, though no official announcement has been made by U.S. Bank or Kroger.
-  
-  The future of existing Kroger cardholders is uncertain. Speculation suggests U.S. Bank could either convert the cards to a different product (such as a cash rewards card), allow them to remain in an inactive state similar to the discontinued U.S. Bank AAdvantage Rewards card, or sunset the product entirely.
-  
-  This continues a pattern of U.S. Bank scaling back its co-branded credit card portfolio in recent years. The bank has been selective about maintaining partnership agreements, and the Kroger partnership's discontinuation would represent another shift in its card offerings.
-  
-  Cardholders currently holding Kroger cards should monitor their accounts for communication from U.S. Bank regarding next steps.
-  
+  **Update (July 27, 2026):** It is official. U.S. Bank has posted a [conversion notice](https://www.usbank.com/credit-cards/splash/mysmartlyvisa.html) confirming that "our partnership with Kroger is coming to an end" and that existing Kroger co-branded cardholders will be moved to the bank's flat-rate cash back card, the [Smartly Visa Signature](/card/us-bank-smartly-visa-signature).
+
+  Here is how the conversion works:
+
+  - **Timing:** Replacement cards arrive between **August and October 2026**, with a new card number and expiration date.
+  - **Balances and terms:** Any existing balance moves to the new account automatically at the same APR, and credit limits carry over unchanged.
+  - **Rewards:** Existing rewards balances transfer to the new card. On the Smartly card, rewards expire after 12 consecutive months of inactivity.
+  - **The new card:** The Smartly Visa Signature has a **$0 annual fee** and earns **unlimited 2% cash back** on all purchases, with no caps and no categories to track. Converted cardholders also earn an extra 1% at gas stations and grocery stores for the first 12 months, for a total of 3% at those merchants.
+  - **Kroger perks:** The 5-cents-per-gallon fuel discount at Kroger Fuel Centers ends as soon as the new card is activated. A Boost membership obtained through the card continues through its current expiration date.
+
+  ---
+
+  **Original report (May 12, 2026):** U.S. Bank's Kroger credit card partnership appears to be winding down. The cards, which include versions of the Kroger cash rewards card, are **no longer accepting new applications**, according to multiple reports from the churning community.
+
+  Application availability ceased in late April, though the exact timeline and reason for the halt were unconfirmed at the time. Customer service representatives contacted by cardholders indicated the change might be permanent, though no official announcement had been made by U.S. Bank or Kroger.
+
+  The future of existing Kroger cardholders was initially uncertain, with speculation that U.S. Bank could convert the cards to a different product, leave them in an inactive state like the discontinued U.S. Bank AAdvantage Rewards card, or sunset the product entirely. The conversion notice above settles it: the cards move to the Smartly Visa Signature.
+
+  This continues a pattern of U.S. Bank scaling back its co-branded credit card portfolio, most recently by [discontinuing the Shopper Cash Rewards](/news/us-bank-shopper-cash-rewards-discontinued).

--- a/data/news/schema.json
+++ b/data/news/schema.json
@@ -13,6 +13,11 @@
       "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
       "description": "Date in YYYY-MM-DD format"
     },
+    "updated": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Date of the last substantive update in YYYY-MM-DD format (optional). Shown as an 'Updated' date on the article and used for dateModified in structured data. Sorting still uses date."
+    },
     "title": {
       "type": "string",
       "minLength": 1,

--- a/scripts/build-news.js
+++ b/scripts/build-news.js
@@ -69,6 +69,11 @@ function validateNewsItem(item, schema) {
     errors.push(`Invalid date format: ${item.date} (must be YYYY-MM-DD)`);
   }
 
+  // Validate updated format
+  if (item.updated && !/^\d{4}-\d{2}-\d{2}$/.test(item.updated)) {
+    errors.push(`Invalid updated format: ${item.updated} (must be YYYY-MM-DD)`);
+  }
+
   // Validate tags
   if (item.tags) {
     if (!Array.isArray(item.tags)) {


### PR DESCRIPTION
## Summary

U.S. Bank posted an [official conversion notice](https://www.usbank.com/credit-cards/splash/mysmartlyvisa.html) confirming the Kroger co-brand partnership is ending. This updates the May 12 news article ([/news/us-bank-kroger-cards-no-longer-accepting-applications](https://creditodds.com/news/us-bank-kroger-cards-no-longer-accepting-applications)) with the confirmed details and marks it updated today (2026-07-27).

### Article changes
- Retitled to "U.S. Bank Kroger Cards Convert to Smartly Visa" (46 chars, within SEO budget); same id/URL.
- New update section: cardholders auto-convert to the Smartly Visa Signature, replacement cards arrive August–October 2026 with new numbers; balances move at the same APR, credit limits and rewards carry over; $0 AF, unlimited 2% cash back plus an extra 1% at gas/grocery for the first 12 months; the 5¢/gal Kroger fuel discount ends at activation, Boost continues through its current expiration.
- Original May reporting kept below as a dated "Original report" section; source switched from Doctor of Credit to the official U.S. Bank notice; article now links the Smartly Visa Signature card page.

### Updated-date support (new)
- `data/news/schema.json` + `build-news.js`: optional `updated` (YYYY-MM-DD) field with validation.
- News detail page: shows "Updated <date>" next to the publish date, sets `dateModified` in JSON-LD and `article:modified_time` in OpenGraph. Sorting still uses `date`.
- `formatDate` now pins `timeZone: 'UTC'` — YYYY-MM-DD parses as UTC midnight, so local-time formatting rolled the shown day back by one on servers west of Greenwich (same class of bug as #1679).

## Verification
- `build:cards` + `build-news.js` pass; `updated` flows into news.json and the Smartly card image resolves.
- Rendered page checked on the dev server: title/h1, update section, both dates correct (May 12 / Updated July 27), JSON-LD `datePublished`/`dateModified` = 2026-05-12/2026-07-27, `article:modified_time` present.