### PR TITLE
Treat samsclub.com as a known bot-block in the card-page check

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -269,12 +269,35 @@ function stripHtml(html) {
 // (The Atmos cards previously listed here moved to scrapeable Bank of America
 // apply_links; the alaskaair.com SPA that rendered ~20 chars is no longer used.)
 //
-// Currently empty, and that is the healthy state — an entry here means a card is
-// permanently unverified, so each one needs a measurement behind it, not a
-// hunch. Note what a *host* block is and isn't: it must be a failure no fetch
-// mode can get past. A page that only defeats Playwright belongs in
-// BROWSER_BLOCKED_HOSTS below, which keeps the card checked.
-const KNOWN_BLOCKED_HOSTS = new Map();
+// Near-empty is the healthy state — an entry here means a card is permanently
+// unverified, so each one needs a measurement behind it, not a hunch. Note what
+// a *host* block is and isn't: it must be a failure no fetch mode can get past.
+// A page that only defeats Playwright belongs in BROWSER_BLOCKED_HOSTS below,
+// which keeps the card checked.
+//
+// samsclub.com added 2026-08-02, after Sam's Club Mastercard hit 6 consecutive
+// skips having never once been verified. The apply_link is NOT stale — it is the
+// right page, and a real (headed) browser renders the full offer. The site is a
+// Next.js shell whose content arrives over a persisted-query GraphQL call, and
+// PerimeterX + Akamai gate every non-interactive client. Measured back to back
+// against https://www.samsclub.com/credit:
+//   simple fetch (node fetch + UA header)   -> HTTP 200, 75 chars
+//   Playwright, this script's exact config  -> HTTP 200, 107 chars
+//   curl + full desktop Chrome UA           -> HTTP 200, 326 chars (nav chrome only)
+//   the page's own SamsCreditLandingPage
+//     GraphQL endpoint, called directly     -> HTTP 200, "Let us know you're not
+//                                              a robot" interstitial
+//   headed Chrome                           -> full page, all terms present
+// No URL swap fixes this: /content/credit-cards, /credit/business, m.samsclub.com,
+// apply.syf.com and documents.syf.com were all probed and serve either the same
+// shell or a targeted-offer stub, never the card's terms. The card's stored
+// values were hand-verified against the live page on 2026-08-02 (no annual fee,
+// $30 statement credit after $30 in club purchases in 30 days, purchase APR
+// 20.15%/28.15%, no intro APR) and all four matched. Re-verify by hand when the
+// offer is expected to move; drop this entry if the bot wall ever eases.
+const KNOWN_BLOCKED_HOSTS = new Map([
+  ['samsclub.com', 'samsclub.com serves a JS-only shell to every non-interactive client and answers direct GraphQL calls with a bot interstitial; only a headed browser renders the terms'],
+]);
 
 // Hosts that answer headless Chromium with a bot interstitial but serve a plain
 // HTTP fetch normally. These are NOT skips: the card is still checked, we just

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -302,13 +302,13 @@ function stripHtml(html) {
 // m.samsclub.com, apply.syf.com and documents.syf.com were all probed and serve
 // either the same shell or a targeted-offer stub, never the card's terms.
 //
-// So this card is verified by hand instead — see the monthly
-// `sams-club-manual-verify` scheduled task. Its stored values were checked
-// against the live page on 2026-08-02 (no annual fee, $30 statement credit after
-// $30 in club purchases in 30 days, purchase APR 20.15%/28.15%, no intro APR)
-// and all four matched. Drop this entry if the bot wall ever eases.
+// So this card has to be verified by hand, in an ordinary browser. Its stored
+// values were checked that way on 2026-08-02 (no annual fee, $30 statement
+// credit after $30 in club purchases in 30 days, purchase APR 20.15%/28.15%,
+// no intro APR) and all four matched. The welcome offer amount is the field that
+// rotates, so that is the one to watch. Drop this entry if the bot wall eases.
 const KNOWN_BLOCKED_HOSTS = new Map([
-  ['samsclub.com', 'samsclub.com serves a JS-only shell to every non-interactive client and answers direct GraphQL calls with a bot interstitial; only a headed browser renders the terms'],
+  ['samsclub.com', 'samsclub.com serves a JS-only shell to automated clients and answers direct GraphQL calls with a bot interstitial; headed mode does not help (navigator.webdriver is true either way)'],
 ]);
 
 // Hosts that answer headless Chromium with a bot interstitial but serve a plain

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -277,24 +277,36 @@ function stripHtml(html) {
 //
 // samsclub.com added 2026-08-02, after Sam's Club Mastercard hit 6 consecutive
 // skips having never once been verified. The apply_link is NOT stale — it is the
-// right page, and a real (headed) browser renders the full offer. The site is a
+// right page, and an ordinary browser renders the full offer. The site is a
 // Next.js shell whose content arrives over a persisted-query GraphQL call, and
-// PerimeterX + Akamai gate every non-interactive client. Measured back to back
-// against https://www.samsclub.com/credit:
+// PerimeterX + Akamai gate the request. Measured against
+// https://www.samsclub.com/credit:
 //   simple fetch (node fetch + UA header)   -> HTTP 200, 75 chars
 //   Playwright, this script's exact config  -> HTTP 200, 107 chars
 //   curl + full desktop Chrome UA           -> HTTP 200, 326 chars (nav chrome only)
 //   the page's own SamsCreditLandingPage
 //     GraphQL endpoint, called directly     -> HTTP 200, "Let us know you're not
 //                                              a robot" interstitial
-//   headed Chrome                           -> full page, all terms present
-// No URL swap fixes this: /content/credit-cards, /credit/business, m.samsclub.com,
-// apply.syf.com and documents.syf.com were all probed and serve either the same
-// shell or a targeted-offer stub, never the card's terms. The card's stored
-// values were hand-verified against the live page on 2026-08-02 (no annual fee,
-// $30 statement credit after $30 in club purchases in 30 days, purchase APR
-// 20.15%/28.15%, no intro APR) and all four matched. Re-verify by hand when the
-// offer is expected to move; drop this entry if the bot wall ever eases.
+//   ordinary (non-automated) Chrome         -> full page, all terms present
+//
+// DON'T bother trying headed mode — it was measured on 2026-08-02 and does not
+// help. The gate is the automation surface, not headlessness: Playwright reports
+// navigator.webdriver === true in BOTH headed and headless mode, and all four of
+// {bundled Chromium, real Chrome channel} x {headed, headless}, including a
+// persistent user profile, returned the same ~1,000-char stub. Same IP and same
+// minute, a non-automated Chrome returned 6,292 chars with every offer marker.
+// It is also not transient rate-limiting: a single cold request after a 15-minute
+// quiet period still came back as the stub.
+//
+// No URL swap fixes this either: /content/credit-cards, /credit/business,
+// m.samsclub.com, apply.syf.com and documents.syf.com were all probed and serve
+// either the same shell or a targeted-offer stub, never the card's terms.
+//
+// So this card is verified by hand instead — see the monthly
+// `sams-club-manual-verify` scheduled task. Its stored values were checked
+// against the live page on 2026-08-02 (no annual fee, $30 statement credit after
+// $30 in club purchases in 30 days, purchase APR 20.15%/28.15%, no intro APR)
+// and all four matched. Drop this entry if the bot wall ever eases.
 const KNOWN_BLOCKED_HOSTS = new Map([
   ['samsclub.com', 'samsclub.com serves a JS-only shell to every non-interactive client and answers direct GraphQL calls with a bot interstitial; only a headed browser renders the terms'],
 ]);


### PR DESCRIPTION
## Why

Sam's Club Mastercard has been skipped **6 consecutive runs** and has *never* been verified, tripping the stale-card alarm nightly (#1881) and failing the publish step.

The apply URL is **not** stale. `https://www.samsclub.com/credit` is the right page and an ordinary browser renders the full offer. The site is a Next.js shell whose content arrives over a persisted-query GraphQL call, with PerimeterX + Akamai gating the request.

## What the gate actually keys on

Not headlessness — the **automation surface**. Playwright reports `navigator.webdriver === true` in headed mode too, which is why every automation config fails identically. Measured 2026-08-02 against the same URL:

| Client | `navigator.webdriver` | Result |
|---|---|---|
| bundled Chromium, headless | `true` | ~1,000 chars, no offer markers |
| bundled Chromium, **headed** | `true` | ~1,000 chars, no offer markers |
| real Chrome channel, headed | `true` | ~1,000 chars, no offer markers |
| real Chrome, headed, persistent profile | `true` | ~1,000 chars, no offer markers |
| ordinary non-automated Chrome, same IP, same minute | `false` | **6,292 chars, all markers** |

Fetch-path measurements for the same page:

| Fetch mode | Result |
|---|---|
| simple fetch (node fetch + UA header) | HTTP 200, 75 chars |
| Playwright, this script's exact config | HTTP 200, 107 chars |
| curl + full desktop Chrome UA | HTTP 200, 326 chars (nav chrome only) |
| its own `SamsCreditLandingPage` GraphQL endpoint, called directly | HTTP 200, "Let us know you're not a robot" |

## Ruled out

- **Headed mode** — see the table above. Recorded in the code comment so nobody repeats the experiment.
- **Transient rate-limiting** — a single cold request after a 15-minute quiet period still returned the stub.
- **A different URL** — `/content/credit-cards`, `/credit/business`, `m.samsclub.com`, `apply.syf.com` and `documents.syf.com` all serve either the same shell or a targeted-offer stub, never the card's terms.
- **A longer settle window** — the script already waits `networkidle` (8s) plus a flat 3s, more than the one probe that did succeed.

Since no fetch mode gets past it, this is a `KNOWN_BLOCKED_HOSTS` entry rather than `BROWSER_BLOCKED_HOSTS` (which is for hosts that only defeat Playwright and keep the card checked).

Deliberately **not** attempted: masking the automation fingerprint to defeat the bot detection. It would be brittle against their next detection update and would silently revert the card to unverified.

## Effect

- The card short-circuits instead of burning ~30s on a doomed fetch.
- It still appears in the end-of-run skip summary, so the coverage gap stays visible.
- It stops counting toward the stale alarm, so the run no longer fails on it.

Verified by running the fetch and finish phases scoped to the slug: the skip is reported and no `.card-page-check-stale.md` is written.

## Data verification

Since the card can't be checked automatically, its stored values were hand-verified against the live page on 2026-08-02 — **all four matched**, no YAML change needed:

- no annual fee
- \$30 statement credit after \$30 in eligible Sam's Club purchases within 30 days
- purchase APR 20.15% / 28.15%
- no intro APR

The welcome offer amount is the field that rotates, so that's the one to watch on a manual re-check. Drop the entry if the bot wall ever eases.