### PR TITLE
Make generated social posts factual, drop emoji and em dashes

### DIFF
--- a/scripts/lib/social-text.js
+++ b/scripts/lib/social-text.js
@@ -1,0 +1,84 @@
+/**
+ * Shared text rules for generated social posts.
+ *
+ * Both scripts/queue-social.js (queues via the social-posting-service) and
+ * scripts/post-social.js (posts to X directly) generate tweet text with an LLM
+ * and then append the item URL. These helpers keep the two paths honest about
+ * the same two things: how long the text may be, and what characters may
+ * appear in it.
+ */
+
+/**
+ * X counts every link as a fixed-width t.co URL (23 chars) no matter how long
+ * the real URL is, and both posting paths join text and URL with "\n\n".
+ * So the text budget is 280 - 23 - 2 = 255. Anything above this produces a
+ * tweet over the limit that X rejects at post time.
+ */
+const TWEET_MAX = 280;
+const TCO_LENGTH = 23;
+const URL_SEPARATOR_LENGTH = 2; // the "\n\n" between text and URL
+const TWEET_TEXT_LIMIT = TWEET_MAX - TCO_LENGTH - URL_SEPARATOR_LENGTH; // 255
+
+/**
+ * Strip characters the house style bans, regardless of what the model returned.
+ * The prompt already forbids these; this is the backstop so a single ignored
+ * instruction cannot put an emoji or an em dash in front of readers.
+ *
+ * Emoji are removed outright (they render as "????" in some downstream clients
+ * and read as meme-y). Em/en dashes become a comma or period depending on
+ * whether the dash was joining a clause or ending one.
+ */
+function sanitizeSocialText(input) {
+  let text = String(input || '');
+
+  // Em dash / en dash / horizontal bar -> comma, then collapse the spacing.
+  // " word — word " and " word—word " both become " word, word ".
+  text = text.replace(/\s*[—–―]\s*/g, ', ');
+
+  // Drop emoji, pictographs, dingbats, symbols, and variation selectors.
+  text = text
+    .replace(
+      /[\u{1F000}-\u{1FAFF}\u{1F900}-\u{1F9FF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE00}-\u{FE0F}\u{1F1E6}-\u{1F1FF}\u{200D}]/gu,
+      ''
+    )
+    // Leftover skin-tone / keycap modifiers.
+    .replace(/[\u{1F3FB}-\u{1F3FF}\u{20E3}]/gu, '');
+
+  // Tidy the damage: doubled punctuation, space before punctuation, trailing
+  // separators, and runs of spaces introduced by the removals above.
+  text = text
+    .replace(/,\s*,/g, ',')
+    .replace(/\s+([,.!?;:])/g, '$1')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[\s,;:]+$/g, '')
+    .trim();
+
+  return text;
+}
+
+/**
+ * Sanitize, then hard-cap to the text budget. Truncation prefers the last
+ * sentence or line break so a clipped post still ends on a complete fact
+ * rather than mid-number; it falls back to an ellipsis only when there is no
+ * clean break to cut at.
+ */
+function enforceTweetLimit(input, limit = TWEET_TEXT_LIMIT) {
+  const text = sanitizeSocialText(input);
+  if (text.length <= limit) return text;
+
+  const clipped = text.slice(0, limit);
+  const lastBreak = Math.max(
+    clipped.lastIndexOf('\n'),
+    clipped.lastIndexOf('. '),
+    clipped.lastIndexOf('.')
+  );
+  // Only accept a clean break if it keeps most of the post.
+  if (lastBreak >= limit * 0.6) {
+    return clipped.slice(0, lastBreak + 1).trim().replace(/[\s,;:]+$/g, '');
+  }
+  return `${clipped.slice(0, limit - 3).trim()}...`;
+}
+
+module.exports = { TWEET_TEXT_LIMIT, TWEET_MAX, sanitizeSocialText, enforceTweetLimit };

