### PR TITLE
Reddit Data Points 2026-07-28

### DIFF
--- a/data/reddit-datapoints/2026-07-28-t3_1v8687r.yaml
+++ b/data/reddit-datapoints/2026-07-28-t3_1v8687r.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1v8687r"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1v8687r/credit_card_recommendation_venture_x_prime_amex/"
+posted: "2026-07-27"
+evidence: "Poster asking for a next-card recommendation reports having recently been approved for the Prime card, with a FICO of 800, a 20 year oldest account, and an existing Chase relationship."
+card_name: "Amazon Prime Rewards Visa Signature"
+result: "approved"
+credit_score: 800
+credit_score_source: 0
+length_credit: 20
+bank_customer: true
+date_applied: "2026-07"

--- a/data/reddit-datapoints/2026-07-28-t3_1v8687r.yaml
+++ b/data/reddit-datapoints/2026-07-28-t3_1v8687r.yaml
@@ -1,11 +1,12 @@
 source_id: "t3_1v8687r"
 permalink: "https://www.reddit.com/r/CreditCards/comments/1v8687r/credit_card_recommendation_venture_x_prime_amex/"
 posted: "2026-07-27"
-evidence: "Poster asking for a next-card recommendation reports having recently been approved for the Prime card, with a FICO of 800, a 20 year oldest account, and an existing Chase relationship."
+evidence: "Poster asking for a next-card recommendation reports having recently been approved for the Prime card, with a FICO of 800, a 20 year oldest account, and an existing Chase relationship. Income is recorded as the floor of the open-ended figure they gave."
 card_name: "Amazon Prime Rewards Visa Signature"
 result: "approved"
 credit_score: 800
 credit_score_source: 0
+listed_income: 250000
 length_credit: 20
 bank_customer: true
 date_applied: "2026-07"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-28

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1v8687r](https://www.reddit.com/r/CreditCards/comments/1v8687r/credit_card_recommendation_venture_x_prime_amex/) | Amazon Prime Rewards Visa Signature | approved | 800 | $250,000 | — | 20 | 2026-07 | `2026-07-28-t3_1v8687r.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.

