### PR TITLE
Reddit Data Points 2026-07-30

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1tx0mea.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tx0mea.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1tx0mea"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tx0mea/switching_to_travel_from_cashback/"
+posted: "2026-06-04"
+evidence: "Poster states they were denied for the Venture and then pre-approved for the VentureOne. No reason given and no date stated, so this is dated to the post month per the standing rule. Very high velocity, self described as roughly 12/24."
+card_name: "Capital One Venture Rewards"
+result: "denied"
+credit_score: 775
+credit_score_source: 0
+listed_income: 100000
+length_credit: 2
+date_applied: "2026-06"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1txv67x.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1txv67x.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1txv67x"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1txv67x/a_bit_lost_after_getting_amex_green_and_i_have/"
+posted: "2026-06-05"
+evidence: "Heavy churner at 6/24 who reports getting the Green in May 2026 and has already met its $4,000 spend. Card count is the seventeen open lines listed before this one."
+card_name: "American Express Green"
+result: "approved"
+credit_score: 786
+credit_score_source: 0
+listed_income: 96000
+length_credit: 9
+total_open_cards: 17
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1tzke34.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tzke34.yaml
@@ -1,0 +1,14 @@
+source_id: "t3_1tzke34"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tzke34/approval_odds_for_chase_freedom_unlimited/"
+posted: "2026-06-07"
+evidence: "Student with one card and twelve months of history, denied at a 751 Experian score on income grounds."
+card_name: "Blue Cash Everyday"
+result: "denied"
+credit_score: 751
+credit_score_source: 1
+listed_income: 13000
+length_credit: 1
+total_open_cards: 1
+date_applied: "2026-06"
+reason_denied: "Amex cited insufficient income and assets for the credit applied for"
+reason_denied_code: "income_too_low"

--- a/data/reddit-datapoints/2026-07-30-t3_1tzqxpc.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tzqxpc.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1tzqxpc"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tzqxpc/build_in_amex_ecosystem_now_recently_got_sub_for/"
+posted: "2026-06-07"
+evidence: "Approval taken from the poster's own card list, which dates the Venture X to 05/2026 with a $3,000 limit and confirms one card approved in the past six months. Income recorded as the floor of an open ended figure."
+card_name: "Capital One Venture X Rewards"
+result: "approved"
+credit_score: 750
+credit_score_source: 2
+listed_income: 200000
+length_credit: 5
+starting_credit_limit: 3000
+total_open_cards: 3
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1u38q5q.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1u38q5q.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1u38q5q"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1u38q5q/dp_approved_for_citi_double_cash_right_after/"
+posted: "2026-06-11"
+evidence: "Approved for $7,600 after an initial decline caused by entering $0 housing cost, resolved on a call. Same poster and day as the Wells Fargo Attune denial row."
+card_name: "Citi Double Cash"
+result: "approved"
+credit_score: 797
+credit_score_source: 1
+listed_income: 90000
+starting_credit_limit: 7600
+inquiries_12: 1
+inquiries_24: 2
+date_applied: "2026-06"

--- a/data/reddit-datapoints/2026-07-30-t3_1u38q5q_2.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1u38q5q_2.yaml
@@ -1,0 +1,14 @@
+source_id: "t3_1u38q5q#2"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1u38q5q/dp_approved_for_citi_double_cash_right_after/"
+posted: "2026-06-11"
+evidence: "Same poster, same day as the Citi Double Cash approval. Wells Fargo pulled Experian, which is the score recorded here, and confirmed the reason on the reconsideration line."
+card_name: "Wells Fargo Attune"
+result: "denied"
+credit_score: 797
+credit_score_source: 1
+listed_income: 90000
+inquiries_12: 1
+inquiries_24: 2
+date_applied: "2026-06"
+reason_denied: "Wells Fargo cited duplicate applications"
+reason_denied_code: "other"

--- a/data/reddit-datapoints/2026-07-30-t3_1u5lk9x.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1u5lk9x.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1u5lk9x"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1u5lk9x/got_approved_for_the_amazon_prime_visa_card/"
+posted: "2026-06-14"
+evidence: "Approved with only two months of credit history at a 703 score, after the application went to further review. Poster credits a four year Chase banking relationship."
+card_name: "Amazon Prime Rewards Visa Signature"
+result: "approved"
+credit_score: 703
+credit_score_source: 0
+length_credit: 0
+total_open_cards: 1
+bank_customer: true
+date_applied: "2026-06"

