### PR TITLE
Rebuild stores.json: pick up co-brand links from #1818 (H-E-B, Sam's Club, Target)

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-25T17:37:22.559Z",
+  "generated_at": "2026-07-28T18:15:39.962Z",
   "count": 956,
   "stores": [
     {
@@ -5376,6 +5376,9 @@
         "groceries"
       ],
       "website": "https://www.heb.com",
+      "co_brand_cards": [
+        "heb-visa-signature"
+      ],
       "intro": "H-E-B is the dominant Texas supermarket chain, with about 425 stores under H-E-B,\nCentral Market, and Joe V's banners. The chain is privately held and well-regarded for\nstore-brand products and Texas-only specialty items. H-E-B codes as groceries on every\ncard we track and supports curbside pickup and delivery on most product lines.\n"
     },
     {
@@ -10287,6 +10290,9 @@
       ],
       "website": "https://www.samsclub.com",
       "parent_company": "Walmart, Inc.",
+      "co_brand_cards": [
+        "sams-club-mastercard"
+      ],
       "intro": "Sam's Club is Walmart's warehouse-club arm, with about 600 U.S. clubs and a steadily\ngrowing online and Scan & Go catalog. Member tiers (Club vs. Plus) affect free-shipping\nand curbside perks but not the rewards math at the register. Sam's accepts Visa,\nMastercard, Amex, and Discover, and Sam's Club gas pumps code as wholesale clubs rather\nthan gas stations — the same rule as Costco.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38733.1007189514&trid=1552713.157929&foc=16&fot=9999&fos=6",
@@ -11490,9 +11496,13 @@
         "Target Corp"
       ],
       "categories": [
-        "online_shopping"
+        "online_shopping",
+        "target"
       ],
       "website": "https://www.target.com",
+      "co_brand_cards": [
+        "target-circle-card"
+      ],
       "also_earns": [
         {
           "card": "us-bank-shopper",

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-25T17:37:22.559Z",
+  "generated_at": "2026-07-28T18:15:39.962Z",
   "count": 956,
   "stores": [
     {
@@ -5376,6 +5376,9 @@
         "groceries"
       ],
       "website": "https://www.heb.com",
+      "co_brand_cards": [
+        "heb-visa-signature"
+      ],
       "intro": "H-E-B is the dominant Texas supermarket chain, with about 425 stores under H-E-B,\nCentral Market, and Joe V's banners. The chain is privately held and well-regarded for\nstore-brand products and Texas-only specialty items. H-E-B codes as groceries on every\ncard we track and supports curbside pickup and delivery on most product lines.\n"
     },
     {
@@ -10287,6 +10290,9 @@
       ],
       "website": "https://www.samsclub.com",
       "parent_company": "Walmart, Inc.",
+      "co_brand_cards": [
+        "sams-club-mastercard"
+      ],
       "intro": "Sam's Club is Walmart's warehouse-club arm, with about 600 U.S. clubs and a steadily\ngrowing online and Scan & Go catalog. Member tiers (Club vs. Plus) affect free-shipping\nand curbside perks but not the rewards math at the register. Sam's accepts Visa,\nMastercard, Amex, and Discover, and Sam's Club gas pumps code as wholesale clubs rather\nthan gas stations — the same rule as Costco.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38733.1007189514&trid=1552713.157929&foc=16&fot=9999&fos=6",
@@ -11490,9 +11496,13 @@
         "Target Corp"
       ],
       "categories": [
-        "online_shopping"
+        "online_shopping",
+        "target"
       ],
       "website": "https://www.target.com",
+      "co_brand_cards": [
+        "target-circle-card"
+      ],
       "also_earns": [
         {
           "card": "us-bank-shopper",


### PR DESCRIPTION
## Why

#1818 added the H-E-B Visa Signature, Sam's Club Mastercard, and Target Circle Card and linked them as `co_brand_cards` in their `data/stores/*.yaml` files, but never regenerated the built `data/stores.json` (and its Lambda ranker mirror). The site bundles `stores.json` statically, so the /best-card-for pages for H-E-B, Sam's Club, and Target ranked these cards as plain category matches: no "Co-branded ... card" treatment, no exact-rate tie-break, and the stores don't sort into the co-brand group on the /best-card-for index.

On /best-card-for/heb specifically, the H-E-B Visa Signature currently shows at #3 as a generic 5% groceries match (tied with AAA Daily Advantage at 5% but losing the tie). With the co-brand link it wins the 5% tie and moves to #2 with the co-brand label, behind Blue Cash Preferred's 6% (correct under the pure effective-rate ranking from #1766).

## What

Ran `npm run build:cards && npm run build:stores`. Diff is exactly the three stores touched by #1818:

- `heb`: + `co_brand_cards: [heb-visa-signature]`
- `sams-club`: + `co_brand_cards: [sams-club-mastercard]`
- `target`: + `co_brand_cards: [target-circle-card]`, + `target` category
- `generated_at` timestamp bump

Validation passed: 199 cards, 956 stores, all `merchant_gate` / `co_brand_cards` / `also_earns` references resolve. `data/stores.json` is not in `deploy-frontend.yml`'s `paths-ignore`, so merging triggers the Amplify rebuild that ships it.