### PR TITLE
Add Brevo newsletter integration: audience sync + subscription settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@
   2026-07-09 during the us-east-1 migration. `VpcPrivateSubnetIds` is a legacy
   name from that era; the current subnets are default-VPC subnets, not private
   NAT-routed ones.)
+- **Outbound internet from the Lambdas works via a NAT *instance*** (not a
+  gateway): the Lambda subnets' route tables send `0.0.0.0/0` to EC2 instance
+  `i-0e8173934fd04cf85` in the shared VPC. This is what lets VPC-attached
+  Lambdas call Google (token verification, Places), GitHub, Brevo, etc. If
+  outbound calls from Lambdas ever start timing out, check that instance
+  before debugging application code — it is shared infrastructure this repo
+  does not manage.
 - The database (`database-3` cluster, us-east-1) is shared with other apps.
   CreditOdds connects as the schema-scoped user `creditodds_app` (grants on
   `creditodds.*` only). Never use the cluster `admin` user. The credential lives
@@ -124,6 +131,25 @@ current) but the **DB layer** (numeric `card_id`, `card_stats`, and CardWire
 `wire_changes` → social posts) silently stalled. When touching post-migration
 infra, check IAM policy Resource ARNs for stale `us-east-2` regions, not just
 workflow YAML.
+
+## Newsletter (Brevo)
+
+- Weekly newsletters are sent from **Brevo** (free tier: unlimited contacts,
+  300 emails/day). Campaigns are composed and sent in the Brevo UI; this repo
+  only manages the audience and subscription state.
+- **Audience sync**: `NewsletterSyncFunction` (daily, 06:15 UTC) mirrors
+  Firebase Auth users into the Brevo newsletter list — upserts everyone with
+  an email, prunes list members whose account no longer exists. Idempotent;
+  invoke it manually for a backfill. It never touches `emailBlacklisted`, so
+  unsubscribes always stick.
+- **Subscription state lives in Brevo only** (no DB column): the profile-page
+  toggle goes through `GET/PUT /newsletter-settings`, which reads/writes the
+  contact's `emailBlacklisted` flag — the same suppression the email
+  unsubscribe link uses.
+- **Stack params** (all `Default: ""`, integration no-ops until set):
+  `BrevoApiKey`, `BrevoNewsletterListId` (numeric list id), and
+  `FirebaseServiceAccountB64` (base64 service-account JSON — required for
+  `listUsers`/`deleteUser`; plain token verification never needed it).
 
 ## Database
 

--- a/apps/api/src/handlers/delete-account.js
+++ b/apps/api/src/handlers/delete-account.js
@@ -1,13 +1,11 @@
 // Delete account handler - removes user data but keeps records (data points)
 const mysql = require("../db");
-const admin = require('firebase-admin');
+const { initFirebase } = require('../lib/firebase-init');
+const brevo = require('../lib/brevo');
 
