### PR TITLE
Model purchase-gated discounts as perks, not credits

### DIFF
--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -55,7 +55,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Alaska Lounge+ Membership Discount"
-    value: 100
+    value: 0
     description: "$100 off an annual Alaska Lounge+ membership purchased with the card"
     frequency: "annual"
     category: "lounge"

--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -77,7 +77,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Alaska Lounge+ Membership Discount"
-    value: 100
+    value: 0
     description: "$100 off an annual Alaska Lounge+ Membership"
     frequency: "annual"
     category: "lounge"

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -57,7 +57,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Anniversary Companion Discount"
-    value: 100
+    value: 0
     description: "$100 companion discount for a roundtrip flight between Hawaii and North America each account anniversary"
     frequency: "annual"
     category: "travel"


### PR DESCRIPTION
Last of the benefit-value overstatements from the #1796 / #1807 thread.

| Card | Benefit | Annual credits |
|---|---|---|
| Atmos Rewards Ascent | Alaska Lounge+ Membership Discount | \$100 → **\$0** |
| Atmos Rewards Business | Alaska Lounge+ Membership Discount | \$100 → **\$0** |
| Hawaiian Airlines World Elite | Anniversary Companion Discount | \$100 → **\$0** |

\$100 off an Alaska Lounge+ membership only materialises if you first buy the ~\$450 membership; the Hawaiian companion discount needs a roundtrip ticket. Neither is money you receive for existing, so neither belongs in a credits total.

`value: 0` moves them to the **perks** list. That is already the house convention for this class — **25** purchase-gated perks carry no dollar value, including:

- Capital One Venture X — *Discounted Cultivist Membership* (the direct analog: a discount on a paid membership)
- Companion certificates across Delta Platinum/Reserve, CitiBusiness AAdvantage, Citi AAdvantage Globe, Iberia, British Airways *Travel Together Ticket*, Aer Lingus *Companion Pass*
- Atmos's own *Companion Fare* / *Coach Companion Fare*, already at 0 on the very same cards

The \$100 stays in each description, so nothing is lost — it just stops being summed as free money.

## Left as-is, deliberately

- **AT&T Wireless / Internet discounts (\$120 each)** — a flat \$10/mo off a bill you already pay, applied automatically. A real recurring credit.
- **Citi hotel credits (\$300 / \$100)** — standard annual travel credits.

## One I'd flag rather than decide

**JetBlue Premier — "Companion Pass Statement Credits", \$2,000/yr.** Same defect, an order of magnitude larger: *"up to \$500 after \$15,000 in eligible purchases, plus an additional up to \$1,500 after \$75,000"*. It is counted as \$2,000 of annual credits today, and \$75,000/yr of spend on a JetBlue card is out of reach for essentially everyone.

I left it alone because the right number is a judgment call rather than an obvious 0 — \$500 at \$15k spend is genuinely attainable, so this may want `value: 500` rather than `value: 0`. Worth noting the precedent cuts toward 0: United Explorer's *Award Flight Discount* (10,000 miles after \$20,000 spend) is already modeled at 0. Happy to change it either way.

## Verification

`build:cards` builds all 184 cards. Each card's annual credits total drops by exactly \$100 to \$0, each benefit now reads `value: 0`, and each description still carries the \$100 figure.