### PR TITLE
reddit data points: widen the application-age window to 6 years

### DIFF
--- a/scripts/check-reddit-datapoints.js
+++ b/scripts/check-reddit-datapoints.js
@@ -62,6 +62,18 @@ const THIS_MONTH = TODAY.slice(0, 7);
 // is generous while keeping the state file bounded.
 const STATE_RETENTION_DAYS = 180;
 
+// How far back a data point's application may be. Was 12 months, on the theory
+// that older applications are too stale to say anything about today's odds.
+// Widened to 6 years (Max, 2026-07-30) because historical backfills are worth
+// more than that theory: the daily routine only ever sees the last few days, so
+// a narrow window silently discarded every historical sweep.
+//
+// Worth knowing when reading the odds: refresh-card-stats.js aggregates every
+// record with admin_review = 1 AND active = 1 and applies NO date filter or
+// recency weighting, so a six-year-old row counts exactly as much as one from
+// last week in both the approval rate and the median score/income/history.
+const MAX_DATA_POINT_AGE_MONTHS = 72;
+
 const CAPS = {
   newPosts: 40,
   threadComments: 60,
@@ -433,7 +445,7 @@ You are a meticulous data curator for CreditOdds. From the r/CreditCards candida
 2. **First person**: their own application. Skip second-hand reports ("my wife got approved" is allowed ONLY when the poster gives that person's full details; "my friend says" is not), hypotheticals, jokes, and obvious sarcasm.
 3. **A specific credit score**: 300–850. "742", "about 750" (use 750) qualify; "mid 700s", "good credit" do not.
 4. **A card in the catalog below**: match against current names and the "previously:" aliases, but always output the CURRENT catalog name, exactly as written. If the card is not in the catalog, skip the data point and mention the card in your run report instead.
-5. **A recent application**: the application happened within roughly the last 6 months (default assumption: the post date). Skip stories about applications from years past.
+5. **A datable application**: you can place the application in a specific month. The default is the month the post was written, which is almost always right because people post about an application when it happens. Historical posts are in scope — anything within the last ${MAX_DATA_POINT_AGE_MONTHS / 12} years counts, so do NOT skip a data point merely for being old. Skip only when the application cannot be dated at all, or when the poster describes an application from before that window.
 
 Any of these may come from the post body or from an \`OP reply\` line — see below.
 
@@ -450,7 +462,7 @@ Some candidates carry \`OP reply:\` lines. Those are later comments on that same
 - **total_open_cards**: open credit cards at time of application. Do NOT confuse with "cards opened in the last 24 months" (that is velocity, not open cards). Omit when unclear.
 - **inquiries_3 / inquiries_12 / inquiries_24**: hard inquiries in the last 3/12/24 months. Only when the poster clearly counts inquiries — do not derive from card-opening history. Omit when unclear.
 - **bank_customer**: true/false ONLY when the post states a relationship with the issuing bank ("been with Chase 10 years" → true; "no prior relationship" → false). Omit when unstated — do not guess.
-- **date_applied**: "YYYY-MM". Default to the post month; shift when the post says otherwise ("applied last month"). Never in the future.
+- **date_applied**: "YYYY-MM". **Use the post's month**, unless the post states the application date explicitly ("applied 3/14", "applied last month", the open date in a card list) — an explicit date always wins over the post month. Never in the future. On a historical sweep the post month IS the application month for practically every data point, so do not agonise over it.
 - **reason_denied** (denials only): a SHORT paraphrase in your own words of the issuer-cited reason, max 100 chars, plain factual tone, no em dashes (this text renders on the public site). Omit when the poster does not give a reason.
 - **reason_denied_code** (denials only): one of ${REASON_DENIED_CODES.join(', ')}. Use \`not_specified\` when no reason is given at all; otherwise pick the closest code. Two pairs are easy to confuse:
   - \`length_of_credit_too_short\` is about TIME (a thin or young file). \`too_few_accounts\` is about COUNT ("too few established/open accounts") and applies even to someone with a 20-year history. Citi denials routinely cite the count, not the age.
@@ -559,7 +571,9 @@ function validateDataPoint(dp, { candidateById, cardByName, aliasToName, usedSou
     const monthsAgo =
       (Number(THIS_MONTH.slice(0, 4)) - Number(dateApplied.slice(0, 4))) * 12 +
       (Number(THIS_MONTH.slice(5)) - Number(dateApplied.slice(5)));
-    if (monthsAgo > 12) errors.push(`date_applied is ${monthsAgo} months old — too stale for odds data`);
+    if (monthsAgo > MAX_DATA_POINT_AGE_MONTHS) {
+      errors.push(`date_applied is ${monthsAgo} months old — beyond the ${MAX_DATA_POINT_AGE_MONTHS}-month window`);
+    }
   }
 
   if (dp.result === 'approved') {

--- a/scripts/check-reddit-datapoints.test.js
+++ b/scripts/check-reddit-datapoints.test.js
@@ -18,6 +18,7 @@ const {
   fetchOpReplies,
   expandOpReplies,
   buildExtractPrompt,
+  validateDataPoint,
   CAPS,
 } = require('./check-reddit-datapoints.js');
 
@@ -241,6 +242,37 @@ test('buildExtractPrompt renders OP replies and documents how to read them', () 
   // The absence of replies must not render an empty label the model could
   // misread. Count only rendered candidate lines, not the instructions section.
   assert.equal((prompt.match(/^ {4}OP reply: /gm) || []).length, 1);
+});
+
+// The age window went 12 months -> 72 (Max, 2026-07-30): historical backfills
+// are the whole point of a multi-year sweep, and the old limit silently
+// rejected almost everything one would produce.
+test('date_applied is accepted back to 72 months and rejected beyond it', () => {
+  const ctx = () => ({
+    candidateById: new Map([['t3_abc', { id: 't3_abc', url: 'u', posted: '2020-06-01' }]]),
+    cardByName: new Map([['Chase Sapphire Preferred', {}]]),
+    aliasToName: new Map(),
+    usedSourceIds: new Set(),
+    importedIds: new Set(),
+  });
+  const dp = (date_applied) => ({
+    source_id: 't3_abc', permalink: 'u', card_name: 'Chase Sapphire Preferred',
+    result: 'approved', credit_score: 750, credit_score_source: 0, date_applied,
+  });
+  const ageErrors = (date) => validateDataPoint(dp(date), ctx()).errors.filter((e) => /months old/.test(e));
+
+  // THIS_MONTH is captured at module load, so derive the boundary rather than
+  // hardcoding dates that would rot the moment this file is read in a new month.
+  const now = new Date();
+  const shift = (months) => {
+    const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - months, 1));
+    return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+  };
+
+  assert.deepEqual(ageErrors(shift(0)), [], 'this month must be accepted');
+  assert.deepEqual(ageErrors(shift(71)), [], '71 months must be accepted');
+  assert.deepEqual(ageErrors(shift(72)), [], '72 months is the boundary and must be accepted');
+  assert.equal(ageErrors(shift(73)).length, 1, '73 months must be rejected');
 });
 
 run();


### PR DESCRIPTION
Max wants historical data points going back 6 years, dated by post month unless the post says otherwise. This removes the limit that made that impossible.

## What blocked it

One line in `check-reddit-datapoints.js`:

```js
if (monthsAgo > 12) errors.push(`date_applied is ${monthsAgo} months old — too stale for odds data`);
```

Reasonable when the only source was the daily routine, which never sees anything older than a few days. Fatal for a historical sweep — nearly every row a 6-year backfill produces would have been rejected by a rule written for a different job.

The import Lambda only rejects **future** dates, so this was the sole gate.

## Changes

- `MAX_DATA_POINT_AGE_MONTHS = 72`, named rather than inline, so the extraction prompt derives its own wording from the same constant and the two cannot disagree.
- **Requirement 5 rewritten.** It said *"the application happened within roughly the last 6 months … Skip stories about applications from years past"* — which would have told the model to discard exactly the data this backfill exists to collect. It now asks whether the application can be **dated**, not whether it is recent, and says outright not to skip a data point for being old.
- **`date_applied` guidance** encodes the rule directly: use the post's month, unless the post states the date explicitly, in which case the explicit date wins.

## One thing worth knowing

`refresh-card-stats.js` aggregates every record with `admin_review = 1 AND active = 1` and applies **no date filter and no recency weighting**. A 2020 approval will count exactly as much as one from last week, in both the headline approval rate and the median score / income / history.

That is pre-existing, not introduced here — but widening the intake window from 1 year to 6 makes it matter considerably more. I've recorded it in the constant's comment. Whether to weight or window the stats query is a separate decision and I haven't touched it.

## Testing

`node scripts/check-reddit-datapoints.test.js` — new case asserts the boundary precisely: this month, 71 and 72 months accepted; 73 rejected. It derives dates from the current month rather than hardcoding them, so it won't rot when read in a later month.

Verified against the real validator: `2020-07` accepted, `2020-06` rejected as "73 months old".