--- a/data/reddit-datapoints/2026-07-30-t3_1u5vg3f.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1u5vg3f.yaml
@@ -1,0 +1,16 @@
+source_id: "t3_1u5vg3f"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1u5vg3f/help_denied_for_chase_ink_business_cash_cic_at/"
+posted: "2026-06-14"
+evidence: "Denied on an application dated 2026-06-11 at 3/24. Score is the Experian figure printed on the denial letter itself rather than the poster's own pull, which is the strongest provenance available."
+card_name: "Ink Business Cash"
+result: "denied"
+credit_score: 763
+credit_score_source: 1
+listed_income: 97300
+length_credit: 13
+total_open_cards: 22
+inquiries_12: 5
+inquiries_24: 5
+date_applied: "2026-06"
+reason_denied: "Too many active accounts, a recent Chase business card, too many inquiries, business too new"
+reason_denied_code: "other"

--- a/data/reddit-datapoints/2026-07-30-t3_1u67kx3.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1u67kx3.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1u67kx3"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1u67kx3/unsure_whether_to_keep_my_new_credit_card_or/"
+posted: "2026-06-15"
+evidence: "Approved with a $3,000 limit. The 788 is the score the poster says they normally sit at and had at application; the 763 they also mention is the post-application dip."
+card_name: "Capital One Savor Cash Rewards"
+result: "approved"
+credit_score: 788
+credit_score_source: 0
+listed_income: 42000
+length_credit: 3
+starting_credit_limit: 3000
+total_open_cards: 1
+date_applied: "2026-06"

--- a/data/reddit-datapoints/2026-07-30-t3_1u6o429.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1u6o429.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1u6o429"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1u6o429/should_i_stick_with_capital_one_quicksilver/"
+posted: "2026-06-15"
+evidence: "Rebuilding poster with no open cards, approved for the secured Quicksilver at a 575 TransUnion score. Useful low-score data point; the deposit had not been submitted yet at the time of writing."
+card_name: "Capital One Quicksilver Secured Cash Rewards"
+result: "approved"
+credit_score: 575
+credit_score_source: 2
+total_open_cards: 0
+date_applied: "2026-06"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1u6o429](https://www.reddit.com/r/CreditCards/comments/1u6o429/should_i_stick_with_capital_one_quicksilver/) | Capital One Quicksilver Secured Cash Rewards | approved | 575 | — | — | — | 2026-06 | `2026-07-30-t3_1u6o429.yaml` |
| [t3_1tx0mea](https://www.reddit.com/r/CreditCards/comments/1tx0mea/switching_to_travel_from_cashback/) | Capital One Venture Rewards | denied | 775 | $100,000 | — | 2 | 2026-06 | `2026-07-30-t3_1tx0mea.yaml` |
| [t3_1u67kx3](https://www.reddit.com/r/CreditCards/comments/1u67kx3/unsure_whether_to_keep_my_new_credit_card_or/) | Capital One Savor Cash Rewards | approved | 788 | $42,000 | $3,000 | 3 | 2026-06 | `2026-07-30-t3_1u67kx3.yaml` |
| [t3_1u5lk9x](https://www.reddit.com/r/CreditCards/comments/1u5lk9x/got_approved_for_the_amazon_prime_visa_card/) | Amazon Prime Rewards Visa Signature | approved | 703 | — | — | 0 | 2026-06 | `2026-07-30-t3_1u5lk9x.yaml` |
| [t3_1u5vg3f](https://www.reddit.com/r/CreditCards/comments/1u5vg3f/help_denied_for_chase_ink_business_cash_cic_at/) | Ink Business Cash | denied | 763 | $97,300 | — | 13 | 2026-06 | `2026-07-30-t3_1u5vg3f.yaml` |
| [t3_1u38q5q](https://www.reddit.com/r/CreditCards/comments/1u38q5q/dp_approved_for_citi_double_cash_right_after/) | Citi Double Cash | approved | 797 | $90,000 | $7,600 | — | 2026-06 | `2026-07-30-t3_1u38q5q.yaml` |
| [t3_1u38q5q#2](https://www.reddit.com/r/CreditCards/comments/1u38q5q/dp_approved_for_citi_double_cash_right_after/) | Wells Fargo Attune | denied | 797 | $90,000 | — | — | 2026-06 | `2026-07-30-t3_1u38q5q_2.yaml` |
| [t3_1tzke34](https://www.reddit.com/r/CreditCards/comments/1tzke34/approval_odds_for_chase_freedom_unlimited/) | Blue Cash Everyday | denied | 751 | $13,000 | — | 1 | 2026-06 | `2026-07-30-t3_1tzke34.yaml` |
| [t3_1tzqxpc](https://www.reddit.com/r/CreditCards/comments/1tzqxpc/build_in_amex_ecosystem_now_recently_got_sub_for/) | Capital One Venture X Rewards | approved | 750 | $200,000 | $3,000 | 5 | 2026-05 | `2026-07-30-t3_1tzqxpc.yaml` |
| [t3_1txv67x](https://www.reddit.com/r/CreditCards/comments/1txv67x/a_bit_lost_after_getting_amex_green_and_i_have/) | American Express Green | approved | 786 | $96,000 | — | 9 | 2026-05 | `2026-07-30-t3_1txv67x.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
