### PR TITLE
JetBlue Premier: spend-gated companion credits are not annual value

### DIFF
--- a/data/cards/jetblue-premier-card.yaml
+++ b/data/cards/jetblue-premier-card.yaml
@@ -78,7 +78,7 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "Companion Pass Statement Credits"
-    value: 2000
+    value: 0
     description: "Up to $500 companion pass statement credit after $15,000 in eligible purchases in a calendar year, plus an additional up to $1,500 companion pass statement credit after $75,000 in eligible purchases in a calendar year"
     frequency: "annual"
     category: "travel"


### PR DESCRIPTION
Follow-up to #1808, which flagged this one.

`Companion Pass Statement Credits` carried `value: 2000` — *"up to \$500 after \$15,000 in eligible purchases, plus an additional up to \$1,500 after \$75,000"*. It was counted as **\$2,000 of annual credits**, the largest single overstatement in the corpus. \$75,000/yr of spend on a JetBlue card is out of reach for essentially everyone.

**Annual credits: \$2,330 → \$330.**

## Why 0 rather than \$500

I checked how the corpus models spend-gated benefits before picking: **29 of 40** carry no dollar value. The decisive precedent is the identical shape on a sibling card —

> Delta SkyMiles Gold — *"\$200 Delta Flight Credit after spending \$10,000 in purchases in a calendar year"* → `value: 0`

A concrete dollar credit unlocked by a spend threshold, modeled at 0. Same for United Quest's *Spending Award Flight Discount* (10,000 miles after \$20,000) and Hilton Surpass's *Free Night Award* / *Diamond Status Through Spend*.

The \$500 tier is genuinely attainable for some cardholders, which is why I raised it as a judgment call in #1808 rather than assuming — but the house convention is unambiguous and consistency wins. The full terms remain in the description, so nothing is hidden from the reader.

## Three more of this class, not fixed here

The same survey turned up others still carrying spend-gated dollar values:

| Card | Benefit | Value | Gate |
|---|---|---|---|
| Amex Business Platinum | One AP Statement Credits | \$2,400 | **\$250,000** annual spend |
| Amex Business Platinum | Dell Technologies Credit | \$1,150 | \$150 unconditional + \$1,000 after \$5,000 *Dell* spend |
| Disney Inspire Visa | Disney Resorts & Cruise Line Bonus | \$200 | \$2,000 at Disney resorts/cruise |

The Amex One AP credit is the same mechanical case as this PR and would go to 0. Dell is a partial: \$150 is real, so it likely wants \$150 rather than 0. Disney is a judgment call on whether \$2,000 of Disney-specific spend is realistic for that cardholder.

Wyndham Earner Premier's \$100 credit is gated on only \$100 of Wyndham spend, so it is effectively unconditional and correctly modeled as-is.

## Verification

`build:cards` builds all 184 cards. JetBlue Premier's annual credits total drops from \$2,330 to \$330, which is its real \$300 TrueBlue Travel credit plus the amortized \$30/yr Global Entry credit.