### PR TITLE
Card Page Check 2026-07-30

### DIFF
--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -44,7 +44,7 @@ rewards:
     value: 3
     unit: points_per_dollar
 signup_bonus:
-  value: 175000
+  value: 150000
   type: "points"
   spend_requirement: 6000
   timeframe_months: 6

--- a/data/cards/hilton-honors-american-express-business-card.yaml
+++ b/data/cards/hilton-honors-american-express-business-card.yaml
@@ -30,7 +30,7 @@ rewards:
 signup_bonus:
   value: 130000
   type: "points"
-  spend_requirement: 8000
+  spend_requirement: 6000
   timeframe_months: 6
   note: "Limited-time offer through July 29, 2026, which also waives the annual fee for the first year"
 apr:

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -45,7 +45,7 @@ rewards:
     value: 3
     unit: points_per_dollar
 signup_bonus:
-  value: 100000
+  value: 80000
   type: "points"
   spend_requirement: 2000
   timeframe_months: 6


### PR DESCRIPTION
## Card Page Check — 2026-07-30

Detected by fetching official apply pages and extracting card terms with an LLM.
**Verify each change against the source page before merging.**

### Term Changes

| Card | Field | Current | Detected | Source |
|------|-------|---------|----------|--------|
| Hilton Honors American Express Aspire | signup_bonus.value | 175000 | 150000 | [apply page](https://www.americanexpress.com/us/credit-cards/card/hilton-honors-aspire/) |
| Hilton Honors American Express Business | signup_bonus.spend_requirement | 8000 | 6000 | [apply page](https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/hilton-honors/) |
| Hilton Honors | signup_bonus.value | 100000 | 80000 | [apply page](https://www.americanexpress.com/us/credit-cards/card/hilton-honors/) |

### How to Review
1. Click each source link and verify the detected value on the issuer's page
2. Remove any YAML changes that look incorrect before merging
3. Run `npm run build:cards` to validate

---
*Automated PR — review carefully before merging.*
