### PR TITLE
Auto: Costco Anywhere Visa Business by Citi rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -14,6 +14,9 @@ rewards:
     value: 4
     unit: percent
     note: "4% on eligible gas and EV charging worldwide (first $7,000/year combined, then 1%); 5% at Costco gas stations."
+    spend_cap: 7000
+    cap_period: annual
+    rate_after_cap: 1
   - category: dining
     value: 3
     unit: percent


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Costco Anywhere Visa Business by Citi**.

**Apply link (verify against this):** https://www.citi.com/credit-cards/costco-anywhere-visa-business-card

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
