### PR TITLE
Auto: Bank of America Premium Rewards Elite rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -32,6 +32,13 @@ benefits:
     description: "Priority Pass Select memberships for the primary cardholder and up to three authorized users"
     frequency: "ongoing"
     category: "lounge"
+  - name: "Airfare Points Savings"
+    value: 20
+    value_unit: "percent"
+    description: "Save 20% on domestic or international airfare in any class when you pay with points through BofA Travel or the Concierge."
+    frequency: "per_purchase"
+    category: "travel"
+    enrollment_required: false
 tags:
   - travel
   - rewards


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Bank of America Premium Rewards Elite**.

**Apply link (verify against this):** https://www.bankofamerica.com/credit-cards/products/premium-rewards-elite-credit-card/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
