### PR TITLE
card pages: don't crash on a signup bonus without a spend requirement

### DIFF
--- a/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
+++ b/apps/web-next/src/app/bank/[name]/BankCardsTable.tsx
@@ -204,9 +204,11 @@ export default function BankCardsTable({ cards, trendingViews }: BankCardsTableP
                     return (
                       <div>
                         <div className="font-semibold text-gray-900">{valueStr}</div>
-                        <div className="text-xs text-gray-500">
-                          ${bonus.spend_requirement.toLocaleString()} in {bonus.timeframe_months}mo
-                        </div>
+                        {bonus.spend_requirement != null && bonus.timeframe_months != null && (
+                          <div className="text-xs text-gray-500">
+                            ${bonus.spend_requirement.toLocaleString()} in {bonus.timeframe_months}mo
+                          </div>
+                        )}
                       </div>
                     );
                   })()}

--- a/apps/web-next/src/app/best-card-for-me/BestCardForMeClient.tsx
+++ b/apps/web-next/src/app/best-card-for-me/BestCardForMeClient.tsx
@@ -1168,8 +1168,10 @@ function RecCardRow({ rec }: { rec: Recommendation }) {
         {rec.blurb && <p className="bcfm-rec-blurb">{rec.blurb}</p>}
         {c.signup_bonus && c.signup_bonus.value > 0 && (
           <p className="bcfm-rec-sub">
-            Bonus: {c.signup_bonus.value.toLocaleString()} {c.signup_bonus.type} after $
-            {c.signup_bonus.spend_requirement.toLocaleString()} in {c.signup_bonus.timeframe_months} mo
+            Bonus: {c.signup_bonus.value.toLocaleString()} {c.signup_bonus.type}
+            {c.signup_bonus.spend_requirement != null && c.signup_bonus.timeframe_months != null && (
+              <> after ${c.signup_bonus.spend_requirement.toLocaleString()} in {c.signup_bonus.timeframe_months} mo</>
+            )}
           </p>
         )}
         {rec.categories.length > 0 && (

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -497,7 +497,12 @@ export default function CardClient({
       cpp && typeof sb.value === "number"
         ? Math.round((sb.value * cpp) / 100)
         : null;
-    const sub = `After $${sb.spend_requirement.toLocaleString()} in ${sb.timeframe_months} mo${cashEquiv ? ` · ≈ $${cashEquiv.toLocaleString()}` : ""}`;
+    const subParts: string[] = [];
+    if (sb.spend_requirement != null && sb.timeframe_months != null) {
+      subParts.push(`After $${sb.spend_requirement.toLocaleString()} in ${sb.timeframe_months} mo`);
+    }
+    if (cashEquiv) subParts.push(`≈ $${cashEquiv.toLocaleString()}`);
+    const sub = subParts.join(" · ");
     return { value, sub };
   }, [card.card_name, card.signup_bonus]);
 

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -42,7 +42,7 @@ function buildMetaDescription(card: Card): string {
     const valStr = sb.type === 'cash'
       ? `$${sb.value.toLocaleString()}`
       : `${sb.value.toLocaleString()} ${sb.type.replace(/_/g, ' ')}`;
-    const reqStr = sb.spend_requirement
+    const reqStr = sb.spend_requirement && sb.timeframe_months
       ? ` after $${sb.spend_requirement.toLocaleString()} in ${sb.timeframe_months}mo`
       : '';
     facts.push(`a ${valStr} signup bonus${reqStr}`);

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -456,7 +456,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                   {/* Spend Requirement */}
                   <div className="flex justify-between px-4 py-2.5 text-sm">
                     <span className="text-gray-500 font-medium">Spend Requirement</span>
-                    {card.signup_bonus ? (
+                    {card.signup_bonus?.spend_requirement != null && card.signup_bonus.timeframe_months != null ? (
                       <span className="text-gray-900">${card.signup_bonus.spend_requirement.toLocaleString()} in {card.signup_bonus.timeframe_months} mo</span>
                     ) : (
                       <span className="text-gray-400">{'\u2014'}</span>
@@ -677,7 +677,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                 <td className="sticky left-0 z-10 bg-gray-50/50 px-4 py-3 text-sm font-medium text-gray-500">Spend Requirement</td>
                 {activeCards.map((card) => (
                   <td key={card.slug} className="px-4 py-3 text-center text-sm text-gray-900">
-                    {card.signup_bonus ? (
+                    {card.signup_bonus?.spend_requirement != null && card.signup_bonus.timeframe_months != null ? (
                       <span>
                         ${card.signup_bonus.spend_requirement.toLocaleString()} in {card.signup_bonus.timeframe_months} mo
                       </span>

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -73,8 +73,9 @@ export interface Reward {
 export interface SignupBonus {
   value: number;
   type: string;
-  spend_requirement: number;
-  timeframe_months: number;
+  // Some offers (e.g. Bilt Blue's $100 Bilt Cash) have no spend requirement.
+  spend_requirement?: number;
+  timeframe_months?: number;
   note?: string;
 }
 

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -320,6 +320,7 @@ export function formatBonusValue(card: Card): string {
 export function formatBonusRequirement(card: Card): string {
   if (!card.signup_bonus) return '';
   const { spend_requirement, timeframe_months } = card.signup_bonus;
+  if (spend_requirement == null || timeframe_months == null) return '';
   return `after $${spend_requirement.toLocaleString()} in ${timeframe_months} month${timeframe_months !== 1 ? 's' : ''}`;
 }
 


### PR DESCRIPTION
## Problem

Sentry issue `CREDITODDS-JAVASCRIPT-NEXTJS-14`: `TypeError: Cannot read properties of undefined (reading 'toLocaleString')` crashing SSR of https://creditodds.com/card/bilt-blue since this morning.

#1813 (merged today) let the card-page check add a signup bonus to a card that never had one, and the first bonus through that path — Bilt Blue's $100 Bilt Cash offer — has no `spend_requirement` or `timeframe_months`. That's a shape the extractor explicitly supports (`spend_requirement: <number or null>`), but five frontend render sites assumed both fields always exist:

- `CardClient.tsx` `bonusDisplay` useMemo — the actual SSR crash on /card/bilt-blue
- `BankCardsTable.tsx` — /bank/Bilt spend line
- `CompareClient.tsx` — two Spend Requirement rows
- `BestCardForMeClient.tsx` — quiz result bonus line
- `cardDisplayUtils.formatBonusRequirement` — used by /best pages

## Fix

- `SignupBonus` in `api.ts` now marks `spend_requirement` and `timeframe_months` optional, so tsc flags any future unguarded use
- Each site skips the spend-requirement line when the fields are absent (tables fall back to their existing em-dash placeholder)
- `card/[name]/page.tsx` meta description already guarded `spend_requirement` but could interpolate an undefined `timeframe_months`; now guards both

## Verified

- `tsc --noEmit` clean
- Dev server (worktree): /card/bilt-blue SSRs 200 with the $100 bonus box and note, no spend line; /compare?cards=bilt-blue,bilt-mastercard shows $100 + em-dash placeholder; /bank/Bilt 200s. No console errors.