### PR TITLE
Card Page Check 2026-08-02

### DIFF
--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -37,7 +37,7 @@ rewards:
     unit: points_per_dollar
     note: "All purchases earn 1.5x after $150,000 in eligible purchases in a calendar year"
 signup_bonus:
-  value: 80000
+  value: 100000
   type: "miles"
   spend_requirement: 12000
   timeframe_months: 6

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -37,7 +37,7 @@ rewards:
     unit: points_per_dollar
     note: "All purchases earn 1.5x after $150,000 in eligible purchases in a calendar year"
 signup_bonus:
-  value: 100000
+  value: 125000
   type: "miles"
   spend_requirement: 12000
   timeframe_months: 6


### PR DESCRIPTION
## Card Page Check — 2026-08-02

Detected by fetching official apply pages and extracting card terms with an LLM.

### Term Changes

| Card | Field | Current | Applied | Source |
|------|-------|---------|---------|--------|
| Delta SkyMiles Reserve Business American Express | signup_bonus.value | 80000 | **125000** | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/) |

### Correction applied 2026-08-03

The automated run detected **100,000**. Re-checking the live Amex page on 2026-08-03 shows the offer has moved again since the run — the page now reads:

> Earn, previously 80,000, now 125,000 Bonus Miles

after you spend $12,000 in purchases in the first 6 months of Card Membership. The spend requirement and timeframe are unchanged.

The value in this PR has been corrected to **125,000**. This is a rotating "Special Welcome Offer", so it is the field to re-check soonest.

Validated with `npm run build:cards` (199 cards, no errors).