### PR TITLE
Reddit Data Points 2026-07-29

### DIFF
--- a/data/reddit-datapoints/2026-07-29-t3_1v9dzl1.yaml
+++ b/data/reddit-datapoints/2026-07-29-t3_1v9dzl1.yaml
@@ -1,0 +1,14 @@
+source_id: "t3_1v9dzl1"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1v9dzl1/denied_for_csp_but_want_new_credit_card_for_travel/"
+posted: "2026-07-28"
+evidence: "Medical student reports a CSP denial with a 772 Experian FICO, one existing Amex, 0/24, and $20,000 entered as income on the application."
+card_name: "Chase Sapphire Preferred"
+result: "denied"
+credit_score: 772
+credit_score_source: 1
+listed_income: 20000
+length_credit: 10
+total_open_cards: 1
+date_applied: "2026-07"
+reason_denied: "Obligations too high relative to income, high credit usage, and low available credit"
+reason_denied_code: "income_too_low"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-29

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1v9dzl1](https://www.reddit.com/r/CreditCards/comments/1v9dzl1/denied_for_csp_but_want_new_credit_card_for_travel/) | Chase Sapphire Preferred | denied | 772 | $20,000 | — | 10 | 2026-07 | `2026-07-29-t3_1v9dzl1.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
