### PR TITLE
card page: make raw-data table columns sortable

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardRecordsTable.tsx
+++ b/apps/web-next/src/app/card/[name]/CardRecordsTable.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import type { CardRecord } from '@/lib/api';
 
 interface CardRecordsTableProps {
@@ -31,7 +32,70 @@ function formatYears(n: number | null): string {
   return `${n} yr${n === 1 ? '' : 's'}`;
 }
 
+type SortDir = 'asc' | 'desc';
+
+interface Column {
+  key: string;
+  label: string;
+  title?: string;
+  defaultDir: SortDir;
+  getValue: (r: CardRecord) => number | string | null;
+}
+
+const COLUMNS: Column[] = [
+  { key: 'result', label: 'Result', defaultDir: 'desc', getValue: (r) => r.result },
+  { key: 'score', label: 'Credit Score', defaultDir: 'desc', getValue: (r) => r.credit_score },
+  { key: 'income', label: 'Income', defaultDir: 'desc', getValue: (r) => r.listed_income },
+  { key: 'history', label: 'History', defaultDir: 'desc', getValue: (r) => r.length_credit },
+  {
+    key: 'inquiries',
+    label: 'Inq. 3/12/24',
+    title: 'Hard inquiries in the last 3 / 12 / 24 months',
+    defaultDir: 'asc',
+    // Counts are tiny, so weighting orders the 3/12/24 triple
+    // lexicographically as a single number; missing windows count as 0.
+    getValue: (r) => {
+      if ([r.inquiries_3, r.inquiries_12, r.inquiries_24].every((p) => p === null || p === undefined)) {
+        return null;
+      }
+      return (r.inquiries_3 ?? 0) * 1_000_000 + (r.inquiries_12 ?? 0) * 1_000 + (r.inquiries_24 ?? 0);
+    },
+  },
+  { key: 'bank', label: 'Bank cust.', defaultDir: 'desc', getValue: (r) => r.bank_customer },
+  {
+    key: 'outcome',
+    label: 'Outcome',
+    defaultDir: 'desc',
+    getValue: (r) => (r.result === 1 ? r.starting_credit_limit : r.reason_denied || null),
+  },
+  { key: 'applied', label: 'Applied', defaultDir: 'desc', getValue: (r) => {
+    const d = new Date(r.date_applied || r.submit_datetime);
+    return Number.isNaN(d.getTime()) ? null : d.getTime();
+  } },
+];
+
 export default function CardRecordsTable({ records }: CardRecordsTableProps) {
+  const [sort, setSort] = useState<{ key: string; dir: SortDir } | null>(null);
+
+  const sorted = useMemo(() => {
+    if (!sort) return records;
+    const col = COLUMNS.find((c) => c.key === sort.key);
+    if (!col) return records;
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    return [...records].sort((ra, rb) => {
+      const a = col.getValue(ra);
+      const b = col.getValue(rb);
+      // Missing values sink to the bottom regardless of direction.
+      if (a === null && b === null) return 0;
+      if (a === null) return 1;
+      if (b === null) return -1;
+      if (typeof a === 'number' && typeof b === 'number') return (a - b) * dir;
+      if (typeof a === 'string' && typeof b === 'string') return a.localeCompare(b) * dir;
+      // Outcome mixes credit limits and denial reasons — keep limits ahead.
+      return typeof a === 'number' ? -1 : 1;
+    });
+  }, [records, sort]);
+
   if (records.length === 0) {
     return (
       <div className="cj-verdict" style={{ marginTop: 16 }}>
@@ -40,24 +104,45 @@ export default function CardRecordsTable({ records }: CardRecordsTableProps) {
     );
   }
 
+  const handleSort = (col: Column) => {
+    setSort((prev) =>
+      prev?.key === col.key
+        ? { key: col.key, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+        : { key: col.key, dir: col.defaultDir },
+    );
+  };
+
   return (
     <div className="cj-records-wrap" style={{ marginTop: 16 }}>
       <div className="cj-records-scroll">
         <table className="cj-records-table">
           <thead>
             <tr>
-              <th>Result</th>
-              <th>Credit Score</th>
-              <th>Income</th>
-              <th>History</th>
-              <th title="Hard inquiries in the last 3 / 12 / 24 months">Inq. 3/12/24</th>
-              <th>Bank cust.</th>
-              <th>Outcome</th>
-              <th>Applied</th>
+              {COLUMNS.map((col) => {
+                const active = sort?.key === col.key;
+                return (
+                  <th
+                    key={col.key}
+                    aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : undefined}
+                  >
+                    <button
+                      type="button"
+                      className={`cj-records-sort${active ? ' is-active' : ''}`}
+                      onClick={() => handleSort(col)}
+                      title={col.title}
+                    >
+                      {col.label}
+                      <span className="cj-records-sort-arrow" aria-hidden="true">
+                        {active ? (sort!.dir === 'asc' ? '▲' : '▼') : '↕'}
+                      </span>
+                    </button>
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {records.map((r) => {
+            {sorted.map((r) => {
               const approved = r.result === 1;
               return (
                 <tr key={r.record_id}>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7895,6 +7895,37 @@
   background: rgba(210, 58, 98, 0.12);
   color: var(--warn);
 }
+.landing-v2 .cj-records-table thead th {
+  padding: 0;
+}
+.landing-v2 .cj-records-sort {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  padding: 10px 12px;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.landing-v2 .cj-records-sort:hover {
+  color: var(--ink);
+}
+.landing-v2 .cj-records-sort.is-active {
+  color: var(--accent);
+}
+.landing-v2 .cj-records-sort-arrow {
+  font-size: 8px;
+  opacity: 0.45;
+}
+.landing-v2 .cj-records-sort.is-active .cj-records-sort-arrow {
+  opacity: 1;
+}
 .landing-v2 .cj-chart-stage > .cj-chart-body {
   padding: 12px;
   min-width: 0;


### PR DESCRIPTION
## Summary
- Every column header on the Approval odds "Raw data" table is now a sort button: first click sorts by that column (sensible default direction per column — e.g. highest score/income/limit first, fewest inquiries first, newest applications first), second click reverses.
- Missing values ("—") always sink to the bottom regardless of direction.
- The mixed Outcome column sorts credit limits numerically ahead of denial reasons.
- Active column is highlighted with a solid ▲/▼ arrow and `aria-sort` for accessibility; inactive headers show a dim ↕ hint.

## Testing
- `tsc --noEmit` and ESLint pass.
- Verified in the browser on `/card/chase-freedom-unlimited` (n = 35): sorted Credit Score, Income, Outcome, and Applied in both directions; confirmed nulls-last, date ordering (Jul 2026 ↔ Jan 2018), and limits-before-denial-reasons in Outcome.