### PR TITLE
Finish the spend-gated credit sweep

### DIFF
--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -13,7 +13,7 @@ benefits:
     frequency: "annual"
     category: "entertainment"
   - name: "Disney Resorts & Cruise Line Bonus"
-    value: 200
+    value: 0
     description: "200 Disney Rewards Dollars after spending $2,000 each anniversary year at U.S. Disney Resorts and Disney Cruise Line"
     frequency: "annual"
     category: "travel"

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -42,7 +42,7 @@ benefits:
     category: "travel"
     enrollment_required: true
   - name: "Dell Technologies Credit"
-    value: 1150
+    value: 150
     description: "Up to $150 back on U.S. Dell purchases, plus another $1,000 after $5,000 in annual Dell spend"
     frequency: "annual"
     category: "shopping"
@@ -143,13 +143,13 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Amex Travel Flight Credits"
-    value: 1200
+    value: 0
     description: "Up to $1,200 in statement credits toward flights booked through Amex Travel in the next calendar year after spending $250,000 on the card in a calendar year"
     frequency: "annual"
     category: "travel"
     enrollment_required: false
   - name: "One AP Statement Credits"
-    value: 2400
+    value: 0
     description: "Up to $2,400 in One AP statement credits in the next calendar year after spending $250,000 on the card in a calendar year"
     frequency: "annual"
     category: "other"


### PR DESCRIPTION
Completes the pass started in #1808 / #1809.

| Card | Benefit | Value | Why |
|---|---|---|---|
| Amex Business Platinum | One AP Statement Credits | \$2,400 → **\$0** | needs **\$250,000** annual spend |
| Amex Business Platinum | Amex Travel Flight Credits | \$1,200 → **\$0** | same **\$250,000** gate |
| Amex Business Platinum | Dell Technologies Credit | \$1,150 → **\$150** | \$150 unconditional; the other \$1,000 needs \$5,000 of *Dell* spend |
| Disney Inspire Visa | Disney Resorts & Cruise Line Bonus | \$200 → **\$0** | needs \$2,000 at Disney resorts and cruise line |

**Annual credits: Business Platinum \$6,729 → \$2,129. Disney Inspire \$420 → \$220.**

## One addition to the agreed list

`Amex Travel Flight Credits` was not among the three flagged in #1809 — I found it while auditing what made up Business Platinum's remaining total. It sits behind the **identical \$250,000 threshold** as One AP Statement Credits, on the same card, with near-identical wording. Zeroing one and leaving its twin at \$1,200 would have been incoherent, so the same decision is applied to both. Flagging it explicitly since it wasn't in the brief.

## Dell is a partial, not a zero

Its description is *"Up to \$150 back on U.S. Dell purchases, plus another \$1,000 after \$5,000 in annual Dell spend"*. The first \$150 carries no threshold, so \$150 is the honest annual figure — zeroing it would have understated a real credit as badly as \$1,150 overstated it.

## Business Platinum after the change

Every remaining credit is unconditional: Indeed \$360, ChatGPT \$300, Hotel \$300, Adobe \$250, CLEAR Plus \$219, Airline Fee \$200, Hilton for Business \$200, Dell \$150, Wireless \$120, Global Entry \$30 amortized. No spend gate remains anywhere in the total.

## Verification

`build:cards` builds all 184 cards. Totals confirmed by re-summing each card's benefits with the same amortization rule the UI uses, and by re-auditing Business Platinum line by line for any surviving \$250,000 gate — none.