### PR TITLE
chore: refresh our_take editorial copy — 2026-08-01

### DIFF
--- a/data/cards/aaa-daily-advantage-visa-signature.yaml
+++ b/data/cards/aaa-daily-advantage-visa-signature.yaml
@@ -59,17 +59,18 @@ apr:
     min: 17.49
     max: 31.49
 our_take: >
-  The AAA Daily Advantage Visa Signature card offers a compelling 5% cash back
-  on groceries, but keep in mind the combined $500 annual cap with wholesale
-  clubs and gas/EV-charging stations, after which the rate drops to 1%. With
-  no annual fee and no foreign transaction fees, it makes for a cost-effective
-  option for everyday spending. The card also provides 3% cash back on gas, EV
-  charging, streaming, drugstores, and AAA purchases, which adds versatility
-  to its rewards structure. However, the cap on higher earn rates means it
-  might not be the best fit for heavy spenders in these categories. A $100
-  signup bonus for spending $1,000 in the first three months sweetens the
-  deal, and the AAA Redemption Bonus offers an extra 5% when redeeming with
-  AAA Northeast Counselors and Advisors.
+  The Daily Advantage is built around everyday spending: 5% back at grocery
+  stores and 3% at gas and EV-charging stations and wholesale clubs, with no
+  annual fee and no foreign transaction fee. The catch is the cap, and it is a
+  shared one: those top categories draw from a single $500 per year cash back
+  pool, after which everything drops to 1%. That works out to roughly $10,000
+  of grocery spending, or less if you split it across gas and club purchases,
+  so heavy spenders will hit the ceiling well before year-end. The 3% on
+  streaming and pharmacy purchases carries no cap, which makes those the
+  quietly durable rates here. A $100 bonus after $1,000 in the first three
+  months is modest but easy to clear, and the extra 5% when redeeming through
+  AAA Northeast counselors is a small bump if you already book travel that
+  way.
 benefits:
   - name: "AAA Redemption Bonus"
     description: "5% more cash back when redeeming with AAA Northeast Counselors and Advisors"

--- a/data/cards/aaa-travel-advantage-visa-signature.yaml
+++ b/data/cards/aaa-travel-advantage-visa-signature.yaml
@@ -49,16 +49,16 @@ apr:
     min: 17.49
     max: 31.49
 our_take: >
-  The AAA Travel Advantage Visa Signature card offers a standout 5% cash back
-  on gas and EV charging, making it a top choice for frequent drivers,
-  especially with no foreign transaction fees. However, be aware of the $350
-  annual cash back cap on the 5% category, after which the rate drops to 1%.
-  With no annual fee, the card also provides a solid 3% back on groceries,
-  dining, and travel, including AAA purchases, which adds versatility to its
-  rewards structure. The $100 cash signup bonus for spending $1,000 in the
-  first 3 months is a nice perk, though not industry-leading. While the
-  regular APR ranges from 17.49% to 31.49%, the real draw here is the card's
-  strong cash back rates for specific spending categories.
+  The Travel Advantage leads with 5% back at gas and EV-charging stations, a
+  strong rate for a card with no annual fee and no foreign transaction fee.
+  Read the cap before you plan around it: the 5% category is limited to $350
+  in cash back per year, roughly $7,000 of fuel spending, and drops to 1%
+  after that. Below that ceiling the card fills in reasonably well with 3% on
+  groceries, dining, and travel including AAA purchases, though everything
+  outside those categories earns just 1%. The $100 bonus after $1,000 in three
+  months is small but low-effort. This is a commuter's card more than a travel
+  card: if fuel is not a large share of your monthly spending, the headline
+  rate will not do much for you.
 benefits:
   - name: "AAA Redemption Bonus"
     description: "5% more cash back when redeeming with AAA Northeast Counselors and Advisors"

--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -70,14 +70,15 @@ benefits:
     enrollment_required: false
 apply_link: https://creditcards.chase.com/travel-credit-cards/aer-lingus
 our_take: >
-  The Aer Lingus Visa Signature card is a compelling option for frequent
-  travelers to Europe, offering 3 points per dollar on flights with Aer
-  Lingus, British Airways, and Iberia. Its standout feature is the 75,000-mile
-  signup bonus, which you can earn after spending $5,000 in the first three
-  months. The card also provides a 10% discount on Aer Lingus flights from the
-  US to Europe and priority boarding on flights between the US and Ireland,
-  enhancing the travel experience. However, the $95 annual fee and the $30,000
-  spend requirement to earn a complimentary companion ticket may be a hurdle
-  for some. With no foreign transaction fees and a 12-month 0% intro APR on
-  purchases, it's a solid choice for those who travel frequently with Aer
-  Lingus and its partners.
+  The pitch here is the 75,000-mile signup bonus after $5,000 in three months,
+  a large haul for a card with a $95 annual fee and no foreign transaction
+  fees. Ongoing earning is narrow, though: 3x applies only to Aer Lingus,
+  British Airways, and Iberia flights, 2x to hotels booked directly, and
+  everything else earns a flat 1x, which is thin for a card you are paying for
+  annually. The companion ticket is the one benefit that can justify renewal,
+  but it requires $30,000 of spending in a calendar year, a bar most
+  cardholders will not reach without deliberately routing spend here. Priority
+  boarding on US to Ireland flights, 10% off Aer Lingus flights to Europe
+  booked through the cardmember site, and DashPass when activated by the end
+  of 2027 round it out. Worth it if you actually fly Aer Lingus; otherwise
+  take the bonus and reassess at renewal.

--- a/data/cards/alliant-cashback-visa-signature.yaml
+++ b/data/cards/alliant-cashback-visa-signature.yaml
@@ -18,12 +18,13 @@ rewards:
     note: "Flat rate on all purchases since November 1, 2025; the previous 2.5% Tier One structure (with Alliant High-Rate Checking) has been discontinued"
 benefits: []
 our_take: >
-  The Alliant Cashback Visa Signature was for years the enthusiast favorite
-  for flat-rate cash back, paying 2.5% on up to $10,000 per billing cycle for
-  members who kept an Alliant High-Rate Checking account. That era is over:
-  Alliant cut the card to a flat 1.5% on all purchases effective November 1,
-  2025, and quietly closed it to new applicants, so existing cardholders keep
-  a now-ordinary card and everyone else cannot get it at all. At 1.5% with no
-  annual fee it still works fine as a keeper for members who already have it,
-  but there is no reason to chase it. Anyone hunting for above-2% flat cash
-  back today should look at cards like the US Bank Smartly instead.
+  Alliant has closed this card to new applications, so this is a note for
+  existing cardholders rather than a recommendation. As of November 1, 2025 it
+  pays a flat 1.5% on all purchases, replacing the old 2.5% Tier One structure
+  that required an Alliant High-Rate Checking account. That change removes
+  most of the reason people carried it: 1.5% flat with no annual fee is a fine
+  floor, but it is no longer distinctive, and there are no other benefits
+  attached. There is no foreign transaction fee, which is the one remaining
+  edge if you travel and have nothing better in the wallet. If you held it for
+  the 2.5% rate, it is worth checking whether a current flat-rate card would
+  do better on the same spending.

--- a/data/cards/amazon-business-prime-american-express-card.yaml
+++ b/data/cards/amazon-business-prime-american-express-card.yaml
@@ -41,14 +41,13 @@ tags:
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/amazon-business-prime-card/
 network: "amex"
 our_take: >
-  The Amazon Business Prime American Express card offers an impressive 5% cash
-  back on U.S. purchases at Amazon.com, Amazon Business, AWS, and Whole Foods
-  Market, up to $120,000 annually. This makes it a strong contender for
-  businesses that frequently shop with Amazon and its affiliates. With no
-  annual fee, it's an attractive option for cost-conscious business owners.
-  However, the card is no longer accepting new applications, which limits its
-  availability to new users. Beyond the Amazon-centric rewards, the card
-  offers 2% back at U.S. restaurants and gas stations, and 1% on other
-  purchases, which is decent but not exceptional. The $125 cash signup bonus
-  requires no spending, but with the card now closed to new applicants, this
-  perk is moot for those not already holding the card.
+  Amex stopped accepting new applications for this card in April 2026, so it
+  is only relevant if you already hold one. For those who do, it remains a
+  strong business card on Amazon spending: 5% back at Amazon.com, Amazon
+  Business, AWS, and Whole Foods on up to $120,000 a year, which is a high
+  enough ceiling that most small businesses will never reach it. Outside that
+  lane it earns 2% at U.S. restaurants and gas stations and 1% on everything
+  else, so it is a specialist rather than a catch-all. There is no annual fee,
+  which means there is no cost to keeping it open for the Amazon and AWS rate
+  alone. If your business runs meaningful spending through Amazon or AWS, hold
+  onto it, because you cannot get it back once you close it.

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -51,17 +51,17 @@ page_check_url: https://creditcards.chase.com/cash-back-credit-cards/amazon-prim
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Amazon Prime Rewards Visa Signature card shines for Amazon Prime members
-  with a hefty 5% cash back on purchases at Amazon, Whole Foods Market,
-  Shopbop, and Chase Travel. The card also offers 2% back on dining, gas, and
-  transit, and 1% on everything else, making it a solid choice for everyday
-  spending. A $150 Amazon Gift Card is instantly loaded upon approval, though
-  it's worth noting that the signup bonus has recently been reduced from $200.
-  With no annual fee and no foreign transaction fees, this card is
-  cost-effective for frequent Amazon shoppers. However, without a Prime
-  membership, the Amazon and Whole Foods rate drops to 3%, which diminishes
-  its appeal. The additional travel and purchase protections are nice perks if
-  you travel often or want peace of mind on new purchases.
+  For a Prime member who buys regularly from Amazon, this is a straightforward
+  no-annual-fee win: 5% back at Amazon, Whole Foods, and Shopbop, plus 5% on
+  Chase Travel bookings, which is why it sits at #11 on our Best Cash Back
+  list. The 5% rates are tied to an eligible Prime membership and fall to 3%
+  without it, so factor the Prime cost in if you would not otherwise
+  subscribe. Beyond Amazon it is decent but not special: 2% on dining, gas,
+  and transit including rideshare, and 1% on everything else. The $150 gift
+  card at approval briefly rose to $200 in June before dropping back to $150
+  in July, so it is worth watching if you are not in a hurry to apply. No
+  foreign transaction fee and Chase's usual purchase and baggage protections
+  make it easy to keep around even when you are not shopping.
 benefits:
   - name: "Purchase Protection"
     description: "Covers eligible new purchases for 120 days from purchase date against damage or theft up to $500 per item"

--- a/data/cards/amazon-store-card.yaml
+++ b/data/cards/amazon-store-card.yaml
@@ -34,14 +34,16 @@ apr:
 apply_link: https://www.amazon.com/Synchrony-Bank-Amazon-com-Store-Card/dp/B008A0GNA8
 foreign_transaction_fee: false
 our_take: >
-  The Amazon Store card is a no-annual-fee option that shines for frequent
-  Amazon and Whole Foods shoppers, offering 5% cash back on purchases if you
-  have an eligible Prime membership. However, without Prime, that 5% reward
-  disappears, making the card far less appealing. The card also includes 0%
-  APR equal monthly payments for 6 to 24 months on qualifying Amazon
-  purchases, which can be useful for managing larger buys over time. Be aware
-  that this is a closed-loop card, meaning it's only accepted at Amazon and
-  select partners, limiting its versatility. Recent changes have eliminated
-  the signup bonus, so there's no upfront incentive to apply. Consider this
-  card if you're a dedicated Amazon shopper with Prime, but look elsewhere if
-  you need broader acceptance or rewards.
+  This is a closed-loop store card, usable only at Amazon, select Amazon
+  physical stores, Whole Foods via an in-store code, and merchants that accept
+  Amazon Pay, so it cannot function as a general-purpose card. Within that
+  boundary it pays 5% back at Amazon and Whole Foods, but only with an
+  eligible Prime membership: there is no 5% rate without Prime. The Prime Visa
+  earns the same 5% on Amazon and works everywhere else too, which makes the
+  store card hard to justify unless you specifically want the 0% equal monthly
+  payments financing on purchases between $50 and $599.99 over six months,
+  $600 and up over twelve, or twenty-four months on select items. Treat that
+  financing as the entire reason to apply, because the 29.49% regular APR is
+  punishing if you carry a balance outside a promotional plan. The approval
+  gift card has been shrinking too, from $60 down to $10 in June and to
+  nothing in July, so there is no meaningful signup incentive left.

--- a/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
+++ b/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
@@ -32,18 +32,18 @@ apply_link: https://www.citi.com/credit-cards/aadvantage-mile-up-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The American Airlines AAdvantage MileUp Mastercard is a solid choice for
-  frequent flyers who want to earn miles without paying an annual fee. With 2
-  miles per dollar on groceries and eligible American Airlines purchases, plus
-  1 mile per dollar on everything else, it offers a straightforward way to
-  accumulate miles. The card also includes a 15,000-mile signup bonus after
-  spending $500 in the first three months, which is a decent boost for new
-  cardholders. However, the regular APR ranges from 19.49% to 29.49%, so it's
-  best suited for those who can pay off their balance monthly. The 25%
-  discount on inflight food and beverages is a nice perk, but the foreign
-  transaction fee means it's less ideal for international travel. Overall,
-  it's a practical card for domestic travelers who fly American Airlines and
-  want to earn rewards without additional costs.
+  The MileUp is the entry point to AAdvantage: no annual fee, 15,000 miles
+  after just $500 in three months, and 2x miles at grocery stores, which is
+  unusual for a free airline card and earns it our Best No-Fee badge among
+  airline cards. That grocery rate is the real reason to carry it, since the
+  2x on airline purchases applies only to eligible American Airlines spending
+  and everything else earns 1x. What you do not get is the usual airline
+  perks: no free checked bag, no lounge access, and the only stated benefit is
+  25% off inflight food and beverage purchases on American flights. It also
+  charges foreign transaction fees, so leave it home on international trips
+  even though the miles are for an airline you fly abroad. Reasonable as a
+  low-cost way to keep an AAdvantage balance alive, but a paid AA card will
+  serve a frequent flyer better.
 benefits:
   - name: "Inflight Food & Beverage Discount"
     value: 25

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -90,10 +90,20 @@ apply_link: https://www.americanexpress.com/us/credit-cards/business/business-cr
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  Built for businesses with lumpy, varied spend: 4x auto-applies to your top
-  two categories each cycle (U.S. advertising, electronics and cloud, dining,
-  gas, transit, wireless) up to $150k a year, which beats fixed-category
-  business cards if your spending moves around. The catch is a $375 fee that you mostly justify through
-  the statement credits (FedEx/Grubhub/office supply, Walmart+, Squarespace),
-  so it pays off only if you actually use those. If you want simpler flat-rate
-  earning, the no-fee Blue Business Plus is the easier hold.
+  Business Gold's appeal is that you do not have to pick categories: it earns
+  4x automatically on your top two spending categories each billing cycle from
+  six eligible ones, including U.S. advertising, electronics and software or
+  cloud providers, restaurants, gas, transit, and wireless service, on up to
+  $150,000 of combined spending per year before dropping to 1x. The signup
+  bonus was raised in May from 100,000 to as high as 200,000 Membership
+  Rewards points after $15,000 in three months, though Amex words it as "as
+  high as" and your actual offer may come in lower. The $375 annual fee is
+  meant to be offset by credits rather than earnings: $240 a year at FedEx,
+  Grubhub, and office supply stores at $20 a month, $300 in annual ChatGPT
+  credits, $155 toward Walmart+, and $150 with Squarespace, nearly all
+  requiring enrollment and most metered out monthly. That structure only works
+  if your business genuinely uses those merchants, because unused monthly
+  credits do not roll over and the fee is charged regardless. Cell phone
+  protection up to $800 per claim and 3x on flights and prepaid hotels through
+  AmexTravel.com are useful extras, but the math lives or dies on whether your
+  top two categories are big enough to make the 4x rate meaningful.

--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -8,15 +8,19 @@ foreign_transaction_fee: false
 network: "amex"
 card_referral_link: "https://www.americanexpress.com/en-us/referral/personal/gold-card?ref="
 our_take: >
-  The American Express Gold card shines for foodies and travelers alike,
-  offering 4 points per dollar on dining and groceries, and 5 points per
-  dollar on hotels booked through Amex Travel. Its recent signup bonus
-  increase to 100,000 points for spending $8,000 in six months makes it even
-  more enticing. However, the $325 annual fee is a significant consideration,
-  though partially offset by $120 in annual Uber Cash and $120 in dining
-  credits. With no foreign transaction fees, it's a solid choice for
-  international travelers. Just be ready to enroll in various credits to
-  maximize value and consider if the benefits align with your spending habits.
+  The Gold is our #1 pick for dining and groceries because the earn rates are
+  genuinely best in class: 4x at restaurants on up to $50,000 a year and 4x at
+  U.S. supermarkets on up to $25,000, plus 5x on hotels prepaid through Amex
+  Travel and 3x on flights. A 100,000-point bonus after $8,000 in six months
+  is one of the larger offers available and lands it at #5 on our signup bonus
+  list. The $325 annual fee is the honest sticking point, and Amex expects you
+  to cover it with credits rather than points: $120 in Uber Cash, $120 in
+  dining credits at Grubhub, The Cheesecake Factory, Goldbelly, Wine.com, and
+  Five Guys, $84 at Dunkin', and $100 semiannually at Resy restaurants. Those
+  are doled out in $10 and $7 monthly slices at specific merchants and require
+  enrollment, so they only count if you actually spend there each month. If
+  you do not, judge the card on the 4x rates alone and decide whether your
+  grocery and restaurant spending clears $325 of value.
 annual_fee: 325
 benefits:
   - name: "Uber Cash"

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -7,17 +7,18 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/green/
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The American Express Green card stands out for frequent travelers and diners
-  with its 3 points per dollar on travel, transit, and dining purchases,
-  making it a strong choice for those who spend heavily in these categories.
-  The $150 annual fee is offset by valuable perks like the $209 annual CLEAR
-  Plus credit, which can enhance your airport experience, though enrollment is
-  required. A 40,000-point signup bonus after spending $3,000 in the first six
-  months sweetens the deal for new cardholders. However, if your spending
-  doesn't align with these categories, the 1 point per dollar on other
-  purchases may not justify the fee. With no foreign transaction fees, it's
-  also a good companion for international travel. Consider this card if you
-  can leverage the travel and dining rewards and benefits.
+  American Express stopped accepting new applications for the Green in late
+  July 2026, so this is now a card to evaluate only if you already hold it.
+  The math is straightforward: 3 points per dollar on travel, transit, and
+  dining against a $150 annual fee, with 1 point per dollar everywhere else
+  and no foreign transaction fees. The $219 annual CLEAR Plus credit alone can
+  cover the fee if you fly often enough to use it, and the 40,000-point bonus
+  after $3,000 in six months was reachable for anyone traveling regularly. The
+  catch is how narrow the rest of it is: outside those three categories the
+  card earns a flat 1x, and the Venue Collection perk, 10% back on stadium
+  concessions up to $250 a year, only matters if you attend events at
+  participating venues. Existing cardholders who don't use CLEAR should run
+  the numbers before paying the fee again.
 annual_fee: 150
 reward_type: "points"
 rewards:

--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -38,17 +38,17 @@ apply_link: https://www.apple.com/apple-card/
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Apple Card stands out for its seamless integration with Apple Pay,
-  offering 3% cash back on Apple purchases and select merchants like Nike and
-  Uber, and 2% on dining, transit, and groceries when using Apple Pay. There's
-  no annual fee, making it an attractive option for Apple enthusiasts who
-  frequently use Apple Pay. However, if you rely on the physical card, the
-  cash back drops to just 1% on all purchases, which is a significant
-  drawback. The card also includes some niche perks like a six-month free
-  trial of Uber One and travel credits on Booking.com, but these require
-  enrollment and might not appeal to everyone. Overall, it's a solid choice
-  for digital wallet users who can maximize the higher cash back rates through
-  Apple Pay.
+  The Apple Card's real draw is friction-free 2% Daily Cash on anything you
+  pay for with Apple Pay, with no annual fee and no foreign transaction fees.
+  That rises to 3% on Apple's own purchases and a short list of partner
+  merchants including Nike, Uber, Walgreens, Booking.com, Hertz, and Exxon
+  Mobil, again only through Apple Pay. The condition is the whole story: swipe
+  the physical titanium card and you drop to 1%, a below-average base rate, so
+  the card pays off only if Apple Pay covers most of your spending. There are
+  no rotating categories, no transfer partners, and no signup bonus, so what
+  you see is what you get. Extras like 2% in Booking.com Travel Credits
+  through the Apple Card portal and the Hertz rental discounts are pleasant
+  but minor.
 benefits:
   - name: "Booking.com Travel Credits"
     value: 2

--- a/data/cards/atlas-card.yaml
+++ b/data/cards/atlas-card.yaml
@@ -6,13 +6,19 @@ image: "atlas.png"
 apply_link: https://atlascard.com/
 foreign_transaction_fee: false
 our_take: >
-  At a $3,000 annual fee, the Atlas is an ultra-premium lifestyle card aimed at
-  high spenders who will actually use the concierge, private-aviation credits, and
-  curated dining and wellness perks. Earning is simple but thin (5x on Atlas Travel
-  bookings, 1x everything else), so the math rests on the $6,000 in annual travel
-  and experience credits and the member access rather than raw points. For most
-  travelers a card like the Amex Platinum at a fraction of the fee covers the
-  practical perks.
+  Atlas tripled its annual fee from $1,000 to $3,000 in June 2026, which
+  resets who this card makes sense for. The credits can outrun that fee on
+  paper: $3,000 toward private charter flights booked through Atlas Travel,
+  $1,000 for semi-private aviation with BLADE, JSX, Aero, and Slate, $1,000
+  toward business class fares on bookings of $5,000 or more, $1,000 for
+  ticketed experiences, and a $200 Erewhon credit. Every one of those is
+  shaped around a specific kind of spending, so the value is real only if
+  private and semi-private aviation is already part of your travel pattern.
+  Earning is thin outside the ecosystem: the 5 points per dollar rate applies
+  only to bookings made through Atlas Travel, and everything else earns a flat
+  1 point per dollar, though at least there are no foreign transaction fees.
+  Additional credits unlock at $100,000, $250,000, and $1,000,000 in annual
+  spend, which tells you plainly who the card is built for.
 annual_fee: 3000
 category: "travel"
 reward_type: "points"

--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -69,13 +69,16 @@ benefits:
     enrollment_required: false
 apply_link: https://www.bankofamerica.com/credit-cards/products/alaska-airlines-credit-card/
 our_take: >
-  The Atmos Rewards Ascent card offers a compelling signup bonus of 70,000
-  points after spending $2,500 in the first three months, plus a $99 Companion
-  Fare. This makes it an attractive option for frequent flyers looking to
-  maximize their travel rewards. You earn 3 points per dollar on airline
-  purchases, which is a strong rate for those who spend heavily on flights.
-  However, the $95 annual fee is a consideration, especially since the card's
-  other categories like gas, streaming, and transit earn only 2 points per
-  dollar. The annual Companion Fare can offset the fee if you meet the $6,000
-  spending requirement, but if your spending doesn't align with these
-  categories, you might find better value elsewhere.
+  The Ascent is the mid-tier Alaska and Hawaiian card: $95 a year for 3 points
+  per dollar on Alaska and Hawaiian Airlines purchases specifically, 2x on
+  gas, EV charging, streaming, and transit, and 1x on everything else. The
+  current offer is 70,000 points after $2,500 in three months plus a $99
+  Companion Fare, though that bonus has been unstable, climbing to 80,000 in
+  April, falling to 50,000 in May, and settling back at 70,000 in July, so
+  it's worth watching the offer before you apply. The recurring $99 Companion
+  Fare after $6,000 of annual spend, plus a free checked bag and preferred
+  boarding for you and up to six guests on the same reservation, is where the
+  fee earns itself back. It currently ranks #9 on our Best Travel Credit Cards
+  list. Just note that the 3x rate is limited to Alaska and Hawaiian
+  purchases, so if you don't fly them this is really a 2x card in a handful of
+  categories.

--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -14,19 +14,18 @@ check_ignore:
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Atmos Rewards Business card from Bank of America is a strong contender
-  for businesses that frequently book flights with Alaska Airlines, offering 3
-  points per dollar on airline purchases and a 70,000-point signup bonus after
-  spending $4,000 in the first 90 days. The card also comes with valuable
-  travel perks like a free checked bag, priority boarding, and an annual coach
-  companion fare on Alaska Airlines, enhancing its appeal for frequent flyers.
-  However, the $95 annual fee is a consideration, and the recent drop in the
-  signup bonus from 80,000 to 70,000 points might be a disappointment for
-  those looking for the maximum initial value. With no foreign transaction
-  fees and no personal credit reporting, it can be a smart choice for business
-  owners who travel internationally and want to manage their personal credit
-  utilization separately. Just keep in mind that outside of travel, the
-  rewards rate drops to 1 point per dollar on most other purchases.
+  The Atmos Rewards Business card covers the same Alaska and Hawaiian ground
+  as the personal version for $95 a year, earning 3 points per dollar on
+  Alaska and Hawaiian Airlines purchases, 2x on gas, EV charging, transit, and
+  shipping, and 1x elsewhere. The current bonus is 70,000 points plus a $99
+  Companion Fare after $4,000 in the first 90 days, trimmed back in early July
+  from the 80,000 that ran through May and June. The quieter draw is that card
+  activity doesn't report to personal credit bureaus, which keeps the account
+  off your personal utilization and out of 5/24-style counts. A recurring $99
+  Companion Fare after $6,000 of annual spend, a free checked bag, and
+  priority boarding on Alaska flights are what justify the fee year to year.
+  If your business doesn't fly Alaska or Hawaiian, the 3x rate never applies
+  and you're left with an ordinary 2x card.
 tags:
   - travel
   - airline

--- a/data/cards/atmos-rewards-summit.yaml
+++ b/data/cards/atmos-rewards-summit.yaml
@@ -9,17 +9,19 @@ annual_fee: 395
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Atmos Rewards Summit card from Bank of America is designed for frequent
-  travelers who can leverage its robust airline perks, including 3 points per
-  dollar on airlines, dining, and foreign transactions. The standout feature
-  is the 80,000-point signup bonus, plus a 25,000-point Global Companion
-  Award, after spending $4,000 in the first 90 days. However, the $395 annual
-  fee is steep, so you'll need to make full use of benefits like the annual
-  25,000-point Companion Award, free checked bags, and Alaska Lounge passes to
-  justify the cost. The card's lack of foreign transaction fees is a plus for
-  international travelers, but keep in mind that outside of travel and dining,
-  the earn rate drops to 1 point per dollar. If your spending aligns with its
-  strengths, it could be a valuable addition to your wallet.
+  Summit is the premium Alaska and Hawaiian card at $395 a year, and its case
+  rests on the 25,000-point Global Companion Award that arrives every card
+  anniversary with no spend requirement attached. Earning is 3 points per
+  dollar on Alaska and Hawaiian Airlines purchases, dining, and foreign
+  transactions, with 1x on everything else and no foreign transaction fees.
+  The current welcome offer is 80,000 points plus a 25,000-point Global
+  Companion Award after $4,000 in the first 90 days, down from 100,000 points
+  in early July, so you're applying into a weaker offer than existed a month
+  ago. Eight Alaska Lounge passes a year, a $120 Global Entry or TSA PreCheck
+  credit, and a free checked bag with priority boarding for you and up to six
+  guests round out the fee. It sits at #11 on our Best Travel Credit Cards
+  list, and the honest test is whether you'll actually redeem the companion
+  award each year: skip it and $395 is a lot to pay for a 3x airline card.
 tags:
   - travel
   - airline

--- a/data/cards/att-points-plus-from-citi.yaml
+++ b/data/cards/att-points-plus-from-citi.yaml
@@ -7,18 +7,18 @@ apply_link: https://www.citi.com/credit-cards/citi-att-pointsplus-credit-card
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The AT&T Points Plus from Citi stands out with its robust rewards structure,
-  offering 3 points per dollar on gas and EV charging, and 2 points per dollar
-  on groceries and AT&T-related expenses, all with no annual fee. The card
-  also provides valuable telecom benefits, including a $10 monthly discount on
-  AT&T wireless and internet bills when enrolled in AutoPay and paperless
-  billing. However, the signup bonus was recently reduced from $250 to a $200
-  statement credit after a $500 spend in the first three months, which is a
-  notable decrease. Despite this, the card's ongoing rewards and lack of
-  foreign transaction fees make it a versatile option for frequent AT&T users
-  and those looking to maximize points on everyday spending. Just remember
-  that to fully capitalize on the telecom discounts, you must enroll in
-  AutoPay and paperless billing.
+  The pitch here is the statement credits rather than the points: $10 a month
+  off an AT&T wireless line and another $10 a month off eligible AT&T
+  internet, both requiring AutoPay and paperless billing, worth up to $240 a
+  year combined on a card with no annual fee. On top of that, spending $1,000
+  or more in a billing cycle earns a $20 statement credit, up to another $240
+  a year, which is a real return for routine spend. Earning is modest by
+  comparison: 3 points per dollar on gas including EV charging, 2x on
+  groceries, 2x on AT&T products and bill payments, and 1x on everything else,
+  with no foreign transaction fees. Citi recently cut the welcome offer from
+  $250 to $200, payable after $1,000 in purchases in the first three months.
+  If you're not an AT&T customer, most of the value evaporates and there are
+  stronger everyday cards to carry instead.
 annual_fee: 0
 reward_type: "points"
 tags:

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -43,13 +43,14 @@ apply_link: https://www.bankofamerica.com/credit-cards/products/cash-back-secure
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Bank of America Cash Rewards Secured card is a standout option for those
-  looking to build or rebuild credit while earning cash back. With no annual
-  fee, it offers 3% cash back in a category of your choice and 2% at grocery
-  stores and wholesale clubs, both up to a combined $2,500 in quarterly
-  spending, then 1% after that. This makes it an appealing choice for everyday
-  spending if you can stay within the cap. However, the regular APR is a steep
-  27.49%, so it's crucial to pay off your balance in full each month to avoid
-  interest charges. As a secured card, a refundable security deposit is
-  required, but it ranks #3 among secured cards, making it a competitive
-  choice in its category.
+  Most secured cards pay nothing back, so the Cash Rewards Secured stands out
+  for actually earning while you rebuild: 3% in one category you pick from
+  gas, online shopping, dining, travel, drugstores, or home improvement, plus
+  2% at grocery stores and wholesale clubs, with no annual fee. That
+  combination is why it ranks third on our list of the best secured cards. The
+  limits are real, though: the 3% and 2% rates share a combined $2,500 per
+  quarter cap, and anything past it drops to the same 1% you earn on all other
+  spending. The 27.49% APR means this should be a pay-in-full card rather than
+  a place to carry a balance, and the foreign transaction fee makes it a poor
+  travel companion. Use it to build history and pick up a little cash back,
+  then graduate to an unsecured card once your credit supports one.

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -54,15 +54,14 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/cash-back-credit-card/
 our_take: >
-  The Bank of America Customized Cash Rewards card stands out with its
-  flexible 3% cash back in a category of your choice, such as gas, online
-  shopping, or dining, and 2% at grocery stores and wholesale clubs, up to a
-  combined quarterly cap of $2,500. This makes it a versatile option for those
-  who can maximize their spending in these categories, especially since
-  there's no annual fee. A $200 signup bonus after spending $1,000 in the
-  first 3 months adds an attractive upfront incentive. However, once you hit
-  the cap, the earn rate drops to 1%, which is fairly standard. The 15-month
-  0% intro APR on purchases and balance transfers is a nice perk for those
-  looking to manage interest, but the regular APR can climb as high as 27.49%,
-  so plan accordingly. Overall, it's a solid choice for strategic spenders who
-  can leverage the category flexibility.
+  The appeal here is the choice: you pick your 3% category from gas, online
+  shopping, dining, travel, drugstores, or home improvement, and get 2% at
+  grocery stores and wholesale clubs on top, all with no annual fee. A $200
+  bonus after $1,000 of spending in the first three months and 15 months of 0%
+  intro APR on both purchases and balance transfers make for a solid opening
+  stretch. The ceiling is the catch: those 3% and 2% rates share a combined
+  $2,500 per quarter cap, and past it everything falls to the flat 1% base
+  rate, so roughly $10,000 a year of bonus spending is all you get. There is
+  also a foreign transaction fee, which rules the card out for trips abroad.
+  It works well as a targeted category card if your spending fits inside the
+  cap, and poorly as an everything card.

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -57,13 +57,16 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/premium-rewards-elite-credit-card/
 our_take: >
-  The Bank of America Premium Rewards Elite card is designed for frequent
-  travelers who can take full advantage of its substantial benefits. With a
-  $550 annual fee, the card offers a $300 airline incidental credit and a $150
-  lifestyle credit, which can significantly offset the cost if you utilize
-  them fully. The card also provides 2 points per dollar on travel and dining,
-  and 1.5 points on everything else, plus a generous 75,000-point signup bonus
-  for spending $5,000 in the first three months. However, the rewards rate is
-  not the highest among premium cards, so it's best suited for those who will
-  make use of the travel credits and Priority Pass Select membership. If you
-  don't travel frequently, the high annual fee may outweigh the benefits.
+  For a $550 annual fee, Bank of America hands most of it back in credits:
+  $300 a year for airline incidentals like baggage and seat upgrades, $150 for
+  airlines, rideshare, or streaming, and up to $120 toward Global Entry or TSA
+  PreCheck every four years. Priority Pass Select membership extends to the
+  primary cardholder and up to three authorized users, which is unusually
+  generous if you travel with family. Earning is simple rather than rich: 2
+  points per dollar on travel and dining, 1.5 on everything else, no foreign
+  transaction fees, and 75,000 points after $5,000 of spending in the first
+  three months. The math only works if you reliably use both annual credits,
+  since together they cover $450 of the fee, and both require enrollment, so
+  forgetting to opt in quietly costs you real money. If your travel is
+  occasional, skip it: the 2x and 1.5x rates are not high enough to carry $550
+  on their own.

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -44,13 +44,14 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/premium-rewards-credit-card/
 our_take: >
-  The Bank of America Premium Rewards card stands out with a generous
-  60,000-point signup bonus, which you can earn by spending $4,000 in the
-  first three months. This card is a solid choice for travelers, offering 2
-  points per dollar on travel and dining, along with a $100 annual airline
-  incidental credit that can offset its $95 annual fee. Additionally, the card
-  provides up to $120 in statement credits for Global Entry or TSA PreCheck
-  application fees every five years. However, the earn rate drops to 1.5
-  points per dollar on all other purchases, which may not be competitive for
-  everyday spending. Consider it if you travel frequently and can take full
-  advantage of the travel-related perks.
+  The Premium Rewards keeps things simple: 2 points per dollar on travel and
+  dining, 1.5 on everything else, and no foreign transaction fees, so there
+  are no categories to track and no penalty for spending abroad. Against the
+  $95 annual fee sit a $100 annual airline incidental credit and up to $100
+  for Global Entry or TSA PreCheck every four years, which means the card pays
+  for itself in any year you actually use the airline credit. The opening
+  offer is 60,000 points after $4,000 of spending in the first three months.
+  The flat 1.5x floor is the honest tradeoff: it is a fine default rate rather
+  than a standout one, so the case for the card rests on the credits and the
+  2x on travel and dining. It suits someone who wants one uncomplicated travel
+  card and will remember to spend that airline credit each year.

--- a/data/cards/bank-of-america-travel-rewards.yaml
+++ b/data/cards/bank-of-america-travel-rewards.yaml
@@ -30,15 +30,15 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/travel-rewards-credit-card/
 our_take: >
-  The Bank of America Travel Rewards card stands out with its no annual fee
-  and a straightforward rewards structure: 1.5 points per dollar on all
-  purchases. This makes it an appealing option for travelers who want to earn
-  rewards without worrying about category restrictions. The card also offers a
-  25,000-point signup bonus, equivalent to a $250 statement credit for travel
-  and dining, after spending $1,000 in the first three months. Additionally,
-  it provides a 0% intro APR on purchases and balance transfers for 15 months,
-  which is a helpful feature for those planning a big trip or needing to
-  manage existing debt. However, the regular APR can be as high as 27.49%, so
-  it's best suited for those who can pay off their balances each month.
-  Overall, it's a solid choice for travelers looking for a no-fee card with
-  flexible rewards.
+  This is the no-fee, no-fuss option in Bank of America's travel lineup: 1.5
+  points per dollar on everything, no annual fee, and no foreign transaction
+  fees, which is why it carries our Best No-Fee for Travelers badge at number
+  12 on the best travel cards list. The 25,000-point opening bonus after
+  $1,000 of spending in the first three months redeems for a $250 statement
+  credit toward travel and dining, a strong return for a card that costs
+  nothing to hold. It also brings 15 months of 0% intro APR on purchases and
+  balance transfers, so it can double as short-term financing. What it lacks
+  is any bonus category at all: every purchase earns the same 1.5x, so a card
+  with real multipliers will out-earn it on dining, groceries, or travel.
+  Think of it as the clean card you hand over overseas rather than the
+  centerpiece of a points strategy.

--- a/data/cards/bank-of-america-unlimited-cash-rewards.yaml
+++ b/data/cards/bank-of-america-unlimited-cash-rewards.yaml
@@ -32,14 +32,12 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/unlimited-cash-back-credit-card/
 our_take: >
-  The Bank of America Unlimited Cash Rewards card offers a straightforward
-  1.5% cash back on all purchases, making it a solid choice for those who
-  prefer simplicity without the need to track spending categories. With no
-  annual fee and a $200 signup bonus after spending $1,000 in the first three
-  months, it provides a decent upfront incentive. Additionally, the 0% intro
-  APR on purchases and balance transfers for 15 months can help manage large
-  expenses or existing debt interest-free for over a year. The regular APR can
-  be as high as 27.49%, so it's best suited for those who plan to pay off
-  their balance monthly after the intro period. While it doesn't stand out in
-  any Best-of lists, its combination of rewards and introductory offers make
-  it a reliable everyday card.
+  The pitch is simplicity: 1.5% cash back on every purchase, no categories to
+  activate, no caps, and no annual fee. A $200 bonus after $1,000 of spending
+  in the first three months plus 15 months of 0% intro APR on purchases and
+  balance transfers make the first year the strongest one by a wide margin.
+  The weakness is that 1.5% is a middling flat rate, so this card only makes
+  sense if you value never thinking about categories more than you value the
+  extra return a tiered card would produce. The foreign transaction fee is
+  another reason to leave it home on international trips. Reasonable as a
+  catch-all backup, hard to defend as your only card.

