### PR TITLE
Auto: United Business rewards/benefits update — 2026-08-02

### DIFF
--- a/data/cards/united-business.yaml
+++ b/data/cards/united-business.yaml
@@ -122,6 +122,13 @@ benefits:
     description: "Employee cards at no additional cost"
     frequency: "ongoing"
     category: "business"
+  - name: "Award Flight Discount"
+    value: 10
+    value_unit: "percent"
+    description: "Save 10% or more on the miles needed when booking United award flights with miles; Premier members save even more"
+    frequency: "per_trip"
+    category: "travel"
+    enrollment_required: false
 our_take: >
   For a $150 annual fee, the United Business covers most of what a small
   business flying United needs: a free first checked bag for the cardmember


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **United Business**.

**Apply link (verify against this):** https://creditcards.chase.com/business-credit-cards/united/united-business-card

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
