### PR TITLE
admin: rename Records tab to Data Points and show every stored field

### DIFF
--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -161,12 +161,14 @@ exports.AdminRecordsHandler = async (event) => {
           queryParams.push(parseInt(cardIdFilter));
         }
 
-        // Return extra fields when filtering by card
-        const extraFields = cardIdFilter
-          ? `, r.credit_score_source, r.starting_credit_limit, r.bank_customer, r.reason_denied,
-             r.reason_denied_code, r.total_open_cards,
-             r.inquiries_3, r.inquiries_12, r.inquiries_24, r.admin_review`
-          : '';
+        // Every stored field, always. This used to be conditional on a card
+        // filter, which meant the admin Data Points tab could not show a
+        // record's full contents until you had drilled into one card — the
+        // unfiltered list simply never received them. Same row count either
+        // way, so the extra columns cost one wider result set, not more rows.
+        const extraFields = `, r.credit_score_source, r.starting_credit_limit, r.bank_customer,
+             r.reason_denied, r.reason_denied_code, r.total_open_cards,
+             r.inquiries_3, r.inquiries_12, r.inquiries_24, r.admin_review`;
 
         const results = await mysql.query(`
           SELECT

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -293,7 +293,7 @@ export default function AdminPage() {
 
   const tabs = [
     { id: 'stats' as TabType, name: 'Overview', icon: ChartBarIcon },
-    { id: 'records' as TabType, name: 'Records', icon: DocumentTextIcon, count: recordsTotal },
+    { id: 'records' as TabType, name: 'Data Points', icon: DocumentTextIcon, count: recordsTotal },
     { id: 'referrals' as TabType, name: 'Referrals', icon: LinkIcon, count: referralsTotal, badge: stats?.pending_referrals },
     { id: 'activity' as TabType, name: 'Activity', icon: ClipboardDocumentListIcon },
     { id: 'user' as TabType, name: 'User Lookup', icon: UserIcon },
@@ -373,9 +373,9 @@ export default function AdminPage() {
                 <div>
                   <h2 className="av-section-h">
                     <DocumentTextIcon className="av-section-h-icon" />
-                    All records
+                    All data points
                   </h2>
-                  <p className="av-section-sub">{recordsTotal.toLocaleString()} total · click submit to add on behalf of a user</p>
+                  <p className="av-section-sub">{recordsTotal.toLocaleString()} total · every stored field is shown; scroll sideways for the full row</p>
                 </div>
                 <button
                   type="button"
@@ -1297,6 +1297,85 @@ function StoreTrafficTab({ getToken }: { getToken: () => Promise<string | null> 
 }
 
 // ============ RECORDS TAB ============
+// REASON_DENIED_CODES in apps/api/src/handlers/user-records.js.
+const REASON_DENIED_OPTIONS: ReadonlyArray<{ code: string; label: string }> = [
+  { code: 'not_specified', label: "Issuer didn't say" },
+  { code: 'too_many_inquiries', label: 'Too many recent inquiries' },
+  { code: 'too_many_recent_accounts', label: 'Too many recently opened accounts' },
+  { code: 'length_of_credit_too_short', label: 'Credit history too short' },
+  { code: 'too_few_accounts', label: 'Too few established accounts' },
+  { code: 'credit_score_too_low', label: 'Credit score too low' },
+  { code: 'high_utilization', label: 'High utilization / too much revolving debt' },
+  { code: 'too_much_credit_with_issuer', label: 'Too much credit already with this issuer' },
+  { code: 'no_issuer_relationship', label: 'No existing relationship with the issuer' },
+  { code: 'income_too_low', label: 'Income too low' },
+  { code: 'recent_delinquency', label: 'Recent delinquency or late payment' },
+  { code: 'bankruptcy_or_public_record', label: 'Bankruptcy or public record' },
+  { code: 'other', label: 'Other' },
+];
+
+// credit_score_source is stored as an int. Same legend as the submit form and
+// the /records API: 0 FICO (unspecified bureau), 1 Experian, 2 TransUnion,
+// 3 Equifax, 4 VantageScore (which is what Credit Karma reports).
+const SCORE_SOURCE_SHORT: Record<number, string> = {
+  0: 'FICO',
+  1: 'EX',
+  2: 'TU',
+  3: 'EQ',
+  4: 'Vantage',
+};
+
+const DENIAL_CODE_LABEL = new Map(REASON_DENIED_OPTIONS.map((o) => [o.code, o.label]));
+
+// Empty cells read as an explicit blank rather than a gap, so a missing value
+// is distinguishable from a rendering bug. Matches the public records table.
+const BLANK = '—';
+
+function num(value: number | null | undefined): string {
+  return value == null ? BLANK : value.toLocaleString();
+}
+
+function money(value: number | null | undefined): string {
+  return value == null ? BLANK : `$${value.toLocaleString()}`;
+}
+
+// "2026-07-01T00:00:00.000Z" → "2026-07". date_applied is month precision, so
+// rendering it through toLocaleDateString would invent a day and, worse, shift
+// the month backwards in timezones behind UTC.
+function monthOnly(value: string | null | undefined): string {
+  if (!value) return BLANK;
+  const m = String(value).match(/^(\d{4})-(\d{2})/);
+  return m ? `${m[1]}-${m[2]}` : BLANK;
+}
+
+// Deliberately the same column set and widths the tab has always had. Showing
+// every field as its own column needs ~13 of them, which forces sideways
+// scrolling and makes the tab unreadable, so the remaining fields go into
+// labelled lines underneath: rows get taller, never wider.
+const DP_COLUMNS = 'minmax(220px, 1.6fr) 70px 110px 90px minmax(180px, 1.4fr) 90px 36px';
+
+// One labelled value on the detail lines. Kept flush and low-contrast so the
+// primary columns above still carry the row.
+function DpField({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
+  return (
+    <span style={{ display: 'inline-flex', gap: 5, alignItems: 'baseline', whiteSpace: 'nowrap' }}>
+      <span style={{ color: 'var(--muted)', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+        {label}
+      </span>
+      <span className={mono ? 'av-mono' : undefined} style={{ color: 'var(--ink)' }}>{value}</span>
+    </span>
+  );
+}
+
+const DP_DETAIL_ROW: React.CSSProperties = {
+  gridColumn: '1 / -1',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '4px 14px',
+  alignItems: 'baseline',
+  fontSize: 11.5,
+};
+
 function RecordsTab({
   records,
   processingId,
@@ -1309,53 +1388,105 @@ function RecordsTab({
   return (
     <div className="av-tape">
       <div className="av-tape-scroll">
-        <div className="av-tape-head" style={{ gridTemplateColumns: 'minmax(220px, 1.6fr) 70px 110px 90px minmax(180px, 1.4fr) 90px 36px' }}>
+        <div className="av-tape-head" style={{ gridTemplateColumns: DP_COLUMNS }}>
           <span>Card</span>
           <span>Score</span>
           <span>Income</span>
           <span>Result</span>
           <span>Submitter</span>
-          <span>Date</span>
+          <span>Submitted</span>
           <span />
         </div>
         {records.length === 0 ? (
-          <div className="av-tape-empty">No records yet.</div>
-        ) : records.map((record) => (
-          <div key={record.record_id} className="av-tape-row" style={{ gridTemplateColumns: 'minmax(220px, 1.6fr) 70px 110px 90px minmax(180px, 1.4fr) 90px 36px' }}>
-            <div className="av-card-cell">
-              <div className="av-thumb">
-                <CardImage cardImageLink={record.card_image_link} alt={record.card_name} fill className="object-contain" sizes="48px" />
+          <div className="av-tape-empty">No data points yet.</div>
+        ) : records.map((record) => {
+          const denied = !record.result;
+          const codeLabel = record.reason_denied_code
+            ? DENIAL_CODE_LABEL.get(record.reason_denied_code) ?? record.reason_denied_code
+            : null;
+          return (
+            <div
+              key={record.record_id}
+              className="av-tape-row"
+              style={{ gridTemplateColumns: DP_COLUMNS, rowGap: 7, alignItems: 'start' }}
+            >
+              <div className="av-card-cell">
+                <div className="av-thumb">
+                  <CardImage cardImageLink={record.card_image_link} alt={record.card_name} fill className="object-contain" sizes="48px" />
+                </div>
+                <div className="av-card-meta">
+                  <div className="av-card-name">{record.card_name}</div>
+                  <div className="av-card-issuer">{record.bank}</div>
+                </div>
               </div>
-              <div className="av-card-meta">
-                <div className="av-card-name">{record.card_name}</div>
-                <div className="av-card-issuer">{record.bank}</div>
-              </div>
-            </div>
-            <span>{record.credit_score}</span>
-            <span>${record.listed_income?.toLocaleString()}</span>
-            <span>
-              <span className={'av-pill ' + (record.result ? 'av-pill-app' : 'av-pill-den')}>
-                {record.result ? 'Approved' : 'Denied'}
+              <span>
+                {record.credit_score}
+                {record.credit_score_source != null && (
+                  <span style={{ color: 'var(--muted)', fontSize: 10.5, marginLeft: 4 }}>
+                    {SCORE_SOURCE_SHORT[record.credit_score_source] ?? record.credit_score_source}
+                  </span>
+                )}
               </span>
-            </span>
-            <div>
-              <div className="av-mono" style={{ color: 'var(--ink)' }}>{record.submitter_id || 'Unknown'}</div>
-              {record.submitter_ip_address && <div className="av-mono">{record.submitter_ip_address}</div>}
+              <span>{money(record.listed_income)}</span>
+              <span>
+                <span className={'av-pill ' + (record.result ? 'av-pill-app' : 'av-pill-den')}>
+                  {record.result ? 'Approved' : 'Denied'}
+                </span>
+              </span>
+              <div style={{ minWidth: 0 }}>
+                <div className="av-mono" style={{ color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {record.submitter_id || 'Unknown'}
+                </div>
+                {record.submitter_ip_address && <div className="av-mono">{record.submitter_ip_address}</div>}
+              </div>
+              <span className="av-mono">{new Date(record.submit_datetime).toLocaleDateString()}</span>
+              <div className="av-row-actions">
+                <button
+                  type="button"
+                  onClick={() => onDelete(record.record_id)}
+                  disabled={processingId === record.record_id}
+                  className="av-row-action-btn av-action-danger"
+                  title="Delete"
+                >
+                  <TrashIcon />
+                </button>
+              </div>
+
+              {/* Everything the columns above don't carry. Always rendered, with
+                  explicit blanks, so a missing value is visibly missing rather
+                  than silently absent from the row. */}
+              <div style={DP_DETAIL_ROW}>
+                <DpField label="Applied" value={monthOnly(record.date_applied)} mono />
+                <DpField label="History" value={record.length_credit == null ? BLANK : `${record.length_credit}y`} />
+                {/* Approvals only: the importer refuses a starting limit on a denial. */}
+                <DpField label="Start limit" value={denied ? BLANK : money(record.starting_credit_limit)} />
+                <DpField label="Open cards" value={num(record.total_open_cards)} />
+                <DpField
+                  label="Inq 3/12/24"
+                  mono
+                  value={[record.inquiries_3, record.inquiries_12, record.inquiries_24]
+                    .map((v) => (v == null ? BLANK : v))
+                    .join('/')}
+                />
+                {/* bank_customer arrives as 0/1 from MySQL, not a boolean. */}
+                <DpField label="Bank cust" value={record.bank_customer ? 'Yes' : 'No'} />
+                <DpField label="Record" value={record.record_id} mono />
+                {record.admin_review ? <span className="av-pill av-pill-arch">Admin reviewed</span> : null}
+              </div>
+
+              {denied && (
+                <div style={DP_DETAIL_ROW}>
+                  <span className="av-pill av-pill-den" style={{ flex: '0 0 auto' }}>
+                    {codeLabel ?? 'No code'}
+                  </span>
+                  <span style={{ color: record.reason_denied ? 'var(--ink)' : 'var(--muted)' }}>
+                    {record.reason_denied || 'No issuer reason recorded'}
+                  </span>
+                </div>
+              )}
             </div>
-            <span className="av-mono">{new Date(record.submit_datetime).toLocaleDateString()}</span>
-            <div className="av-row-actions">
-              <button
-                type="button"
-                onClick={() => onDelete(record.record_id)}
-                disabled={processingId === record.record_id}
-                className="av-row-action-btn av-action-danger"
-                title="Delete"
-              >
-                <TrashIcon />
-              </button>
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );
@@ -2301,22 +2432,6 @@ function EditRecordModal({
 
 // Keep in sync with REASON_DENIED_OPTIONS in
 // apps/web-next/src/components/forms/SubmitRecordModal.tsx and
-// REASON_DENIED_CODES in apps/api/src/handlers/user-records.js.
-const REASON_DENIED_OPTIONS: ReadonlyArray<{ code: string; label: string }> = [
-  { code: 'not_specified', label: "Issuer didn't say" },
-  { code: 'too_many_inquiries', label: 'Too many recent inquiries' },
-  { code: 'too_many_recent_accounts', label: 'Too many recently opened accounts' },
-  { code: 'length_of_credit_too_short', label: 'Credit history too short' },
-  { code: 'too_few_accounts', label: 'Too few established accounts' },
-  { code: 'credit_score_too_low', label: 'Credit score too low' },
-  { code: 'high_utilization', label: 'High utilization / too much revolving debt' },
-  { code: 'too_much_credit_with_issuer', label: 'Too much credit already with this issuer' },
-  { code: 'no_issuer_relationship', label: 'No existing relationship with the issuer' },
-  { code: 'income_too_low', label: 'Income too low' },
-  { code: 'recent_delinquency', label: 'Recent delinquency or late payment' },
-  { code: 'bankruptcy_or_public_record', label: 'Bankruptcy or public record' },
-  { code: 'other', label: 'Other' },
-];
 
 function SubmitRecordTab({ getToken, onSuccess }: { getToken: () => Promise<string | null>; onSuccess: () => void }) {
   const { cards, error: cardCatalogError } = useCardCatalog({ activeOnly: true });

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1505,6 +1505,9 @@ export async function getAdminStats(token: string): Promise<AdminStats> {
 }
 
 // Admin Records
+// The admin records endpoint returns every stored field on every row, filtered
+// or not, so these live on the base type rather than a Detail variant. They stay
+// optional because rows predating a column carry null.
 export interface AdminRecord {
   record_id: number;
   card_id: number;
@@ -1520,12 +1523,9 @@ export interface AdminRecord {
   submitter_id: string;
   submitter_email?: string;
   submitter_ip_address?: string;
-}
-
-export interface AdminRecordDetail extends AdminRecord {
   credit_score_source?: number;
   starting_credit_limit?: number | null;
-  bank_customer?: boolean;
+  bank_customer?: boolean | number;
   reason_denied?: string | null;
   reason_denied_code?: string | null;
   total_open_cards?: number | null;
@@ -1534,6 +1534,10 @@ export interface AdminRecordDetail extends AdminRecord {
   inquiries_24?: number | null;
   admin_review?: number;
 }
+
+// Retained as an alias: the endpoint no longer distinguishes summary from
+// detail, but existing call sites still name this type.
+export type AdminRecordDetail = AdminRecord;
 
 export interface AdminRecordsResponse {
   records: AdminRecord[];


### PR DESCRIPTION
Requested by Max: rename the `/_admin` Records tab to **Data Points** and show all of a data point's information in each row.

## The blocker was the API, not the UI

The tab rendered 6 fields. It could not render more, because [admin.js](apps/api/src/handlers/admin.js) only selected the other ten **when a card filter was present**:

```js
const extraFields = cardIdFilter ? `, r.credit_score_source, ...` : '';
```

So the unfiltered list never received `credit_score_source`, `starting_credit_limit`, `bank_customer`, `reason_denied`, `reason_denied_code`, `total_open_cards`, the three inquiry counts, or `admin_review`. Now unconditional — the identical column list, so it is one wider result set, not more rows, and no new column names are introduced.

## Layout: taller, not wider

Per Max's follow-up, the row keeps **exactly** the column template it has always had:

```
minmax(220px, 1.6fr) 70px 110px 90px minmax(180px, 1.4fr) 90px 36px
```

Giving every field its own column needs ~13, which forces sideways scrolling. Instead the remaining fields render as labelled values on lines beneath each row.

Two deliberate choices:

- **Details always render**, with an explicit blank for nulls, so a missing field is visibly missing rather than indistinguishable from a rendering bug.
- **Denials always show a reason line**, falling back to "No code" / "No issuer reason recorded" instead of omitting it. A denial with no recorded reason is exactly what a reviewer wants to notice.

`reason_denied_code` renders through the same `REASON_DENIED_OPTIONS` labels the submit form uses, so the two surfaces cannot drift apart — including the two codes added in #1845.

## Bug caught while writing this

`REASON_DENIED_OPTIONS` was declared *after* `RecordsTab`. A module-level `Map` built from it would have hit the temporal dead zone and thrown at import, breaking `/_admin` entirely. The declaration moved above both consumers.

## Types

`AdminRecordDetail`'s fields fold into `AdminRecord`, since the endpoint no longer distinguishes summary from detail. The name is retained as an alias so existing call sites keep compiling.

## Verification

`/_admin` is auth-gated, so I rendered `RecordsTab` directly against fixture rows on a temporary local route (since removed) covering an approval, two denials with issuer reasons, and a denial with no reason at all:

- every field present in each row
- no horizontal overflow at 1280px
- nulls render as explicit blanks
- score source suffixes correct (FICO / EX / TU / EQ / Vantage)

Also: `tsc --noEmit` clean, `apps/api` Jest 10 suites / 51 tests pass.