### PR TITLE
CONTRIBUTING: fix stale credit_score_source legend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ User-submitted credit card application results.
 | `card_id` | INT (FK) | References `cards.card_id` |
 | `submitter_id` | VARCHAR | Firebase UID |
 | `credit_score` | INT | 300–850 |
-| `credit_score_source` | INT | 0=Equifax, 1=Experian, 2=TransUnion, 3=other, 4=unknown |
+| `credit_score_source` | INT | 0=FICO (bureau unspecified), 1=FICO: Experian, 2=FICO: TransUnion, 3=FICO: Equifax, 4=VantageScore |
 | `result` | BOOLEAN | 1=approved, 0=denied |
 | `listed_income` | INT (nullable) | Annual income |
 | `length_credit` | INT | Years of credit history |


### PR DESCRIPTION
## Summary

The `records` table doc in CONTRIBUTING.md described `credit_score_source` as `0=Equifax, 1=Experian, 2=TransUnion, 3=other, 4=unknown`. That legend is stale and never matched the shipped UI.

The operative semantics, per the user-facing submit form (`apps/web-next/src/components/forms/SubmitRecordModal.tsx`, the `credit_score_source` select) and the admin UI (`CREDIT_SCORE_SOURCES` in `apps/web-next/src/app/admin/page.tsx`), are:

| Value | Meaning |
|-------|---------|
| 0 | FICO (bureau unspecified) |
| 1 | FICO: Experian |
| 2 | FICO: TransUnion |
| 3 | FICO: Equifax |
| 4 | VantageScore |

## Notes

- Swept the whole repo for other copies of the stale legend (`Equifax`/`Experian` outside the two UI files): the only non-editorial hit was this CONTRIBUTING.md row. Backend/shared validation only enforces the `0..4` range with no named values, so no code changes needed.
- The `POST /records` JSON example (`"credit_score_source": 0`) stays valid under the corrected legend.