### PR TITLE
Auto: Discover it Student Chrome rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/discover-it-student-chrome-card.yaml
+++ b/data/cards/discover-it-student-chrome-card.yaml
@@ -14,10 +14,16 @@ rewards:
     value: 2
     unit: percent
     note: "Up to $1,000/quarter combined with dining"
+    spend_cap: 1000
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: dining
     value: 2
     unit: percent
     note: "Up to $1,000/quarter combined with gas"
+    spend_cap: 1000
+    cap_period: quarterly
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: percent


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Discover it Student Chrome**.

**Apply link (verify against this):** https://www.discover.com/credit-cards/student/chrome-card.html

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
