### PR TITLE
Model mobile-wallet-gated rates as their own reward category

### DIFF
--- a/apps/api/src/lib/ranker/categoryLabels.js
+++ b/apps/api/src/lib/ranker/categoryLabels.js
@@ -31,6 +31,7 @@ const categoryLabels = {
   amazon: "Amazon.com",
   rei: "REI",
   everything_else: "Everything Else",
+  mobile_wallet: "Mobile Wallet Purchases",
   fast_food: "Fast Food",
   electronics_stores: "Electronics Stores",
   tv_internet_streaming: "TV, Internet & Streaming Services",

--- a/apps/api/src/lib/ranker/nextCardRanking.js
+++ b/apps/api/src/lib/ranker/nextCardRanking.js
@@ -60,6 +60,14 @@ function isPortalCategory(category) {
   return typeof category === "string" && category.endsWith("_portal");
 }
 
+// `mobile_wallet` rewards (a rate conditional on paying through the card's
+// own mobile wallet — Apple Card's 2%, Samsung Galaxy Card's 3%) are
+// deliberately absent from SPEND_CATEGORY_MAP and from the base rate here:
+// the quiz doesn't know whether the user pays by phone, so cards are judged
+// on their unconditional everything_else rate. A future "do you usually pay
+// with your phone?" question could credit mobile_wallet as an
+// everything-else booster, the way loyalty selections unlock co-brand
+// travel rates.
 function flatRateEff(card) {
   const r = (card.rewards || []).find((x) => x.category === "everything_else");
   if (!r) return 0;

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -8,6 +8,7 @@ import {
   FilmIcon,
   ComputerDesktopIcon,
   CreditCardIcon,
+  DevicePhoneMobileIcon,
 } from "@heroicons/react/24/outline";
 import { Card, CardBenefit, Reward } from "@/lib/api";
 import { getValuation } from "@/lib/valuations";
@@ -42,6 +43,7 @@ export const categoryLabels: Record<string, string> = {
   rakuten: "Rakuten.com",
   rakuten_dining: "Rakuten Dining",
   everything_else: "Everything Else",
+  mobile_wallet: "Mobile Wallet Purchases",
   phone: "Phone Services",
   utilities: "Utilities",
   ev_charging: "EV Charging",
@@ -155,6 +157,8 @@ export function CategoryIcon({ category, className }: { category: string; classN
       return <SparklesIcon className={iconClass} />;
     case "everything_else":
       return <GlobeAltIcon className={iconClass} />;
+    case "mobile_wallet":
+      return <DevicePhoneMobileIcon className={iconClass} />;
     default:
       return <CreditCardIcon className={iconClass} />;
   }

--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -14,22 +14,20 @@ rewards:
     # category matching so store pages don't surface this card for
     # arbitrary online retailers (e.g. bloomingdales.com).
     merchant_specific: true
-  - category: dining
+  # Apple's real structure is 3-2-1: 3% at Apple + select merchants, 2% on
+  # ANY purchase paid with Apple Pay, 1% with the physical card. The 2% used
+  # to be modeled as everything_else (plus per-category dining/transit/
+  # groceries duplicates), which fed rankers a base rate the card only earns
+  # when tapping. mobile_wallet carries the conditional 2%; everything_else
+  # is the honest ungated floor.
+  - category: mobile_wallet
     value: 2
     unit: percent
-    note: "Via Apple Pay"
-  - category: transit
-    value: 2
-    unit: percent
-    note: "Via Apple Pay"
-  - category: groceries
-    value: 2
-    unit: percent
-    note: "Via Apple Pay"
+    note: "2% Daily Cash on any purchase paid with Apple Pay; the physical titanium card earns 1%"
   - category: everything_else
-    value: 2
+    value: 1
     unit: percent
-    note: "2% Daily Cash requires paying with Apple Pay; the physical titanium card earns 1%"
+    note: "Purchases made with the physical titanium card"
 tags:
   - cashback
 apr:

--- a/data/cards/samsung-galaxy-card.yaml
+++ b/data/cards/samsung-galaxy-card.yaml
@@ -25,10 +25,14 @@ rewards:
     value: 2
     unit: percent
     note: "Streaming services like Netflix, Disney+ and Spotify"
-  - category: everything_else
+  - category: mobile_wallet
     value: 3
     unit: percent
-    note: "3% requires paying through Samsung Wallet; purchases made with the physical card or outside Samsung Wallet earn 1%"
+    note: "Any purchase paid through Samsung Wallet; purchases made with the physical card or outside Samsung Wallet earn 1%"
+  - category: everything_else
+    value: 1
+    unit: percent
+    note: "Purchases made with the physical card or outside Samsung Wallet"
 signup_bonus:
   value: 200
   type: "cash"

--- a/data/categories.yaml
+++ b/data/categories.yaml
@@ -77,6 +77,13 @@ categories:
     label: Military Base
   - id: everything_else
     label: Everything Else
+  # Purchases paid through the card's own mobile wallet (Apple Pay on the
+  # Apple Card, Samsung Wallet on the Samsung Galaxy Card). A separate
+  # category, NOT everything_else: the rate is conditional on the payment
+  # method, so ranking code that ignores unknown categories falls back to
+  # the card's honest ungated everything_else rate.
+  - id: mobile_wallet
+    label: Mobile Wallet Purchases
   - id: department_stores
     label: Department Stores
   # U.S. Bank Cash+ 5% bucket categories — issuer-specific labels lifted

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -662,6 +662,15 @@ one with overlapping coverage. Use the closest matching reward category
 from categories.yaml (rideshare → transit; streaming services → streaming;
 fitness equipment → fitness or shopping if no fitness).
 
+An earn rate conditional on paying through the card's own mobile wallet
+("2% Daily Cash when you use Apple Pay", "3% when paying with Samsung
+Wallet") belongs in the \`mobile_wallet\` category, NOT in
+\`everything_else\` — everything_else is reserved for the unconditional
+rate the physical card earns (usually 1% on these cards). Do NOT propose
+moving an existing \`mobile_wallet\` row into \`everything_else\` just
+because the page phrases it as "on every purchase": the wallet condition
+makes it a different row.
+
 # DO NOT INCLUDE — earn / redemption / finance mechanics
 - "rewards" describes per-CATEGORY EARN RATES on spend (e.g. "5% on dining"). Use category ids that already appear in the example cards below.
 - DO NOT include redemption mechanics (e.g. "Points Payback", "no blackout dates"), generic federal-law standards (e.g. "$0 Fraud Liability"), or network-tier perks (e.g. "Visa Signature Concierge", "Mastercard World Elite Benefits").

--- a/scripts/post-best-rankings.js
+++ b/scripts/post-best-rankings.js
@@ -220,6 +220,9 @@ const REWARD_LABELS = {
   foreign_transactions: 'FOREIGN',
   rent: 'RENT',
   everything_else: 'EVERYTHING',
+  // Payment-method-gated rate (Apple Pay / Samsung Wallet). The label names
+  // the condition so the stat never reads as an unconditional flat rate.
+  mobile_wallet: 'MOBILE WALLET',
 };
 
 function formatRate(reward) {

--- a/scripts/post-new-card.js
+++ b/scripts/post-new-card.js
@@ -93,6 +93,15 @@ function isMerchantGated(reward) {
     || (Array.isArray(reward.merchant_gate) && reward.merchant_gate.length > 0);
 }
 
+// `mobile_wallet` rates (Apple Card's 2% via Apple Pay, Samsung Galaxy Card's
+// 3% via Samsung Wallet) are conditional on the payment method the same way
+// merchant-gated rates are conditional on the merchant — stating one plainly
+// ("3% on everything") oversells the card. Quarantine them with the gated
+// rates so the copy carries the wallet condition from the note.
+function isWalletGated(reward) {
+  return reward.category === 'mobile_wallet';
+}
+
 // The schema's only units are `percent` and `points_per_dollar` — the bare
 // `points` this used to check is not a value any card carries, so every points
 // and miles card fed the model raw "5points_per_dollar on travel portal".
@@ -126,7 +135,7 @@ function summarizeRewards(rewards) {
   const isBonusCategory = r => r.category !== 'everything_else';
 
   const ungatedParts = valid
-    .filter(r => isBonusCategory(r) && !isMerchantGated(r))
+    .filter(r => isBonusCategory(r) && !isMerchantGated(r) && !isWalletGated(r))
     .sort(byValueDesc)
     .slice(0, 3)
     .map(r => `${formatRate(r)} on ${categoryLabel(r.category)}`);
@@ -139,7 +148,7 @@ function summarizeRewards(rewards) {
   }
 
   const gatedParts = valid
-    .filter(r => isBonusCategory(r) && isMerchantGated(r) && r.note)
+    .filter(r => isBonusCategory(r) && (isMerchantGated(r) || isWalletGated(r)) && r.note)
     .sort(byValueDesc)
     .map(r => `${formatRate(r)} in the ${categoryLabel(r.category)} category, limited to: ${truncateNote(r.note)}`);
 
@@ -172,8 +181,9 @@ function buildCardSummary(card) {
   if (ungated) parts.push(`Top rewards, each applying to the whole category named: ${ungated}`);
   if (gated) {
     parts.push(
-      'Merchant-limited rates, which apply ONLY at the merchants named and NOT to the '
-      + `whole category: ${gated}`
+      'Conditional rates, which apply ONLY under the condition named (a specific merchant '
+      + 'list, or paying through the card\'s mobile wallet) and NOT as a flat or '
+      + `category-wide rate: ${gated}`
     );
   }
   return parts.join('. ');

--- a/scripts/post-new-card.test.js
+++ b/scripts/post-new-card.test.js
@@ -146,7 +146,7 @@ console.log('\nbuildCardSummary against real card YAML');
 test('intuit-business leads with the flat 2%, quarantines the Intuit-only 5%', () => {
   const summary = buildCardSummary(loadCard('intuit-business'));
   assert.match(summary, /whole category named: 2% on every purchase/);
-  assert.match(summary, /Merchant-limited rates[^.]*5% in the online shopping category, limited to: Intuit products/);
+  assert.match(summary, /Conditional rates[^.]*5% in the online shopping category, limited to: Intuit products/);
   // The exact wording that shipped wrong: 5% presented as a category-wide rate.
   assert.ok(
     !/whole category named:[^.]*online shopping/.test(summary),
@@ -156,7 +156,7 @@ test('intuit-business leads with the flat 2%, quarantines the Intuit-only 5%', (
 
 test('apple-card scopes the 3% to its merchant list', () => {
   const summary = buildCardSummary(loadCard('apple-card'));
-  assert.match(summary, /Merchant-limited rates[^.]*3% in the online shopping category, limited to: Apple purchases/);
+  assert.match(summary, /Conditional rates[^.]*3% in the online shopping category, limited to: Apple purchases/);
   assert.ok(
     !/whole category named:[^.]*online shopping/.test(summary),
     `Apple 3% still presented as a category rate:\n${summary}`
@@ -166,7 +166,7 @@ test('apple-card scopes the 3% to its merchant list', () => {
 test('chase-ink-business-unlimited scopes the Lyft 5% out of transit', () => {
   const summary = buildCardSummary(loadCard('chase-ink-business-unlimited'));
   assert.match(summary, /whole category named: 1\.5% on every purchase/);
-  assert.match(summary, /Merchant-limited rates[^.]*5% in the transit category, limited to: On Lyft rides/);
+  assert.match(summary, /Conditional rates[^.]*5% in the transit category, limited to: On Lyft rides/);
   assert.ok(
     !/whole category named:[^.]*transit/.test(summary),
     `Ink Lyft 5% still presented as a category rate:\n${summary}`

--- a/scripts/refresh-best-pages.js
+++ b/scripts/refresh-best-pages.js
@@ -252,6 +252,7 @@ const SHARED_GUIDELINES = `RANKING GUIDELINES:
 - Category relevance matters: for a "Best Cash Back" page a card's cash back rates matter most; for "Best Travel" transfer partners, travel perks, and portal multipliers matter most.
 - Consider the full picture: a card with a slightly lower bonus but much better ongoing rewards may deserve a higher rank.
 - A reward marked "merchant_specific": true or carrying a "merchant_gate" list earns its rate ONLY at the merchants named in its "note", not across the category it is filed under. Weigh it as the narrow perk it is, and judge everyday earning on the ungated rates (including "everything_else"). A card whose only high rate is gated is not a high-earning card in that category.
+- A reward in the "mobile_wallet" category earns its rate ONLY when the purchase is paid through the card's mobile wallet (e.g. Apple Pay, Samsung Wallet), never on ordinary swipes of the physical card. Judge everyday earning on the "everything_else" rate: a card whose only high flat rate is mobile_wallet-gated is not a high flat-rate card, because many merchants and purchases cannot be paid by phone.
 - A reward carrying "spend_cap" earns its headline rate only on the first spend_cap dollars of spend per "cap_period"; everything above that earns "rate_after_cap". Judge it on what the cap is actually worth, not on the headline rate: 6% on the first $6,000 of yearly grocery spend is worth about $360 a year, so it can lose to a lower uncapped rate for anyone who spends past the cap. A tight cap on a card's headline rate makes it weaker than that rate suggests.
 
 RULES:
@@ -301,6 +302,7 @@ RULES:
 - Keep the cards array in the EXACT order provided. Do NOT reorder, add, or remove cards.
 - ONLY use facts from card_data. Never invent or assume numbers.
 - A reward marked "merchant_specific": true or carrying a "merchant_gate" list applies ONLY at the merchants named in its "note". If you mention such a rate, name that limit (e.g. "5% on Intuit products", "5% on Lyft rides"). Never write it as if it covered the whole category it is filed under, and prefer an ungated rate when one makes the point.
+- A reward in the "mobile_wallet" category applies ONLY to purchases paid through the card's mobile wallet. If you mention such a rate, name that condition (e.g. "3% when paying through Samsung Wallet", "2% via Apple Pay") and treat the "everything_else" rate as the card's true base rate. Never present a mobile_wallet rate as an unconditional flat rate.
 - A reward carrying "spend_cap" earns its headline rate only on the first spend_cap dollars per "cap_period", then drops to "rate_after_cap". If you mention such a rate, state the cap and the window (e.g. "6% at U.S. supermarkets on up to $6,000 a year, then 1%", "5% on your top category on up to $500 a month"). Never present a capped rate as if it ran unlimited.
 - If a signup_bonus value is a string like "4 Free Night Awards", use it as-is.
 - Match the existing concise, factual, comparative editorial tone. No hype words like "incredible", "amazing", or "unbeatable". Do not use em dashes.

--- a/scripts/refresh-our-takes.js
+++ b/scripts/refresh-our-takes.js
@@ -125,6 +125,7 @@ Voice and rules:
 - If the recent-changes list shows a material move (an intro APR window or signup bonus that just dropped or rose, a fee change, or the card no longer accepting applications), work it in naturally, e.g. "recently trimmed from 24 to 21 months".
 - If the card tops a Best-of list, you may note that once and naturally, but never force it.
 - Do not invent benefits, credits, categories, or numbers that are not in the data.
+- A reward in the "mobile_wallet" category earns its rate only when the purchase is paid through the card's own mobile wallet (Apple Pay, Samsung Wallet). If you cite it, name that condition, and treat the "everything_else" rate as the card's true base rate. A reward marked merchant_specific or carrying a merchant_gate list applies only at the merchants its note names, never to its whole category.
 
 Return ONLY a JSON object of the exact shape {"our_take": "<the paragraph>"}.
 


### PR DESCRIPTION
## Problem

The Samsung Galaxy Card won the /best-card-for-me quiz for essentially every user. Its 3% rate only applies when paying through Samsung Wallet, but it was modeled as an unconditional `everything_else` rate with the condition living only in the prose `note`. Deterministic consumers (the quiz ranker's `flatRateEff`, wallet earnings math) took the 3% at face value, giving Samsung a floor that beat every honest flat 2% card on all unbonused spend.

Apple Card has the identical shape (2% only via Apple Pay, note-only) but never surfaced because 2% merely ties flat-rate cards.

Same class of bug as the merchant_gate lesson from #1787: a rate's condition must be structured data, not prose.

## Fix

New `mobile_wallet` reward category, mirroring the `_portal` convention: the wallet-conditional rate moves there, and `everything_else` becomes the honest ungated floor (1% on both cards). Ranking code maps known categories into spend buckets and ignores the rest, so the fix is fail-safe by construction, with no ranker logic changes needed.

- **data**: `mobile_wallet` added to categories.yaml; Samsung remodeled as mobile_wallet 3% + everything_else 1%; Apple as mobile_wallet 2% + everything_else 1%. Apple's per-category 2%-via-Apple-Pay rows (dining/transit/groceries) were duplicates of the same wallet-gated rate and collapse into the single mobile_wallet row.
- **display**: "Mobile Wallet Purchases" label + phone icon in cardDisplayUtils and the ranker's categoryLabels, so card pages still show the 3%/2% prominently with the catch named.
- **LLM prompts**: rules in refresh-best-pages (voter + writer) and refresh-our-takes: a mobile_wallet rate must be cited with its condition and everything_else treated as the true base rate.
- **social copy**: post-new-card quarantines wallet-gated rates with merchant-gated ones; post-best-rankings labels the stat `MOBILE WALLET`.
- **nightly page check**: extractor guidance so check-card-rewards-and-benefits doesn't propose moving mobile_wallet rates back into everything_else.

## Verification

- `npm run build:cards`: 199 cards validate (regenerated cards.json not committed, per convention)
- `audit-store-rankings.js`: passes
- web-next vitest (91) + api jest (51) + script node tests: all pass (post-new-card.test.js updated for the new "Conditional rates" prefix)
- Ranker against rebuilt data: Samsung/Apple base rate now 1%, flat 2% card earns 2x Samsung on everything-else spend; Samsung's only bucket boost is streaming 2%
- Dev server: both card pages render the new "Mobile Wallet Purchases" row plus honest "Everything Else" row

## Follow-up (not in this PR)

Phase 2: a "do you usually pay with your phone?" quiz question that credits mobile_wallet as an everything-else booster, the way loyalty selections unlock co-brand travel rates. /best pages will pick up the re-rank + prompt rules on their next refresh; worth eyeballing Samsung's placement afterward.