--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -21,14 +21,15 @@ apply_link: https://www.bankofamerica.com/credit-cards/products/bankamericard-cr
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The BankAmericard stands out with its extended 21-month 0% intro APR on both
-  purchases and balance transfers, recently increased from 18 months. This
-  makes it a compelling choice for those looking to manage existing debt or
-  finance new purchases without interest for nearly two years, all with no
-  annual fee. However, the card lacks rewards, so once the intro period ends,
-  there's little incentive to keep it in your wallet. With regular APRs
-  ranging from 14.49% to 24.49%, it's important to have a plan to pay off your
-  balance before the intro period concludes. Its recognition as 'Best Value'
-  in the Best 0% APR Credit Cards list underscores its strength in the balance
-  transfer category.
+  The BankAmericard is a debt-payoff tool and nothing else: 21 months of 0%
+  intro APR on both purchases and balance transfers, with no annual fee. That
+  is among the longest interest-free runways available, and it is why the card
+  sits at number two with our Best Value badge on the best 0% APR list. After
+  the intro window the rate lands between 14.99% and 25.99%, and the low end
+  of that range is unusually mild for this class of card, which softens the
+  landing if your payoff runs long. Be clear about the tradeoff: this card
+  earns no rewards at all, so there is no reason to keep spending on it once
+  the promotional period closes, and it charges foreign transaction fees on
+  top. Open it with a payoff schedule, execute the schedule, and then let it
+  sit.
 

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -10,16 +10,21 @@ annual_fee: 0
 reward_type: "points"
 release_date: "2025-01-15"
 our_take: >
-  The Bilt Blue card stands out for its unique ability to pay rent without
-  transaction fees while earning points, making it a strong choice for renters
-  looking to maximize rewards. With no annual fee, it offers up to 4x points
-  at participating Bilt Dining restaurants and 3x points on Lyft rides, though
-  the dining network is limited. For travel enthusiasts, it provides 3x points
-  on hotels and 2x on flights booked through Bilt Travel. However, the
-  everyday earn rate is just 1x points, and the alternative 4% Bilt Cash
-  option is a separate currency, not traditional cash back. This card is best
-  suited for those who can leverage its niche benefits, particularly in rent
-  payments and dining, rather than for general spending.
+  Bilt Blue exists to let you pay rent by card without the usual processing
+  fee, earning up to 1.25 points per dollar on rent and mortgage payments if
+  you select the housing rewards track. Around that sit 3x on hotels and 2x on
+  flights booked through Bilt Travel, 3x on Lyft rides specifically once you
+  link your Lyft account, and no foreign transaction fees, all with no annual
+  fee. Everything else earns a plain 1 point per dollar, and the alternative
+  4% Bilt Cash option on everyday spend replaces the rent multiplier rather
+  than adding to it, so you pick one track or the other, and Bilt Cash is a
+  closed currency used mainly for point accelerators rather than real cash
+  back. The rent rate is not fixed either: it is recalculated each billing
+  cycle from your everyday spend relative to your housing payment, so 1.25x is
+  a ceiling and not a promise. Read the intro APR carefully too, because it is
+  10% rather than 0% for the first 12 billing cycles and 26.74% to 34.74%
+  after that, so this is not a financing card, and the $100 welcome offer
+  arrives as Bilt Cash rather than money.
 benefits:
   - name: "Rent Payment Without Fees"
     value: 0

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -10,16 +10,22 @@ annual_fee: 95
 reward_type: "points"
 release_date: "2025-01-15"
 our_take: >
-  The Bilt Obsidian card is a compelling option for renters who want to earn
-  rewards without paying transaction fees on rent payments. With a $95 annual
-  fee, it offers flexible earning potential: 3 points per dollar in your
-  choice of dining or groceries, up to 6x at select Bilt Dining restaurants,
-  and 4x on hotels booked through the Bilt Travel Portal. The card also
-  provides a $100 annual hotel credit split into two $50 credits, which can
-  help offset the annual fee if you utilize the Bilt Travel Portal. However,
-  the rewards cap on groceries and the limited network for the 6x dining rate
-  might restrict your earning potential. Overall, it's a solid pick for those
-  who can maximize its unique rent payment feature and travel benefits.
+  Obsidian is the paid tier of Bilt's rent-focused lineup: $95 a year buys 3x
+  on your choice of dining or groceries, 4x on hotels and 3x on flights booked
+  through Bilt Travel, 2x on other travel, 3x on Lyft rides after you link
+  your Lyft account, and up to 1.25 points per dollar on rent and mortgage
+  payments with no transaction fee. Two $50 statement credits a year for Bilt
+  Travel hotel bookings offset most of the fee, and the welcome offer is $200
+  in Bilt Cash deposited at approval with no minimum spend, which is rare. The
+  fine print matters more than usual here: the 3x category is capped at
+  $25,000 a year and drops to 1x after, the up to 6x dining rate applies only
+  at the limited network of participating Bilt Dining restaurants, the transit
+  rate covers Lyft and nothing else, and the rent multiplier is recalculated
+  each cycle from your everyday spend against your housing payment, so 1.25x
+  is a ceiling. Everything outside those buckets earns 1 point per dollar, a
+  thin base for a card carrying an annual fee. Note also that the intro APR is
+  10%, not 0%, for the first 12 billing cycles, with 26.74% to 34.74% after,
+  so treat this strictly as a spending card.
 benefits:
   - name: "Rent Payment Without Fees"
     value: 0

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -7,19 +7,22 @@ apply_link: https://www.biltrewards.com/card/apply
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Bilt Palladium card stands out with its unique ability to pay rent
-  without transaction fees while earning points, a rare feature among premium
-  cards. With a hefty $495 annual fee, it offers substantial benefits like a
-  $400 annual hotel credit through the Bilt Travel Portal, complimentary
-  Priority Pass lounge access, and a lucrative signup bonus of 50,000 points
-  plus $300 Bilt Cash after spending $4,000 in the first 90 days. The card
-  excels in dining with up to 5x points at participating Bilt Dining
-  restaurants and 4x points on Lyft rides, but the limited dining network and
-  specific booking channels for travel rewards may not suit everyone. The
-  annual Bilt Cash Award of $200 and the potential to earn Gold Status add
-  further value, though the card's rewards structure can be complex. Overall,
-  it's a strong choice for frequent travelers and renters who can leverage its
-  benefits to offset the high fee.
+  Bilt built the Palladium around something almost no other card does: you can
+  put rent or mortgage on it with no transaction fee and still earn up to
+  1.25x points, on top of a flat 2x on everyday spend. At $495 a year the math
+  leans on the credits, a $400 annual hotel credit paid as two $200 statement
+  credits for Bilt Travel bookings and $200 in annual Bilt Cash, plus Priority
+  Pass lounge access and no foreign transaction fees. The catch is how
+  conditional the best numbers are: the 1.25x on housing only applies on the
+  housing rewards track, since the Bilt Cash track drops housing to 1x, the 4x
+  transit rate covers Lyft rides only after you link your account, and the 4x
+  hotels and 3x flights require booking through Bilt Travel. The intro APR is
+  unusual and worth reading twice, a 10% fixed rate for the first 12 billing
+  cycles rather than 0%, before a regular 26.74% to 34.74%. It opens with
+  50,000 points plus $300 Bilt Cash after $4,000 in three months, and that
+  same $4,000 in 90 days earns Gold Status. It is worth the fee mainly if your
+  rent is large enough that fee-free housing points carry the $495 on their
+  own.
 annual_fee: 495
 reward_type: "points"
 release_date: "2025-01-15"

--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -32,14 +32,14 @@ apply_link: https://www.americanexpress.com/en-us/business/credit-cards/blue-bus
 foreign_transaction_fee: true
 network: "amex"
 our_take: >
-  The Blue Business Cash Card from American Express offers a straightforward
-  2% cash back on all purchases up to $50,000 annually, then 1% thereafter,
-  making it a solid choice for small businesses looking to earn consistent
-  rewards without an annual fee. The $250 signup bonus, earned after spending
-  $3,000 in the first three months, adds an appealing upfront incentive.
-  However, the card's value diminishes if your business spends significantly
-  over the $50,000 cap, as the earn rate drops to 1%. Additionally, the 0%
-  intro APR on purchases for 12 months can help manage cash flow, but the
-  regular APR ranges from 18.49% to 26.49%, so it's best to pay off balances
-  in full after the intro period. Overall, it's a no-frills option for
-  businesses that want simple cash back without the burden of annual fees.
+  The Blue Business Cash keeps things simple: 2% cash back on every purchase,
+  no categories to track, no annual fee. The cap is the thing to plan around,
+  since 2% applies to the first $50,000 of spend each year and everything past
+  that earns 1%, which is plenty of room for most small businesses but worth
+  watching if you run real volume. A $250 bonus after $3,000 in the first
+  three months plus 0% intro APR on purchases for 12 months make the first
+  year the strongest one, especially if you are financing equipment or startup
+  costs. The obvious gap is international spend: this card charges foreign
+  transaction fees, so keep it domestic and carry something else on trips
+  abroad. After the intro window the regular rate runs 16.74% to 28.49%, so
+  plan to have the balance clear by then.

--- a/data/cards/blue-business-plus-credit-card-from-american-express.yaml
+++ b/data/cards/blue-business-plus-credit-card-from-american-express.yaml
@@ -32,15 +32,13 @@ apply_link: https://www.americanexpress.com/us/credit-cards/business/business-cr
 foreign_transaction_fee: true
 network: "amex"
 our_take: >
-  The Blue Business Plus from American Express stands out for its
-  straightforward rewards structure, offering 2 points per dollar on all
-  purchases up to $50,000 annually, which is rare for a no-annual-fee card.
-  This makes it an excellent choice for small business owners who want to earn
-  consistent rewards without worrying about rotating categories. However, once
-  you exceed the $50,000 spend cap, the earn rate drops to 1 point per dollar,
-  which might not be as competitive for higher spenders. The card also offers
-  a 0% intro APR on purchases for 12 months, providing some breathing room for
-  new expenses. Keep in mind the foreign transaction fee, which could be a
-  drawback for businesses with international dealings. The 15,000-point signup
-  bonus for spending $3,000 in the first three months is a modest perk to get
-  you started.
+  The Blue Business Plus earns a flat 2x points on everything with no annual
+  fee and no categories to manage, which makes it a low-effort default for
+  routine business spend. The rate is capped: 2x covers the first $50,000 of
+  purchases each year and drops to 1x after that, so higher-volume businesses
+  will want a second card for the overflow. The welcome offer is modest at
+  15,000 points after $3,000 in three months, so this is a keeper card rather
+  than a bonus play. A 0% intro APR on purchases for 12 months gives some
+  breathing room on early expenses before the 16.74% to 28.49% regular rate
+  takes over. One real limitation: it charges foreign transaction fees, which
+  makes it the wrong card for spending abroad.

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -8,18 +8,19 @@ foreign_transaction_fee: true
 network: "amex"
 card_referral_link: "https://americanexpress.com/en-us/referral/blue-cash-everyday-credit-card?ref="
 our_take: >
-  The Blue Cash Everyday card from American Express is a no-annual-fee option
-  that shines with 3% cash back on up to $6,000 annually in spending at U.S.
-  supermarkets, gas stations, and online retail purchases. This makes it a
-  great card for everyday spending, especially if you frequently shop in these
-  categories. However, once you hit the annual cap, the earn rate drops to
-  just 1%, which might limit its appeal for high spenders. The card also
-  offers a $200 signup bonus after spending $2,000 in the first 6 months,
-  adding extra value upfront. While there's a 15-month 0% intro APR on
-  purchases, the regular APR ranges from 19.49% to 28.49%, so it's best to pay
-  off balances promptly. Keep in mind the foreign transaction fees if you
-  travel abroad, but enjoy perks like the Disney streaming credit and purchase
-  protection domestically.
+  For a card with no annual fee, the Blue Cash Everyday covers a lot of
+  ordinary household ground: 3% back at U.S. supermarkets, U.S. gas stations,
+  and U.S. online retail. Each of those categories carries its own $6,000
+  annual cap and drops to 1% after that, so the practical ceiling is about
+  $180 back per category per year. The extras are real but modest, up to $7 a
+  month in statement credits toward Disney+, Hulu, or ESPN+ if you enroll,
+  plus purchase protection on eligible items. A 0% intro APR for 15 months on
+  purchases and on balance transfers requested within 60 days makes it
+  workable as a payoff card too, and the $200 bonus after $2,000 in six months
+  is an easy target over that long a window. It sits at #7 on our Best Cash
+  Back list and makes a sensible first cash-back card, though anyone spending
+  more than about $500 a month at the supermarket will hit that cap well
+  before year end.
 annual_fee: 0
 reward_type: "cashback"
 tags:

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -7,18 +7,20 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/blue-cash-prefe
 foreign_transaction_fee: true
 network: "amex"
 our_take: >
-  The Blue Cash Preferred card from American Express is a standout for
-  families and frequent shoppers, offering an impressive 6% cash back on up to
-  $6,000 spent annually at U.S. supermarkets, then 1%, and on select U.S.
-  streaming subscriptions. The recent boost to a $300 signup bonus when you
-  spend $3,000 in the first 6 months sweetens the deal. It also provides 3%
-  back on transit and U.S. gas stations, making it a versatile option for
-  everyday expenses. However, the $95 annual fee and foreign transaction fees
-  are worth considering, especially if you travel abroad. The card's 12-month
-  0% intro APR on purchases can help manage large expenses, but the regular
-  APR can climb as high as 28.49%. Additional perks like the Disney Bundle
-  discount and purchase protection add value, but ensure they align with your
-  spending habits.
+  The Blue Cash Preferred is built around groceries: 6% back at U.S.
+  supermarkets on up to $6,000 a year, which is $360 at the cap against a $95
+  annual fee. Another 6% on select U.S. streaming subscriptions plus 3% on
+  transit and at U.S. gas stations rounds it into a strong everyday card, and
+  it ranks #2 on our dining and groceries list. The catches are that
+  supermarket cap, after which groceries fall to 1%, and the flat 1% on
+  everything outside the bonus categories. The protection package is deeper
+  than most cash-back cards bother with: purchase protection, return
+  protection, and up to an extra year of extended warranty, plus up to $7 a
+  month toward the Disney Bundle if you enroll. A $300 bonus after $3,000 in
+  six months and 0% intro APR for 12 months on purchases and qualifying
+  balance transfers make the first year clearly fee-positive. If groceries are
+  a small line in your budget, though, the $95 is harder to earn back than the
+  headline rate suggests.
 annual_fee: 95
 reward_type: "cashback"
 rewards:

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -70,16 +70,18 @@ benefits:
     category: "protection"
     enrollment_required: false
 our_take: >
-  The British Airways Visa Signature card is a solid choice for frequent
-  flyers of British Airways, Aer Lingus, and Iberia, offering 3 miles per
-  dollar on these airlines and a generous 75,000-mile signup bonus after
-  spending $5,000 in the first three months. With an annual fee of $95 and no
-  foreign transaction fees, it's designed for international travelers.
-  However, the card's real value comes from its travel perks: a Travel
-  Together Ticket after $30,000 in annual spending, up to $600 in reward
-  flight statement credits, and a 10% discount on flights from the US to
-  London. The main downside is that outside of airline and hotel bookings, the
-  earn rate drops to just 1 mile per dollar on other purchases. If you're not
-  a loyal British Airways customer, the rewards might not justify the annual
-  fee, but for those who are, the benefits could easily outweigh the cost.
+  The 75,000 Avios welcome offer after $5,000 in three months is the main
+  reason to open this card, and at a $95 annual fee with no foreign
+  transaction fees it is a reasonable one to keep for transatlantic travel.
+  Ongoing earning is narrow: the 3x rate applies only to British Airways, Aer
+  Lingus, and Iberia flights, hotels booked directly earn 2x, and everything
+  else is a flat 1x, so this is not a card for daily spend. What partly
+  offsets that is the reward flight statement credits, up to three a year
+  worth $100 on Economy or Premium Economy and $200 on Business or First,
+  which take the sting out of the taxes and carrier charges on Avios reward
+  bookings. The Travel Together Ticket is the headline perk but requires
+  $30,000 of spend in a calendar year, a bar most cardholders will not clear
+  while earning 1x. There is also no intro APR here, and the regular rate runs
+  19.24% to 27.74%. It ranks #5 on our airline card list, and it earns that
+  spot only if you actually fly British Airways.
 apply_link: https://creditcards.chase.com/travel-credit-cards/british-airways

--- a/data/cards/capital-one-platinum-secured.yaml
+++ b/data/cards/capital-one-platinum-secured.yaml
@@ -15,13 +15,14 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/platinum-secured/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One Platinum Secured card is a solid option for those looking to
-  build or rebuild their credit, with no annual fee and a refundable security
-  deposit that determines your credit line. Its main appeal lies in the
-  opportunity to improve your credit score with responsible use, as Capital
-  One reports to all three major credit bureaus. However, the regular APR is
-  steep at 28.99%, so carrying a balance could become costly. Unlike many
-  secured cards, it doesn't offer rewards, but its primary purpose is credit
-  building rather than earning cash back or points. As a result, it's best
-  suited for those focused on establishing a positive credit history.
+  The Platinum Secured is a pure credit-building tool: no annual fee, no
+  rewards, and a deposit-backed line meant to get an account reporting in your
+  name. That narrow purpose is the point, and it does it without charging you
+  anything annually or adding foreign transaction fees. Be clear about what it
+  does not do, though: there is no cash back, no points, no signup bonus, and
+  no intro APR, so there is nothing to earn and nothing to finance. The
+  regular APR is a flat 28.99%, high enough that this card only makes sense if
+  you pay in full every month. It ranks #6 on our secured card list, and the
+  right move is to build a year of clean history and then graduate to a card
+  that pays you back.
 

--- a/data/cards/capital-one-platinum.yaml
+++ b/data/cards/capital-one-platinum.yaml
@@ -14,11 +14,12 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/platinum/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One Platinum card is a straightforward option for those looking
-  to build or rebuild their credit, with no annual fee to worry about. Its
-  main appeal lies in the opportunity to establish a positive credit history
-  without the burden of extra costs. However, the card offers no rewards
-  program, so don't expect cash back or points for your spending. The regular
-  APR is a steep 28.99%, which means carrying a balance could become costly.
-  It's best suited for someone who plans to pay off their balance in full each
-  month while focusing on improving their credit score.
+  The Platinum is Capital One's plain starter card, and its whole job is
+  access: an account that reports to the bureaus at no annual cost while you
+  build or rebuild credit. It also skips foreign transaction fees, which is a
+  small but genuine bonus at this tier. What it lacks is everything else, with
+  no cash back, no points, no signup bonus, and no intro APR on purchases or
+  balance transfers. The regular rate is a flat 28.99%, so carrying a balance
+  here is expensive and the card only works if you clear it monthly. Use it to
+  establish history for a year or so, then move to a card that gives you
+  something back for the same spend.

--- a/data/cards/capital-one-quicksilver-secured.yaml
+++ b/data/cards/capital-one-quicksilver-secured.yaml
@@ -23,9 +23,13 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/quicksilver-secured/
 foreign_transaction_fee: false
 our_take: >
-  One of the stronger secured cards because it actually earns: a flat 1.5% on
-  everything plus 5% on hotels and rental cars booked through Capital One Travel, with
-  no annual fee and a path to graduate to an unsecured card. Most secured cards earn
-  nothing, so if you can fund the deposit this is a better credit-builder than a
-  rewardless option like the Citi or U.S. Bank secured cards. The 28.99% APR means you
-  still want to pay in full each month.
+  Most secured cards pay nothing, which is what makes the Quicksilver Secured
+  stand out: a flat 1.5% cash back on every purchase while you build credit,
+  with no annual fee and no foreign transaction fees. Booking hotels and
+  rental cars through the card's travel portal earns 5%, which is worth using
+  on the occasional trip but is not the reason to hold the card. It ranks #2
+  on our secured card list, and the earn rate is why. The number to respect is
+  the APR, a flat 28.99% with no intro period, so the deposit and the cash
+  back only work in your favor if you pay the balance in full every month.
+  Treat it as a credit builder that happens to pay you, not as a card to
+  finance anything on.

--- a/data/cards/capital-one-quicksilver.yaml
+++ b/data/cards/capital-one-quicksilver.yaml
@@ -34,18 +34,17 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/quicksilver/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One Quicksilver Cash Rewards card stands out with its
-  straightforward 1.5% cash back on all purchases and an elevated 5% back on
-  hotels and rental cars booked through Capital One Travel, all with no annual
-  fee. This makes it a versatile choice for everyday spending and occasional
-  travel. The card also offers a $200 cash signup bonus after spending $500
-  within the first three months, which is a solid incentive for new
-  cardholders. Plus, the 15-month 0% intro APR on both purchases and balance
-  transfers provides a decent window for managing expenses interest-free.
-  However, the regular APR ranges from 18.49% to 28.49%, so carrying a balance
-  beyond the intro period could become costly. While it ranks #8 on our Best
-  Cash Back Credit Cards list, the lack of additional ongoing perks means it
-  primarily shines for its cash back simplicity and intro offers.
+  The Quicksilver's pitch is simplicity: a flat 1.5% cash back on everything
+  with no annual fee and no foreign transaction fee, so there are no
+  categories to track or activate. The $200 bonus after $500 of spend in the
+  first three months is unusually easy to clear, and the 15 months of 0% intro
+  APR on both purchases and balance transfers give it a second life as a
+  short-term financing card. The tradeoff is that 1.5% is now the low end of
+  flat-rate cash back, which is why it lands at #8 on our Best Cash Back list
+  rather than the top. The only bonus rate is 5% on hotels and rental cars
+  booked through Capital One Travel, which locks you into that portal to get
+  it. Reasonable as a no-fuss backup card, but don't expect it to be the
+  highest earner in your wallet.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-quicksilverone.yaml
+++ b/data/cards/capital-one-quicksilverone.yaml
@@ -20,13 +20,13 @@ apr:
     max: 28.99
 apply_link: https://www.capitalone.com/credit-cards/quicksilverone/
 our_take: >
-  The Capital One QuicksilverOne Cash Rewards card offers a straightforward
-  1.5% cash back on all purchases, making it a reliable choice for those who
-  prefer a simple rewards structure without worrying about rotating
-  categories. Additionally, it provides 5% cash back on hotels and car rentals
-  booked through Capital One's travel portal, which can be a nice perk for
-  travelers. However, the card comes with a $39 annual fee, which might offset
-  some of the rewards for those with lower spending. The regular APR is a
-  steep 28.99%, so it's crucial to pay off your balance in full each month to
-  avoid costly interest charges. With no foreign transaction fees, it's also a
-  decent option for international use.
+  The QuicksilverOne earns the same 1.5% flat cash back as Capital One's
+  no-fee Quicksilver, plus 5% on hotels and rental cars booked through Capital
+  One Travel, and it waives foreign transaction fees. The difference is the
+  $39 annual fee, which means you need roughly $2,600 of spending a year just
+  to break even on the base rate before the card earns you anything. It also
+  comes with no signup bonus and no intro APR offer, so there's no upfront
+  value to offset that fee in year one. The regular APR is a flat 28.99%, high
+  enough that carrying a balance would erase the rewards entirely. It makes
+  sense only if you can't qualify for the no-fee version and want a
+  straightforward card to use and pay off in full each month.

--- a/data/cards/capital-one-savor-student.yaml
+++ b/data/cards/capital-one-savor-student.yaml
@@ -42,17 +42,17 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/savor-student/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One Savor Student Cash Rewards card stands out with its generous
-  3% cash back on dining, entertainment, streaming, and groceries, making it
-  an excellent choice for students who spend in these categories.
-  Additionally, the card offers a strong 5% back on hotels and car rentals
-  booked through Capital One Travel. The recently increased $100 signup bonus
-  for spending $300 in the first three months adds extra value for new
-  cardholders. With no annual fee and no foreign transaction fees, it's a
-  cost-effective option for students. However, the regular APR ranges from
-  18.49% to 28.49%, so carrying a balance could become costly. The card's
-  Price Drop Protection provides a minor travel credit perk, but the real draw
-  is the robust cash back on everyday spending.
+  For a student card with no annual fee, the Savor Student's earn structure is
+  genuinely broad: 3% back on dining, entertainment, streaming, and groceries,
+  which covers most of what a college budget actually goes toward. Capital One
+  recently doubled the signup bonus from $50 to $100, and the $300 spending
+  requirement over three months is low enough that most cardholders will clear
+  it without changing their habits. There's also 5% on hotels and rental cars
+  booked through Capital One Travel, and no foreign transaction fee, which is
+  useful for a semester abroad. The catch is the 1% base rate on everything
+  outside those categories, so this shouldn't be the card you reach for by
+  default. There's no intro APR either, and with a regular APR from 18.49% to
+  28.49% the card only works if you pay in full each month.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -49,17 +49,17 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/savor/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One Savor Cash Rewards card is a strong contender for those who
-  spend heavily on dining, entertainment, and groceries, offering a solid 3%
-  cash back in these categories. Additionally, it provides an impressive 8%
-  back on Capital One Entertainment purchases and 5% on hotels and car rentals
-  booked through their portal, all with no annual fee. The recent increase in
-  the signup bonus to $250 after spending $500 in the first three months adds
-  further appeal. However, the card's regular APR ranges from 18.49% to
-  28.49%, so it's best suited for those who can pay off their balance each
-  month. While the 12-month 0% intro APR on purchases and balance transfers is
-  a nice perk, the card's true value lies in its rewards structure for
-  frequent spenders in the highlighted categories.
+  The Savor packs an unusually wide 3% earn structure into a card with no
+  annual fee: dining, entertainment, streaming, and groceries all pay the same
+  rate, with 8% on Capital One Entertainment bookings and 5% on hotels and
+  rental cars booked through Capital One Travel. Capital One recently raised
+  the signup bonus from $200 to $250, still against a modest $500 spend in the
+  first three months, so the upfront value is easy to capture. You also get 12
+  months of 0% intro APR on purchases and balance transfers and no foreign
+  transaction fee. The honest limit is the 1% base rate: anything outside
+  those four categories earns the bare minimum, so this works best as a
+  specialist card paired with a flat-rate earner. If your spending clusters in
+  restaurants and groceries, though, it's hard to argue with 3% for free.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-savorone.yaml
+++ b/data/cards/capital-one-savorone.yaml
@@ -41,14 +41,14 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/savorone/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One SavorOne Cash Rewards card offers a strong 3% cash back rate
-  on dining, entertainment, streaming, and groceries, making it a versatile
-  option for those who spend heavily in these categories. However, recent
-  changes have introduced a $39 annual fee and removed the previous $200
-  signup bonus, which might dampen its appeal for new applicants. The card
-  still provides a 12-month 0% intro APR on purchases and balance transfers,
-  giving you a year to manage expenses interest-free. While the rewards
-  structure remains competitive, the new annual fee means you'll need to weigh
-  whether your spending justifies the cost. If dining and entertainment are
-  significant parts of your budget, the SavorOne might still earn its keep in
-  your wallet.
+  The SavorOne covers the same four everyday categories at 3% back: dining,
+  entertainment, streaming, and groceries, with 12 months of 0% intro APR on
+  purchases and balance transfers and no foreign transaction fee. That
+  category spread is strong enough to put it at #4 on our Best Credit Cards
+  for Dining and Groceries list. The problem is the $39 annual fee attached to
+  it, which means about $1,300 a year in those 3% categories just to earn the
+  fee back. There's also no signup bonus at all, so nothing offsets that cost
+  in the first year the way a welcome offer normally would. Everything outside
+  the bonus categories earns 1%, so unless your dining and grocery spending is
+  substantial, Capital One's no-fee Savor covers the same ground without the
+  annual charge.

--- a/data/cards/capital-one-venture-business.yaml
+++ b/data/cards/capital-one-venture-business.yaml
@@ -59,14 +59,17 @@ apr:
 apply_link: https://www.capitalone.com/small-business/credit-cards/venture-business/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One Venture Business card is a solid choice for business owners
-  who travel frequently, offering 5 miles per dollar on hotels and rental cars
-  booked through Capital One Business Travel and 2 miles per dollar on all
-  other purchases. The standout feature is the signup bonus of 100,000 miles,
-  earned after spending $10,000 in the first three months. However, the bonus
-  was recently reduced from 150,000 miles, which may be a consideration if
-  you're looking for the highest possible initial reward. The $95 annual fee
-  is offset by benefits like a $50 annual travel credit and up to $120 for
-  Global Entry or TSA PreCheck every five years. Free employee cards and no
-  foreign transaction fees add further value, making it a worthwhile option
-  for businesses with international dealings.
+  Venture Business earns a flat 2x miles on every purchase with a $95 annual
+  fee, which makes it a clean fit for a business whose spending is spread
+  across categories that no bonus structure captures well. The current 100,000
+  mile bonus after $10,000 in three months is the headline, though be aware it
+  has moved twice recently: up to 150,000 in June, then back down to 100,000
+  in July, so the offer is clearly in flux. Recurring value comes from a $50
+  annual Capital One Business Travel credit, up to $50 a year in software and
+  advertising statement credits, and up to $120 toward Global Entry or TSA
+  PreCheck every four years, plus free employee cards that earn on the primary
+  account. Bookings through Capital One Business Travel earn 5x on hotels,
+  vacation rentals, and rental cars, so the top rate requires using that
+  portal. The $10,000 spending requirement is the real gate here: if your
+  business can't clear it in three months, most of the card's first-year value
+  disappears.

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -52,14 +52,17 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/venture/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One Venture Rewards card stands out for frequent travelers with
-  its 2 miles per dollar on most purchases and 5 miles per dollar on hotels
-  and car rentals booked through Capital One Travel. The $95 annual fee is
-  offset by a hefty 75,000-mile signup bonus after spending $4,000 in the
-  first three months, plus a $250 travel credit in the first year. While the
-  card offers valuable perks like a Global Entry or TSA PreCheck credit and
-  50% off handcrafted beverages at Capital One Cafés, the Lifestyle Collection
-  Experience Credit is niche and may not appeal to everyone. With no foreign
-  transaction fees, it's a solid choice for international travel. However, if
-  you're not a frequent traveler, the annual fee and travel-centric benefits
-  might not justify the cost.
+  Venture Rewards is the straightforward version of a travel card: 2x miles on
+  everything, a $95 annual fee, and no foreign transaction fee, so you don't
+  have to think about categories. The welcome offer is the strongest reason to
+  apply right now at 75,000 miles after $4,000 in three months, plus a $250
+  travel credit in your first cardholder year, which more than covers the fee
+  up front. Ongoing perks are modest but real: up to $120 toward Global Entry
+  or TSA PreCheck every four years, a $50 experience credit on Lifestyle
+  Collection stays, and half off handcrafted drinks at Capital One Cafés. Be
+  careful with the two 5x rates, since both require Capital One's own
+  channels: hotels and rental cars booked through the travel portal, and
+  tickets bought specifically on the Capital One Entertainment platform, which
+  excludes ordinary entertainment spending and Capital One Dining. It sits at
+  #8 on our Best Travel Cards list, and that's about right: a solid flat 2x
+  foundation rather than a card with standout ongoing benefits.

--- a/data/cards/capital-one-venture-x-business.yaml
+++ b/data/cards/capital-one-venture-x-business.yaml
@@ -72,14 +72,17 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  The Capital One Venture X Business takes the popular Venture X formula and
-  scales it for companies: a flat 2 miles per dollar on everything, 10x on
-  hotels and rental cars and 5x on flights booked through Capital One Business
-  Travel, and a massive 150,000-mile welcome offer for businesses that can put
-  $30,000 on the card in three months. The $300 annual travel credit and
-  10,000 anniversary miles effectively cancel out the $395 fee, making the
-  lounge access, Global Entry credit, and Hertz status close to free. Note
-  that this is a pay-in-full charge card with no preset spending limit, so
-  balances cannot be carried month to month, and complimentary guest lounge
-  access now requires $75,000 in annual spend. For a business with meaningful
-  travel volume, it is one of the strongest flat-earn travel cards available.
+  Venture X Business is built for companies with heavy, spread-out spending:
+  2x miles on everything, 10x on hotels and rental cars and 5x on flights and
+  vacation rentals booked through Capital One Business Travel, all for a $395
+  annual fee. The $300 annual travel credit and 10,000 anniversary miles do
+  most of the work offsetting that fee before you count Capital One Lounges,
+  Capital One Landings, and Priority Pass access for the primary cardholder.
+  Employee and virtual cards are unlimited and free, and employee spending
+  also earns 2x, which is where a growing team gets real leverage. Two limits
+  deserve attention: the 150,000 mile bonus demands $30,000 of spend in three
+  months and is closed to anyone who holds or has held a Capital One business
+  card, and complimentary guest access at lounges only unlocks after $75,000
+  of annual spend. If your business travels enough to use the $300 credit, the
+  $100 Premier Collection credits, and the lounges, the math works; if not,
+  the fee is hard to justify.

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -103,16 +103,17 @@ apply_link: https://www.capitalone.com/credit-cards/venture-x/
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Capital One Venture X Rewards card stands out with a substantial
-  75,000-mile signup bonus after spending $4,000 in the first three months,
-  making it a top contender for those looking to maximize travel rewards. The
-  annual $300 travel credit through the Capital One Travel portal effectively
-  reduces its $395 annual fee, and the 10,000 bonus miles on your account
-  anniversary add further value. You'll earn 10x miles on hotels and rental
-  cars booked through the portal, 5x on flights, and 2x on all other
-  purchases, providing solid earning potential for frequent travelers. Lounge
-  access, including Capital One Lounges and Priority Pass Select membership,
-  enhances the travel experience, while the Global Entry/TSA PreCheck credit
-  and Hertz President's Circle status are useful extras. However, if you don't
-  frequently book through Capital One's portal or value lounge access, the
-  high annual fee may outweigh the benefits.
+  Venture X is the rare premium card where the recurring credits nearly cancel
+  the fee on their own: a $300 annual travel credit through the Capital One
+  Travel portal and 10,000 anniversary miles every year against a $395 annual
+  fee. Add Capital One Lounge access, Priority Pass Select covering 1,300 or
+  more lounges, up to $120 toward Global Entry or TSA PreCheck, Hertz
+  President's Circle status, and a complimentary PRIOR subscription valued at
+  $149, and it earns its #2 spot with the Best Premium badge on our Best
+  Travel Cards list. Earning is straightforward too, at 2x miles on everything
+  with 10x on portal hotels and rental cars and 5x on portal flights. The 5x
+  on entertainment applies only to tickets bought through the Capital One
+  Entertainment platform and excludes dining reservations and Capital One
+  Dining, so treat it as a narrow perk rather than a category. The main caveat
+  is that the $300 credit is portal-locked, so if you refuse to book through
+  Capital One Travel, the effective fee stays close to the full $395.

--- a/data/cards/capital-one-ventureone-rewards.yaml
+++ b/data/cards/capital-one-ventureone-rewards.yaml
@@ -31,18 +31,17 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/ventureone/
 foreign_transaction_fee: false
 our_take: >
-  The Capital One VentureOne Rewards card is a solid choice for travelers who
-  want to earn miles without paying an annual fee. It offers 5 miles per
-  dollar on hotels and car rentals booked through Capital One Travel, and 1.25
-  miles per dollar on all other purchases, making it a versatile option for
-  everyday spending. The card also comes with a 20,000-mile signup bonus for
-  spending $500 in the first three months, which is a nice boost for new
-  cardholders. Additionally, it offers a 0% intro APR on purchases for 15
-  months, providing some breathing room for larger expenses. However, if
-  you're looking for premium travel perks or higher earn rates on specific
-  categories, you might need to look elsewhere. The card's travel-related
-  benefits like Price Drop Protection and Price Match Guarantee add some
-  value, but they're not game-changers.
+  VentureOne is the entry point to Capital One miles: 1.25x on every purchase
+  with no annual fee and no foreign transaction fee, which makes it a
+  low-commitment way to hold a miles balance and use it abroad. The 20,000
+  mile bonus needs only $500 of spend in the first three months, one of the
+  easier thresholds around, and there are 15 months of 0% intro APR on
+  purchases if you have something to finance. The tradeoff is the earn rate:
+  1.25x is well below the 2x on Capital One's fee-charging Venture cards, so
+  this is the version you carry when you don't want to pay $95 rather than the
+  one that maximizes miles. Only hotels and rental cars booked through Capital
+  One Travel break that pattern, at 5x. Note that the intro APR covers
+  purchases only, not balance transfers, so it isn't a debt-payoff card.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/cash-magnet-card.yaml
+++ b/data/cards/cash-magnet-card.yaml
@@ -13,12 +13,13 @@ rewards:
 apply_link: https://www.americanexpress.com/us/credit-cards/card/cash-magnet/
 network: "amex"
 our_take: >
-  The American Express Cash Magnet card offers a straightforward 1.5%
-  unlimited cash back on all eligible purchases, making it a simple choice for
-  those who prefer a flat-rate rewards structure without an annual fee.
-  However, it's important to note that the card is not currently accepting
-  applications, which limits its availability to new cardholders. While the
-  lack of an annual fee is appealing, the card doesn't offer any standout
-  features or bonuses to differentiate itself from other flat-rate cash back
-  cards. If you're already a cardholder, it's a decent option for everyday
-  spending, but new applicants will need to look elsewhere for now.
+  American Express has stopped accepting new applications for the Cash Magnet,
+  so this is really a card for people who already hold one. What it does, it
+  does simply: 1.5% unlimited cash back on all eligible purchases, no annual
+  fee, and no categories to track or activate. That flat rate was never
+  class-leading, and there are no bonus categories, statement credits, or
+  intro APR offer in the mix to make up the difference. If it is already in
+  your wallet, it is a reasonable no-fee backup for spending that does not fit
+  anywhere else, and closing it would shorten your credit history for no real
+  gain. If you are shopping for a new card, you will have to look elsewhere,
+  because this one is closed.

