### PR TITLE
Reddit Data Points 2026-07-30

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1qdwpw5.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1qdwpw5.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1qdwpw5"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1qdwpw5/im_18_with_3_credit_cards_did_i_do_the_right_thing/"
+posted: "2026-01-15"
+evidence: "Approved on 2026-01-01 with a $500 limit, nine months after opening their first card at eighteen. Score is the lower bound of the 760-770 range the poster reports for December."
+card_name: "Chase Freedom Rise"
+result: "approved"
+credit_score: 760
+credit_score_source: 0
+length_credit: 1
+starting_credit_limit: 500
+total_open_cards: 1
+date_applied: "2026-01"

--- a/data/reddit-datapoints/2026-07-30-t3_1qdwpw5_2.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1qdwpw5_2.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1qdwpw5#2"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1qdwpw5/im_18_with_3_credit_cards_did_i_do_the_right_thing/"
+posted: "2026-01-15"
+evidence: "Approved about two weeks after the Freedom Rise, with a $4,000 limit against that card's $500. Same poster, same reported score range."
+card_name: "Capital One Savor Cash Rewards"
+result: "approved"
+credit_score: 760
+credit_score_source: 0
+length_credit: 1
+starting_credit_limit: 4000
+total_open_cards: 2
+date_applied: "2026-01"

--- a/data/reddit-datapoints/2026-07-30-t3_1qj9jjd.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1qj9jjd.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1qj9jjd"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1qj9jjd/best_balance_transfer_card/"
+posted: "2026-01-21"
+evidence: "Declined while carrying $11k on a Discover card at 27% APR, with 21% overall utilisation across $53k of limits and no missed payments in nine years. Score is the lower bound of the 753-758 range the poster gives across three bureaus. Income omitted because they are a bartender with deliberately v…"
+card_name: "Citi Simplicity"
+result: "denied"
+credit_score: 753
+credit_score_source: 0
+total_open_cards: 5
+date_applied: "2026-01"
+reason_denied_code: "not_specified"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1qj9jjd](https://www.reddit.com/r/CreditCards/comments/1qj9jjd/best_balance_transfer_card/) | Citi Simplicity | denied | 753 | — | — | — | 2026-01 | `2026-07-30-t3_1qj9jjd.yaml` |
| [t3_1qdwpw5](https://www.reddit.com/r/CreditCards/comments/1qdwpw5/im_18_with_3_credit_cards_did_i_do_the_right_thing/) | Chase Freedom Rise | approved | 760 | — | $500 | 1 | 2026-01 | `2026-07-30-t3_1qdwpw5.yaml` |
| [t3_1qdwpw5#2](https://www.reddit.com/r/CreditCards/comments/1qdwpw5/im_18_with_3_credit_cards_did_i_do_the_right_thing/) | Capital One Savor Cash Rewards | approved | 760 | — | $4,000 | 1 | 2026-01 | `2026-07-30-t3_1qdwpw5_2.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
