### PR TITLE
Reddit Data Points 2026-08-03

### DIFF
--- a/data/reddit-datapoints/2026-08-03-t3_1vdq0y5.yaml
+++ b/data/reddit-datapoints/2026-08-03-t3_1vdq0y5.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1vdq0y5"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vdq0y5/dp_apple_card_targeted_300_sub_5k_credit_line/"
+posted: "2026-08-02"
+evidence: "Poster reports opening the Apple Card off a targeted $300 bonus offer, receiving a $5,000 credit line, with a TransUnion score in the 750s and eight existing cards."
+card_name: "Apple Card"
+result: "approved"
+credit_score: 750
+credit_score_source: 2
+starting_credit_limit: 5000
+total_open_cards: 8
+date_applied: "2026-08"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-08-03

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vdq0y5](https://www.reddit.com/r/CreditCards/comments/1vdq0y5/dp_apple_card_targeted_300_sub_5k_credit_line/) | Apple Card | approved | 750 | — | $5,000 | — | 2026-08 | `2026-08-03-t3_1vdq0y5.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
