### PR TITLE
Run the non-Reddit news sources concurrently with the Reddit lane

### DIFF
--- a/scripts/check-card-news.js
+++ b/scripts/check-card-news.js
@@ -752,24 +752,63 @@ async function phaseFetch() {
   fs.rmSync(WORK_DIR, { recursive: true, force: true });
   fs.mkdirSync(PROPOSED_DIR, { recursive: true });
 
+  // Two lanes, run concurrently.
+  //
+  // Both Reddit fetchers draw on the same ~1-request-per-60s per-IP budget, so
+  // they share a lane and stay sequential: firing them together would just make
+  // one of them eat a 429 and undo the header pacing. The other three sources
+  // are independent hosts, so they run alongside the Reddit lane and each other.
+  //
+  // That hides the non-Reddit work inside the Reddit waits. It does NOT shorten
+  // the Reddit lane itself, which is the long pole: 3-4 sequential Reddit reads
+  // against a one-per-minute ceiling is a hard ~3 minute floor.
+  const REDDIT_LANE = 'reddit';
   const fetchers = [
-    ['r/churning', fetchChurningCandidates],
-    ['r/CreditCards', fetchCreditCardsSubreddit],
+    ['r/churning', fetchChurningCandidates, REDDIT_LANE],
+    ['r/CreditCards', fetchCreditCardsSubreddit, REDDIT_LANE],
     ['Doctor of Credit', fetchDoctorOfCredit],
     ['Google News', fetchGoogleNews],
     ['Brave', fetchBrave],
   ];
 
-  const all = [];
-  const sourceStatus = [];
-  for (const [name, fn] of fetchers) {
+  // Results are stored by declaration index, never by completion order: the
+  // order candidates enter `all` decides which copy of a syndicated story wins
+  // dedup below, so it has to stay stable no matter who finishes first.
+  const results = new Array(fetchers.length);
+
+  const runFetcher = async (index) => {
+    const [name, fn] = fetchers[index];
     try {
       const { label, candidates } = await fn();
-      sourceStatus.push(`  ✓ ${label}: ${candidates.length} candidate(s)`);
-      all.push(...candidates);
+      results[index] = {
+        line: `  ✓ ${label}: ${candidates.length} candidate(s)`,
+        candidates,
+      };
     } catch (err) {
-      sourceStatus.push(`  ✗ ${name} FAILED: ${err.message.split('\n')[0]}`);
+      results[index] = {
+        line: `  ✗ ${name} FAILED: ${err.message.split('\n')[0]}`,
+        candidates: [],
+      };
     }
+  };
+
+  const redditLane = (async () => {
+    for (let i = 0; i < fetchers.length; i++) {
+      if (fetchers[i][2] === REDDIT_LANE) await runFetcher(i);
+    }
+  })();
+  const independent = fetchers
+    .map((f, i) => (f[2] === REDDIT_LANE ? null : runFetcher(i)))
+    .filter(Boolean);
+
+  // runFetcher swallows its own errors, so this never rejects.
+  await Promise.all([redditLane, ...independent]);
+
+  const all = [];
+  const sourceStatus = [];
+  for (const result of results) {
+    sourceStatus.push(result.line);
+    all.push(...result.candidates);
   }
   console.log('Sources:');
   sourceStatus.forEach((s) => console.log(s));


### PR DESCRIPTION
## Why

The five source fetchers ran one after another, so the ~150s the Reddit lane spends waiting out its one-request-per-60s budget (see #1896) was dead time while Doctor of Credit, Google News and Brave sat idle.

## What changed

Two lanes, run concurrently:

- **Reddit lane** (`r/churning` then `r/CreditCards`) stays **sequential**. Both draw on the same per-IP budget, so firing them together would just make one eat a 429 and undo the header pacing from #1896.
- **Everything else** (Doctor of Credit, Google News, Brave) runs alongside the Reddit lane and each other. These are independent hosts, and no source issues requests any faster internally than before, so this adds no rate-limit pressure anywhere.

## The part that isn't cosmetic

Results are stored by **declaration index, not completion order**. The order candidates enter `all` decides which copy of a syndicated story survives dedup further down, so Reddit has to keep outranking the wire sources regardless of who finishes first. Getting this wrong would silently reshuffle which version of a duplicated story reaches triage.

## Verification

**Live run: 150s, down from 262s** (-43%), with identical per-source counts and the same total after dedup:

```
  ✓ r/churning "...August 02, 2026" + "...August 01, 2026": 19 candidate(s)
  ✓ r/CreditCards top (day): 25 candidate(s)
  ✓ Doctor of Credit (credit-cards feed): 11 candidate(s)
  ✓ Google News RSS (8 queries): 96 candidate(s)
  ✓ Brave web search: 30 candidate(s)
Candidates after dedup: 140
EXIT=0 ELAPSED=150s
```

Candidate blocks in the generated triage prompt appear in exact declaration order (19 churning, 25 CreditCards, 11 DoC, then Google News), with the 140 cap landing in the same place as the sequential run.

**Scheduling block tested directly** with mock fetchers that finish in reverse declaration order (actual completion order was `r/churning < Doctor of Credit < Google News < r/CreditCards`):

```
ok    status lines in declaration order
ok    candidates in declaration order (dedup precedence)
ok    reddit lane sequential (CreditCards starts after churning finishes)
ok    failed source recorded, message truncated to first line
ok    lanes ran concurrently — 242ms (sequential would be ~640ms)
```

## Correcting my earlier estimate

When I flagged this follow-up on #1896 I said it would bring the phase "back under a minute." That was wrong. The Reddit lane *is* the long pole: 3-4 sequential reads against a one-per-minute ceiling is a hard ~150s floor, and parallelising can only hide the other sources inside it, not shorten it. 262s to 150s is the real ceiling on this change. Getting under a minute would mean making fewer Reddit requests, which is a content decision (drop the second churning thread, or drop a subreddit) rather than a scheduling one.