--- a/data/cards/chase-aeroplan.yaml
+++ b/data/cards/chase-aeroplan.yaml
@@ -74,16 +74,17 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/aircanada/aeroplan
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Chase Aeroplan card is a strong contender for frequent Air Canada
-  travelers, offering 3 points per dollar on Air Canada purchases, dining, and
-  groceries. The standout feature is the first checked bag free for you and up
-  to 8 companions on Air Canada flights, which can add up to significant
-  savings for families or groups. However, the recent reduction in the signup
-  bonus from 75,000 to 60,000 points means you'll need to weigh the value of
-  the card's ongoing rewards and benefits against its $95 annual fee. With no
-  foreign transaction fees and perks like two years of Aeroplan 25K Elite
-  Status and a $120 credit for Global Entry, TSA PreCheck, or NEXUS, the card
-  is well-suited for international travelers. Just be mindful that outside of
-  travel, dining, and groceries, the earn rate drops to 1 point per dollar,
-  which may limit its everyday appeal.
+  The Aeroplan earns 3 points per dollar on dining and groceries, two everyday
+  categories most airline cards ignore, plus 3 points per dollar on purchases
+  made directly with Air Canada, all for a $95 annual fee. New cardmembers
+  also get two years of Aeroplan 25K Elite Status and a free first checked bag
+  for themselves and up to eight companions on Air Canada flights, which is
+  the clearest reason to carry it if you fly the airline at all. Chase
+  recently cut the signup bonus from 75,000 to 60,000 points after $3,000 in
+  spend within three months, so the entry offer is meaningfully weaker than it
+  was in the spring. The catch is that everything outside those categories
+  earns just 1 point per dollar, and the points land in Aeroplan, so the value
+  depends on you actually using Air Canada's award chart. No foreign
+  transaction fees and a $120 Global Entry, TSA PreCheck, or NEXUS credit
+  every four years round it out.
 

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -61,18 +61,18 @@ apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/flex
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Chase Freedom Flex stands out as the top pick for cash back enthusiasts,
-  offering a robust 5% back on quarterly rotating categories like gas
-  stations, EV charging, public transit, and select live entertainment, up to
-  $1,500 per quarter. With no annual fee, it's a versatile card that also
-  provides 5% back on travel booked through Chase, 3% on dining and
-  drugstores, and 1% on everything else. The $200 signup bonus after spending
-  $500 in the first three months is a compelling incentive for new
-  cardholders. However, the card does carry a foreign transaction fee, making
-  it less ideal for international use. The 15-month 0% intro APR on purchases
-  and balance transfers adds further appeal, especially if you're planning a
-  big purchase or need to manage existing debt. Cell phone protection is a
-  nice touch, offering up to $1,000 per year in coverage.
+  The Freedom Flex tops our Best Cash Back list because it packs a lot into a
+  card with no annual fee: 5% back on rotating quarterly categories on up to
+  $1,500 in spend, 5% on travel booked through the Chase portal, and 3% on
+  both dining and drugstores year-round. The $200 bonus after $500 in spend in
+  three months is one of the easier ones to clear, and a 15-month 0% intro APR
+  on purchases and balance transfers gives the card a second use. The rotating
+  categories are the work, though: they change every quarter, the Q3 2026
+  lineup covers gas stations and EV charging, public transit, and select live
+  entertainment, and once you clear the $1,500 quarterly cap the rate drops to
+  1%. Everything outside a bonus category earns 1%, so this is a card to pair
+  with a flat-rate earner rather than use alone. It also charges foreign
+  transaction fees, which keeps it home when you travel.
 benefits:
   - name: "Cell Phone Protection"
     value: 1000

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -33,16 +33,18 @@ apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/rise
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Chase Freedom Rise offers a straightforward 1.5% cash back on all
-  purchases with no annual fee, making it a solid entry-level choice for those
-  looking to earn rewards on everyday spending. The real draw is the $25
-  statement credit for enrolling in automatic payments within the first three
-  months, which can be a nice bonus for setting up good financial habits.
-  However, the card's high regular APR of 25.24% means it's best suited for
-  those who plan to pay off their balance in full each month. The 6-month
-  complimentary DashPass membership adds some value for frequent DoorDash or
-  Caviar users, but it's a one-time perk. Overall, it's a decent starter card
-  for building credit and earning consistent cash back.
+  The Freedom Rise is built as a starter card: 1.5% cash back on everything,
+  no annual fee, and no categories to track. New accounts get 3% back on
+  dining, including takeout and eligible delivery, on up to $6,000 spent in
+  the first six months, after which that spending settles back to the standard
+  1.5%. There is no signup bonus, so the closest thing to one is the $25
+  statement credit for enrolling in automatic payments within your first three
+  months and staying enrolled for at least 90 days, which is a useful nudge if
+  you are building a payment history. Lyft rides earn 2% through September 30,
+  2027, a half percent over the base rate and only at Lyft, so treat it as a
+  small extra rather than a reason to choose the card. It is a fine first
+  card, but the flat 1.5% is where it settles, so expect to outgrow it once
+  your credit supports something with real bonus categories.
 benefits:
   - name: "DashPass Complimentary Membership"
     value: 0

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -47,16 +47,18 @@ apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/unlimit
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Chase Freedom Unlimited is a versatile cash-back card with no annual
-  fee, offering a solid 1.5% back on all purchases and higher rates in
-  specific categories: 5% on travel booked through Chase, and 3% on dining and
-  drugstore purchases. It also features a 0% intro APR for 15 months on both
-  purchases and balance transfers, making it a strong option for those looking
-  to manage interest costs in the short term. The current signup bonus is $200
-  after spending $500 in the first three months, which is competitive but
-  recently reduced from $250. However, the card does charge foreign
-  transaction fees, so it's not ideal for international use. The complimentary
-  6-month DashPass membership adds value for frequent DoorDash users.
+  The Freedom Unlimited's appeal is that its floor is high: 1.5% back on
+  everything with no annual fee and no categories to activate, plus 3% on
+  dining and drugstores and 5% on travel booked through the Chase portal. That
+  combination is why it sits at #2 on our Best Cash Back list as the best
+  no-fee pick, and it makes a natural partner for a card with rotating
+  categories. Chase trimmed the signup bonus from $250 to $200 in April,
+  though the $500 spend requirement over three months is still easy to clear,
+  and the 15-month 0% intro APR on purchases and balance transfers gives new
+  cardholders room to finance something. The tradeoffs are ordinary but real:
+  there is a foreign transaction fee, so leave it behind when you travel
+  abroad, and the 2% on Lyft rides through September 2027 applies only at
+  Lyft. As a keep-forever no-fee card, it is hard to argue with.
 benefits:
   - name: "DashPass Complimentary Membership"
     description: "6 months of complimentary DashPass membership with $0 delivery fees on eligible orders."

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -70,16 +70,17 @@ apply_link: https://creditcards.chase.com/business-credit-cards/ink/cash
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Ink Business Cash card stands out with its generous 5% cash back on
-  office supplies, internet, cable, and phone services, up to a combined
-  $25,000 annually. This makes it an excellent choice for businesses with
-  significant expenses in these categories. The card also offers a strong
-  signup bonus of $1,000 after spending $8,000 in the first four months,
-  recently increased from $750. However, the rewards drop to 1% after reaching
-  the cap, and the 2% cash back on gas and dining is less competitive. While
-  the card has no annual fee, be mindful of the foreign transaction fee if you
-  travel internationally. The 12-month 0% intro APR on purchases is a nice
-  perk for managing cash flow.
+  The Ink Business Cash pays 5% back on office supply stores and on internet,
+  cable, and phone services across a combined $25,000 of annual spend, which
+  is a lot of 5% room for a card with no annual fee. Chase raised the signup
+  bonus in June from $750 to $1,000 after $8,000 in spend within four months,
+  and a 12-month 0% intro APR on purchases helps if you are financing startup
+  costs. Gas stations and restaurants earn 2% on their own $25,000 cap, and
+  everything past a cap or outside a category drops to 1%, so the card rewards
+  businesses whose spending clusters in those specific buckets. It also
+  carries a foreign transaction fee, which makes it a poor fit if you buy from
+  overseas suppliers. Pair it with a flat-rate business card and the 1% base
+  rate stops mattering much.
 benefits:
   - name: "Instacart+ Membership"
     description: "Complimentary three-month Instacart+ membership with a $20 Instacart credit each month"

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -39,19 +39,19 @@ apr:
     min: 17.74
     max: 26.74
 our_take: >
-  The Ink Business Preferred from Chase stands out with a hefty 100,000-point
-  signup bonus after spending $8,000 in the first three months, making it a
-  top contender for businesses looking to maximize rewards quickly. Its 3x
-  points on travel, shipping, internet, cable, phone, and advertising on
-  search engines and social media (up to $150,000 annually) cater well to
-  business expenses, while the limited-time 5x points on Lyft rides adds extra
-  value for frequent travelers. The $95 annual fee is reasonable given the
-  card's robust earning potential and benefits like primary auto rental
-  coverage and cell phone protection. However, beyond the bonus categories,
-  the 1x point rate on other purchases is less compelling. For businesses with
-  significant spending in the bonus categories, this card offers substantial
-  value, but those with more varied expenses might find the everyday earn rate
-  less appealing.
+  The Ink Business Preferred's 100,000-point signup bonus after $8,000 in
+  spend within three months is large enough to land it at #7 on our Best
+  Signup Bonuses list, and it comes attached to a $95 annual fee rather than a
+  premium one. The ongoing structure is the real draw for spending-heavy
+  businesses: 3 points per dollar on travel, shipping, internet, cable and
+  phone, and search and social advertising, on a combined $150,000 per year
+  before the rate falls to 1 point. Cell phone protection up to $1,000 per
+  claim when you pay the bill with the card, plus primary auto rental coverage
+  on business rentals, are the kind of practical benefits that justify keeping
+  it past year one. The weakness is everything else: non-bonus spend earns a
+  single point per dollar, so this is a card you aim at specific categories,
+  not a daily driver. No foreign transaction fees make it workable for
+  international business spending.
 benefits:
   - name: "Cell Phone Protection"
     value: 0

--- a/data/cards/chase-ink-business-premier.yaml
+++ b/data/cards/chase-ink-business-premier.yaml
@@ -64,14 +64,16 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  The Ink Business Premier is built for businesses with big invoices: every
-  purchase earns 2% cash back, purchases of $5,000 or more earn 2.5%, and
-  travel booked through Chase Travel earns 5%. The $1,000 welcome bonus after
-  $10,000 in spend is one of the largest flat-cash bonuses on any business
-  card, and cell phone protection plus primary rental coverage add practical
-  value. The catch is flexibility: this is a pay-in-full card (balances can
-  only revolve through Chase's Flex for Business feature), and its rewards
-  cannot be pooled with other Ink or Sapphire cards or transferred to Chase's
-  travel partners, so points maximizers should look at the Ink Business
-  Preferred instead. For a high-spend business that just wants cash back, the
-  $195 annual fee pays for itself quickly.
+  The Ink Business Premier is aimed at businesses that make large purchases:
+  all spending earns 2% back, and single transactions of $5,000 or more earn
+  2.5%, which is an unusual structure and the main reason to pay the $195
+  annual fee. Travel booked through Chase Travel earns 5%, and the signup
+  bonus is $1,000 after $10,000 in spend within three months. Protections are
+  solid for a card at this price: up to $1,000 per claim in cell phone
+  coverage, purchase protection for 120 days up to $10,000 per item, an extra
+  year on eligible manufacturer warranties, and primary rental coverage up to
+  $60,000 on business rentals, with employee cards at no cost. There are no
+  foreign transaction fees, so international purchasing does not get taxed.
+  The math only works if your volume is high, though, because a no-fee 2%
+  business card gets you most of the way there unless you regularly push
+  single charges above $5,000.

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -32,19 +32,17 @@ apr:
     min: 16.74
     max: 24.74
 our_take: >
-  The Ink Business Unlimited card from Chase offers a straightforward 1.5%
-  cash back on all purchases, making it an easy choice for business owners who
-  want simple, reliable rewards without tracking bonus categories. A standout
-  feature is the recently increased signup bonus of $1,000 after spending
-  $8,000 in the first four months, which is a generous incentive for new
-  cardholders. The card also provides a 12-month 0% intro APR on purchases,
-  which can be beneficial for managing cash flow on new business expenses.
-  However, the card does carry a foreign transaction fee, so it's not ideal
-  for international business travel. Additionally, there's a limited-time
-  offer of 5% back on Lyft rides through September 2027 and a complimentary
-  three-month Instacart+ membership with monthly credits, adding some extra
-  value. With no annual fee, this card is a solid option for businesses
-  seeking uncomplicated rewards and a strong introductory offer.
+  The Ink Business Unlimited is the simple option in Chase's business lineup:
+  1.5% back on every purchase, no categories to track, and no annual fee.
+  Chase raised the signup bonus in June from $750 to $1,000 after $8,000 in
+  spend in the first four months, a strong return for a card that costs
+  nothing to hold, and the 12-month 0% intro APR on purchases makes it usable
+  for equipment or inventory you plan to pay off over the year. The flip side
+  is that 1.5% is all there is: no bonus categories, and no ongoing perks
+  beyond a three-month Instacart+ membership with a $20 monthly credit. It
+  also charges foreign transaction fees, so keep it away from overseas
+  suppliers. Use it alongside a category card, catching whatever spending the
+  other card does not reward.
 apply_link: https://creditcards.chase.com/business-credit-cards/ink/unlimited
 foreign_transaction_fee: true
 network: "visa"

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -98,15 +98,18 @@ apply_link: https://creditcards.chase.com/rewards-credit-cards/sapphire/preferre
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Chase Sapphire Preferred stands out with its recently increased signup
-  bonus of 100,000 points after spending $5,000 in the first three months,
-  making it a top choice for travelers and dining enthusiasts. With 5 points
-  per dollar on travel booked through Chase, 3 points on dining, gas,
-  streaming, and online groceries, and 2 points on other travel, it offers
-  robust earning potential for a $95 annual fee. The $50 annual hotel credit
-  and the Global Entry/TSA PreCheck credit every four years add further value,
-  alongside perks like a complimentary year of Apple TV and DoorDash DashPass.
-  However, the online grocery rewards exclude major retailers like Target and
-  Walmart, which might limit its appeal for some. Overall, it's a strong
-  contender for anyone looking to maximize travel and dining rewards, as
-  evidenced by its top ranking in the Best Travel Credit Cards list.
+  Chase raised the Sapphire Preferred's signup bonus from 75,000 to 100,000
+  points in June, and at $5,000 of spend over three months that is an
+  unusually low bar for a bonus that size. The everyday earn holds up too: 3
+  points per dollar on dining worldwide, on gas and EV charging, and on
+  streaming, 5 points on travel booked through Chase Travel, and 2 points on
+  all other travel, all for a $95 annual fee with no foreign transaction fees,
+  which is a big part of why it tops our Best Travel ranking. A $100 hotel
+  credit each anniversary year for stays booked through Chase Travel covers
+  most of the fee on its own, and there is a $120 Global Entry, TSA PreCheck,
+  or NEXUS credit every four years. Read the fine print on two of the 3x
+  categories: groceries only count when bought online and exclude Target,
+  Walmart, and wholesale clubs, and the vacation rental rate applies only to
+  bookings made directly with brands like Airbnb, Vrbo, and Vacasa. Everything
+  outside a category earns 1 point, so this is a travel and dining card first,
+  not a card for general spending.

--- a/data/cards/chase-sapphire-reserve-business.yaml
+++ b/data/cards/chase-sapphire-reserve-business.yaml
@@ -145,16 +145,18 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  The Chase Sapphire Reserve for Business brings the full premium Sapphire
-  treatment to business owners, with 8x points on Chase Travel bookings, 4x on
-  flights and hotels booked directly, and a huge welcome offer for those who
-  can meet the $30,000 spend requirement. The $795 annual fee looks steep, but
-  the stack of credits, including $300 in travel, up to $500 through The Edit,
-  $400 for ZipRecruiter, and $200 for Google Workspace, can more than cover it
-  for a business that would spend on those services anyway. Lounge access
-  through Sapphire Lounges and Priority Pass rounds out the travel perks, and
-  heavy spenders unlock another $1,000 in credits plus hotel and Southwest
-  elite status at $120,000 in annual purchases. Note that this is a pay-in-full
-  card, so there is no revolving APR outside of the Flex for Business feature.
-  If your business travels often and can use even half the credits, the math
-  works; if not, the Ink Business Preferred is the cheaper Chase travel play.
+  The Sapphire Reserve for Business pairs a $795 annual fee with a stack of
+  credits aimed squarely at owners who already travel and advertise: $300 in
+  annual travel credit, $500 a year through The Edit by Chase Travel, $400 in
+  ZipRecruiter credits, and $200 toward Google Workspace. Earning is
+  front-loaded on travel, at 8x through Chase Travel and 4x on hotels and
+  flights booked directly, plus 3x on social media and search engine
+  advertising, while everything else sits at 1x. The signup bonus is currently
+  an elevated 200,000 points after $30,000 in six months, well above the
+  standard 150,000, but that spending hurdle rules out most small operations.
+  The real question is whether you will actually use the credits, since most
+  arrive in semi-annual chunks with 2027 expiration dates, and the 5x transit
+  rate applies only to Lyft rides and only through September 30, 2027. If your
+  business books travel through Chase and pays for hiring and Workspace
+  anyway, the math can work; otherwise $795 is a lot to pay for 1x on ordinary
+  spend.

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -142,16 +142,17 @@ apply_link: https://creditcards.chase.com/rewards-credit-cards/sapphire/reserve
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Chase Sapphire Reserve is a top-tier choice for luxury travelers,
-  offering an array of premium benefits that can offset its hefty $795 annual
-  fee. The standout feature is the $300 annual travel credit, which
-  effectively reduces the fee to $495 if fully utilized. Recent changes have
-  seen the signup bonus drop to 100,000 points after spending $6,000 in the
-  first three months, still a substantial incentive. You'll earn 8 points per
-  dollar on travel booked through the Chase portal, 4 points on hotels and
-  airlines, and 3 points on dining, making it a strong contender for frequent
-  travelers and diners. The card also provides extensive lounge access and a
-  suite of credits, including $500 annually for bookings through The Edit by
-  Chase Travel and $300 for dining, which can add significant value. However,
-  if you don't take full advantage of these perks, the high annual fee may
-  outweigh the benefits.
+  Chase cut the Sapphire Reserve's signup bonus from 150,000 points to 100,000
+  in June, and it now takes $6,000 in three months to earn, yet the card still
+  ranks third on our Best Travel Credit Cards list on the strength of its
+  credits and lounge access. Against the $795 annual fee you get $300 in
+  annual travel credit, $500 a year through The Edit by Chase Travel, $300 in
+  OpenTable dining credits, $300 in StubHub credits, and both Priority Pass
+  Select and Chase Sapphire Lounge access. Earning is strong where it counts
+  for travelers: 8x through Chase Travel, 4x on hotels and flights booked
+  directly, and 3x on dining, though everything else earns just 1x. The catch
+  is that the fee only works if you actively chase a long list of narrow
+  credits, several capped semi-annually and tied to specific partners, and the
+  headline 10x and 5x rates apply only at Peloton and Lyft respectively and
+  expire in 2027. Add up the credits you would genuinely use before assuming
+  the $795 pays for itself.

--- a/data/cards/chase-slate-edge.yaml
+++ b/data/cards/chase-slate-edge.yaml
@@ -15,12 +15,14 @@ apply_link: https://creditcards.chase.com/credit-building-credit-cards/edge
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Slate Edge is a simple no-annual-fee card built around one idea: a built-in incentive
-  to lower your APR over time if you pay on time and spend a set amount each year. It no
-  longer carries the long 0% intro balance-transfer offer it was once known for, and it
-  earns no rewards, so it mainly suits people who sometimes carry a balance and want an
-  automatic path to a lower rate. If you need a true 0% intro window, cards like the Wells
-  Fargo Reflect are the better tool.
+  Slate Edge is a financing card first and last: no annual fee, and it lands
+  sixth on our Best 0% APR list on the strength of its intro financing window.
+  There is no rewards program attached, so nothing is earning on your spend,
+  and once the intro period ends the ongoing APR is a flat 28.99%. It also
+  charges foreign transaction fees, which rules it out for travel. The lone
+  extra is six months of complimentary DashPass for DoorDash and Caviar. Open
+  it with a payoff plan and a date, and don't expect a reason to keep spending
+  on it after that.
 benefits:
   - name: "Complimentary DashPass"
     value: 0

--- a/data/cards/chase-united-presidential-plus.yaml
+++ b/data/cards/chase-united-presidential-plus.yaml
@@ -10,12 +10,11 @@ tags:
   - airline
   - travel
 our_take: >
-  The United Presidential Plus card from Chase is a high-end travel card that
-  is no longer accepting new applications, which limits its appeal to existing
-  cardholders. With an annual fee of $495, it's positioned for frequent United
-  Airlines flyers who can take advantage of its premium travel benefits.
-  However, without details on specific earn rates or perks, it's challenging
-  to assess its ongoing value compared to other airline cards. If you already
-  have it, weigh the benefits you're actually using against the steep fee. For
-  newcomers, the closed application status means you'll need to look elsewhere
-  for a comparable travel card.
+  The United Presidential Plus is closed to new applicants, so this is a card
+  you either already hold or you don't. At $495 a year it sits in premium
+  airline territory, but we have no earn rates, statement credits, or lounge
+  benefits on file for it, which makes it hard to argue the fee is doing much
+  work. If you're carrying it, the honest exercise is to compare the miles and
+  perks you actually collected last year against that $495, and against what a
+  currently open United card would give you for less. Account age is worth
+  something, but not $495 a year on its own.

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -86,17 +86,18 @@ apply_link: https://www.citi.com/usc/lpaca/aa/aadvantage/exec/ps/index0.html
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Citi AAdvantage Executive World Elite Mastercard is a strong contender
-  for frequent American Airlines flyers, offering full Admirals Club lounge
-  access for both cardholders and authorized users. The card also provides
-  valuable travel perks like a free first checked bag and preferred boarding
-  on domestic American Airlines flights. However, the recent reduction of the
-  signup bonus from 100,000 to 70,000 miles, requiring $7,000 in spending
-  within three months, may dampen its initial appeal. The $595 annual fee is
-  steep, but it is partially offset by up to $360 in annual credits across
-  Lyft, Grubhub, and car rentals. With 4 miles per dollar on American Airlines
-  purchases and 10 miles per dollar on eligible hotels and car rentals through
-  AA portals, it can be rewarding for loyalists, though the 1 mile per dollar
-  on other purchases is less competitive. Consider this card if you can
-  leverage the travel benefits and credits to justify the high fee.
+  The Executive is really an Admirals Club membership with a credit card
+  attached: full lounge access for you and your authorized users is the reason
+  to pay $595 a year, and if you fly American enough to buy that membership
+  outright, this is the cheaper way in. Around it sit $120 each in annual
+  Lyft, Grubhub, and Avis or Budget credits, a Global Entry or TSA PreCheck
+  credit, a free first checked bag on domestic American itineraries, and
+  preferred boarding. Earning is narrow: 10x on hotels and car rentals booked
+  through American's portals and 4x on American Airlines purchases only,
+  rising to 5x after $150,000 in a calendar year, with everything else at 1x.
+  The signup bonus is 70,000 miles after $7,000 in three months, and the
+  10,000 point Loyalty Points bonuses at the 50,000 and 90,000 marks help if
+  you're chasing status. It ranks 16th on our Best Airline Credit Cards list,
+  which reflects the reality that without the lounge access, $595 buys a card
+  you shouldn't be putting ordinary spend on.
 

--- a/data/cards/citi-aadvantage-globe.yaml
+++ b/data/cards/citi-aadvantage-globe.yaml
@@ -95,14 +95,17 @@ apply_link: https://www.citi.com/credit-cards/citi-aadvantage-globe-mastercard
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Citi AAdvantage Globe card stands out for frequent American Airlines
-  travelers with perks like a free first checked bag and preferred boarding.
-  It offers a solid rewards structure, including 6 miles per dollar on
-  eligible hotel bookings through aadvantagehotels.com and 3 miles per dollar
-  on American Airlines purchases. However, the $350 annual fee is significant,
-  and the recent drop in the signup bonus from 90,000 to 60,000 miles makes it
-  less enticing for new applicants. The card also provides up to $240 in Turo
-  statement credits and four Admirals Club Globe Passes annually, which can
-  help offset the fee if you use them. Overall, it's a card best suited for
-  those who can maximize the travel benefits and are loyal to American
-  Airlines.
+  Citi briefly raised the Globe's signup bonus to 90,000 miles in May and
+  pulled it back to 60,000 after $4,000 in three months on July 1, so you're
+  seeing the card at its baseline offer. The $350 annual fee is meant to be
+  covered by credits: $240 a year on Turo rentals, $100 on inflight purchases,
+  $100 across a short list of splurge partners, a Global Entry or TSA PreCheck
+  credit, and four Admirals Club Globe passes rather than full membership.
+  Earning is respectable for an airline card, with 6x on hotels booked through
+  aadvantagehotels.com, 3x on American Airlines purchases, 2x on dining and
+  transit, and 1x on everything else. The catch is how specific those credits
+  are, since Turo, inflight spending, and 1stDibs or Live Nation are not
+  everyday categories, so the real value depends on whether your habits happen
+  to match the list. It sits 14th on our Best Airline Credit Cards list, and
+  the companion certificate that starts in the second year is the piece most
+  likely to justify a renewal.

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -62,13 +62,14 @@ apply_link: https://www.citi.com/credit-cards/citi-aadvantage-platinum-select-wo
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Citi AAdvantage Platinum Select World Elite Mastercard shines for
-  frequent American Airlines flyers, offering a generous 80,000-mile signup
-  bonus after spending $3,500 in the first 4 months. This card is especially
-  appealing if you value travel perks like a free first checked bag and
-  preferred boarding on American Airlines flights. The annual fee is waived
-  for the first year, giving you a full year to evaluate its benefits.
-  However, the ongoing rewards are limited to 2 miles per dollar on American
-  Airlines purchases, dining, and gas, with just 1 mile per dollar on
-  everything else. If you're not a loyal American Airlines traveler, the
-  card's value might diminish after the initial bonus and fee-free period.
+  This is our top-ranked airline card, largely because of how little it asks:
+  the $99 annual fee is waived for the first 12 months, and the signup bonus
+  is back up to 80,000 miles after $3,500 in four months following a dip to
+  50,000 this spring. The free first checked bag on domestic American Airlines
+  itineraries can cover the fee by itself for a couple that flies once or
+  twice a year, and preferred boarding plus 25% off inflight food and drink
+  come along with it. Earning is modest but sensible: 2x on American Airlines
+  purchases, dining, and gas, and 1x on everything else. Don't expect more
+  than that, because there is no lounge access, no travel credit, and no
+  companion certificate here. It's a card you keep for the bag benefit and the
+  occasional award redemption, not one you route your whole budget through.

--- a/data/cards/citi-custom-cash.yaml
+++ b/data/cards/citi-custom-cash.yaml
@@ -47,13 +47,15 @@ apr:
     max: 27.49
 apply_link: https://www.citi.com/credit-cards/citi-custom-cash-credit-card
 our_take: >
-  The Citi Custom Cash card is a versatile choice for those who want to
-  maximize cash back in their top spending category each month, with an
-  automatic 5% back on up to $500 spent in eligible categories like dining,
-  groceries, and gas. This makes it a flexible option for varied spending
-  habits, especially with no annual fee. However, the card is currently not
-  accepting new applications, which limits its availability. Beyond the 5%
-  category, the card offers just 1% back on other purchases, so it's best used
-  in tandem with a broader rewards strategy. The 15-month 0% intro APR on
-  purchases and balance transfers is a solid perk for managing interest, and
-  the $200 signup bonus for $1,500 spent in six months adds initial value.
+  Citi stopped accepting new applications for the Custom Cash on May 28, so
+  this is now a card for existing holders rather than one to chase. If you
+  have it, the appeal is unchanged: 5% back automatically on your top eligible
+  spending category each billing cycle, drawn from a list that includes
+  dining, groceries, gas, transit, travel, and streaming, with no annual fee.
+  The limit is the cap of $500 in purchases per month, so the 5% tops out
+  around $25 a month before falling to 1%, and everything outside your top
+  category earns 1% as well. That makes it a strong complement to a broader
+  cash back card rather than a primary one, which is about where it lands on
+  our lists at sixth for cash back and ninth for dining and groceries. The 15
+  month 0% intro APR on purchases and balance transfers only matters if you
+  opened it while the door was still open.

--- a/data/cards/citi-diamond-preferred.yaml
+++ b/data/cards/citi-diamond-preferred.yaml
@@ -21,12 +21,13 @@ apply_link: https://www.citi.com/credit-cards/citi-diamond-preferred-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Citi Diamond Preferred card stands out for its lengthy 21-month 0% intro
-  APR on balance transfers, making it a top choice for those focused on paying
-  down existing debt without interest pressure. With no annual fee, it's a
-  cost-effective option for managing balances over an extended period.
-  However, the card offers no rewards program, so it lacks ongoing value once
-  the balance transfer period ends. It also has a 12-month 0% intro APR on
-  purchases, which can be useful for short-term financing, but the regular APR
-  ranges from 16.49% to 27.24% afterward. Keep in mind the foreign transaction
-  fees if you plan to use it abroad.
+  The Diamond Preferred is a debt payoff tool, not a rewards card: 21 months
+  of 0% intro APR on balance transfers and 12 months on purchases, with no
+  annual fee, which is what puts it fourth on our Best 0% APR list. That
+  transfer runway is among the longer ones available, so if your goal is to
+  move existing debt and clear it on a schedule, it does the job cleanly. Be
+  clear about the tradeoff, though: this card earns nothing at all, no cash
+  back and no points, so there is no reason to spend on it once the intro
+  window closes. It also charges foreign transaction fees, so leave it home
+  when you travel. Open it with a payoff plan, follow the plan, and expect the
+  card to go quiet afterward.

--- a/data/cards/citi-double-cash.yaml
+++ b/data/cards/citi-double-cash.yaml
@@ -33,14 +33,15 @@ apply_link: https://www.citi.com/credit-cards/citi-double-cash-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Citi Double Cash card stands out for its straightforward cash back
-  structure, offering 2% on all purchases: 1% when you buy and an additional
-  1% when you pay. This makes it an excellent choice for those who prefer a
-  simple, flat-rate rewards card with no annual fee. The card also offers 5%
-  cash back on hotels, car rentals, and attractions booked through the Citi
-  Travel portal, which can be a nice perk for travelers. However, it does come
-  with a foreign transaction fee, so it might not be the best option for
-  international use. Additionally, there's a $200 signup bonus if you spend
-  $1,500 in the first six months, adding extra value for new cardholders. With
-  an 18-month 0% intro APR on balance transfers, it's also a solid option for
-  those looking to manage existing debt.
+  The Double Cash earns a flat 2% on everything, paid as 1% when you buy and
+  1% when you pay the balance, and that simplicity at no annual fee is why it
+  sits fourth on our Best Cash Back list. It's the card for spending that
+  doesn't fit anyone's bonus categories, and 5% on hotels, car rentals, and
+  attractions booked through the Citi Travel portal gives it one bright spot
+  if you book that way. There's a $200 bonus after $1,500 in six months and an
+  18 month 0% intro APR on balance transfers, which makes it unusually useful
+  as both a payoff card and a long-term keeper. Two limits are worth knowing:
+  the second 1% only lands when you actually pay, so carrying a balance costs
+  you half the rate, and it charges foreign transaction fees, so it isn't the
+  card for trips abroad. As a base layer underneath category cards, it's hard
+  to beat for free.

--- a/data/cards/citi-prestige.yaml
+++ b/data/cards/citi-prestige.yaml
@@ -7,12 +7,12 @@ annual_fee: 495
 reward_type: "points"
 network: "mastercard"
 our_take: >
-  The Citi Prestige card is no longer accepting applications, which limits its
-  appeal to current cardholders who already enjoy its benefits. With a high
-  annual fee of $495, this card is aimed at those who can take full advantage
-  of its premium perks, such as travel credits and lounge access. However,
-  without the ability to apply for it, new customers will need to look
-  elsewhere for a premium travel rewards card. For those who already have it,
-  the points-earning potential and luxury benefits may still justify keeping
-  it in their wallet, but it's crucial to weigh these against the steep annual
-  fee.
+  Citi has stopped accepting applications for the Prestige, so it is only
+  relevant to people who already hold one, and the decision is whether to
+  renew rather than whether to apply. At $495 a year, that renewal only makes
+  sense if you are actively using enough of what the card still delivers to
+  clear the fee. Keep in mind that closing it is effectively permanent: with
+  applications shut, you cannot pick the card back up later if you change your
+  mind. If the fee no longer pencils out, ask Citi about a product change to a
+  card that is still open before you cancel outright. For everyone else, treat
+  this as reference material rather than a shopping option.

--- a/data/cards/citi-rewards.yaml
+++ b/data/cards/citi-rewards.yaml
@@ -7,12 +7,12 @@ reward_type: "points"
 image: "citi-rewards-plus.png"
 network: "mastercard"
 our_take: >
-  The Citi Rewards+ card is no longer accepting applications, which is a shame
-  given its unique rewards structure. With no annual fee, it offered a
-  compelling option for those looking to earn points on everyday purchases.
-  The standout feature was its ability to round up every purchase to the
-  nearest 10 points, which could significantly boost earnings on small
-  transactions. However, without the ability to apply for it now, potential
-  cardholders will need to look elsewhere for similar benefits. If you already
-  have the card, it's still a useful tool for maximizing points on minor
-  spending.
+  The Rewards+ is closed to new applications, so it only matters if one is
+  already in your wallet. The good news for existing cardholders is the $0
+  annual fee, which means there is no ongoing cost to keeping it open and no
+  urgency to make a decision. That matters more than it sounds: leaving a
+  free, aged account open supports the average age of your credit history,
+  while closing it gives up that history and returns nothing. Since you cannot
+  reapply, the default move is to keep it open, put an occasional small charge
+  on it, and build your everyday earning around a card that is still
+  available. Do not plan on this being your primary points card going forward.

--- a/data/cards/citi-secured-mastercard.yaml
+++ b/data/cards/citi-secured-mastercard.yaml
@@ -15,13 +15,14 @@ apply_link: https://www.citi.com/credit-cards/citi-secured-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Citi Secured Mastercard is a straightforward tool for building or
-  rebuilding your credit, with no annual fee to worry about. As a secured
-  card, it requires a security deposit, but this is standard for the category
-  and helps you establish a credit line. The regular APR is high at 26.74%, so
-  it's crucial to pay off your balance in full each month to avoid costly
-  interest charges. While it doesn't offer rewards or perks, its primary value
-  lies in its ability to help you improve your credit score over time. Be
-  mindful of the foreign transaction fee if you plan to use it abroad. Ranked
-  #4 on our Best Secured Credit Cards list, it's a solid option for those
-  focused on credit improvement.
+  The value here is access, not rewards: the Citi Secured Mastercard is built
+  for people establishing or rebuilding credit, it carries no annual fee, and
+  it ranks fourth on our list of the best secured cards. Because it is
+  secured, your line comes from the refundable deposit you put down, so it
+  functions as a credit reporting tool rather than a spending tool. There are
+  no earn rates at all, so every dollar you run through it buys you credit
+  history and nothing else. The 25.99% APR is the reason to treat this
+  strictly as a pay in full card, since carrying a balance would erase the
+  progress you are making. Two other limits are worth knowing: it charges
+  foreign transaction fees, so leave it home when you travel, and once your
+  scores recover you should graduate to a card that actually pays you back.

--- a/data/cards/citi-simplicity-card.yaml
+++ b/data/cards/citi-simplicity-card.yaml
@@ -21,9 +21,13 @@ apply_link: https://www.citi.com/credit-cards/citi-simplicity-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Simplicity is a debt-payoff card: 18 months of 0% intro APR on both
-  purchases and balance transfers (transfers must be completed within the first
-  4 months) with no annual fee, and it is one of the stronger
-  picks for a long 0% runway. It earns no rewards and charges a foreign
-  transaction fee, so open it to clear a balance on a fixed plan, not to keep
-  spending on after the intro period ends.
+  Simplicity is a debt payoff tool first: 18 months of 0% intro APR on both
+  purchases and balance transfers with no annual fee, which is enough runway
+  to clear a meaningful balance if you actually plan the payments. That
+  combination earns it the fifth spot on our best 0% APR list. The tradeoff is
+  that the card earns nothing at all, no cash back and no points, so there is
+  no reason to keep spending on it once the intro window closes. Rates then
+  reset into a 17.49% to 28.24% range depending on your credit, which is
+  exactly what you opened the card to avoid. It also charges foreign
+  transaction fees, so keep it out of your travel wallet and use it for what
+  it is: a fixed window to get out from under interest.

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -88,9 +88,20 @@ apply_link: https://www.citi.com/credit-cards/citi-strata-elite-credit-card
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  Citi's run at the premium-travel tier, a $595 card stacked with credits (hotel,
-  splurge, Blacklane), Priority Pass, and a strong 75,000-point bonus, and it ranks among
-  the better travel cards on our lists. The 1.5x base earn is soft for the price, so the math
-  only works if you reliably use the credits and value ThankYou transfer partners. Against
-  the $795 Sapphire Reserve and $395 Venture X, it lands in between: cheaper than Chase, more
-  credit-juggling than Capital One.
+  The Strata Elite is priced for people who will actually use its credits:
+  $595 a year, offset by a $300 annual hotel credit on stays of two or more
+  nights booked through Citi Travel, a $200 Blacklane chauffeur credit split
+  into $100 halves across the year, and a $200 splurge credit you can point at
+  up to two of five brands including American Airlines and Best Buy. Earning
+  is top heavy inside Citi's own portal, at 12x on hotels, car rentals, and
+  attractions and 6x on flights booked through Citi Travel, with 3x on dining
+  that rises to 6x during Citi Nights on Friday and Saturday evenings, and
+  1.5x on everything else. A 75,000 point welcome bonus after $6,000 in three
+  months, unlimited Priority Pass access, and four Admirals Club passes are
+  why it lands seventh on our best travel list with a Best for High Earners
+  badge. The catch is how conditional the headline numbers are: the biggest
+  credits and multipliers only pay out inside Citi Travel or at named brands,
+  so if you book direct or through another portal the math thins out quickly.
+  There is no foreign transaction fee and a $120 Global Entry or TSA PreCheck
+  credit every four years, but add up the credits you will realistically use
+  before you commit to the fee.

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -53,17 +53,18 @@ apply_link: https://www.citi.com/credit-cards/citi-strata-premier-credit-card
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Citi Strata Premier card stands out with its impressive 10 points per
-  dollar on hotels, car rentals, and attractions booked through Citi Travel,
-  making it an attractive option for frequent travelers. The card also offers
-  a solid 3 points per dollar on airlines, dining, groceries, gas, and hotels
-  booked directly, providing a well-rounded rewards structure. The $100 annual
-  hotel credit offsets the $95 annual fee if you book a qualifying stay, but
-  be mindful that the card's value hinges on your ability to leverage these
-  travel benefits. The 60,000-point signup bonus after spending $4,000 in the
-  first three months is a strong incentive, but the regular APR starts at a
-  relatively high 20.24%, so carrying a balance could be costly. With no
-  foreign transaction fees, it's a good companion for international travel,
-  but ensure the rewards align with your spending habits to maximize its
-  potential.
+  For $95 a year the Strata Premier covers an unusually wide set of
+  categories: 3x points on airlines, hotels booked direct, dining, groceries,
+  and gas including EV charging, plus 10x on hotels, car rentals, and
+  attractions booked through Citi Travel. That breadth is why it sits at
+  number four on our best travel list with a Best Value badge and fifth among
+  cards for dining and groceries. A 60,000 point bonus after $4,000 in three
+  months and no foreign transaction fees make the first year easy to justify,
+  and the $100 credit on a single Citi Travel hotel stay of $500 or more can
+  cover the fee outright if you book that way. The limits are worth naming:
+  everything outside those categories earns a flat 1x, the hotel credit fires
+  on just one qualifying portal booking per calendar year, and the 10x rate is
+  portal only, so booking a hotel direct drops you to 3x. It is a strong
+  middle tier travel card rather than a premium one, and the value only shows
+  up if your spending genuinely lands in those 3x buckets.
 

