### PR TITLE
card-page-check: an add-a-card bonus is not a spend tier

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -851,6 +851,30 @@ function normalizeBonusType(type) {
   return BONUS_TYPE_ALIASES[t] ?? t;
 }
 
+// A bonus for adding an employee card or authorized user is a supplementary
+// component of the welcome offer, not a spend tier — you unlock it by adding a
+// person, not by spending more. It still reads as "10,000 additional miles",
+// which is exactly the phrasing the tier regex hunts for, so these clauses are
+// removed before any tier reasoning runs.
+//
+// Missing this deleted live data: United Business and United Club Business both
+// store "Plus 2,000 Premier qualifying points ..., and 10,000 additional miles
+// for adding an employee card in the first 3 months". Chase advertises no spend
+// tiers on either, so the extractor correctly reported offer_is_tiered:false,
+// the note matched the tier regex on its employee-card clause, and the
+// retirement branch proposed erasing both notes (#1830, closed 2026-07-30).
+// The offers were unchanged; merging would have understated each card by 10,000
+// miles and 2,000 PQP.
+//
+// Clause-scoped (stops at , ; .) so only the add-a-card phrase is dropped and a
+// genuine tier in the same note still counts. "additional" does not trip \badd\b.
+const ADD_CARD_BONUS_CLAUSE_RE =
+  /[^,;.]*\b(?:for|after|when|upon)\s+(?:you\s+)?add(?:ing)?\b[^,;.]*?\b(?:employee|authorized\s+user|\bAU\b|additional\s+card)[^,;.]*/gi;
+
+function stripAddCardBonusClauses(noteText) {
+  return (noteText || '').replace(ADD_CARD_BONUS_CLAUSE_RE, ' ');
+}
+
 // A tiered note carries the tier amounts it describes ("70,000 miles ... an
 // additional 20,000 miles"). Pull them out so the tier-collapse guard can
 // insist that a proposed downgrade actually LANDS on one of them. Only counts
@@ -1131,9 +1155,15 @@ function detectChanges(card, extracted, now = new Date(), suppressions = [], pag
     // Ordering matters: a suppression that fires forever is invisible, so every
     // skip is recorded in `suppressions` and reported at the end of the run.
     const noteText = cur.note || '';
+    // Tier reasoning reads the note WITHOUT its add-an-employee-card / AU
+    // clauses: those are extra components, not spend tiers, and their "N
+    // additional miles" phrasing otherwise reads as a tier breakdown.
+    // noteOfferHasExpired keeps the full text — the "Offer ends" date can sit
+    // anywhere in the note, including inside a stripped clause.
+    const tierNoteText = stripAddCardBonusClauses(noteText);
     const tieredAdditionalMatch =
-      noteText.match(/(\d[\d,]*)\s+(?:additional|more)\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+night)/i) ||
-      noteText.match(/(?:additional|more)\s+(\d[\d,]*)\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+night)/i);
+      tierNoteText.match(/(\d[\d,]*)\s+(?:additional|more)\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+night)/i) ||
+      tierNoteText.match(/(?:additional|more)\s+(\d[\d,]*)\s+(?:\w+\s+){0,4}(?:points|miles|nights|free\s+night)/i);
     // offer_is_tiered:false is only trustworthy when the page actually rendered
     // the welcome offer. On JS-gated pages the extractor echoes the stored value
     // and defaults offer_is_tiered:false; treating that as "flat" would disarm the
