### PR TITLE
Teach the extractor what belongs in a benefit's value, and gate the rest

### DIFF
--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -482,7 +482,7 @@ Return ONLY valid JSON in this exact shape — no markdown, no commentary:
   "benefits": [
     {
       "name": "<short benefit name>",
-      "value": <number or 0 if perk has no monetary value>,
+      "value": <what the cardholder receives in a year for free — 0 for a perk with no monetary value, AND 0 for anything gated behind a spend threshold or a discretionary purchase. See "BENEFITS — what goes in value" below>,
       "value_unit": "usd" | "points" | "miles" | "percent",
       "description": "<one short sentence>",
       "frequency": "monthly" | "quarterly" | "semi_annual" | "annual" | "multi_year" | "ongoing" | "per_purchase" | "per_flight" | "per_trip" | "per_visit" | "per_rental" | "per_claim" | "one_time",
@@ -502,7 +502,8 @@ A benefit is a FREE thing of QUANTIFIABLE MONETARY VALUE that you get from
 holding this specific card. Examples of real benefits:
   - "$300 annual travel credit"
   - "Free checked bag for cardholder + 8 companions"
-  - "Companion certificate after $30K spend"
+  - "Companion certificate after $30K spend" (a real benefit, but value: 0 —
+    see rule 2 below)
   - "10,000 anniversary points each year"
   - "Free unlimited Priority Pass lounge access"
   - "Anniversary free night award (up to 35,000 points)"
@@ -514,6 +515,45 @@ When in doubt, UNDER-report. We'd rather miss a real benefit than list a
 non-benefit. Only include items you can clearly describe with either a
 dollar amount, a point/mile amount, a free count (e.g. "free first checked
 bag"), an elite status tier, or a clearly free recurring service.
+
+# BENEFITS — what goes in \`value\` (CRITICAL)
+\`value\` is what a typical cardholder RECEIVES IN A YEAR having done nothing
+but hold the card. It is summed into a "Total annual credits" figure shown to
+users, so a number that requires extra spending to unlock is a lie about the
+card. Four rules, all confirmed from real mistakes:
+
+1. CAPPED PERCENTAGE REBATE → put the RATE in \`value\` with
+   \`value_unit: "percent"\`. NEVER the cap. The cap is a maximum you reach
+   only by spending; it is not money you are given.
+     "10% back on concessions, up to \$250 per calendar year"
+       → value: 10, value_unit: "percent"    NOT value: 250
+     "20% savings on inflight purchases"
+       → value: 20, value_unit: "percent"
+   Keep the cap in \`description\` so the reader still sees it.
+
+2. UNLOCKED BY A SPEND THRESHOLD → \`value: 0\`. If the copy says "after
+   spending \$X", "after \$X in eligible purchases", or "after \$X in annual
+   purchases", the cardholder is buying it, not receiving it.
+     "\$200 flight credit after spending \$10,000 in a calendar year" → value: 0
+     "up to \$500 after \$15,000, plus \$1,500 more after \$75,000" → value: 0
+     "\$2,400 in credits after spending \$250,000 on the card"      → value: 0
+   Still list the benefit — the terms belong in \`description\`. Only \`value\`
+   is 0.
+
+3. DISCOUNT ON A DISCRETIONARY PURCHASE → \`value: 0\`. Money off something
+   you must choose to buy first is not an annual credit.
+     "\$100 off an annual Alaska Lounge+ membership"        → value: 0
+     "\$100 companion discount on a roundtrip ticket"       → value: 0
+     "50% off a companion fare", "discounted membership"    → value: 0
+   A credit against a bill you already pay is NOT this case: "\$10/month off
+   your AT&T wireless bill" is automatic, so value: 120 is correct.
+
+4. PART UNCONDITIONAL, PART GATED → \`value\` is ONLY the unconditional part.
+     "Up to \$150 back on Dell purchases, plus another \$1,000 after \$5,000
+      in annual Dell spend" → value: 150    NOT 1150, NOT 0
+
+If you cannot tell whether a threshold applies, use 0. Understating a credit
+is recoverable; overstating one reaches production as a false claim.
 
 # DO NOT INCLUDE — these are CARD FEATURES, not benefits
 - "Paperless Statements", "eStatements", "Digital Statements" — features.
@@ -1430,6 +1470,18 @@ function looksLikeSameByDescription(benefit, currentBenefits) {
   return null;
 }
 
+// True when a proposal claims a DOLLAR value that the copy also says must be
+// unlocked by spending. Points/miles are excluded: an "annual spend bonus" of
+// 20,000 points is a real modeled award, not a credits-total inflation.
+const SPEND_GATE_RE =
+  /after\s+(?:you\s+)?spend(?:ing)?\s+\$[\d,]+|after\s+\$[\d,]+\s+(?:or more\s+)?in\s+[a-z ]*(?:purchases|spend)\b|after\s+\$[\d,]+\s+annual/i;
+
+function isSpendGatedDollarValue(benefit) {
+  const isUsd = !benefit.value_unit || benefit.value_unit === 'usd';
+  if (!isUsd || !(benefit.value > 0)) return false;
+  return SPEND_GATE_RE.test(String(benefit.description || ''));
+}
+
 function diffBenefits(current, proposed, policy, removedFromThisCard, signupBonus) {
   // Each proposed benefit is routed by classifyBenefit(); only "auto" routes
   // into the YAML. Existing benefits aren't touched (the human curated those).
@@ -1468,6 +1520,22 @@ function diffBenefits(current, proposed, policy, removedFromThisCard, signupBonu
     // standing rule: "benefits are free things with VALUE, not features."
     if (!hasMonetaryValue(b)) {
       skipped.push({ ...b, tier: 'no_monetary_value' });
+      continue;
+    }
+    // Spend-gated dollar value — route to a human instead of auto-PRing.
+    //
+    // `value` feeds a "Total annual credits" figure, so a dollar amount you
+    // only reach by spending is a false claim about the card. Six of these
+    // were live at once (Amex Business Platinum $2,400 behind $250K of spend,
+    // JetBlue Premier $2,000 behind $75K — PRs #1809/#1810).
+    //
+    // Deliberately NOT auto-zeroed. The same phrasing covers entries where a
+    // number is right: Amex Business Platinum's Dell credit is $150
+    // unconditional plus $1,000 gated, and the Hawaiian/Atmos annual spend
+    // bonuses are point awards the team models with real values. Only a human
+    // can tell those apart, so this routes rather than rewrites.
+    if (isSpendGatedDollarValue(b)) {
+      review.push({ ...b, tier: 'spend_gated_value' });
       continue;
     }
     const tier = classifyBenefit(b.name, policy, removedFromThisCard);
@@ -1881,9 +1949,22 @@ function appendReviewEntries(card, reviewItems, rewardsDiff, ftxnDiff) {
       lines.push(`- \`${r.category}\`: ${r.value}${r.unit === 'percent' ? '%' : 'x'} (verify before removing)`);
     }
   }
