### PR TITLE
Auto: Marriott Bonvoy Bevy American Express rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/marriott-bonvoy-bevy-american-express.yaml
+++ b/data/cards/marriott-bonvoy-bevy-american-express.yaml
@@ -30,10 +30,16 @@ rewards:
     value: 4
     unit: points_per_dollar
     note: "Restaurants worldwide and U.S. supermarkets (up to $15,000/yr combined, then 2x)"
+    spend_cap: 15000
+    cap_period: annual
+    rate_after_cap: 2
   - category: groceries
     value: 4
     unit: points_per_dollar
     note: "U.S. supermarkets and restaurants (up to $15,000/yr combined, then 2x)"
+    spend_cap: 15000
+    cap_period: annual
+    rate_after_cap: 2
   - category: everything_else
     value: 2
     unit: points_per_dollar


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Marriott Bonvoy Bevy American Express**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy-bevy/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
