### PR TITLE
Auto: Hilton Honors American Express Aspire rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -98,6 +98,11 @@ benefits:
     frequency: "annual"
     category: "entertainment"
     enrollment_required: true
+  - name: "Cell Phone Protection"
+    description: "Reimburses the lesser of repair or replacement cost after damage or theft, up to $800 per claim and 2 claims per 12 months, with a $50 deductible, when the wireless bill is paid with the card"
+    frequency: "per_claim"
+    category: "telecom"
+    enrollment_required: false
 tags:
   - hotel
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Hilton Honors American Express Aspire**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/hilton-honors-aspire/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
