### PR TITLE
Auto: Delta SkyMiles Reserve Business American Express rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -111,6 +111,11 @@ benefits:
     description: "Zone 5 priority boarding, and unaccompanied cardmembers are added to the complimentary upgrade list"
     frequency: "ongoing"
     category: "travel"
+  - name: "Cell Phone Protection"
+    description: "Reimbursement for a damaged or stolen cell phone up to $800 per claim, 2 claims per 12 months, with a $50 deductible, when the prior month's wireless bill was paid with the card"
+    frequency: "per_claim"
+    category: "telecom"
+    enrollment_required: false
 our_take: >
   The Delta SkyMiles Reserve Business American Express is Delta's flagship
   business card, built around lounge access and elite status. It includes 15


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Delta SkyMiles Reserve Business American Express**.

**Apply link (verify against this):** https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
