### PR TITLE
Auto: Gemini Credit rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/gemini-credit.yaml
+++ b/data/cards/gemini-credit.yaml
@@ -14,10 +14,16 @@ rewards:
     value: 4
     unit: percent
     note: "Gas, EV charging, and transit combined: 4% on the first $300 in spend per month, then 1%; the cap resets on the 1st of each month"
+    spend_cap: 300
+    cap_period: monthly
+    rate_after_cap: 1
   - category: transit
     value: 4
     unit: percent
     note: "Shares the $300/month cap with gas and EV charging, then 1%; the cap resets on the 1st of each month"
+    spend_cap: 300
+    cap_period: monthly
+    rate_after_cap: 1
   - category: dining
     value: 3
     unit: percent


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Gemini Credit**.

**Apply link (verify against this):** https://www.gemini.com/credit-card

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
