### PR TITLE
Reddit Data Points 2026-07-30

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1toj88j.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1toj88j.yaml
@@ -1,0 +1,14 @@
+source_id: "t3_1toj88j"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1toj88j/college_student_20_desires_another_card_to/"
+posted: "2026-05-26"
+evidence: "Student denied with two cards of their own at a 773 Experian score. The issuer's wording is a textbook case for the too_few_accounts code rather than a history-length problem, since their oldest tradeline is 22 years old as an authorised user."
+card_name: "US Bank Altitude Connect"
+result: "denied"
+credit_score: 773
+credit_score_source: 1
+listed_income: 20000
+length_credit: 2
+total_open_cards: 2
+date_applied: "2026-05"
+reason_denied: "US Bank cited a limited number of satisfactory trade lines"
+reason_denied_code: "too_few_accounts"

--- a/data/reddit-datapoints/2026-07-30-t3_1tos6s3.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tos6s3.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1tos6s3"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tos6s3/citi_strata_elite_custom_cash_datapoint/"
+posted: "2026-05-27"
+evidence: "Instant approval with a $30,500 limit on 2026-05-26, applied minutes before the Custom Cash that was instantly denied. Existing Citi relationship of Double Cash plus Costco."
+card_name: "Citi Strata Elite"
+result: "approved"
+credit_score: 830
+credit_score_source: 0
+starting_credit_limit: 30500
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1tos6s3_2.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tos6s3_2.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1tos6s3#2"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tos6s3/citi_strata_elite_custom_cash_datapoint/"
+posted: "2026-05-27"
+evidence: "Instant denial minutes after the same issuer instantly approved this poster for the Strata Elite with a $30,500 limit. No reason given."
+card_name: "Citi Custom Cash"
+result: "denied"
+credit_score: 830
+credit_score_source: 0
+date_applied: "2026-05"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1tppqu1.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tppqu1.yaml
@@ -1,0 +1,9 @@
+source_id: "t3_1tppqu1"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tppqu1/approved_for_custom_cash_at_16_212/"
+posted: "2026-05-28"
+evidence: "Approved at 1/6 and 2/12 despite opening a card two weeks earlier. First Citi card, no prior relationship; Citi pulled Experian and quoted the 761 back to them."
+card_name: "Citi Custom Cash"
+result: "approved"
+credit_score: 761
+credit_score_source: 1
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1tq7l7t.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tq7l7t.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1tq7l7t"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tq7l7t/possible_travel_card_upgrade_csp/"
+posted: "2026-05-28"
+evidence: "Denied again after repeated attempts, including applying directly having been turned down by the pre-approval tool. Poster treats this as settled and is moving on to other premium cards."
+card_name: "Capital One Venture X Rewards"
+result: "denied"
+credit_score: 792
+credit_score_source: 0
+length_credit: 9
+total_open_cards: 8
+date_applied: "2026-05"
+reason_denied: "Capital One cited too many open accounts"
+reason_denied_code: "other"

--- a/data/reddit-datapoints/2026-07-30-t3_1trdi3u.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1trdi3u.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1trdi3u"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1trdi3u/ccs_with_relatively_lowspending_subs_to_get_for/"
+posted: "2026-05-29"
+evidence: "Poster confirms the CSP was approved in early May with a $7,500 limit, taking them to 5/24, and that they nearly met the $5k spend already."
+card_name: "Chase Sapphire Preferred"
+result: "approved"
+credit_score: 748
+credit_score_source: 1
+listed_income: 60000
+length_credit: 1
+starting_credit_limit: 7500
+total_open_cards: 4
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1trdy9d.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1trdy9d.yaml
@@ -1,0 +1,14 @@
+source_id: "t3_1trdy9d"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1trdy9d/i_was_denied_the_bilt_blue_and_the_wells_fargo/"
+posted: "2026-05-29"
+evidence: "Denied at a 753 score with no debt and $712 of split rent, which the poster finds hard to square with the stated reason."
+card_name: "Bilt Blue"
+result: "denied"
+credit_score: 753
+credit_score_source: 0
+listed_income: 50000
+length_credit: 3
+total_open_cards: 2
+date_applied: "2026-05"
+reason_denied: "Excessive obligations in relation to income"
+reason_denied_code: "income_too_low"

