### PR TITLE
Fix broken Amex business card apply links

### DIFF
--- a/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
@@ -3,7 +3,7 @@ bank: "American Express"
 slug: "delta-skymiles-platinum-business-american-express-card"
 image: "delta-skymiles-platinum-business-american-express-card.png"
 accepting_applications: true
-apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/delta-skymiles-platinum-business-american-express-card/
+apply_link: https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-platinum/
 foreign_transaction_fee: false
 network: "amex"
 category: "business"

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -3,7 +3,7 @@ bank: "American Express"
 slug: "delta-skymiles-reserve-business-american-express-card"
 image: "delta-skymiles-reserve-business-american-express-card.png"
 accepting_applications: true
-apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/delta-skymiles-reserve-business-american-express-card/
+apply_link: https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/
 foreign_transaction_fee: false
 network: "amex"
 category: "business"

--- a/data/cards/hilton-honors-american-express-business-card.yaml
+++ b/data/cards/hilton-honors-american-express-business-card.yaml
@@ -3,7 +3,7 @@ bank: "American Express"
 slug: "hilton-honors-american-express-business-card"
 image: "hilton-honors-american-express-business-card.png"
 accepting_applications: true
-apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/hilton-honors-business/
+apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/hilton-honors/
 foreign_transaction_fee: false
 network: "amex"
 category: "business"

--- a/data/cards/marriott-bonvoy-business-american-express.yaml
+++ b/data/cards/marriott-bonvoy-business-american-express.yaml
@@ -3,7 +3,7 @@ bank: "American Express"
 slug: "marriott-bonvoy-business-american-express"
 image: "marriott-bonvoy-business-american-express.png"
 accepting_applications: true
-apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/marriott-bonvoy-business/
+apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/amex-marriott-bonvoy-business-credit-card/
 foreign_transaction_fee: false
 network: "amex"
 category: "business"


### PR DESCRIPTION
Fixes #1834.

The daily apply-link health check flagged 4 Amex business card apply links redirecting to Amex's business 404 page. Verified in a real browser: the old URLs genuinely 404 (not bot-detection noise) — Amex restructured its business card pages. The Delta business cards moved to the newer `/en-us/business/credit-cards/` path (same format the Delta Gold Business already used), and the Hilton/Marriott pages kept the old path but changed slugs.

All 4 replacement URLs were taken from Amex's own [business cards listing page](https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/) and each was confirmed to load the correct card page:

| Card | New apply link |
|------|----------------|
| Delta SkyMiles Platinum Business | https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-platinum/ |
| Delta SkyMiles Reserve Business | https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/ |
| Hilton Honors Business | https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/hilton-honors/ |
| Marriott Bonvoy Business | https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/amex-marriott-bonvoy-business-credit-card/ |

Validated with `npm run build:cards` (199 cards OK); regenerated `cards.json` discarded per convention. No other files in the repo reference the old URLs.