### PR TITLE
Reddit Data Points 2026-07-31

### DIFF
--- a/data/reddit-datapoints/2026-07-31-t3_1vc3nji.yaml
+++ b/data/reddit-datapoints/2026-07-31-t3_1vc3nji.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1vc3nji"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vc3nji/credit_card_recommendation/"
+posted: "2026-07-31"
+evidence: "Poster says they applied for the Capital One Venture and were denied that day, citing a 790 score, $220k income, and three existing cards with no missed payments."
+card_name: "Capital One Venture Rewards"
+result: "denied"
+credit_score: 790
+credit_score_source: 0
+listed_income: 220000
+total_open_cards: 3
+date_applied: "2026-07"
+reason_denied_code: "not_specified"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-07-31

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vc3nji](https://www.reddit.com/r/CreditCards/comments/1vc3nji/credit_card_recommendation/) | Capital One Venture Rewards | denied | 790 | $220,000 | — | — | 2026-07 | `2026-07-31-t3_1vc3nji.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