--- a/data/reddit-datapoints/2026-07-30-t3_1trdy9d_2.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1trdy9d_2.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1trdy9d#2"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1trdy9d/i_was_denied_the_bilt_blue_and_the_wells_fargo/"
+posted: "2026-05-29"
+evidence: "Second denial the same week as the Bilt Blue row, immediate rather than reviewed. No reason had arrived by the time of posting."
+card_name: "Wells Fargo Active Cash"
+result: "denied"
+credit_score: 753
+credit_score_source: 0
+listed_income: 50000
+length_credit: 3
+total_open_cards: 2
+date_applied: "2026-05"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1trkbx9.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1trkbx9.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1trkbx9"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1trkbx9/approved_dp_us_bank_altitude_connect_credit_card/"
+posted: "2026-05-30"
+evidence: "Instant approval with a $25,000 limit at 3/24, only US Bank relationship being a Cash+ card. Same poster as the June Sapphire Preferred approval, different card and month."
+card_name: "US Bank Altitude Connect"
+result: "approved"
+credit_score: 815
+credit_score_source: 0
+listed_income: 140000
+starting_credit_limit: 25000
+total_open_cards: 12
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1ts917g.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1ts917g.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1ts917g"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1ts917g/should_i_accept_the_amex_blue_cash_preferred_card/"
+posted: "2026-05-30"
+evidence: "Approved on a $21,000 income with eight inquiries on file; the poster is asking whether to accept now or wait for inquiries to age off."
+card_name: "Blue Cash Preferred"
+result: "approved"
+credit_score: 736
+credit_score_source: 0
+listed_income: 21000
+total_open_cards: 3
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1tt39du.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tt39du.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1tt39du"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tt39du/sw_premier_credit_card_approved/"
+posted: "2026-05-31"
+evidence: "Approved with a $12,100 limit on the 85k point offer, second Chase card. Income omitted because the poster only says low 40s. Chase pulled Experian and TransUnion."
+card_name: "Southwest Rapid Rewards Premier"
+result: "approved"
+credit_score: 806
+credit_score_source: 1
+starting_credit_limit: 12100
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1tt464s.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tt464s.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1tt464s"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tt464s/capital_one_venture_x_approval_dp_after_previous/"
+posted: "2026-05-31"
+evidence: "Rebuild data point: approved with a $10k limit three years after six cards were charged off, two of them Capital One's own. Score recorded is the Credit Karma TransUnion figure, which is a VantageScore; the poster also cites 660 Experian."
+card_name: "Capital One Venture X Rewards"
+result: "approved"
+credit_score: 720
+credit_score_source: 4
+listed_income: 95000
+starting_credit_limit: 10000
+total_open_cards: 10
+date_applied: "2026-05"

--- a/data/reddit-datapoints/2026-07-30-t3_1ttugri.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1ttugri.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1ttugri"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1ttugri/wf_active_cash_approval_dp/"
+posted: "2026-06-01"
+evidence: "Approved for $4,000 at 4/24 on the third attempt; the same card had denied them twice over the preceding eight months. Only Wells Fargo relationship is an Autograph opened ten months earlier."
+card_name: "Wells Fargo Active Cash"
+result: "approved"
+credit_score: 810
+credit_score_source: 0
+listed_income: 200000
+starting_credit_limit: 4000
+date_applied: "2026-06"

--- a/data/reddit-datapoints/2026-07-30-t3_1tvr8xp.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1tvr8xp.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1tvr8xp"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1tvr8xp/what_are_my_approval_odds_for_chase_sapphire/"
+posted: "2026-06-03"
+evidence: "Poster's own update reports approval after a verification call, with an $11,000 limit and the 150k point offer, at 4/24."
+card_name: "Chase Sapphire Reserve"
+result: "approved"
+credit_score: 773
+credit_score_source: 1
+listed_income: 100000
+length_credit: 2
+starting_credit_limit: 11000
+total_open_cards: 2
+date_applied: "2026-06"

