### PR TITLE
Reddit Data Points 2026-07-30

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1sa50n3.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1sa50n3.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1sa50n3"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1sa50n3/best_balance_transfer_plan_with_a_628_credit/"
+posted: "2026-04-02"
+evidence: "Approved with a $1,000 limit and 21 months at zero interest while carrying about $12k of card debt at a 628 Experian score."
+card_name: "Chase Slate Edge"
+result: "approved"
+credit_score: 628
+credit_score_source: 1
+starting_credit_limit: 1000
+date_applied: "2026-04"

--- a/data/reddit-datapoints/2026-07-30-t3_1sa50n3_2.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1sa50n3_2.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1sa50n3#2"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1sa50n3/best_balance_transfer_plan_with_a_628_credit/"
+posted: "2026-04-02"
+evidence: "Second approval in the same run, taken deliberately to widen available credit rather than for rewards."
+card_name: "Capital One Platinum"
+result: "approved"
+credit_score: 628
+credit_score_source: 1
+starting_credit_limit: 3000
+date_applied: "2026-04"

--- a/data/reddit-datapoints/2026-07-30-t3_1sa50n3_3.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1sa50n3_3.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1sa50n3#3"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1sa50n3/best_balance_transfer_plan_with_a_628_credit/"
+posted: "2026-04-02"
+evidence: "Denied in the same period the poster was approved for two other cards, which makes the trio a useful contrast at a 628 score."
+card_name: "Wells Fargo Reflect"
+result: "denied"
+credit_score: 628
+credit_score_source: 1
+date_applied: "2026-04"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1sbrbac.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1sbrbac.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1sbrbac"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1sbrbac/please_help_did_the_no_ding_application_approved/"
+posted: "2026-04-03"
+evidence: "Unusual pairing: a 789 Experian score and $184k income, but Capital One's no-ding tool offered only the $200 secured Quicksilver, which the poster accepted by accident. Open-card count omitted because one of the listed cards is reporting as closed."
+card_name: "Capital One Quicksilver Secured Cash Rewards"
+result: "approved"
+credit_score: 789
+credit_score_source: 1
+listed_income: 184000
+length_credit: 7
+starting_credit_limit: 200
+date_applied: "2026-04"

--- a/data/reddit-datapoints/2026-07-30-t3_1seapn7.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1seapn7.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1seapn7"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1seapn7/what_card_to_get_for_best_current_sub_going_to_be/"
+posted: "2026-04-06"
+evidence: "Denied about a week before posting while at 0/24. The poster speculates it was because they had already taken this card's bonus and downgraded it, but Chase gave no reason, so none is recorded."
+card_name: "Ink Business Preferred"
+result: "denied"
+credit_score: 780
+credit_score_source: 0
+listed_income: 130000
+length_credit: 10
+total_open_cards: 8
+date_applied: "2026-03"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1shn9qd.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1shn9qd.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1shn9qd"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1shn9qd/chase_ink_business_preferred_524_denial_not/"
+posted: "2026-04-10"
+evidence: "Instant denial on a reapplication at 5/24 with an 818 TransUnion score. Two reconsideration reps confirmed the recently-opened-accounts reason is 5/24 and is not recon-able, which is the useful part of this data point."
+card_name: "Ink Business Preferred"
+result: "denied"
+credit_score: 818
+credit_score_source: 2
+total_open_cards: 6
+date_applied: "2026-04"
+reason_denied: "Chase cited recently opened accounts, which two recon reps confirmed means 5/24"
+reason_denied_code: "too_many_recent_accounts"

--- a/data/reddit-datapoints/2026-07-30-t3_1sivow9.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1sivow9.yaml
@@ -1,0 +1,9 @@
+source_id: "t3_1sivow9"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1sivow9/should_i_get_a_macys_or_jcp_card/"
+posted: "2026-04-11"
+evidence: "Poster mentions in passing that they were just approved for the secured Platinum at a 675 score, while asking about store cards."
+card_name: "Capital One Platinum Secured"
+result: "approved"
+credit_score: 675
+credit_score_source: 0
+date_applied: "2026-04"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1sivow9](https://www.reddit.com/r/CreditCards/comments/1sivow9/should_i_get_a_macys_or_jcp_card/) | Capital One Platinum Secured | approved | 675 | — | — | — | 2026-04 | `2026-07-30-t3_1sivow9.yaml` |
| [t3_1shn9qd](https://www.reddit.com/r/CreditCards/comments/1shn9qd/chase_ink_business_preferred_524_denial_not/) | Ink Business Preferred | denied | 818 | — | — | — | 2026-04 | `2026-07-30-t3_1shn9qd.yaml` |
| [t3_1seapn7](https://www.reddit.com/r/CreditCards/comments/1seapn7/what_card_to_get_for_best_current_sub_going_to_be/) | Ink Business Preferred | denied | 780 | $130,000 | — | 10 | 2026-03 | `2026-07-30-t3_1seapn7.yaml` |
| [t3_1sbrbac](https://www.reddit.com/r/CreditCards/comments/1sbrbac/please_help_did_the_no_ding_application_approved/) | Capital One Quicksilver Secured Cash Rewards | approved | 789 | $184,000 | $200 | 7 | 2026-04 | `2026-07-30-t3_1sbrbac.yaml` |
| [t3_1sa50n3](https://www.reddit.com/r/CreditCards/comments/1sa50n3/best_balance_transfer_plan_with_a_628_credit/) | Chase Slate Edge | approved | 628 | — | $1,000 | — | 2026-04 | `2026-07-30-t3_1sa50n3.yaml` |
| [t3_1sa50n3#2](https://www.reddit.com/r/CreditCards/comments/1sa50n3/best_balance_transfer_plan_with_a_628_credit/) | Capital One Platinum | approved | 628 | — | $3,000 | — | 2026-04 | `2026-07-30-t3_1sa50n3_2.yaml` |
| [t3_1sa50n3#3](https://www.reddit.com/r/CreditCards/comments/1sa50n3/best_balance_transfer_plan_with_a_628_credit/) | Wells Fargo Reflect | denied | 628 | — | — | — | 2026-04 | `2026-07-30-t3_1sa50n3_3.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
