### PR TITLE
api: retry + timeout on CDN cards.json fetch to stop stale-socket 500s

### DIFF
--- a/apps/api/src/handlers/all-cards.js
+++ b/apps/api/src/handlers/all-cards.js
@@ -1,30 +1,10 @@
 // Fetch cards from CloudFront CDN
-const https = require('https');
 const mysql = require("../db");
-
-const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
+const { fetchCardsFromCDN } = require("../lib/cards-cdn");
 
 const responseHeaders = {
   "Access-Control-Allow-Origin": "*",
 };
-
-// Fetch cards.json from CloudFront
-async function fetchCardsFromCDN() {
-  return new Promise((resolve, reject) => {
-    https.get(CARDS_URL, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json.cards);
-        } catch (err) {
-          reject(new Error('Failed to parse cards.json'));
-        }
-      });
-    }).on('error', reject);
-  });
-}
 
 // Fetch card stats and metadata from MySQL
 async function fetchCardStatsAndMetadata() {

--- a/apps/api/src/handlers/card-by-id.js
+++ b/apps/api/src/handlers/card-by-id.js
@@ -1,30 +1,10 @@
 // Fetch card details from CloudFront CDN and MySQL
-const https = require('https');
 const mysql = require("../db");
-
-const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
+const { fetchCardsFromCDN } = require("../lib/cards-cdn");
 
 const responseHeaders = {
   "Access-Control-Allow-Origin": "*",
 };
-
-// Fetch cards.json from CloudFront
-async function fetchCardsFromCDN() {
-  return new Promise((resolve, reject) => {
-    https.get(CARDS_URL, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json.cards);
-        } catch (err) {
-          reject(new Error('Failed to parse cards.json'));
-        }
-      });
-    }).on('error', reject);
-  });
-}
 
 // Look up card in database by name and get stats
 async function fetchCardFromDB(cardName) {

--- a/apps/api/src/handlers/card-records.js
+++ b/apps/api/src/handlers/card-records.js
@@ -4,31 +4,12 @@
 // Used by the card-page "Raw data" view to back the table that's an
 // alternative to the scatter-plot charts.
 
-const https = require('https');
 const mysql = require('../db');
-
-const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
+const { fetchCardsFromCDN } = require('../lib/cards-cdn');
 
 const responseHeaders = {
   'Access-Control-Allow-Origin': '*',
 };
-
-function fetchCardsFromCDN() {
-  return new Promise((resolve, reject) => {
-    https.get(CARDS_URL, (res) => {
-      let data = '';
-      res.on('data', (chunk) => (data += chunk));
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json.cards || []);
-        } catch (err) {
-          reject(new Error('Failed to parse cards.json'));
-        }
-      });
-    }).on('error', reject);
-  });
-}
 
 
 // Cacheable headers for public GET reads: lets CloudFront/browser cache
@@ -58,7 +39,7 @@ exports.CardRecordsHandler = async (event) => {
   }
 
   try {
-    const cards = await fetchCardsFromCDN();
+    const cards = (await fetchCardsFromCDN()) || [];
     const cdnCard = cards.find(
       (c) => c.card_name === cardNameParam || c.name === cardNameParam || c.slug === cardNameParam,
     );

--- a/apps/api/src/handlers/check-odds.js
+++ b/apps/api/src/handlers/check-odds.js
@@ -1,7 +1,5 @@
-const https = require('https');
 const mysql = require("../db");
-
-const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
+const { fetchCardsFromCDN } = require("../lib/cards-cdn");
 
 const responseHeaders = {
   // Authenticated, user-specific responses: never cache at browser or any
@@ -14,24 +12,6 @@ const responseHeaders = {
   "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
   "X-Requested-With": "*",
 };
-
-// Fetch cards.json from CloudFront
-async function fetchCardsFromCDN() {
-  return new Promise((resolve, reject) => {
-    https.get(CARDS_URL, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json.cards);
-        } catch (err) {
-          reject(new Error('Failed to parse cards.json'));
-        }
-      });
-    }).on('error', reject);
-  });
-}
 
 // Read precomputed per-card stats from card_stats (totals + medians) plus card
 // metadata. card_stats is refreshed every 5 min by RefreshCardStatsFunction and

