### PR TITLE
Show the Missing-a-card GitHub CTA in the hero search empty state

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -286,7 +286,32 @@ function Hero({ cards }: { cards: LandingCard[] }) {
             {open && query.trim() && (
               <div className="search-results" role="listbox" id="hero-search-results">
                 {matches.length === 0 ? (
-                  <div className="opt-empty">No cards match &ldquo;{query}&rdquo;.</div>
+                  <div className="opt-empty">
+                    <p>No cards match &ldquo;{query}&rdquo;.</p>
+                    <p style={{ marginTop: 8 }}>
+                      Missing a card?{' '}
+                      <a
+                        href="https://github.com/CreditOdds/creditodds/issues/new?title=Add+card:+&labels=new+card"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="empty-cta-link"
+                        onMouseDown={(e) => e.preventDefault()}
+                      >
+                        Open an issue
+                      </a>{' '}
+                      or{' '}
+                      <a
+                        href="https://github.com/CreditOdds/creditodds/blob/main/CONTRIBUTING.md"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="empty-cta-link"
+                        onMouseDown={(e) => e.preventDefault()}
+                      >
+                        add it yourself
+                      </a>{' '}
+                      on GitHub.
+                    </p>
+                  </div>
                 ) : (
                   matches.map((c, idx) => (
                     <Link


### PR DESCRIPTION
When the home-page hero search turns up no matches, the dropdown previously showed only "No cards match ...". It now also shows the same "Missing a card? Open an issue or add it yourself on GitHub." message used by the /explore empty state, with the same links (new-issue template and CONTRIBUTING.md).

The links carry `onMouseDown={preventDefault}` like the existing result options, so the input's blur handler doesn't close the dropdown before the click lands. The `empty-cta-link` class already applies since the landing wrapper carries both `landing-v2` and `landing-v3` scopes.

Verified in the dev server: typing a gibberish query shows the message with working accent-colored links, no console errors.