-// Initialize Firebase Admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp({
-    projectId: process.env.FIREBASE_PROJECT_ID || 'creditodds',
-  });
-}
+// Shared init: uses FIREBASE_SERVICE_ACCOUNT_B64 when present, which is what
+// makes the privileged deleteUser() call below actually succeed.
+const admin = initFirebase();
 
 const responseHeaders = {
   // Authenticated, user-specific responses: never cache at browser or any
@@ -78,6 +76,18 @@ exports.DeleteAccountHandler = async (event) => {
       // Log but don't fail if Firebase deletion fails
       // The user's data is already cleaned up
       console.error("Firebase user deletion failed:", firebaseError.message);
+    }
+
+    // 5. Remove from the newsletter audience (best-effort; the daily
+    // newsletter-sync prune also catches this if the call fails here)
+    const email = event.requestContext?.authorizer?.email;
+    if (email && brevo.isConfigured()) {
+      try {
+        await brevo.deleteContact(email);
+        console.info(`Brevo contact removed for ${userId}`);
+      } catch (brevoError) {
+        console.error("Brevo contact deletion failed:", brevoError.message);
+      }
     }
 
     return {

--- a/apps/api/src/handlers/newsletter-settings.js
+++ b/apps/api/src/handlers/newsletter-settings.js
@@ -1,0 +1,85 @@
+// /newsletter-settings — the authenticated user's newsletter subscription,
+// backed directly by Brevo (single source of truth for suppression, so the
+// in-app toggle and the email unsubscribe link can never disagree).
+//
+// GET returns { available, subscribed }. available=false means Brevo isn't
+// configured yet — the frontend hides the row entirely in that case.
+//
+// PUT { subscribed: boolean }:
+//   false -> emailBlacklisted=true (identical to clicking unsubscribe in an
+//            email: suppressed from all marketing sends).
+//   true  -> upsert into the newsletter list + emailBlacklisted=false. This
+//            is an explicit user opt-in, the one case where clearing the
+//            blacklist flag is legitimate.
+
+const brevo = require('../lib/brevo');
+
+const responseHeaders = {
+  // Authenticated, user-specific responses: never cache at browser or any
+  // shared edge (CloudFront/proxy). Belt-and-suspenders for routing the API
+  // through a CDN without leaking one user's data to another.
+  'Cache-Control': 'no-store',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+  'Access-Control-Allow-Methods': 'GET,PUT,OPTIONS',
+};
+
+function reply(statusCode, body) {
+  return { statusCode, headers: responseHeaders, body: JSON.stringify(body) };
+}
+
+exports.NewsletterSettingsHandler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: responseHeaders, body: '' };
+  }
+
+  const email = event.requestContext?.authorizer?.email;
+  if (!email) {
+    return reply(401, { error: 'Unauthorized' });
+  }
+
+  if (!brevo.isConfigured()) {
+    return reply(200, { available: false, subscribed: false });
+  }
+  const listId = brevo.listId();
+
+  try {
+    if (event.httpMethod === 'GET') {
+      const contact = await brevo.getContact(email);
+      const subscribed = Boolean(
+        contact &&
+          !contact.emailBlacklisted &&
+          (contact.listIds || []).includes(listId)
+      );
+      return reply(200, { available: true, subscribed });
+    }
+
+    if (event.httpMethod === 'PUT') {
+      let body;
+      try {
+        body = event.body ? JSON.parse(event.body) : {};
+      } catch {
+        return reply(400, { error: 'Invalid JSON body' });
+      }
+      if (typeof body.subscribed !== 'boolean') {
+        return reply(400, { error: 'subscribed must be a boolean' });
+      }
+
+      if (body.subscribed) {
+        await brevo.upsertContact(email, { listIds: [listId] });
+        await brevo.updateContact(email, { emailBlacklisted: false });
+      } else {
+        const contact = await brevo.getContact(email);
+        if (contact) {
+          await brevo.updateContact(email, { emailBlacklisted: true });
+        }
+      }
+      return reply(200, { available: true, subscribed: body.subscribed });
+    }
+
+    return reply(405, { error: 'Method not allowed' });
+  } catch (error) {
+    console.error('newsletter-settings error:', error);
+    return reply(500, { error: 'Internal server error' });
+  }
+};