--- a/apps/api/src/handlers/get-card-graphs.js
+++ b/apps/api/src/handlers/get-card-graphs.js
@@ -1,30 +1,10 @@
 // Create MySQL client and set shared const values outside of the handler.
-const https = require('https');
 const mysql = require("../db");
-
-const CARDS_URL = process.env.CARDS_JSON_URL || 'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
+const { fetchCardsFromCDN } = require("../lib/cards-cdn");
 
 const responseHeaders = {
   "Access-Control-Allow-Origin": "*",
 };
-
-// Fetch cards.json from CloudFront
-async function fetchCardsFromCDN() {
-  return new Promise((resolve, reject) => {
-    https.get(CARDS_URL, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json.cards);
-        } catch (err) {
-          reject(new Error('Failed to parse cards.json'));
-        }
-      });
-    }).on('error', reject);
-  });
-}
 
 
 // Cacheable headers for public GET reads: lets CloudFront/browser cache

--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -1,29 +1,5 @@
-const https = require("https");
 const mysql = require("../db");
-
-const CARDS_URL = process.env.CardsJsonUrl || "https://d2hxvzw7msbtvt.cloudfront.net/cards.json";
-
-// Fetch cards.json from CloudFront CDN
-async function fetchCardsFromCDN() {
-  return new Promise((resolve, reject) => {
-    // Add cache-busting query param to get fresh data after deploy
-    const url = `${CARDS_URL}?t=${Date.now()}`;
-    https
-      .get(url, (res) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => {
-          try {
-            const json = JSON.parse(data);
-            resolve(json.cards || []);
-          } catch (err) {
-            reject(new Error("Failed to parse cards.json"));
-          }
-        });
-      })
-      .on("error", reject);
-  });
-}
+const { fetchCardsFromCDN } = require("../lib/cards-cdn");
 
 // Extract metric values from a CDN card for change detection
 function extractMetrics(cdnCard) {
@@ -286,8 +262,8 @@ exports.updateCardsGitHubHandler = async (event) => {
   console.log(`Syncing cards: ${triggerReason}`);
 
   try {
-    // Fetch cards from CDN
-    const cdnCards = await fetchCardsFromCDN();
+    // Fetch cards from CDN (cache-busted so a post-deploy sync sees fresh data)
+    const cdnCards = (await fetchCardsFromCDN({ cacheBust: true })) || [];
     console.log(`Fetched ${cdnCards.length} cards from CDN`);
 
     // Sync to database

--- a/apps/api/src/lib/cards-cdn.js
+++ b/apps/api/src/lib/cards-cdn.js
@@ -1,0 +1,65 @@
+// Shared cards.json fetcher for every handler that reads the CDN copy.
+//
+// Warm Lambda containers freeze between invocations while the global http
+// agent (keep-alive by default on Node 22) holds a pooled socket to
+// CloudFront. After a few idle minutes CloudFront closes that socket
+// server-side, and the next invocation fails instantly with ECONNRESET
+// ("socket hang up"). A GET retry on a fresh connection is safe, so transient
+// socket errors get one retry, and each attempt carries an idle timeout
+// (https.get has none by default).
+const https = require('https');
+
+// Handlers historically read CARDS_JSON_URL but template.yml sets CardsJsonUrl;
+// accept both so the template override actually applies.
+const CARDS_URL =
+  process.env.CARDS_JSON_URL ||
+  process.env.CardsJsonUrl ||
+  'https://d2hxvzw7msbtvt.cloudfront.net/cards.json';
+
+const REQUEST_TIMEOUT_MS = 5000;
+const TRANSIENT_CODES = new Set(['ECONNRESET', 'ETIMEDOUT', 'EPIPE']);
+
+function requestCardsOnce(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          resolve(json.cards);
+        } catch (err) {
+          reject(new Error('Failed to parse cards.json'));
+        }
+      });
+    });
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      const err = new Error(`cards.json request timed out after ${REQUEST_TIMEOUT_MS}ms`);
+      err.code = 'ETIMEDOUT';
+      req.destroy(err);
+    });
+    req.on('error', reject);
+  });
+}
+
+function isTransientNetworkError(err) {
+  return TRANSIENT_CODES.has(err.code) || /socket hang up/i.test(err.message || '');
+}
+
+// Returns json.cards (undefined when the key is missing — callers that want an
+// empty-array fallback apply `|| []` themselves). Pass cacheBust: true to
+// append a timestamp query param so a post-deploy sync bypasses the CDN cache.
+async function fetchCardsFromCDN({ cacheBust = false } = {}) {
+  const url = cacheBust ? `${CARDS_URL}?t=${Date.now()}` : CARDS_URL;
+  try {
+    return await requestCardsOnce(url);
+  } catch (err) {
+    if (!isTransientNetworkError(err)) throw err;
+    console.warn(
+      `cards.json fetch failed (${err.code || err.message}); retrying on a fresh connection`
+    );
+    return requestCardsOnce(url);
+  }
+}
+
+module.exports = { fetchCardsFromCDN };