--- a/data/cards/citi-strata.yaml
+++ b/data/cards/citi-strata.yaml
@@ -59,15 +59,15 @@ apply_link: https://www.citi.com/credit-cards/citi-strata-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Citi Strata card stands out with its 5 points per dollar on hotels, car
-  rentals, and attractions booked through Citi Travel, making it a strong
-  contender for frequent travelers who book through that portal. With no
-  annual fee, it also offers 3 points per dollar on groceries, transit, gas,
-  and a self-selected category, providing solid rewards for everyday spending.
-  The 15-month 0% intro APR on purchases and balance transfers is a generous
-  window for managing new expenses or existing debt. However, the card's value
-  diminishes outside of these categories, offering just 1 point per dollar on
-  everything else. The 20,000-point signup bonus for spending $1,000 in the
-  first three months is a nice initial boost, but the regular APR range of
-  18.49% to 28.49% means carrying a balance could get expensive after the
-  intro period.
+  The no annual fee Strata works as an everyday card if your spending clusters
+  in its 3x categories: groceries, transit, and gas including EV charging,
+  plus one self-select category you can change each quarter from streaming,
+  fitness clubs, live entertainment, salons, or pet supply stores. It also
+  pays 5x on hotels, car rentals, and attractions booked through Citi Travel
+  and 2x on dining, but everything outside those buckets falls to a plain 1x.
+  The 15 month 0% intro APR on both purchases and balance transfers is a real
+  extra at this price point, though the rate afterward lands between 18.49%
+  and 28.49%. The 20,000 point welcome bonus after only $1,000 in three months
+  is modest but genuinely easy to hit. The mismatch to flag: a card shelved
+  under travel still charges foreign transaction fees, so pair it with
+  something else before you go abroad.

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -18,19 +18,21 @@ foreign_transaction_fee: false
 network: "mastercard"
 reward_type: "miles"
 our_take: >
-  The Citi AAdvantage Business World Elite Mastercard is a solid choice for
-  frequent American Airlines travelers, offering 2 miles per dollar on
-  eligible American Airlines purchases, as well as on car rentals, gas, and
-  telecommunications expenses. The card also comes with a generous signup
-  bonus of 65,000 miles after spending $4,000 in the first four months, though
-  this was recently reduced from 75,000 miles. The first year is free of the
-  $99 annual fee, giving you a chance to evaluate its benefits like a free
-  checked bag and preferred boarding on American Airlines flights. However,
-  the card's value diminishes if you don't fly American Airlines often, as the
-  everyday earn rate on other purchases is just 1 mile per dollar. The
-  companion certificate could be a nice perk if you meet the $30,000 annual
-  spend requirement, but consider if the spending aligns with your business
-  needs.
+  This is a straightforward American Airlines business card: 65,000 miles
+  after $4,000 in four months, a $99 annual fee waived for the first 12
+  months, and no foreign transaction fees. The perks are the real reason to
+  hold it, with a free first checked bag on domestic American itineraries and
+  Group 5 boarding for you and up to four companions on the same reservation,
+  which can pay for the fee on a single trip with a small team. Earning is
+  narrower than it looks: the 2x rate applies only to eligible American
+  Airlines purchases, alongside 2x on car rentals, gas, and telecom, cable,
+  and satellite providers, with everything else at 1x. The bonus history is
+  worth watching, since Citi raised it to 75,000 miles in late April and
+  pulled it back to 65,000 about ten days later, so if you are not in a hurry
+  it may be worth waiting to see whether the higher offer returns. The
+  companion certificate reads well but requires $30,000 in purchases each
+  cardmembership year, which most small businesses running this card will not
+  reach.
 tags:
   - travel
   - airline

--- a/data/cards/coinbase-one.yaml
+++ b/data/cards/coinbase-one.yaml
@@ -24,14 +24,17 @@ apr:
     max: 29.49
 foreign_transaction_fee: false
 our_take: >
-  The Coinbase One card offers a straightforward 2% cashback rate on all
-  purchases, which can be increased to 4% if you maintain higher crypto
-  balances on Coinbase and have a Coinbase One membership. With no annual fee,
-  this card is appealing for those already engaged with the Coinbase ecosystem
-  and looking to maximize their rewards through cryptocurrency holdings.
-  However, the requirement to hold a Coinbase One membership to unlock the
-  full earning potential is a notable limitation. If you're not already a
-  Coinbase user or don't plan to maintain substantial crypto balances, the
-  card's appeal diminishes. It's a solid choice for crypto enthusiasts but
-  less so for those seeking straightforward cash back without additional
-  commitments.
+  The pitch is 2% back in bitcoin on everything, rising to 2.5%, 3%, or 4%
+  depending on how much you hold on Coinbase, with no annual fee on the card
+  itself. The conditions do most of the work here, though: anything above the
+  2% tier is capped at $10,000 of eligible purchases per month and reverts to
+  2% beyond that, and the whole program requires an active Coinbase One
+  membership, which is a separate cost to account for. Flights, hotels, and
+  cars booked through the Coinbase One Card travel portal earn 5% and sit
+  outside that tier cap, which is the most interesting rate on the card.
+  Rewards pay out in bitcoin, so what you earn moves with the market instead
+  of sitting still like cash back, and you should be comfortable with that
+  before routing everyday spending here. With a 19.49% to 29.49% APR and no
+  foreign transaction fee, it fits people already deep in the Coinbase
+  ecosystem better than someone shopping for a dependable flat rate cash back
+  card.

--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -40,11 +40,15 @@ apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-business-card
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  Effectively free if you are already paying for a Costco membership (no separate
-  annual fee), and the gas rate is the draw: 5% at Costco gas stations and 4% on
-  other gas and EV charging, on up to $7,000 a year combined, plus 3% on dining
-  and travel and no foreign transaction fees. The
-  rewards mirror the personal Costco Anywhere card, so it is best for business
-  owners who fuel up a lot and shop Costco. The big catches are that cash back
-  comes once a year as a certificate redeemable only at Costco, and you must keep
-  an active membership to hold the card.
+  Fuel is the strongest reason to carry this one: 4% back on gas and EV
+  charging worldwide on the first $7,000 each year, and 5% at Costco gas
+  stations, which is a high rate for a card with no annual fee. From there it
+  pays 3% on dining and 3% on travel including Costco Travel, both useful for
+  a business with people on the road. Watch the wholesale club line, though,
+  because the 2% rate applies only at Costco and Costco.com, not at Sam's
+  Club, BJ's, or any other warehouse club, making it a merchant specific rate
+  rather than a real category. Everything else earns 1%, and gas past the
+  $7,000 cap drops to 1% as well, so a business with heavy fleet spending will
+  outrun the best part of this card partway through the year. No foreign
+  transaction fee helps if you buy abroad, and the 18.74% to 26.74% APR is a
+  reminder to clear the balance every month.

--- a/data/cards/costco-anywhere-visa-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-card-by-citi.yaml
@@ -39,13 +39,14 @@ apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-card
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Costco Anywhere Visa by Citi stands out for its strong cashback rates,
-  especially if you're a frequent Costco shopper or driver. You'll earn 5%
-  back at Costco gas stations and 4% on other eligible gas and EV charging, up
-  to $7,000 annually, which is a great deal for those with significant fuel
-  expenses. Dining and travel purchases earn a solid 3%, while Costco
-  purchases earn 2%. The card has no annual fee, but remember, it's only
-  available to Costco members, and the rewards are limited outside of Costco
-  and gas spending. There's also no foreign transaction fee, making it a
-  reasonable choice for international travel. Just be aware of the 18.74% to
-  26.74% variable APR if you carry a balance.
+  Fuel is the reason to carry this one: 4% back on eligible gas and EV
+  charging worldwide on the first $7,000 each year, and 5% at Costco's own gas
+  stations, with no annual fee and no foreign transaction fee. Dining and
+  travel both earn 3%, and that travel rate covers Costco Travel bookings,
+  which makes the card useful well beyond the pump. The catches are
+  structural. The 2% rate is Costco-specific: it applies only at Costco and
+  Costco.com, not at Sam's Club, BJ's, or any other warehouse club, and
+  everything outside the bonus categories falls to 1%, including gas once you
+  clear that $7,000 annual cap. There is no intro APR and the ongoing rate
+  runs 18.74% to 26.74%, so this is a card to pay in full each month and use
+  as a gas, restaurant, and travel earner rather than a borrowing tool.

--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -7,16 +7,19 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Delta SkyMiles Blue American Express card stands out as a no-annual-fee
-  option for Delta flyers, offering 2 miles per dollar on Delta purchases and
-  dining. It's a solid choice if you're looking to earn miles without
-  committing to an annual fee, and the 10,000-mile signup bonus for spending
-  $1,000 in the first six months adds a nice boost. While it lacks the premium
-  perks of higher-tier airline cards, the 20% inflight purchase credit and no
-  foreign transaction fees make it a decent travel companion. However, with
-  only 1 mile per dollar on other purchases, it may not be the best everyday
-  card unless you're focused on Delta and dining rewards. Consider it if you
-  want to dip your toes into earning Delta miles without a fee.
+  Blue is the no-fee entry point into the SkyMiles lineup, and it plays that
+  role honestly: 2 miles per dollar on Delta purchases and at restaurants, 1
+  mile everywhere else, no annual fee, and no foreign transaction fee. The
+  welcome offer is modest at 10,000 miles after $1,000 of spend in six months,
+  but the commitment is modest too. What it does not carry is the perk most
+  people buy a Delta card for: no free checked bag and no priority boarding,
+  just a 20% statement credit on eligible Delta in-flight food and drinks and
+  10% back on concessions at select stadiums through the Amex Venue
+  Collection, capped at $250 a year and requiring enrollment. We rate it the
+  best no-fee option among airline cards, though its #19 overall ranking
+  reflects how thin the benefits are once the price stops being the argument.
+  It makes sense if you fly Delta occasionally and want somewhere to
+  accumulate miles without paying for the privilege.
 annual_fee: 0
 reward_type: "miles"
 tags:

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -7,17 +7,21 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Delta SkyMiles Gold American Express card stands out with its generous
-  signup bonus of up to 90,000 miles, which requires $5,000 in spending within
-  the first six months. This card is particularly appealing for frequent Delta
-  flyers, offering perks like a free first checked bag and priority boarding
-  on Delta flights. You'll also earn 2 miles per dollar on Delta purchases,
-  dining, and U.S. supermarkets, which can add up quickly for everyday
-  spenders. However, the $150 annual fee is a consideration, especially since
-  the card's ongoing rewards rate is modest outside of Delta and select
-  categories. The lack of foreign transaction fees is a plus for international
-  travelers, but be sure to weigh the benefits against the cost if you're not
-  a regular Delta customer.
+  Free checked bags are what actually justify the $150 annual fee here: the
+  first bag is free on Delta flights worldwide, the second is free
+  domestically, and it extends to you and up to eight companions on the same
+  reservation, so one family trip can cover the cost. The welcome offer was
+  briefly bumped to 90,000 miles in June and settled back to 80,000 after
+  $2,000 of spend in six months in mid-July, and it is advertised as an up-to
+  figure, so the offer you actually see may be lower. Earning is respectable
+  without being deep: 2 miles per dollar on Delta purchases, at restaurants,
+  and at U.S. supermarkets, and 1 mile on everything else. Much of the
+  remaining value is conditional, including a $200 Delta flight credit that
+  only arrives after $10,000 of calendar-year spend, a $100 Delta Stays
+  credit, and up to $10 a month in rideshare credits that you have to enroll
+  for. If you check bags on Delta a few times a year the math works
+  comfortably; if you rarely check a bag, the earn rates alone do not carry
+  $150.
 annual_fee: 150
 reward_type: "miles"
 benefits:

--- a/data/cards/delta-skymiles-gold-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-business-american-express-card.yaml
@@ -7,17 +7,22 @@ apply_link: https://www.americanexpress.com/en-us/business/credit-cards/delta-sk
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Delta SkyMiles Gold Business American Express card stands out with a
-  limited-time signup bonus of 90,000 miles after spending $6,000 in the first
-  6 months, a notable increase from 60,000 miles. This makes it an attractive
-  option for businesses looking to maximize travel rewards quickly. The card
-  earns 2 miles per dollar on Delta purchases, dining, and select shipping and
-  advertising expenses, but the $150 annual fee and the cap on shipping and
-  advertising rewards might limit its appeal for some. Ongoing perks like a
-  first checked bag free, priority boarding, and a $200 Delta flight credit
-  after $10,000 in annual spending add value for frequent Delta flyers.
-  However, if your business doesn't frequently fly with Delta, the card's
-  benefits may not fully justify the cost.
+  For a $150 business card, the checked bag benefit does most of the heavy
+  lifting: first bag free on Delta worldwide, second free domestically, for
+  you and up to eight companions on the same reservation. Timing matters on
+  the welcome offer, which has moved three times since May and currently sits
+  at 60,000 miles after $4,000 in six months, down from the 90,000 that ran
+  from early to mid July, so waiting for the higher offer to return is a
+  reasonable play. The earn structure is business-shaped: 2 miles per dollar
+  on Delta purchases and at restaurants worldwide, 2 miles on U.S. shipping
+  providers up to $50,000 a year and 1 mile after that, with a separate
+  $50,000 cap for U.S. advertising, and 1 mile on everything else. The soft
+  benefits are real but conditional, including a $200 Delta flight credit only
+  after $10,000 of calendar-year spend, a $150 Delta Stays credit, and up to
+  $10 monthly in rideshare credits that requires enrollment and does not start
+  until after your first renewal. It is a sensible card for a small business
+  that flies Delta and ships regularly, and a poor one if Delta is not your
+  default airline.
 category: "business"
 annual_fee: 150
 reward_type: "miles"

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -7,20 +7,20 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Delta SkyMiles Platinum American Express card is a strong contender for
-  frequent Delta flyers, offering a generous signup bonus of up to 100,000
-  miles after meeting a $6,000 spend requirement within six months. This card
-  shines with travel perks like an annual domestic Main Cabin companion
-  certificate and 15% off Delta award flights, making it a valuable asset for
-  those who often fly with Delta. However, the $350 annual fee is a
-  significant consideration, and while the card offers solid earn rates of 3
-  miles per dollar on Delta and direct hotel purchases, 2 miles on dining and
-  U.S. supermarkets, and 1 mile on everything else, the rewards may not
-  outweigh the fee for infrequent travelers. Added benefits like a $100 Global
-  Entry or TSA PreCheck credit and various monthly credits for rideshares and
-  dining help offset the cost, but the value is best realized by those who can
-  fully utilize these perks. If you're a Delta loyalist looking to maximize
-  travel benefits, this card could be a worthwhile addition to your wallet.
+  The annual companion certificate is the whole argument for this card: it
+  arrives every year after renewal with no spend requirement and covers a
+  Delta Main round-trip within the U.S. or to Mexico, the Caribbean, or
+  Central America, which can outrun the $350 annual fee on one trip. Earning
+  is better than the Gold's at 3 miles per dollar on Delta purchases and on
+  hotels booked directly, plus 2 miles at restaurants and U.S. supermarkets
+  and 1 mile elsewhere. The welcome offer rose to 100,000 miles in June and
+  came back down to 90,000 after $3,000 of spend in six months in mid-July,
+  and it is an up-to number, so your actual offer may be smaller. Status
+  chasers get the clearest secondary benefit: a $2,500 MQD headstart each
+  Medallion Qualification Year plus $1 in MQDs for every $20 spent. Just note
+  how much of the rest is credit-shaped rather than cash, including $150 in
+  Delta Stays, up to $10 a month at Resy restaurants, and up to $10 a month in
+  rideshare, all of which only count if you would have spent there anyway.
 annual_fee: 350
 reward_type: "miles"
 benefits:

--- a/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
@@ -117,15 +117,18 @@ benefits:
     frequency: "per_claim"
     category: "insurance"
 our_take: >
-  The Delta SkyMiles Platinum Business American Express hits the sweet spot
-  for businesses that fly Delta regularly but do not need lounge access. The
-  annual Main Cabin companion certificate can single-handedly justify the
-  $350 fee, and the June 2026 refresh added a free second checked bag on
-  domestic flights on top of the existing first-bag benefit for up to nine
-  travelers. Earning is Delta-centric at 3 miles per dollar on Delta and
-  direct hotel purchases, with 1.5 miles on transit, U.S. shipping, and large
-  purchases of $5,000 or more. Up to $440 in annual Delta Stays, Resy, and
-  rideshare credits offsets most of the fee for those who use them, and the
-  $2,500 MQD headstart plus an MQD boost on every purchase make it a genuine
-  status-building tool. Skip it only if you never fly Delta or you want Sky
-  Club access, which requires the Reserve Business.
+  The yearly companion certificate is the anchor benefit: issued after each
+  renewal, good for a round-trip Delta Main Cabin ticket within the 48
+  contiguous states or to the Caribbean or Central America, with taxes and
+  fees from $22 to $250, which is the main way a business justifies the $350
+  fee. Beyond that you get 3 miles per dollar on Delta purchases and on hotels
+  booked directly with the property, plus 1.5 miles on transit, U.S. shipping,
+  and single purchases of $5,000 or more, all sharing a $100,000 annual cap
+  before dropping to 1 mile. The welcome offer is 70,000 miles after $6,000 of
+  spend in six months, a heavier requirement than the consumer version asks
+  for. Elite qualification gets a boost from the $2,500 MQD headstart and $1
+  in MQDs per $20 spent, and there is genuinely useful cell phone protection
+  worth up to $800 per claim with a $50 deductible when the prior month's bill
+  was paid with the card. The weak spot is the base rate: everything outside
+  those categories earns 1 mile, so this only pencils out if Delta flights and
+  the companion certificate are things you will actually use.

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -9,18 +9,22 @@ network: "amex"
 annual_fee: 650
 reward_type: "miles"
 our_take: >
-  The Delta SkyMiles Reserve American Express card stands out for frequent
-  Delta flyers with its complimentary Delta Sky Club access and a generous
-  125,000-mile signup bonus after meeting the $9,000 spend requirement in the
-  first 6 months. This offer, recently increased, makes it an attractive
-  choice for those looking to maximize their miles. However, the $650 annual
-  fee is steep, and the rewards rate is limited to 3 miles per dollar on Delta
-  purchases and 1 mile per dollar on everything else. The card's value is
-  bolstered by additional perks like the annual First Class companion
-  certificate and up to $240 in Resy dining credits, but you'll need to
-  leverage these benefits to justify the high cost. It's a premium card best
-  suited for dedicated Delta travelers who can take full advantage of its
-  travel-centric benefits.
+  Lounge access is what you are paying $650 for: 15 Delta Sky Club visits per
+  Medallion Year when flying Delta, unlimited visits once you spend $75,000 in
+  a calendar year, plus Centurion Lounge access when the Delta flight is
+  booked with the card. The companion certificate is the other pillar, issued
+  annually after renewal with no spend requirement and usable in Delta First,
+  Premium Select, Comfort, or Main on round-trips within the U.S. and to
+  Mexico, the Caribbean, or Central America. The welcome offer climbed to
+  125,000 miles in June and dropped back to 100,000 after $5,000 of spend in
+  six months in mid-July, and it is an up-to figure rather than a guarantee.
+  Be clear about the earning, though, because it is the card's real weakness:
+  3 miles per dollar on Delta purchases and a flat 1 mile on absolutely
+  everything else, so this is not a card for daily spend. Frequent Delta
+  flyers chasing Medallion status get the most from it, helped by the $2,500
+  MQD headstart and $1 in MQDs per $10 spent, while the $240 Resy, $200 Delta
+  Stays, and $120 rideshare credits only reduce the fee if you were already
+  spending in those places.
 benefits:
   - name: "Delta Sky Club Access"
     value: 0

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -112,15 +112,20 @@ benefits:
     frequency: "ongoing"
     category: "travel"
 our_take: >
-  The Delta SkyMiles Reserve Business American Express is Delta's flagship
-  business card, built around lounge access and elite status. It includes 15
-  Delta Sky Club visits per year with unlimited access unlocked at $75,000 in
-  annual spend, Centurion Lounge access when flying Delta, and the strongest
-  MQD accelerator of any Delta card at $1 per $10 spent on top of a $2,500
-  annual headstart. The annual companion certificate now covers Delta First
-  and Premium Select, which can be worth far more than the $650 fee on a
-  single trip. Up to $610 in Delta Stays, Resy, and rideshare credits helps
-  close the gap for those who use them. Earning outside Delta purchases is
-  thin at 1x to 1.5x, so this card is about perks and status rather than
-  everyday rewards; businesses that just want miles should choose the
-  Platinum Business version instead.
+  This is the Delta card for a business that lives in airports: 15 Sky Club
+  visits per Medallion Year with unlimited access after $75,000 in
+  calendar-year purchases, Centurion Lounge access on same-day Delta tickets
+  bought with the card, and an annual companion certificate good in Delta
+  First, Premium Select, Comfort+, or Main Cabin within the 48 states or to
+  the Caribbean or Central America, with taxes and fees from $22 to $250.
+  Earning is Delta-centric at 3 miles per dollar on Delta purchases, with 1.5
+  miles on transit, U.S. shipping, and U.S. office supply stores, and 1 mile
+  on the rest until you cross $150,000 in a calendar year, after which
+  everything earns 1.5 miles. The welcome offer of 80,000 miles is real money
+  but demands $12,000 of spend in six months, the steepest requirement in the
+  Delta lineup. Against a $650 annual fee, the credits help but come with
+  conditions: $250 in Delta Stays, up to $20 a month at Resy restaurants, and
+  up to $10 a month in rideshare, the latter two requiring enrollment. Skip it
+  unless Delta lounges and Medallion qualification are things your travel
+  schedule genuinely uses, because the $2,500 MQD headstart and $1 in MQDs per
+  $10 spent are where the fee earns itself back.

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -37,14 +37,15 @@ apply_link: https://www.discover.com/credit-cards/cash-back/it-card.html
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  The Discover it Cash Back card stands out with its 5% cash back on quarterly
-  rotating categories like gas, EV charging, transit, airlines, and
-  drugstores, up to $1,500 in spending per quarter, after which you earn 1%.
-  This makes it a great option for those who can maximize these categories and
-  don't mind activating them each quarter. With no annual fee and a 15-month
-  0% intro APR on both purchases and balance transfers, it offers solid value
-  for those looking to manage interest costs. However, the everyday earn rate
-  is just 1% after hitting the quarterly cap or on non-category purchases, so
-  it's less appealing for ongoing use outside the bonus categories. Ranked #3
-  in Best Cash Back Credit Cards, it's a strong contender for strategic
-  spenders who can leverage the rotating categories.
+  The 5% rotating category is the draw, and this quarter it is unusually
+  broad: gas, EV charging, transit, airlines, and drugstores all qualify in Q3
+  2026, on up to $1,500 in spend per quarter after you activate. Pair that
+  with 15 months of 0% intro APR on both purchases and balance transfers, no
+  annual fee, and no foreign transaction fee, and it works as a payoff card
+  and an earner at the same time. The limits are the familiar ones: you have
+  to remember to activate each quarter, the cap works out to $75 in bonus cash
+  back per quarter, and everything outside the rotating category earns a flat
+  1%. The regular APR of 17.49% to 26.49% is reasonable, but the card is built
+  to be paid in full once the intro window closes. It is our #3 cash back
+  pick, best used alongside a flat-rate card that handles the spending
+  Discover only pays 1% on.

--- a/data/cards/discover-it-for-students-card.yaml
+++ b/data/cards/discover-it-for-students-card.yaml
@@ -34,17 +34,18 @@ apply_link: https://www.discover.com/credit-cards/student/it-card.html
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  The Discover it for Students card is a solid starter option with no annual
-  fee and a unique Cashback Match feature that doubles your cash back at the
-  end of the first year. It offers 5% cash back on rotating categories like
-  gas, transit, and drugstores, up to $1,500 in purchases per quarter, after
-  which it earns 1%. This can be a great way to maximize rewards if you keep
-  track of the categories and activate them each quarter. The card also offers
-  a 0% intro APR on purchases for the first 6 months, which can be helpful for
-  managing initial expenses. However, the regular APR ranges from 16.49% to
-  25.49%, so it's best to pay off balances in full to avoid high interest
-  charges. With no foreign transaction fees, it's also a good companion for
-  students studying abroad.
+  The Cashback Match is what makes this a genuinely strong first card:
+  Discover automatically matches everything you earn at the end of your first
+  year, with no cap and no fixed dollar amount, which effectively doubles
+  year-one rewards. Underneath it is the standard Discover structure, 5% back
+  on quarterly rotating categories on up to $1,500 in spend after activation,
+  covering gas, EV charging, transit, airlines, and drugstores in Q3 2026, and
+  1% on everything else. There is no annual fee and no foreign transaction
+  fee, which matters if you study abroad. The intro APR is thin at 0% for just
+  six months on purchases, and the ongoing rate of 16.49% to 25.49% is low for
+  a student card but still expensive if you carry a balance. Treat it as a
+  rewards and credit-building card rather than a way to finance anything,
+  activate the categories each quarter, and pay the statement in full.
 benefits:
   - name: "Cashback Match"
     value: 0

--- a/data/cards/discover-it-miles.yaml
+++ b/data/cards/discover-it-miles.yaml
@@ -26,13 +26,14 @@ apply_link: https://www.discover.com/credit-cards/travel/
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  The Discover it Miles card offers a straightforward rewards structure with
-  1.5 miles per dollar on every purchase, making it a solid choice for those
-  who prefer simplicity without an annual fee. What sets it apart is the 0%
-  intro APR for 15 months on both purchases and balance transfers, providing a
-  good opportunity to manage existing debt or finance new purchases
-  interest-free. However, the regular APR range of 17.49% to 26.49% means
-  carrying a balance after the intro period could become expensive. With no
-  foreign transaction fees, it's also a decent option for international
-  travel. Just remember that while the rewards are consistent, they aren't
-  particularly high compared to other travel-focused cards.
+  The Discover it Miles keeps things simple: 1.5 miles per dollar on every
+  purchase, no annual fee, and no foreign transaction fee, with nothing to
+  activate and no categories to track. It also carries 15 months of 0% intro
+  APR on both purchases and balance transfers, which gives it a second use as
+  a short-term financing card. The tradeoff is that the flat rate is the
+  entire rewards program: there are no bonus categories and no welcome offer,
+  so any card paying 2% or more on everyday spend will out-earn it over time.
+  The regular APR runs 17.49% to 26.49%, so the intro window only helps if you
+  have a real payoff plan behind it. Think of it as a low-maintenance travel
+  card for someone who does not want to think about categories, not a card for
+  maximizing returns.

--- a/data/cards/discover-it-secured-credit-card.yaml
+++ b/data/cards/discover-it-secured-credit-card.yaml
@@ -30,10 +30,15 @@ apply_link: https://www.discover.com/credit-cards/secured-credit-card/
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  One of the best secured cards for building credit because it earns like a real
-  rewards card: 5% on rotating quarterly categories (up to $1,500 in spend,
-  activation required) and 1% on everything else, with no annual fee and automatic
-  reviews to graduate to the unsecured Discover it Cash Back. Reported approvals
-  skew toward fair credit and are not guaranteed, so fund the deposit and keep
-  balances low against the 26.49% APR. It out-earns rewardless secured cards while
-  still being a genuine credit-builder.
+  This is the rare secured card that actually earns like a real rewards card,
+  which is why we rank it first among secured picks: 5% back on rotating
+  quarterly categories on up to $1,500 in spending per quarter, with Q3 2026
+  covering gas, EV charging, transit, airlines, and drugstores, plus 1% on
+  everything else. There is no annual fee and no foreign transaction fee, so
+  the only money tied up is your deposit. Two things to stay on top of: you
+  have to activate the 5% categories each quarter, and once you pass the
+  $1,500 quarterly cap that spending drops to 1%, the same as the base rate.
+  The bigger catch is the APR, a flat 26.49% with no intro period, so carrying
+  a balance will erase the rewards several times over. Use it to build
+  history, pay the statement in full every month, and treat the 5% as a bonus
+  rather than the reason to apply.

--- a/data/cards/discover-it-student-chrome-card.yaml
+++ b/data/cards/discover-it-student-chrome-card.yaml
@@ -32,10 +32,14 @@ apply_link: https://www.discover.com/credit-cards/student/chrome-card.html
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  A starter card for students who want simple, capped rewards without tracking
-  rotating categories: 2% at gas and restaurants on up to $1,000 combined per
-  quarter, 1% elsewhere, no annual fee, and no foreign transaction fees. It also
-  brings a 6-month 0% intro APR on purchases to ease into your first card. If
-  you can handle quarterly activation, Discover's rotating 5%
-  student card earns more; this one trades that upside for set-and-forget
-  simplicity, making it a fine first card to build credit responsibly.
+  The Student Chrome pays 2% back at gas stations and restaurants on up to
+  $1,000 in combined spending each quarter, which lines up well with how most
+  students actually spend, and it charges no annual fee and no foreign
+  transaction fee. Everything beyond that combined $4,000 a year, and every
+  other category, earns 1%, so the ceiling on this card is low by design. The
+  0% intro APR on purchases lasts only 6 months, which is a short runway
+  compared with what non-student cards offer, and the go-to rate of 16.49% to
+  25.49% takes over quickly after that. There is no welcome bonus to speak of,
+  so the value here is entirely in the ongoing earn rate and the credit
+  history you build. It is a reasonable first card if you drive and eat out,
+  but plan to graduate to something stronger once you have a track record.

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -91,11 +91,16 @@ apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/inspire
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Inspire is the top Disney card, with a $149 fee buying a $300 Disney eGift
-  card up front, 10% back on Disney+/Hulu/ESPN+, and 3% on Disney purchases.
-  But the earn rates are mediocre for a fee card (most spend lands at 1-2%), and
-  the park-ticket, resort, and streaming credits all require Disney spending to
-  unlock, so they only cover the cost if you spend heavily in the Disney
-  ecosystem. For most fans the $49 Disney
-  Premier or even the no-fee Disney Visa is the saner choice; reach for the
-  Inspire only if you are a frequent park-goer who values the extra perks.
+  Chase recently trimmed the Inspire's welcome offer from $600 to $500, now
+  structured as a $300 Disney eGift Card on approval plus a $200 statement
+  credit after $1,000 of spending in the first three months. The stronger case
+  for keeping it is the recurring credits: up to $120 a year in $10 monthly
+  statement credits on Disney+, Hulu, or ESPN+, which requires annual
+  enrollment, plus $100 back each anniversary year after $200 on U.S. Disney
+  theme park tickets. Together those two cover more than the $149 annual fee
+  if you reliably use both. Be careful reading the earn chart, though: the 10%
+  streaming rate applies only to Disney+, Hulu, and ESPN+, and the 3%
+  entertainment rate only at most U.S. Disney locations, which leaves 3% on
+  gas, 2% on groceries and dining, and 1% on everything else as the card's
+  real everyday profile. If you are not visiting the parks or paying for
+  Disney streaming, that fee is hard to earn back.

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -73,19 +73,19 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  The Disney Premier Visa from Chase stands out with a generous signup bonus
-  recently increased to $300, which includes a $200 Disney eGift Card upon
-  approval and a $100 statement credit after spending $500 in the first three
-  months. This card is particularly appealing for Disney enthusiasts, offering
-  5% cash back on Disney+, Hulu, and ESPN+ streaming services, and 2% on
-  select Disney purchases, gas, groceries, and dining. However, it comes with
-  a $49 annual fee, which may offset some of the rewards unless you're a
-  frequent Disney spender. Additional perks include discounts on Disney park
-  merchandise, dining, and guided tours, as well as private photo
-  opportunities, making it a solid choice for those who regularly visit Disney
-  parks. Just be aware that everyday purchases outside these categories earn
-  only 1% cash back, so its value is best maximized when used strategically
-  for Disney-related expenses.
+  At a $49 annual fee, the Premier is the middle Disney card, and its welcome
+  offer has the easiest bar of the family: $300 total, as a $200 Disney eGift
+  Card on approval plus a $100 statement credit after just $500 of spending in
+  three months. Ongoing earning is modest and narrower than the headline
+  suggests: the 5% rate covers only Disney+, Hulu, and ESPN+, and the 2%
+  entertainment rate applies only at most U.S. Disney locations, alongside 2%
+  on gas, groceries, and dining, and 1% on everything else. The perks are
+  park-centric rather than financial, mainly 10% off select merchandise
+  purchases of $50 or more and select dining, 15% off select guided tours, and
+  cardmember photo locations. One real drawback is that this card charges
+  foreign transaction fees, so leave it home for trips abroad. It earns its
+  keep if you visit Disneyland or Walt Disney World regularly, and very little
+  otherwise.
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/premier
 foreign_transaction_fee: true
 network: "visa"

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -24,17 +24,18 @@ apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/rewards
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Disney Visa from Chase is an attractive option for Disney enthusiasts,
-  especially with its recently increased signup bonus of $150. This bonus is
-  split between a $100 Disney eGift Card upon approval and a $50 statement
-  credit after spending $500 in the first three months. With no annual fee,
-  the card offers 1% back in Disney Rewards Dollars on all purchases, which
-  can be a modest way to save for your next Disney trip. However, the card's
-  everyday earning rate is not competitive compared to other cashback cards,
-  and it carries a foreign transaction fee, making it less ideal for
-  international travel. Additional perks like a complimentary one-year
-  DashPass membership and purchase protection add some value, but the card is
-  best suited for those who frequently spend at Disney locations.
+  The no-annual-fee Disney Visa is best understood as a park-perks card with a
+  welcome offer attached: $150 total, split between a $100 Disney eGift Card
+  on approval and a $50 statement credit after $500 of spending in the first
+  three months. Ongoing, it earns a flat 1% in Disney Rewards Dollars on all
+  purchases, which is below what a plain no-fee cash back card pays, and those
+  rewards are most useful inside the Disney ecosystem rather than as cash. The
+  reason to keep it in a drawer is the in-park discounts, 10% off select
+  merchandise and select dining and 15% off select guided tours, plus a
+  complimentary one-year DoorDash DashPass membership that requires
+  enrollment. It also charges foreign transaction fees, so it is not a card
+  for travel outside the U.S. Grab it for the sign-up value and the park
+  discounts if you go often, but do not put your everyday spending on it.
 benefits:
   - name: "DoorDash DashPass"
     value: 0

--- a/data/cards/fidelity-rewards-visa-signature.yaml
+++ b/data/cards/fidelity-rewards-visa-signature.yaml
@@ -26,17 +26,17 @@ apply_link: https://www.fidelity.com/spend-save/visa-signature-card
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Fidelity Rewards Visa Signature card offers a straightforward 2% cash
-  back on all purchases when you deposit the rewards into an eligible Fidelity
-  account, making it a solid choice for those who want to boost their
-  investment savings with everyday spending. With no annual fee and a 12-month
-  0% intro APR on both purchases and balance transfers, it provides a decent
-  runway for managing expenses interest-free. However, the recent removal of
-  the signup bonus means there's no initial incentive beyond the ongoing earn
-  rate. The card also includes a valuable perk of up to $100 in reward points
-  for Global Entry or TSA PreCheck application fees every five years. While
-  the regular APR has been slightly reduced, ranging from 16.49% to 26.49%,
-  it's still important to pay off balances to avoid interest charges.
+  The Fidelity Rewards Visa Signature is a clean flat-rate play: 2% back on
+  every purchase with no annual fee and no foreign transaction fee, which puts
+  it at the top tier for uncomplicated everyday spending. The condition to
+  understand is that the 2% holds when rewards are deposited into an eligible
+  Fidelity account, so this really only works if you already bank or invest
+  with Fidelity. It also reimburses up to $100 in points toward a Global Entry
+  or TSA PreCheck application fee once every five years, a small but genuine
+  extra for a no-fee card. Worth noting that the $150 welcome bonus was pulled
+  in July 2026, so there is no sign-up offer to sweeten the first year. There
+  is also no intro APR and the regular rate runs 16.49% to 26.49%, so this is
+  a card to pay in full, not to finance with.
 benefits:
   - name: "Global Entry or TSA PreCheck Credit"
     value: 100

--- a/data/cards/gemini-credit.yaml
+++ b/data/cards/gemini-credit.yaml
@@ -35,9 +35,13 @@ apply_link: https://www.gemini.com/credit-card
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The hook here is that rewards pay out in crypto, with 4% on gas, EV charging, and transit
-  (capped at $300 of combined spend per month), 3% dining, 2% groceries, and 1% on everything
-  else, all with no annual fee or foreign transaction fees. It makes sense if you actively use
-  Gemini and want to accumulate crypto, not dollars. As a plain cash-back card it is
-  unremarkable, the high end of the APR runs up to 34.49%, and the rewards' value rides on
-  whatever coin you hold, so carry no balance and treat the payout as speculative.
+  The headline here is 4% back on gas, EV charging, and transit, but read the
+  fine print: those three share a single $300 per month cap, and spending past
+  it drops to 1%. That works out to about $12 a month at the top rate, so
+  treat this as a commuter card rather than the one you reach for by default.
+  Below that, 3% on dining and 2% on groceries are respectable for a card with
+  no annual fee and no foreign transaction fee, though everything else earns
+  just 1%. The cap resets on the 1st of each month, which makes it easy to
+  plan around if your driving and transit spend is steady. The regular APR
+  runs from 16.49% to 34.49% and there's no signup bonus to jumpstart the
+  first year, so this is a slow, pay-in-full build rather than a quick win.