--- a/scripts/lib/social-text.test.js
+++ b/scripts/lib/social-text.test.js
@@ -1,0 +1,122 @@
+// Tests for the social post text rules in scripts/lib/social-text.js.
+//
+// Guards two bugs that reached production on 2026-08-02:
+//
+//   1. The Citi Curated Table tweet went out with a trailing fire emoji, which
+//      rendered as "????" for readers and read as meme-y rather than factual.
+//      The prompt at the time allowed "0-1 emoji max", so the model was within
+//      its instructions. Emoji are now banned outright and stripped here as a
+//      backstop.
+//   2. The same tweet used em dashes, which the house style bans everywhere in
+//      user-facing copy. Nothing enforced that on the social path.
+//
+// Also pins the length budget. X counts every link as a 23-char t.co URL and
+// both posting paths join text and URL with "\n\n", so text above 255 chars
+// produces a tweet over 280 that X rejects at post time. The old cap was 260.
+//
+// Run: `node scripts/lib/social-text.test.js`. Exits non-zero on any failure.
+
+const assert = require('node:assert/strict');
+
+const {
+  TWEET_TEXT_LIMIT,
+  TWEET_MAX,
+  sanitizeSocialText,
+  enforceTweetLimit,
+} = require('./social-text.js');
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+const EMOJI_RE =
+  /[\u{1F000}-\u{1FAFF}\u{1F900}-\u{1F9FF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{1F1E6}-\u{1F1FF}]/u;
+
+console.log('social text sanitizer');
+
+// The exact string that was posted on 2026-08-02.
+const SHIPPED_TWEET =
+  'NEW: Citi is hosting exclusive Curated Table events for Strata Elite ' +
+  'cardmembers—New York on Sept 9, Austin on Oct 21, Miami on Dec 2. ' +
+  'Tickets start at $100—first come, first served! \u{1F525}';
+
+test('the shipped tweet loses its emoji and em dashes', () => {
+  const out = sanitizeSocialText(SHIPPED_TWEET);
+  assert.ok(!EMOJI_RE.test(out), `emoji survived: ${out}`);
+  assert.ok(!/[—–―]/.test(out), `dash survived: ${out}`);
+  // The facts must all still be there.
+  for (const fact of ['Sept 9', 'Oct 21', 'Dec 2', '$100', 'Strata Elite']) {
+    assert.ok(out.includes(fact), `lost fact "${fact}": ${out}`);
+  }
+});
+
+test('strips flag, skin-tone, and ZWJ-sequence emoji', () => {
+  const out = sanitizeSocialText('Rates up \u{1F1FA}\u{1F1F8} today \u{1F44D}\u{1F3FD} and family \u{1F468}‍\u{1F469}‍\u{1F467} gone');
+  assert.equal(out, 'Rates up today and family gone');
+});
+
+test('em dash and en dash both become commas, spacing collapses', () => {
+  assert.equal(
+    sanitizeSocialText('Fee goes 95 – 150 next month — effective Sept 1'),
+    'Fee goes 95, 150 next month, effective Sept 1'
+  );
+});
+
+test('a dangling dash at the end does not leave trailing punctuation', () => {
+  assert.equal(sanitizeSocialText('Something happened —'), 'Something happened');
+});
+
+test('newlines are preserved so multi-line posts survive', () => {
+  const multiline =
+    'NEW: Citi expands Curated Table.\n\nNew York: Sept 9\nAustin: Oct 21\nMiami: Dec 2';
+  const out = sanitizeSocialText(multiline);
+  assert.ok(out.includes('\n'), 'newlines were flattened');
+  assert.equal(out.split('\n').filter(Boolean).length, 4);
+});
+
+test('null and empty input are safe', () => {
+  assert.equal(sanitizeSocialText(null), '');
+  assert.equal(enforceTweetLimit(undefined), '');
+});
+
+console.log('\nlength budget');
+
+test('the text limit leaves room for a t.co link and the "\\n\\n" join', () => {
+  assert.equal(TWEET_TEXT_LIMIT, 255);
+  assert.equal(TWEET_TEXT_LIMIT + 23 + 2, TWEET_MAX);
+});
+
+test('text plus link plus separator never exceeds the tweet max', () => {
+  const long = enforceTweetLimit(`NEW: ${'Fact about the card here. '.repeat(40)}`);
+  assert.ok(long.length <= TWEET_TEXT_LIMIT, `text was ${long.length}`);
+  const composed = `${long}\n\n${'x'.repeat(23)}`;
+  assert.ok(composed.length <= TWEET_MAX, `composed tweet was ${composed.length}`);
+});
+
+test('overlong text is cut at a sentence boundary, not mid-number', () => {
+  const out = enforceTweetLimit(`NEW: ${'The annual fee is $250. '.repeat(20)}`);
+  assert.ok(out.length <= TWEET_TEXT_LIMIT);
+  assert.ok(out.endsWith('.'), `did not end on a sentence: ${out}`);
+  assert.ok(!out.endsWith('...'), 'fell back to ellipsis despite clean breaks');
+});
+
+test('text with no clean break falls back to an ellipsis within the limit', () => {
+  const out = enforceTweetLimit('a'.repeat(300), 50);
+  assert.equal(out.length, 50);
+  assert.ok(out.endsWith('...'));
+});
+
+test('text already within the limit is returned unchanged apart from sanitizing', () => {
+  const clean = 'NEW: Citi expands Curated Table for Strata Elite cardmembers.';
+  assert.equal(enforceTweetLimit(clean), clean);
+});
+
+console.log(failures === 0 ? '\nAll tests passed.' : `\n${failures} test(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/post-new-card.js
+++ b/scripts/post-new-card.js
@@ -19,6 +19,7 @@
 const fs = require('fs');
 const yaml = require('js-yaml');
 const { appendBankHandles } = require('./lib/bank-handles');
+const { TWEET_TEXT_LIMIT, enforceTweetLimit } = require('./lib/social-text');
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -234,9 +235,9 @@ Rules:
   }
 
   const data = await response.json();
-  let text = (data.choices[0]?.message?.content || '').trim();
-  if (text.length > 260) text = text.substring(0, 257) + '...';
-  return text;
+  // Strips banned characters (emoji, em dashes) and caps at the real text
+  // budget, which leaves room for the t.co link the queued post carries.
+  return enforceTweetLimit(data.choices[0]?.message?.content || '');
 }
 
 async function queuePost(textContent, twitterText, linkUrl, sourceId) {
@@ -311,7 +312,7 @@ async function main() {
       postText = await generatePost(card);
       console.log(`  Generated (${postText.length} chars): ${postText}`);
       const banks = card.bank ? [card.bank] : [];
-      const withHandles = appendBankHandles(postText, banks, 260);
+      const withHandles = appendBankHandles(postText, banks, TWEET_TEXT_LIMIT);
       if (withHandles !== postText) {
         twitterText = withHandles;
         console.log(`  Twitter variant (${twitterText.length} chars): ${twitterText}`);

--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -17,6 +17,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 const { TwitterApi } = require('twitter-api-v2');
 const { appendBankHandles, resolveBanksFromCardNames } = require('./lib/bank-handles');
+const { TWEET_TEXT_LIMIT, enforceTweetLimit } = require('./lib/social-text');
 
 // Parse CLI args
 function parseArgs() {
@@ -83,19 +84,30 @@ async function generatePost(type, item) {
   const cardList = getCardNameList(item);
   const cardNames = cardList.length > 0 ? cardList.join(', ') : 'N/A';
 
-  const prompt = `Write a short tweet for CreditOdds about this credit card ${type}:
+  const prompt = `Write a tweet for CreditOdds about this credit card ${type}:
 Title: ${item.title}
 Summary: ${item.summary}
 Cards: ${cardNames}
 
+Voice: a factual trade-desk account. Informative and specific, never promotional
+and never meme-y. The reader should finish the post knowing the concrete facts.
+
 Rules:
-- Max 200 characters (shorter is better)
-- Lead with a hook like "BREAKING:" or "NEW:" or a bold statement when appropriate
-- Write like a human, not a corporate account — be direct, casual, punchy
+- Max ${TWEET_TEXT_LIMIT} characters total. Length is fine when every line carries a fact;
+  do not pad to fill it, and do not compress facts out to be short
+- Multiple lines are encouraged. Put each distinct fact (dates, cities, prices,
+  deadlines) on its own line so the post scans
+- Lead with "NEW:" or "BREAKING:" when the item is genuinely new, otherwise open
+  with the plain factual statement
+- State the concrete terms from the summary (exact amounts, spend requirements,
+  dates, deadlines). "$200 back on $1,000" beats "a great new offer"
+- Plain declarative sentences. No hype, no rhetorical questions, no second-person
+  hard sell, no "don't miss", no "act fast", no exclamation marks
 - No filler words, no "excited to announce", no "stay tuned"
 - 1 hashtag max, only if it adds value. Skip hashtags if the tweet is strong without one
 - Do NOT include any URL
-- Do NOT use emojis excessively — 0-1 emoji max`;
+- Do NOT use emojis, emoticons, or decorative symbols anywhere. Zero emoji
+- Do NOT use em dashes or en dashes. Use a period, comma, colon, or new line instead`;
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -118,14 +130,9 @@ Rules:
   }
 
   const data = await response.json();
-  let text = (data.choices[0]?.message?.content || '').trim();
-
-  // Safety: truncate if somehow over 260 chars
-  if (text.length > 260) {
-    text = text.substring(0, 257) + '...';
-  }
-
-  return text;
+  // Strips banned characters (emoji, em dashes) and caps at the real text
+  // budget, which leaves room for the t.co link appended in publishToTwitter.
+  return enforceTweetLimit(data.choices[0]?.message?.content || '');
 }
 
 /**
@@ -201,7 +208,7 @@ async function main() {
       postText = await generatePost(type, item);
       const banks = resolveBanksFromCardNames(getCardNameList(item));
       if (banks.length > 0) {
-        const withHandles = appendBankHandles(postText, banks, 260);
+        const withHandles = appendBankHandles(postText, banks, TWEET_TEXT_LIMIT);
         if (withHandles !== postText) {
           console.log(`  Appended bank handles: ${withHandles.slice(postText.length).trim()}`);
           postText = withHandles;

--- a/scripts/queue-social.js
+++ b/scripts/queue-social.js
@@ -13,6 +13,7 @@
 const fs = require('fs');
 const yaml = require('js-yaml');
 const { appendBankHandles, resolveBanksFromCardNames } = require('./lib/bank-handles');
+const { TWEET_TEXT_LIMIT, enforceTweetLimit } = require('./lib/social-text');
 
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -130,21 +131,31 @@ async function generatePost(type, item) {
           ? 'site page'
           : type;
 
-  const prompt = `Write a short tweet for CreditOdds about this ${label}:
+  const prompt = `Write a tweet for CreditOdds about this ${label}:
 Title: ${item.title}
 Summary: ${summary}
 Cards: ${cardNames}
 
+Voice: a factual trade-desk account. Informative and specific, never promotional
+and never meme-y. The reader should finish the post knowing the concrete facts.
+
 Rules:
-- Max 200 characters (shorter is better)
-- Lead with a hook like "BREAKING:" or "NEW:" or a bold statement when appropriate
-- State the concrete terms from the summary (exact amounts, spend requirements, deadlines) — "$200 back on $1,000" beats "a great new offer"
+- Max ${TWEET_TEXT_LIMIT} characters total. Length is fine when every line carries a fact;
+  do not pad to fill it, and do not compress facts out to be short
+- Multiple lines are encouraged. Put each distinct fact (dates, cities, prices,
+  deadlines) on its own line so the post scans
+- Lead with "NEW:" or "BREAKING:" when the item is genuinely new, otherwise open
+  with the plain factual statement
+- State the concrete terms from the summary (exact amounts, spend requirements,
+  dates, deadlines). "$200 back on $1,000" beats "a great new offer"
 - If the summary says where to act (an app tab, activation page), include it
-- Write like a human, not a corporate account — be direct, casual, punchy
+- Plain declarative sentences. No hype, no rhetorical questions, no second-person
+  hard sell, no "don't miss", no "act fast", no exclamation marks
 - No filler words, no "excited to announce", no "stay tuned"
 - 1 hashtag max, only if it adds value. Skip hashtags if the tweet is strong without one
 - Do NOT include any URL
-- Do NOT use emojis excessively — 0-1 emoji max`;
+- Do NOT use emojis, emoticons, or decorative symbols anywhere. Zero emoji
+- Do NOT use em dashes or en dashes. Use a period, comma, colon, or new line instead`;
 
   const response = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -165,9 +176,9 @@ Rules:
   }
 
   const data = await response.json();
-  let text = (data.choices[0]?.message?.content || '').trim();
-  if (text.length > 260) text = text.substring(0, 257) + '...';
-  return text;
+  // Strips banned characters (emoji, em dashes) and caps at the real text
+  // budget, which leaves room for the t.co link appended at post time.
+  return enforceTweetLimit(data.choices[0]?.message?.content || '');
 }
 
 // Fetch a remote image and return { base64, mimeType } suitable for the
@@ -269,7 +280,7 @@ async function main() {
       console.log(`  Generated post (${postText.length} chars): ${postText}`);
       const banks = resolveBanksFromCardNames(getCardNameList(item));
       if (banks.length > 0) {
-        const withHandles = appendBankHandles(postText, banks, 260);
+        const withHandles = appendBankHandles(postText, banks, TWEET_TEXT_LIMIT);
         if (withHandles !== postText) {
           twitterText = withHandles;
           console.log(`  Twitter variant (${twitterText.length} chars): ${twitterText}`);


### PR DESCRIPTION
## Why

The Citi Curated Table tweet went out as:

> NEW: Citi is hosting exclusive Curated Table events for Strata Elite cardmembers—New York on Sept 9, Austin on Oct 21, Miami on Dec 2. Tickets start at $100—first come, first served! 🔥

Two problems, both prompt-level:

1. **The trailing emoji** rendered as `????` for readers and reads as meme-y. The prompt explicitly permitted it (`0-1 emoji max`), so the model was following instructions.
2. **Em dashes**, which the house style bans in user-facing copy. Nothing on the social path enforced that.

## What changed

**Tone.** The news/article prompt in `queue-social.js` and its twin in `post-social.js` moves from "direct, casual, punchy" to a factual trade-desk voice: plain declarative sentences, no hype, no rhetorical questions, no exclamation marks, zero emoji, no em dashes.

**Length.** Guidance rises from 200 characters to the real budget, and multi-line posts are encouraged with each fact (dates, cities, prices) on its own line. Longer is fine when every line carries a fact; the prompt explicitly says not to pad.

**Backstop.** New `scripts/lib/social-text.js` strips emoji and converts em/en dashes regardless of what the model returns, so one ignored instruction can't reach readers.

## Latent bug fixed along the way

X counts every link as a 23-char `t.co` URL, and both posting paths join text and URL with `\n\n`. So the text budget is `280 - 23 - 2 = 255`. Three scripts capped at **260**, which composes a 285-char tweet that X rejects at post time. Nothing had hit it because the prompts asked for 200 chars, but raising the length guidance would have made it reachable.

`post-weekly-top-cards.js` keeps its 260 cap deliberately: it posts the link as a separate reply, so its main tweet carries no inline URL.

## Verification

- `node scripts/lib/social-text.test.js` — 11 new tests, all pass. Pins the exact shipped tweet as a regression case, plus flag/skin-tone/ZWJ emoji, dash handling, newline preservation, and the length arithmetic.
- `node scripts/post-new-card.test.js` and `node scripts/post-best-rankings.test.js` — still pass.
- Sanitizer output on the real tweet:

```
NEW: Citi is hosting exclusive Curated Table events for Strata Elite cardmembers, New York on Sept 9, Austin on Oct 21, Miami on Dec 2. Tickets start at $100, first come, first served!
```

Note the `!` survives sanitizing by design. Exclamation marks are a tone question handled by the prompt; stripping punctuation mechanically would mangle legitimate copy.

## Not verified here

I have no `OPENAI_API_KEY` locally, so I could not run the new prompt through gpt-4o-mini to see real generated output. The first live news post after merge is worth a look.