--- a/apps/api/src/handlers/newsletter-sync.js
+++ b/apps/api/src/handlers/newsletter-sync.js
@@ -1,0 +1,102 @@
+// newsletter-sync — mirrors Firebase Auth users into the Brevo newsletter list.
+//
+// Runs on a daily EventBridge schedule (and can be invoked manually for a
+// backfill — the sync is idempotent, so backfill and incremental runs are the
+// same code path):
+//   1. Lists every Firebase user with an email (skipping disabled accounts).
+//   2. Upserts each into the Brevo newsletter list. Upserts never touch
+//      emailBlacklisted, so anyone who unsubscribed stays unsubscribed.
+//   3. Removes list members whose email no longer exists in Firebase
+//      (account deleted) — removed from the list only, not deleted from
+//      Brevo, so their unsubscribe history survives a re-signup.
+//
+// Requires BREVO_API_KEY + BREVO_LIST_ID and FIREBASE_SERVICE_ACCOUNT_B64
+// (listUsers is a privileged Admin API call). No-ops with a log line when
+// unconfigured so the stack deploys cleanly before the Brevo account exists.
+
+const { initFirebase } = require('../lib/firebase-init');
+const brevo = require('../lib/brevo');
+
+const UPSERT_CONCURRENCY = 5; // Brevo free tier allows ~10 req/s
+
+async function listAllFirebaseUsers(admin) {
+  const users = [];
+  let pageToken;
+  do {
+    const page = await admin.auth().listUsers(1000, pageToken);
+    users.push(...page.users);
+    pageToken = page.pageToken;
+  } while (pageToken);
+  return users;
+}
+
+function splitName(displayName) {
+  const name = (displayName || '').trim();
+  if (!name) return { FIRSTNAME: '', LASTNAME: '' };
+  const parts = name.split(/\s+/);
+  return { FIRSTNAME: parts[0], LASTNAME: parts.slice(1).join(' ') };
+}
+
+exports.NewsletterSyncHandler = async () => {
+  if (!brevo.isConfigured()) {
+    console.info('newsletter-sync: BREVO_API_KEY / BREVO_LIST_ID not set, skipping');
+    return { skipped: true, reason: 'brevo not configured' };
+  }
+  if (!process.env.FIREBASE_SERVICE_ACCOUNT_B64) {
+    console.info('newsletter-sync: FIREBASE_SERVICE_ACCOUNT_B64 not set, skipping');
+    return { skipped: true, reason: 'firebase credentials not configured' };
+  }
+
+  const admin = initFirebase();
+  const listId = brevo.listId();
+
+  const users = await listAllFirebaseUsers(admin);
+  const eligible = users.filter((u) => u.email && !u.disabled);
+  console.info(
+    `newsletter-sync: ${users.length} Firebase users, ${eligible.length} with email`
+  );
+
+  // Upsert in small batches to stay under Brevo's rate limit.
+  let upserted = 0;
+  const failures = [];
+  for (let i = 0; i < eligible.length; i += UPSERT_CONCURRENCY) {
+    const batch = eligible.slice(i, i + UPSERT_CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map((u) =>
+        brevo.upsertContact(u.email, {
+          attributes: splitName(u.displayName),
+          listIds: [listId],
+        })
+      )
+    );
+    results.forEach((r, idx) => {
+      if (r.status === 'fulfilled') {
+        upserted += 1;
+      } else {
+        failures.push({ email: batch[idx].email, error: r.reason?.message });
+      }
+    });
+  }
+  if (failures.length) {
+    console.error('newsletter-sync: upsert failures:', JSON.stringify(failures));
+  }
+
+  // Prune: list members with no matching Firebase account (deleted users).
+  const firebaseEmails = new Set(eligible.map((u) => u.email.toLowerCase()));
+  const listEmails = await brevo.getListEmails(listId);
+  const stale = listEmails.filter((email) => !firebaseEmails.has(email));
+  if (stale.length) {
+    await brevo.removeFromList(listId, stale);
+    console.info(`newsletter-sync: removed ${stale.length} stale contacts from list`);
+  }
+
+  const summary = {
+    firebase_users: users.length,
+    eligible: eligible.length,
+    upserted,
+    failed: failures.length,
+    removed_from_list: stale.length,
+  };
+  console.info('newsletter-sync: done', JSON.stringify(summary));
+  return summary;
+};

