### PR TITLE
Reddit data points: state plainly that pre-qual is not an outcome

### DIFF
--- a/scripts/check-reddit-datapoints.js
+++ b/scripts/check-reddit-datapoints.js
@@ -425,7 +425,9 @@ function buildExtractPrompt({ candidates, cards }) {
 You are a meticulous data curator for CreditOdds. From the r/CreditCards candidates below, extract application data points: a poster reporting the outcome of THEIR OWN credit card application. These become public odds data, so precision beats recall — when a field is ambiguous, omit the field; when the whole data point is ambiguous, skip it. Extracting zero data points from a quiet day is a successful run.
 
 ## A data point MUST have all of
-1. **A stated outcome**: the poster was approved or denied. Pending applications, reconsideration-line limbo, pre-approval offers, and "what are my odds?" questions are NOT outcomes.
+1. **A stated outcome**: the poster submitted a real application and was approved or denied. Pending applications, reconsideration-line limbo, and "what are my odds?" questions are NOT outcomes.
+
+   **Pre-qualification is never an outcome, in either direction.** Not an offer received, not a "pre-approved" banner, and not a pre-qual tool turning someone down — even when that rejection quotes an issuer reason and full credit stats, which makes it look exactly like a real denial. Pre-qual is a soft-pull marketing check against different criteria than the real underwriting decision, so recording it would mix two different questions into one odds number. If the poster later actually applies and reports that result, THAT is the data point. Phrases to treat as pre-qual: "pre-approval tool", "pre-qualified", "prequal", "checked my odds", "got denied on the pre-approval page".
 2. **First person**: their own application. Skip second-hand reports ("my wife got approved" is allowed ONLY when the poster gives that person's full details; "my friend says" is not), hypotheticals, jokes, and obvious sarcasm.
 3. **A specific credit score**: 300–850. "742", "about 750" (use 750) qualify; "mid 700s", "good credit" do not.
 4. **A card in the catalog below**: match against current names and the "previously:" aliases, but always output the CURRENT catalog name, exactly as written. If the card is not in the catalog, skip the data point and mention the card in your run report instead.

--- a/scripts/check-reddit-datapoints.test.js
+++ b/scripts/check-reddit-datapoints.test.js
@@ -235,6 +235,9 @@ test('buildExtractPrompt renders OP replies and documents how to read them', () 
   });
   assert.match(prompt, /OP reply: Forgot to add: my FICO is 704 Experian\./);
   assert.match(prompt, /## OP reply lines/);
+  // Pre-qual results are not data points (Max, 2026-07-30). The rule has to
+  // survive future prompt edits, hence asserting on it here.
+  assert.match(prompt, /Pre-qualification is never an outcome, in either direction/);
   // The absence of replies must not render an empty label the model could
   // misread. Count only rendered candidate lines, not the instructions section.
   assert.equal((prompt.match(/^ {4}OP reply: /gm) || []).length, 1);


### PR DESCRIPTION
Encodes a decision from Max on 2026-07-30: pre-approvals are not applications, so they are not data points.

## Why the wording needed changing

The rule already excluded "pre-approval offers" — which reads as covering an offer someone *receives*. The 2026-07-30 run hit the opposite shape: a Capital One **pre-approval tool denial** ([t3_1va21kc](https://www.reddit.com/r/CreditCards/comments/1va21kc/advice_on_getting_venture_x_approvalpreapproval/)) that quoted an issuer-cited reason next to a complete credit profile — 795 Experian FICO 8, $100k income, 0/6, 0/12, 4/24, $108k total limits, 2% utilization.

It was skipped correctly, but on the spirit of the rule rather than its letter, and it was the most complete-looking record in a 17-candidate batch. That combination is what future drift looks like: a run reasons that a denial with a cited reason and full stats must be real, and one soft-pull marketing decision lands in the odds data.

## Change

States the exclusion directly and in both directions, with the reason attached so it survives paraphrasing: pre-qual is a soft-pull check against different criteria than real underwriting, so recording it mixes two different questions into one odds number. Also lists the phrases that signal pre-qual, since the issuer-reason text is the part that reads as legitimate.

Notes explicitly that if the poster later actually applies and reports the result, that *is* the data point.

## Testing

`node scripts/check-reddit-datapoints.test.js` — the prompt test now asserts the rule is present, so a future prompt rewrite cannot quietly drop it. No behavior change to fetch or validation; this is extraction guidance only.