### PR TITLE
Reddit data points: abort OP expansion after repeated feed failures

### DIFF
--- a/scripts/check-reddit-datapoints.js
+++ b/scripts/check-reddit-datapoints.js
@@ -73,6 +73,7 @@ const CAPS = {
   expandPosts: 8,
   opCommentsPerPost: 5,
   opCommentChars: 600,
+  abortAfterFailures: 2,
 };
 
 // Mirrors REASON_DENIED_CODES in apps/api/src/handlers/user-records.js.
@@ -319,24 +320,43 @@ async function fetchOpReplies(candidate) {
 // Mutates candidates in place, adding `opReplies` where any were found. Never
 // throws: a post whose comment feed fails just goes to the model without its
 // replies, exactly as before this expansion existed.
+//
+// Bails out after CAPS.abortAfterFailures consecutive failures. Every failure
+// here has already eaten a 61s backoff inside redditRss, so a genuinely
+// rate-limited run would otherwise spend ~9 minutes getting nothing while
+// making Reddit angrier. Replies are a bonus on top of the post body, so
+// giving up early costs far less than the alternative.
 async function expandOpReplies(candidates) {
   const queue = rankForExpansion(candidates).slice(0, CAPS.expandPosts);
   let expanded = 0;
   let failures = 0;
+  let consecutiveFailures = 0;
+  let attempted = 0;
   for (const candidate of queue) {
+    if (consecutiveFailures >= CAPS.abortAfterFailures) {
+      // Say what was dropped: a silent cap here reads as "no replies existed".
+      console.warn(
+        `  ! OP reply expansion aborted after ${consecutiveFailures} consecutive failures — ` +
+          `${queue.length - attempted} post(s) not expanded (likely Reddit rate limiting)`
+      );
+      break;
+    }
+    attempted++;
     await sleep(8000);
     try {
       const replies = await fetchOpReplies(candidate);
+      consecutiveFailures = 0;
       if (replies.length > 0) {
         candidate.opReplies = replies;
         expanded++;
       }
     } catch (err) {
       failures++;
+      consecutiveFailures++;
       console.warn(`  ! OP replies for ${candidate.id} failed: ${err.message.split('\n')[0]}`);
     }
   }
-  return { attempted: queue.length, expanded, failures };
+  return { attempted, expanded, failures };
 }
 
 // ── Extraction prompt ────────────────────────────────────────────────────────
@@ -767,6 +787,8 @@ module.exports = {
   hasPlausibleScore,
   rankForExpansion,
   fetchOpReplies,
+  expandOpReplies,
   buildExtractPrompt,
   validateDataPoint,
+  CAPS,
 };

--- a/scripts/check-reddit-datapoints.test.js
+++ b/scripts/check-reddit-datapoints.test.js
@@ -16,7 +16,9 @@ const {
   hasPlausibleScore,
   rankForExpansion,
   fetchOpReplies,
+  expandOpReplies,
   buildExtractPrompt,
+  CAPS,
 } = require('./check-reddit-datapoints.js');
 
 // Queue every case, then run them in order — several stub global.fetch, so they
@@ -118,6 +120,36 @@ test('rankForExpansion puts scoreless outcome posts first and skips megathread c
   const ranked = rankForExpansion(candidates);
   assert.deepEqual(ranked.map((c) => c.id), ['t3_b', 't3_c', 't3_a']);
   assert.ok(!ranked.some((c) => c.kind === 'comment'), 'megathread comments must not be expanded');
+});
+
+// Slow by design (~16s): expandOpReplies spaces requests 8s apart and that
+// spacing is not stubbable. Guards a failure mode seen live on 2026-07-29,
+// where 2 of 3 comment feeds returned 429 and each cost a 61s backoff.
+testAsync('expandOpReplies gives up after consecutive failures instead of grinding', async () => {
+  const original = global.fetch;
+  let calls = 0;
+  // 500 rather than 429: redditRss retries a 429 after 61s, which would make
+  // this test unrunnable. Either way the fetch throws and the loop counts it.
+  global.fetch = async () => {
+    calls++;
+    return { ok: false, status: 500, text: async () => '' };
+  };
+  const candidates = Array.from({ length: 6 }, (_, i) => ({
+    id: `t3_p${i}`,
+    kind: 'post',
+    title: 'Denied for the CSP',
+    text: 'No score in the body.',
+    url: `https://www.reddit.com/r/CreditCards/comments/p${i}/x/`,
+  }));
+  try {
+    const result = await expandOpReplies(candidates);
+    assert.equal(calls, CAPS.abortAfterFailures, `expected ${CAPS.abortAfterFailures} requests before bailing, made ${calls}`);
+    assert.equal(result.attempted, CAPS.abortAfterFailures);
+    assert.equal(result.expanded, 0);
+    assert.ok(!candidates.some((c) => c.opReplies), 'no candidate should have gained replies');
+  } finally {
+    global.fetch = original;
+  }
 });
 
 test('buildExtractPrompt renders OP replies and documents how to read them', () => {


### PR DESCRIPTION
Follow-up to #1829, prompted by live-testing that change.

## What the test found

Running the expansion against three real r/CreditCards posts, **2 of 3 comment-feed requests came back 429**. The existing `redditRss` backoff handled each one correctly (61s wait, retry, success), so the data was still fetched. But it exposed the cost shape: on a genuinely rate-limited morning the fetch phase would work through all 8 queued posts at ~70s each, spending ~9 minutes to get little or nothing while continuing to hammer Reddit.

The expansion already degrades gracefully in the sense that a failed feed leaves the candidate untouched. It just does so very slowly.

## Change

Abort the expansion loop after 2 consecutive failures. OP replies are a bonus on top of the post body that the routine did fine without until today, so giving up early costs a little recall on a bad day and protects the run.

The abort logs how many posts went unexpanded. A silent cap would be indistinguishable from "those posts had no replies", which is the same false-negative shape as the card-page-check issues.

Also exports `expandOpReplies` and `CAPS` so the loop is directly testable instead of only its parts.

## Testing

`node scripts/check-reddit-datapoints.test.js` — new case asserts the loop stops after exactly `abortAfterFailures` requests and leaves every candidate unmodified. It is deliberately slow (~16s) because the 8s request spacing is not stubbable; it uses a 500 rather than a 429 so it does not sit through the real backoff.