--- a/apps/api/src/lib/brevo.js
+++ b/apps/api/src/lib/brevo.js
@@ -1,0 +1,122 @@
+// Minimal Brevo (v3) API client for newsletter contact management.
+// Uses the runtime's global fetch (node22) — no SDK dependency.
+//
+// All functions throw on non-2xx responses (except where noted) with the
+// Brevo error body in the message so CloudWatch logs show the real cause.
+
+const BASE = 'https://api.brevo.com/v3';
+
+function apiKey() {
+  return process.env.BREVO_API_KEY || '';
+}
+
+function listId() {
+  const raw = process.env.BREVO_LIST_ID || '';
+  const id = parseInt(raw, 10);
+  return Number.isFinite(id) ? id : null;
+}
+
+// True when both the API key and the newsletter list id are configured.
+// Handlers no-op gracefully when this is false so the stack deploys and runs
+// before the Brevo account exists.
+function isConfigured() {
+  return Boolean(apiKey()) && listId() !== null;
+}
+
+async function request(method, path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      'api-key': apiKey(),
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    const err = new Error(`Brevo ${method} ${path} -> ${res.status}: ${text}`);
+    err.status = res.status;
+    throw err;
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+// Create-or-update a contact and link it to the given lists. Does NOT touch
+// emailBlacklisted, so contacts who unsubscribed via a campaign link stay
+// unsubscribed even though they remain list members.
+async function upsertContact(email, { attributes = {}, listIds = [] } = {}) {
+  return request('POST', '/contacts', {
+    email,
+    attributes,
+    listIds,
+    updateEnabled: true,
+  });
+}
+
+// Returns the contact object, or null when Brevo has never seen this email.
+async function getContact(email) {
+  try {
+    return await request('GET', `/contacts/${encodeURIComponent(email)}`);
+  } catch (err) {
+    if (err.status === 404) return null;
+    throw err;
+  }
+}
+
+// Partial update: pass only the fields to change, e.g.
+// { emailBlacklisted: true } or { listIds: [3] } / { unlinkListIds: [3] }.
+async function updateContact(email, fields) {
+  return request('PUT', `/contacts/${encodeURIComponent(email)}`, fields);
+}
+
+// Best-effort hard delete (used when a user deletes their account).
+// Missing contacts are not an error.
+async function deleteContact(email) {
+  try {
+    await request('DELETE', `/contacts/${encodeURIComponent(email)}`);
+    return true;
+  } catch (err) {
+    if (err.status === 404) return false;
+    throw err;
+  }
+}
+
+// All contact emails currently in a list (paginated, lowercased).
+async function getListEmails(id) {
+  const emails = [];
+  const limit = 500;
+  for (let offset = 0; ; offset += limit) {
+    const page = await request(
+      'GET',
+      `/contacts/lists/${id}/contacts?limit=${limit}&offset=${offset}`
+    );
+    const contacts = page?.contacts || [];
+    for (const c of contacts) {
+      if (c.email) emails.push(c.email.toLowerCase());
+    }
+    if (contacts.length < limit) break;
+  }
+  return emails;
+}
+
+// Remove emails from a list without deleting the contacts (keeps their
+// unsubscribe history intact). Brevo caps the batch at 150 emails.
+async function removeFromList(id, emails) {
+  for (let i = 0; i < emails.length; i += 150) {
+    await request('POST', `/contacts/lists/${id}/contacts/remove`, {
+      emails: emails.slice(i, i + 150),
+    });
+  }
+}
+
+module.exports = {
+  isConfigured,
+  listId,
+  upsertContact,
+  getContact,
+  updateContact,
+  deleteContact,
+  getListEmails,
+  removeFromList,
+};

--- a/apps/api/src/lib/firebase-init.js
+++ b/apps/api/src/lib/firebase-init.js
@@ -1,0 +1,31 @@
+// Shared firebase-admin initialization.
+//
+// Token *verification* (the API Gateway authorizer) works with just a project
+// id because it only fetches Google's public certificates. Privileged Admin
+// API calls — auth().listUsers(), auth().deleteUser() — need real service
+// account credentials, supplied as base64-encoded service-account JSON in
+// FIREBASE_SERVICE_ACCOUNT_B64 (stack param FirebaseServiceAccountB64).
+// Without it those calls fail with a credential error at call time; callers
+// that treat that as best-effort keep working as before.
+
+const admin = require('firebase-admin');
+
+function initFirebase() {
+  if (admin.apps.length) return admin;
+
+  const projectId = process.env.FIREBASE_PROJECT_ID || 'creditodds';
+  const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_B64 || '';
+
+  if (b64) {
+    const serviceAccount = JSON.parse(Buffer.from(b64, 'base64').toString('utf8'));
+    admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount),
+      projectId,
+    });
+  } else {
+    admin.initializeApp({ projectId });
+  }
+  return admin;
+}
+
+module.exports = { initFirebase };

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -38,6 +38,20 @@ Parameters:
     Description: Google Places API (New) key for the wallet "Best Card Here" feature
     NoEcho: true
     Default: ""
