### PR TITLE
Reddit Data Points 2026-08-01

### DIFF
--- a/data/reddit-datapoints/2026-08-01-t3_1vcgb5x.yaml
+++ b/data/reddit-datapoints/2026-08-01-t3_1vcgb5x.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1vcgb5x"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vcgb5x/approved_for_savor_for_students_w_5000_cl_4/"
+posted: "2026-08-01"
+evidence: "Student poster reports approval with a 751 score, roughly $20k to $30k income, four months of personal credit history, and a $5,000 starting limit."
+card_name: "Capital One Savor Student Cash Rewards"
+result: "approved"
+credit_score: 751
+credit_score_source: 0
+listed_income: 20000
+starting_credit_limit: 5000
+date_applied: "2026-08"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-08-01

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vcgb5x](https://www.reddit.com/r/CreditCards/comments/1vcgb5x/approved_for_savor_for_students_w_5000_cl_4/) | Capital One Savor Student Cash Rewards | approved | 751 | $20,000 | $5,000 | — | 2026-08 | `2026-08-01-t3_1vcgb5x.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