--- a/data/reddit-datapoints/2026-07-30-t3_1uktdba.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1uktdba.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1uktdba"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1uktdba/ive_applied_to_amazon_prime_visa_and_apple_card/"
+posted: "2026-07-01"
+evidence: "Applicant has never held a credit card, denied for both cards they applied to. Thin file at a 726 Experian score with student loans paid on time."
+card_name: "Amazon Prime Rewards Visa Signature"
+result: "denied"
+credit_score: 726
+credit_score_source: 1
+listed_income: 42000
+total_open_cards: 0
+date_applied: "2026-07"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1uktdba_2.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1uktdba_2.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1uktdba#2"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1uktdba/ive_applied_to_amazon_prime_visa_and_apple_card/"
+posted: "2026-07-01"
+evidence: "Second of two same-day denials for a first time applicant with no credit card history."
+card_name: "Apple Card"
+result: "denied"
+credit_score: 726
+credit_score_source: 1
+listed_income: 42000
+total_open_cards: 0
+date_applied: "2026-07"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1uos07l.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1uos07l.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1uos07l"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1uos07l/denied_for_chase_slate_edge/"
+posted: "2026-07-06"
+evidence: "Denied and denied again on the reconsideration line, at a 615 score with three charge offs, one still unsettled. Chase did not state a reason, so none is recorded even though the charge offs are the obvious cause."
+card_name: "Chase Slate Edge"
+result: "denied"
+credit_score: 615
+credit_score_source: 0
+bank_customer: true
+date_applied: "2026-07"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1uq5bwc.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1uq5bwc.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1uq5bwc"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1uq5bwc/approved_for_fidelity_visa_with_18k_credit_line/"
+posted: "2026-07-07"
+evidence: "Approved with an $18,000 line at a 743 TransUnion score, holding roughly $150k in Fidelity assets."
+card_name: "Fidelity Rewards Visa Signature"
+result: "approved"
+credit_score: 743
+credit_score_source: 2
+starting_credit_limit: 18000
+date_applied: "2026-07"

--- a/data/reddit-datapoints/2026-07-30-t3_1ursc2c.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1ursc2c.yaml
@@ -1,0 +1,9 @@
+source_id: "t3_1ursc2c"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1ursc2c/chase_approved_me_at_524_for_csp/"
+posted: "2026-07-09"
+evidence: "Instant approval at 5/24, which the poster expected to block them until August. No new accounts or inquiries in the prior year."
+card_name: "Chase Sapphire Preferred"
+result: "approved"
+credit_score: 765
+credit_score_source: 0
+date_applied: "2026-07"

--- a/data/reddit-datapoints/2026-07-30-t3_1us4je3.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1us4je3.yaml
@@ -1,0 +1,9 @@
+source_id: "t3_1us4je3"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1us4je3/approved_without_preapproval/"
+posted: "2026-07-09"
+evidence: "Approved in under 30 seconds despite the card never appearing in the Chase app and pre-approval showing zero offers. No new card in over two years."
+card_name: "Chase Sapphire Reserve"
+result: "approved"
+credit_score: 809
+credit_score_source: 1
+date_applied: "2026-07"

