### PR TITLE
Reddit Data Points 2026-07-30

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1rjdlw9.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1rjdlw9.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1rjdlw9"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1rjdlw9/venture_x_approval_suprisingly_30k_limit/"
+posted: "2026-03-03"
+evidence: "Approved with a $30,000 limit despite a previous Venture X that Capital One closed in 2023 over two bounced payments, and a late payment from two years earlier. Scores were split at the time: Experian 760 recorded here, with Equifax 716 and TransUnion 674."
+card_name: "Capital One Venture X Rewards"
+result: "approved"
+credit_score: 760
+credit_score_source: 1
+length_credit: 19
+starting_credit_limit: 30000
+date_applied: "2026-03"

--- a/data/reddit-datapoints/2026-07-30-t3_1rkbsst.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1rkbsst.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1rkbsst"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1rkbsst/two_barclays_cards_1_inquire/"
+posted: "2026-03-04"
+evidence: "Approved for $5,000, which the poster believes is the card's minimum, on an application they made by accident. Score is their TransUnion figure before the inquiry. Barclays granted a second card on the same pull, but that one is not in the catalog."
+card_name: "JetBlue Premier"
+result: "approved"
+credit_score: 710
+credit_score_source: 2
+starting_credit_limit: 5000
+date_applied: "2026-03"

--- a/data/reddit-datapoints/2026-07-30-t3_1rlaf0s.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1rlaf0s.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1rlaf0s"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1rlaf0s/citi_strata_elite_denial_what_to_say_to/"
+posted: "2026-03-05"
+evidence: "Denied at an 833 score on a $360k income with 3% utilisation, holding an existing Citi AAdvantage card. Five cards opened in the last twelve months but none in the last six. History length omitted because the poster gives average account age, not the oldest."
+card_name: "Citi Strata Elite"
+result: "denied"
+credit_score: 833
+credit_score_source: 0
+listed_income: 360000
+date_applied: "2026-03"
+reason_denied: "Citi cited too many recently opened accounts and short time since accounts were established"
+reason_denied_code: "too_many_recent_accounts"

--- a/data/reddit-datapoints/2026-07-30-t3_1t40ziz.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1t40ziz.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1t40ziz"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1t40ziz/9_credit_cards_at_19_10_months_of_credit_history/"
+posted: "2026-05-05"
+evidence: "Nineteen year old applied for the Customized Cash Rewards and Premium Rewards together and was denied only the latter. Score is their Experian figure as of the post, roughly five weeks after the application. No issuer reason given; the poster guesses it was the card's minimum credit line."
+card_name: "Bank of America Premium Rewards"
+result: "denied"
+credit_score: 712
+credit_score_source: 1
+date_applied: "2026-03"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-07-30-t3_1t40ziz_2.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1t40ziz_2.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1t40ziz#2"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1t40ziz/9_credit_cards_at_19_10_months_of_credit_history/"
+posted: "2026-05-05"
+evidence: "Approved on 2026-04-28 with a $500 limit and no hard pull, after freezing Experian following the soft pull. Poster notes the card had not yet reported when they quoted this score, so it is close to their score at application."
+card_name: "Robinhood Gold"
+result: "approved"
+credit_score: 712
+credit_score_source: 1
+starting_credit_limit: 500
+date_applied: "2026-04"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1t40ziz](https://www.reddit.com/r/CreditCards/comments/1t40ziz/9_credit_cards_at_19_10_months_of_credit_history/) | Bank of America Premium Rewards | denied | 712 | — | — | — | 2026-03 | `2026-07-30-t3_1t40ziz.yaml` |
| [t3_1t40ziz#2](https://www.reddit.com/r/CreditCards/comments/1t40ziz/9_credit_cards_at_19_10_months_of_credit_history/) | Robinhood Gold | approved | 712 | — | $500 | — | 2026-04 | `2026-07-30-t3_1t40ziz_2.yaml` |
| [t3_1rlaf0s](https://www.reddit.com/r/CreditCards/comments/1rlaf0s/citi_strata_elite_denial_what_to_say_to/) | Citi Strata Elite | denied | 833 | $360,000 | — | — | 2026-03 | `2026-07-30-t3_1rlaf0s.yaml` |
| [t3_1rkbsst](https://www.reddit.com/r/CreditCards/comments/1rkbsst/two_barclays_cards_1_inquire/) | JetBlue Premier | approved | 710 | — | $5,000 | — | 2026-03 | `2026-07-30-t3_1rkbsst.yaml` |
| [t3_1rjdlw9](https://www.reddit.com/r/CreditCards/comments/1rjdlw9/venture_x_approval_suprisingly_30k_limit/) | Capital One Venture X Rewards | approved | 760 | — | $30,000 | 19 | 2026-03 | `2026-07-30-t3_1rjdlw9.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
