### PR TITLE
Auto: Southwest Rapid Rewards Plus rewards/benefits update — 2026-08-02

### DIFF
--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -14,10 +14,16 @@ rewards:
     value: 2
     unit: points_per_dollar
     note: "Gas stations and grocery stores (first $5,000/year)"
+    spend_cap: 5000
+    cap_period: annual
+    rate_after_cap: 1
   - category: groceries
     value: 2
     unit: points_per_dollar
     note: "Gas stations and grocery stores (first $5,000/year)"
+    spend_cap: 5000
+    cap_period: annual
+    rate_after_cap: 1
   - category: everything_else
     value: 1
     unit: points_per_dollar


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Southwest Rapid Rewards Plus**.

**Apply link (verify against this):** https://creditcards.chase.com/travel-credit-cards/southwest/plus

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
