### PR TITLE
Reddit Data Points 2026-07-29

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1va66cl.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1va66cl.yaml
@@ -1,0 +1,14 @@
+source_id: "t3_1va66cl"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1va66cl/chase_freedom_flex_approved_as_a_student/"
+posted: "2026-07-29"
+evidence: "College student reports an instant approval at 746 with a $5,600 starting limit, about $20k income from internships and campus work, two prior cards, and a Chase checking relationship since 2024."
+card_name: "Chase Freedom Flex"
+result: "approved"
+credit_score: 746
+credit_score_source: 0
+listed_income: 20000
+length_credit: 2
+starting_credit_limit: 5600
+total_open_cards: 2
+bank_customer: true
+date_applied: "2026-07"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1va66cl](https://www.reddit.com/r/CreditCards/comments/1va66cl/chase_freedom_flex_approved_as_a_student/) | Chase Freedom Flex | approved | 746 | $20,000 | $5,600 | 2 | 2026-07 | `2026-07-30-t3_1va66cl.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