--- a/data/reddit-datapoints/2026-07-30-t3_1ushhj7.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1ushhj7.yaml
@@ -1,0 +1,9 @@
+source_id: "t3_1ushhj7"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1ushhj7/from_a_300_capital_one_limit_to_810k_amex_at_19/"
+posted: "2026-07-10"
+evidence: "Nineteen year old reports applying for the Gold around June 20th and holding it now. The 705 is the score they cite for their Amex applications."
+card_name: "American Express Gold"
+result: "approved"
+credit_score: 705
+credit_score_source: 0
+date_applied: "2026-06"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1ursc2c](https://www.reddit.com/r/CreditCards/comments/1ursc2c/chase_approved_me_at_524_for_csp/) | Chase Sapphire Preferred | approved | 765 | — | — | — | 2026-07 | `2026-07-30-t3_1ursc2c.yaml` |
| [t3_1tt464s](https://www.reddit.com/r/CreditCards/comments/1tt464s/capital_one_venture_x_approval_dp_after_previous/) | Capital One Venture X Rewards | approved | 720 | $95,000 | $10,000 | — | 2026-05 | `2026-07-30-t3_1tt464s.yaml` |
| [t3_1tt39du](https://www.reddit.com/r/CreditCards/comments/1tt39du/sw_premier_credit_card_approved/) | Southwest Rapid Rewards Premier | approved | 806 | — | $12,100 | — | 2026-05 | `2026-07-30-t3_1tt39du.yaml` |
| [t3_1trkbx9](https://www.reddit.com/r/CreditCards/comments/1trkbx9/approved_dp_us_bank_altitude_connect_credit_card/) | US Bank Altitude Connect | approved | 815 | $140,000 | $25,000 | — | 2026-05 | `2026-07-30-t3_1trkbx9.yaml` |
| [t3_1ts917g](https://www.reddit.com/r/CreditCards/comments/1ts917g/should_i_accept_the_amex_blue_cash_preferred_card/) | Blue Cash Preferred | approved | 736 | $21,000 | — | — | 2026-05 | `2026-07-30-t3_1ts917g.yaml` |
| [t3_1trdy9d](https://www.reddit.com/r/CreditCards/comments/1trdy9d/i_was_denied_the_bilt_blue_and_the_wells_fargo/) | Bilt Blue | denied | 753 | $50,000 | — | 3 | 2026-05 | `2026-07-30-t3_1trdy9d.yaml` |
| [t3_1trdy9d#2](https://www.reddit.com/r/CreditCards/comments/1trdy9d/i_was_denied_the_bilt_blue_and_the_wells_fargo/) | Wells Fargo Active Cash | denied | 753 | $50,000 | — | 3 | 2026-05 | `2026-07-30-t3_1trdy9d_2.yaml` |
| [t3_1trdi3u](https://www.reddit.com/r/CreditCards/comments/1trdi3u/ccs_with_relatively_lowspending_subs_to_get_for/) | Chase Sapphire Preferred | approved | 748 | $60,000 | $7,500 | 1 | 2026-05 | `2026-07-30-t3_1trdi3u.yaml` |
| [t3_1tppqu1](https://www.reddit.com/r/CreditCards/comments/1tppqu1/approved_for_custom_cash_at_16_212/) | Citi Custom Cash | approved | 761 | — | — | — | 2026-05 | `2026-07-30-t3_1tppqu1.yaml` |
| [t3_1tq7l7t](https://www.reddit.com/r/CreditCards/comments/1tq7l7t/possible_travel_card_upgrade_csp/) | Capital One Venture X Rewards | denied | 792 | — | — | 9 | 2026-05 | `2026-07-30-t3_1tq7l7t.yaml` |
| [t3_1tos6s3](https://www.reddit.com/r/CreditCards/comments/1tos6s3/citi_strata_elite_custom_cash_datapoint/) | Citi Strata Elite | approved | 830 | — | $30,500 | — | 2026-05 | `2026-07-30-t3_1tos6s3.yaml` |
| [t3_1us4je3](https://www.reddit.com/r/CreditCards/comments/1us4je3/approved_without_preapproval/) | Chase Sapphire Reserve | approved | 809 | — | — | — | 2026-07 | `2026-07-30-t3_1us4je3.yaml` |
| [t3_1tos6s3#2](https://www.reddit.com/r/CreditCards/comments/1tos6s3/citi_strata_elite_custom_cash_datapoint/) | Citi Custom Cash | denied | 830 | — | — | — | 2026-05 | `2026-07-30-t3_1tos6s3_2.yaml` |
| [t3_1toj88j](https://www.reddit.com/r/CreditCards/comments/1toj88j/college_student_20_desires_another_card_to/) | US Bank Altitude Connect | denied | 773 | $20,000 | — | 2 | 2026-05 | `2026-07-30-t3_1toj88j.yaml` |
| [t3_1uq5bwc](https://www.reddit.com/r/CreditCards/comments/1uq5bwc/approved_for_fidelity_visa_with_18k_credit_line/) | Fidelity Rewards Visa Signature | approved | 743 | — | $18,000 | — | 2026-07 | `2026-07-30-t3_1uq5bwc.yaml` |
| [t3_1uos07l](https://www.reddit.com/r/CreditCards/comments/1uos07l/denied_for_chase_slate_edge/) | Chase Slate Edge | denied | 615 | — | — | — | 2026-07 | `2026-07-30-t3_1uos07l.yaml` |
| [t3_1uktdba](https://www.reddit.com/r/CreditCards/comments/1uktdba/ive_applied_to_amazon_prime_visa_and_apple_card/) | Amazon Prime Rewards Visa Signature | denied | 726 | $42,000 | — | — | 2026-07 | `2026-07-30-t3_1uktdba.yaml` |
| [t3_1uktdba#2](https://www.reddit.com/r/CreditCards/comments/1uktdba/ive_applied_to_amazon_prime_visa_and_apple_card/) | Apple Card | denied | 726 | $42,000 | — | — | 2026-07 | `2026-07-30-t3_1uktdba_2.yaml` |
| [t3_1tvr8xp](https://www.reddit.com/r/CreditCards/comments/1tvr8xp/what_are_my_approval_odds_for_chase_sapphire/) | Chase Sapphire Reserve | approved | 773 | $100,000 | $11,000 | 2 | 2026-06 | `2026-07-30-t3_1tvr8xp.yaml` |
| [t3_1ushhj7](https://www.reddit.com/r/CreditCards/comments/1ushhj7/from_a_300_capital_one_limit_to_810k_amex_at_19/) | American Express Gold | approved | 705 | — | — | — | 2026-06 | `2026-07-30-t3_1ushhj7.yaml` |
| [t3_1ttugri](https://www.reddit.com/r/CreditCards/comments/1ttugri/wf_active_cash_approval_dp/) | Wells Fargo Active Cash | approved | 810 | $200,000 | $4,000 | — | 2026-06 | `2026-07-30-t3_1ttugri.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