-  if (benefits.length > 0) {
+  const spendGated = benefits.filter(b => b.tier === 'spend_gated_value');
+  const borderline = benefits.filter(b => b.tier !== 'spend_gated_value');
+  if (spendGated.length > 0) {
+    lines.push(`### Spend-gated dollar value — decide the number before adding`);
+    lines.push(
+      `<sub>\`value\` is summed into a "Total annual credits" figure, so it must be what a ` +
+      `cardholder gets for free. Use 0 when the whole amount is behind a spend threshold, or ` +
+      `just the unconditional part when only some of it is.</sub>`
+    );
+    for (const b of spendGated) {
+      lines.push(`- **${b.name}** (proposed \`value: ${b.value}\`) — ${b.description}`);
+    }
+  }
+  if (borderline.length > 0) {
     lines.push(`### Borderline benefits proposed (manual decision)`);
-    for (const b of benefits) {
+    for (const b of borderline) {
       lines.push(`- **${b.name}** — ${b.description}`);
     }
   }
@@ -2284,6 +2365,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  isSpendGatedDollarValue,
   editRewardCapFields,
   findRewardBlock,
   editRewardValue,

--- a/scripts/check-card-rewards-and-benefits.test.js
+++ b/scripts/check-card-rewards-and-benefits.test.js
@@ -14,6 +14,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const yamlLib = require('js-yaml');
 const {
+  isSpendGatedDollarValue,
   editRewardValue,
   isBroaderThan,
   editRewardCapFields,
@@ -977,6 +978,40 @@ test('every standard insurance name is excluded, not borderline', () => {
 
 test('borderline is empty, so nothing is re-litigated weekly by default', () => {
   assert.deepEqual(POLICY_RAW.borderline || [], []);
+});
+
+// ─── Spend-gated dollar values ──────────────────────────────────────────────
+//
+// `value` feeds a "Total annual credits" figure, so a dollar amount unlocked
+// by spending is a false claim. Six were live at once (Amex Business Platinum
+// $2,400 behind $250K, JetBlue Premier $2,000 behind $75K). These route to a
+// human rather than being auto-zeroed, because the same phrasing covers
+// entries where a number is correct.
+console.log('\nspend-gated dollar values:');
+
+const gated = (description, value = 500, value_unit) =>
+  isSpendGatedDollarValue({ name: 'x', value, value_unit, description });
+
+test('catches the real cases that reached production', () => {
+  assert.equal(gated('Up to $500 companion pass statement credit after $15,000 in eligible purchases in a calendar year'), true);
+  assert.equal(gated('Up to $2,400 in One AP statement credits in the next calendar year after spending $250,000 on the card in a calendar year'), true);
+  assert.equal(gated('$200 Delta Flight Credit after spending $10,000 in purchases in a calendar year'), true);
+  assert.equal(gated('200 Disney Rewards Dollars after spending $2,000 each anniversary year'), true);
+});
+
+test('ignores point and mile awards, which are modeled with real values', () => {
+  // Hawaiian's annual spend bonuses are legitimately valued in points.
+  assert.equal(gated('20,000 bonus miles after $50,000 in purchases', 20000, 'points'), false);
+  assert.equal(gated('100,000 miles after spending $24,000', 100000, 'miles'), false);
+});
+
+test('ignores an unconditional credit', () => {
+  assert.equal(gated('$300 annual travel credit, applied automatically'), false);
+  assert.equal(gated('$10/line monthly discount on AT&T wireless bill'), false);
+});
+
+test('ignores a zero-valued perk even when the copy is gated', () => {
+  assert.equal(gated('Companion certificate after $30,000 in purchases', 0), false);
 });
 
 console.log('\nDone.\n');


### PR DESCRIPTION
Closes the loop on #1796 → #1810. Those PRs corrected the data; this stops it coming back.

## Why it happened

The extraction prompt specified `value` as *"<number or 0 if perk has no monetary value>"* and said nothing else. So the extractor put whatever dollar figure the page showed into it — a rebate's annual cap, a credit behind a \$250,000 spend threshold, a discount on a membership you first have to buy. That number is summed into the **Total annual credits** figure users see, which is how twelve cards came to overstate value by roughly \$8,000.

## Prompt

New **BENEFITS — what goes in `value` (CRITICAL)** block, mirroring the existing one for capped reward rates. Four rules, each taken from a mistake that actually shipped:

1. **Capped percentage rebate** → the RATE, with `value_unit: "percent"`, never the cap. *(Amex Venue Collection: 10, not 250)*
2. **Unlocked by a spend threshold** → `value: 0`. *(JetBlue \$500 after \$15K; Amex \$2,400 after \$250K)*
3. **Discount on a discretionary purchase** → `value: 0`, with an explicit carve-out that a credit against a bill you already pay is not this case. *(Alaska Lounge+ \$100 off a membership → 0; AT&T \$10/mo off your bill → 120)*
4. **Part unconditional, part gated** → only the unconditional part. *(Dell: 150, not 1150 and not 0)*

Closing instruction: when unsure, use 0 — understating is recoverable, overstating reaches production as a false claim.

Also corrected the `value` field description in the JSON shape, and an example in the list above it (*"Companion certificate after \$30K spend"*) that directly contradicted rule 2.

## Guard

A prompt is advisory. `isSpendGatedDollarValue` routes any dollar-valued proposal whose description states a spend threshold to the **review queue** under its own heading, rather than auto-PRing it. The heading explains the rule so the triager can pick the right number.

## Why not auto-zero

I built the auto-zeroing version first and tested it against the corpus before trusting it. It would have clobbered three legitimate entries:

- **Dell Technologies Credit \$150** — the \$150 is unconditional; only the extra \$1,000 is gated
- **Hawaiian Annual Spend Bonus 20,000 / 40,000 points** — point awards the team models with real values
- **Wyndham \$100 credit** — gated on only \$100 of Wyndham spend, effectively unconditional

Only a human can separate those from the real overstatements, so the guard routes rather than rewrites. Points and miles are excluded from it entirely.

## Verification

Four new tests covering the exact strings that reached production (JetBlue, Amex One AP, Delta Gold, Disney) plus the three that must NOT trip it. End-to-end through `diffBenefits`: both spend-gated proposals route to review with tier `spend_gated_value`, an unconditional \$300 credit and a 20,000-point spend bonus still auto-apply. Full suite passes; `build:cards` builds all 184 cards.