### PR TITLE
reddit data points: catch the same application reported in two posts

### DIFF
--- a/scripts/check-reddit-datapoints.js
+++ b/scripts/check-reddit-datapoints.js
@@ -149,19 +149,70 @@ function loadState() {
   }
 }
 
-// source_ids already sitting in data/reddit-datapoints/ (accepted + merged).
-function loadImportedSourceIds() {
-  if (!fs.existsSync(DATAPOINTS_DIR)) return new Set();
-  const ids = new Set();
+// Every data point already sitting in data/reddit-datapoints/ (accepted + merged).
+function loadImportedDataPoints() {
+  if (!fs.existsSync(DATAPOINTS_DIR)) return [];
+  const rows = [];
   for (const file of fs.readdirSync(DATAPOINTS_DIR).filter((f) => /\.ya?ml$/.test(f))) {
     try {
       const dp = yaml.load(fs.readFileSync(path.join(DATAPOINTS_DIR, file), 'utf8'));
-      if (dp && dp.source_id) ids.add(String(dp.source_id).replace(/#\d+$/, ''));
+      if (dp && dp.source_id) rows.push(dp);
     } catch {
       /* unparseable committed files are caught in review, not here */
     }
   }
-  return ids;
+  return rows;
+}
+
+// source_ids already sitting in data/reddit-datapoints/ (accepted + merged).
+function loadImportedSourceIds() {
+  return new Set(loadImportedDataPoints().map((dp) => String(dp.source_id).replace(/#\d+$/, '')));
+}
+
+// ── Cross-post duplicate detection ───────────────────────────────────────────
+//
+// source_id dedupe only catches the same POST twice. It cannot catch the same
+// APPLICATION written up in two different posts, which is common and gets more
+// common the harder we sweep: the same person posts "denied, what now?" and then
+// "here's my DP" ten days later, and a backfill querying by flair and then by
+// 199 card names hits both. Seen live on 2026-07-30 — one Blue Cash Everyday
+// denial at 644 Experian appeared as t3_1unbuu8 and t3_1uei5qj.
+//
+// Nothing downstream would catch it either: the import Lambda dedupes on
+// submitter_id, which is derived from source_id, so both rows insert and the
+// card's approval rate quietly counts one person twice.
+
+// Fields that would differ between two genuinely different people who happen to
+// share a card, outcome, score and month. Where BOTH rows carry one of these and
+// the values disagree, they are different applications.
+const DISTINGUISHING_FIELDS = ['listed_income', 'starting_credit_limit', 'total_open_cards', 'length_credit'];
+
+function monthsBetween(a, b) {
+  const [ay, am] = a.split('-').map(Number);
+  const [by, bm] = b.split('-').map(Number);
+  return Math.abs((ay - by) * 12 + (am - bm));
+}
+
+/**
+ * Does `dp` look like the same application as `other`, reported separately?
+ *
+ * Requires card, result and exact score to match, and the application month to
+ * be within one (people misremember whether they applied in late June or early
+ * July). Then: if any distinguishing field disagrees, they are different people
+ * and this is a coincidence, not a duplicate.
+ */
+function looksLikeSameApplication(dp, other) {
+  if (dp.card_name !== other.card_name) return false;
+  if (dp.result !== other.result) return false;
+  if (dp.credit_score !== other.credit_score) return false;
+  if (!dp.date_applied || !other.date_applied) return false;
+  if (monthsBetween(dp.date_applied, other.date_applied) > 1) return false;
+  for (const field of DISTINGUISHING_FIELDS) {
+    const a = dp[field];
+    const b = other[field];
+    if (a != null && b != null && a !== b) return false;
+  }
+  return true;
 }
 
 // ── Reddit fetching (same constraints as check-card-news.js: Atom only,
@@ -508,7 +559,7 @@ function isIntInRange(v, min, max) {
   return Number.isInteger(v) && v >= min && v <= max;
 }
 
-function validateDataPoint(dp, { candidateById, cardByName, aliasToName, usedSourceIds, importedIds }) {
+function validateDataPoint(dp, { candidateById, cardByName, aliasToName, usedSourceIds, importedIds, priorRecords = [] }) {
   const errors = [];
   const warnings = [];
 
@@ -602,6 +653,21 @@ function validateDataPoint(dp, { candidateById, cardByName, aliasToName, usedSou
   if (typeof dp.evidence === 'string' && dp.evidence.length > 300) {
     dp.evidence = `${dp.evidence.slice(0, 297)}…`;
     warnings.push('evidence truncated to 300 chars');
+  }
+
+  // Cross-post duplicate check, last because it needs the canonicalized
+  // card_name and the validated score/date above. Only meaningful on a row that
+  // is otherwise sound, so skip it when the row is already failing.
+  if (errors.length === 0) {
+    const twin = priorRecords.find((other) => looksLikeSameApplication(dp, other));
+    if (twin) {
+      errors.push(
+        `looks like the same application as ${twin.source_id} ` +
+          `(${dp.card_name}, ${dp.result}, score ${dp.credit_score}, ${dp.date_applied}) — ` +
+          `same application reported in two posts, or a genuine coincidence. Delete this file if it is a duplicate; ` +
+          `if the two are really different people, add a distinguishing field (${DISTINGUISHING_FIELDS.join('/')}) to tell them apart.`
+      );
+    }
   }
 
   return { errors, warnings };
@@ -763,8 +829,11 @@ function phaseFinish() {
   }
   const candidates = JSON.parse(fs.readFileSync(CANDIDATES_FILE, 'utf8'));
   const candidateById = new Map(candidates.map((c) => [c.id, c]));
-  const importedIds = loadImportedSourceIds();
+  const importedRecords = loadImportedDataPoints();
+  const importedIds = new Set(importedRecords.map((dp) => String(dp.source_id).replace(/#\d+$/, '')));
   const usedSourceIds = new Set();
+  // Grows as rows are accepted, so a batch is checked against itself too.
+  const priorRecords = [...importedRecords];
 
   const files = fs.readdirSync(PROPOSED_DIR).filter((f) => /\.ya?ml$/.test(f));
   if (files.length === 0) {
@@ -795,6 +864,7 @@ function phaseFinish() {
       aliasToName,
       usedSourceIds,
       importedIds,
+      priorRecords,
     });
     if (errors.length) {
       console.log(`✗ ${file}: ${errors.join('; ')}`);
@@ -805,6 +875,7 @@ function phaseFinish() {
     const filename = writeDataPointFile(dp);
     if (filename) {
       usedSourceIds.add(dp.source_id);
+      priorRecords.push(dp);
       written.push({ dp, filename });
     }
   }
@@ -843,6 +914,7 @@ if (require.main === module) {
 
 module.exports = {
   parseAtom,
+  looksLikeSameApplication,
   hasPlausibleScore,
   rankForExpansion,
   fetchOpReplies,

--- a/scripts/check-reddit-datapoints.test.js
+++ b/scripts/check-reddit-datapoints.test.js
@@ -19,6 +19,7 @@ const {
   expandOpReplies,
   buildExtractPrompt,
   validateDataPoint,
+  looksLikeSameApplication,
   CAPS,
 } = require('./check-reddit-datapoints.js');
 
@@ -273,6 +274,66 @@ test('date_applied is accepted back to 72 months and rejected beyond it', () => 
   assert.deepEqual(ageErrors(shift(71)), [], '71 months must be accepted');
   assert.deepEqual(ageErrors(shift(72)), [], '72 months is the boundary and must be accepted');
   assert.equal(ageErrors(shift(73)).length, 1, '73 months must be rejected');
+});
+
+// source_id dedupe catches the same POST twice. It cannot catch the same
+// APPLICATION written up in two posts, which is what actually happens: one Blue
+// Cash Everyday denial at 644 Experian appeared as both t3_1unbuu8 and
+// t3_1uei5qj on 2026-07-30. The import Lambda dedupes on submitter_id, derived
+// from source_id, so both would insert and count one person twice.
+test('looksLikeSameApplication catches the same application reported twice', () => {
+  const a = {
+    source_id: 't3_1unbuu8', card_name: 'Blue Cash Everyday', result: 'denied',
+    credit_score: 644, date_applied: '2026-06', total_open_cards: 2,
+  };
+  const retold = { ...a, source_id: 't3_1uei5qj' };
+  assert.equal(looksLikeSameApplication(retold, a), true, 'the retelling must be caught');
+
+  // Same story, month off by one — people misremember late June vs early July.
+  assert.equal(looksLikeSameApplication({ ...retold, date_applied: '2026-07' }, a), true);
+  assert.equal(looksLikeSameApplication({ ...retold, date_applied: '2026-09' }, a), false, 'two months apart is not the same application');
+});
+
+test('looksLikeSameApplication does not collapse two different people', () => {
+  const a = {
+    source_id: 't3_aaa', card_name: 'Chase Sapphire Preferred', result: 'approved',
+    credit_score: 750, date_applied: '2026-06', listed_income: 90000,
+  };
+  // Same popular card, same month, same score — but a different income, so a
+  // coincidence rather than a duplicate. This is the false positive that would
+  // silently discard real data if the check were keyed on card+score alone.
+  const other = { ...a, source_id: 't3_bbb', listed_income: 140000 };
+  assert.equal(looksLikeSameApplication(other, a), false);
+
+  // Differing on any distinguishing field is enough.
+  assert.equal(looksLikeSameApplication({ ...a, source_id: 't3_ccc', starting_credit_limit: 5000 },
+                                        { ...a, starting_credit_limit: 22000 }), false);
+
+  // And the obvious negatives.
+  assert.equal(looksLikeSameApplication({ ...a, card_name: 'Chase Freedom Unlimited' }, a), false);
+  assert.equal(looksLikeSameApplication({ ...a, result: 'denied' }, a), false);
+  assert.equal(looksLikeSameApplication({ ...a, credit_score: 751 }, a), false);
+});
+
+test('the finish phase rejects a duplicate row and names its twin', () => {
+  const existing = {
+    source_id: 't3_1unbuu8', card_name: 'Blue Cash Everyday', result: 'denied',
+    credit_score: 644, date_applied: '2026-06',
+  };
+  const dp = {
+    source_id: 't3_1uei5qj', permalink: 'u', card_name: 'Blue Cash Everyday',
+    result: 'denied', credit_score: 644, credit_score_source: 1, date_applied: '2026-06',
+  };
+  const { errors } = validateDataPoint(dp, {
+    candidateById: new Map([['t3_1uei5qj', { id: 't3_1uei5qj', url: 'u', posted: '2026-06-24' }]]),
+    cardByName: new Map([['Blue Cash Everyday', {}]]),
+    aliasToName: new Map(),
+    usedSourceIds: new Set(),
+    importedIds: new Set(),
+    priorRecords: [existing],
+  });
+  assert.equal(errors.length, 1, `expected exactly the duplicate error, got ${JSON.stringify(errors)}`);
+  assert.match(errors[0], /same application as t3_1unbuu8/);
 });
 
 run();


### PR DESCRIPTION
Adds cross-post duplicate detection to the finish phase. Requested by Max before grinding through the remaining ~417 backfill candidates.

## The gap

`source_id` dedupe catches the same **post** twice. It cannot catch the same **application** written up in two different posts — which happens routinely:

> One Blue Cash Everyday denial at 644 Experian appeared as **t3_1unbuu8** and **t3_1uei5qj**, ten days apart, same user.

I caught that by eye. **Nothing downstream would have.** `import-reddit-records.js` dedupes on `submitter_id`, which is derived from `source_id`, so both rows insert and the card's approval rate counts one person twice.

The risk scales with sweep intensity. A backfill querying by flair and then by 199 separate card names hits the same popular posts from multiple angles, and eyeballing ~100 proposed rows is not a control.

## The rule

`looksLikeSameApplication` requires:

- same `card_name`, same `result`, **exact** same `credit_score`
- `date_applied` within one month (people misremember late June vs early July)
- **and** no disagreement on `listed_income`, `starting_credit_limit`, `total_open_cards`, or `length_credit` where both rows carry a value

That last clause is the important one. Two different people who both got a Sapphire Preferred at 750 in June is common on a popular card — but they will almost never share an income *and* a starting limit. Keying on card+score alone would silently discard real data.

Runs last in `validateDataPoint` (needs the canonicalized `card_name` and validated score/date), only on rows that are otherwise sound. Rejects with a message naming the twin and what to do in either direction. Batches are checked against themselves as well as against everything already committed.

## Testing

`node scripts/check-reddit-datapoints.test.js` — three new cases:

- the real t3_1unbuu8 / t3_1uei5qj pair is caught, including the month-off-by-one variant, and two months apart is not
- two different people sharing card/score/month are **not** collapsed when income or starting limit differ
- the finish phase rejects the duplicate row and names its twin in the error

Also run against the 50 rows already in `data/reddit-datapoints/`: **no collisions**, confirming it isn't over-firing on real data.