### PR TITLE
Add a request timeout to every card-news source fetch

### DIFF
--- a/scripts/check-card-news.js
+++ b/scripts/check-card-news.js
@@ -175,6 +175,35 @@ function truncate(text, max) {
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /**
+ * Every source fetch goes through this. Bare `fetch()` has no default timeout,
+ * so a source that accepts the connection and then stalls parks the whole
+ * fetch phase forever: the per-source try/catch in the fetcher loop never runs
+ * because the promise never settles. That happened on 2026-08-02, when a run
+ * sat idle for 34 minutes at 0% CPU with no open sockets before it was killed.
+ *
+ * With a deadline on each request, a stalled source fails like any other and
+ * lands as a "✗ FAILED" line instead of hanging the run. Worst-case phase time
+ * is now bounded: roughly 4 Reddit calls (each up to the timeout plus one 61s
+ * backoff) plus 8 Google News queries, 3 Brave queries and 1 Doctor of Credit
+ * call at the timeout each, so about 9 minutes if every source stalls.
+ */
+const FETCH_TIMEOUT_MS = 20000;
+
+async function fetchWithTimeout(url, options = {}, timeoutMs = FETCH_TIMEOUT_MS) {
+  try {
+    return await fetch(url, { ...options, signal: AbortSignal.timeout(timeoutMs) });
+  } catch (err) {
+    // AbortSignal.timeout rejects with TimeoutError; a caller-supplied signal
+    // or a genuine abort surfaces as AbortError. Relabel both so the failure
+    // line says what happened rather than "The operation was aborted".
+    if (err && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
+      throw new Error(`timed out after ${Math.round(timeoutMs / 1000)}s`);
+    }
+    throw err;
+  }
+}
+
+/**
  * Reddit access, mid-2026: the logged-out JSON API is login-walled (403/302
  * to /login?reason=lor2) even with a browser UA, but the RSS/Atom feeds still
  * serve — under an aggressive per-IP rate limit. So: Atom feeds only, browser
@@ -184,7 +213,7 @@ const BROWSER_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
 
 async function redditRss(url, { retried = false } = {}) {
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     headers: { 'User-Agent': BROWSER_UA, Accept: 'application/atom+xml,application/xml,text/xml,*/*' },
   });
   if (res.status === 429 && !retried) {
@@ -323,7 +352,7 @@ async function fetchCreditCardsSubreddit() {
 }
 
 async function fetchDoctorOfCredit() {
-  const res = await fetch('https://www.doctorofcredit.com/category/credit-cards/feed/', {
+  const res = await fetchWithTimeout('https://www.doctorofcredit.com/category/credit-cards/feed/', {
     headers: { 'User-Agent': 'CreditOdds-NewsBot/1.0' },
   });
   if (!res.ok) throw new Error(`Doctor of Credit feed -> ${res.status}`);
@@ -367,7 +396,7 @@ async function fetchGoogleNews() {
   for (const q of queries) {
     try {
       const params = new URLSearchParams({ q: `${q} when:7d`, hl: 'en-US', gl: 'US', ceid: 'US:en' });
-      const res = await fetch(`https://news.google.com/rss/search?${params}`, {
+      const res = await fetchWithTimeout(`https://news.google.com/rss/search?${params}`, {
         headers: { 'User-Agent': 'CreditOdds-NewsBot/1.0' },
       });
       if (!res.ok) throw new Error(`-> ${res.status}`);
@@ -403,7 +432,7 @@ async function fetchBrave() {
   for (const q of queries) {
     try {
       const params = new URLSearchParams({ q, count: String(CAPS.braveItemsPerQuery), freshness: 'pw', text_decorations: 'false' });
-      const res = await fetch(`https://api.search.brave.com/res/v1/web/search?${params}`, {
+      const res = await fetchWithTimeout(`https://api.search.brave.com/res/v1/web/search?${params}`, {
         headers: { Accept: 'application/json', 'X-Subscription-Token': apiKey },
       });
       if (!res.ok) throw new Error(`-> ${res.status}`);


### PR DESCRIPTION
## Why

Bare `fetch()` has no default timeout. A source that accepts the connection and then stalls never settles its promise, so the per-source `try/catch` in the fetcher loop never runs and the whole fetch phase hangs instead of recording a failure.

This bit the nightly card-news routine on 2026-08-02: one run sat idle for **34 minutes** at 0% CPU with no open sockets before it was killed, and a second attempt stalled the same way. The symptom was silence, because the loop only prints its source-status block after all five fetchers return, so there was nothing to look at while it hung.

## What changed

All four call sites (Reddit RSS, Doctor of Credit, Google News, Brave) now go through a `fetchWithTimeout` helper with a **20s** deadline. `TimeoutError`/`AbortError` are relabeled so the failure line reads `timed out after 20s` rather than the unhelpful `The operation was aborted`.

A stalled source now degrades to a `✗ FAILED` line, which the routine already tolerates by design, and worst-case phase time is bounded at roughly 9 minutes even if every source stalls.

`AbortSignal.timeout` needs Node 17.3+; the repo floor is `>=18.0.0` and the workflow pins Node 18, so it is safe.

## The subtle part

Non-2xx responses still **return** rather than throw. `redditRss` depends on this: it inspects `res.status === 429` to trigger its 61s backoff. Wrapping the call in something that threw on non-2xx would have silently disabled Reddit's rate-limit recovery. There is an explicit test for it.

## Verification

- **Stall path**: a local server that accepts the connection and never responds aborts at the deadline (2006ms against a 2s budget) with `timed out after 2s`.
- **Success paths**: normal, slow-but-within-budget (800ms), and 429 responses are all unaffected; the 429 comes back as a response, not an exception.
- **End to end**: a real fetch phase against live sources completed in **94s, exit 0**, with all five sources succeeding, including a Reddit 429 that backed off 61s and recovered.

```
Sources:
  ✓ r/churning "News and Updates Thread - August 01, 2026": 17 candidate(s)
  ✓ r/CreditCards top (day): 25 candidate(s)
  ✓ Doctor of Credit (credit-cards feed): 9 candidate(s)
  ✓ Google News RSS (8 queries): 96 candidate(s)
  ✓ Brave web search: 30 candidate(s)
Candidates after dedup: 140
EXIT=0 ELAPSED=94s
```

## Note on the 20s value

20s is a judgment call, not a measured optimum. Healthy responses in the verified run landed well under a second, so the deadline only engages on genuine stalls. If a source ever legitimately needs longer, the per-call third argument overrides it without touching the others.