### PR TITLE
Reddit Data Points 2026-07-30

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1q5a1bj.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1q5a1bj.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1q5a1bj"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1q5a1bj/denied_for_a_chase_business_cc_what_now/"
+posted: "2026-01-06"
+evidence: "Denied on 2025-12-31 and again on reconsideration at an 820 score while only 4/24 on personal cards. The rep told them Chase was already extending a lot of credit, which suggests a business-side velocity limit distinct from 5/24."
+card_name: "Ink Business Cash"
+result: "denied"
+credit_score: 820
+credit_score_source: 0
+total_open_cards: 4
+date_applied: "2025-12"
+reason_denied: "Chase cited two business cards opened recently"
+reason_denied_code: "too_many_recent_accounts"

--- a/data/reddit-datapoints/2026-07-30-t3_1q6jmof.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1q6jmof.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1q6jmof"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1q6jmof/chase_reconsideration_line_approved/"
+posted: "2026-01-07"
+evidence: "Rebuild case and the second lowest score in the dataset. Declined, declined again on reconsideration for poor credit history with apartment debt in collections, then approved for $500 after the poster removed fraud alerts from their reports. Chase pulled TransUnion, recorded here; Experian was 658."
+card_name: "Chase Freedom Rise"
+result: "approved"
+credit_score: 600
+credit_score_source: 2
+starting_credit_limit: 500
+bank_customer: true
+date_applied: "2026-01"

--- a/data/reddit-datapoints/2026-07-30-t3_1qiajls.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1qiajls.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1qiajls"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1qiajls/capital_one_savor_approval_odds/"
+posted: "2026-01-20"
+evidence: "Nineteen year old with no primary cards of their own, declined on 2025-12-31. Chase pulled TransUnion, which is the score recorded. History length omitted because the poster gives average account age."
+card_name: "Chase Freedom Unlimited"
+result: "denied"
+credit_score: 752
+credit_score_source: 2
+listed_income: 35000
+total_open_cards: 0
+date_applied: "2025-12"
+reason_denied_code: "not_specified"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1qiajls](https://www.reddit.com/r/CreditCards/comments/1qiajls/capital_one_savor_approval_odds/) | Chase Freedom Unlimited | denied | 752 | $35,000 | — | — | 2025-12 | `2026-07-30-t3_1qiajls.yaml` |
| [t3_1q6jmof](https://www.reddit.com/r/CreditCards/comments/1q6jmof/chase_reconsideration_line_approved/) | Chase Freedom Rise | approved | 600 | — | $500 | — | 2026-01 | `2026-07-30-t3_1q6jmof.yaml` |
| [t3_1q5a1bj](https://www.reddit.com/r/CreditCards/comments/1q5a1bj/denied_for_a_chase_business_cc_what_now/) | Ink Business Cash | denied | 820 | — | — | — | 2025-12 | `2026-07-30-t3_1q5a1bj.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
