### PR TITLE
explore: tighten the gap between the filter toolbar and the results

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -1434,10 +1434,18 @@
 }
 .landing-v2.explore-v2 .filter-bar {
   border-bottom: 0;
-  padding-block: 0 16px;
+  padding-block: 0 6px;
 }
 .landing-v2.explore-v2 .card-table {
   border-radius: 0;
+}
+/* The toolbar's floating menus mean nothing pushes the table down, so the
+   old chip-era breathing room above it just reads as dead space. */
+.landing-v2.explore-v2 .card-table-wrap {
+  padding-top: 8px;
+}
+.landing-v2.explore-v2 .card-grid {
+  padding-top: 12px;
 }
 @media (max-width: 640px) {
   .landing-v2.explore-v2 .explore-hero {


### PR DESCRIPTION
Follow-up to #1817. The toolbar's menus float, so the old chip-era breathing room above the table read as dead space. Scoped to explore only: filter-bar bottom padding 16px -> 6px, table top padding 24px -> 8px, grid top padding 32px -> 12px (~40px gap -> ~14px). Verified both views in the browser.