### PR TITLE
Reddit data points: count 429 backoffs, not just failures

### DIFF
--- a/scripts/check-reddit-datapoints.js
+++ b/scripts/check-reddit-datapoints.js
@@ -74,6 +74,14 @@ const CAPS = {
   opCommentsPerPost: 5,
   opCommentChars: 600,
   abortAfterFailures: 2,
+  // Separate and slightly looser than the failure cap: a throttled request
+  // still returns its data, so it is worth absorbing a couple before quitting.
+  // Bounds backoff cost at roughly 3 minutes.
+  abortAfterThrottled: 3,
+  // Timings, named so the tests can shrink them — otherwise every case that
+  // exercises the retry or the request loop would sit through the real waits.
+  requestSpacingMs: 8000,
+  rateLimitBackoffMs: 61000,
 };
 
 // Mirrors REASON_DENIED_CODES in apps/api/src/handlers/user-records.js.
@@ -150,13 +158,20 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const BROWSER_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
 
+// Count of 61s backoffs taken. A 429 that succeeds on retry is not a failure —
+// the caller gets its data and never knows — but it still costs a minute, so
+// throttling has to be observable to anything that loops over requests.
+let rateLimitBackoffs = 0;
+const getRateLimitBackoffs = () => rateLimitBackoffs;
+
 async function redditRss(url, { retried = false } = {}) {
   const res = await fetch(url, {
     headers: { 'User-Agent': BROWSER_UA, Accept: 'application/atom+xml,application/xml,text/xml,*/*' },
   });
   if (res.status === 429 && !retried) {
-    console.warn(`  Reddit 429 on ${url} — backing off 61s and retrying once`);
-    await sleep(61000);
+    console.warn(`  Reddit 429 on ${url} — backing off ${Math.round(CAPS.rateLimitBackoffMs / 1000)}s and retrying once`);
+    rateLimitBackoffs++;
+    await sleep(CAPS.rateLimitBackoffMs);
     return redditRss(url, { retried: true });
   }
   if (!res.ok) throw new Error(`Reddit RSS ${url} -> ${res.status}`);
@@ -237,7 +252,7 @@ async function fetchNewPosts(seenIds) {
 }
 
 async function fetchMegathreadComments(seenIds) {
-  await sleep(8000); // space Reddit requests; the new-posts fetcher runs first
+  await sleep(CAPS.requestSpacingMs); // space Reddit requests; the new-posts fetcher runs first
   const hot = parseAtom(await redditRss('https://www.reddit.com/r/CreditCards/hot/.rss?limit=10'));
   // Stickied megathreads surface at the top of /hot. Match the recurring
   // approval/DP thread shapes without pinning to one moderator's title format.
@@ -247,7 +262,7 @@ async function fetchMegathreadComments(seenIds) {
   if (!thread) {
     return { label: 'r/CreditCards megathread (none found in /hot)', candidates: [] };
   }
-  await sleep(8000);
+  await sleep(CAPS.requestSpacingMs);
   const threadUrl = thread.link.replace(/\/$/, '');
   const entries = parseAtom(await redditRss(`${threadUrl}/.rss?sort=new&limit=100`));
   // First entry is the post itself; the rest are comments.
@@ -321,28 +336,48 @@ async function fetchOpReplies(candidate) {
 // throws: a post whose comment feed fails just goes to the model without its
 // replies, exactly as before this expansion existed.
 //
-// Bails out after CAPS.abortAfterFailures consecutive failures. Every failure
-// here has already eaten a 61s backoff inside redditRss, so a genuinely
-// rate-limited run would otherwise spend ~9 minutes getting nothing while
-// making Reddit angrier. Replies are a bonus on top of the post body, so
-// giving up early costs far less than the alternative.
+// Bails out on sustained Reddit pushback, tracked as two separate signals
+// because they look nothing alike from in here:
+//
+//   failures  — the feed threw. Cheap to detect, and the candidate loses its
+//               replies. Cap is tight (2).
+//   throttled — the feed 429'd and only succeeded after a 61s backoff. The
+//               caller still gets its data, so this is invisible to a
+//               failure counter, but it is the expensive case: the 2026-07-30
+//               run took 7 backoffs across 8 posts, about 7 minutes of the
+//               fetch phase, without tripping a single failure. Cap is looser
+//               (3) since these requests do deliver.
+//
+// Replies are a bonus on top of the post body, so quitting early costs a
+// little recall and saves the run.
 async function expandOpReplies(candidates) {
   const queue = rankForExpansion(candidates).slice(0, CAPS.expandPosts);
   let expanded = 0;
   let failures = 0;
   let consecutiveFailures = 0;
+  let consecutiveThrottled = 0;
   let attempted = 0;
   for (const candidate of queue) {
+    // Say what was dropped either way: a silent cap here reads as "no replies
+    // existed", which is the same false negative shape as a missed data point.
+    const remaining = queue.length - attempted;
     if (consecutiveFailures >= CAPS.abortAfterFailures) {
-      // Say what was dropped: a silent cap here reads as "no replies existed".
       console.warn(
         `  ! OP reply expansion aborted after ${consecutiveFailures} consecutive failures — ` +
-          `${queue.length - attempted} post(s) not expanded (likely Reddit rate limiting)`
+          `${remaining} post(s) not expanded (likely Reddit rate limiting)`
+      );
+      break;
+    }
+    if (consecutiveThrottled >= CAPS.abortAfterThrottled) {
+      console.warn(
+        `  ! OP reply expansion aborted after ${consecutiveThrottled} consecutive 429 backoffs — ` +
+          `${remaining} post(s) not expanded (Reddit is throttling; replies still cost 61s each)`
       );
       break;
     }
     attempted++;
-    await sleep(8000);
+    await sleep(CAPS.requestSpacingMs);
+    const backoffsBefore = getRateLimitBackoffs();
     try {
       const replies = await fetchOpReplies(candidate);
       consecutiveFailures = 0;
@@ -355,8 +390,10 @@ async function expandOpReplies(candidates) {
       consecutiveFailures++;
       console.warn(`  ! OP replies for ${candidate.id} failed: ${err.message.split('\n')[0]}`);
     }
+    // Counted on both paths: a request can back off and then still fail.
+    consecutiveThrottled = getRateLimitBackoffs() > backoffsBefore ? consecutiveThrottled + 1 : 0;
   }
-  return { attempted, expanded, failures };
+  return { attempted, expanded, failures, throttled: getRateLimitBackoffs() };
 }
 
 // ── Extraction prompt ────────────────────────────────────────────────────────
@@ -654,10 +691,11 @@ async function phaseFetch() {
   // existing candidate, never candidates of their own, so this changes nothing
   // about dedupe.
   if (candidates.some((c) => c.kind === 'post')) {
-    const { attempted, expanded, failures } = await expandOpReplies(candidates);
+    const { attempted, expanded, failures, throttled } = await expandOpReplies(candidates);
     console.log(
       `\nOP replies: expanded ${expanded}/${attempted} post(s)` +
-        (failures ? `, ${failures} feed(s) failed` : '')
+        (failures ? `, ${failures} feed(s) failed` : '') +
+        (throttled ? `, ${throttled} × 61s 429 backoff` : '')
     );
   }
 
@@ -790,5 +828,6 @@ module.exports = {
   expandOpReplies,
   buildExtractPrompt,
   validateDataPoint,
+  getRateLimitBackoffs,
   CAPS,
 };

--- a/scripts/check-reddit-datapoints.test.js
+++ b/scripts/check-reddit-datapoints.test.js
@@ -21,6 +21,11 @@ const {
   CAPS,
 } = require('./check-reddit-datapoints.js');
 
+// Shrink the real waits (8s between requests, 61s on a 429) so the loop tests
+// run in milliseconds instead of minutes.
+CAPS.requestSpacingMs = 1;
+CAPS.rateLimitBackoffMs = 1;
+
 // Queue every case, then run them in order — several stub global.fetch, so they
 // must not overlap.
 let failures = 0;
@@ -122,9 +127,6 @@ test('rankForExpansion puts scoreless outcome posts first and skips megathread c
   assert.ok(!ranked.some((c) => c.kind === 'comment'), 'megathread comments must not be expanded');
 });
 
-// Slow by design (~16s): expandOpReplies spaces requests 8s apart and that
-// spacing is not stubbable. Guards a failure mode seen live on 2026-07-29,
-// where 2 of 3 comment feeds returned 429 and each cost a 61s backoff.
 testAsync('expandOpReplies gives up after consecutive failures instead of grinding', async () => {
   const original = global.fetch;
   let calls = 0;
@@ -147,6 +149,69 @@ testAsync('expandOpReplies gives up after consecutive failures instead of grindi
     assert.equal(result.attempted, CAPS.abortAfterFailures);
     assert.equal(result.expanded, 0);
     assert.ok(!candidates.some((c) => c.opReplies), 'no candidate should have gained replies');
+  } finally {
+    global.fetch = original;
+  }
+});
+
+// The 2026-07-30 run's actual failure mode: 7 of 8 comment feeds returned 429,
+// each backed off 61s and then SUCCEEDED. Every request delivered its data, so
+// the consecutive-failure counter stayed at zero and the run still burned about
+// 7 minutes. Throttling has to be counted separately from failure.
+testAsync('expandOpReplies gives up when 429 backoffs keep succeeding', async () => {
+  const original = global.fetch;
+  const seenUrls = new Map();
+  // First call per URL 429s, the retry succeeds — a backoff, never a failure.
+  global.fetch = async (url) => {
+    const n = (seenUrls.get(url) || 0) + 1;
+    seenUrls.set(url, n);
+    if (n === 1) return { ok: false, status: 429, text: async () => '' };
+    return { ok: true, status: 200, text: async () => COMMENT_FEED };
+  };
+  const candidates = Array.from({ length: 8 }, (_, i) => ({
+    id: `t3_q${i}`,
+    kind: 'post',
+    title: 'Denied for the CSP',
+    text: 'No score in the body.',
+    url: `https://www.reddit.com/r/CreditCards/comments/q${i}/x/`,
+  }));
+  try {
+    const result = await expandOpReplies(candidates);
+    assert.equal(result.failures, 0, 'these are backoffs, not failures — the old guard saw nothing wrong');
+    assert.equal(
+      result.attempted,
+      CAPS.abortAfterThrottled,
+      `expected to stop after ${CAPS.abortAfterThrottled} throttled posts, attempted ${result.attempted}`
+    );
+    // The requests that did go through still delivered, so their replies stick.
+    assert.equal(result.expanded, CAPS.abortAfterThrottled);
+    assert.equal(candidates.filter((c) => c.opReplies).length, CAPS.abortAfterThrottled);
+  } finally {
+    global.fetch = original;
+  }
+});
+
+testAsync('a clean request resets the throttle counter', async () => {
+  const original = global.fetch;
+  let call = 0;
+  // 429-then-success on the first post, clean on every later one: the counter
+  // must reset so one slow request does not eventually abort a healthy run.
+  global.fetch = async () => {
+    call++;
+    if (call === 1) return { ok: false, status: 429, text: async () => '' };
+    return { ok: true, status: 200, text: async () => COMMENT_FEED };
+  };
+  const candidates = Array.from({ length: 5 }, (_, i) => ({
+    id: `t3_r${i}`,
+    kind: 'post',
+    title: 'Denied for the CSP',
+    text: 'No score in the body.',
+    url: `https://www.reddit.com/r/CreditCards/comments/r${i}/x/`,
+  }));
+  try {
+    const result = await expandOpReplies(candidates);
+    assert.equal(result.attempted, 5, 'a single backoff must not end the run');
+    assert.equal(result.expanded, 5);
   } finally {
     global.fetch = original;
   }


### PR DESCRIPTION
Follow-up to #1832, which guarded the wrong signal. Found by running the fetch phase on real candidates.

## What happened

The 2026-07-30 fetch run expanded 8 posts and logged **7 Reddit 429s** — and the abort guard from #1832 never fired. It couldn't: `redditRss` retries a 429 after 61s, that retry succeeded every time, so the caller got its data and `consecutiveFailures` stayed at 0.

Net result: the phase spent ~7 minutes in backoff, which is the precise cost #1832 was meant to bound. The guard was correct about the danger and wrong about how to detect it.

```
OP replies: expanded 3/8 post(s)     ← 7 × 61s of backoff, 0 failures
```

## Change

Count throttling separately from failure:

| Signal | Meaning | Cap |
|---|---|---|
| `failures` | feed threw, candidate loses replies | 2 |
| `throttled` | feed 429'd, backed off 61s, then succeeded | 3 |

The throttle cap is looser because those requests *do* deliver. It bounds backoff cost at ~3 min. On 2026-07-30's evidence this costs nothing measurable: that run got replies from 3 posts, which is exactly where the new cap stops.

The fetch phase summary now reports backoffs, so a chronically throttled morning is visible in the routine's own output instead of buried in warnings.

## Testability

`requestSpacingMs` and `rateLimitBackoffMs` move into `CAPS` so tests can shrink them. Two new cases:

- the throttle abort fires on backoff-then-success (asserting `failures === 0`, i.e. the old guard would have seen nothing wrong)
- **a single backoff resets the counter** — without this, one slow request early on would eventually abort an otherwise healthy run

Suite runs in 0.2s, down from 16s, since the old failure test no longer sits through real 8s spacing.

## Still worth watching

7 of 8 requests being throttled suggests 8s spacing may be too aggressive for the added request volume, but today's numbers are polluted by heavy manual testing from this IP. The guard bounds the damage either way. If tomorrow's unattended 8:15a run also logs the abort, spacing is the next lever.