--- a/data/cards/graphite-business-cash-unlimited.yaml
+++ b/data/cards/graphite-business-cash-unlimited.yaml
@@ -10,17 +10,17 @@ apply_link: "https://www.americanexpress.com/us/credit-cards/business/business-c
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Graphite Business Cash Unlimited card from American Express offers a
-  straightforward 2% cash back on all eligible purchases, making it a reliable
-  choice for businesses with varied spending. For those who frequently travel,
-  the card sweetens the deal with 5% cash back on flights and prepaid hotels
-  booked through American Express Travel. However, the $295 annual fee is a
-  significant consideration, and the substantial $50,000 spend requirement to
-  earn the $1,500 signup bonus may not suit smaller businesses. There's also a
-  potential $2,400 statement credit for American Express One AP fees, but it
-  requires a hefty $250,000 in annual spending to unlock. This card is best
-  for businesses with high expenses that can leverage both the travel rewards
-  and the premium benefits.
+  Graphite Business Cash Unlimited pays a flat, unlimited 2% on eligible
+  purchases with no categories to track, plus 5% on flights and prepaid hotels
+  booked through American Express Travel, which is a clean setup for a
+  business that spends broadly. The problem is the $295 annual fee: at 2%, it
+  swallows the return on roughly your first $15,000 of spend, so a no-fee 2%
+  card stays ahead of it below that line. The welcome offer is sized for the
+  same audience, $1,500 back after $50,000 in purchases within six months. So
+  is the one real perk: up to $2,400 in statement credits toward American
+  Express One AP monthly fees, which requires $250,000 in eligible purchases
+  in a calendar year. This is a card for genuinely high-volume businesses, and
+  if your spend is modest the math simply doesn't get there.
 tags:
   - business
   - cashback

--- a/data/cards/hawaiian-airlines-business-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-business-mastercard.yaml
@@ -38,18 +38,18 @@ signup_bonus:
   spend_requirement: 4000
   timeframe_months: 3
 our_take: >
-  The Hawaiian Airlines Business Mastercard offers a solid 3 points per dollar
-  on Hawaiian and Alaska Airlines purchases, making it a strong choice for
-  businesses with frequent travel to Hawaii or Alaska. The card also provides
-  2 points per dollar on gas, dining, and office supplies, which can add up
-  for everyday business expenses. However, the $99 annual fee and a regular
-  APR starting at 20.24% mean you'll need to leverage the rewards to offset
-  these costs. The 50,000-mile signup bonus, earned after spending $4,000 in
-  the first three months, is a notable perk for new cardholders. For high
-  spenders, there's an opportunity to earn up to 40,000 additional bonus
-  points annually, but it requires significant spending to reach those
-  thresholds. Overall, it's a niche card best suited for businesses that can
-  maximize its airline and spending bonuses.
+  The Hawaiian Airlines Business Mastercard earns 3x specifically on Hawaiian
+  Airlines and Alaska Airlines purchases, plus 2x on gas, dining, and office
+  supplies, which covers a fair slice of ordinary business spend for a $99
+  annual fee. The 50,000-mile welcome bonus after $4,000 in three months is
+  the clearest value on offer, and there's no foreign transaction fee. Beyond
+  that, the rewards are built for volume: 20,000 bonus Atmos Rewards points at
+  $50,000 of calendar-year spend, or 40,000 at $100,000 in place of the
+  smaller tier. Those thresholds are steep, so a business spending well under
+  $50,000 a year is really buying the welcome bonus, the airline multiplier,
+  and a one-time 50% off companion discount. Everything outside the bonus
+  categories earns 1x, and with a regular APR of 19.49% to 29.49% this only
+  works as a pay-in-full card.
 
 apr:
   regular:

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -43,13 +43,19 @@ apr:
     min: 20.24
     max: 29.99
 our_take: >
-  For a $99 fee this Barclays co-brand earns 3x on Hawaiian Airlines and a useful
-  2x on gas, dining, and groceries, which is broader everyday earning than most
-  airline cards offer. With the Alaska-Hawaiian merger, the value increasingly
-  hinges on how those miles convert, so treat it as a card for people flying
-  Hawaiian routes who want a few bonus categories alongside the airline loyalty.
-  The 50,000-mile bonus after $2,000 of spend is easy to hit; just don't expect
-  premium travel perks at this price.
+  Ranked #10 on our Best Airline Credit Cards list, this card earns its $99
+  annual fee mostly through baggage: first and second checked bags free for
+  the cardmember on eligible Hawaiian and Alaska operated flights booked with
+  the card. Layered on top are a $100 companion discount for a Hawaii to North
+  America roundtrip each anniversary, a one-time 50% off companion discount,
+  and a 50,000-mile bonus after just $2,000 in three months, which is a
+  notably low bar for a bonus that size. Earning is modest by comparison: the
+  3x rate applies only to Hawaiian Airlines purchases, with 2x on gas, dining,
+  and groceries and 1x on everything else. There's also 15 months of 0% intro
+  APR on balance transfers, unusual for an airline card, though the regular
+  rate then sits between 20.24% and 29.99%. Fly to Hawaii once or twice a year
+  and the bag and companion perks cover the fee comfortably; fly there rarely
+  and nothing else on the card will.
 benefits:
   - name: "Two Free Checked Bags"
     description: "First and second checked bags free for the cardmember on eligible Hawaiian Airlines and Alaska Airlines operated flights when the card is used to book"

--- a/data/cards/heb-visa-signature.yaml
+++ b/data/cards/heb-visa-signature.yaml
@@ -38,15 +38,13 @@ benefits:
     frequency: "ongoing"
     category: "other"
 our_take: >
-  The H-E-B Visa Signature, issued by First Electronic Bank and powered by
-  Imprint, is built for the Texas grocery faithful: 5% cash back on H-E-B and
-  Central Market own-brand products and on Favor delivery orders, with an
-  unlimited 1.5% on everything else. The own-brand catch matters, since
-  national brands in your H-E-B cart earn only the base rate, but H-E-B's
-  private labels are extensive and well-loved, so heavy shoppers can rack up
-  real money with no annual fee and no foreign transaction fees. There is
-  currently no welcome bonus, and the APR range stretches to a steep 35.99%
-  at the low end of approvals, so carry no balance. Note that the card is
-  only available to residents of Texas, Louisiana, Arkansas, Oklahoma, and
-  New Mexico. For anyone outside H-E-B country, a flat 2% card beats the
-  1.5% base rate.
+  If you shop at H-E-B, this is a simple no-annual-fee proposition: 5% back,
+  but only on H-E-B and Central Market own-brand products in-store and on
+  heb.com, plus Favor delivery orders. That gate is the whole story, because
+  national brands sitting in the same cart don't qualify, and pharmacy
+  prescriptions, fuel, gift cards, and in-store restaurants are excluded
+  outright. Everything else earns a flat 1.5%, which is a serviceable backstop
+  but trails a dedicated 2% cash back card. Cash back never expires, there's
+  no foreign transaction fee, and the usual Visa Signature concierge, hotel,
+  and rental car privileges come along for free. With an APR reaching 35.99%,
+  the value holds only if you clear the balance every month.

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -7,18 +7,20 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors-a
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Hilton Honors American Express Aspire card is a powerhouse for frequent
-  Hilton guests, offering a massive 14 points per dollar on eligible Hilton
-  purchases and a generous 175,000-point signup bonus after spending $6,000 in
-  the first six months. The card's $550 annual fee is steep, but the extensive
-  benefits can offset this cost if you maximize them: a $400 Hilton resort
-  credit, a $200 flight credit, and a complimentary night annually at most
-  Hilton properties. Additionally, the card provides Hilton Honors Diamond
-  status, which includes perks like room upgrades and executive lounge access.
-  However, if you don't frequently stay at Hilton hotels or can't fully
-  utilize the credits, the high annual fee may outweigh the rewards. Consider
-  this card if you're a dedicated Hilton traveler who can leverage its rich
-  rewards and benefits.
+  The Aspire is a credits card before it's a rewards card: up to $400 a year
+  in Hilton resort credits paid $200 at a time, up to $200 in flight credits
+  at $50 per quarter, and up to $219 for CLEAR Plus. Use all three and they
+  more than cover the $550 annual fee, and that's before an annual Free Night
+  Award, automatic Diamond status, and additional Free Night Rewards at
+  $30,000 and $60,000 of calendar-year spend. Earning is strong where it
+  should be: 14x at Hilton hotels and resorts specifically, 7x on flights, car
+  rentals, and U.S. restaurants, and 3x on everything else. The welcome offer
+  is 150,000 points after $6,000 in six months, cut back from 175,000 on July
+  30 after bouncing between those two levels twice already this year, so it
+  may be worth waiting for the higher number to return. The real catch is that
+  the credits arrive on Amex's quarterly and semiannual schedule, not yours,
+  so breaking even takes active management rather than a single well-timed
+  stay.
 annual_fee: 550
 reward_type: "points"
 rewards:

--- a/data/cards/hilton-honors-american-express-business-card.yaml
+++ b/data/cards/hilton-honors-american-express-business-card.yaml
@@ -55,14 +55,17 @@ benefits:
     frequency: "ongoing"
     category: "hotel"
 our_take: >
-  The Hilton Honors American Express Business is a straightforward earner for
-  businesses that sleep at Hilton properties: 12x points on Hilton purchases
-  and a strong 5x on everything else up to $100,000 a year, which makes it one
-  of the highest flat earn rates of any business card when measured in Hilton
-  points. Up to $240 in quarterly Hilton credits and complimentary Gold status
-  do the work of offsetting the $195 annual fee, and big spenders can unlock
-  Diamond status at $40,000 in a calendar year. The notable gap is that,
-  unlike the personal Surpass card, this card no longer offers a spend-based
-  Free Night Reward, so weigh that against the Surpass if you are choosing
-  between them. For a business with steady travel and supply spend that stays
-  loyal to Hilton, the points pile up fast.
+  The draw here is the base rate: 5x Hilton Honors points on everything for
+  the first $100,000 of purchases each calendar year, dropping to 3x after
+  that, on top of 12x at Hilton properties themselves. For a business that
+  spends broadly and redeems into Hilton stays, that's a lot of points for a
+  $195 annual fee. Up to $240 a year in Hilton credits, paid as $60 back each
+  quarter, offsets a meaningful chunk of the fee if you book directly with
+  Hilton portfolio properties, and complimentary Gold status comes with the
+  card, with Diamond available after $40,000 in eligible purchases. Check the
+  welcome offer before you apply: the 130,000 points after $6,000 in six
+  months, which also waived the first-year annual fee, was flagged as a
+  limited-time offer running through July 29, 2026, so confirm what's actually
+  live. The limitation is flexibility, since these are Hilton points that only
+  spend at Hilton, so the case rests entirely on your travel being
+  Hilton-centric.

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -8,17 +8,19 @@ foreign_transaction_fee: false
 network: "amex"
 annual_fee: 150
 our_take: >
-  The Hilton Honors American Express Surpass card stands out for frequent
-  Hilton guests with its impressive 12 points per dollar on eligible Hilton
-  purchases and a generous signup bonus of 130,000 points plus a Free Night
-  Reward after spending $3,000 in the first six months. The card also offers 6
-  points per dollar at U.S. restaurants, supermarkets, and gas stations,
-  making it versatile for everyday spending. However, the $150 annual fee is a
-  consideration, and the card's value diminishes if you don't frequently stay
-  at Hilton properties. The added perks of complimentary Gold status and up to
-  $200 in Hilton credits each year help offset the fee, but you'll need to
-  spend $15,000 annually for an additional Free Night Reward. If you're a
-  loyal Hilton traveler, the benefits can easily outweigh the cost.
+  Surpass sits in the middle of Hilton's Amex lineup and earns its $150 annual
+  fee mostly through everyday categories: 6x at U.S. restaurants,
+  supermarkets, and gas stations, 4x on eligible U.S. online retail, and 3x on
+  everything else, with the 12x rate reserved for purchases made directly at
+  Hilton properties. Up to $200 a year in Hilton credits, split as $50 per
+  quarter, covers most of that fee provided you stay with Hilton often enough
+  to use each quarter's allotment. The current welcome offer is 130,000 points
+  after $3,000 in six months plus a Free Night Reward, a low spend bar for a
+  bonus that size. Complimentary Gold status is the most valuable ongoing
+  perk, and heavier spenders pick up a Free Night Reward at $15,000 and
+  Diamond status at $40,000 in a calendar year. Just remember these points
+  only spend at Hilton, so those 6x grocery and gas multipliers are worth less
+  than they look if your stays are occasional.
 reward_type: "points"
 rewards:
   - category: hotels

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -7,18 +7,19 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors/
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Hilton Honors American Express Card shines with a generous 100,000-point
-  signup bonus, recently increased from 80,000, plus a $100 statement credit
-  when you spend $2,000 within the first six months. This makes it a strong
-  contender for travelers who frequently stay at Hilton properties, as it
-  offers 7 points per dollar on eligible Hilton purchases. Dining, groceries,
-  and gas earn a solid 5 points per dollar, adding value for everyday
-  spending. With no annual fee and no foreign transaction fees, it's a
-  cost-effective option for both domestic and international travel. The card
-  also includes complimentary Hilton Honors Silver status, which provides
-  perks like a fifth night free on reward stays. However, the regular APR
-  ranges from 19.49% to 28.49%, so it's best suited for those who plan to pay
-  off their balance monthly.
+  This is a reasonable way to keep earning Hilton points without paying
+  anything for the privilege: 7x at Hilton hotels and resorts, 5x at U.S.
+  restaurants, supermarkets, and gas stations, and 3x on everything else, all
+  with no annual fee. The welcome offer is 80,000 points after $2,000 in six
+  months plus a $100 statement credit, though it was trimmed from 100,000 on
+  July 30, so this is a weaker moment to apply than a few weeks ago.
+  Complimentary Silver status is thin on substance, essentially the fifth
+  night free on reward stays, and reaching Gold takes $20,000 of eligible
+  purchases in a calendar year. Because the points only spend at Hilton, those
+  5x categories are worth less than the multiplier suggests unless you
+  actually stay at Hilton properties. It's a fine no-cost keeper for
+  occasional Hilton guests, but anyone staying often enough to care about
+  status should look at Surpass instead.
 card_referral_link: "https://www.americanexpress.com/en-us/credit-cards/referral/prospect/hilton-honors/personal?ref="
 annual_fee: 0
 reward_type: "points"

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -8,17 +8,18 @@ foreign_transaction_fee: false
 network: "visa"
 reward_type: "miles"
 our_take: >
-  The Iberia Visa Signature card is a compelling choice for frequent flyers of
-  Iberia, British Airways, and Aer Lingus, offering 3 points per dollar on
-  flights with these airlines. The standout feature is the generous 75,000
-  miles signup bonus, earned after spending $5,000 in the first three months.
-  However, the $95 annual fee and the high spending requirement for the
-  companion voucher, which demands $30,000 in a calendar year, might be a
-  drawback for some. The card also offers a 10% discount on Iberia flights
-  booked through a special site and includes travel perks like baggage delay
-  insurance and lost luggage reimbursement. With no foreign transaction fees,
-  it's a solid travel companion, but its value diminishes if you don't
-  frequently fly with the associated airlines.
+  The pull here is the 75,000 mile signup bonus after $5,000 in three months,
+  paired with a $95 annual fee and no foreign transaction fees, which is a
+  reasonable trade if Iberia, British Airways, or Aer Lingus are already in
+  your travel rotation. Beyond the bonus the earn chart is narrow: 3x applies
+  only to flights on those three airlines, 2x to hotels booked directly, and
+  everything else sits at 1x, so this is not a card for everyday spending. The
+  companion voucher worth up to $1,000 reads like the headline perk, but it
+  takes $30,000 of purchases in a calendar year to unlock, which is a lot of
+  1x spending to push through. Baggage delay and lost luggage coverage, plus
+  10% off Iberia flights booked through the cardmember site, round things out.
+  Earn the bonus, put it toward transatlantic awards, and reassess each year
+  whether the $95 still earns its place.
 tags:
   - airline
   - travel

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -112,13 +112,16 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/p
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The IHG One Rewards Premier card shines for frequent IHG travelers with its
-  standout benefit of up to 26x points per dollar at IHG hotels. It also
-  offers a solid 140,000-point signup bonus after spending $3,000 in the first
-  3 months, though this has recently been reduced from 185,000 points. The
-  card's $99 annual fee is offset by a free night award each anniversary,
-  valid at properties up to 40,000 points, and the 4th reward night free on
-  stays. However, if you're not loyal to IHG, the value diminishes, as the
-  rewards structure is heavily geared towards their hotels. Additional perks
-  like Platinum Elite status, a Global Entry/TSA PreCheck credit, and a United
-  TravelBank cash offer add value, but only if you utilize them.
+  The anniversary free night at properties costing up to 40,000 points is the
+  reason this card stays in a wallet past year one, and against a $99 annual
+  fee it does not take much to come out ahead. The 140,000 point bonus after
+  $3,000 in three months still ranks second on our best signup bonuses list,
+  though it recently came back down from 185,000 after moving three separate
+  times since April. Earning is strong by hotel-card standards: 10x at IHG
+  hotels and only at IHG hotels, 5x on travel, gas, and dining, and 3x on
+  everything else, alongside a $120 Global Entry or TSA PreCheck credit every
+  four years and up to $50 in United TravelBank cash annually. Automatic
+  Platinum Elite status and a fourth reward night free make longer point stays
+  noticeably cheaper. The catch is that all of this value routes through one
+  chain, so if IHG rarely fits your travel, the points will pile up faster
+  than you can spend them.

--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -95,14 +95,15 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/t
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The IHG Rewards Club Traveler card is a solid choice for frequent IHG hotel
-  guests, offering up to 17x points per dollar spent at IHG properties with no
-  annual fee. The card's standout feature is the fourth night free on reward
-  stays, which can significantly extend your points' value for longer trips.
-  However, the recent drop in the signup bonus from 125,000 to 80,000 points
-  means you'll need to weigh the initial incentive against your travel plans.
-  While it offers 3x points on dining, gas, and utilities, and 2x on
-  everything else, the card's true value hinges on how often you stay at IHG
-  hotels. Additional perks like a complimentary DashPass membership and a
-  monthly Instacart credit add some everyday utility, but the card is best
-  suited for those who can make the most of its hotel-specific benefits.
+  For a card with no annual fee, the Traveler earns unusually well: 5x at IHG
+  hotels, 3x on a combined bucket covering dining, gas, utilities, internet,
+  cable, phone, and select streaming, and 2x on everything else. That makes it
+  a defensible keep-forever card even in years you never book an IHG stay, and
+  automatic Silver Elite plus the fourth reward night free cost nothing to
+  hold. The 80,000 point bonus after just $2,000 in three months is fair, but
+  it recently fell from 125,000, so anyone who is not in a rush may want to
+  see whether Chase pushes it back up. What you give up against the $99
+  Premier is the anniversary free night, which is usually the benefit that
+  justifies paying a fee on an IHG card. The 10,000 anniversary bonus points
+  here require $10,000 of annual spending, so treat that as a stretch goal
+  rather than a yearly given.

--- a/data/cards/intuit-business.yaml
+++ b/data/cards/intuit-business.yaml
@@ -53,13 +53,17 @@ benefits:
     frequency: "one_time"
     category: "other"
 our_take: >
-  Intuit's first business card is a clean no annual fee 2% earner with a 5% rate on
-  Intuit's own products, which is real money if you already pay for QuickBooks Online,
-  TurboTax, and Mailchimp every year. The flat 2% matches the best no fee business cash
-  back cards rather than beating them, so the reason to pick this one is the plumbing:
-  transactions and receipts land in QuickBooks automatically, employee cards are unlimited
-  and free, and approval can put a virtual card in your wallet the same day. The $300
-  bonus after $3,000 in three months is modest next to what Chase and Amex pay on their
-  business cards, and the 2.7% foreign transaction fee makes it a poor travel card.
-  Credit lines run $1,000 to $50,000, so a business with heavy monthly spend may find the
-  ceiling low. A QuickBooks subscription is not required to apply.
+  A flat 2% back on all business spending with no annual fee is the real story
+  here, along with a $300 bonus after $3,000 in the first three months. The 5%
+  rate is narrower than it first appears: it applies only to Intuit's own
+  products and services such as QuickBooks, TurboTax, and Mailchimp, and it
+  excludes transactional fees like merchant services, so most businesses will
+  earn 2% on nearly everything they buy. The draw beyond rewards is
+  bookkeeping, since transactions and captured receipts flow straight into
+  QuickBooks and you can issue unlimited virtual and physical employee cards
+  with their own limits and controls at no extra cost. Two things to watch:
+  the card charges foreign transaction fees, which makes it a poor fit for
+  spending abroad, and the APR runs as high as 35.24%, so this is a
+  pay-in-full card. If your books already live in QuickBooks, that automatic
+  matching may be worth more to you than the small edge another 2% business
+  card would offer.

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -39,17 +39,18 @@ apr:
     min: 19.49
     max: 29.49
 our_take: >
-  The JetBlue Business card stands out with a strong 6 points per dollar on
-  JetBlue purchases, making it a compelling choice for frequent JetBlue
-  travelers. The card also offers a solid signup bonus of 50,000 points when
-  you spend $4,000 in the first 3 months, though note that this was recently
-  reduced from 60,000 points. With a $99 annual fee, the card provides
-  valuable perks like a free first checked bag for you and up to three
-  companions, and 50% off inflight purchases. However, if your business
-  expenses don't heavily involve JetBlue travel, the 2 points per dollar on
-  dining and office supplies, along with 1 point per dollar on other
-  purchases, may not justify the annual cost. Consider this card if JetBlue is
-  your airline of choice and you can maximize the travel-related benefits.
+  If your business flies JetBlue with any regularity, the free first checked
+  bag for you and up to three traveling companions on every booking can cover
+  the $99 annual fee on its own. Earning is 6x on JetBlue purchases, 2x at
+  restaurants and office supply stores, and 1x on everything else, so it
+  functions as a JetBlue-spend card rather than a general business card. The
+  current offer is 50,000 points after $4,000 in three months, trimmed from
+  60,000 back in May. The recurring extras are small individually but add up
+  for frequent flyers: 5,000 anniversary points, 50% off inflight food,
+  drinks, and Wi-Fi, a 10% points rebate on award flights you actually travel,
+  and a $100 statement credit on one JetBlue Vacations package a year. Mosaic
+  status is available but requires $50,000 in purchases, which is a hard
+  target when most of that spending earns only 1x.
 benefits:
   - name: "Anniversary Points Bonus"
     value: 5000

--- a/data/cards/jetblue-card.yaml
+++ b/data/cards/jetblue-card.yaml
@@ -41,17 +41,16 @@ apr:
     min: 19.49
     max: 29.49
 our_take: >
-  The JetBlue Card by Barclays stands out with its 3 points per dollar on
-  JetBlue purchases, making it a solid choice for frequent flyers of the
-  airline. With no annual fee and no foreign transaction fees, it's a
-  cost-effective option for international travelers. The card also offers 2
-  points per dollar on dining and groceries, adding value for everyday
-  spending. A 10,000-point signup bonus for spending $1,000 in the first 3
-  months is a nice perk, though not the most competitive in the airline
-  category. The 12-month 0% intro APR on balance transfers can be useful, but
-  the regular APR is on the higher side, ranging from 19.74% to 29.74%. While
-  the 50% savings on inflight purchases sweetens the deal, the card's primary
-  appeal is to JetBlue loyalists looking to maximize their travel rewards.
+  This is the entry-level JetBlue card and it behaves like one: no annual fee,
+  3x points on JetBlue purchases, 2x at restaurants and grocery stores, and 1x
+  everywhere else. The bonus is a modest 10,000 points after $1,000 in three
+  months, and the lone ongoing perk is 50% off inflight food, drinks, and
+  Wi-Fi, so there is no free checked bag and no anniversary points to look
+  forward to. It does carry 12 months of 0% intro APR on balance transfers,
+  which gives it a secondary use if you are moving existing debt.
+  Realistically it fits occasional JetBlue flyers who want to collect a few
+  TrueBlue points without paying anything to keep the card open. If you check
+  a bag even twice a year, the $99 JetBlue Plus is the better arithmetic.
 benefits:
   - name: "50% Off Inflight Purchases"
     value: 50

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -10,17 +10,19 @@ foreign_transaction_fee: false
 network: "mastercard"
 reward_type: "points"
 our_take: >
-  The JetBlue Plus card is a strong contender for frequent JetBlue flyers,
-  offering 6 points per dollar on JetBlue purchases and a solid 60,000-point
-  signup bonus after spending $1,000 in the first 3 months. While the signup
-  bonus was recently reduced from 70,000 to 60,000 points, it still provides
-  substantial value for new cardholders. The $99 annual fee is offset by perks
-  like the first checked bag free for you and up to three companions, 50% off
-  inflight purchases, and an annual 5,000-point anniversary bonus. Dining and
-  groceries earn 2 points per dollar, though everyday spending only earns 1
-  point per dollar, so it's best used for travel-related expenses. With no
-  foreign transaction fees and a 10% points rebate on award flights, it
-  remains a top choice for JetBlue loyalists despite the recent bonus cut.
+  A 60,000 point bonus for only $1,000 of spending in three months is one of
+  the lowest thresholds on any airline card, and it is a large part of why the
+  Plus sits at number two on our best airline cards list with the Best Overall
+  badge. The recurring case is simpler still: a free first checked bag for you
+  and up to three companions, 5,000 anniversary points, and a $100 JetBlue
+  Vacations statement credit each year can outrun the $99 fee for anyone who
+  flies JetBlue a couple of times annually. Earning is 6x on JetBlue
+  purchases, 2x at restaurants and grocery stores, and 1x on everything else,
+  so it belongs in your wallet for flights and not much else. The offer did
+  come down from 70,000 in May, so the current bonus is not the strongest this
+  card has shown. Value is concentrated entirely in JetBlue itself, and the
+  Mosaic status boost needs $50,000 in purchases, which is out of reach for
+  most cardholders at these earn rates.
 tags:
   - travel
   - airline

--- a/data/cards/jetblue-premier-card.yaml
+++ b/data/cards/jetblue-premier-card.yaml
@@ -42,17 +42,20 @@ apr:
     min: 19.49
     max: 29.49
 our_take: >
-  The JetBlue Premier card from Barclays is a powerhouse for frequent JetBlue
-  flyers, offering a hefty 6 points per dollar on JetBlue and TrueBlue Travel
-  purchases. The card's $499 annual fee is steep, but it comes with
-  substantial perks like $300 in annual TrueBlue Travel statement credits,
-  complimentary BlueHouse lounge access, and a 15% rebate on award flight
-  redemptions. You'll also earn 100,000 bonus points after spending $5,000 in
-  the first three months, which can significantly offset travel costs.
-  However, the card's value diminishes for those who don't frequently fly with
-  JetBlue, as its highest earn rate is limited to their purchases. Consider
-  this card if you can leverage the travel benefits and rewards to justify the
-  annual fee.
+  At $499 a year this is JetBlue's premium card, and the math starts with up
+  to $300 in annual TrueBlue Travel statement credits plus a $120 Global Entry
+  or TSA PreCheck credit every four years, which take a real bite out of the
+  fee before anything else counts. Lounge access is the true differentiator:
+  complimentary BlueHouse entry on eligible fares and Priority Pass at more
+  than 1,800 lounges, on top of free checked bags for you and up to three
+  companions and a 15% points rebate on award flights. The 100,000 point bonus
+  after $5,000 in three months is the largest of the JetBlue lineup by a wide
+  margin. Where it gets demanding is the companion pass credits, up to $500
+  after $15,000 of purchases and up to $1,500 more after $75,000, which is
+  where a lot of the advertised value quietly sits. Earning is still 6x on
+  JetBlue and TrueBlue Travel and just 1x on most other purchases, so unless
+  you fly the airline often enough to use the lounges and burn the credits,
+  the $99 Plus covers the same essentials for a fifth of the price.
 benefits:
   - name: "TrueBlue Travel Statement Credits"
     value: 300

--- a/data/cards/marriott-bonvoy-bevy-american-express.yaml
+++ b/data/cards/marriott-bonvoy-bevy-american-express.yaml
@@ -7,16 +7,19 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Marriott Bonvoy Bevy American Express card is a strong choice for
-  frequent Marriott travelers, offering 6 points per dollar at participating
-  hotels and 4 points per dollar on dining and U.S. supermarkets, up to
-  $15,000 annually. The standout feature is the generous signup bonus of
-  135,000 points, earned by spending $7,000 within the first six months.
-  However, the $250 annual fee is a significant consideration, and you'll need
-  to spend $15,000 annually to earn a Free Night Award. While it provides
-  valuable perks like Gold Elite Status and 15 Elite Night Credits, the card's
-  value diminishes if you're not a regular Marriott guest. With no foreign
-  transaction fees, it's also a good option for international travel.
+  The Bevy's most useful trait is that it earns well away from hotels: 4x at
+  restaurants worldwide and U.S. supermarkets on up to $15,000 a year
+  combined, then 2x, with a 2x floor on everything else, which is better than
+  most hotel co-brands manage. At Marriott Bonvoy properties it earns 6x, and
+  complimentary Gold Elite status plus 15 Elite Night Credits each year move
+  you toward higher tiers without any spending requirement. The current
+  135,000 point bonus arrives in two pieces, 85,000 after $5,000 and another
+  50,000 after $2,000 more, both within the first six months, and it climbed
+  back up in June after a sharp cut in May. The weak spot is a $250 annual fee
+  against a free night award that only shows up after $15,000 of purchases in
+  a calendar year, so there is no automatic anniversary night to lean on the
+  way most hotel cards provide. Clear that threshold and stay at Marriott a
+  few times a year and it works; fall short and the fee is hard to defend.
 annual_fee: 250
 reward_type: "points"
 rewards:

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -80,17 +80,19 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/bo
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Marriott Bonvoy Bold card is a solid choice for travelers who frequent
-  Marriott properties, offering 3 points per dollar spent at Marriott Bonvoy
-  hotels without an annual fee. It also provides automatic Silver Elite
-  status, which can enhance your stay with perks like priority late checkout.
-  However, the card's everyday rewards are modest, with 2 points per dollar on
-  groceries, streaming, utilities, phone services, and transit, and just 1
-  point per dollar on everything else. While the complimentary DashPass
-  membership for DoorDash and Caviar adds some value, it's a one-time benefit
-  that requires enrollment. Overall, this card is best suited for Marriott
-  enthusiasts who want to earn rewards on hotel stays without the burden of an
-  annual fee.
+  The Bold is the low-commitment way into Marriott Bonvoy: no annual fee, no
+  foreign transaction fee, and 60,000 points after just $1,000 of spending in
+  three months, which is one of the easiest spend requirements you'll find on
+  a hotel card. It also hands you automatic Silver Elite status and 5 elite
+  night credits a year, so it can quietly nudge you toward a higher tier
+  without costing anything. The tradeoff is the earn rate: 3x applies only at
+  Marriott Bonvoy properties, the 2x buckets are narrow (groceries, select
+  streaming, internet and cable, phone service, and rideshare), and everything
+  else earns a flat 1x. Silver Elite is also the softest status Marriott
+  offers, so this is not the card to put a big travel budget on. Treat it as a
+  free keeper that protects your Bonvoy balance and adds a few elite nights,
+  with the one-year DashPass membership and the baggage and trip delay
+  coverage as extras rather than reasons to apply.
 signup_bonus:
   value: 60000
   type: "points"

--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -88,16 +88,17 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/bo
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Marriott Bonvoy Boundless card from Chase is a strong contender for
-  frequent Marriott guests, offering 6 points per dollar at Marriott Bonvoy
-  hotels and a hefty signup bonus of 125,000 points plus a Free Night Award
-  after spending $3,000 in the first 3 months. The card's $95 annual fee is
-  offset by solid perks like a free night award worth up to 35,000 points
-  annually and 15 elite night credits toward status. However, the rewards
-  structure outside of Marriott stays is less compelling, with 3 points per
-  dollar on groceries, gas, and dining capped at $6,000 annually, then
-  dropping to 2 points. The card also includes up to $100 in airline statement
-  credits and a complimentary year of DoorDash DashPass, adding some value for
-  travelers and diners. If you're not a regular Marriott guest, the benefits
-  may not justify the fee, but for loyalists, it can enhance your stay and
-  earn status faster.
+  Chase recently pushed the Boundless signup bonus up to 125,000 points plus a
+  Free Night Award after $3,000 in three months, which is a large opening for
+  a $95 card. The ongoing case rests on the annual Free Night Award worth up
+  to 35,000 points, since one decent redemption can cover the fee on its own,
+  and you also get 15 elite night credits, automatic Silver Elite, and up to
+  $100 a year in airline statement credits ($50 each half after $250 in
+  airline spend). Earning is respectable if unspectacular: 6x at Marriott
+  Bonvoy hotels, 3x on groceries, gas, and dining but only on a combined
+  $6,000 a year before dropping to 2x, 2x on other travel, and 2x on
+  everything else. The real catch is redemption ceilings: the free night caps
+  at 35,000 points, so it works best for mid-tier properties, not the
+  aspirational ones. If you stay with Marriott a few times a year and will
+  actually use the certificate, the math holds; if you won't, the fee outruns
+  the benefits.

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -7,18 +7,19 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Marriott Bonvoy Brilliant American Express card is a strong choice for
-  frequent Marriott guests, offering 6 points per dollar at Marriott
-  properties and a generous 150,000-point signup bonus after meeting the
-  $8,000 spend requirement in the first six months. However, the $650 annual
-  fee is steep, so you'll need to take full advantage of its benefits to
-  justify the cost. These include an annual free night award worth up to
-  85,000 points, $300 in dining credits, and complimentary Marriott Bonvoy
-  Platinum Elite status. The card also provides a $100 credit for Global Entry
-  or TSA PreCheck every five years and Priority Pass Select membership for
-  airport lounge access. While the rewards on dining and airline purchases are
-  decent at 3 points per dollar, the card's real value lies in its
-  Marriott-specific perks.
+  The Brilliant is the only Bonvoy card here that hands you Platinum Elite
+  status outright, and that plus a Free Night Award good for redemptions up to
+  85,000 points is the reason to pay $650 a year. The credits do a lot of the
+  work: $25 a month in dining statement credits ($300 a year), a $100 property
+  credit on stays of two or more consecutive nights, Global Entry or TSA
+  PreCheck reimbursement every four years, and Priority Pass Select lounge
+  access. Amex cut the welcome offer from 200,000 points in May and has since
+  brought it back to 150,000, earned in two stages after $8,000 of spending in
+  six months. Earning is fine but not the draw: 6x at Marriott Bonvoy hotels,
+  3x at restaurants and on flights booked directly with airlines, and 2x on
+  everything else. This card only works if you stay at Marriott enough for
+  Platinum to matter and you reliably use the monthly dining credit, because
+  $650 is a lot to carry on status alone.
 annual_fee: 650
 reward_type: "points"
 rewards:

--- a/data/cards/marriott-bonvoy-business-american-express.yaml
+++ b/data/cards/marriott-bonvoy-business-american-express.yaml
@@ -78,14 +78,17 @@ benefits:
     frequency: "ongoing"
     category: "hotel"
 our_take: >
-  The Marriott Bonvoy Business American Express is an easy card to justify for
-  any business that stays at Marriott properties even a few nights a year. The
-  annual free night award, worth up to 35,000 points, typically covers a room
-  that costs more than the $125 annual fee on its own, and a second free night
-  unlocks at $60,000 in annual spend. Earning is well matched to business
-  spending, with 6x points at Marriott hotels and 4x on dining, U.S. gas,
-  wireless service, and shipping. Complimentary Gold Elite status, 15 elite
-  night credits, and a 7% discount on standard-rate direct bookings deepen the
-  Marriott relationship further. The tiered welcome offer of up to 125,000
-  points is substantial, though it takes $9,000 in spend over six months to
-  collect it all.
+  For $125 a year, the Bonvoy Business gives you an annual Free Night Award
+  good for redemptions up to 35,000 points, Gold Elite status, and 15 elite
+  night credits, which is a lot of Bonvoy value packed under a modest fee. Its
+  category lineup is genuinely useful for a small business: 4x at restaurants
+  worldwide, U.S. gas stations, U.S. wireless providers, and U.S. shipping
+  providers, plus 6x at Marriott Bonvoy hotels and 2x on everything else. The
+  current welcome offer is 125,000 points, split as 75,000 after $6,000 and
+  another 50,000 after $3,000 more, all within the first six months, so plan
+  for $9,000 of spending to collect the whole thing. The honest limits: Gold
+  is a mid-tier status, the free night caps at 35,000 points, and the second
+  Free Night Award requires $60,000 in purchases in a calendar year, which
+  most small businesses won't hit. If your points go to Bonvoy and you can use
+  one certificate a year, the fee is easy to justify; if you don't stay at
+  Marriott, the 4x categories alone aren't reason enough.

--- a/data/cards/navy-federal-cash-rewards-plus.yaml
+++ b/data/cards/navy-federal-cash-rewards-plus.yaml
@@ -9,18 +9,17 @@ foreign_transaction_fee: false
 network: "visa"
 reward_type: "cashback"
 our_take: >
-  The Navy Federal cashRewards Plus card stands out for its straightforward
-  cashback structure, offering 2% back on all purchases if you're approved for
-  a credit limit of $5,000 or more. With no annual fee and no foreign
-  transaction fees, it's a solid option for those who spend both domestically
-  and abroad. The card also includes a $250 signup bonus when you spend $2,500
-  within the first three months, which is a decent incentive for new
-  cardholders. However, if your credit limit is below $5,000, the cashback
-  rate drops to 1.5%, which is less competitive. Additionally, the 1.99% intro
-  APR on balance transfers for 12 months is appealing, especially since there
-  are no balance transfer fees, but the regular APR can be as high as 18%.
-  Overall, it's a good choice for those who can maximize the 2% rate and plan
-  to take advantage of the introductory balance transfer offer.
+  The cashRewards Plus is a flat 2% cash back on everything with no annual fee
+  and no foreign transaction fee, which puts it in the same tier as the best
+  no-fee flat-rate cards. The catch is baked into approval: you get the Plus
+  version at 2% only if you're approved for a credit limit of $5,000 or more,
+  and lower limits land on the standard cashRewards card at 1.5% instead.
+  There's a $250 bonus after $2,500 in the first three months on applications
+  through January 3, 2027, and the balance transfer terms are unusually
+  friendly: 1.99% intro APR for 12 months with no balance transfer fee at all,
+  which is rare. Ongoing APRs run 14.15% to 18%, well below the typical
+  rewards-card range. Just don't expect much beyond the cash back, since a
+  rental car collision damage waiver is the only real perk attached.
 tags:
   - cashback
   - rewards

