### PR TITLE
Reddit Data Points 2026-08-02

### DIFF
--- a/data/reddit-datapoints/2026-08-02-t3_1vcwn09.yaml
+++ b/data/reddit-datapoints/2026-08-02-t3_1vcwn09.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1vcwn09"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vcwn09/bilt_palladium_approval_dp/"
+posted: "2026-08-01"
+evidence: "Self-described churner reports an approval with a $50k starting limit and roughly 800 across all three bureaus."
+card_name: "Bilt Palladium"
+result: "approved"
+credit_score: 800
+credit_score_source: 0
+starting_credit_limit: 50000
+date_applied: "2026-08"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-08-02

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vcwn09](https://www.reddit.com/r/CreditCards/comments/1vcwn09/bilt_palladium_approval_dp/) | Bilt Palladium | approved | 800 | — | $50,000 | — | 2026-08 | `2026-08-02-t3_1vcwn09.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
