### PR TITLE
Reddit data points: fetch OP replies in the fetch phase

### DIFF
--- a/scripts/check-reddit-datapoints.js
+++ b/scripts/check-reddit-datapoints.js
@@ -12,8 +12,13 @@
  * Phases:
  *   --phase=fetch   Pull candidate posts from r/CreditCards (new posts with
  *                   approval/denial signals, plus the current approval/data-
- *                   point megathread's comments when one exists). Drop
- *                   anything already recorded in .github/reddit-datapoint-state.json,
+ *                   point megathread's comments when one exists). For the most
+ *                   promising posts, also pull that post's comment feed and
+ *                   attach the OP's own replies — posters routinely leave the
+ *                   score or the outcome in a reply rather than the body, and
+ *                   the session cannot fetch Reddit itself (WebFetch is blocked
+ *                   for reddit.com), so it has to arrive here. Drop anything
+ *                   already recorded in .github/reddit-datapoint-state.json,
  *                   then write one self-contained extraction prompt to
  *                   .reddit-dp-work/extract-prompt.md.
  *
@@ -62,6 +67,12 @@ const CAPS = {
   threadComments: 60,
   bodyChars: 2500,
   totalCandidates: 60,
+  // OP-reply expansion. Each expanded post costs one extra Reddit request at 8s
+  // spacing, so the cap is what bounds the fetch phase's runtime (and our rate
+  // of unauthenticated requests) more than anything else.
+  expandPosts: 8,
+  opCommentsPerPost: 5,
+  opCommentChars: 600,
 };
 
 // Mirrors REASON_DENIED_CODES in apps/api/src/handlers/user-records.js.
@@ -163,9 +174,10 @@ function unescapeEntities(text) {
 }
 
 /**
- * Parse a Reddit Atom feed into {id, title, link, content, updated}.
+ * Parse a Reddit Atom feed into {id, title, link, content, updated, author}.
  * Unlike the news parser this keeps the entry <id> (the t3_/t1_ fullname —
- * our dedupe key) and <updated> (the DP's default application month).
+ * our dedupe key), <updated> (the DP's default application month), and the
+ * <author> name (how OP replies are told apart from everyone else's).
  */
 function parseAtom(xml) {
   const entries = [];
@@ -178,13 +190,16 @@ function parseAtom(xml) {
     const title = unescapeEntities(e.match(/<title>([\s\S]*?)<\/title>/)?.[1] || '').trim();
     const link = e.match(/<link[^>]*href="([^"]+)"/)?.[1] || '';
     const updated = e.match(/<updated>([\s\S]*?)<\/updated>/)?.[1]?.slice(0, 10) || '';
+    const author = unescapeEntities(e.match(/<author>[\s\S]*?<name>([\s\S]*?)<\/name>/)?.[1] || '')
+      .trim()
+      .replace(/^\/u\//, '');
     const rawContent = e.match(/<content[^>]*>([\s\S]*?)<\/content>/)?.[1] || '';
     // Content is XML-escaped HTML: unescape to HTML, strip tags, unescape again.
     const content = unescapeEntities(unescapeEntities(rawContent).replace(/<[^>]+>/g, ' '))
       .replace(/\s+/g, ' ')
       .trim();
     if (id && (title || content)) {
-      entries.push({ id, title, link: unescapeEntities(link), content, updated });
+      entries.push({ id, title, link: unescapeEntities(link), content, updated, author });
     }
   }
   return entries;
@@ -253,6 +268,77 @@ async function fetchMegathreadComments(seenIds) {
   };
 }
 
+// ── OP reply expansion ───────────────────────────────────────────────────────
+
+// A post body that already quotes a plausible FICO number is less likely to
+// need its comments read. Deliberately loose: this only orders the expansion
+// queue, it never excludes a post outright.
+function hasPlausibleScore(text) {
+  const matches = (text || '').match(/\b\d{3}\b/g) || [];
+  return matches.some((n) => Number(n) >= 300 && Number(n) <= 850);
+}
+
+const STRONG_OUTCOME_RE = /(approved|denied|rejected|instant.{0,12}(approval|decision)|got (the card|approved|denied))/i;
+
+// Posts most worth an extra request first: an outcome the OP describes but no
+// score in the body is exactly the case where the score sits in a reply.
+function rankForExpansion(candidates) {
+  return candidates
+    .filter((c) => c.kind === 'post' && /\/comments\//.test(c.url))
+    .map((c) => {
+      const body = `${c.title} ${c.text}`;
+      const priority = (hasPlausibleScore(body) ? 0 : 2) + (STRONG_OUTCOME_RE.test(body) ? 1 : 0);
+      return { candidate: c, priority };
+    })
+    .sort((a, b) => b.priority - a.priority)
+    .map((r) => r.candidate);
+}
+
+/**
+ * Fetch a post's comment feed and return the OP's own replies.
+ *
+ * The permalink feed's first entry is the post itself, which is what makes this
+ * reliable: it names the author we then filter comments by, so we never have to
+ * trust an author parsed out of a different feed.
+ */
+async function fetchOpReplies(candidate) {
+  const feedUrl = `${candidate.url.replace(/\/$/, '')}/.rss?sort=new&limit=100`;
+  const entries = parseAtom(await redditRss(feedUrl));
+  if (entries.length === 0) return [];
+  const op = entries[0].author;
+  if (!op) return [];
+  return entries
+    .slice(1)
+    .filter((c) => c.author === op)
+    .filter((c) => c.content && c.content.length >= 20)
+    .filter((c) => !/^\[(deleted|removed)\]$/i.test(c.content.trim()))
+    .slice(0, CAPS.opCommentsPerPost)
+    .map((c) => truncate(c.content, CAPS.opCommentChars));
+}
+
+// Mutates candidates in place, adding `opReplies` where any were found. Never
+// throws: a post whose comment feed fails just goes to the model without its
+// replies, exactly as before this expansion existed.
+async function expandOpReplies(candidates) {
+  const queue = rankForExpansion(candidates).slice(0, CAPS.expandPosts);
+  let expanded = 0;
+  let failures = 0;
+  for (const candidate of queue) {
+    await sleep(8000);
+    try {
+      const replies = await fetchOpReplies(candidate);
+      if (replies.length > 0) {
+        candidate.opReplies = replies;
+        expanded++;
+      }
+    } catch (err) {
+      failures++;
+      console.warn(`  ! OP replies for ${candidate.id} failed: ${err.message.split('\n')[0]}`);
+    }
+  }
+  return { attempted: queue.length, expanded, failures };
+}
+
 // ── Extraction prompt ────────────────────────────────────────────────────────
 
 function buildCardListSection(cards) {
@@ -270,6 +356,9 @@ function buildExtractPrompt({ candidates, cards }) {
       const lines = [`[${i + 1}] (${c.kind}, posted ${c.posted}, id ${c.id}) ${c.title}`];
       lines.push(`    URL: ${c.url}`);
       if (c.text && c.text !== c.title) lines.push(`    Text: ${c.text}`);
+      for (const reply of c.opReplies || []) {
+        lines.push(`    OP reply: ${reply}`);
+      }
       return lines.join('\n');
     })
     .join('\n\n');
@@ -284,6 +373,11 @@ You are a meticulous data curator for CreditOdds. From the r/CreditCards candida
 3. **A specific credit score**: 300–850. "742", "about 750" (use 750) qualify; "mid 700s", "good credit" do not.
 4. **A card in the catalog below**: match against current names and the "previously:" aliases, but always output the CURRENT catalog name, exactly as written. If the card is not in the catalog, skip the data point and mention the card in your run report instead.
 5. **A recent application**: the application happened within roughly the last 6 months (default assumption: the post date). Skip stories about applications from years past.
+
+Any of these may come from the post body or from an \`OP reply\` line — see below.
+
+## OP reply lines
+Some candidates carry \`OP reply:\` lines. Those are later comments on that same post written by the post's own author, already filtered for you (comments by anyone else are never included). Read them as a continuation of the poster's first-person account: an outcome, score, income, or limit stated in a reply counts exactly as if it were in the body, and a reply may resolve a body that got truncated. Two cautions: a reply that answers a hypothetical ("if I applied I'd probably be around 700") is still not a stated outcome, and when a reply corrects the body, the reply wins. The absence of \`OP reply\` lines means nothing — most posts are never expanded.
 
 ## Field extraction rules
 - **result**: \`approved\` or \`denied\`.
@@ -535,6 +629,18 @@ async function phaseFetch() {
   sourceStatus.forEach((s) => console.log(s));
 
   const candidates = all.slice(0, CAPS.totalCandidates);
+
+  // Pull OP replies before the state is staged: replies are context hung off an
+  // existing candidate, never candidates of their own, so this changes nothing
+  // about dedupe.
+  if (candidates.some((c) => c.kind === 'post')) {
+    const { attempted, expanded, failures } = await expandOpReplies(candidates);
+    console.log(
+      `\nOP replies: expanded ${expanded}/${attempted} post(s)` +
+        (failures ? `, ${failures} feed(s) failed` : '')
+    );
+  }
+
   fs.writeFileSync(CANDIDATES_FILE, JSON.stringify(candidates, null, 1));
 
   // Stage the seen-state update: every candidate presented this run counts as
@@ -649,7 +755,18 @@ async function main() {
   process.exit(1);
 }
 
-main().catch((err) => {
-  console.error('Fatal:', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Fatal:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  parseAtom,
+  hasPlausibleScore,
+  rankForExpansion,
+  fetchOpReplies,
+  buildExtractPrompt,
+  validateDataPoint,
+};

--- a/scripts/check-reddit-datapoints.test.js
+++ b/scripts/check-reddit-datapoints.test.js
@@ -1,0 +1,146 @@
+// Tests for the OP-reply expansion in check-reddit-datapoints.js.
+//
+// Why this exists: r/CreditCards posters routinely put the credit score, or the
+// outcome itself, in a reply to their own post rather than in the body. The
+// extraction session cannot go get those — WebFetch is blocked for reddit.com —
+// so the fetch phase has to hand them over, and it has to hand over the OP's
+// replies only. A bug that let another commenter's numbers through would look
+// exactly like a valid data point and would silently poison the odds data.
+//
+// Run: `node scripts/check-reddit-datapoints.test.js`. Exits non-zero on failure.
+
+const assert = require('node:assert/strict');
+
+const {
+  parseAtom,
+  hasPlausibleScore,
+  rankForExpansion,
+  fetchOpReplies,
+  buildExtractPrompt,
+} = require('./check-reddit-datapoints.js');
+
+// Queue every case, then run them in order — several stub global.fetch, so they
+// must not overlap.
+let failures = 0;
+const queue = [];
+const test = (name, fn) => queue.push({ name, fn });
+const testAsync = test;
+
+async function run() {
+  for (const { name, fn } of queue) {
+    try {
+      await fn();
+      console.log(`✓ ${name}`);
+    } catch (err) {
+      failures++;
+      console.error(`✗ ${name}\n  ${err.message}`);
+    }
+  }
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed.`);
+    process.exit(1);
+  }
+  console.log('\nAll tests passed.');
+}
+
+// Shaped after a real r/CreditCards permalink feed: entry 0 is the post itself
+// (which is how we learn who OP is), the rest are comments in mixed authorship.
+function entry({ id, author, title, content, updated = '2026-07-28' }) {
+  return `<entry><author><name>/u/${author}</name><uri>https://www.reddit.com/user/${author}</uri></author>` +
+    `<id>t3_x:${id}</id><id>${id}</id>` +
+    `<link href="https://www.reddit.com/r/CreditCards/comments/abc123/x/"/>` +
+    `<updated>${updated}T12:00:00+00:00</updated>` +
+    `<title>${title}</title>` +
+    `<content type="html">&lt;div&gt;${content}&lt;/div&gt;</content></entry>`;
+}
+
+const COMMENT_FEED = `<?xml version="1.0"?><feed>${[
+  entry({ id: 't3_abc123', author: 'OrigPoster', title: 'Denied for CSP', content: 'I applied and got denied. Details in comments.' }),
+  entry({ id: 't1_c1', author: 'HelpfulStranger', title: '/u/HelpfulStranger on Denied for CSP', content: 'My score was 810 and I got approved instantly with a 25k limit.' }),
+  entry({ id: 't1_c2', author: 'OrigPoster', title: '/u/OrigPoster on Denied for CSP', content: 'Forgot to add: my FICO is 704 Experian and income is $61,000.' }),
+  entry({ id: 't1_c3', author: 'OrigPoster', title: '/u/OrigPoster on Denied for CSP', content: 'ty!' }),
+  entry({ id: 't1_c4', author: 'OrigPoster', title: '/u/OrigPoster on Denied for CSP', content: '[deleted]' }),
+].join('')}</feed>`;
+
+test('parseAtom pulls the author name and strips the /u/ prefix', () => {
+  const entries = parseAtom(COMMENT_FEED);
+  assert.equal(entries.length, 5);
+  assert.equal(entries[0].author, 'OrigPoster');
+  assert.equal(entries[1].author, 'HelpfulStranger');
+});
+
+testAsync('fetchOpReplies returns only the OP\'s substantive replies', async () => {
+  const original = global.fetch;
+  global.fetch = async () => ({ ok: true, status: 200, text: async () => COMMENT_FEED });
+  try {
+    const replies = await fetchOpReplies({
+      id: 't3_abc123',
+      url: 'https://www.reddit.com/r/CreditCards/comments/abc123/x/',
+    });
+    // The stranger's "810 approved, 25k limit" is the dangerous one: it reads
+    // like a perfect data point but belongs to someone else's application.
+    assert.equal(replies.length, 1, `expected 1 OP reply, got ${replies.length}: ${JSON.stringify(replies)}`);
+    assert.match(replies[0], /704 Experian/);
+    assert.ok(!replies.some((r) => /810/.test(r)), 'a non-OP commenter\'s score leaked into OP replies');
+    assert.ok(!replies.some((r) => /deleted/.test(r)), 'a [deleted] reply leaked through');
+    assert.ok(!replies.some((r) => r === 'ty!'), 'a trivially short reply leaked through');
+  } finally {
+    global.fetch = original;
+  }
+});
+
+testAsync('fetchOpReplies yields nothing rather than guessing when the feed is empty', async () => {
+  const original = global.fetch;
+  global.fetch = async () => ({ ok: true, status: 200, text: async () => '<?xml version="1.0"?><feed></feed>' });
+  try {
+    const replies = await fetchOpReplies({ id: 't3_abc123', url: 'https://www.reddit.com/r/CreditCards/comments/abc123/x/' });
+    assert.deepEqual(replies, []);
+  } finally {
+    global.fetch = original;
+  }
+});
+
+test('hasPlausibleScore only counts numbers in FICO range', () => {
+  assert.equal(hasPlausibleScore('my score is 742'), true);
+  assert.equal(hasPlausibleScore('300 exactly'), true);
+  assert.equal(hasPlausibleScore('850 exactly'), true);
+  assert.equal(hasPlausibleScore('limit is 250 and i am 29'), false);
+  assert.equal(hasPlausibleScore('no numbers here at all'), false);
+});
+
+test('rankForExpansion puts scoreless outcome posts first and skips megathread comments', () => {
+  const candidates = [
+    { id: 't3_a', kind: 'post', title: 'Got approved', text: 'FICO 742, approved.', url: 'https://www.reddit.com/r/CreditCards/comments/a/x/' },
+    { id: 't3_b', kind: 'post', title: 'Just got denied for the CSP', text: 'No idea why.', url: 'https://www.reddit.com/r/CreditCards/comments/b/x/' },
+    { id: 't3_c', kind: 'post', title: 'What card next?', text: 'Looking for advice.', url: 'https://www.reddit.com/r/CreditCards/comments/c/x/' },
+    { id: 't1_d', kind: 'comment', title: 'approved 760', text: 'approved 760', url: 'https://www.reddit.com/r/CreditCards/comments/mega/x/' },
+  ];
+  const ranked = rankForExpansion(candidates);
+  assert.deepEqual(ranked.map((c) => c.id), ['t3_b', 't3_c', 't3_a']);
+  assert.ok(!ranked.some((c) => c.kind === 'comment'), 'megathread comments must not be expanded');
+});
+
+test('buildExtractPrompt renders OP replies and documents how to read them', () => {
+  const prompt = buildExtractPrompt({
+    cards: [{ name: 'Chase Sapphire Preferred', bank: 'Chase', previous_names: [] }],
+    candidates: [
+      {
+        id: 't3_abc123',
+        kind: 'post',
+        title: 'Denied for CSP',
+        text: 'I applied and got denied.',
+        url: 'https://www.reddit.com/r/CreditCards/comments/abc123/x/',
+        posted: '2026-07-28',
+        opReplies: ['Forgot to add: my FICO is 704 Experian.'],
+      },
+      { id: 't3_noreplies', kind: 'post', title: 'Other post', text: 'Body.', url: 'https://x/', posted: '2026-07-28' },
+    ],
+  });
+  assert.match(prompt, /OP reply: Forgot to add: my FICO is 704 Experian\./);
+  assert.match(prompt, /## OP reply lines/);
+  // The absence of replies must not render an empty label the model could
+  // misread. Count only rendered candidate lines, not the instructions section.
+  assert.equal((prompt.match(/^ {4}OP reply: /gm) || []).length, 1);
+});
+
+run();


### PR DESCRIPTION
## Problem

The `reddit-datapoints-local` routine told the extraction session it could open a post's permalink with WebFetch when the body alone was inconclusive. It cannot: WebFetch is blocked for `reddit.com`, so every attempt fails.

That escape hatch existed for a common case. On r/CreditCards, posters routinely leave the credit score, and sometimes the outcome itself, in a reply to their own post rather than in the body. A specific score is a hard requirement for a data point, so those posts were being dropped. In today's run, 4 of 13 candidates reported a real approval and were skipped for exactly this reason.

## Fix

The fetch phase already has working Reddit access (browser UA, 8s spacing, one 61s backoff on 429), so it does the work instead. For up to 8 posts per run it pulls the permalink's comment feed and attaches the OP's own replies to the candidate as `OP reply:` lines in the extraction prompt. Posts that describe an outcome but carry no plausible score in the body are expanded first, since that is where a reply is most likely to be decisive.

**Only the OP's replies are attached.** A permalink feed's first entry is the post itself, which names the author to filter by, so this never depends on matching authors across two feeds. That filter is the load-bearing part: another commenter replying "810, approved, 25k limit" reads exactly like a valid data point and would be attributed to the wrong person's application.

The extraction prompt gains a section explaining how to read the replies, including that a reply answering a hypothetical is still not a stated outcome, and that a reply correcting the body wins.

## Blast radius

- Expansion is best-effort: a comment feed that fails leaves the candidate exactly as it was.
- Replies are context hung off an existing candidate, never candidates of their own, so dedupe and seen-state are unchanged.
- Fetch phase goes from ~3 to ~11 Reddit requests, still at 8s spacing (well under an unauthenticated rate limit). Runtime moves from 1-2 min to 2-4 min.

## Testing

New `scripts/check-reddit-datapoints.test.js` (`node scripts/check-reddit-datapoints.test.js`), covering author parsing, the OP-only filter (including the non-OP-score leak case), expansion ordering, and prompt rendering. Also verified live against a real post: `fetchOpReplies` returned that OP's 2 replies and none of the other commenters'.

The scheduled task's SKILL.md is updated separately (it lives outside the repo) to drop the dead WebFetch instruction.