--- a/data/cards/navy-federal-cash-rewards-secured.yaml
+++ b/data/cards/navy-federal-cash-rewards-secured.yaml
@@ -30,15 +30,16 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  The Navy Federal cashRewards Secured card is a solid choice for those
-  looking to build or rebuild their credit, offering 1% cash back on all
-  purchases with no annual fee. A standout feature is the upgrade path: after
-  just 6 months of responsible use, you may be eligible to transition to the
-  unsecured cashRewards card and get your deposit back. This makes it more
-  than just a stepping stone, as it can grow with you as your credit improves.
-  The card also offers rental car collision damage waiver coverage, adding a
-  touch of travel protection. However, the 18% APR is on the high side, so
-  it's best suited for those who can pay off their balance in full each month.
-  With no foreign transaction fees, it can also be a cost-effective option for
-  international use.
+  This is a credit-builder card with a clear exit plan, which is the main
+  reason to pick it: after three months you can be considered for a credit
+  limit increase without adding to your deposit, and starting at six months
+  the account is reviewed monthly for an upgrade to the unsecured cashRewards
+  card, with your security deposit ($200 minimum) returned when that happens.
+  It earns 1% cash back on everything with no annual fee and no foreign
+  transaction fee, which is modest but better than most secured cards, and the
+  APR is a flat 18% rather than the 25% and up that's common in this category.
+  There's no signup bonus and no bonus categories, so nobody should carry this
+  for the rewards. Rental car collision damage waiver is the only extra. Use
+  it to establish a payment history, pay in full every month, and treat the
+  upgrade to the unsecured card as the actual finish line.
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards-secured.html

--- a/data/cards/navy-federal-cash-rewards.yaml
+++ b/data/cards/navy-federal-cash-rewards.yaml
@@ -39,15 +39,16 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  The Navy Federal cashRewards card offers a straightforward 1.5% cash back on
-  all purchases, with the potential to earn 2% if your approved credit limit
-  is $5,000 or more under the cashRewards Plus program. This makes it a solid
-  choice for those looking for a no-annual-fee card with consistent rewards.
-  The $250 signup bonus is a nice perk, though it requires a $2,500 spend in
-  the first three months to qualify. Additionally, the card features a 1.99%
-  intro APR on balance transfers for 12 months and no foreign transaction
-  fees, adding value for those who travel or need to manage existing debt.
-  However, the regular APR ranges from 14.15% to 18%, so it's best suited for
-  those who can pay off their balances monthly. The lack of balance transfer
-  fees and rental car collision damage waiver are useful extras.
+  The cashRewards earns a flat 1.5% cash back on everything with no annual fee
+  and no foreign transaction fee, a straightforward setup with one wrinkle
+  worth knowing: approvals at a credit limit of $5,000 or more are issued as
+  cashRewards Plus, which earns 2% instead, so the same application can land
+  you a better card. The $250 bonus after $2,500 in the first three months (on
+  applications through January 3, 2027) is solid for a no-fee card. Where it
+  stands out is debt: 1.99% intro APR on balance transfers for 12 months with
+  no balance transfer fee, and an ongoing range of 14.15% to 18% that stays
+  below what most rewards cards charge. The downside is 1.5% is now the low
+  end for flat-rate cash back, and there are no bonus categories to lift the
+  average. Take it for the low rates and the chance at the 2% version, not as
+  a rewards centerpiece.
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards.html

--- a/data/cards/navy-federal-flagship-rewards.yaml
+++ b/data/cards/navy-federal-flagship-rewards.yaml
@@ -8,20 +8,20 @@ annual_fee: 49
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Navy Federal Visa Signature Flagship Travel Rewards card is a strong
-  contender for frequent travelers, offering 3 points per dollar on a wide
-  range of travel expenses from airlines to amusement parks. With a modest $49
-  annual fee, the card provides solid value, especially when you factor in the
-  35,000-point signup bonus, worth $350 when you spend $3,500 in the first
-  three months, plus a free Amazon Prime annual membership (a $139 value) each
-  year when you pay for it with the card. The card also includes
-  valuable travel perks like up to $120 in statement credits for Global Entry
-  or TSA PreCheck every four years and a complimentary 3GB GigSky
-  international mobile data plan. However, outside of travel, the rewards rate
-  drops to 2 points per dollar, which is decent but not exceptional. With no
-  foreign transaction fees, this card is well-suited for international
-  travelers, but those seeking everyday rewards might find better options
-  elsewhere.
+  The Flagship pairs 3x points on a broad travel definition (airlines, hotels,
+  car rentals, ride-sharing, parking, tolls, museums, amusement parks, and
+  golf courses) with 2x on everything else, so the base rate is stronger than
+  most cards charging a similar fee. At $49 a year the fee is nearly
+  self-funding through the annual Amazon Prime statement credit worth up to
+  $139 when you pay for the membership with the card, and the Global Entry or
+  TSA PreCheck credit of up to $120 every four years adds to that. The welcome
+  offer is 35,000 points, stated as worth $350, after $3,500 in the first
+  three months. Ongoing APRs of 14.74% to 18% are low for a travel card,
+  there's no foreign transaction fee, and Navy Federal charges no balance
+  transfer fees. The limits are real, though: the points are worth about a
+  cent each rather than transferable to airline partners, and lounge access
+  isn't part of the package, so this is a value card rather than a premium
+  one.
 reward_type: "points"
 tags:
   - travel

--- a/data/cards/navy-federal-go-biz-rewards.yaml
+++ b/data/cards/navy-federal-go-biz-rewards.yaml
@@ -29,13 +29,15 @@ benefits:
     enrollment_required: false
 apply_link: https://www.navyfederal.org/services/business/credit-cards.html
 our_take: >
-  The Navy Federal GO BIZ Rewards card is a straightforward choice for
-  business owners seeking a no-annual-fee card with basic rewards. You'll earn
-  1 point per dollar on all purchases, which is modest but consistent for
-  business expenses. A significant advantage is the absence of foreign
-  transaction fees, making it a practical option for international business
-  travel. The card also offers purchase protection and allows you to issue
-  cards to multiple employees at no extra cost, adding convenience for
-  managing business expenses. However, the relatively high regular APR range
-  of 16.65% to 18% means it's best suited for those who can pay off balances
-  monthly to avoid interest charges.
+  GO BIZ Rewards earns a flat 1 point per dollar on everything, and that's the
+  whole rewards story, so it isn't the card to run your business spending
+  through if you care about maximizing points. What it does offer is cost
+  control: no annual fee, no foreign transaction fee, cards for multiple
+  employees on one account at no extra charge, and an ongoing APR range of
+  16.65% to 18% that stays well under what most business cards charge at the
+  top end. There's no welcome bonus, no bonus categories, and no travel
+  credits, so nothing here rewards heavy spending. Purchase protection on
+  eligible items is the only meaningful coverage attached. Consider it a
+  low-cost operating card for a small team that values a predictable rate and
+  free employee cards, then put category spending on something that earns
+  more.

--- a/data/cards/navy-federal-go-rewards.yaml
+++ b/data/cards/navy-federal-go-rewards.yaml
@@ -38,15 +38,13 @@ benefits:
     enrollment_required: false
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/go-rewards.html
 our_take: >
-  The Navy Federal GO REWARDS card stands out with its strong rewards on
-  dining, offering 3 points per dollar spent, and 2 points per dollar on gas,
-  all with no annual fee. This makes it an appealing option for those who
-  frequently dine out or drive. Additionally, the card offers a 0.99% intro
-  APR on purchases for the first 6 months, which can be useful for short-term
-  financing. However, the regular APR ranges from 13.49% to 18%, so it's
-  important to pay off balances promptly after the intro period. The lack of
-  foreign transaction fees and no balance transfer fees add extra value,
-  especially for those who travel or are looking to transfer existing balances
-  without additional costs. While it's not currently featured on any Best-of
-  list, its combination of rewards and low fees make it a solid choice for
-  everyday use.
+  GO REWARDS is built around eating out: 3x points on dining and 2x at gas
+  stations, with no annual fee and no foreign transaction fee, which makes it
+  a cheap card to keep for restaurant spending. The regular APR range of
+  13.49% to 18% is low by rewards-card standards, and Navy Federal charges no
+  balance transfer fees, so it doubles as a reasonable place to move a
+  balance. The intro offer is a 0.99% APR on purchases for six months, which
+  is a short window compared with the 0% runways elsewhere on the market, and
+  there's no signup bonus at all. Everything outside dining and gas earns a
+  flat 1x, so this shouldn't be your only card. Use it where the 3x lands and
+  let something with a better base rate handle the rest.

--- a/data/cards/navy-federal-more-rewards-american-express.yaml
+++ b/data/cards/navy-federal-more-rewards-american-express.yaml
@@ -9,17 +9,18 @@ foreign_transaction_fee: false
 network: "amex"
 reward_type: "points"
 our_take: >
-  The Navy Federal More Rewards American Express card stands out for its
-  strong 3 points per dollar earn rate across dining, groceries, gas, and
-  transit, all with no annual fee. This makes it a versatile choice for
-  everyday spending, especially if you frequently spend in these categories.
-  The card also offers a signup bonus of 20,000 points, worth $200, when you
-  spend $2,000 within the first three months. While it lacks a 0% intro APR
-  offer, the regular APR is fairly competitive, ranging from 14.15% to 18%.
-  Additional perks include no foreign transaction fees and no balance transfer
-  fees, plus up to 25% off car rentals with insurance included. Overall, it's
-  a solid rewards card for Navy Federal members who want to maximize points on
-  common expenses.
+  The More Rewards American Express packs an unusually wide 3x band into a
+  card with no annual fee: dining including food delivery, groceries, gas, and
+  transit all earn 3 points per dollar, which covers most of a typical
+  household budget. The welcome offer adds 20,000 points worth $200 after
+  $2,000 in spending in the first three months, though that offer is only good
+  for applications through 1/3/2027. Standard APRs run 14.15% to 18%, low
+  enough that carrying an occasional balance is less punishing than on most
+  rewards cards, and there are no foreign transaction fees and no balance
+  transfer fees. The tradeoff is that everything outside those four categories
+  earns a flat 1 point per dollar, so spending on travel, online shopping, or
+  bills gets no lift here. Rental car discounts of up to 25% with loss and
+  damage coverage are a real but minor extra.
 tags:
   - rewards
   - dining

--- a/data/cards/navy-federal-platinum.yaml
+++ b/data/cards/navy-federal-platinum.yaml
@@ -30,15 +30,15 @@ benefits:
     enrollment_required: false
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/platinum.html
 our_take: >
-  The Navy Federal Platinum card is a solid option for those looking to manage
-  existing debt, thanks to its 0.99% intro APR on balance transfers for 12
-  months and the added benefit of no balance transfer fees. This makes it
-  particularly appealing if you want to avoid the typical 3% to 5% fees other
-  cards charge. While it doesn't offer rewards, its low regular APR range of
-  10.24% to 18% is competitive, especially for ongoing balances. The card also
-  includes some travel perks like a rental car collision damage waiver and
-  24/7 travel and emergency assistance, which add value for frequent
-  travelers. With no annual fee and no foreign transaction fees, it's a
-  cost-effective choice if you're focused on reducing debt without incurring
-  extra charges.
+  The Platinum is built for one job: moving debt cheaply. Navy Federal charges
+  no balance transfer fee at all, which is rare, and pairs it with a 0.99%
+  intro APR for 12 months and a standard rate that starts at 10.24% and tops
+  out at 18%. That combination means the math can still work even if you need
+  longer than a year to finish paying down the balance, unlike cards that dump
+  you into a 28% rate after the intro window. Be clear on the catch: the intro
+  rate is 0.99%, not 0%, and this card earns no rewards whatsoever, with no
+  annual fee and no foreign transaction fee as its only other selling points.
+  A rental car collision damage waiver and 24/7 travel assistance round it
+  out. Use it to clear a balance at a low rate, then keep a rewards card for
+  actual spending.
 

--- a/data/cards/nhl-discover-it.yaml
+++ b/data/cards/nhl-discover-it.yaml
@@ -36,15 +36,15 @@ apply_link: https://www.discover.com/credit-cards/cash-back/nhl-card.html
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  The NHL Discover it card stands out with its 5% cashback on quarterly
-  rotating categories, which currently include gas, EV charging, transit,
-  airlines, and drugstores, up to $1,500 in spending per quarter. This makes
-  it a strong choice for those who can maximize these categories and remember
-  to activate each quarter. The card also offers a 15-month 0% intro APR on
-  both purchases and balance transfers, providing a decent window for
-  interest-free spending or debt consolidation. However, beyond the rotating
-  categories, the card only earns 1% cashback on other purchases, which might
-  not be compelling for everyday spending. With no annual fee, it's a
-  cost-effective option if you can leverage the rotating categories, but it
-  may not offer much value once the intro period and bonus categories are
-  exhausted.
+  This is the standard Discover it cash back structure in NHL packaging: 5%
+  back on quarterly rotating categories, which for Q3 2026 covers gas, EV
+  charging, transit, airlines, and drugstores, plus a 0% intro APR for 15
+  months on both purchases and balance transfers with no annual fee. The 5% is
+  capped at $1,500 in spending per quarter and drops to 1% after that, so the
+  ceiling is $75 in bonus cash per quarter, and you have to activate the
+  categories every three months or you earn nothing extra. Everything outside
+  the rotating category earns a flat 1%, which is below what a plain 2% card
+  returns. There is no foreign transaction fee, but Discover acceptance is
+  narrower than Visa or Mastercard, so it is a poor sole card for travel.
+  Worth it if you will actually track the quarterly activations, and skippable
+  if you will not.

--- a/data/cards/paypal-cashback-mastercard.yaml
+++ b/data/cards/paypal-cashback-mastercard.yaml
@@ -26,13 +26,14 @@ apply_link: https://www.paypal.com/us/digital-wallet/manage-money/paypal-cashbac
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The PayPal Cashback Mastercard stands out for its simple and effective
-  rewards structure: 3% cash back on purchases made through PayPal checkout,
-  whether online or using in-store QR codes, and 1.5% on all other purchases.
-  With no annual fee, it's a good choice for frequent PayPal users who want to
-  maximize their cash back on online shopping. However, the card's rewards
-  drop to 1.5% when PayPal isn't used, which is less competitive compared to
-  other flat-rate cash back cards. Additionally, the card carries a foreign
-  transaction fee, making it less ideal for international use. If you often
-  shop online and use PayPal regularly, this card can offer solid value
-  without added costs.
+  The pitch here is 3% back on purchases, but read the condition carefully:
+  the 3% only applies when you check out through PayPal, whether online or
+  with the in-store QR code. Pay any other way and the card earns 1.5%, which
+  is also its rate on everything else, so 1.5% is the honest base rate to plan
+  around. There is no annual fee, so if a meaningful share of your online
+  shopping already routes through PayPal, that 3% is real money for no
+  carrying cost. Two things blunt it: the card charges foreign transaction
+  fees, making it a bad choice abroad, and the standard APR runs from 18.49%
+  all the way to 33.24%, so this is strictly a pay-in-full card. There is no
+  signup bonus to sweeten the start, so the value has to come from steady
+  PayPal-routed spending.

--- a/data/cards/playstation-visa.yaml
+++ b/data/cards/playstation-visa.yaml
@@ -44,13 +44,19 @@ apr:
     min: 17.74
     max: 31.74
 our_take: >
-  A niche card for PlayStation diehards: 5x on PlayStation, PlayStation Direct,
-  and Sony Store purchases, plus 3x on streaming and 2x on dining and groceries,
-  with no annual fee. Points only redeem for PlayStation Store codes and gift cards, so the value
-  is locked into the Sony ecosystem and there is no flexibility if your habits
-  change. It also charges foreign transaction fees and tops out at a high 31.74%
-  APR, so treat it as a spend-and-redeem card for gaming, not a primary everyday
-  card.
+  If you buy a lot from PlayStation, this card earns 5 points per dollar at
+  PlayStation, PlayStation Direct, and the Sony Store, and nowhere else, which
+  is the single reason to carry it. Around that sit some genuinely competitive
+  everyday rates for a no annual fee store card: 3x on streaming, cable, and
+  internet subscriptions, and 2x on dining including takeout and delivery,
+  plus 2x at grocery stores. A $100 statement credit after $500 in purchases
+  within 60 days is easy to clear, and hitting $6,000 in purchases in a
+  calendar year earns a 12-month PlayStation Plus Premium membership. The
+  limits are real: everything else earns 1 point per dollar, points redeem
+  into PlayStation Store codes and digital gift cards rather than cash, the
+  card charges foreign transaction fees, and the APR range tops out at 31.74%.
+  This is a card for a committed PlayStation household, not a general-purpose
+  earner.
 benefits:
   - name: "PlayStation Plus Premium Membership"
     description: "12-month PlayStation Plus Premium membership after $6,000 in purchases in a calendar year"

--- a/data/cards/pnc-cash-rewards.yaml
+++ b/data/cards/pnc-cash-rewards.yaml
@@ -57,14 +57,15 @@ benefits:
     frequency: "ongoing"
     category: "telecom"
 our_take: >
-  The PNC Cash Rewards card stands out for its generous 4% cash back on gas
-  purchases, making it a great choice for frequent drivers. It also offers 3%
-  back on dining and 2% on groceries, all within a combined annual cap of
-  $8,000 across these categories. After reaching the cap, the earn rate drops
-  to 1%, which is also the rate for all other purchases. The card comes with
-  no annual fee and includes a $200 signup bonus if you spend $1,000 in the
-  first three months, adding an extra incentive to apply. Additionally,
-  there's a 0% intro APR on balance transfers for 15 months, but be mindful of
-  the regular APR ranging from 18.49% to 28.49% after that period. Overall,
-  it's a solid card for cash back on everyday spending, especially if you can
-  maximize the rewards within the cap.
+  PNC Cash Rewards leads with a 4% rate on gas, which is higher than most no
+  annual fee cards offer, backed by 3% on dining and 2% at grocery stores. The
+  catch is a shared ceiling: all three categories draw on one combined $8,000
+  annual cap, after which they fall to 1%, so the realistic maximum bonus
+  spending is about $667 a month across gas, restaurants, and groceries put
+  together. A $200 bonus after $1,000 in spending in the first three months is
+  straightforward, and there is a 0% intro APR for 15 months on balance
+  transfers, though purchases get no intro window. Everything outside the
+  bonus categories earns 1%, and the card charges foreign transaction fees, so
+  leave it home when you travel abroad. Cell phone protection of up to $800
+  per claim when you pay your wireless bill with the card is a solid quiet
+  perk.

--- a/data/cards/pnc-cash-unlimited.yaml
+++ b/data/cards/pnc-cash-unlimited.yaml
@@ -39,13 +39,15 @@ benefits:
     frequency: "ongoing"
     category: "other"
 our_take: >
-  The PNC Cash Unlimited card offers a straightforward 2% cash back on all
-  purchases with no annual fee, making it a solid choice for those who prefer
-  a simple, flat-rate rewards structure. Its 15-month 0% intro APR on balance
-  transfers can provide some relief if you're looking to manage existing debt.
-  However, the regular APR starts at a relatively high 18.49%, so it's best
-  suited for those who plan to pay off their balances monthly. The card also
-  includes cell phone protection and purchase security, which add some value
-  beyond the cash back. With no foreign transaction fees, it's a practical
-  option for international use as well.
+  Cash Unlimited is a flat 2% back on everything with no annual fee and no
+  foreign transaction fee, which puts it at the top tier of no-effort cash
+  back cards and makes it usable overseas. There are no categories to track,
+  no caps, and no activation, so it works well as the card you reach for when
+  nothing else earns a bonus. It also carries a 0% intro APR for 15 months on
+  balance transfers, so it can pull double duty as a payoff card while still
+  earning on new spending. The gaps: there is no signup bonus at all, so
+  nothing accelerates your first year, and there is no intro APR on purchases.
+  Cell phone protection up to $800 per claim, purchase security on items
+  damaged or stolen within 90 days, and Visa Signature concierge are useful
+  but not reasons to apply on their own.
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-cash-unlimited-visa-credit-card.html

--- a/data/cards/pnc-secured.yaml
+++ b/data/cards/pnc-secured.yaml
@@ -15,11 +15,14 @@ foreign_transaction_fee: true
 network: "visa"
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-secured-credit-card.html
 our_take: >
-  The PNC Secured card is a straightforward option for those looking to build
-  or rebuild their credit, offering no annual fee which is a plus for a
-  secured card. It's designed for credit-building, so don't expect rewards or
-  cash back, but it can be a useful tool for establishing a positive credit
-  history if used responsibly. Since there have been no recent changes to its
-  terms, you can rely on its stability as you work on improving your credit
-  score. Just remember that as with any secured card, you'll need to provide a
-  security deposit, which will determine your credit limit.
+  The PNC Secured card does exactly one thing: it lets you build payment
+  history with a refundable deposit backing the line, and it does not charge
+  an annual fee to do it. That last part matters, since plenty of
+  credit-building cards charge $35 to $50 a year for the same function, and
+  paying nothing means the card costs you only the deposit you get back. Be
+  clear about what you are not getting: there are no rewards of any kind, no
+  intro APR, and no benefits attached. The APR is a fixed 25.49%, so the card
+  only works if you pay in full every month, and it charges foreign
+  transaction fees, which makes it a poor choice for travel. Treat it as a
+  stepping stone, use it for small recurring charges, and move to a rewards
+  card once your credit supports one.

--- a/data/cards/pnc-spend-wise.yaml
+++ b/data/cards/pnc-spend-wise.yaml
@@ -49,16 +49,18 @@ benefits:
     frequency: "ongoing"
     category: "telecom"
 our_take: >
-  The PNC Spend Wise card offers a solid 18-month 0% intro APR on both
-  purchases and balance transfers, making it a good choice for those looking
-  to manage debt or finance a big purchase interest-free for a year and a
-  half. With no annual fee, it also provides some useful perks like price
-  protection and porch piracy protection, which can offer peace of mind for
-  your purchases. However, the card lacks ongoing rewards, so it may not be
-  the best fit if you're looking to earn cash back or points on everyday
-  spending. The Purchase APR Reduction Program could be appealing if you plan
-  to carry a balance, as it offers a potential reduction in your standard
-  purchase APR over time. Additionally, the $25 annual digital subscription
-  credit is a nice bonus for those who regularly use services like Spotify,
-  Netflix, or Disney+.
+  Spend Wise offers 18 months of 0% intro APR on both purchases and balance
+  transfers with no annual fee, one of the longer runways available, which
+  makes it a straightforward choice for financing a large purchase or clearing
+  existing debt. The unusual wrinkle is the Purchase APR Reduction Program:
+  each 12-billing-cycle review period where you make at least $3,000 in net
+  purchases and pay the minimum by every due date knocks 2 percentage points
+  off your standard purchase APR, down to a floor of an 8.74% margin. That is
+  a genuine reason to keep the card past the intro window, because most
+  balance-transfer cards give you none. The tradeoff is that this card earns
+  no rewards at all, and it charges foreign transaction fees. Up to $25 a year
+  in credits on Spotify, Netflix, and Disney+ purchases, price protection,
+  cell phone protection, and coverage of up to $10,000 for packages stolen
+  within 90 days of purchase are the extras, none large enough to carry the
+  card by themselves.
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-spend-wise-visa-credit-card.html

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -6,17 +6,17 @@ slug: "princess-cruises-rewards-visa-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/credit-card/b2e0e09c-e93c-43be-8758-57d22bb39ec1
 our_take: >
-  The Princess Rewards Visa is a niche card designed for loyal
-  Princess Cruises passengers, offering 2 points per dollar on purchases made
-  with the cruise line. With no annual fee and a 20,000-point signup bonus
-  after spending $1,000 in the first 3 months, it's a low-cost way to earn
-  rewards for your next voyage. However, outside of Princess Cruises
-  purchases, the card only earns 1 point per dollar on everything else, which
-  is not competitive compared to broader travel cards. The 15-month 0% intro
-  APR on balance transfers is a nice touch, but with a regular APR ranging
-  from 18.49% to 29.49%, carrying a balance long-term could be costly.
-  Consider this card if you're a frequent Princess cruiser, but look elsewhere
-  for more versatile travel rewards.
+  This card is narrow by design: the 2 points per dollar rate applies only to
+  Princess Cruises purchases, and everything else, including other travel,
+  earns 1 point per dollar. The opening offer is the real draw, 20,000 points
+  after just $1,000 in spending in the first three months, which is a low bar
+  for a card with no annual fee. It also carries no foreign transaction fee,
+  which is useful on a cruise itinerary with foreign port charges, plus a 0%
+  intro APR for 15 months on balance transfers. The problem is what happens
+  after the bonus: with a flat 1x on non-Princess spending, a plain 2% cash
+  back card beats it on nearly everything, and the standard APR runs 18.49% to
+  29.49%. Worth opening if you have a Princess sailing booked and want the
+  bonus toward it, but not a card that earns its keep day to day.
 category: "travel"
 image: "barclays-princess.png"
 annual_fee: 0

--- a/data/cards/rakuten-american-express.yaml
+++ b/data/cards/rakuten-american-express.yaml
@@ -49,9 +49,14 @@ apr:
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  This card is built for Rakuten loyalists: 4% on Rakuten.com (up to $10,000 a year)
-  and 5% on Rakuten Dining stack on top of the usual cash-back portal, with a $100
-  signup bonus, all for no annual fee.
-  Off the Rakuten ecosystem the rates are ordinary (2% groceries and dining, 1% on
-  everything else), so a flat 2% card like the Active Cash will beat it for general
-  spending.
+  If you already shop through Rakuten, this card stacks on top of that: 4%
+  back on Rakuten.com purchases on up to $10,000 of spend per calendar year, a
+  cap that was raised from $7,000 in July 2026, plus 5% on Rakuten Dining, all
+  with no annual fee and no foreign transaction fee. Away from Rakuten the
+  math cools off fast, with 2% on groceries and dining and just 1% on
+  everything else, so this is a supplement rather than a primary card. The
+  signup bonus was also cut in half recently, from $200 to $100 after $1,000
+  of spend in the first three months, which takes some of the shine off
+  opening it today. The regular APR runs from 19.74% to 33.99%, so this is a
+  card to pay in full each month. Worth it if Rakuten is a regular habit, easy
+  to skip if it isn't.

--- a/data/cards/rei-co-op-mastercard.yaml
+++ b/data/cards/rei-co-op-mastercard.yaml
@@ -20,16 +20,17 @@ rewards:
     value: 1.5
     unit: percent
 our_take: >
-  The REI Co-op Mastercard offers a compelling 5% cashback rate on purchases
-  at REI retail locations and REI.com, making it an excellent choice for
-  frequent REI shoppers. With no annual fee and no foreign transaction fees,
-  it is a cost-effective option for both domestic and international use. The
-  card also provides a $100 REI gift card as a signup bonus after your first
-  purchase outside of REI within the first 60 days, adding immediate value.
-  However, the 1.5% cashback on all other purchases is modest, so it may not
-  be the best fit if you're looking for higher everyday rewards. Consider it a
-  strong addition if you regularly shop at REI, but less so if you're seeking
-  a versatile cashback card for broader spending.
+  The pitch is simple: 5% back at REI retail stores and REI.com, with no
+  annual fee and no foreign transaction fee, which makes it a straightforward
+  pick if you buy gear at the co-op regularly. The 1.5% flat rate on
+  everything else is respectable for a store-branded card, so it isn't dead
+  weight between outdoor purchases, though plenty of general cash back cards
+  match or beat it. The welcome offer is a $100 REI gift card after your first
+  purchase outside REI within 60 days, which is one of the easier bonuses to
+  trigger since there's no spending threshold to clear. Just note that the
+  payoff comes back to you as REI value, so it only counts if you were going
+  to spend it there anyway. With a regular APR of 17.49% to 28.49%, carry a
+  balance and the 5% stops mattering quickly.
 signup_bonus:
   value: 100
   type: cash

--- a/data/cards/robinhood-gold-card.yaml
+++ b/data/cards/robinhood-gold-card.yaml
@@ -43,10 +43,13 @@ apply_link: https://robinhood.com/creditcard/
 # 2026-07-01; accounts opened before that date are grandfathered with no fee.
 foreign_transaction_fee: true
 our_take: >
-  The headline 3% flat cash back on everything is the best unlimited rate going, beating
-  standard 2% cards by a wide margin, with 5% on travel booked through Robinhood. A 3%
-  foreign transaction fee now applies to accounts opened on or after July 1, 2026 (earlier
-  accounts keep the no-fee terms). The real cost is the Robinhood Gold subscription you must keep to
-  hold the card, so factor that fee in: at moderate spend the 3% still wins, but it erodes the
-  edge for light spenders. Access has also been gated by waitlist, and the 29.99% APR means
-  this only pays off if you clear the balance every month.
+  A flat 3% back on everything is the whole argument here, and it's a strong
+  one: most no-category cards top out at 2%, so the extra point applies to
+  every purchase without any tracking or activation. Travel booked through the
+  Robinhood travel portal earns 5%, and the card throws in trip cancellation,
+  trip delay, and lost luggage coverage plus cell phone protection when you
+  pay your bill with it. The catches are real, though. There's a $50 annual
+  fee, so you need roughly $5,000 of annual spend just to beat a fee-free 2%
+  card, and the card charges foreign transaction fees, which rules it out for
+  travel abroad despite the travel perks. The APR is a flat 29.99%, so this
+  only works as a pay-in-full everyday card.

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -109,11 +109,18 @@ apr:
 apply_link: https://robinhood.com/us/en/creditcard/platinum/
 foreign_transaction_fee: false
 our_take: >
-  Robinhood's $695 premium card leans on a long list of lifestyle credits (DoorDash, dining,
-  hotel and travel statement credits, plus health perks like One Medical and a $270
-  wearables credit) and
-  Priority Pass access, much of it routed through the Robinhood app. The earning is
-  credit-heavy, not rate-heavy: outside 5% dining and the 5% to 10% travel booked through
-  Robinhood's own portal, base spend earns just 1%. It only pays off if you live in the
-  Robinhood ecosystem and will actually use the credits.
+  Robinhood built the Platinum as a credit-heavy premium card: $695 a year
+  buys $500 in hotel credits booked through the Robinhood Banking app, $300 in
+  travel credits, $270 for health wearables, $250 at DoorDash, $250 for
+  eligible autonomous rides, $250 at eligible restaurants, and up to $120 for
+  Global Entry or TSA PreCheck every four years, plus unlimited Priority Pass
+  lounge access and complimentary Robinhood Gold, One Medical, Function
+  Health, and DashPass memberships. The earn rates look enormous at 10% on
+  hotels and car rentals and 5% on flights, but all of that requires booking
+  through the Robinhood Banking app, so it only pays if you're willing to move
+  your travel bookings there. Dining earns 5%, and the true base rate on
+  everything else is just 1%, which is thin for a card at this price. There's
+  no foreign transaction fee, and the APR is a flat 29.99%. This is a card
+  that pencils out only if you actually use most of the credits and book
+  travel in Robinhood's own app.
 

--- a/data/cards/sams-club-mastercard.yaml
+++ b/data/cards/sams-club-mastercard.yaml
@@ -50,13 +50,13 @@ benefits:
     frequency: "ongoing"
     category: "shopping"
 our_take: >
-  The Sam's Club Mastercard is really a gas card wearing a warehouse club
-  badge: 5% back on the first $6,000 in fuel each year is among the best
-  pump rates anywhere, and 3% on dining is a solid add. At Sam's Club itself
-  the card earns 3% only for Plus members, who also get an extra 2% from the
-  membership itself, while basic Club members earn just 1%. Rewards accrue
-  as Sam's Cash, redeemable at Sam's Club or for cash at member services,
-  with total earnings capped at $5,000 per year. There is no annual fee
-  beyond the required Sam's Club membership, and unlike the store card it is
-  a full Mastercard usable anywhere. Costco loyalists have the Citi
-  equivalent; for Sam's shoppers who drive a lot, this one earns its keep.
+  The headline rate isn't the club at all: 5% back on gas worldwide, including
+  but not limited to Sam's Club stations, on the first $6,000 each year, then
+  1%. That, plus 3% on dining and takeout and no annual fee on the card
+  itself, makes it a decent standalone gas and restaurant card. Sam's Club
+  purchases earn 3% only for Plus members, so Club-tier members get 1%
+  in-store and should not open this expecting a warehouse multiplier. Two caps
+  matter: the $6,000 gas ceiling, and a hard $5,000 Sam's Cash limit on total
+  card earnings per calendar year. The card also doubles as your membership
+  card at the door, and the current welcome offer is a modest $30 statement
+  credit after $30 in Sam's Club purchases within 30 days.

--- a/data/cards/samsung-galaxy-card.yaml
+++ b/data/cards/samsung-galaxy-card.yaml
@@ -54,15 +54,14 @@ benefits:
     merchants:
       - samsung
 our_take: >
-  Samsung's first U.S. credit card is a clear answer to the Apple Card: issued
-  by Barclays on the Visa network, living in Samsung Wallet, with a recycled
-  steel physical card for everything else. The earning structure is strong for
-  the ecosystem it targets, with 5% back on purchases made directly from
-  Samsung, 3% on anything paid through Samsung Wallet, 2% on streaming
-  services, and 1% otherwise. That beats the Apple Card tier for tier, and the
-  $200 bonus after $2,000 in 90 days is unusually generous for a $0 annual fee
-  store-adjacent card. The catch is the same as Apple's: the everyday 3% rate
-  depends on paying by phone, so value drops sharply if you swipe the physical
-  card or don't carry a Galaxy device. For Samsung loyalists who upgrade
-  phones and appliances through Samsung.com, this is an easy win; for everyone
-  else a flat 2% card is simpler.
+  This is a Samsung loyalty card first: 5% back on purchases made directly
+  from Samsung in the U.S., in store or online, with no annual fee and no
+  foreign transaction fee. The 3% rate is the one to read carefully, because
+  it only applies when you pay through Samsung Wallet; tap with the physical
+  card or check out anywhere Samsung Wallet isn't accepted and you're back to
+  the 1% base rate. Streaming services like Netflix, Disney+, and Spotify earn
+  2%. The $200 welcome bonus after $2,000 of spend in the first 90 days is
+  reasonable for a no-fee card, and cardholders get 20% off the $149.99
+  Samsung VIP Advantage membership at checkout. With a regular APR of 23.49%
+  to 32.24%, the value here is concentrated in Samsung buyers who will
+  actually route their spending through Samsung Wallet.

--- a/data/cards/southwest-rapid-rewards-performance-business-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-performance-business-credit-card.yaml
@@ -103,14 +103,20 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  The Southwest Rapid Rewards Performance Business is the top card in the
-  Southwest lineup, earning 4 points per dollar on Southwest purchases and 2
-  points on gas, dining, hotels, transit, and internet, cable, phone, and
-  advertising services. The 80,000 point welcome offer and 9,000 anniversary
-  points are the largest of any Southwest card, and unlimited Extra Legroom
-  seat upgrades near departure plus seat selection at booking address the two
-  costs Southwest flyers now actually face. A Global Entry credit, free first
-  checked bags for up to nine travelers, and 2,500 tier qualifying points per
-  $5,000 spent sweeten the deal for road warriors chasing A-List. The $299
-  annual fee is justified if your business flies Southwest monthly; if not,
-  the Premier Business covers the essentials for half the price.
+  The Performance Business is the top of Chase's Southwest business lineup,
+  and the perks justify the $299 annual fee for frequent Southwest flyers:
+  9,000 anniversary points, unlimited Extra Legroom seat upgrades within 48
+  hours of departure when available, complimentary Preferred or Standard seat
+  selection at booking, Group 5 boarding, and a free first checked bag for you
+  and up to eight passengers on the same reservation. It earns 4 points per
+  dollar on Southwest purchases and 2x across gas, dining, hotels booked
+  directly, transit, and internet, cable, phone, and advertising spend, with
+  80,000 points after $5,000 in the first three months. It also builds status
+  faster than the rest of the family: 2,500 tier qualifying points toward
+  A-List for every $5,000 spent, plus 10,000 Companion Pass qualifying points
+  each year, though those Companion Pass points don't count toward flight
+  redemptions. Rounding it out are a Global Entry, TSA PreCheck, or NEXUS
+  credit of up to $120, 25% back on inflight purchases, no foreign transaction
+  fees, and free employee cards. If your business doesn't fly Southwest
+  several times a year, the cheaper Premier Business covers most of the same
+  ground for $150 less.

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -93,15 +93,16 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/plus
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Southwest Rapid Rewards Plus card is a solid choice for frequent
-  Southwest flyers, with 2 points per dollar on Southwest purchases and a
-  recent signup bonus of 50,000 points after spending $1,000 in the first
-  three months. The card also offers 2 points per dollar at gas stations and
-  grocery stores, but only on the first $5,000 spent annually. While the $99
-  annual fee is a consideration, the perks like the annual 3,000-point
-  anniversary bonus, first checked bag free, and no foreign transaction fees
-  can offset the cost for regular travelers. The card's ongoing rewards
-  structure may not be as competitive for non-Southwest purchases, but the
-  additional benefits such as the Companion Pass boost and inflight purchase
-  credits can add value for loyalists. Overall, it's a compelling option if
-  you frequently fly Southwest and can leverage the travel benefits.
+  The Plus is the entry point to Southwest's cobranded lineup, and its real
+  draw is the 10,000 Companion Pass qualifying points deposited each year,
+  which shortens the path to a Companion Pass for a $99 annual fee. You also
+  get 3,000 anniversary points, a free first checked bag for you and up to
+  eight passengers on the same reservation, a 10% flight discount code each
+  year, 25% back on inflight drinks and Wi-Fi, and no foreign transaction
+  fees. Earn rates are modest: 2 points per dollar on Southwest purchases and
+  on gas and groceries up to $5,000 a year, then 1x on everything else, so
+  this isn't a card to put heavy spend on. Timing matters right now, because
+  the signup bonus climbed to 80,000 points in late May and fell back to
+  50,000 after $1,000 of spend in July, which is the offer on the table today.
+  It ranks ninth on our best airline cards list, a fair reflection of a card
+  that earns its keep through Southwest perks rather than points.

