### PR TITLE
Auto: Southwest Rapid Rewards Premier rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -15,10 +15,16 @@ rewards:
     value: 2
     unit: points_per_dollar
     note: "Grocery stores and restaurants (first $8,000/year)"
+    spend_cap: 8000
+    cap_period: annual
+    rate_after_cap: 1
   - category: dining
     value: 2
     unit: points_per_dollar
     note: "Grocery stores and restaurants (first $8,000/year)"
+    spend_cap: 8000
+    cap_period: annual
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: points_per_dollar


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Southwest Rapid Rewards Premier**.

**Apply link (verify against this):** https://creditcards.chase.com/travel-credit-cards/southwest/premier

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
