### PR TITLE
Auto: Delta SkyMiles Platinum American Express rewards/benefits update — 2026-08-02

### DIFF
--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -82,6 +82,19 @@ benefits:
     frequency: "per_purchase"
     category: "dining"
     enrollment_required: false
+  - name: "American Express Venue Collection"
+    value: 10
+    value_unit: "percent"
+    description: "On-site benefits such as dedicated entrances at select stadiums and arenas, plus 10% back on qualifying concessions purchases up to $250 per calendar year."
+    frequency: "annual"
+    category: "entertainment"
+    enrollment_required: true
+  - name: "Cell Phone Protection"
+    value: 800
+    description: "Up to $800 per claim to repair or replace a damaged or stolen cell phone, limit 2 approved claims per 12 months with a $50 deductible, when the prior month's wireless bill was paid with the card."
+    frequency: "per_claim"
+    category: "telecom"
+    enrollment_required: false
 tags:
   - airline
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Delta SkyMiles Platinum American Express**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-platinum-american-express-card/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