--- a/data/cards/southwest-rapid-rewards-premier-business-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-business-credit-card.yaml
@@ -92,14 +92,17 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  The Southwest Rapid Rewards Premier Business card is the workhorse option
-  for businesses loyal to Southwest, earning 3 points per dollar on Southwest
-  purchases and 2 points on gas, restaurants, and local commuting. The 60,000
-  point welcome offer covers a lot of domestic flying, and the 10,000
-  Companion Pass qualifying points each year give a meaningful head start
-  toward Southwest's most valuable perk. With Southwest now charging for
-  checked bags and assigned seating, the free first checked bag for up to
-  nine travelers and complimentary seat selection near departure carry real
-  weight against the $149 annual fee, and 6,000 anniversary points cover
-  most of the rest. Heavy spenders chasing A-List status or unlimited 2x
-  categories should step up to the Performance Business instead.
+  The Premier Business is the sensible middle of Chase's Southwest business
+  cards: $149 a year buys 6,000 anniversary points, a free first checked bag
+  for the cardmember and up to eight passengers on the same reservation, Group
+  5 boarding, complimentary Standard or Preferred seat selection within 48
+  hours of departure, and free employee cards with individual spending limits.
+  It earns 3 points per dollar on Southwest purchases, 2x on transit, and 2x
+  on gas and restaurants up to a combined $8,000 a year before dropping to 1x,
+  with 1x on everything else, so the spending categories are useful but
+  capped. The welcome offer is 60,000 points after $3,000 in the first three
+  months. For status chasers it delivers 2,000 tier qualifying points toward
+  A-List per $5,000 spent and 10,000 Companion Pass qualifying points each
+  year, though those Companion Pass points don't count toward flight
+  redemptions. There's no foreign transaction fee, but with a 19.24% to 27.74%
+  APR the value evaporates if you carry a balance.

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -97,15 +97,16 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/premier
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Southwest Rapid Rewards Premier card is a strong choice for frequent
-  Southwest flyers, offering 3 points per dollar on Southwest Airlines
-  purchases and a generous 55,000-point signup bonus after spending $1,500 in
-  the first three months. However, the bonus was recently reduced from 85,000
-  points, so it's worth considering if you missed the higher offer. The $149
-  annual fee is offset by benefits like 6,000 anniversary points, a 15% flight
-  discount on your cardmember anniversary, and a 25% rebate on inflight
-  purchases. While the card also earns 2 points per dollar on groceries and
-  dining up to $8,000 annually, it's primarily a travel card with perks that
-  cater to Southwest enthusiasts. The lack of foreign transaction fees is a
-  nice touch for international travelers, but the card's value diminishes if
-  you're not loyal to Southwest.
+  The Premier's case rests entirely on the Southwest ecosystem: 3x points on
+  Southwest purchases, 6,000 anniversary points every year, and a 10,000-point
+  Companion Pass qualifying boost that shortens the path to Southwest's best
+  perk, all for a $149 annual fee. A free first checked bag for you and up to
+  eight passengers on the same reservation can cover that fee outright if you
+  fly the airline as a family. Timing matters on the bonus: Chase ran it up to
+  85,000 points in late May and pulled it back to 55,000 points after $1,500
+  in three months on July 3, so the current offer sits at the low end of its
+  recent range. Everyday earning is modest, with 2x on groceries and
+  restaurants capped at the first $8,000 a year and 1x after that, so this is
+  not a card to route general spending through. It lands at #3 on our Best
+  Airline Credit Cards list, which is a fair read: strong if you fly Southwest
+  often, unremarkable if you don't.

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -101,15 +101,17 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/priority
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Southwest Rapid Rewards Priority card is a strong choice for frequent
-  Southwest flyers, offering 4 points per dollar on Southwest purchases and a
-  valuable set of travel perks. The card's standout features include a $75
-  annual Southwest travel credit, 7,500 anniversary points, and four upgraded
-  boardings each year. However, the $229 annual fee is a significant
-  consideration, and the 2 points per dollar on gas and dining may not be
-  compelling enough for those who don't primarily fly Southwest. The recent
-  adjustment of the signup bonus back to 60,000 points after a brief increase
-  to 90,000 points is worth noting, especially for those eyeing the bonus as a
-  key factor. With no foreign transaction fees and benefits like a free first
-  checked bag and a 25% inflight purchase rebate, this card is best suited for
-  those who can maximize its Southwest-specific advantages.
+  The Priority is the Southwest card for people who actually fly the airline
+  several times a year: 4x points on Southwest purchases, a $75 annual
+  Southwest travel credit, 7,500 anniversary points, and a 10,000-point
+  Companion Pass qualifying boost, which together offset a real chunk of the
+  $229 annual fee before you count a free first checked bag worth up to $90
+  round trip. Extra Legroom and Preferred seat access when available are the
+  practical day-of-travel perks. The current 60,000-point bonus after $2,000
+  in three months is the weaker end of the recent range, since Chase pushed it
+  to 90,000 in late May and cut it back on July 3. Outside Southwest the earn
+  rates are ordinary, 2x on gas and dining and 1x on everything else, so this
+  works as a dedicated airline card rather than a daily driver. We rank it #4
+  among airline cards and flag it as the best premium option there, but the
+  math only holds if the travel credit and anniversary points get used every
+  single year.

--- a/data/cards/target-circle-card.yaml
+++ b/data/cards/target-circle-card.yaml
@@ -44,14 +44,16 @@ benefits:
     category: "shopping"
     enrollment_required: true
 our_take: >
-  The Target Circle Card, the renamed RedCard, keeps the pitch that made it
-  one of the most-held store cards in the country: an instant 5% discount on
-  nearly everything at Target and Target.com, taken at the register rather
-  than accrued as rewards. Free two-day shipping, an extra 30 days on
-  returns, and half off the Target Circle 360 membership sweeten the deal
-  for regulars. The base version is a closed-loop card that works only at
-  Target, though well-qualified applicants may be issued a Mastercard
-  version that earns 2% on gas and dining elsewhere. There is no annual fee,
-  so for anyone who shops Target weekly this is close to free money; just
-  avoid carrying a balance at the steep 27.4% APR, and look elsewhere if you
-  want one card for all your spending.
+  If you shop at Target regularly, this is one of the simplest wins available:
+  an instant 5% off at Target stores and Target.com, including in-store
+  Starbucks and Target subscriptions, with no annual fee, so the discount hits
+  at the register rather than accruing as points you have to redeem. Free
+  two-day shipping on eligible Target.com items, an extra 30 days on returns,
+  and 50% off the $99 Target Circle 360 membership add up if Target is a real
+  part of your budget. The signup offer is small but easy, $50 in Target
+  Circle Rewards after spending $50 in the first 60 days. The limits are the
+  point of the card: the 5% does not apply to Target GiftCards, prescriptions,
+  or some services, and the base card earns nothing outside Target, though a
+  Mastercard version issued to well-qualified applicants adds 2% on gas and
+  dining and 1% elsewhere. With a 27.4% APR and no intro rate, this only makes
+  sense as a pay-in-full store card, never a place to carry a balance.

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -162,11 +162,19 @@ apply_link: https://www.americanexpress.com/us/credit-cards/business/business-cr
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The most loaded business travel card there is: Centurion and Priority Pass
-  lounge access, 5x on Amex Travel flights and prepaid hotels, a 200k-point
-  bonus, and a stack of credits (Dell, Indeed, wireless, Adobe, CLEAR, hotels)
-  that can more than cover the $895 fee. The math only works if you actually use
-  those credits, since they are split across vendors and require enrollment;
-  ignore them and the fee is hard to swallow. Everyday non-travel earning is just
-  1x (2x on select business categories and $5,000+ purchases), so pair it with a
-  category card for the rest of your spend.
+  Amex is running the Business Platinum's welcome offer at 300,000 points
+  after $20,000 in three months, up from 200,000 in mid-July, and that alone
+  is the strongest reason to look at the card right now. The ongoing case is a
+  stack of business-flavored credits: $360 a year for Indeed job postings,
+  $300 in ChatGPT credits, $250 with Adobe, $200 with Hilton, $150 at Dell,
+  $120 toward a U.S. wireless bill, plus $200 in airline incidentals and up to
+  $600 a year on Fine Hotels + Resorts or The Hotel Collection bookings, with
+  Centurion and Priority Pass lounge access on the travel side. The catch is
+  the $895 annual fee and the fact that nearly every one of those credits
+  requires enrollment and has to be spent with one specific vendor on a fixed
+  schedule, so it only pencils out if your business genuinely buys from those
+  vendors. Earning is lopsided too: 5x on flights and prepaid hotels booked
+  through Amex Travel, but only 1x on ordinary spend, with 2x reserved for a
+  narrow set of U.S. supplier categories and single purchases of $5,000 or
+  more. Treat it as a credits-and-bonus card you audit every year, not a card
+  to put general business spending on.

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -8,20 +8,20 @@ foreign_transaction_fee: false
 network: "amex"
 card_referral_link: "https://americanexpress.com/en-us/referral/platinum-card?ref="
 our_take: >
-  The Platinum Card from American Express stands out with a massive
-  175,000-point signup bonus, contingent on spending $12,000 in the first six
-  months, making it the top choice on our Best Credit Card Signup Bonuses
-  list. This card is a powerhouse for travelers, offering 5 points per dollar
-  on flights booked directly with airlines or through Amex Travel, and on
-  prepaid hotels booked through AmexTravel.com, up to $500,000 annually.
-  However, the steep $895 annual fee is a significant consideration, though it
-  is offset by a suite of benefits like $200 in annual airline fee credits,
-  $200 in Uber Cash, and access to exclusive airport lounges. The card also
-  provides valuable perks like hotel credits, automatic elite status with
-  Hilton and Marriott, and a range of monthly credits for services like
-  digital entertainment and gym memberships. If you travel frequently and can
-  maximize these benefits, The Platinum Card could be a rewarding addition to
-  your wallet.
+  The Platinum's welcome offer, 175,000 points after $12,000 in six months,
+  tops our Best Credit Card Signup Bonuses list and is the clearest reason to
+  open the card in year one. After that the value comes from credits rather
+  than earning: $600 a year on Fine Hotels + Resorts or The Hotel Collection,
+  $400 at U.S. Resy restaurants, $300 in digital entertainment, $300 at
+  Equinox, $300 at Lululemon, $200 in Uber Cash, $200 in airline incidentals,
+  and $219 for CLEAR Plus, alongside Centurion and Priority Pass lounge
+  access. Those add up on paper, but they arrive in monthly and quarterly
+  slices at specific merchants and most require enrollment, so the $895 annual
+  fee only works if your spending already looks like that list. Earning is
+  narrow as well: 5x on flights booked directly or through Amex Travel and 5x
+  on prepaid hotels on AmexTravel.com, with everything else at 1x. Open it for
+  the bonus and the credits you will actually use, and re-run the math each
+  renewal.
 annual_fee: 895
 reward_type: "points"
 rewards:

--- a/data/cards/united-business.yaml
+++ b/data/cards/united-business.yaml
@@ -123,15 +123,17 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  The United Business card earns 2 miles per dollar on United purchases, gas,
-  dining, office supplies, and local transit, and its welcome offer of 100,000
-  miles plus 2,000 Premier qualifying points is an elevated haul for a $150
-  annual fee. The card leans hard on partner credits: $125 back for frequent
-  United flyers, hotel and rental car credits, monthly rideshare and Instacart
-  credits, and two United Club passes each year can comfortably outrun the fee
-  if you actually use them. Free first checked bags and priority boarding
-  cover the airline basics, and holding a personal United card adds 5,000
-  bonus miles every anniversary. Spend also earns Premier qualifying points
-  toward status, capped at 1,000 PQP per year. For a business that flies
-  United even a few times a year, this is the default choice over the pricier
-  United Club Business.
+  For a $150 annual fee, the United Business covers most of what a small
+  business flying United needs: a free first checked bag for the cardmember
+  and one companion, priority boarding, two United Club one-time passes a
+  year, and 2x miles across United purchases, gas, dining, office supplies,
+  and transit. The current welcome offer is 100,000 miles after $5,000 in
+  three months, plus 2,000 Premier qualifying points and another 10,000 miles
+  for adding an employee card in the first three months, which is a lot of
+  value for that spend level. Recurring credits fill in the rest: $125 back
+  after five United flight purchases of $100 or more in a calendar year, up to
+  $100 in rideshare credits, $120 with Instacart, $100 toward JSX, and $50 on
+  Avis or Budget rentals. The tradeoff is the flat 1x on everything outside
+  those bonus categories, so this belongs alongside a stronger general
+  business card rather than replacing one. Employee cards at no additional
+  cost make it easy to push team spending through it without extra fees.

--- a/data/cards/united-club-business.yaml
+++ b/data/cards/united-club-business.yaml
@@ -109,16 +109,17 @@ benefits:
     frequency: "per_purchase"
     category: "travel"
 our_take: >
-  The United Club Business card is the lounge card: its headline benefit is a
-  full United Club All Access membership, worth more than $750 a year on its
-  own, plus free first and second checked bags and Premier Access at the
-  airport. Earning is a simple 2 miles per dollar on United purchases and a
-  strong 1.5 miles on everything else, and card spend generates Premier
-  qualifying points at the fastest clip of any United business card, with an
-  automatic 1,500 PQP boost each year. Chase piles on over $900 in annual
-  partner credits across Renowned Hotels, rideshare, Instacart, Avis and
-  Budget, JSX, and FareLock, which can offset much of the $695 fee for
-  businesses that use them. If you would buy a United Club membership anyway,
-  this card effectively pays you to hold it; if lounge access is optional, the
-  standard United Business delivers most of the flying perks at a fraction of
-  the cost.
+  The United Club Business is a lounge membership with a credit card attached:
+  United Club All Access for the primary cardmember, which Chase pegs at over
+  $750 in annual value, plus four one-time passes for employee cardholders,
+  first and second checked bags free, and Premier Access priority at check-in,
+  security, and boarding. At $695 a year, that membership is most of the
+  argument, with credits filling in the rest: up to $200 on prepaid United
+  Hotels stays, $240 with Instacart, $200 toward JSX, $150 in rideshare
+  credits, and $100 on Avis or Budget rentals. Earning is unusual for an
+  airline card, with 1.5x on all non-category spend instead of the typical 1x,
+  2x on United purchases, and 5x on prepaid Renowned Hotels bookings. The
+  welcome offer is 100,000 miles after $5,000 in three months, with 2,000
+  Premier qualifying points and 10,000 more miles for adding an employee card
+  early. The catch is straightforward: if your team doesn't fly United often
+  enough to use the clubs regularly, nothing here justifies $695.

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -110,14 +110,18 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/united/club-infini
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The United Club Infinite card is a premium choice for frequent United
-  flyers, offering a strong 5 miles per dollar on United purchases and a
-  significant 80,000-mile signup bonus after spending $5,000 in the first 3
-  months. The card's standout feature is the complimentary United Club
-  membership, providing access to airport lounges for you and eligible
-  companions. However, the $695 annual fee is steep, so you'll need to
-  maximize the extensive travel benefits like the $200 Renowned Hotels credit,
-  two free checked bags, and various travel credits to justify the cost.
-  Dining and other travel purchases earn 2 miles per dollar, but the real
-  value lies in the perks for loyal United travelers. If you're not a regular
-  on United, the fee might outweigh the benefits.
+  The Club Infinite's $695 annual fee is essentially the price of a United
+  Club membership for the primary cardholder, bundled with two free checked
+  bags and Premier Access priority at the airport. Around that, the card is
+  built to hold frequent United flyers: 5x miles on United purchases, 1,500
+  Premier qualifying points a year plus 1 PQP for every $15 spent up to
+  28,000, a 10,000-mile award flight discount after $20,000 in purchases, and
+  credits worth up to $200 on prepaid Renowned Hotels stays, $240 with
+  Instacart, $200 toward JSX, $150 in rideshare, $100 at Avis or Budget, and
+  Global Entry or TSA PreCheck every four years. Chase cut the welcome offer
+  from 100,000 to 80,000 miles after $5,000 in three months back in May, so
+  you are buying in at a weaker moment than earlier this year. Outside 2x on
+  dining and travel, everything else earns 1x, which makes it a poor home for
+  general spending. We rank it #13 among airline cards with a best premium
+  tag, and the honest test is simple: if you wouldn't otherwise pay for club
+  access, the fee is hard to justify.

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -106,15 +106,16 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-expl
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The United Explorer card is a solid choice for frequent United Airlines
-  travelers, offering 3 miles per dollar on eligible United purchases and a
-  generous suite of travel perks, including a first checked bag free and
-  priority boarding. However, the recent reduction in the signup bonus from
-  60,000 to 50,000 miles means you'll need to weigh the $150 annual fee
-  against the benefits you actually use. With 2 miles per dollar on dining and
-  hotel stays, and 1 mile per dollar on other purchases, the card provides
-  decent earning potential for travel enthusiasts. Additional perks like two
-  United Club passes annually, a $100 United Hotels credit, and a Global Entry
-  or TSA PreCheck fee credit every five years add value, but only if these
-  align with your travel habits. If you frequently fly United and can take
-  advantage of the benefits, this card could earn its place in your wallet.
+  The Explorer is the sensible middle of United's personal lineup: $150 a year
+  for a free first checked bag, priority boarding, two United Club one-time
+  passes, and a Global Entry or TSA PreCheck credit up to $120 every four
+  years, which covers the fee for anyone checking a bag more than a couple of
+  times a year. Earning is 3x miles on United purchases, 2x on dining and
+  hotels, and 1x on everything else. Chase trimmed the welcome offer from
+  60,000 to 50,000 miles after $3,000 in three months in late May, with
+  another 10,000 miles available for adding an authorized user in the first
+  three months. The annual credits are small but real: up to $100 on prepaid
+  United Hotels stays, $120 with Instacart, $100 toward JSX, $60 in rideshare,
+  and $50 at Avis or Budget. It sits at #7 on our Best Airline Credit Cards
+  list, which matches what it is, a solid card for occasional United flyers
+  rather than one to run all your spending through.

--- a/data/cards/united-gateway.yaml
+++ b/data/cards/united-gateway.yaml
@@ -40,17 +40,20 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-gate
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The United Gateway card stands out with its $0 annual fee and a solid
-  rewards structure, offering 2 miles per dollar on United purchases, gas, and
-  transit, and 1 mile per dollar on everything else. Its 30,000-mile signup
-  bonus, achievable with a $1,000 spend in the first 3 months, is a decent
-  start, though it was briefly higher at 40,000 miles. The 12-month 0% intro
-  APR on purchases is a nice touch for new cardholders looking to manage
-  expenses interest-free. However, the real value lies in United-specific
-  perks like 25% back on inflight purchases and potential discounts on flights
-  booked with miles after meeting spending thresholds. While it lacks everyday
-  cash back, it's a cost-effective option for United flyers who can leverage
-  the airline benefits.
+  The Gateway is the low-commitment way into United's ecosystem: no annual
+  fee, no foreign transaction fees, 2 miles per dollar on United purchases,
+  gas, and transit, and 12 months of 0% intro APR on purchases, which is
+  unusual on an airline card. The 30,000-mile bonus after $1,000 in three
+  months, plus 10,000 more for adding an authorized user, is easy to reach,
+  though it briefly rose to 40,000 in early April before Chase pulled it back
+  two days later, so a better offer may resurface. The real limits are the
+  perks: two free checked bags and the 10% discount on award flights only
+  unlock after $10,000 of spend in a calendar year, which is a lot to put on a
+  card earning 1 mile per dollar outside its three bonus categories. The 25%
+  rebate on inflight food, drinks, and Wi-Fi is a nice touch but small. It's
+  our pick for the best no-fee card on the Best Airline Credit Cards list, and
+  that's the right frame: a cheap way to hold United miles, not a card for
+  daily spending.
 benefits:
   - name: "Checked Bags"
     value: 0

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -134,14 +134,17 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-ques
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The United Quest card is a strong contender for frequent United Airlines
-  travelers, offering 4 miles per dollar on United purchases and a $200 annual
-  United TravelBank credit, which helps offset its $350 annual fee. The card
-  also provides valuable perks like two free checked bags and a 10,000-mile
-  anniversary award flight discount, making it appealing for those who fly
-  United regularly. However, the recent drop in the signup bonus from 90,000
-  to 60,000 miles may lessen its initial appeal. While the card offers 5 miles
-  per dollar on prepaid hotel stays through Renowned Hotels and Resorts, the
-  general travel and dining rewards rate is only 2 miles per dollar. Consider
-  this card if you're committed to maximizing United-specific benefits and can
-  take advantage of the various travel credits and discounts.
+  The Quest earns its $350 annual fee through credits rather than earn rates:
+  $200 in United TravelBank cash each year, two free checked bags, a
+  10,000-mile award flight discount every anniversary, and up to $150 back on
+  prepaid Renowned Hotels stays. Stack the narrower credits (up to $180 at
+  Instacart, $150 on JSX flights, $100 on rideshares, $80 on Avis or Budget
+  rentals) and a regular United flyer can clear the fee several times over,
+  but a few require annual enrollment and several only pay off if you already
+  spend in those places. Earn rates are solid without being remarkable: 4
+  miles per dollar on United purchases, 2 on travel, dining, and select
+  streaming, and 1 on everything else. Chase cut the signup bonus from 90,000
+  to 60,000 miles in May 2026, so the entry point is meaningfully weaker than
+  it was a few months ago. If you fly United a few times a year and will
+  actually use the checked bags and TravelBank credit, the math works;
+  occasional flyers should start with a cheaper United card.

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -66,9 +66,16 @@ apply_link: https://www.usbank.com/credit-cards/altitude-connect-visa-signature-
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  Unusually generous for a no-annual-fee travel card: 4x on travel and gas, 5x through the
-  travel portal, plus a Global Entry credit and a 12-month Priority Pass Select membership,
-  perks usually reserved for cards that charge a fee. The catch is the gas 4x caps at $1,000 a quarter, and US Bank
-  points stretch furthest booked through its own travel center. A strong keeper for occasional
-  travelers who want lounge access at no annual cost.
+  For a card with no annual fee, the Altitude Connect carries unusual travel
+  extras: a $100 Global Entry or TSA PreCheck credit every five years, a
+  complimentary 12-month Priority Pass Select membership, and no foreign
+  transaction fees. The earn rates hold up too, at 5 points per dollar on
+  hotels and car rentals booked through the U.S. Bank portal, 4 on other
+  travel and on gas and EV charging, and 2 at grocery stores, restaurants, and
+  on streaming. Watch the gas cap: that 4x rate stops after $1,000 per quarter
+  and falls to 1 point per dollar, the same as everything outside the bonus
+  categories. The signup bonus is modest at 20,000 points after $1,000 in
+  three months, so you're buying the ongoing rates and the lounge membership,
+  not the opening offer. The 15 months of 0% intro APR on both purchases and
+  balance transfers is a genuine bonus if you also have a balance to clear.
 

--- a/data/cards/us-bank-altitude-go-visa-signature.yaml
+++ b/data/cards/us-bank-altitude-go-visa-signature.yaml
@@ -49,17 +49,19 @@ apply_link: https://www.usbank.com/credit-cards/altitude-go-visa-signature-credi
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The U.S. Bank Altitude Go Visa Signature card stands out with its impressive
-  4 points per dollar on dining, up to $2,000 per quarter, making it a top
-  choice for food enthusiasts. With no annual fee and a 15-month 0% intro APR
-  on purchases, it's also a cost-effective option for those looking to manage
-  expenses or make a big purchase. The card's rewards extend to 2 points per
-  dollar on groceries, gas, and streaming services, providing a well-rounded
-  earning potential. However, the foreign transaction fee is a downside for
-  international travelers. The $20,000-point signup bonus for spending $1,000
-  in the first three months adds an attractive incentive, and the $15 annual
-  streaming credit is a small but nice perk. This card is a solid fit for
-  those who prioritize dining and everyday spending rewards.
+  The Altitude Go pairs 4 points per dollar on dining with no annual fee,
+  which is a strong combination for anyone whose restaurant and takeout
+  spending is the biggest line in their budget. Groceries, gas, and streaming
+  all earn 2 points, and the 20,000-point bonus after just $1,000 in three
+  months is one of the easier opening offers to hit. Two things temper it: the
+  4x dining rate is capped at $2,000 per quarter and drops to 1 point after
+  that, and the card charges foreign transaction fees, so it should stay home
+  on international trips. The $15 annual streaming credit requires enrollment
+  and 11 months of streaming activity, so treat it as a rounding error rather
+  than a reason to apply. It shows up at #6 on our best cards for dining and
+  groceries and as a beginner-friendly pick on the travel list, and that's
+  about right: a simple, free card to anchor everyday spending, helped along
+  by 15 billing cycles of 0% intro APR on purchases and balance transfers.
 benefits:
   - name: "Streaming Service Credit"
     value: 15

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -8,16 +8,18 @@ annual_fee: 400
 reward_type: "points"
 network: "visa"
 our_take: >
-  The U.S. Bank Altitude Reserve Visa Infinite offers a compelling travel
-  package with its standout $325 annual travel credit for purchases made via a
-  mobile wallet, which significantly offsets its $400 annual fee. For frequent
-  travelers, the unlimited Priority Pass lounge access and a $100 credit for
-  Global Entry or TSA PreCheck every five years add further value. However,
-  the card is not currently accepting applications, so it may not be an option
-  for new applicants. While the travel perks are strong, the lack of recent
-  changes or Best-of list placements suggests it may not be at the forefront
-  of the travel card market right now. If you already have it, the benefits
-  can still justify the cost, but new seekers will need to look elsewhere.
+  U.S. Bank has stopped accepting applications for the Altitude Reserve, so
+  this is now a card you evaluate for keeping rather than one you can go out
+  and get. For existing holders, the $400 annual fee rests almost entirely on
+  the $325 annual travel credit, and that credit only applies to travel
+  purchases made through a mobile wallet, which is a real condition and not a
+  formality. If you routinely pay with Apple Pay or a similar wallet, the
+  credit is straightforward to use and the effective cost drops to $75 before
+  you count anything else. On top of that sit unlimited Priority Pass Select
+  lounge access and a $100 Global Entry or TSA PreCheck credit every five
+  years, which is enough to justify the remainder for most people who travel
+  regularly. If mobile wallet payments aren't part of how you spend, the
+  credit goes unused and the fee is much harder to defend.
 benefits:
   - name: "Annual Travel Credit"
     value: 325

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -52,15 +52,15 @@ apply_link: https://www.usbank.com/credit-cards/cash-plus-visa-signature-credit-
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The U.S. Bank Cash+ Visa Signature card shines with its customizable 5% cash
-  back on two categories of your choice each quarter, up to $2,000 in combined
-  spending, making it a standout for those who can maximize these rotating
-  categories. Additionally, you earn 2% back on one everyday category like
-  groceries, gas, or dining, which adds flexibility to your spending strategy.
-  The recent increase in the signup bonus to $250 after spending $1,000 in the
-  first three months is a nice boost, especially with no annual fee. However,
-  the card's foreign transaction fee makes it less appealing for international
-  use, and outside of the selected categories, the 1% back on other purchases
-  is modest. The 15-month 0% intro APR on both purchases and balance transfers
-  is a solid perk for those looking to manage their finances interest-free for
-  a while.
+  The Cash+ is one of the more flexible 5% cards on the market: you choose two
+  categories each quarter from a list that includes cell phone providers, home
+  utilities, TV and streaming, department stores, and fast food, earning 5% on
+  up to $2,000 of combined spend, then pick one everyday category (groceries,
+  gas, or restaurants) for 2%. The signup bonus recently improved from $200 to
+  $250 after $1,000 in the first three months, and there's no annual fee plus
+  15 months of 0% intro APR on purchases and balance transfers. The catch is
+  the upkeep: categories reset every quarter and must be reselected, and if
+  you forget, that spending drops to the 1% base rate. Past the $2,000
+  quarterly cap and outside your chosen categories you also earn 1%, which
+  makes this a supporting card rather than the one you reach for by default.
+  It charges foreign transaction fees too, so leave it behind on trips abroad.

--- a/data/cards/us-bank-secured.yaml
+++ b/data/cards/us-bank-secured.yaml
@@ -5,14 +5,16 @@ image: "us-bank-secured.png"
 accepting_applications: true
 apply_link: https://www.usbank.com/credit-cards/secured-visa-credit-card.html
 our_take: >
-  The U.S. Bank Secured card is a solid option for those looking to build or
-  rebuild their credit, as it requires no annual fee, making it an affordable
-  choice for budget-conscious consumers. With a consistent APR of 27.49%, it's
-  crucial to pay off your balance in full each month to avoid high interest
-  charges. While it doesn't offer rewards or cash back, its primary value lies
-  in helping you establish a positive credit history. Ranked #5 on our Best
-  Secured Credit Cards list, this card is best suited for those focused on
-  improving their credit score without the burden of an annual fee.
+  The case for the U.S. Bank Secured is narrow and honest: it's a real Visa
+  with no annual fee, which matters more than anything else in the secured
+  category because many competitors charge one just to let you build credit.
+  It currently sits at #5 on our list of the best secured cards, largely on
+  that basis. What you give up is everything else, since there are no rewards,
+  no signup bonus, and no intro APR, and the ongoing rate is a flat 27.49%, so
+  this only works if you pay the balance in full every month. It also charges
+  foreign transaction fees, which rules it out for travel. Use it to build a
+  payment history for a year or so, then graduate to a card that actually
+  earns something.
 annual_fee: 0
 category: "secured"
 tags:

--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -27,16 +27,18 @@ apply_link: https://www.usbank.com/credit-cards/pm/shield-visa-credit-card.html
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  U.S. Bank recently trimmed the Shield's 0% intro APR from 24 months to 21,
-  but it still offers one of the longest interest-free periods available,
-  covering both purchases and balance transfers with no annual fee. This makes
-  it an excellent choice if you're looking to pay down debt or finance a large
-  purchase over nearly two years without interest. However, the card's rewards
-  are limited: you earn 4% cash back only on prepaid travel booked through the
-  U.S. Bank Travel Center, with no other everyday earn rates. The $20 annual
-  statement credit and cell phone protection are minor perks, but they don't
-  add significant value. Use the Shield for its top-ranked APR offer, then
-  consider other options for ongoing rewards.
+  Twenty-one months of 0% intro APR on both purchases and balance transfers,
+  with no annual fee, is the entire argument for the Shield, and it's a strong
+  enough one to make it our top overall pick among 0% APR cards. If you're
+  paying down existing debt or spreading a large purchase across the next year
+  and a half, very few cards hand you that much runway for free. The tradeoff
+  is that rewards are almost nonexistent: 4% back on prepaid travel booked
+  through the U.S. Bank Travel Rewards Center is the only earn rate, with
+  nothing at all on everyday spending. That leaves little reason to keep the
+  card active once the intro window closes. The $20 annual statement credit
+  for 11 consecutive months of purchases and the cell phone protection are
+  minor extras, not reasons to apply, and the foreign transaction fee means
+  this isn't a travel card despite that 4% portal rate.
 benefits:
   - name: "Annual Statement Credit"
     value: 20

--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -62,17 +62,20 @@ benefits:
     category: "telecom"
     enrollment_required: false
 our_take: >
-  The U.S. Bank Shopper Cash Rewards card shines for frequent shoppers,
-  offering 6% cash back at your choice of two major retailers each quarter,
-  like Amazon and Target, on up to $1,500 in combined spending. This makes it
-  a strong contender for those who can maximize these quarterly categories.
-  The card also offers 3% back in one everyday category of your choice, such
-  as gas or utilities, and 5.5% on travel booked through their portal. The
-  $250 signup bonus after spending $2,000 in the first four months is a nice
-  boost, especially with no annual fee for the first year. However, the $95
-  annual fee kicks in after that, and the foreign transaction fee makes it
-  less ideal for international use. Overall, it's a great card for strategic
-  spenders who can take full advantage of the rotating categories.
+  U.S. Bank stopped accepting applications for the Shopper Cash Rewards in
+  July 2026, so the only live question is whether existing holders should keep
+  paying for it. The draw was 6% back at two retailers you select each quarter
+  from a fixed list including Amazon, Apple, Costco, Target, and Walmart,
+  which pays only at those specific merchants rather than on online shopping
+  generally, and only on up to $1,500 of combined spend before dropping to
+  1.5%. Add 3% on one everyday category (gas, wholesale clubs, or utilities)
+  capped at $1,500 a quarter and a 1.5% base rate, and someone who
+  concentrates real money at a couple of big-box stores can clear the $95
+  annual fee, which was waived the first year. If your spending is more spread
+  out, you're paying $95 to manage quarterly selections for a fairly narrow
+  slice of purchases. Cell phone protection up to $600 per claim when you pay
+  your bill with the card is a fair tiebreaker if the rest of the math is
+  close.
 apply_link: https://www.usbank.com/credit-cards/shopper-cash-rewards-visa-signature-credit-card.html
 foreign_transaction_fee: true
 network: "visa"

--- a/data/cards/us-bank-smartly-visa-signature.yaml
+++ b/data/cards/us-bank-smartly-visa-signature.yaml
@@ -5,17 +5,15 @@ image: "smartly-signature.png"
 accepting_applications: true
 apply_link: https://www.usbank.com/credit-cards/bank-smartly-visa-signature-credit-card.html
 our_take: >
-  The U.S. Bank Smartly Visa Signature card offers a straightforward 2% cash
-  back on all purchases, making it a solid choice for those who prefer
-  simplicity in their rewards. With no annual fee, it's easy to justify
-  keeping in your wallet for everyday spending. The card also provides a
-  12-month 0% intro APR on both purchases and balance transfers, which can be
-  helpful if you're planning a big purchase or need to consolidate debt.
-  However, after the intro period, the regular APR ranges from 17.74% to
-  27.99%, so it's best to pay off your balance in full each month to avoid
-  interest charges. While it doesn't currently top any Best-of lists, its
-  consistent earn rate and lack of fees make it a reliable option for regular
-  use.
+  The Smartly Visa Signature is a plain flat-rate card: 2% cash back on
+  everything, no annual fee, no categories to track or activate. That makes it
+  a reasonable default for spending that doesn't trigger a bonus rate on your
+  other cards, and the 12 months of 0% intro APR on both purchases and balance
+  transfers gives it a second use if you have a balance to clear. What it
+  lacks is a signup bonus, so there's no upfront reward to make opening it
+  worthwhile on its own. It also charges foreign transaction fees, which takes
+  it out of the running for travel. Think of it as a quiet base-rate card that
+  fills gaps in a wallet rather than one you build around.
 category: "cashback"
 annual_fee: 0
 reward_type: "cashback"

--- a/data/cards/us-bank-split.yaml
+++ b/data/cards/us-bank-split.yaml
@@ -11,15 +11,16 @@ apply_link: https://www.usbank.com/credit-cards/offers/split-card-world-masterca
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The U.S. Bank Split card stands out with its unique 3-month interest-free
-  payment plans for purchases of $100 or more, allowing for flexibility
-  without incurring interest or fees. This feature can be particularly useful
-  for managing larger expenses in smaller, manageable chunks. However, the
-  card lacks a rewards program, which means there's no opportunity to earn
-  cash back or points on everyday spending. With no annual fee, it can be a
-  practical tool for short-term financing, but its utility diminishes if
-  you're looking for long-term rewards or benefits. Be mindful of the foreign
-  transaction fee if you plan to use it abroad.
+  The Split's one real trick is its financing structure: any purchase of $100
+  or more can be paid off over three months with no interest and no fees, on a
+  card that charges no annual fee. If you regularly make mid-sized purchases
+  you'd rather spread out, that's a cleaner deal than carrying a balance at a
+  standard APR, and it requires no enrollment. The catch is that the card
+  earns nothing: there are no cash back or points categories at all, so it
+  gives you no reason to reach for it once a purchase is paid off. It also
+  charges foreign transaction fees, which rules it out for travel. Think of it
+  as a budgeting tool for occasional larger buys rather than a card you put
+  daily spending on.
 benefits:
   - name: "3-Month Interest-Free Plans"
     description: "No interest or fees on 3-month payment plans for all purchases of $100 or more."

--- a/data/cards/usaa-cashback-rewards-plus.yaml
+++ b/data/cards/usaa-cashback-rewards-plus.yaml
@@ -36,13 +36,14 @@ apr:
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The USAA Cashback Rewards Plus card offers standout value for military
-  families and frequent drivers, with 5% cash back on gas and purchases at
-  military bases, though both categories cap at $3,000 and $5,000 per year,
-  respectively. Groceries earn a solid 3% cash back up to $3,000 annually,
-  making it a strong contender for everyday spending. With no annual fee, it's
-  an appealing option for those who can maximize these categories. However,
-  once you hit the spending caps, the rewards drop to a standard 1% on
-  everything else, so it's less compelling for higher spenders who exceed
-  those limits. The regular APR ranges from 16.9% to 30.9%, so carrying a
-  balance could get expensive.
+  The standout here is 5% cash back on gas, on the first $3,000 a year,
+  alongside 5% on military base purchases up to $5,000 a year and 3% at
+  grocery stores on the first $3,000, all with no annual fee and no foreign
+  transaction fees. Those are strong rates for a fee-free card, and the caps
+  are generous enough to cover a typical year of commuting and food shopping.
+  Two things temper it: everything outside those categories earns just 1%, so
+  this works as a supplement rather than a sole card, and the military base
+  bonus only pays off if you actually shop on base. There's also a 0% intro
+  APR for 20 months on balance transfers that post by November 30, 2026,
+  though the 5% transfer fee eats into that benefit. Regular APR runs 15.4% to
+  27.4%, so the caps are worth tracking if you'd otherwise carry a balance.

--- a/data/cards/usaa-eagle-navigator.yaml
+++ b/data/cards/usaa-eagle-navigator.yaml
@@ -29,17 +29,19 @@ apr:
     min: 18.40
     max: 26.65
 our_take: >
