### PR TITLE
Relabel the credits table, and fix the store page's percent renderer

### DIFF
--- a/apps/web-next/src/app/best-card-for/[slug]/page.tsx
+++ b/apps/web-next/src/app/best-card-for/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getAllStores, getStore, getStoresGeneratedAt } from "@/lib/stores";
 import { getAllCards } from "@/lib/api";
 import { rankCards, formatRate, labelForCategory } from "@/lib/storeRanking";
 import { getRelatedStores } from "@/lib/relatedStores";
+import { creditAmountLabel } from "@/lib/cardDisplayUtils";
 import { BreadcrumbSchema, FAQSchema, CollectionPageSchema } from "@/components/seo/JsonLd";
 import CardImage from "@/components/ui/CardImage";
 import { V2Footer } from "@/components/landing-v2/Chrome";
@@ -76,24 +77,6 @@ const CATEGORY_TAG_LABELS: Record<string, string> = {
 function tagLabelForCategory(id: string): string {
   return CATEGORY_TAG_LABELS[id]
     || id.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-}
-
-// Cadence suffix for a credit amount. A benefit's `value` is always the annual
-// rollup (see CardBenefit in lib/api.ts — value_per_cycle holds the per-cycle
-// figure), so every recurring frequency renders "/yr"; a $10/month credit is
-// stored as value: 120 and shows "$120/yr", not "$120/mo".
-const CREDIT_FREQUENCY_SUFFIX: Record<string, string> = {
-  annual: '/yr',
-  semi_annual: '/yr',
-  quarterly: '/yr',
-  monthly: '/yr',
-  multi_year: '',
-  ongoing: '',
-};
-
-function creditAmountLabel(value: number, frequency: string): string {
-  if (!value || value <= 0) return '';
-  return `$${value.toLocaleString()}${CREDIT_FREQUENCY_SUFFIX[frequency] ?? ''}`;
 }
 
 export default async function BestCardForStorePage({ params }: PageProps) {
@@ -230,14 +213,14 @@ export default async function BestCardForStorePage({ params }: PageProps) {
               </h2>
             </div>
             <p className="store-credits-sub">
-              These cards include a statement credit or complimentary membership you can use at{' '}
+              These cards include a statement credit, rebate, or complimentary membership you can use at{' '}
               {store.name}, on top of whatever you earn on the purchase. Weigh these alongside the
               ranked picks below.
             </p>
             {dollarCredits.length > 0 && (
               <ul className="store-credits-list">
                 {dollarCredits.map(({ card, benefit }) => {
-                  const amount = creditAmountLabel(benefit.value, benefit.frequency);
+                  const amount = creditAmountLabel(benefit.value, benefit.frequency, benefit.value_unit);
                   return (
                     <li key={`${card.slug}-${benefit.name}`} className="store-credit">
                       <Link

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -1206,12 +1206,12 @@ export default function CardClient({
               </div>
 
               <div>
-                <div className="cj-table-label">Statement credits</div>
+                <div className="cj-table-label">Credits &amp; rebates</div>
                 {creditBenefits.length > 0 ? (
                   <table className="cj-table">
                     <thead>
                       <tr>
-                        <th>Credit</th>
+                        <th>Benefit</th>
                         <th className="cj-tr">Value</th>
                       </tr>
                     </thead>
@@ -1234,7 +1234,7 @@ export default function CardClient({
                         <tr className="cj-row-total">
                           <td>
                             <span className="cj-row-total-label">
-                              Total annual value
+                              Total annual credits
                             </span>
                           </td>
                           <td className="cj-tr">
@@ -1248,7 +1248,7 @@ export default function CardClient({
                   </table>
                 ) : (
                   <div className="cj-cell-detail">
-                    No statement credits tracked.
+                    No credits or rebates tracked.
                   </div>
                 )}
               </div>

--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -50,7 +50,7 @@ export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) 
                   Credits &amp; Perks
                 </p>
                 <p className="mt-2 text-sm sm:text-base text-gray-600">
-                  Annual statement credits and benefits included with the {cardName}.
+                  Annual credits, rebates and perks included with the {cardName}.
                 </p>
               </div>
               <div className="mt-4 sm:mt-0 flex-shrink-0 text-center sm:text-right">

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -181,7 +181,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
           </div>
         </div>
         <div className="cj-readoff-cell">
-          <div className="cj-readoff-k">Statement credits</div>
+          <div className="cj-readoff-k">Credits &amp; rebates</div>
           <div className="cj-readoff-v">{allCredits.length}</div>
           <div className="cj-readoff-foot">
             {enrollCount > 0 ? `${enrollCount} require enrollment` : 'no enrollment needed'}
@@ -221,11 +221,11 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
         <>
           {allCredits.length > 0 && (
             <>
-              <div className="cj-table-label" style={{ marginTop: 16 }}>Statement credits</div>
+              <div className="cj-table-label" style={{ marginTop: 16 }}>Credits &amp; rebates</div>
               <div className="cj-tape cj-tape-credits">
                 <div className="cj-tape-head">
                   <div></div>
-                  <div>Credit</div>
+                  <div>Benefit</div>
                   <div className="cj-tape-res">Value</div>
                 </div>
                 {allCredits.map((b, i) => (

--- a/apps/web-next/src/lib/cardDisplayUtils.test.ts
+++ b/apps/web-next/src/lib/cardDisplayUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   formatBenefitValue,
+  creditAmountLabel,
   amortizedAnnualValue,
   isMonetaryBenefit,
   spendableValue,
@@ -63,5 +64,30 @@ describe('spendableValue', () => {
   it('splits a dollar total across its cycle', () => {
     expect(spendableValue({ name: 'x', value: 240, frequency: 'monthly' } as never)).toBe(20);
     expect(spendableValue({ name: 'x', value: 200, frequency: 'quarterly' } as never)).toBe(50);
+  });
+});
+
+// The store page (/best-card-for/<slug>) had its own copy of this formatter,
+// which unconditionally prefixed "$". Samsung's 20%-off VIP Advantage
+// membership rendered as "$20/yr" in production. It now lives here next to
+// formatBenefitValue so the two cannot drift apart again.
+describe('creditAmountLabel', () => {
+  it('renders a percent benefit as a rate with no dollar sign or cadence', () => {
+    expect(creditAmountLabel(20, 'annual', 'percent')).toBe('20%');
+  });
+
+  it('renders dollar credits with a per-year cadence', () => {
+    expect(creditAmountLabel(300, 'annual')).toBe('$300/yr');
+    expect(creditAmountLabel(120, 'monthly')).toBe('$120/yr');
+    expect(creditAmountLabel(100, 'multi_year')).toBe('$100');
+  });
+
+  it('renders points and miles in their own unit', () => {
+    expect(creditAmountLabel(5000, 'annual', 'points')).toBe('5,000 points/yr');
+    expect(creditAmountLabel(10000, 'annual', 'miles')).toBe('10,000 miles/yr');
+  });
+
+  it('returns nothing for a zero-value perk', () => {
+    expect(creditAmountLabel(0, 'annual')).toBe('');
   });
 });

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -390,3 +390,28 @@ export function RewardTypeBadge({ type }: { type?: string }) {
     </span>
   );
 }
+
+// Cadence suffix for a credit amount. A benefit's `value` is always the annual
+// rollup (see CardBenefit in lib/api.ts — value_per_cycle holds the per-cycle
+// figure), so every recurring frequency renders "/yr"; a $10/month credit is
+// stored as value: 120 and shows "$120/yr", not "$120/mo".
+export const CREDIT_FREQUENCY_SUFFIX: Record<string, string> = {
+  annual: '/yr',
+  semi_annual: '/yr',
+  quarterly: '/yr',
+  monthly: '/yr',
+  multi_year: '',
+  ongoing: '',
+};
+
+export function creditAmountLabel(value: number, frequency: string, valueUnit?: string): string {
+  if (!value || value <= 0) return '';
+  // A `percent` benefit's value is a RATE, so it carries neither a dollar sign
+  // nor a per-year suffix — Samsung's 20%-off VIP membership rendered as
+  // "$20/yr" before this guard. Same class of bug as formatBenefitValue.
+  if (valueUnit === 'percent') return `${value.toLocaleString()}%`;
+  if (valueUnit === 'points' || valueUnit === 'miles') {
+    return `${value.toLocaleString()} ${valueUnit}${CREDIT_FREQUENCY_SUFFIX[frequency] ?? ''}`;
+  }
+  return `$${value.toLocaleString()}${CREDIT_FREQUENCY_SUFFIX[frequency] ?? ''}`;
+}


### PR DESCRIPTION
Follow-up to #1796.

## The label

The table headed **"Statement credits"** is populated by `benefits.filter(b => b.value > 0)`, which includes percentage rebates. A statement credit is money you get for free; a 10% rebate capped at \$250 needs \$2,500 of spend to realise. Three surfaces shared the wrong label — the card page, the wallet, and `CardBenefits`.

| Before | After |
|---|---|
| `Statement credits` | `Credits & rebates` |
| `No statement credits tracked.` | `No credits or rebates tracked.` |
| column header `Credit` | `Benefit` |
| `Total annual value` | `Total annual credits` |

`Total annual value` was its own small lie: the sum only counts USD benefits, so a table mixing rebates in made it read as though everything above were included. `Total annual credits` says what it actually adds up, and matches the wording `CardBenefits` already used.

The `/best-card-for` sub-copy now reads "a statement credit, rebate, or complimentary membership", since a rebate can appear in that block.

## A second copy of the percent bug

#1796 fixed `formatBenefitValue`. The store page had its **own** formatter, `creditAmountLabel`, which unconditionally prefixed `$`. Samsung's 20%-off VIP Advantage membership therefore rendered as **"$20/yr"** on `/best-card-for/samsung` — confirmed live before this change.

It's now moved into `lib/cardDisplayUtils` beside `formatBenefitValue`, exported and covered by tests, so a percent fix can't land in one formatter and miss the other. It also gained correct points/miles handling, which it never had.

## Verification

11 tests on `cardDisplayUtils` (4 new for `creditAmountLabel`, including the exact `20% → "20%"` case observed in production). Full web-next suite **85 passed**; `tsc --noEmit` clean. Grep confirms no `Statement credits` string remains in the UI.

**I could not verify this in the browser.** The preview server wouldn't stay registered in this session and navigation was denied, and the launch config resolves to the main checkout rather than my worktree — so a preview would have served different code anyway. The changes are static JSX strings plus one pure function that is unit-tested, and typecheck passes, but the rendered pages have not been eyeballed. Worth a glance after deploy.