--- a/apps/api/tests/cards-cdn.test.js
+++ b/apps/api/tests/cards-cdn.test.js
@@ -1,0 +1,137 @@
+// Unit tests for the shared CDN fetcher (src/lib/cards-cdn.js). Written when
+// the copy-pasted per-handler fetchers were consolidated: warm Lambda
+// containers hold a keep-alive socket that CloudFront closes after a few idle
+// minutes, so the next invocation died instantly with ECONNRESET ("socket
+// hang up") and the handler 500'd. The fetcher must retry transient socket
+// errors exactly once on a fresh connection, time out stalled requests, and
+// NOT retry non-transient failures (bad DNS, malformed JSON).
+
+const { EventEmitter } = require("events");
+
+jest.mock("https", () => ({ get: jest.fn() }));
+const https = require("https");
+const { fetchCardsFromCDN } = require("../src/lib/cards-cdn");
+
+const CARDS = [{ card_name: "Test Card" }];
+const BODY = JSON.stringify({ cards: CARDS });
+
+function mockRequest() {
+  const req = new EventEmitter();
+  req.setTimeout = jest.fn();
+  // Real ClientRequest.destroy(err) emits 'error' with err; replicate that.
+  req.destroy = jest.fn((err) => {
+    if (err) req.emit("error", err);
+  });
+  return req;
+}
+
+function respondWith(body) {
+  return (url, cb) => {
+    const req = mockRequest();
+    process.nextTick(() => {
+      const res = new EventEmitter();
+      cb(res);
+      res.emit("data", body);
+      res.emit("end");
+    });
+    return req;
+  };
+}
+
+function failWith(err) {
+  return () => {
+    const req = mockRequest();
+    process.nextTick(() => req.emit("error", err));
+    return req;
+  };
+}
+
+function codedError(code, message) {
+  const err = new Error(message || code);
+  if (code) err.code = code;
+  return err;
+}
+
+beforeEach(() => {
+  https.get.mockReset();
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  console.warn.mockRestore();
+});
+
+test("resolves cards on first-try success without retrying", async () => {
+  https.get.mockImplementation(respondWith(BODY));
+
+  await expect(fetchCardsFromCDN()).resolves.toEqual(CARDS);
+  expect(https.get).toHaveBeenCalledTimes(1);
+});
+
+test("retries once after ECONNRESET and succeeds", async () => {
+  https.get
+    .mockImplementationOnce(failWith(codedError("ECONNRESET", "socket hang up")))
+    .mockImplementationOnce(respondWith(BODY));
+
+  await expect(fetchCardsFromCDN()).resolves.toEqual(CARDS);
+  expect(https.get).toHaveBeenCalledTimes(2);
+});
+
+test("retries on a bare 'socket hang up' error with no code", async () => {
+  https.get
+    .mockImplementationOnce(failWith(new Error("socket hang up")))
+    .mockImplementationOnce(respondWith(BODY));
+
+  await expect(fetchCardsFromCDN()).resolves.toEqual(CARDS);
+  expect(https.get).toHaveBeenCalledTimes(2);
+});
+
+test("retries only once: transient failure on both attempts rejects", async () => {
+  https.get.mockImplementation(failWith(codedError("ECONNRESET", "socket hang up")));
+
+  await expect(fetchCardsFromCDN()).rejects.toThrow("socket hang up");
+  expect(https.get).toHaveBeenCalledTimes(2);
+});
+
+test("does not retry non-transient network errors", async () => {
+  https.get.mockImplementation(failWith(codedError("ENOTFOUND", "getaddrinfo ENOTFOUND")));
+
+  await expect(fetchCardsFromCDN()).rejects.toThrow("getaddrinfo ENOTFOUND");
+  expect(https.get).toHaveBeenCalledTimes(1);
+});
+
+test("does not retry a JSON parse failure", async () => {
+  https.get.mockImplementation(respondWith("<html>not json</html>"));
+
+  await expect(fetchCardsFromCDN()).rejects.toThrow("Failed to parse cards.json");
+  expect(https.get).toHaveBeenCalledTimes(1);
+});
+
+test("arms a request timeout and retries after it fires", async () => {
+  let firstReq;
+  https.get
+    .mockImplementationOnce(() => {
+      firstReq = mockRequest();
+      // Simulate the idle timeout firing instead of a response arriving.
+      process.nextTick(() => firstReq.setTimeout.mock.calls[0][1]());
+      return firstReq;
+    })
+    .mockImplementationOnce(respondWith(BODY));
+
+  await expect(fetchCardsFromCDN()).resolves.toEqual(CARDS);
+  expect(https.get).toHaveBeenCalledTimes(2);
+  expect(firstReq.setTimeout).toHaveBeenCalledWith(5000, expect.any(Function));
+  expect(firstReq.destroy).toHaveBeenCalledWith(
+    expect.objectContaining({ code: "ETIMEDOUT" })
+  );
+});
+
+test("cacheBust appends a timestamp query param", async () => {
+  https.get.mockImplementation(respondWith(BODY));
+
+  await fetchCardsFromCDN({ cacheBust: true });
+  expect(https.get.mock.calls[0][0]).toMatch(/cards\.json\?t=\d+$/);
+
+  await fetchCardsFromCDN();
+  expect(https.get.mock.calls[1][0]).toMatch(/cards\.json$/);
+});