@@ -1148,7 +1178,9 @@ function detectChanges(card, extracted, now = new Date(), suppressions = [], pag
       sb.value != null &&
       cur.value != null &&
       sb.value < cur.value &&
-      tierAmountsInNote(noteText).includes(sb.value);
+      // Same stripped text: an add-a-card amount must not count as a tier the
+      // proposed value is allowed to land on.
+      tierAmountsInNote(tierNoteText).includes(sb.value);
 
     const spendOvercount =
       noteDescribesTiered &&

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -207,6 +207,110 @@ test('offer_is_tiered=false retires the stale tier breakdown (note → null)', (
   assert.equal(note.old_value, WORLD_OF_HYATT.data.signup_bonus.note);
 });
 
+// #1830 (closed 2026-07-30): a bonus for adding an employee card reads as
+// "10,000 additional miles", the same phrasing the tier regex hunts for. Chase
+// advertises no spend tiers on either United business card, so the extractor
+// correctly said offer_is_tiered:false and the retirement branch proposed
+// erasing two accurate notes. Merging would have understated both offers by
+// 10,000 miles and 2,000 PQP.
+const UNITED_BUSINESS = {
+  data: {
+    name: 'United Business',
+    signup_bonus: {
+      value: 100000,
+      type: 'miles',
+      spend_requirement: 5000,
+      timeframe_months: 3,
+      note:
+        'Plus 2,000 Premier qualifying points on meeting the spend requirement, and 10,000 additional miles for adding an employee card in the first 3 months',
+    },
+  },
+};
+const UNITED_LIVE_PAGE =
+  'Earn 100,000 bonus miles + 2,000 PQP after you spend $5,000 on purchases in the first 3 months your account is open. ' +
+  'Earn 10,000 bonus miles after you add an employee card in the first 3 months. welcome offer';
+
+test('an employee-card bonus is not a tier: the note survives a flat page', () => {
+  const changes = detectChanges(
+    UNITED_BUSINESS,
+    {
+      signup_bonus: {
+        value: 100000,
+        spend_requirement: 5000,
+        timeframe_months: 3,
+        type: 'miles',
+        bonus_note: null,
+        offer_is_tiered: false,
+      },
+    },
+    new Date('2026-07-29'),
+    [],
+    UNITED_LIVE_PAGE
+  );
+  assert.deepEqual(changes, [], `expected no changes, got ${JSON.stringify(changes)}`);
+});
+
+test('an authorized-user bonus is not a tier either', () => {
+  const card = {
+    data: {
+      name: 'Some Card',
+      signup_bonus: {
+        value: 60000,
+        type: 'points',
+        spend_requirement: 4000,
+        timeframe_months: 3,
+        note: 'Plus 15,000 additional points for adding an authorized user in the first 3 months',
+      },
+    },
+  };
+  const changes = detectChanges(
+    card,
+    {
+      signup_bonus: {
+        value: 60000,
+        spend_requirement: 4000,
+        timeframe_months: 3,
+        type: 'points',
+        bonus_note: null,
+        offer_is_tiered: false,
+      },
+    },
+    new Date('2026-07-29'),
+    [],
+    'Earn 60,000 bonus points after you spend $4,000 in the first 3 months. welcome offer bonus points'
+  );
+  const note = changes.find(c => c.field === 'signup_bonus.note');
+  assert.equal(note, undefined, 'an AU-bonus note must not be retired as a stale tier');
+});
+
+test('a real tier alongside an employee-card bonus still counts as tiered', () => {
+  const card = {
+    data: {
+      name: 'Hybrid Card',
+      signup_bonus: {
+        value: 135000,
+        type: 'points',
+        spend_requirement: 6000,
+        timeframe_months: 6,
+        note:
+          'Earn 85,000 points after $6,000 in purchases, plus an additional 50,000 points after an additional $3,000 in purchases, and 10,000 additional points for adding an employee card',
+      },
+    },
+  };
+  const suppressions = [];
+  detectChanges(
+    card,
+    {
+      signup_bonus: { value: 50000, spend_requirement: 6000, timeframe_months: 6, type: 'points', offer_is_tiered: null },
+    },
+    new Date('2026-07-29'),
+    suppressions,
+    'Earn 85,000 bonus points welcome offer'
+  );
+  assert.equal(suppressions.length, 1, 'stripping the employee-card clause must not disarm a genuine tier');
+  assert.equal(suppressions[0].guard, 'tier-collapse');
+});
+
 test("offer_is_tiered=false prefers the extractor's replacement note over deletion", () => {
   const changes = detectChanges(WORLD_OF_HYATT, {
     signup_bonus: {


### PR DESCRIPTION
Root-cause fix for #1830, which I closed as a false negative.

## What #1830 tried to do

Delete the `signup_bonus.note` from **United Business** and **United Club Business**. Both notes were accurate — verified against the live Chase pages:

> "Earn 100,000 bonus miles + 2,000 PQP after you spend \$5,000 on purchases in the first 3 months" … "Earn 10,000 bonus miles after you add an employee card to your account in the first 3 months"

Merging would have understated both offers by 10,000 miles and 2,000 PQP, and left YAML that a future check would read as agreeing with the page.

## Why it happened

The note-retirement branch (`detectChanges`, ~line 1291) clears a stale tier breakdown once the live page stops advertising tiers. It identifies "this note is a tier breakdown" by the phrase `N additional <currency>`.

An employee-card bonus is worded exactly that way — "10,000 additional miles for adding an employee card" — while being a *supplementary component*, not a tier. You unlock it by adding a person, not by spending more.

So every premise fired correctly and the conclusion was still wrong:

1. `tieredAdditionalMatch` matched the employee-card clause → "note looks tiered"
2. `pageSaysFlat` was true, **correctly** — Chase advertises no spend tiers on these cards, so `offer_is_tiered: false` was the right extraction
3. → "note describes a dead tiered offer, retire it"

Reproduced deterministically against the committed YAML for both cards before changing anything.

## Fix

Strip add-an-employee-card / authorized-user clauses before any tier reasoning runs. Two properties worth noting:

- **Clause-scoped** (stops at `,` `;` `.`), so a note carrying a real tier *and* an add-a-card bonus still reads as tiered. Covered by a test.
- `tierAmountsInNote` uses the stripped text too, so an add-a-card amount can't serve as a tier that a proposed downgrade is permitted to land on. That's the same root cause one guard over.

`noteOfferHasExpired` deliberately keeps the full text, since an "Offer ends" date can sit inside a stripped clause.

## Blast radius

Scanned all card YAMLs. Six notes match the tier regex; exactly the two United cards were affected. The other four are genuine tiers and are unchanged:

| Card | Verdict |
|---|---|
| United Business | **was at risk** — fixed |
| United Club Business | **was at risk** — fixed |
| Marriott Bonvoy Bevy / Brilliant / Business | genuine tier ("additional 50,000 points after an additional \$3,000") |
| World of Hyatt | genuine tier |

## Testing

`node scripts/check-card-pages.test.js` — 110 pass. Three new cases: the United note surviving a flat page, an AU-bonus note surviving, and a genuine tier alongside an employee-card bonus still suppressing a base-tier misparse (guarding against the strip going too far).