### PR TITLE
let the card-page check ADD a signup_bonus, not just diff one

### DIFF
--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -65,3 +65,9 @@ apr:
   regular:
     min: 26.74
     max: 34.74
+signup_bonus:
+  value: 100
+  type: "cash"
+  spend_requirement: 0
+  timeframe_months: 0
+  note: "$100 in Bilt Cash deposited upon approval; no minimum spend required"

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -29,6 +29,12 @@ apr:
   regular:
     min: 18.24
     max: 27.74
+signup_bonus:
+  value: 25
+  type: "cash"
+  spend_requirement: 0
+  timeframe_months: 3
+  note: "$25 statement credit for enrolling in automatic payments within the first 3 months of account opening and staying enrolled at least 90 days; no minimum spend required"
 apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/rise
 foreign_transaction_fee: true
 network: "visa"

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -58,9 +58,3 @@ benefits:
     enrollment_required: true
     merchants:
       - doordash
-  - name: "Automatic Payment Statement Credit"
-    value: 25
-    description: "Earn a $25 statement credit when you sign up for automatic payments within the first three months of opening your account and remain enrolled for at least 90 days."
-    frequency: "one_time"
-    category: "statement_credit"
-    enrollment_required: true

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -76,6 +76,11 @@ apr:
   regular:
     min: 19.24
     max: 27.74
+signup_bonus:
+  value: 60000
+  type: "points"
+  spend_requirement: 1000
+  timeframe_months: 3
 apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/bold
 foreign_transaction_fee: false
 network: "visa"

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -957,7 +957,9 @@ function detectChanges(card, extracted, now = new Date(), suppressions = [], pag
     }
   }
 
-  // signup_bonus subfields — only compare if the card already has a signup_bonus
+  // signup_bonus subfields. Two paths: a DIFF when the card already stores a
+  // block (every guard below is a comparison against a known value), and an
+  // ADDITION when it doesn't — see the else-if at the end of this section.
   if (extracted.signup_bonus && current.signup_bonus) {
     const sb = extracted.signup_bonus;
     const cur = current.signup_bonus;
@@ -1226,6 +1228,73 @@ function detectChanges(card, extracted, now = new Date(), suppressions = [], pag
       !ignoreFields.has('signup_bonus.note')
     ) {
       changes.push({ field: 'signup_bonus.note', old_value: cur.note, new_value: null });
+    }
+  } else if (extracted.signup_bonus && !current.signup_bonus) {
+    // ADDITION — the card stores no signup_bonus block at all and the page
+    // advertises a welcome offer. Before this branch existed the diff above was
+    // the only path, so a missing block meant the offer was invisible to the
+    // check FOREVER, not just for one run: Marriott Bonvoy Bold's 60,000-point
+    // offer, Freedom Rise's $25 autopay credit and Bilt Blue's $100 Bilt Cash
+    // were all extracted correctly on 2026-07-28 and all silently dropped. Same
+    // false-negative class as the signup_bonus.type gap fixed on #1711.
+    //
+    // The intro-APR block below keeps its own current.apr gate deliberately
+    // ("never invent an intro offer for a card without one") because APR wording
+    // is genuinely easy to misparse. A welcome offer isn't: it's stated plainly,
+    // and missing one is expensive — the SUB is the headline number on /compare,
+    // in wallet ranking and in every card_wire post.
+    //
+    // Guards, so an extractor null can't manufacture an empty block:
+    //   - the page must actually render an offer (pageShowsSignupOffer), the
+    //     same gate pageSaysFlat and the type diff use. On a JS-gated page the
+    //     extractor happily infers a plausible-sounding bonus from branding.
+    //   - a concrete positive value is required. value 0 is real data on an
+    //     EXISTING block (a publicly-gated offer, see #1579) but as an addition
+    //     it's indistinguishable from "this card has no bonus", which is exactly
+    //     what an absent block already means. Leave that one to a human.
+    // check_ignore is honored per subfield, plus a bare `signup_bonus` entry to
+    // opt a card out of additions wholesale.
+    const sb = extracted.signup_bonus;
+    if (sb.timeframe_months != null) {
+      sb.timeframe_months = normalizeTimeframeMonths(sb.timeframe_months);
+    }
+    const proposedType = normalizeBonusType(sb.type);
+
+    if (
+      pageShowsSignupOffer(pageContent) &&
+      sb.value != null &&
+      sb.value > 0 &&
+      !ignoreFields.has('signup_bonus')
+    ) {
+      const addField = (subfield, value) => {
+        // 0 is meaningful for spend_requirement/timeframe_months — an
+        // on-approval bonus with no minimum spend stores both as 0 (Bilt
+        // Obsidian, the Amazon instant gift cards). Only null/undefined skip.
+        if (value === null || value === undefined) return;
+        if (ignoreFields.has(`signup_bonus.${subfield}`)) return;
+        changes.push({ field: `signup_bonus.${subfield}`, old_value: null, new_value: value });
+      };
+
+      addField('value', sb.value);
+      // Fall back to the card's reward_type when the extractor doesn't name a
+      // unit. The unit is load-bearing downstream (card_wire refuses to diff
+      // across units, /compare reads cash as dollars), so a block that lands
+      // without one is worse than one that inherits the card's currency.
+      addField('type', proposedType ?? normalizeBonusType(current.reward_type));
+      addField('spend_requirement', sb.spend_requirement);
+      addField('timeframe_months', sb.timeframe_months);
+
+      if (sb.authorized_user_bonus != null) {
+        const bonusType = proposedType ?? normalizeBonusType(current.reward_type) ?? 'points';
+        addField(
+          'note',
+          `Plus ${sb.authorized_user_bonus.toLocaleString()} bonus ${bonusType} for adding an authorized user`
+        );
+      } else {
+        // The valueChanged gate the diff path uses to suppress boilerplate notes
+        // is satisfied by construction here — an addition always moves value.
+        addField('note', sb.bonus_note);
+      }
     }
   }
 

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -897,4 +897,134 @@ test('an empty or missing reason is not retried', () => {
   assert.equal(isTransientNetworkError(undefined), false);
 });
 