### PR DESCRIPTION
## Problem

`AllCardsFunction` logs ~1-3 `Error: socket hang up` (ECONNRESET) 500s per day (e.g. 2026-07-28 at 00:28:47, 22:06:06, 23:12:28 UTC), each failing in ~40ms while neighboring requests succeed.

Root cause: warm Lambda containers (Node 22, whose global http agent has keep-alive on by default) freeze between invocations while holding a pooled socket to CloudFront. After a few idle minutes CloudFront closes that socket server-side; the next invocation reuses the dead socket and `https.get` fails instantly, rejecting the whole `Promise.all` in the handler.

The same raw `https.get` with no retry and no timeout was copy-pasted across **six** handlers: `all-cards`, `card-by-id`, `card-records`, `check-odds`, `get-card-graphs`, and `update-cards-github` (sync-cards).

## Fix

- New shared `apps/api/src/lib/cards-cdn.js`; all six handlers now use it (esbuild bundles the relative require - verified in the built artifact).
- **One retry on transient socket errors** (ECONNRESET / ETIMEDOUT / EPIPE / "socket hang up") - safe for a GET, and the dead socket is evicted from the pool on failure so the retry gets a fresh connection.
- **5s idle timeout** per attempt (`https.get` has none by default), surfaced as a retryable ETIMEDOUT. Worst case 10s, well under the 29s API Gateway limit.
- Non-transient errors and JSON parse failures fail fast with the same messages as before; per-handler `|| []` fallbacks and the sync-cards cache-busting query param are preserved via call sites / a `cacheBust` option.
- Latent env-var fix: template.yml sets `CardsJsonUrl` but five handlers read `CARDS_JSON_URL`, so the override never applied (harmless - same URL). The helper accepts both.

## Testing

- New `apps/api/tests/cards-cdn.test.js` (8 tests): first-try success, retry-then-success, bare "socket hang up" with no code, retry-only-once, no retry on ENOTFOUND, no retry on parse failure, timeout arming + retry, cacheBust URL shape. All pass; full jest suite 30/30.
- `sam build AllCardsFunction` succeeds and the bundle contains the retry path.

Deploys via `deploy-api.yml` on merge.