### PR TITLE
card-page check: let a card gain a signup bonus it never had

### DIFF
--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -65,3 +65,7 @@ apr:
   regular:
     min: 26.74
     max: 34.74
+signup_bonus:
+  value: 100
+  type: "cash"
+  note: "Awarded as $100 of Bilt Cash to spend across the Bilt ecosystem."

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -91,3 +91,8 @@ our_take: >
   that requires enrollment. Overall, this card is best suited for Marriott
   enthusiasts who want to earn rewards on hotel stays without the burden of an
   annual fee.
+signup_bonus:
+  value: 60000
+  type: "points"
+  spend_requirement: 1000
+  timeframe_months: 3

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -957,6 +957,75 @@ function detectChanges(card, extracted, now = new Date(), suppressions = [], pag
     }
   }
 
+  // signup_bonus ADDITION — the card stores no signup_bonus block at all and the
+  // live page advertises a welcome offer. Handled on its own path because every
+  // guard in the update block below compares against a stored value that does not
+  // exist here.
+  //
+  // Until now the diff required `current.signup_bonus`, so a card that had never
+  // carried an offer could never gain one: a genuinely new SUB stayed invisible on
+  // every run, not just one. Three cards were sitting in that blind spot when this
+  // was found (Marriott Bonvoy Bold's 60,000-point offer, Chase Freedom Student's
+  // $25 autopay credit, Bilt Blue's $100 Bilt Cash). Same false-negative class as
+  // the signup_bonus.type that went undiffed until #1711 — a check that cannot
+  // report a field is worse than one that reports it noisily, because the silence
+  // looks identical to "nothing changed".
+  //
+  // The APR block below keeps its equivalent gate deliberately: intro-APR wording
+  // is easy to misparse, so inventing an offer there is a live risk. A welcome
+  // offer is stated plainly on the page, and two conditions keep this honest:
+  //   - the page must actually render a welcome-offer BODY (pageShowsSignupOffer),
+  //     so a JS-gated page that returned placeholders cannot manufacture a block;
+  //   - the extracted value must be a positive number. Per the YAML convention a
+  //     card with no public offer omits signup_bonus entirely, and a gated offer is
+  //     value: 0 on a card that ALREADY stores the block (#1579) — neither of those
+  //     is an addition, so a null or 0 here means "still no offer".
+  //
+  // KNOWN BLIND SPOT: pageShowsSignupOffer keys on spend language ("after you spend
+  // $X") anchored to a new-account window, so a welcome offer with NO spend
+  // requirement is invisible to it — Chase Freedom Rise's "$25 for enrolling in
+  // automatic payments in the first 3 months" reads as no offer at all. Loosening
+  // the gate is not the fix: it is the same function the tier guards rely on, and
+  // the header-label alternatives it deliberately rejects (Amex ships "Welcome
+  // Offer" above a "Loading" body, #1590) would make it lie in the other direction.
+  // Spend-free welcome offers stay a manual catch. Freedom Rise's $25 is already
+  // stored as a one_time benefit, which is the other reasonable home for them.
+  if (extracted.signup_bonus && !current.signup_bonus) {
+    const sb = extracted.signup_bonus;
+    if (sb.timeframe_months != null) {
+      sb.timeframe_months = normalizeTimeframeMonths(sb.timeframe_months);
+    }
+    const type = normalizeBonusType(sb.type);
+
+    if (
+      typeof sb.value === 'number' &&
+      sb.value > 0 &&
+      type != null &&
+      pageShowsSignupOffer(pageContent) &&
+      !ignoreFields.has('signup_bonus')
+    ) {
+      // An authorized-user bonus becomes the templated note, matching the update
+      // path; otherwise fall back to the extractor's own bonus_note.
+      const note =
+        sb.authorized_user_bonus != null
+          ? `Plus ${sb.authorized_user_bonus.toLocaleString()} bonus ${type} for adding an authorized user`
+          : sb.bonus_note;
+
+      const additions = [
+        ['value', sb.value],
+        ['type', type],
+        ['spend_requirement', sb.spend_requirement],
+        ['timeframe_months', sb.timeframe_months],
+        ['note', note],
+      ];
+      for (const [key, value] of additions) {
+        const field = `signup_bonus.${key}`;
+        if (value === null || value === undefined || ignoreFields.has(field)) continue;
+        changes.push({ field, old_value: null, new_value: value });
+      }
+    }
+  }
+
   // signup_bonus subfields — only compare if the card already has a signup_bonus
   if (extracted.signup_bonus && current.signup_bonus) {
     const sb = extracted.signup_bonus;

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -466,6 +466,110 @@ test('check_ignore suppresses an intro APR field', () => {
   assert.deepEqual(fieldsChanged(changes), ['apr.balance_transfer_intro.months']);
 });
 
+// ─── signup_bonus additions on a card that stores no block ──────────────────
+//
+// Before this path existed the diff required `current.signup_bonus`, so a card
+// that had never carried an offer could never gain one — Marriott Bonvoy Bold's
+// live 60,000-point offer was invisible on every run.
+
+const NO_BONUS = { data: { name: 'Marriott Bonvoy Bold', annual_fee: 0 } };
+
+// pageShowsSignupOffer(null) returns true, so tests that don't care about the
+// rendered-page gate can omit pageContent. This one exercises the gate directly.
+const BOLD_OFFER_PAGE =
+  'Earn 60,000 bonus points after you spend $1,000 on purchases in your first 3 months from account opening.';
+
+console.log('\nsignup_bonus additions (card stores no signup_bonus):');
+
+test('a new offer on a card with no signup_bonus block surfaces every subfield', () => {
+  const changes = detectChanges(
+    NO_BONUS,
+    {
+      signup_bonus: { value: 60000, type: 'points', spend_requirement: 1000, timeframe_months: 3 },
+    },
+    new Date(),
+    [],
+    BOLD_OFFER_PAGE
+  );
+  assert.deepEqual(fieldsChanged(changes), [
+    'signup_bonus.spend_requirement',
+    'signup_bonus.timeframe_months',
+    'signup_bonus.type',
+    'signup_bonus.value',
+  ]);
+  const value = changes.find(c => c.field === 'signup_bonus.value');
+  assert.equal(value.old_value, null);
+  assert.equal(value.new_value, 60000);
+});
+
+test('subfields the page did not state are left out rather than written as null', () => {
+  const changes = detectChanges(NO_BONUS, {
+    signup_bonus: { value: 100, type: 'cashback', spend_requirement: null, timeframe_months: null },
+  });
+  assert.deepEqual(fieldsChanged(changes), ['signup_bonus.type', 'signup_bonus.value']);
+  // "cashback" is the prompt's spelling; YAML stores "cash".
+  assert.equal(changes.find(c => c.field === 'signup_bonus.type').new_value, 'cash');
+});
+
+test('a page with no rendered offer body cannot manufacture a block', () => {
+  const changes = detectChanges(
+    NO_BONUS,
+    { signup_bonus: { value: 60000, type: 'points' } },
+    new Date(),
+    [],
+    'Earn 3X points at restaurants. Welcome Offer Loading...'
+  );
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('value 0 or null means "still no public offer", not an addition', () => {
+  for (const value of [0, null, undefined]) {
+    const changes = detectChanges(NO_BONUS, {
+      signup_bonus: { value, type: 'points', spend_requirement: 1000, timeframe_months: 3 },
+    });
+    assert.deepEqual(fieldsChanged(changes), [], `value ${value} should add nothing`);
+  }
+});
+
+test('an addition with no type is rejected — the unit is not inferable', () => {
+  const changes = detectChanges(NO_BONUS, {
+    signup_bonus: { value: 60000, type: null, spend_requirement: 1000 },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('an authorized-user bonus becomes the templated note', () => {
+  const changes = detectChanges(NO_BONUS, {
+    signup_bonus: { value: 60000, type: 'points', authorized_user_bonus: 10000 },
+  });
+  assert.equal(
+    changes.find(c => c.field === 'signup_bonus.note').new_value,
+    'Plus 10,000 bonus points for adding an authorized user'
+  );
+});
+
+test('a raw day count is converted to months on the way in', () => {
+  const changes = detectChanges(NO_BONUS, {
+    signup_bonus: { value: 60000, type: 'points', spend_requirement: 1000, timeframe_months: 90 },
+  });
+  assert.equal(changes.find(c => c.field === 'signup_bonus.timeframe_months').new_value, 3);
+});
+
+test('check_ignore: "signup_bonus" opts a card out of additions entirely', () => {
+  const ignored = { data: { ...NO_BONUS.data, check_ignore: ['signup_bonus'] } };
+  const changes = detectChanges(ignored, {
+    signup_bonus: { value: 60000, type: 'points', spend_requirement: 1000 },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('a card that already stores a signup_bonus still takes the update path', () => {
+  const changes = detectChanges(WORLD_OF_HYATT, {
+    signup_bonus: { value: 60000, spend_requirement: 15000, timeframe_months: 6 },
+  });
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
 // ─── annual_fee: first-year-waiver misread + check_ignore ───────────────────
 
 // Citi AAdvantage pattern: ongoing $99, waived the first 12 months. The fee is


### PR DESCRIPTION
## The gap

`detectChanges` gated the entire `signup_bonus` diff on the card **already** storing one:

```js
if (extracted.signup_bonus && current.signup_bonus)
```

A card that had never carried an offer could therefore never gain one. A genuinely new SUB was invisible on **every** run, not just one, and that silence looked identical to "nothing changed" — the same false-negative class as the `signup_bonus.type` that went undiffed until #1711.

Found by the 2026-07-28 daily card-page check, which reported "no changes" while three cards had live offers their YAML didn't carry.

## The fix

Additions take their own path, because every guard in the update block compares against a stored value that doesn't exist yet. Two conditions keep it from inventing an offer:

- **The page must render a welcome-offer body** (`pageShowsSignupOffer`), so a JS-gated page that returned placeholders can't manufacture a block.
- **The value must be a positive number.** Per the YAML convention a card with no public offer omits `signup_bonus` entirely, and a gated offer is `value: 0` on a card that *already* stores the block (#1579). Neither is an addition.

The APR block keeps its equivalent gate deliberately — intro-APR wording is easy to misparse, so inventing an offer there is a real risk. A welcome offer is stated plainly on the page.

## Card data

Both verified against the live issuer page text captured in this run:

| Card | Offer | Source wording |
|---|---|---|
| Marriott Bonvoy Bold | 60,000 points / $1,000 / 3 mo | "Earn 60,000 Bonus Points after spending $1,000 on eligible purchases within 3 months" |
| Bilt Blue | $100 Bilt Cash | "Sign-up bonus — $100 of Bilt Cash. Spend across the Bilt ecosystem." (no spend requirement or window stated) |

## Why Chase Freedom Rise is not here

It looked like a third case, but its $25 autopay credit is **already stored as a `one_time` benefit** — adding a `signup_bonus` would double-count it.

It also exposes a real blind spot in the gate, now documented in place: `pageShowsSignupOffer` keys on spend language anchored to a new-account window, so a welcome offer with **no spend requirement** reads as no offer at all. Loosening that isn't the fix — it's the same function the tier guards rely on, and the header-label alternatives it deliberately rejects (Amex ships "Welcome Offer" above a "Loading" body, #1590) would make it lie in the other direction. Spend-free welcome offers stay a manual catch.

## Tests

9 new cases covering the addition path — subfield coverage, the rendered-offer gate, `value: 0`/null rejection, missing type, AU-bonus note templating, days-to-months conversion, `check_ignore`, and that a card already storing a bonus still takes the update path.

```bash
node scripts/check-card-pages.test.js
```

107 pass, exit 0. `npm run build:cards` builds all 184 cards clean (regenerated `cards.json` not committed).

## Review note

Please check both cards against the live issuer pages before merging — this is card data.