### PR TITLE
explore: compact single-row filter toolbar

### DIFF
--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import CardImage from '@/components/ui/CardImage';
 import { V2Footer } from '@/components/landing-v2/Chrome';
@@ -22,7 +22,6 @@ type FeeBucket = 'all' | 'free' | 'low' | 'mid' | 'high';
 type NetworkFilter = 'all' | 'visa' | 'mastercard' | 'amex' | 'discover';
 
 const NETWORKS: [NetworkFilter, string][] = [
-  // "Any" rather than "All" so this doesn't collide with the Type row's chip
   ['all', 'Any'],
   ['visa', 'Visa'],
   ['mastercard', 'Mastercard'],
@@ -30,11 +29,11 @@ const NETWORKS: [NetworkFilter, string][] = [
   ['discover', 'Discover'],
 ];
 
-const REWARD_TYPES: [RewardTypeFilter, string, string | null][] = [
-  ['all', 'All', null],
-  ['cashback', 'Cashback', '💵'],
-  ['points', 'Points', '✨'],
-  ['miles', 'Miles', '✈️'],
+const REWARD_TYPES: [RewardTypeFilter, string][] = [
+  ['all', 'All'],
+  ['cashback', 'Cashback'],
+  ['points', 'Points'],
+  ['miles', 'Miles'],
 ];
 
 const FEE_BUCKETS: [FeeBucket, string][] = [
@@ -44,6 +43,30 @@ const FEE_BUCKETS: [FeeBucket, string][] = [
   ['mid', '$100–$250'],
   ['high', 'Over $250'],
 ];
+
+// The four presets in the Sort menu. Column-header sorts can produce
+// combinations outside this list (e.g. bonus desc); sortLabel covers those.
+const SORT_CHOICES: { key: SortKey; dir: SortDir; label: string }[] = [
+  { key: 'trending', dir: 'desc', label: 'Trending' },
+  { key: 'approval', dir: 'desc', label: 'Best odds' },
+  { key: 'records', dir: 'desc', label: 'Most records' },
+  { key: 'fee', dir: 'asc', label: 'Lowest fee' },
+];
+
+function sortLabel(sort: SortKey, dir: SortDir): string {
+  switch (sort) {
+    case 'trending':
+      return 'Trending';
+    case 'records':
+      return 'Most records';
+    case 'approval':
+      return dir === 'desc' ? 'Best odds' : 'Lowest odds';
+    case 'fee':
+      return dir === 'asc' ? 'Lowest fee' : 'Highest fee';
+    case 'bonus':
+      return dir === 'desc' ? 'Biggest bonus' : 'Smallest bonus';
+  }
+}
 
 function feeMatchesBucket(fee: number | undefined, bucket: FeeBucket): boolean {
   if (bucket === 'all') return true;
@@ -81,14 +104,18 @@ function SortChevron({ active, dir }: { active: boolean; dir: SortDir }) {
   );
 }
 
-function IssuerDropdown({
-  banks,
-  selected,
-  onChange,
+function Facet({
+  label,
+  value,
+  set,
+  alignRight,
+  children,
 }: {
-  banks: { name: string; count: number }[];
-  selected: Set<string>;
-  onChange: (next: Set<string>) => void;
+  label: string;
+  value: string;
+  set?: boolean;
+  alignRight?: boolean;
+  children: (close: () => void) => ReactNode;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -111,64 +138,93 @@ function IssuerDropdown({
     };
   }, [open]);
 
-  const label = selected.size === 0 ? 'Issuer' : `Issuer (${selected.size})`;
-
-  function toggle(bank: string) {
-    const next = new Set(selected);
-    if (next.has(bank)) next.delete(bank);
-    else next.add(bank);
-    onChange(next);
-  }
-
   return (
-    <div className="issuer-dropdown" ref={ref}>
+    <div className="facet" ref={ref}>
       <button
         type="button"
-        className={'filter-chip ' + (selected.size > 0 ? 'active' : '')}
+        className={'facet-btn' + (set ? ' set' : '')}
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
-        aria-haspopup="listbox"
+        aria-haspopup="true"
       >
-        {label}
+        <span className="facet-k">{label}</span>
+        <span className="facet-v">{value}</span>
         <svg
-          width="10"
-          height="10"
-          viewBox="0 0 24 24"
+          width="9"
+          height="6"
+          viewBox="0 0 10 6"
           fill="none"
           stroke="currentColor"
-          strokeWidth="2.5"
+          strokeWidth="1.6"
           aria-hidden="true"
         >
-          <polyline points="6 9 12 15 18 9" />
+          <path d="m1 1 4 4 4-4" />
         </svg>
       </button>
       {open && (
-        <div className="issuer-panel" role="listbox">
-          {selected.size > 0 && (
-            <button
-              type="button"
-              className="issuer-clear"
-              onClick={() => onChange(new Set())}
-            >
-              Clear all
-            </button>
-          )}
-          <div className="issuer-options">
-            {banks.map((b) => (
-              <label key={b.name} className="issuer-option">
-                <input
-                  type="checkbox"
-                  checked={selected.has(b.name)}
-                  onChange={() => toggle(b.name)}
-                />
-                <span className="issuer-name">{b.name}</span>
-                <span className="issuer-count">{b.count}</span>
-              </label>
-            ))}
-          </div>
+        <div className={'facet-pop' + (alignRight ? ' right' : '')}>
+          {children(() => setOpen(false))}
         </div>
       )}
     </div>
+  );
+}
+
+function FacetOption({
+  selected,
+  count,
+  onSelect,
+  children,
+}: {
+  selected: boolean;
+  count?: number;
+  onSelect: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className={'facet-opt' + (selected ? ' sel' : '')}
+      onClick={onSelect}
+    >
+      <svg
+        className="facet-ck"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        aria-hidden="true"
+      >
+        <path d="m4 12 6 6L20 6" />
+      </svg>
+      <span className="facet-opt-label">{children}</span>
+      {count != null && <span className="facet-cnt">{count}</span>}
+    </button>
+  );
+}
+
+function FacetSwitch({
+  on,
+  onToggle,
+  children,
+}: {
+  on: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className={'facet-switch' + (on ? ' on' : '')}
+      onClick={onToggle}
+      role="switch"
+      aria-checked={on}
+    >
+      <span className="tr" aria-hidden="true" />
+      {children}
+    </button>
   );
 }
 
@@ -349,6 +405,54 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [cards, includeArchived]);
 
+  // Per-option counts for the Network / Annual fee menus. Like banksList,
+  // these are counted against the archived-filtered pool only, so an option's
+  // number doesn't shift as other facets are toggled.
+  const facetCounts = useMemo(() => {
+    const pool = cards.filter((c) => includeArchived || c.accepting_applications);
+    const network: Record<NetworkFilter, number> = {
+      all: pool.length,
+      visa: 0,
+      mastercard: 0,
+      amex: 0,
+      discover: 0,
+    };
+    const fee: Record<FeeBucket, number> = {
+      all: pool.length,
+      free: 0,
+      low: 0,
+      mid: 0,
+      high: 0,
+    };
+    for (const c of pool) {
+      const n = c.network as NetworkFilter | undefined;
+      if (n && n !== 'all' && n in network) network[n]++;
+      for (const bucket of ['free', 'low', 'mid', 'high'] as FeeBucket[]) {
+        if (feeMatchesBucket(c.annual_fee, bucket)) fee[bucket]++;
+      }
+    }
+    return { network, fee };
+  }, [cards, includeArchived]);
+
+  function toggleBank(bank: string) {
+    setSelectedBanks((prev) => {
+      const next = new Set(prev);
+      if (next.has(bank)) next.delete(bank);
+      else next.add(bank);
+      return next;
+    });
+  }
+
+  const issuerValue =
+    selectedBanks.size === 0
+      ? 'All'
+      : selectedBanks.size === 1
+      ? [...selectedBanks][0]
+      : `${selectedBanks.size} selected`;
+
+  const moreCount =
+    (businessOnly ? 1 : 0) + (noForeignFeeOnly ? 1 : 0) + (includeArchived ? 1 : 0);
+
   const filtered = useMemo(() => {
     const q = query.trim();
     const pool = cards.filter((c) => {
@@ -501,104 +605,142 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
               </button>
             </div>
           </div>
-          <div className="filter-chip-row">
-            <span className="filter-group-label">Type</span>
-            {REWARD_TYPES.map(([k, l, emoji]) => (
-              <button
-                key={k}
-                type="button"
-                className={'filter-chip ' + (rewardType === k ? 'active' : '')}
-                onClick={() => setRewardType(k)}
-              >
-                {emoji && <span aria-hidden="true">{emoji}</span>}
-                {l}
-              </button>
-            ))}
-          </div>
-          <div className="filter-chip-row">
-            <span className="filter-group-label">Network</span>
-            {NETWORKS.map(([k, l]) => (
-              <button
-                key={k}
-                type="button"
-                className={'filter-chip ' + (network === k ? 'active' : '')}
-                onClick={() => setNetwork(k)}
-              >
-                {l}
-              </button>
-            ))}
-          </div>
-          <div className="filter-chip-row">
-            <span className="filter-group-label">Fee</span>
-            {FEE_BUCKETS.map(([k, l]) => (
-              <button
-                key={k}
-                type="button"
-                className={'filter-chip ' + (feeBucket === k ? 'active' : '')}
-                onClick={() => setFeeBucket(k)}
-              >
-                {l}
-              </button>
-            ))}
-            <IssuerDropdown
-              banks={banksList}
-              selected={selectedBanks}
-              onChange={setSelectedBanks}
-            />
-          </div>
-          <div className="filter-bottom-row">
-            <div className="filter-chip-row">
-              <span className="filter-group-label">Sort</span>
-              {(
-                [
-                  ['trending', 'Trending'],
-                  ['records', 'Records'],
-                ] as [SortKey, string][]
-              ).map(([k, l]) => (
+          <div className="explore-toolbar">
+            <span className="toolbar-label">Type</span>
+            <div className="seg-control" role="group" aria-label="Reward type">
+              {REWARD_TYPES.map(([k, l]) => (
                 <button
                   key={k}
                   type="button"
-                  className={'filter-chip ' + (sort === k ? 'active' : '')}
-                  onClick={() => setSort(k)}
+                  className={'seg-btn' + (rewardType === k ? ' on' : '')}
+                  onClick={() => setRewardType(k)}
+                  aria-pressed={rewardType === k}
                 >
                   {l}
                 </button>
               ))}
             </div>
-            <div className="filter-chip-row">
-              <span className="filter-group-label">Show</span>
-              <button
-                type="button"
-                className={'filter-chip ' + (businessOnly ? 'active' : '')}
-                onClick={() => setBusinessOnly((v) => !v)}
-              >
-                Business only
+            <span className="toolbar-vr" aria-hidden="true" />
+            <Facet
+              label="Network"
+              value={NETWORKS.find(([k]) => k === network)?.[1] ?? 'Any'}
+              set={network !== 'all'}
+            >
+              {(close) =>
+                NETWORKS.map(([k, l]) => (
+                  <FacetOption
+                    key={k}
+                    selected={network === k}
+                    count={facetCounts.network[k]}
+                    onSelect={() => {
+                      setNetwork(k);
+                      close();
+                    }}
+                  >
+                    {k === 'all' ? 'Any network' : l}
+                  </FacetOption>
+                ))
+              }
+            </Facet>
+            <Facet
+              label="Annual fee"
+              value={FEE_BUCKETS.find(([k]) => k === feeBucket)?.[1] ?? 'Any'}
+              set={feeBucket !== 'all'}
+            >
+              {(close) =>
+                FEE_BUCKETS.map(([k, l]) => (
+                  <FacetOption
+                    key={k}
+                    selected={feeBucket === k}
+                    count={facetCounts.fee[k]}
+                    onSelect={() => {
+                      setFeeBucket(k);
+                      close();
+                    }}
+                  >
+                    {k === 'all' ? 'Any fee' : k === 'free' ? 'No annual fee' : l}
+                  </FacetOption>
+                ))
+              }
+            </Facet>
+            <Facet label="Issuer" value={issuerValue} set={selectedBanks.size > 0}>
+              {() => (
+                <>
+                  {selectedBanks.size > 0 && (
+                    <button
+                      type="button"
+                      className="facet-clear"
+                      onClick={() => setSelectedBanks(new Set())}
+                    >
+                      Clear all
+                    </button>
+                  )}
+                  <div className="facet-scroll">
+                    {banksList.map((b) => (
+                      <label key={b.name} className="facet-check">
+                        <input
+                          type="checkbox"
+                          checked={selectedBanks.has(b.name)}
+                          onChange={() => toggleBank(b.name)}
+                        />
+                        <span className="facet-opt-label">{b.name}</span>
+                        <span className="facet-cnt">{b.count}</span>
+                      </label>
+                    ))}
+                  </div>
+                </>
+              )}
+            </Facet>
+            <Facet label="More" value={String(moreCount)} set={moreCount > 0}>
+              {() => (
+                <>
+                  <div className="facet-ph">Show</div>
+                  <FacetSwitch on={businessOnly} onToggle={() => setBusinessOnly((v) => !v)}>
+                    Business cards only
+                  </FacetSwitch>
+                  <FacetSwitch
+                    on={noForeignFeeOnly}
+                    onToggle={() => setNoForeignFeeOnly((v) => !v)}
+                  >
+                    No foreign transaction fee
+                  </FacetSwitch>
+                  <FacetSwitch
+                    on={includeArchived}
+                    onToggle={() => setIncludeArchived((v) => !v)}
+                  >
+                    Include archived cards
+                  </FacetSwitch>
+                </>
+              )}
+            </Facet>
+            <span className="toolbar-spacer" />
+            {hasActiveFilters && (
+              <button type="button" className="toolbar-clear" onClick={clearFilters}>
+                Clear
               </button>
-              <button
-                type="button"
-                className={'filter-chip ' + (noForeignFeeOnly ? 'active' : '')}
-                onClick={() => setNoForeignFeeOnly((v) => !v)}
-              >
-                No foreign fee
-              </button>
-              <button
-                type="button"
-                className={'filter-chip ' + (includeArchived ? 'active' : '')}
-                onClick={() => setIncludeArchived((v) => !v)}
-              >
-                Archived
-              </button>
-            </div>
+            )}
+            <span className="toolbar-count">
+              <b>{filtered.length.toLocaleString()}</b> card{filtered.length === 1 ? '' : 's'}
+            </span>
+            <Facet label="Sort" value={sortLabel(sort, sortDir)} alignRight>
+              {(close) =>
+                SORT_CHOICES.map((s) => (
+                  <FacetOption
+                    key={s.label}
+                    selected={sort === s.key && sortDir === s.dir}
+                    onSelect={() => {
+                      setSort(s.key);
+                      setSortDir(s.dir);
+                      close();
+                    }}
+                  >
+                    {s.label}
+                  </FacetOption>
+                ))
+              }
+            </Facet>
           </div>
         </div>
-
-        {hasActiveFilters && (
-          <div className="filter-results-bar">
-            <button type="button" className="filter-clear-btn" onClick={clearFilters}>
-              Clear filters
-            </button>
-          </div>
-        )}
 
         {filtered.length === 0 ? (
           <div

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1448,6 +1448,300 @@
   }
 }
 
+/* ---------- Explore compact toolbar (single row: seg control + facet menus) ---------- */
+.landing-v2 .explore-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  width: 100%;
+  padding-top: 2px;
+}
+.landing-v2 .toolbar-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+  margin-right: 2px;
+}
+.landing-v2 .toolbar-vr {
+  width: 1px;
+  height: 22px;
+  background: var(--line-2);
+}
+.landing-v2 .toolbar-spacer {
+  flex: 1 1 auto;
+}
+.landing-v2 .toolbar-count {
+  font-size: 11.5px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.landing-v2 .toolbar-count b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.landing-v2 .toolbar-clear {
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--line-2);
+}
+.landing-v2 .toolbar-clear:hover {
+  color: var(--ink);
+}
+.landing-v2 .seg-control {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+}
+.landing-v2 .seg-btn {
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--muted);
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.landing-v2 .seg-btn:hover:not(.on) {
+  color: var(--ink);
+}
+.landing-v2 .seg-btn.on {
+  background: var(--ink);
+  color: var(--paper);
+}
+.landing-v2 .facet {
+  position: relative;
+  display: inline-block;
+}
+.landing-v2 .facet-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 34px;
+  padding: 0 10px 0 11px;
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  background: var(--paper);
+  cursor: pointer;
+  font-family: inherit;
+}
+.landing-v2 .facet-btn:hover {
+  border-color: var(--muted-2);
+}
+.landing-v2 .facet-btn > svg {
+  color: var(--muted-2);
+  flex: none;
+}
+.landing-v2 .facet-k {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.landing-v2 .facet-v {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink);
+  max-width: 140px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.landing-v2 .facet-btn.set {
+  border-color: var(--ink);
+  box-shadow: inset 0 0 0 1px var(--ink);
+}
+.landing-v2 .facet-btn.set .facet-v {
+  color: var(--accent);
+}
+.landing-v2 .facet-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 30;
+  min-width: 190px;
+  max-width: min(280px, calc(100vw - 32px));
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 11px;
+  box-shadow: 0 20px 44px -18px rgba(26, 19, 48, 0.3);
+  padding: 6px;
+}
+.landing-v2 .facet-pop.right {
+  left: auto;
+  right: 0;
+}
+.landing-v2 .facet-ph {
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+  padding: 6px 8px 4px;
+}
+.landing-v2 .facet-opt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--ink-2);
+  padding: 7px 8px;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.landing-v2 .facet-opt:hover {
+  background: var(--paper-2);
+  color: var(--ink);
+}
+.landing-v2 .facet-ck {
+  flex: none;
+  color: var(--accent);
+  opacity: 0;
+}
+.landing-v2 .facet-opt.sel {
+  color: var(--ink);
+  font-weight: 500;
+}
+.landing-v2 .facet-opt.sel .facet-ck {
+  opacity: 1;
+}
+.landing-v2 .facet-opt-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.landing-v2 .facet-cnt {
+  margin-left: auto;
+  font-size: 10.5px;
+  color: var(--muted-2);
+}
+.landing-v2 .facet-scroll {
+  max-height: 280px;
+  overflow-y: auto;
+}
+.landing-v2 .facet-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px;
+  border-radius: 7px;
+  font-size: 13px;
+  color: var(--ink);
+  cursor: pointer;
+}
+.landing-v2 .facet-check:hover {
+  background: var(--paper-2);
+}
+.landing-v2 .facet-check input[type='checkbox'] {
+  cursor: pointer;
+  margin: 0;
+  accent-color: var(--accent);
+}
+.landing-v2 .facet-clear {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-size: 11.5px;
+  font-family: inherit;
+  font-weight: 500;
+  color: var(--accent);
+  cursor: pointer;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 4px;
+}
+.landing-v2 .facet-clear:hover {
+  background: var(--paper-2);
+}
+.landing-v2 .facet-switch {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--ink-2);
+  padding: 7px 8px;
+  border-radius: 7px;
+}
+.landing-v2 .facet-switch:hover {
+  background: var(--paper-2);
+}
+.landing-v2 .facet-switch .tr {
+  width: 30px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--line-2);
+  position: relative;
+  flex: none;
+  transition: background 0.15s;
+}
+.landing-v2 .facet-switch .tr::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--paper);
+  box-shadow: 0 1px 2px rgba(26, 19, 48, 0.3);
+  transition: transform 0.15s;
+}
+.landing-v2 .facet-switch.on {
+  color: var(--ink);
+}
+.landing-v2 .facet-switch.on .tr {
+  background: var(--accent);
+}
+.landing-v2 .facet-switch.on .tr::after {
+  transform: translateX(12px);
+}
+@media (max-width: 640px) {
+  .landing-v2 .explore-toolbar {
+    gap: 6px;
+  }
+  .landing-v2 .explore-toolbar .toolbar-vr {
+    display: none;
+  }
+  .landing-v2 .seg-btn {
+    padding: 6px 10px;
+    font-size: 12px;
+  }
+  .landing-v2 .facet-v {
+    max-width: 90px;
+  }
+}
+
 /* ---------- Filter bar + chips ---------- */
 .landing-v2 .filter-bar {
   display: flex;


### PR DESCRIPTION
Implements option **A — Compact toolbar** from the "Explore Filter Alternatives" design (claude.ai/design). Only the filter/tool bar changes; search, view toggle, table, and grid are untouched.

## What changed

The old filter block was five chip groups stacked across three rows (~184px). It's now one row:

- **Type** stays visible as a segmented control (All / Cashback / Points / Miles)
- **Network** and **Annual fee** become labelled dropdown facets showing their current value, with per-option card counts (counted against the archived-filtered pool, same convention as the issuer list)
- **Issuer** keeps its multi-select checkbox list, restyled as a facet; value shows the bank name (1 selected) or a count
- **More** holds the Business only / No foreign fee / Archived toggles as switches, with an active-count badge
- A live **result count** and a **Sort** facet (Trending / Best odds / Most records / Lowest fee) sit on the right; Sort shares state with the table-header sorts, so header clicks are reflected in the facet label (including Fee/Bonus/Approval combinations outside the four presets)
- **Clear** appears inline in the toolbar when any filter is active (replaces the separate results bar)

Menus float over the table; they never push it down. On mobile the row wraps and popovers clamp to the viewport. No new fonts; everything uses the existing v2 vars in landing.css. Filtering/sorting logic is unchanged.

## Verification

Exercised in the browser (desktop + 375px mobile): every facet, the switches, multi-select issuer, sort/header sync, and Clear. Result counts update correctly; console is clean. `tsc --noEmit` and `eslint --max-warnings=0` pass.