+  BrevoApiKey:
+    Type: String
+    Description: Brevo (v3) API key for newsletter contact sync and subscription management. Empty disables all Brevo integration (handlers no-op).
+    NoEcho: true
+    Default: ""
+  BrevoNewsletterListId:
+    Type: String
+    Description: Numeric id of the Brevo contact list that mirrors Firebase users (the weekly-newsletter audience).
+    Default: ""
+  FirebaseServiceAccountB64:
+    Type: String
+    Description: Base64-encoded Firebase service-account JSON. Needed for privileged Admin API calls (listUsers in newsletter-sync, deleteUser in delete-account); token verification works without it.
+    NoEcho: true
+    Default: ""
   IpHashPepper:
     Type: String
     Description: Server-side pepper used to hash visitor IPs into stable per-IP tokens for unique-click counting. Treat as a long-lived secret; rotating resets all uniqueness chains.
@@ -437,6 +451,9 @@ Resources:
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
           FIREBASE_PROJECT_ID: creditodds
+          FIREBASE_SERVICE_ACCOUNT_B64: !Ref FirebaseServiceAccountB64
+          BREVO_API_KEY: !Ref BrevoApiKey
+          BREVO_LIST_ID: !Ref BrevoNewsletterListId
       Events:
         DeleteAccount:
           Type: Api
@@ -449,6 +466,81 @@ Resources:
           Type: Api
           Properties:
             Path: /account
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
+  # ---- Newsletter (Brevo) ----
+  # Mirrors Firebase Auth users into the Brevo newsletter list once a day.
+  # Idempotent: the first configured run doubles as the initial backfill, and
+  # it can be invoked manually at any time (no HTTP route). Upserts never
+  # touch unsubscribe state; pruning removes deleted accounts from the list.
+  NewsletterSyncFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/newsletter-sync.NewsletterSyncHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 300
+      Description: Daily sync of Firebase users into the Brevo newsletter list
+      Environment:
+        Variables:
+          FIREBASE_PROJECT_ID: creditodds
+          FIREBASE_SERVICE_ACCOUNT_B64: !Ref FirebaseServiceAccountB64
+          BREVO_API_KEY: !Ref BrevoApiKey
+          BREVO_LIST_ID: !Ref BrevoNewsletterListId
+      Events:
+        DailySync:
+          Type: Schedule
+          Properties:
+            Schedule: cron(15 6 * * ? *)
+            Description: Sync Firebase users to the Brevo newsletter list
+            Enabled: true
+
+  # The authenticated user's newsletter subscription, backed directly by
+  # Brevo so the in-app toggle and email unsubscribe links share one source
+  # of truth (Brevo's suppression list).
+  NewsletterSettingsFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/newsletter-settings.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
+    Properties:
+      Handler: src/handlers/newsletter-settings.NewsletterSettingsHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 15
+      Description: "GET/PUT the authenticated user's newsletter subscription (Brevo-backed)"
+      Environment:
+        Variables:
+          BREVO_API_KEY: !Ref BrevoApiKey
+          BREVO_LIST_ID: !Ref BrevoNewsletterListId
+      Events:
+        GetNewsletterSettings:
+          Type: Api
+          Properties:
+            Path: /newsletter-settings
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        PutNewsletterSettings:
+          Type: Api
+          Properties:
+            Path: /newsletter-settings
+            Method: PUT
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        NewsletterSettingsOptions:
+          Type: Api
+          Properties:
+            Path: /newsletter-settings
             Method: OPTIONS
             RestApiId:
               Ref: CreditCardOddsAPI

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -9,7 +9,7 @@ import { useAuth } from "@/auth/AuthProvider";
 import { useUserSettings } from "@/user-settings/UserSettingsProvider";
 import UserAvatar from "@/components/user/UserAvatar";
 import { V2Footer } from "@/components/landing-v2/Chrome";