-  The USAA Eagle Navigator card is a solid choice for frequent travelers,
-  offering 3 points per dollar spent on travel and 2 points on all other
-  purchases. With a $95 annual fee, it's not the cheapest option, but the card
-  compensates with valuable perks like a $100 credit for Global Entry or TSA
-  PreCheck every four years and no foreign transaction fees. The 30,000-point
-  signup bonus, earned after spending $3,000 in the first three months,
-  provides a nice initial boost. Additionally, active duty military members
-  benefit from a waived annual fee and potentially reduced APR under the
-  Servicemembers Civil Relief Act. However, if you're not traveling often, the
-  annual fee might outweigh the rewards, making it less appealing for everyday
-  use.
+  The Eagle Navigator earns 2 points per dollar on everything and 3 on travel
+  and transit, including rideshare and tolls, which puts a flat above-average
+  rate on every purchase without you having to think about categories. The
+  30,000-point bonus after $3,000 in three months, a $120 Global Entry or TSA
+  PreCheck credit every four years, and 10,000 bonus points each year for
+  booking a hotel stay or car rental through the USAA Rewards Center all help
+  offset the $95 annual fee. Active duty members get a stronger version of the
+  deal: no annual fee while serving, plus a reduced APR under the
+  Servicemembers Civil Relief Act. The tradeoff is that the annual booking
+  bonus is tied to USAA's own portal, so you have to book where USAA wants you
+  to book in order to claim it. With no foreign transaction fee and an APR of
+  18.4% to 26.65%, it's a reasonable single-card travel setup as long as
+  you'll use the credits.
 benefits:
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120

--- a/data/cards/usaa-preferred-cash-rewards.yaml
+++ b/data/cards/usaa-preferred-cash-rewards.yaml
@@ -15,11 +15,16 @@ rewards:
     value: 1.5
     unit: percent
 our_take: >
-  A straightforward no-fee card for USAA members: a flat 1.5% on everything, a $250 bonus
-  after $1,000 of spend, and no foreign transaction fees.
-  It is fine as a simple everyday card, but the 1.5% rate is beaten by widely available flat
-  2% cards like Wells Fargo Active Cash. Get it mainly if you already bank with USAA and want
-  to keep your cards under one roof.
+  This is a simple flat-rate card: 1.5% cash back on everything, no annual
+  fee, no foreign transaction fee, and a $250 bonus after $1,000 in purchases
+  within three months. That bonus is generous relative to the low spending
+  requirement, and the lack of foreign transaction fees makes it usable
+  abroad, which not every no-fee cash back card can say. The honest catch is
+  the earn rate itself: 1.5% flat trails the better flat-rate cash back cards,
+  so over a full year of spending you're leaving money on the table compared
+  with a 2% option. There are no bonus categories to make up the difference
+  either. Worth opening for the bonus and keeping for overseas purchases, but
+  it shouldn't be the card you default to at home.
 signup_bonus:
   value: 250
   type: cash

--- a/data/cards/usaa-rate-advantage.yaml
+++ b/data/cards/usaa-rate-advantage.yaml
@@ -18,8 +18,14 @@ apr:
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  A low-rate card for USAA members who carry a balance: a roughly 20-month 0% intro on transfers and,
-  more notably, an ongoing regular APR that starts as low as 10.40%, well below most cards.
-  It earns no rewards and has no signup bonus, so the entire pitch is cheap borrowing. For a
-  pure 0% balance-transfer runway, the Wells Fargo Reflect and U.S. Bank Shield go longer at
-  21 months, but neither matches this card's low rate once the intro period ends.
+  The Rate Advantage is built around its interest rate rather than rewards:
+  the regular APR starts at 10.4% and tops out at 24.4%, a lower floor than
+  most general-purpose cards, and there's no annual fee and no foreign
+  transaction fee. If you know you'll occasionally carry a balance, that low
+  end is the entire argument for the card. There's also a 0% intro APR for 20
+  months on balance transfers that post by November 30, 2026, running through
+  the March 2028 billing cycle, but the 5% transfer fee is steep and should be
+  weighed against the interest you'd actually save. Be clear that this card
+  earns no cash back or points whatsoever, so it does nothing for you outside
+  of the borrowing math. Use it to hold or pay down debt cheaply, and put your
+  everyday spending elsewhere.

--- a/data/cards/usaa-rewards.yaml
+++ b/data/cards/usaa-rewards.yaml
@@ -25,13 +25,14 @@ apr:
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The USAA Rewards card offers a straightforward rewards structure with no
-  annual fee, making it a practical choice for those who frequently spend on
-  dining and gas. You'll earn 2 points per dollar in those categories, and 1
-  point per dollar on everything else. However, the card doesn't stand out in
-  any particular area, as it's not currently featured on any Best-of list. The
-  regular APR range from 13.4% to 27.4% is fairly standard, so it's best
-  suited for those who pay off their balance each month to avoid interest
-  charges. Overall, it's a solid option for USAA members looking to earn
-  points on everyday purchases without the burden of an annual fee.
+  USAA Rewards pays 2 points per dollar on dining and gas with no annual fee
+  and no foreign transaction fees, which covers two of the most common
+  everyday spending categories without asking anything in return. The uncapped
+  structure is a plus: unlike some category cards, there's no annual spending
+  limit noted on those bonus rates. The limits are real, though. Everything
+  outside dining and gas earns just 1 point per dollar, there's no signup
+  bonus to get you started, and the card offers no intro APR window. The
+  regular APR of 13.4% to 27.4% is unremarkable. It's a fine no-cost companion
+  card for restaurants and fill-ups, but it isn't strong enough to anchor a
+  wallet on its own.
 

--- a/data/cards/usaa-secured-american-express.yaml
+++ b/data/cards/usaa-secured-american-express.yaml
@@ -15,10 +15,13 @@ apr:
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  This is a no-fee secured card for building or rebuilding credit. The 26.40%
-  APR is in line with typical secured cards, so treat it as a credit-building
-  tool and pay the balance in full each month rather than carrying a balance.
-  There are no foreign transaction fees, a rarity in the secured space. The
-  catch is eligibility, since USAA membership is generally limited to the
-  military community; if you qualify, it is a solid no-fee way to establish
-  credit.
+  USAA dropped this card's annual fee from $35 to $0 in April 2026, which
+  removes the main reason to skip it and makes it a genuinely free way to
+  build credit with a deposit. Add no foreign transaction fees, unusual for a
+  secured card, and it works for someone building history who also spends
+  abroad. The tradeoffs are what you'd expect from a starter product: there
+  are no rewards of any kind, so the card gives you nothing back on your
+  spending, and the APR is a flat 26.4%, which means carrying a balance is
+  expensive. As an American Express, acceptance abroad can also be narrower
+  than a Visa. Use it to establish payment history, pay in full every month,
+  and plan to graduate to a rewards card once your score supports it.

--- a/data/cards/usaa-secured-visa-platinum.yaml
+++ b/data/cards/usaa-secured-visa-platinum.yaml
@@ -15,12 +15,13 @@ apr:
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The USAA Secured Visa Platinum is a straightforward option for those looking
-  to build or rebuild their credit without the burden of an annual fee. With a
-  variable APR ranging from 11.4% to 21.4%, it offers a relatively competitive
-  interest rate for a secured card, which can be beneficial if you
-  occasionally carry a balance. However, the card lacks rewards or perks, so
-  it won't earn you cash back or points on your spending. It's best suited for
-  individuals who are focused on improving their credit score and are
-  comfortable with its basic features. If you're a USAA member seeking to
-  establish credit, this card provides a no-frills path to doing so.
+  The most useful thing about this secured card is its APR: 11.4% to 21.4% is
+  well below what secured and starter cards typically charge, and there's no
+  annual fee and no foreign transaction fee. For someone building or
+  rebuilding credit who may occasionally carry a balance, that lower rate is a
+  meaningful cushion. What you give up is any earning at all: there are no
+  rewards, no signup bonus, and no intro APR offer, so the card exists purely
+  to establish payment history against a deposit. The Visa network gives it
+  broader acceptance than an Amex-branded secured alternative. Open it for the
+  credit-building and the cheap rate, then move on once you qualify for a card
+  that pays you back.

--- a/data/cards/venmo-credit-card.yaml
+++ b/data/cards/venmo-credit-card.yaml
@@ -49,10 +49,15 @@ apply_link: https://venmo.com/about/creditcard
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  A no-fee card that auto-adjusts to your spending: 3% on your top category and 2%
-  on your second each statement period, from a list of eight, with 1% on the rest.
-  It is a good fit for existing Venmo users who want rewards without picking
-  categories, and there are no foreign transaction fees. The tradeoff is the lack
-  of a real signup bonus and a high APR up to 30.74%, so flat 2%-on-everything
-  cards like the Wells Fargo Active Cash or Citi Double Cash will out-earn it
-  unless your spending is concentrated in those top two categories.
+  The Venmo card's appeal is that it does the category optimization for you:
+  each statement period it automatically pays 3% on your highest-spend
+  eligible category and 2% on the second, drawn from eight options including
+  groceries, dining, travel, transit, entertainment, gas, utilities, and
+  health and beauty. That means you never have to activate or guess right,
+  which is genuinely useful if your spending shifts month to month. Everything
+  outside those two categories earns 1%, so the card's real value depends on
+  how concentrated your spending is; if it's spread evenly, a flat 2% card
+  will beat this. There's no annual fee and no foreign transaction fee, but
+  there's also no signup bonus, and the regular APR runs a high 18.74% to
+  30.74%. Best treated as a set-and-forget everyday card for someone with
+  clearly lopsided spending.

--- a/data/cards/wells-fargo-active-cash.yaml
+++ b/data/cards/wells-fargo-active-cash.yaml
@@ -32,16 +32,17 @@ apply_link: https://creditcards.wellsfargo.com/active-cash-credit-card
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Wells Fargo Active Cash card stands out for its straightforward 2% cash
-  back on every purchase, making it an excellent choice for those who prefer a
-  simple, no-fuss rewards structure. With no annual fee, it offers a solid
-  $200 signup bonus after spending $500 in the first three months, providing a
-  quick return on your initial spending. Additionally, the card includes 12
-  months of 0% intro APR on both purchases and balance transfers, which can
-  help manage expenses interest-free for the first year. However, it does have
-  a foreign transaction fee, so it might not be the best option for
-  international use. The cellular telephone protection is a nice perk, but the
-  card's real value lies in its flat-rate cash back and introductory offers.
+  The Active Cash is one of the cleanest no-fee cash back cards available: a
+  flat 2% on every purchase with no categories to track, no annual fee, and a
+  $200 bonus after just $500 in purchases in three months, one of the lowest
+  spending requirements around. It currently ranks fifth on our Best Cash Back
+  Credit Cards list. You also get 12 months of 0% intro APR on both purchases
+  and qualifying balance transfers, plus cell phone protection worth up to
+  $600 per claim, with a $25 deductible, when you pay your bill with the card.
+  The one clear drawback is the foreign transaction fee, which makes it a poor
+  choice for travel abroad, and the flat structure means high spenders in
+  specific categories can beat 2% elsewhere. For a single card that handles
+  everything domestically without thought, it's hard to fault.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 0

--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -60,16 +60,19 @@ apr:
 apply_link: https://creditcards.wellsfargo.com/attune-credit-card
 network: "mastercard"
 our_take: >
-  The Wells Fargo Attune card offers a robust 4% cash back on a diverse range
-  of categories including gyms, entertainment, streaming services, and even
-  eco-friendly spending like public transit and EV charging, all with no
-  annual fee. It's a strong contender for those who spend heavily in these
-  areas and want to maximize their rewards. The card also features a modest
-  $100 signup bonus after spending $500 in the first three months, alongside a
-  12-month 0% intro APR on purchases. However, the card is no longer accepting
-  new applications, which limits its availability to new customers. If you
-  already have it, the ongoing rewards can make it a valuable addition to your
-  wallet, but new applicants will need to look elsewhere.
+  The Attune's appeal is the shape of its 4% categories: gyms and salons,
+  movie theaters and live events, streaming, pet care, gardening, public
+  transportation, EV charging and secondhand stores, all with no annual fee.
+  That is an unusually specific list, and if your spending happens to land
+  inside it the card outearns most flat-rate cash back options, which is part
+  of why it still sits at #9 on our Best Cash Back list. The catch is timing:
+  Wells Fargo stopped accepting new applications in June 2026, so this is now
+  a card you keep rather than one you can get. Everything outside those
+  categories earns just 1%, and the rest of the package is modest: a $100
+  bonus after $500 of spend in three months, 12 months of 0% intro APR on
+  purchases, and up to $600 of cell phone protection with a $25 deductible. If
+  you already hold it, keep it for the 4% categories and pair it with a
+  stronger base-rate card.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 0

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -63,9 +63,15 @@ apply_link: https://creditcards.wellsfargo.com/autograph-journey-visa-credit-car
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  A strong mid-tier travel card: 5x on hotels, 4x on airlines, and 3x on dining and other
-  travel, plus a $50 annual statement credit and no foreign transaction fee for $95. The travel
-  earning rates beat the Chase Sapphire Preferred and Citi Strata Premier in their own
-  categories, and the 60,000-point bonus only needs $4,000 in three months. The main caveat is
-  that Wells Fargo's points transfer to fewer partners than Chase or Amex, so weigh how you
-  plan to redeem.
+  Wells Fargo built the Autograph Journey around travel spend and the rates
+  back that up: 5 points per dollar on hotels, 4 on airlines, and 3 on dining
+  and other travel, with no foreign transaction fees. The 60,000-point signup
+  bonus after $4,000 in three months is the single biggest reason to apply,
+  and the $50 annual credit on a $50 minimum airline purchase claws back more
+  than half of the $95 annual fee if you actually use it. The protections are
+  better than the price suggests, with up to $1,000 in cell phone coverage,
+  $15,000 in trip cancellation and interruption reimbursement, and $3,000 for
+  lost baggage. The tradeoff is a 1 point per dollar base rate, so the card
+  only pays off if travel and dining are a real share of your spending.
+  Nothing in the benefit set covers lounges or hotel elite status, so treat
+  this as a mid-tier earner rather than a premium travel card.

--- a/data/cards/wells-fargo-autograph.yaml
+++ b/data/cards/wells-fargo-autograph.yaml
@@ -55,13 +55,15 @@ apply_link: https://creditcards.wellsfargo.com/autograph-visa-credit-card
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Wells Fargo Autograph card stands out with its 3x points on dining,
-  travel, gas, transit, and streaming, all with no annual fee, making it a
-  versatile choice for everyday spending. Its $0 foreign transaction fees and
-  a 20,000-point signup bonus after spending $1,000 in the first 3 months add
-  further appeal. However, the card's regular APR range of 18.49% to 28.49% is
-  on the higher side, so it's best suited for those who plan to pay off their
-  balance monthly. The 12-month 0% intro APR on purchases provides some
-  breathing room for new cardholders. Cell phone protection up to $600 per
-  claim is a nice perk, but the card's real value lies in its broad 3x rewards
-  categories.
+  The Autograph earns 3 points per dollar across six categories, dining,
+  travel, gas, transit, streaming and phone plans, and charges no annual fee,
+  which is a wide bonus footprint for a free card and why we tag it the best
+  no-fee pick on our Best Travel list at #6. The 20,000-point bonus after just
+  $1,000 of spend in three months is one of the easier thresholds around, and
+  there are no foreign transaction fees, so it travels without a penalty. A
+  12-month 0% intro APR on purchases gives it a secondary use if you have
+  something large to finance. The limits are real, though: everything outside
+  those six categories earns 1 point per dollar, and the only ongoing
+  protection is up to $600 of cell phone coverage when you pay the bill with
+  the card. Think of it as a strong everyday companion rather than the only
+  card you carry.

--- a/data/cards/wells-fargo-cash-back-college.yaml
+++ b/data/cards/wells-fargo-cash-back-college.yaml
@@ -14,13 +14,11 @@ rewards:
     value: 1
     unit: percent
 our_take: >
-  The Wells Fargo Cash Back College card is a straightforward option for
-  students looking to build credit with no annual fee. It offers a basic 1%
-  cash back on all purchases, which is modest compared to other student cards
-  that may offer higher rewards in specific categories. However, the lack of
-  an annual fee makes it an easy choice for students who want to start their
-  credit journey without any upfront costs. Unfortunately, the card is no
-  longer accepting applications, so those interested will need to explore
-  other student card options. While it doesn't offer any standout features or
-  rewards, it could have been a simple stepping stone for students to
-  establish credit.
+  The Cash Back College was a starter card in the plainest sense: no annual
+  fee and a flat 1% back on everything, with no bonus categories to learn or
+  track. That simplicity was the whole point for a first card, but 1% is the
+  floor now rather than a selling point, and Wells Fargo no longer accepts
+  applications for it. If you still hold one, it is worth keeping open for the
+  age it adds to your credit history while day to day spending goes on
+  something that earns more. Students shopping for a first card today should
+  look at current no-fee options with real earn rates instead.

--- a/data/cards/wells-fargo-choice-privileges-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-mastercard.yaml
@@ -44,17 +44,19 @@ apply_link: https://creditcards.wellsfargo.com/choice-hotel-privileges-mastercar
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Wells Fargo Choice Privileges Mastercard is a strong contender for
-  travelers who frequently stay at Choice Hotels, offering 5 points per dollar
-  on stays at participating properties. With no annual fee and a generous
-  60,000-point signup bonus after spending $1,000 in the first three months,
-  it's a cost-effective option for budget-conscious travelers. You'll also
-  earn 3 points per dollar on gas, groceries, home improvement, and phone
-  expenses, which adds value for everyday purchases. The card includes
-  automatic Gold Elite Status and 10 elite qualifying nights annually,
-  enhancing your hotel experience. However, the regular APR ranges from 19.99%
-  to 28.74%, so carrying a balance could be costly. With no foreign
-  transaction fees, it's also a practical choice for international travel.
+  For a card with no annual fee, the Choice Privileges Mastercard asks very
+  little and hands back a reasonable amount, starting with 60,000 bonus points
+  after $1,000 of spend in three months. That offer is worth watching: Wells
+  Fargo cut it to 40,000 in April 2026 before restoring the full 60,000 in
+  May. The 5 points per dollar rate applies only at participating Choice
+  Hotels properties, but 3 points per dollar on gas, groceries, home
+  improvement and phone plans is unusually broad for a free hotel card, and
+  automatic Gold Elite status plus 10 elite qualifying nights a year come
+  along with it. There are no foreign transaction fees and up to $800 of cell
+  phone protection when you pay your monthly bill with the card. The honest
+  limit is the currency: Choice Privileges points only matter if you actually
+  stay at Choice properties, and 1 point per dollar on everything else is a
+  weak base rate.
 benefits:
   - name: "Automatic Gold Elite Status"
     value: 0

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -9,20 +9,19 @@ foreign_transaction_fee: false
 network: "mastercard"
 reward_type: "points"
 our_take: >
-  The Wells Fargo Choice Privileges Select Mastercard is a compelling option
-  for frequent travelers who favor Choice Hotels, offering a strong 10 points
-  per dollar spent at participating properties. The card's $95 annual fee is
-  offset by a generous 60,000-point signup bonus after spending $3,000 in the
-  first three months, and an annual 30,000-point anniversary bonus, which can
-  translate to about three reward nights. Additional perks include automatic
-  Platinum Elite status, which provides a 25% bonus on points earned during
-  stays and potential room upgrades. While it offers 5 points per dollar on
-  gas, groceries, home improvement, and phone expenses, everyday purchases
-  only earn 1 point per dollar, which might limit its appeal for non-travel
-  spending. With no foreign transaction fees and a $120 credit for Global
-  Entry or TSA PreCheck every four years, it's a solid choice for
-  international travelers, but those who don't frequently stay at Choice
-  Hotels may find better value elsewhere.
+  The Select's case is mostly arithmetic: a 30,000-point anniversary bonus,
+  described as roughly three reward nights at participating Choice hotels, set
+  against a $95 annual fee. If you would use those nights, the fee covers
+  itself before you spend a dollar. The earn rates hold up for the price too,
+  at 10 points per dollar at participating Choice Hotels properties and 5
+  points per dollar on gas, groceries, home improvement and phone plans,
+  alongside automatic Platinum Elite status and a $120 Global Entry or TSA
+  PreCheck credit once every four years. The signup bonus is 60,000 points
+  after $3,000 of spend in three months, with no foreign transaction fees on
+  the card. The catch is the one every single-brand hotel card carries: the
+  points are worth little unless Choice properties are genuinely part of your
+  travel, and everything outside the bonus categories earns just 1 point per
+  dollar.
 tags:
   - travel
   - hotel

--- a/data/cards/wells-fargo-propel-american-express.yaml
+++ b/data/cards/wells-fargo-propel-american-express.yaml
@@ -28,13 +28,13 @@ rewards:
     unit: "points_per_dollar"
 network: "amex"
 our_take: >
-  The Wells Fargo Propel American Express card offers a strong earn rate of 3
-  points per dollar on popular categories like dining, travel, transit, gas,
-  and select streaming services, all with no annual fee. This makes it an
-  attractive option for those who spend heavily in these areas and want to
-  rack up rewards without worrying about a fee eating into their earnings.
-  However, the card is no longer accepting applications, so if you don't
-  already have it, you'll need to look elsewhere for similar benefits. For
-  existing cardholders, the 1 point per dollar on other purchases is modest,
-  but the lack of an annual fee keeps it a cost-effective choice for targeted
-  spending.
+  The Propel was one of the better no-fee rewards cards of its era: 3 points
+  per dollar on dining, travel, transit, gas and select streaming services,
+  with no annual fee attached. That category spread still holds up, covering
+  most of what a typical household spends outside of groceries. The catch is
+  availability, since Wells Fargo no longer accepts applications, so this is a
+  card you can only keep rather than open. Everything outside the bonus
+  categories earns 1 point per dollar, so if you are still carrying it, use it
+  for those five categories and route general spending elsewhere. With no
+  annual fee to justify, there is rarely a reason to close it and give up the
+  account history.

--- a/data/cards/wells-fargo-reflect.yaml
+++ b/data/cards/wells-fargo-reflect.yaml
@@ -21,15 +21,17 @@ apply_link: https://creditcards.wellsfargo.com/reflect-visa-credit-card
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Wells Fargo Reflect card offers a standout 21-month 0% intro APR on both
-  purchases and balance transfers, making it a top choice for those looking to
-  manage existing debt or finance a large purchase interest-free. With no
-  annual fee, it's a cost-effective option for those focused solely on paying
-  down balances. However, the card doesn't earn any rewards, so once the intro
-  period ends, it may not have much appeal for everyday use. The card does
-  offer up to $600 in cell phone protection, which can be a nice perk if you
-  pay your phone bill with it. Overall, it's a strategic choice for the intro
-  APR, but not a long-term keeper.
+  Twenty-one months of 0% intro APR on both purchases and qualifying balance
+  transfers, with no annual fee, is the whole pitch here, and it is strong
+  enough to put the Reflect at #3 on our Best 0% APR list. That window gives
+  you close to two years to clear existing debt or spread out a large purchase
+  before the regular 17.49% to 28.24% variable APR takes over. Be clear about
+  what you give up in exchange: the card earns no rewards at all, so nothing
+  keeps it in rotation once the intro period ends, and it charges foreign
+  transaction fees, which rules it out for travel. Cell phone protection of up
+  to $600 per claim, limited to two claims per 12 months with a $25
+  deductible, is the lone ongoing perk. Open it with a payoff schedule already
+  written down, and expect it to go quiet after the 21 months are up.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 600

--- a/data/cards/wells-fargo-rewards.yaml
+++ b/data/cards/wells-fargo-rewards.yaml
@@ -6,11 +6,13 @@ accepting_applications: false
 annual_fee: 0
 reward_type: "points"
 our_take: >
-  The Wells Fargo Rewards card is no longer accepting applications, which
-  limits its appeal to existing cardholders. With no annual fee, it remains a
-  cost-effective option for those already using it, but the lack of recent
-  updates suggests it's not a priority for Wells Fargo. While the card offers
-  points as its reward type, the absence of a standout earn rate or unique
-  perks means it might not compete well with newer options. If you already
-  have this card, it can serve as a no-cost addition to your wallet, but don't
-  expect it to be a powerhouse for rewards or benefits.
+  Wells Fargo has stopped accepting applications for the Rewards, so the only
+  real question is what existing cardholders should do with it. The case for
+  keeping it is narrow but legitimate: there is no annual fee, so leaving the
+  account open costs nothing and preserves your account history. The case
+  against using it is simpler, since the card carries no published earn
+  categories, only a general points balance, which means every dollar you put
+  on it is a dollar earning less than it would on a current no fee rewards
+  card. Move your everyday spending elsewhere and let this one sit in a drawer
+  as a credit history anchor. Closing it is low stakes if you want to
+  simplify, just weigh the effect on your average account age first.

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -6,14 +6,18 @@ apply_link: https://creditcards.wellsfargo.com/business-credit-cards/signify-bus
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  A clean, no-fee business card built on simplicity: a flat 2% back on every
-  purchase with no categories to track and a 12-month 0% intro APR on purchases,
-  though it does charge a 3% foreign transaction fee, so leave it home when
-  traveling abroad. The $500 bonus after $5,000 in spend is one of the
-  better no-fee business offers around, and the flat 2% means it earns well as a
-  catch-all for mixed business spending. If your purchases concentrate in specific
-  categories, a tiered business card may beat it, but for broad spend this is hard
-  to fault.
+  The Signify Business Cash is the simplest business card to run: a flat 2%
+  cash back on every purchase with no annual fee, so there are no categories
+  to track and no quarterly activation to remember. The $500 bonus after
+  $5,000 of spend in the first three months is easy money for most businesses
+  with real expenses, and it earned a spot at #15 on our Best Credit Card
+  Signup Bonuses list with the Best No Fee badge. The 12 month 0% intro APR on
+  purchases gives you a year to finance equipment or inventory without
+  interest, which matters more for a small business than most consumer perks.
+  The catch is that this card charges foreign transaction fees, so it is the
+  wrong tool for overseas spend or foreign vendors. Beyond up to $250,000 of
+  travel accident insurance on tickets bought with the card, there is nothing
+  else here, and that is the point.
 image: "wells-fargo-signify-business-cash.png"
 category: "business"
 annual_fee: 0

--- a/data/cards/wells-fargo-visa-signature.yaml
+++ b/data/cards/wells-fargo-visa-signature.yaml
@@ -7,11 +7,13 @@ annual_fee: 0
 reward_type: "points"
 network: "visa"
 our_take: >
-  The Wells Fargo Visa Signature card is no longer accepting applications,
-  which limits its availability to new users. For those who already have it,
-  the card offers points as its reward type with no annual fee, making it a
-  cost-effective option for earning rewards without upfront costs. However,
-  without any recent changes or features that place it on a Best-of list, the
-  card might not stand out in a crowded market. Existing cardholders can still
-  benefit from the rewards structure, but new applicants will need to look
-  elsewhere for a similar offering.
+  Wells Fargo is no longer accepting applications for the Visa Signature,
+  which makes this a legacy card rather than a live option. If you already
+  carry one, the no annual fee structure means there is no cost to leaving the
+  account open, and keeping it open protects the age of your credit file. What
+  it will not do is earn competitively, because the card has no published
+  category rates attached to it, so routine spending is better placed on a
+  current rewards card. Treat it as a Visa in reserve and a line of credit
+  that quietly helps your utilization ratio. If you decide to close it, do it
+  deliberately and understand you are giving up the account age, not any
+  ongoing value.

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -79,11 +79,19 @@ apply_link: https://creditcards.chase.com/business-credit-cards/world-of-hyatt/h
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  Aimed at business owners loyal to Hyatt: up to 9x at Hyatt properties,
-  automatic Discoverist status, up to $100 in Hyatt statement credits each
-  anniversary year, and 2x in your top three spend categories each quarter.
-  Unlike the personal card there is no annual free night, so the $199 fee has
-  to be earned back through the credits and the spend-based perks, which are 5
-  elite night credits per $10,000 spent and 10% of redeemed points back after
-  $50,000 in annual spend. It only pays off if both your stays and your
-  business spending run through Hyatt at real volume.
+  If your business books Hyatt with any regularity, this card is built around
+  that: 4x points at Hyatt hotels, automatic Discoverist status, and 5 Tier
+  Qualifying Night credits for every $10,000 you spend each year, which is the
+  rare way to buy elite progress with ordinary business expenses. The 70,000
+  point bonus after $7,000 in three months is worth noting for timing reasons:
+  Chase cut it from 80,000 to 60,000 in April, then brought it back up to
+  70,000 in July, so the current offer is a recovery rather than a peak.
+  Outside Hyatt, the earn is thinner than the headline suggests, since the 2x
+  rate applies only to your top three spend categories each quarter from a
+  fixed list that includes dining, shipping, airfare bought directly, transit,
+  car rentals, gas, internet and phone, with everything else at 1x. The $199
+  annual fee needs the $100 in Hyatt statement credits, delivered as two $50
+  credits on qualifying Hyatt purchases, plus real Hyatt stays to justify
+  itself. If your company sleeps at Marriott or Hilton instead, none of this
+  converts, and the card ranks #13 on our signup bonus list mostly on the
+  strength of that opening offer.

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -75,14 +75,18 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/world-of-hyatt-cre
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The World of Hyatt Credit Card is a strong choice for Hyatt loyalists,
-  offering up to 9x points at Hyatt properties when combined with World of
-  Hyatt membership. The standout feature is the annual free night award at any
-  Category 1-4 Hyatt hotel, which can easily offset the $95 annual fee if used
-  wisely. The card also grants automatic Discoverist status and 5 qualifying
-  night credits each year, helping you climb the Hyatt elite status ladder.
-  The recent increase in the signup bonus to 75,000 points adds substantial
-  value, though it requires $15,000 in spending over six months to fully
-  unlock. However, for those who don't frequent Hyatt hotels, the card's
-  appeal diminishes, as everyday earn rates outside of Hyatt are modest at 2
-  points per dollar on dining, airlines, and transit.
+  The annual Category 1 to 4 free night award is the whole argument for this
+  card: one night at a qualifying Hyatt is routinely worth more than the $95
+  annual fee, and you get it every year without doing anything but renewing.
+  The current 75,000 point offer is the best it has been in months, since the
+  bonus fell from 60,000 to 30,000 in April before climbing back to 60,000 in
+  June and then 75,000 in July, though the structure is demanding: 45,000
+  points after $5,000 in the first three months, plus up to 30,000 more earned
+  at 2x on up to $15,000 of spend within six months. Day to day the card earns
+  4x at Hyatt hotels only, with 2x on dining, airfare booked directly with the
+  airline, transit, and gym memberships, and just 1x on everything else, so it
+  is not a card for general spending. Automatic Discoverist status and 5
+  qualifying night credits toward elite status are modest but free, and a
+  second Category 1 to 4 free night arrives if you push $15,000 through the
+  card in a cardmember year. Worth it if you stay at Hyatt even a couple of
+  nights a year, hard to justify if you do not.

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -4,15 +4,20 @@ slug: "wyndham-rewards-earner-business-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner-business-card/
 our_take: >
-  The Wyndham Rewards Earner Business card offers a compelling value for
-  frequent Wyndham travelers, with a hefty 100,000 points signup bonus after
-  meeting the spending requirements, and 8 points per dollar spent at Wyndham
-  hotels. However, the recent increase in the annual fee to $149 is a notable
-  tradeoff. The card also shines with 5 points per dollar on gas, EV charging,
-  office supplies, and shipping, making it a versatile choice for business
-  expenses. Automatic Wyndham Rewards Diamond status and a 20% discount on
-  points redemptions sweeten the deal for loyalists. Just be sure the rewards
-  and benefits align with your spending habits to justify the higher fee.
+  This card is a bet on Wyndham stays and gas: 8x points at Wyndham hotels and
+  5x on gas, EV charging, office supplies, and shipping, which is an unusually
+  good fit for contractors, fleets, and anyone whose business runs on the
+  road. Barclays raised the annual fee from $95 to $149 in June, but paired it
+  with a jump in the signup bonus from 45,000 to 100,000 points, structured as
+  45,000 after $3,000 of spend in 90 days plus 55,000 after $500 at Wyndham
+  hotels within 180 days. The recurring math holds up better than the fee
+  increase suggests, because 15,000 anniversary points each year covers up to
+  two award nights, automatic Diamond status is included for as long as you
+  hold the card, and award bookings cost 20% fewer points. Watch the fine
+  print on the headline rate: the 8x applies only at Wyndham properties, and
+  everything outside the bonus categories earns a flat 1x, which is weak. If
+  your team does not stay at Wyndham brands, the $149 fee and a $65 warehouse
+  club credit will not carry this on their own.
 category: "business"
 image: "barclays-wyndham-earner-business.png"
 annual_fee: 149

--- a/data/cards/wyndham-rewards-earner-card.yaml
+++ b/data/cards/wyndham-rewards-earner-card.yaml
@@ -9,13 +9,19 @@ annual_fee: 0
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The no-fee entry to Wyndham's lineup: 5x at Hotels by Wyndham, 3x on dining
-  and groceries, automatic Gold status, and a 10% discount on award-night
-  redemptions, with no foreign transaction fee. Because Wyndham free nights cap
-  out at a flat point cost, the value here can be very high for budget hotel
-  stays. If you stay often, the $95 Plus (6x hotels, 4x on the bonus
-  categories) earns enough more to justify its fee, but the base card is a
-  reasonable keeper precisely because it costs nothing.
+  For a card with no annual fee, the Earner covers a surprising amount of
+  ground: 5x points at Hotels by Wyndham, 3x on dining and groceries,
+  automatic Gold status, and a 10% discount on award night redemptions that
+  quietly stretches every point you hold. The 75,000 point signup bonus is
+  easy to reach at these thresholds, 30,000 after $1,000 of spend in the first
+  90 days plus 45,000 after just $500 at a Wyndham hotel within 180 days,
+  which is a low bar for a bonus this size. There is also a 15 month 0% intro
+  APR on balance transfers, useful if you are carrying a balance elsewhere and
+  want a rewards card doing double duty. The limits are clear enough: the 5x
+  rate applies only at Wyndham properties, groceries exclude Target and
+  Walmart, everything else earns 1x, and Wyndham points are worth less than
+  transferable currencies. Take it as a free companion card if you ever stay
+  at Wyndham brands, not as your primary earner.
 reward_type: "points"
 tags:
   - hotel

--- a/data/cards/wyndham-rewards-earner-plus-card.yaml
+++ b/data/cards/wyndham-rewards-earner-plus-card.yaml
@@ -46,17 +46,19 @@ apr:
     min: 19.24
     max: 29.99
 our_take: >
-  The Wyndham Rewards Earner Plus card offers a compelling value for frequent
-  Wyndham guests, with 6 points per dollar on Wyndham hotel stays and a
-  generous 100,000-point signup bonus if you meet the spending requirements.
-  However, the recent increase in the annual fee from $75 to $95 means you'll
-  need to take full advantage of its perks, like the 15,000 anniversary points
-  and automatic Diamond status in the first year, to justify the cost. The
-  card also earns 4 points per dollar on dining, groceries, and travel, making
-  it versatile for everyday spending. While it lacks a foreign transaction
-  fee, the regular APR can be as high as 29.99%, so it's best for those who
-  pay off their balance monthly. Overall, this card is a strong choice for
-  loyal Wyndham travelers who can leverage its rewards and benefits.
+  The Earner Plus earns its keep on the anniversary bonus alone: 15,000
+  Wyndham points every year, enough for up to two award nights, against a $95
+  annual fee that Barclays raised from $75 in June. The 100,000 point signup
+  offer is generous relative to the spend required, 45,000 after $1,000 in the
+  first 90 days plus 55,000 after $500 at a Wyndham hotel within 180 days, so
+  most applicants will clear it on a single trip and a month of normal
+  spending. Ongoing you get 6x at Hotels by Wyndham, 4x on dining, groceries,
+  and travel, Diamond status in your first year followed by Platinum, a free
+  night worth up to 15,000 points after five nights in a calendar year, and
+  10% off award redemptions. The honest caveat is that the 6x applies only at
+  Wyndham properties and all non category spend drops to 1x, so this is a
+  hotel card, not a wallet anchor. A 15 month 0% intro APR on balance
+  transfers is a bonus rather than a reason to apply.
 benefits:
   - name: "Anniversary Points Bonus"
     value: 15000

--- a/data/cards/wyndham-rewards-earner-premier-card.yaml
+++ b/data/cards/wyndham-rewards-earner-premier-card.yaml
@@ -36,18 +36,22 @@ rewards:
     unit: points_per_dollar
     note: "Also earns 4x on Wyndham Vacation Club purchases"
 our_take: >
-  The Wyndham Rewards Earner Premier card is a strong contender for frequent
-  Wyndham hotel guests, offering a hefty 8 points per dollar spent at Wyndham
-  properties and a significant signup bonus of up to 120,000 points. This card
-  also provides valuable perks like automatic Wyndham Rewards Diamond status
-  and an annual 30,000-point bonus, which can be used for up to four free
-  nights. However, the $395 annual fee is steep and requires careful
-  consideration of whether you'll fully utilize the card's benefits, such as
-  the $100 hotel credit and various statement credits for dining, streaming,
-  and travel services. While the 15-month 0% intro APR on balance transfers
-  adds some flexibility, the lack of a similar offer on purchases means this
-  card is best suited for those who can maximize its travel rewards and
-  benefits.
+  The Premier is the version for people who actually stay at Wyndham often:
+  30,000 anniversary points each year after the fee is paid, enough for up to
+  four award nights, plus a free night worth up to 30,000 points once you hit
+  five nights in a calendar year and a 25% discount on every award redemption.
+  Earning is topped by 8x at Hotels by Wyndham, including Travel Bundles, with
+  4x on travel, dining, and groceries excluding Target and Walmart, and 1x on
+  everything else. The current 120,000 point offer is a limited time structure
+  and a demanding one: 90,000 after $6,000 of spend and paying the annual fee
+  in full within 120 days, plus 30,000 after $750 at Wyndham hotels within 180
+  days. The problem is the $395 annual fee, which only works if you use the
+  credits rather than admire them: up to $100 at Wyndham hotels, $120 for meal
+  delivery at $10 a month, $100 on streaming, $65 toward a wholesale club
+  membership, and a $120 Global Entry or TSA PreCheck credit every four years.
+  Add Diamond status and a $95 Insider subscription and the paper value clears
+  the fee comfortably, but if you stay at Wyndham once or twice a year, the
+  Earner Plus does the same job for $95.
 signup_bonus:
   value: 120000
   type: "points"


### PR DESCRIPTION
Twice-monthly regeneration of the `our_take` editorial paragraph, written in-session by the local `our-takes-refresh-local` routine rather than by a gpt-4o call per card.

**185 card(s) changed.** Cards whose copy came out byte-identical are not touched, so everything in this diff is a real rewrite.

House style is pinned in the prompt: one paragraph, no em dashes, lead with the strongest reason to carry the card, name the catch honestly, no clickbait.

Skim for accuracy against each card. Merging fires Build and Deploy Cards on the `data/cards/**` push trigger, which refreshes cards.json on the CDN.
