### PR TITLE
Auto: IHG One Rewards Premier Business rewards/benefits update — 2026-08-02

### DIFF
--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -32,6 +32,13 @@ benefits:
     frequency: "multi_year"
     frequency_years: 4
     category: "travel"
+  - name: "Points Purchase Discount"
+    value: 20
+    value_unit: "percent"
+    description: "Save at least 20% when you purchase IHG One Rewards points with this card."
+    frequency: "per_purchase"
+    category: "rewards"
+    enrollment_required: false
 tags:
   - hotel
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **IHG One Rewards Premier Business**.

**Apply link (verify against this):** https://creditcards.chase.com/business-credit-cards/IHG/business-premier

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
