### PR TITLE
Auto: United Club Business rewards/benefits update — 2026-07-30

### DIFF
--- a/data/cards/united-club-business.yaml
+++ b/data/cards/united-club-business.yaml
@@ -108,6 +108,13 @@ benefits:
     description: "25% back as a statement credit on United inflight food, beverage, and Wi-Fi purchases and United Club premium drinks"
     frequency: "per_purchase"
     category: "travel"
+  - name: "Award Booking Mileage Discount"
+    value: 10
+    value_unit: "percent"
+    description: "Save 10% or more on the miles needed when booking United flights with miles; Premier members save even more"
+    frequency: "per_trip"
+    category: "travel"
+    enrollment_required: false
 our_take: >
   The United Club Business card is the lounge card: its headline benefit is a
   full United Club All Access membership, worth more than $750 a year on its


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **United Club Business**.

**Apply link (verify against this):** https://creditcards.chase.com/business-credit-cards/united/united-club-business

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