-import { getAllCards, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, getWalletEvents, deleteAccount, reorderWallet, WalletCard, WalletCardEvent, Card } from "@/lib/api";
+import { getAllCards, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, getWalletEvents, deleteAccount, reorderWallet, getNewsletterSettings, updateNewsletterSettings, NewsletterSettings, WalletCard, WalletCardEvent, Card } from "@/lib/api";
 import "../landing.css";
 import { getNews, NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
@@ -1643,11 +1643,49 @@ interface SettingsTabProps {
 
 function SettingsTab(props: SettingsTabProps) {
   const { email, handle, confirmingDelete, setConfirmingDelete, deleteConfirmText, setDeleteConfirmText, deletingAccount, onDeleteAccount, onLogout } = props;
-  const { authState } = useAuth();
+  const { authState, getToken } = useAuth();
   const { settings, setAvatarSeed } = useUserSettings();
   const [pendingSeed, setPendingSeed] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Newsletter subscription, backed by Brevo via /newsletter-settings. The
+  // row stays hidden until the status loads (and permanently when the
+  // backend reports the integration as unavailable or the fetch fails).
+  const [newsletter, setNewsletter] = useState<NewsletterSettings | null>(null);
+  const [newsletterSaving, setNewsletterSaving] = useState(false);
+  const [newsletterError, setNewsletterError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getToken();
+        if (!token) return;
+        const status = await getNewsletterSettings(token);
+        if (!cancelled) setNewsletter(status);
+      } catch {
+        // Leave the row hidden when the status can't be loaded.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [getToken]);
+
+  const handleNewsletterToggle = async () => {
+    if (!newsletter?.available || newsletterSaving) return;
+    setNewsletterSaving(true);
+    setNewsletterError(null);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error('Not authenticated');
+      const status = await updateNewsletterSettings(!newsletter.subscribed, token);
+      setNewsletter(status);
+    } catch {
+      setNewsletterError('Could not update, try again');
+    } finally {
+      setNewsletterSaving(false);
+    }
+  };
 
   // Same flicker guard as the Navbar: hold until /user-settings resolves so
   // we don't render the UID-seeded fallback before the saved seed lands.
@@ -1760,6 +1798,28 @@ function SettingsTab(props: SettingsTabProps) {
             <span style={{ fontSize: 11, color: 'var(--muted-2)' }}>{/* read-only */}</span>
           </div>
         ))}
+        {newsletter?.available && (
+          <div className="cj-settings-list">
+            <div className="cj-settings-k">Newsletter</div>
+            <div className="cj-settings-v">
+              {newsletter.subscribed ? 'weekly card news in your inbox' : 'not subscribed'}
+            </div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              {newsletterError && (
+                <span style={{ fontSize: 11.5, color: 'var(--warn)' }}>{newsletterError}</span>
+              )}
+              <button
+                type="button"
+                className="cj-settings-edit"
+                onClick={handleNewsletterToggle}
+                disabled={newsletterSaving}
+                style={{ opacity: newsletterSaving ? 0.5 : 1, cursor: newsletterSaving ? 'wait' : 'pointer' }}
+              >
+                {newsletterSaving ? 'saving…' : newsletter.subscribed ? 'unsubscribe →' : 'subscribe →'}
+              </button>
+            </div>
+          </div>
+        )}
         <div className="cj-settings-list">
           <div className="cj-settings-k">Sign out</div>
           <div className="cj-settings-v">end this session</div>

--- a/apps/web-next/src/app/unsubscribe/page.tsx
+++ b/apps/web-next/src/app/unsubscribe/page.tsx
@@ -1,0 +1,50 @@
+import { Metadata } from "next";
+import { V2Footer } from "@/components/landing-v2/Chrome";
+import "../landing.css";
+import "../static-pages.css";
+
+export const metadata: Metadata = {
+  title: "Unsubscribed",
+  description: "You have been unsubscribed from the CreditOdds newsletter.",
+  robots: { index: false, follow: false },
+  alternates: {
+    canonical: "https://creditodds.com/unsubscribe",
+  },
+};
+
+export default function UnsubscribePage() {
+  return (
+    <div className="landing-v2 static-v2">
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <span className="cj-crumb cj-crumb-current">Unsubscribe</span>
+        </nav>
+        <span className="cj-spacer" />
+      </div>
+
+      <div className="cj-layout">
+        <main className="cj-main-static">
+          <header className="cj-page-head">
+            <div className="cj-page-eyebrow">email · unsubscribe</div>
+            <h1 className="cj-page-h1">
+              You&apos;re <em className="cj-section-accent">unsubscribed.</em>
+            </h1>
+            <p className="cj-page-lede">
+              You&apos;ve been removed from the CreditOdds newsletter and won&apos;t
+              receive any more of these emails. You can keep using CreditOdds as
+              normal, and you&apos;re welcome back on the list anytime.
+            </p>
+          </header>
+
+          <p style={{ marginTop: "8px" }}>
+            <a className="cj-cta-btn" href="https://creditodds.com">
+              Back to CreditOdds
+            </a>
+          </p>
+        </main>
+      </div>
+
+      <V2Footer />
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1284,6 +1284,46 @@ export async function getLeaderboard(limit = 25): Promise<LeaderboardResponse> {
   return res.json();
 }
 
+// Newsletter subscription (Brevo-backed). available=false means the backend
+// has no Brevo credentials configured; the settings row hides itself then.
+export interface NewsletterSettings {
+  available: boolean;
+  subscribed: boolean;
+}
+
+export async function getNewsletterSettings(token: string): Promise<NewsletterSettings> {
+  const res = await fetch(`${API_BASE}/newsletter-settings`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to load newsletter settings: ${errorText}`);
+  }
+  return res.json();
+}
+
+export async function updateNewsletterSettings(
+  subscribed: boolean,
+  token: string
+): Promise<NewsletterSettings> {
+  const res = await fetch(`${API_BASE}/newsletter-settings`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ subscribed }),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to update newsletter settings: ${errorText}`);
+  }
+  return res.json();
+}
+
 // Delete user account (removes referrals and wallet, keeps records anonymized)
 export async function deleteAccount(token: string): Promise<{ message: string }> {
   const res = await fetch(`${API_BASE}/account`, {


### PR DESCRIPTION
## What this does

Sets up the plumbing for weekly newsletters via **Brevo** (free tier: unlimited contacts, 300 emails/day). Campaigns get composed and sent in the Brevo UI; this PR keeps the audience in sync with Firebase and gives users an in-app subscription toggle.

### Backend (`apps/api`)
- **`NewsletterSyncFunction`** — daily schedule (06:15 UTC), mirrors Firebase Auth users into the Brevo newsletter list:
  - upserts every non-disabled user with an email (FIRSTNAME/LASTNAME from displayName)
  - prunes list members whose Firebase account no longer exists (removed from the *list*, not deleted, so unsubscribe history survives)
  - **never touches `emailBlacklisted`** — someone who unsubscribed stays unsubscribed forever, no matter how often the sync runs
  - idempotent: the first configured run doubles as the initial backfill; safe to invoke manually
- **`NewsletterSettingsFunction`** — `GET/PUT /newsletter-settings` for the signed-in user, backed directly by Brevo's suppression state (single source of truth: the in-app toggle and the email unsubscribe link can never disagree). No DB involvement.
- **`delete-account`** — now also removes the Brevo contact (best-effort; the daily prune is the backstop), and switches to a shared `firebase-init` helper.
- **New stack params**, all `Default: ""` so every deploy (including CI) works before Brevo is configured — the handlers no-op with a log line until then:
  - `BrevoApiKey` (NoEcho)
  - `BrevoNewsletterListId`
  - `FirebaseServiceAccountB64` (NoEcho, base64 service-account JSON)

### Side fix
`delete-account`'s `admin.auth().deleteUser()` has been **silently failing in production**: firebase-admin was initialized with only a project id, which is enough to *verify* tokens but not for privileged Admin API calls (the error is caught and logged, so account rows were cleaned up but the Firebase auth record survived). Once `FirebaseServiceAccountB64` is set, the shared init gives it real credentials and deletion starts working. The same credential powers `listUsers()` in the sync.

### Frontend (`apps/web-next`)
- Profile → Settings: a **Newsletter** row with subscribe/unsubscribe. Hidden until the backend reports the integration available, so nothing shows up before the Brevo credentials are deployed.

### Docs
- CLAUDE.md: newsletter architecture section, plus a networking correction discovered while verifying egress: outbound internet from the VPC-attached Lambdas works via a **NAT instance** (`i-0e8173934fd04cf85`) in the shared VPC — relevant because the sync Lambda calls both Google and Brevo from inside the VPC.

## Not in this PR (manual, one-time)
Brevo account + sender-domain DNS, list creation, generating the Firebase service-account key, and one `sam deploy --parameter-overrides` to load the three params into the stack. Steps are in the session notes.

## Verification
- `sam validate --lint` passes; `sam build` of both new functions succeeds
- `node --check` on all touched handlers
- `tsc --noEmit` and `eslint --max-warnings=0` clean on the frontend changes
- Not exercised against a live Brevo account yet — the first configured sync run should be watched in CloudWatch (it logs a JSON summary)