+// ─── signup_bonus ADDITIONS (card stores no block at all) ───────────────────
+//
+// Until this landed, detectChanges gated the whole signup_bonus diff on the
+// card ALREADY having a block, so a live welcome offer on a card without one
+// was invisible on every run forever — Marriott Bonvoy Bold's 60,000 points,
+// Freedom Rise's $25 autopay credit and Bilt Blue's $100 Bilt Cash all
+// extracted correctly on 2026-07-28 and were all dropped.
+
+console.log('\nsignup_bonus additions:');
+
+const NO_SUB_CARD = { data: { name: 'Marriott Bonvoy Bold', reward_type: 'points' } };
+// Real Chase Bold copy — carries both halves pageShowsSignupOffer requires.
+const BOLD_PAGE =
+  'NEW CARDMEMBER OFFER Earn 60,000 Bonus Points after spending $1,000 on ' +
+  'eligible purchases within 3 months of account opening.';
+
+test('a rendered offer on a card with no signup_bonus proposes the whole block', () => {
+  const changes = detectChanges(
+    NO_SUB_CARD,
+    { signup_bonus: { value: 60000, type: 'points', spend_requirement: 1000, timeframe_months: 3 } },
+    new Date(),
+    [],
+    BOLD_PAGE
+  );
+  assert.deepEqual(fieldsChanged(changes), [
+    'signup_bonus.spend_requirement',
+    'signup_bonus.timeframe_months',
+    'signup_bonus.type',
+    'signup_bonus.value',
+  ]);
+  assert.equal(changes.find(c => c.field === 'signup_bonus.value').new_value, 60000);
+  // Every addition reads as null → new, so the PR body renders it as an add.
+  assert.ok(changes.every(c => c.old_value === null));
+});
+
+test('spend_requirement 0 / timeframe 0 survive (on-approval bonuses like Bilt)', () => {
+  const changes = detectChanges(
+    { data: { name: 'Bilt Blue', reward_type: 'points' } },
+    { signup_bonus: { value: 100, type: 'cashback', spend_requirement: 0, timeframe_months: 0 } },
+    new Date(),
+    [],
+    BOLD_PAGE
+  );
+  const by = Object.fromEntries(changes.map(c => [c.field, c.new_value]));
+  assert.equal(by['signup_bonus.spend_requirement'], 0);
+  assert.equal(by['signup_bonus.timeframe_months'], 0);
+  // cashback normalizes to the YAML spelling used by the other 36 cash cards.
+  assert.equal(by['signup_bonus.type'], 'cash');
+});
+
+test('a page with no offer language proposes nothing', () => {
+  const changes = detectChanges(
+    NO_SUB_CARD,
+    { signup_bonus: { value: 60000, type: 'points', spend_requirement: 1000, timeframe_months: 3 } },
+    new Date(),
+    [],
+    'Earn 3X points at hotels participating in Marriott Bonvoy. $0 annual fee.'
+  );
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('a null or zero extracted value cannot manufacture an empty block', () => {
+  for (const value of [null, 0]) {
+    const changes = detectChanges(
+      NO_SUB_CARD,
+      { signup_bonus: { value, type: 'points', spend_requirement: 1000, timeframe_months: 3 } },
+      new Date(),
+      [],
+      BOLD_PAGE
+    );
+    assert.deepEqual(fieldsChanged(changes), [], `value ${value} should propose nothing`);
+  }
+});
+
+test('type falls back to the card reward_type when the extractor omits it', () => {
+  const changes = detectChanges(
+    { data: { name: 'Chase Freedom Rise', reward_type: 'cashback' } },
+    { signup_bonus: { value: 25, spend_requirement: 0, timeframe_months: 3 } },
+    new Date(),
+    [],
+    BOLD_PAGE
+  );
+  assert.equal(changes.find(c => c.field === 'signup_bonus.type').new_value, 'cash');
+});
+
+test('bonus_note rides along on an addition (value always moves)', () => {
+  const changes = detectChanges(
+    NO_SUB_CARD,
+    {
+      signup_bonus: {
+        value: 60000, type: 'points', spend_requirement: 1000, timeframe_months: 3,
+        bonus_note: 'Limited-time offer',
+      },
+    },
+    new Date(),
+    [],
+    BOLD_PAGE
+  );
+  assert.equal(changes.find(c => c.field === 'signup_bonus.note').new_value, 'Limited-time offer');
+});
+
+test('check_ignore blocks an addition per-subfield and wholesale', () => {
+  const extracted = {
+    signup_bonus: { value: 60000, type: 'points', spend_requirement: 1000, timeframe_months: 3 },
+  };
+  const perField = detectChanges(
+    { data: { ...NO_SUB_CARD.data, check_ignore: ['signup_bonus.spend_requirement'] } },
+    extracted, new Date(), [], BOLD_PAGE
+  );
+  assert.ok(!fieldsChanged(perField).includes('signup_bonus.spend_requirement'));
+  assert.ok(fieldsChanged(perField).includes('signup_bonus.value'));
+
+  const wholesale = detectChanges(
+    { data: { ...NO_SUB_CARD.data, check_ignore: ['signup_bonus'] } },
+    extracted, new Date(), [], BOLD_PAGE
+  );
+  assert.deepEqual(fieldsChanged(wholesale), []);
+});
+
+test('a days-as-months timeframe is converted before it lands in YAML', () => {
+  const changes = detectChanges(
+    NO_SUB_CARD,
+    { signup_bonus: { value: 60000, type: 'points', spend_requirement: 1000, timeframe_months: 90 } },
+    new Date(),
+    [],
+    BOLD_PAGE
+  );
+  assert.equal(changes.find(c => c.field === 'signup_bonus.timeframe_months').new_value, 3);
+});
+
 console.log('');


### PR DESCRIPTION
## The gap

`detectChanges` gated the entire `signup_bonus` comparison on the card **already** having a block:

```js
if (extracted.signup_bonus && current.signup_bonus) { ... }
```

So when a card's YAML has no `signup_bonus:` key and the live issuer page advertises a welcome offer, nothing is ever proposed — the offer is invisible to the check **forever**, not just for one run. Same false-negative class as the `signup_bonus.type` gap fixed in #1711.

The APR block below it has the same `current.apr` gate, but there it's deliberate and documented ("never invent an intro offer for a card without one") because APR wording is easy to misparse. The signup_bonus gate carried no such reasoning, and a welcome offer is stated plainly on the page.

## The fix

New `else if (extracted.signup_bonus && !current.signup_bonus)` branch in [check-card-pages.js](scripts/check-card-pages.js). Guards, so an extractor null can't manufacture an empty block:

- `pageShowsSignupOffer(pageContent)` must be true — the same gate `pageSaysFlat` and the type diff already use. On a JS-gated page the extractor happily infers a plausible bonus from branding.
- the extracted `value` must be non-null **and positive**. `value: 0` is real data on an *existing* block (a publicly-gated offer, #1579), but as an addition it says exactly what an absent block already says. Left to a human.
- `spend_requirement` and `timeframe_months` of `0` **do** survive — that's how on-approval bonuses are stored (Bilt Obsidian, the Amazon instant gift cards).
- `type` falls back to the card's `reward_type` when the extractor omits it. The unit is load-bearing in card_wire (refuses to diff across units) and /compare (reads cash as dollars), so a block landing without one is worse than one inheriting the card's currency.
- `check_ignore` honored per-subfield, plus a bare `signup_bonus` entry to opt a card out of additions wholesale.

`applyChanges` needed no change — it already does `if (!parsedData.signup_bonus) parsedData.signup_bonus = {}`. Verified end to end on a temp copy of the Bold YAML: the fresh block appends at the end of the file and parses correctly. (Cosmetic note: auto-added blocks land at the bottom rather than beside `apr`. Valid YAML, matches where `bilt-obsidian` already keeps its block. Not worth touching `replaceYamlBlock`'s existing replace path over.)

8 new tests in [check-card-pages.test.js](scripts/check-card-pages.test.js); full suite passes.

## The three cards

All verified against the live issuer pages today, not against a blog.

| Card | Page says | Added |
|---|---|---|
| Marriott Bonvoy Bold | "NEW CARDMEMBER OFFER — Earn 60,000 Bonus Points after spending \$1,000 on eligible purchases within 3 months of account opening" | 60000 / points / \$1,000 / 3 mo |
| Chase Freedom Rise | "\$25 statement credit when you sign up for automatic payments within the first three months of opening your account and remain enrolled for at least 90 days" | 25 / cash / \$0 / 3 mo + note |
| Bilt Blue | "Sign-up bonus — \$100 of Bilt Cash, when you apply and get approved" | 100 / cash / \$0 / 0 mo + note |

**Two judgment calls worth your eye:**

1. **Freedom Rise.** The \$25 is action-gated (autopay enrollment), not spend-gated, and Chase labels that section "AUTOMATIC PAYMENTS" rather than "NEW CARDMEMBER OFFER". I read it as a SUB anyway: it's one-time, earnable only in the first 3 months of account opening, it's one of the three numbers Chase headlines, and the card has no other welcome offer — so showing "no signup bonus" is materially wrong on /compare. Precedent: `rei-co-op-mastercard` stores an action-gated, non-spend-threshold \$100 gift card as a SUB.

2. **Freedom Rise duplication — resolved.** The \$25 also existed as a `benefits` entry ("Automatic Payment Statement Credit", value 25, `frequency: one_time`). Per Max, that entry is now **deleted** — the offer lives in `signup_bonus` only. It never double-counted in annual value (`CardClient.tsx` only rolls up monthly/quarterly/semi_annual/annual/multi_year; `one_time` falls through to `default: return sum`), but it did render twice on the card page. Deleting the `- name:` line is enough to stop the rewards/benefits checker re-proposing it — `getRemovedBenefitsForCard()` deny-lists benefit names it finds deleted in the card's git history.

Bilt Blue mirrors `bilt-obsidian`'s existing block exactly (\$200 → \$100), including the note wording.

`cards.json` deliberately not committed — CI rebuilds it. `npm run build:cards` passes on all 184 cards.
