### PR TITLE
Reddit Data Points 2026-07-30

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1pcazqw.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1pcazqw.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1pcazqw"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1pcazqw/0_balance_transfer_credit_card_question/"
+posted: "2025-12-02"
+evidence: "Approved for only $3,000 against $30,000 of debt they hoped to transfer. Strong provenance on the score: the poster states 760 was shown to them during the application itself."
+card_name: "Citi Simplicity"
+result: "approved"
+credit_score: 760
+credit_score_source: 0
+listed_income: 98500
+starting_credit_limit: 3000
+date_applied: "2025-12"

--- a/data/reddit-datapoints/2026-07-30-t3_1ptb8m6.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1ptb8m6.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1ptb8m6"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1ptb8m6/capital_one_venturex_business/"
+posted: "2025-12-22"
+evidence: "Third denial for this card in a year, at a 790 score. The poster checked all three bureaus and found no delinquency matching the stated reason, which is what makes this one worth keeping. Income recorded as the floor of an open ended figure."
+card_name: "Capital One Venture X Business"
+result: "denied"
+credit_score: 790
+credit_score_source: 0
+listed_income: 120000
+total_open_cards: 3
+date_applied: "2025-12"
+reason_denied: "Capital One cited delinquent past or present credit obligations"
+reason_denied_code: "recent_delinquency"

--- a/data/reddit-datapoints/2026-07-30-t3_1pwn2l1.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1pwn2l1.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1pwn2l1"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1pwn2l1/should_i_get_the_apple_card/"
+posted: "2025-12-27"
+evidence: "Approved at eighteen with two existing cards, posting to ask whether to accept it."
+card_name: "Apple Card"
+result: "approved"
+credit_score: 744
+credit_score_source: 0
+total_open_cards: 2
+date_applied: "2025-12"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1pwn2l1](https://www.reddit.com/r/CreditCards/comments/1pwn2l1/should_i_get_the_apple_card/) | Apple Card | approved | 744 | — | — | — | 2025-12 | `2026-07-30-t3_1pwn2l1.yaml` |
| [t3_1ptb8m6](https://www.reddit.com/r/CreditCards/comments/1ptb8m6/capital_one_venturex_business/) | Capital One Venture X Business | denied | 790 | $120,000 | — | — | 2025-12 | `2026-07-30-t3_1ptb8m6.yaml` |
| [t3_1pcazqw](https://www.reddit.com/r/CreditCards/comments/1pcazqw/0_balance_transfer_credit_card_question/) | Citi Simplicity | approved | 760 | $98,500 | $3,000 | — | 2025-12 | `2026-07-30-t3_1pcazqw.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
