### PR TITLE
Reddit Data Points 2026-07-30

### DIFF
--- a/data/reddit-datapoints/2026-07-30-t3_1vawzhg.yaml
+++ b/data/reddit-datapoints/2026-07-30-t3_1vawzhg.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1vawzhg"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vawzhg/dp_approved_for_woh_biz_card_at_824/"
+posted: "2026-07-30"
+evidence: "Poster reports approval with an 830 FICO and a $17k starting limit, noting they were at 8/24 on Chase velocity."
+card_name: "World of Hyatt Business"
+result: "approved"
+credit_score: 830
+credit_score_source: 0
+starting_credit_limit: 17000
+date_applied: "2026-07"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-30

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vawzhg](https://www.reddit.com/r/CreditCards/comments/1vawzhg/dp_approved_for_woh_biz_card_at_824/) | World of Hyatt Business | approved | 830 | — | $17,000 | — | 2026-07 | `2026-07-30-t3_1vawzhg.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
