### PR TITLE
Add a Product changes flow section to card pages

### DIFF
--- a/apps/api/src/handlers/card-product-changes.js
+++ b/apps/api/src/handlers/card-product-changes.js
@@ -1,0 +1,178 @@
+// Aggregate the product-change graph around a single card.
+//
+// Every product change a user logs in their wallet writes a row to
+// wallet_card_events (event_type = 'product_change') with the card they came
+// from and the card they landed on. Rolled up per card, that gives two flows:
+//
+//   inbound  — cards people product-changed INTO this card
+//   outbound — cards people product-changed this card INTO
+//
+// GET /card-product-changes?card_id=74[&limit=6] returns both sides with a
+// per-edge count and its share of that direction's total, which the card page
+// renders as a flow diagram sized by share.
+//
+// Shares are computed over the direction's FULL total before the top-N slice,
+// so a truncated list still reports honest percentages (and `inbound.length <
+// inbound_edge_count` tells the client the tail was cut).
+
+const mysql = require("../db");
+
+const responseHeaders = {
+  "Access-Control-Allow-Headers":
+    "Content-Type,X-Amz-Date,X-Amz-Security-Token,x-api-key,Authorization,Origin,Host,X-Requested-With,Accept,Access-Control-Allow-Methods,Access-Control-Allow-Origin,Access-Control-Allow-Headers",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+  "X-Requested-With": "*",
+};
+
+const DEFAULT_LIMIT = 6;
+const MAX_LIMIT = 12;
+
+// Both directions in one round trip. INNER JOIN cards on purpose: an edge that
+// points at a card no longer in the catalog can't be rendered or linked, so
+// dropping it here keeps it out of the totals too. old <> new guards against a
+// self-loop, which a malformed client write could otherwise produce.
+const EDGE_SQL = `
+  SELECT
+    'in' AS direction,
+    e.old_card_id AS other_card_id,
+    c.card_name AS other_card_name,
+    c.bank AS other_bank,
+    c.card_image_link AS other_card_image_link,
+    COUNT(*) AS event_count,
+    COUNT(DISTINCT e.user_id) AS user_count,
+    SUM(e.reason = 'forced') AS forced_count,
+    MAX(e.change_date) AS last_change_date
+  FROM wallet_card_events e
+  JOIN cards c ON c.card_id = e.old_card_id
+  WHERE e.event_type = 'product_change'
+    AND e.new_card_id = ?
+    AND e.old_card_id <> e.new_card_id
+  GROUP BY e.old_card_id, c.card_name, c.bank, c.card_image_link
+
+  UNION ALL
+
+  SELECT
+    'out' AS direction,
+    e.new_card_id AS other_card_id,
+    c.card_name AS other_card_name,
+    c.bank AS other_bank,
+    c.card_image_link AS other_card_image_link,
+    COUNT(*) AS event_count,
+    COUNT(DISTINCT e.user_id) AS user_count,
+    SUM(e.reason = 'forced') AS forced_count,
+    MAX(e.change_date) AS last_change_date
+  FROM wallet_card_events e
+  JOIN cards c ON c.card_id = e.new_card_id
+  WHERE e.event_type = 'product_change'
+    AND e.old_card_id = ?
+    AND e.old_card_id <> e.new_card_id
+  GROUP BY e.new_card_id, c.card_name, c.bank, c.card_image_link
+`;
+
+function toEdge(row, directionTotal) {
+  const count = Number(row.event_count);
+  return {
+    card_id: Number(row.other_card_id),
+    card_name: row.other_card_name,
+    bank: row.other_bank,
+    card_image_link: row.other_card_image_link || null,
+    count,
+    // Distinct wallets behind the count. Equal to `count` except when one
+    // person logged the same change on two copies of the card.
+    users: Number(row.user_count),
+    // 'forced' means the issuer moved the cardholder rather than the
+    // cardholder choosing to. Worth surfacing: a mostly-forced outbound edge
+    // reads very differently from a mostly-voluntary one.
+    forced: Number(row.forced_count || 0),
+    share: directionTotal > 0 ? Math.round((count / directionTotal) * 1000) / 10 : 0,
+    last_change_date: row.last_change_date
+      ? new Date(row.last_change_date).toISOString().slice(0, 10)
+      : null,
+  };
+}
+
+exports.CardProductChangesHandler = async (event) => {
+  console.info("received:", event.httpMethod, event.path);
+
+  let response = {};
+
+  switch (event.httpMethod) {
+    case "OPTIONS":
+      response = {
+        statusCode: 200,
+        headers: responseHeaders,
+        body: JSON.stringify({ statusText: "OK" }),
+      };
+      break;
+
+    case "GET":
+      try {
+        const cardId = parseInt(event.queryStringParameters?.card_id, 10);
+        if (!Number.isInteger(cardId) || cardId <= 0) {
+          response = {
+            statusCode: 400,
+            headers: responseHeaders,
+            body: JSON.stringify({ error: "card_id query parameter required (numeric card id)" }),
+          };
+          break;
+        }
+
+        const limitRaw = parseInt(event.queryStringParameters?.limit, 10);
+        const limit = Number.isFinite(limitRaw)
+          ? Math.min(Math.max(limitRaw, 1), MAX_LIMIT)
+          : DEFAULT_LIMIT;
+
+        const rows = await mysql.query(EDGE_SQL, [cardId, cardId]);
+        await mysql.end();
+
+        const inRows = rows.filter((r) => r.direction === "in");
+        const outRows = rows.filter((r) => r.direction === "out");
+
+        const sumCounts = (rs) => rs.reduce((acc, r) => acc + Number(r.event_count), 0);
+        const inboundTotal = sumCounts(inRows);
+        const outboundTotal = sumCounts(outRows);
+
+        const rank = (rs, total) =>
+          rs
+            .map((r) => toEdge(r, total))
+            .sort((a, b) => b.count - a.count || a.card_name.localeCompare(b.card_name))
+            .slice(0, limit);
+
+        response = {
+          statusCode: 200,
+          headers: responseHeaders,
+          body: JSON.stringify({
+            card_id: cardId,
+            inbound: rank(inRows, inboundTotal),
+            outbound: rank(outRows, outboundTotal),
+            inbound_total: inboundTotal,
+            outbound_total: outboundTotal,
+            // Distinct source/destination cards before the top-N slice, so the
+            // client can tell whether it is showing the whole picture.
+            inbound_edge_count: inRows.length,
+            outbound_edge_count: outRows.length,
+          }),
+        };
+      } catch (error) {
+        console.error("Error fetching card product changes:", error);
+        response = {
+          statusCode: 500,
+          headers: responseHeaders,
+          body: JSON.stringify({ error: "Failed to fetch product changes" }),
+        };
+      }
+      break;
+
+    default:
+      response = {
+        statusCode: 405,
+        headers: responseHeaders,
+        body: `CardProductChanges only accepts GET, OPTIONS — you tried: ${event.httpMethod}`,
+      };
+      break;
+  }
+
+  console.info(`response from: ${event.path} statusCode: ${response.statusCode}`);
+  return response;
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -1863,3 +1863,45 @@ Resources:
               Ref: CreditCardOddsAPI
             Auth:
               Authorizer: NONE
+
+  CardProductChangesFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/card-product-changes.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
+    Properties:
+      Handler: src/handlers/card-product-changes.CardProductChangesHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 30
+      Description: Returns the inbound/outbound product-change flows for one card
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+      Events:
+        GetCardProductChanges:
+          Type: Api
+          Properties:
+            Path: /card-product-changes
+            Method: GET
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+        CardProductChangesOptions:
+          Type: Api
+          Properties:
+            Path: /card-product-changes
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -37,6 +37,7 @@ import { resolveApplyLink, withApplySource } from "@/lib/applyLink";
 import posthog from "posthog-js";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import CardRecordsTable from "./CardRecordsTable";
+import ProductChangeFlow, { ProductChangeNode } from "./ProductChangeFlow";
 import "../../landing.css";
 
 const ScatterPlot = dynamic(() => import("@/components/charts/ScatterPlot"), {
@@ -227,6 +228,12 @@ interface CardClientProps {
   wire?: CardWireEntry[];
   frequentlyComparedCards?: Card[];
   bestRankings?: Array<{ rank: number; title: string; slug: string }>;
+  productChanges?: {
+    inbound: ProductChangeNode[];
+    outbound: ProductChangeNode[];
+    inboundTotal: number;
+    outboundTotal: number;
+  };
 }
 
 // Isolated so useSearchParams doesn't bail the whole CardClient out of static
@@ -286,6 +293,7 @@ export default function CardClient({
   wire = [],
   frequentlyComparedCards = [],
   bestRankings = [],
+  productChanges,
 }: CardClientProps) {
   // ---------- State + chrome ----------
   const [showModal, setShowModal] = useState(false);
@@ -526,6 +534,33 @@ export default function CardClient({
         .slice(0, 12),
     [news],
   );
+
+  // A card with no logged product changes has nothing to draw, so the whole
+  // section stays out of the page rather than rendering an empty diagram.
+  const hasProductChanges =
+    (productChanges?.inbound.length ?? 0) + (productChanges?.outbound.length ?? 0) > 0;
+
+  const hasDetails =
+    Boolean(card.apr) || typeof card.foreign_transaction_fee === "boolean";
+
+  // Section numbers are derived from what actually renders, not hardcoded.
+  // Four of the seven sections are conditional, so fixed numbers would leave a
+  // visible gap ("04 · approval odds" followed by "06 · news") on any card
+  // missing one — which, for product changes, is most of them today.
+  const sectionNumbers = useMemo(() => {
+    const visible = [
+      "overview",
+      "earn",
+      ...(hasDetails ? ["details"] : []),
+      "odds",
+      ...(hasProductChanges ? ["changes"] : []),
+      ...(news.length > 0 ? ["wire"] : []),
+      ...(articles.length > 0 ? ["reading"] : []),
+    ];
+    return Object.fromEntries(
+      visible.map((id, i) => [id, String(i + 1).padStart(2, "0")]),
+    ) as Record<string, string>;
+  }, [hasDetails, hasProductChanges, news.length, articles.length]);
 
   // Wire entries for the right-rail block, newest first.
   const wireEntries = useMemo(
@@ -873,36 +908,41 @@ export default function CardClient({
         <aside className="cj-toc">
           <div className="cj-toc-heading">Contents</div>
           <a href="#overview" className="cj-toc-link">
-            <span className="cj-toc-num">01</span>Overview
+            <span className="cj-toc-num">{sectionNumbers.overview}</span>Overview
           </a>
           <a href="#earn" className="cj-toc-link">
-            <span className="cj-toc-num">02</span>Earn &amp; credits
+            <span className="cj-toc-num">{sectionNumbers.earn}</span>Earn &amp; credits
           </a>
-          {(card.apr || typeof card.foreign_transaction_fee === "boolean") && (
+          {hasDetails && (
             <a href="#details" className="cj-toc-link">
-              <span className="cj-toc-num">03</span>Card details
+              <span className="cj-toc-num">{sectionNumbers.details}</span>Card details
             </a>
           )}
           <a href="#odds" className="cj-toc-link">
-            <span className="cj-toc-num">04</span>Approval odds
+            <span className="cj-toc-num">{sectionNumbers.odds}</span>Approval odds
           </a>
+          {hasProductChanges && (
+            <a href="#changes" className="cj-toc-link">
+              <span className="cj-toc-num">{sectionNumbers.changes}</span>Product changes
+            </a>
+          )}
           {newsEntries.length > 0 && (
             <a href="#wire" className="cj-toc-link">
-              <span className="cj-toc-num">05</span>News
+              <span className="cj-toc-num">{sectionNumbers.wire}</span>News
             </a>
           )}
           {articles.length > 0 && (
             <a href="#reading" className="cj-toc-link">
-              <span className="cj-toc-num">06</span>Reading
+              <span className="cj-toc-num">{sectionNumbers.reading}</span>Reading
             </a>
           )}
         </aside>
 
         {/* Main */}
         <main className="cj-main">
-          {/* 01 Overview */}
+          {/* Overview */}
           <section id="overview" className="cj-section">
-            <div className="cj-section-num">01 · overview</div>
+            <div className="cj-section-num">{sectionNumbers.overview} · overview</div>
             <div className="cj-overview-grid">
               <div>
                 <h1 className="cj-section-h1">
@@ -1070,9 +1110,9 @@ export default function CardClient({
           {/* Mobile-only welcome offer / apply box, shown above section 02 */}
           <div className="cj-apply-mobile">{applyBlock}</div>
 
-          {/* 02 Earn & credits */}
+          {/* Earn & credits */}
           <section id="earn" className="cj-section">
-            <div className="cj-section-num">02 · earn &amp; credits</div>
+            <div className="cj-section-num">{sectionNumbers.earn} · earn &amp; credits</div>
             <h2 className="cj-section-h2">
               Earn rates <em className="cj-section-accent">&amp; credits</em>
             </h2>
@@ -1260,11 +1300,11 @@ export default function CardClient({
             </div>
           </section>
 
-          {/* 03 Card details */}
+          {/* Card details */}
           {(card.apr ||
             typeof card.foreign_transaction_fee === "boolean") && (
             <section id="details" className="cj-section">
-              <div className="cj-section-num">03 · card details</div>
+              <div className="cj-section-num">{sectionNumbers.details} · card details</div>
               <h2 className="cj-section-h2">
                 Card <em className="cj-section-accent">details</em>
               </h2>
@@ -1326,9 +1366,9 @@ export default function CardClient({
             </section>
           )}
 
-          {/* 04 Approval odds */}
+          {/* Approval odds */}
           <section id="odds" className="cj-section">
-            <div className="cj-section-num">04 · approval odds</div>
+            <div className="cj-section-num">{sectionNumbers.odds} · approval odds</div>
             <div className="cj-odds-header">
               <h2 className="cj-section-h2">
                 Approval <em className="cj-section-accent">odds</em>
@@ -1588,10 +1628,34 @@ export default function CardClient({
             )}
           </section>
 
-          {/* 04 News */}
+          {/* Product changes — only renders once at least one member has
+              logged a change in or out of this card. */}
+          {hasProductChanges && productChanges && (
+            <section id="changes" className="cj-section">
+              <div className="cj-section-num">{sectionNumbers.changes} · product changes</div>
+              <h2 className="cj-section-h2">
+                Product <em className="cj-section-accent">changes</em>
+              </h2>
+              <p className="pcf-lede">
+                Where cardholders came from before landing on this card, and
+                what they moved it to afterwards. Thicker flows carry a larger
+                share of the changes in that direction.
+              </p>
+              <ProductChangeFlow
+                cardName={card.card_name}
+                cardImageLink={card.card_image_link}
+                inbound={productChanges.inbound}
+                outbound={productChanges.outbound}
+                inboundTotal={productChanges.inboundTotal}
+                outboundTotal={productChanges.outboundTotal}
+              />
+            </section>
+          )}
+
+          {/* News */}
           {newsEntries.length > 0 && (
             <section id="wire" className="cj-section">
-              <div className="cj-section-num">05 · news</div>
+              <div className="cj-section-num">{sectionNumbers.wire} · news</div>
               <h2 className="cj-section-h2">
                 In the <em className="cj-section-accent">news</em>
               </h2>
@@ -1635,10 +1699,10 @@ export default function CardClient({
             </section>
           )}
 
-          {/* 05 Reading */}
+          {/* Reading */}
           {articles.length > 0 && (
             <section id="reading" className="cj-section">
-              <div className="cj-section-num">06 · reading</div>
+              <div className="cj-section-num">{sectionNumbers.reading} · reading</div>
               <h2 className="cj-section-h2">
                 Further <em className="cj-section-accent">reading</em>
               </h2>

--- a/apps/web-next/src/app/card/[name]/ProductChangeFlow.tsx
+++ b/apps/web-next/src/app/card/[name]/ProductChangeFlow.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import Link from "next/link";
+import CardImage from "@/components/ui/CardImage";
+
+// A left-to-right flow diagram of the product-change graph around one card:
+// sources on the left, this card in the middle, destinations on the right, with
+// each connector's thickness set by that edge's share of its direction's total.
+//
+// Geometry is computed, not measured. Every node row is exactly ROW_H tall with
+// ROW_GAP between rows, so the connector y-coordinates follow from the row index
+// alone. That keeps the SVG in sync with the DOM without refs, a ResizeObserver,
+// or a post-hydration reflow. The CSS enforces the same row height the math
+// assumes, so the two must be changed together.
+const ROW_H = 62;
+const ROW_GAP = 10;
+const PITCH = ROW_H + ROW_GAP;
+const GUTTER_W = 96;
+// Floor for the diagram height so a single edge on each side still leaves the
+// centre card room to breathe.
+const MIN_H = 172;
+
+// Connector thickness, in px, at 0% and 100% share. The floor keeps a 1-of-40
+// edge visible rather than hairline-thin.
+const STROKE_MIN = 2.5;
+const STROKE_MAX = 13;
+
+export interface ProductChangeNode {
+  cardId: number;
+  cardName: string;
+  // Missing when the card is no longer in cards.json, in which case the node
+  // renders as plain text instead of a link.
+  slug?: string;
+  cardImageLink?: string | null;
+  count: number;
+  share: number;
+  forced: number;
+}
+
+interface ProductChangeFlowProps {
+  cardName: string;
+  cardImageLink?: string | null;
+  inbound: ProductChangeNode[];
+  outbound: ProductChangeNode[];
+  inboundTotal: number;
+  outboundTotal: number;
+}
+
+function strokeFor(share: number): number {
+  const clamped = Math.max(0, Math.min(100, share));
+  return STROKE_MIN + (clamped / 100) * (STROKE_MAX - STROKE_MIN);
+}
+
+function columnHeight(count: number): number {
+  return count > 0 ? count * PITCH - ROW_GAP : 0;
+}
+
+// Centre of row `i` within a column of `count` rows, in diagram coordinates.
+// The column itself is centred vertically, matching `justify-content: center`.
+function rowCenterY(i: number, count: number, height: number): number {
+  const top = (height - columnHeight(count)) / 2;
+  return top + i * PITCH + ROW_H / 2;
+}
+
+function NodeCard({ node }: { node: ProductChangeNode }) {
+  const inner = (
+    <>
+      <span className="pcf-node-img">
+        <CardImage
+          cardImageLink={node.cardImageLink}
+          alt={node.cardName}
+          width={56}
+          height={35}
+          style={{ width: "100%", height: "auto", objectFit: "contain" }}
+        />
+      </span>
+      <span className="pcf-node-text">
+        <span className="pcf-node-name">{node.cardName}</span>
+        <span className="pcf-node-meta">
+          {node.share}% · {node.count} {node.count === 1 ? "report" : "reports"}
+          {node.forced > 0 && (
+            <span className="pcf-node-forced" title={`${node.forced} of these were issuer-initiated`}>
+              {node.forced === node.count ? "issuer-initiated" : `${node.forced} issuer-initiated`}
+            </span>
+          )}
+        </span>
+      </span>
+    </>
+  );
+
+  return node.slug ? (
+    <Link href={`/card/${node.slug}`} className="pcf-node pcf-node-link">
+      {inner}
+    </Link>
+  ) : (
+    <span className="pcf-node">{inner}</span>
+  );
+}
+
+// One gutter's worth of connectors. `direction` flips which end carries the
+// arrowhead: inbound flows point at the centre card, outbound flows point away.
+function Connectors({
+  nodes,
+  height,
+  direction,
+}: {
+  nodes: ProductChangeNode[];
+  height: number;
+  direction: "in" | "out";
+}) {
+  const centerY = height / 2;
+  // Inset so the arrowhead lands just clear of the node it points at rather
+  // than tucking under the card border.
+  const INSET = 6;
+
+  return (
+    <svg
+      className="pcf-connectors"
+      width={GUTTER_W}
+      height={height}
+      viewBox={`0 0 ${GUTTER_W} ${height}`}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        {/* userSpaceOnUse (not strokeWidth) so a 13px-thick flow and a 2.5px
+            one get the same size arrowhead. Scaling with the stroke would make
+            the heaviest edge's head wider than the gutter. */}
+        <marker
+          id={`pcf-arrow-${direction}`}
+          markerUnits="userSpaceOnUse"
+          markerWidth="11"
+          markerHeight="11"
+          refX="9"
+          refY="5.5"
+          orient="auto"
+        >
+          <path d="M0,0 L11,5.5 L0,11 z" fill="var(--accent)" />
+        </marker>
+      </defs>
+      {nodes.map((node, i) => {
+        const y = rowCenterY(i, nodes.length, height);
+        const [x1, y1, x2, y2] =
+          direction === "in"
+            ? [0, y, GUTTER_W - INSET, centerY]
+            : [INSET, centerY, GUTTER_W - INSET, y];
+        // Horizontal control points give an S-curve that leaves and arrives
+        // flat, so connectors read as flows rather than straight-line joins.
+        const cx = (x1 + x2) / 2;
+        return (
+          <path
+            key={node.cardId}
+            d={`M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}`}
+            fill="none"
+            stroke="var(--accent)"
+            strokeWidth={strokeFor(node.share)}
+            strokeLinecap="butt"
+            // Heavier flows read as more solid; the lightest still stay legible.
+            opacity={0.42 + (Math.max(0, Math.min(100, node.share)) / 100) * 0.48}
+            markerEnd={`url(#pcf-arrow-${direction})`}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+// Mobile fallback for one side: the connector becomes a weight bar inside each
+// row, since there is no room for a centre column flanked by two gutters.
+function StackedSide({
+  nodes,
+  label,
+}: {
+  nodes: ProductChangeNode[];
+  label: string;
+}) {
+  if (nodes.length === 0) return null;
+  return (
+    <div className="pcf-stack-side">
+      <div className="pcf-stack-label">{label}</div>
+      {nodes.map((node) => (
+        <div key={node.cardId} className="pcf-stack-row">
+          <NodeCard node={node} />
+          {/* Stands in for the connector. Thickness matches the desktop scale,
+              but width carries the share too: at phone size a 4px vs 9px bar is
+              hard to compare, whereas length is read at a glance. */}
+          <span
+            className="pcf-stack-bar"
+            style={{
+              height: `${strokeFor(node.share)}px`,
+              width: `${Math.max(12, Math.min(100, node.share))}%`,
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ProductChangeFlow({
+  cardName,
+  cardImageLink,
+  inbound,
+  outbound,
+  inboundTotal,
+  outboundTotal,
+}: ProductChangeFlowProps) {
+  const height = Math.max(
+    columnHeight(inbound.length),
+    columnHeight(outbound.length),
+    MIN_H,
+  );
+
+  return (
+    <div className="pcf">
+      {/* Wide layout: sources | connectors | this card | connectors | destinations.
+          The labels occupy their own grid row so they cannot shift the node
+          columns out of alignment with the connector geometry. */}
+      <div
+        className="pcf-diagram"
+        style={{ ["--pcf-h" as string]: `${height}px` }}
+      >
+        <div className="pcf-col-label pcf-label-in">
+          {inbound.length > 0 && "Changed from"}
+        </div>
+        <div />
+        <div />
+        <div />
+        <div className="pcf-col-label pcf-label-out">
+          {outbound.length > 0 && "Changed into"}
+        </div>
+
+        <div className="pcf-col pcf-col-in">
+          {inbound.map((node) => (
+            <NodeCard key={node.cardId} node={node} />
+          ))}
+        </div>
+
+        <div className="pcf-gutter">
+          {inbound.length > 0 && (
+            <Connectors nodes={inbound} height={height} direction="in" />
+          )}
+        </div>
+
+        <div className="pcf-center">
+          <span className="pcf-center-img">
+            <CardImage
+              cardImageLink={cardImageLink}
+              alt={cardName}
+              width={112}
+              height={70}
+              style={{ width: "100%", height: "auto", objectFit: "contain" }}
+            />
+          </span>
+          <span className="pcf-center-name">{cardName}</span>
+        </div>
+
+        <div className="pcf-gutter">
+          {outbound.length > 0 && (
+            <Connectors nodes={outbound} height={height} direction="out" />
+          )}
+        </div>
+
+        <div className="pcf-col pcf-col-out">
+          {outbound.map((node) => (
+            <NodeCard key={node.cardId} node={node} />
+          ))}
+        </div>
+      </div>
+
+      {/* Narrow layout: the same data as two stacked lists around the card. */}
+      <div className="pcf-stacked">
+        <StackedSide nodes={inbound} label="Changed from" />
+        <div className="pcf-stack-center">
+          <span className="pcf-center-img">
+            <CardImage
+              cardImageLink={cardImageLink}
+              alt={cardName}
+              width={112}
+              height={70}
+              style={{ width: "100%", height: "auto", objectFit: "contain" }}
+            />
+          </span>
+          <span className="pcf-center-name">{cardName}</span>
+        </div>
+        <StackedSide nodes={outbound} label="Changed into" />
+      </div>
+
+      <p className="pcf-note">
+        Based on {inboundTotal + outboundTotal}{" "}
+        {inboundTotal + outboundTotal === 1 ? "product change" : "product changes"}{" "}
+        logged by CreditOdds members in their wallets. Percentages are shares of
+        each direction, not of all cardholders, and a small sample can swing a
+        long way.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Card, CardBenefit, getCard, getCardGraphs, getCardRecords, getAllCards, getCardRatings, getCardWire, getComparePartners, GraphData, CardRecord, CardWireEntry } from "@/lib/api";
+import { Card, CardBenefit, getCard, getCardGraphs, getCardRecords, getAllCards, getCardRatings, getCardWire, getCardProductChanges, getComparePartners, EMPTY_PRODUCT_CHANGES, GraphData, CardRecord, CardWireEntry, ProductChangeEdge } from "@/lib/api";
 import { getNews, NewsItem } from "@/lib/news";
 import { getArticles, Article } from "@/lib/articles";
 import { getBestPages } from "@/lib/best";
@@ -178,6 +178,11 @@ export default async function CardPage({ params }: CardPageProps) {
           wire: Number.isInteger(wireId)
             ? await getCardWire(wireId).catch(() => [] as CardWireEntry[])
             : ([] as CardWireEntry[]),
+          // Same numeric-id requirement as card-wire: wallet_card_events stores
+          // DB card ids, so an unsynced card has nothing to look up.
+          productChanges: Number.isInteger(wireId)
+            ? await getCardProductChanges(wireId)
+            : EMPTY_PRODUCT_CHANGES,
         };
       }),
       getCardGraphs(slug).catch(() => [] as GraphData[]),
@@ -189,7 +194,7 @@ export default async function CardPage({ params }: CardPageProps) {
       getBestPages().catch(() => []),
     ]);
 
-    const { card, ratings, wire } = cardWithRatingsAndWire;
+    const { card, ratings, wire, productChanges } = cardWithRatingsAndWire;
 
     // Merge benefits from local cards.json: use as fallback when API has none,
     // and overlay value_unit on API benefits while CloudFront catches up to the
@@ -233,6 +238,30 @@ export default async function CardPage({ params }: CardPageProps) {
       .filter((c): c is Card => c !== undefined && c.active !== false)
       .slice(0, 3);
 
+    // Product-change edges come back from the DB keyed by card_name (the cards
+    // table has no slug column), so resolve each one against cards.json to get a
+    // link target and the canonical image. An edge whose card is gone from the
+    // catalog still renders, just without a link.
+    const cardsByName = new Map(allCards.map(c => [c.card_name.toLowerCase(), c]));
+    const toFlowNode = (edge: ProductChangeEdge) => {
+      const match = cardsByName.get(edge.card_name.toLowerCase());
+      return {
+        cardId: edge.card_id,
+        cardName: match?.card_name ?? edge.card_name,
+        slug: match?.slug,
+        cardImageLink: match?.card_image_link ?? edge.card_image_link,
+        count: edge.count,
+        share: edge.share,
+        forced: edge.forced,
+      };
+    };
+    const productChangeFlow = {
+      inbound: productChanges.inbound.map(toFlowNode),
+      outbound: productChanges.outbound.map(toFlowNode),
+      inboundTotal: productChanges.inbound_total,
+      outboundTotal: productChanges.outbound_total,
+    };
+
     // Top-3 placements across the /best/* pages — surfaced as social-proof
     // badges in the overview block, with deep links back to each list.
     const bestRankings = bestPages
@@ -245,7 +274,7 @@ export default async function CardPage({ params }: CardPageProps) {
       .filter((r): r is { rank: number; title: string; slug: string } => r !== null)
       .sort((a, b) => a.rank - b.rank);
 
-    return <CardClient card={card} graphData={graphData} records={records} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} frequentlyComparedCards={frequentlyComparedCards} bestRankings={bestRankings} />;
+    return <CardClient card={card} graphData={graphData} records={records} news={cardNews} articles={cardArticles} ratings={ratings} similarCards={similarCards} wire={wire} frequentlyComparedCards={frequentlyComparedCards} bestRankings={bestRankings} productChanges={productChangeFlow} />;
   } catch {
     notFound();
   }

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -8593,6 +8593,189 @@
   border-bottom: 1px solid var(--warn);
 }
 
+/* ---------- Product-change flow (section 05 on the card page) ----------
+   Two layouts of the same data. `.pcf-diagram` is the wide one: five grid
+   columns (sources | connectors | this card | connectors | destinations) whose
+   node rows are a fixed 62px tall with a 10px gap, because ProductChangeFlow.tsx
+   derives the SVG connector y-coordinates from those exact numbers. Changing
+   either height here means changing ROW_H / ROW_GAP in that file too.
+   `.pcf-stacked` is the narrow one and carries no such constraint. */
+.landing-v2 .pcf-lede {
+  margin: 0 0 24px;
+  max-width: 620px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--muted);
+}
+.landing-v2 .pcf-diagram {
+  display: grid;
+  grid-template-columns: 1fr 96px minmax(140px, 172px) 96px 1fr;
+  grid-template-rows: auto var(--pcf-h);
+  align-items: start;
+  column-gap: 0;
+  row-gap: 8px;
+}
+.landing-v2 .pcf-col-label {
+  font-family: var(--font-inter-tight), sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.landing-v2 .pcf-label-out { text-align: right; }
+
+.landing-v2 .pcf-col {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 10px;
+  height: var(--pcf-h);
+}
+.landing-v2 .pcf-col-in { align-items: stretch; padding-right: 12px; }
+.landing-v2 .pcf-col-out { align-items: stretch; padding-left: 12px; }
+
+.landing-v2 .pcf-gutter {
+  height: var(--pcf-h);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.landing-v2 .pcf-connectors { display: block; overflow: visible; }
+
+/* Node row. The 62px height is load-bearing for the connector math. */
+.landing-v2 .pcf-node {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  align-items: center;
+  gap: 10px;
+  height: 62px;
+  padding: 0 12px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--radius);
+  background: var(--paper);
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+}
+.landing-v2 .pcf-col-out .pcf-node { grid-template-columns: 1fr 56px; }
+.landing-v2 .pcf-col-out .pcf-node .pcf-node-img { order: 2; }
+.landing-v2 .pcf-col-out .pcf-node .pcf-node-text { order: 1; text-align: right; }
+
+.landing-v2 a.pcf-node-link {
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.landing-v2 a.pcf-node-link:hover {
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--line-2));
+  background: color-mix(in oklab, var(--accent) 5%, var(--paper));
+}
+.landing-v2 .pcf-node-img {
+  display: block;
+  width: 56px;
+  line-height: 0;
+}
+.landing-v2 .pcf-node-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.landing-v2 .pcf-node-name {
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1.25;
+  /* Two lines then clamp: card names run long and the row height is fixed. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.landing-v2 .pcf-node-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-inter), sans-serif;
+  font-size: 10.5px;
+  color: var(--muted);
+}
+.landing-v2 .pcf-col-out .pcf-node-meta { justify-content: flex-end; }
+.landing-v2 .pcf-node-forced {
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--warn-2);
+  color: var(--warn);
+  font-size: 9.5px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* Centre node — the card the page is about. Deliberately heavier than the
+   satellites so the direction of flow reads at a glance. */
+.landing-v2 .pcf-center,
+.landing-v2 .pcf-stack-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 16px 14px;
+  border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--line-2));
+  border-radius: var(--radius);
+  background: color-mix(in oklab, var(--accent) 6%, var(--paper));
+  box-shadow: var(--shadow-sm);
+}
+.landing-v2 .pcf-center { align-self: center; }
+.landing-v2 .pcf-center-img { display: block; width: 96px; line-height: 0; }
+.landing-v2 .pcf-center-name {
+  font-family: var(--font-inter-tight), sans-serif;
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 1.25;
+  text-align: center;
+}
+
+.landing-v2 .pcf-note {
+  margin: 16px 0 0;
+  font-family: var(--font-inter), sans-serif;
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+/* Narrow layout is off by default; the media query swaps the two. */
+.landing-v2 .pcf-stacked { display: none; }
+.landing-v2 .pcf-stack-side { display: flex; flex-direction: column; gap: 10px; }
+.landing-v2 .pcf-stack-label {
+  font-family: var(--font-inter-tight), sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.landing-v2 .pcf-stack-row { display: flex; flex-direction: column; }
+/* Connector stand-in. Width and height both come from the share (inline), so
+   only the paint lives here. Indented to sit under the node's card art. */
+.landing-v2 .pcf-stack-bar {
+  display: block;
+  margin-left: 20px;
+  background: var(--accent);
+  opacity: 0.6;
+  border-radius: 1px;
+}
+
+@media (max-width: 820px) {
+  .landing-v2 .pcf-diagram { display: none; }
+  .landing-v2 .pcf-stacked {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 14px;
+  }
+  .landing-v2 .pcf-stack-center { align-self: center; min-width: 180px; }
+}
+
 /* ---------- Store / "Best card for [merchant]" page (.store-v2) ---------- */
 .landing-v2.store-v2 .store-body {
   padding-top: 24px;

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1199,6 +1199,70 @@ export async function getCardWire(cardId: number): Promise<CardWireEntry[]> {
   return data.changes || [];
 }
 
+// One card-to-card product-change flow, aggregated across every wallet that
+// logged the move. `share` is this edge's percentage of its direction's total.
+export interface ProductChangeEdge {
+  card_id: number;
+  card_name: string;
+  bank: string;
+  card_image_link: string | null;
+  count: number;
+  users: number;
+  // How many of the moves the cardholder did not choose (issuer-initiated).
+  forced: number;
+  share: number;
+  last_change_date: string | null;
+}
+
+export interface CardProductChanges {
+  card_id: number;
+  // Cards people product-changed INTO this card.
+  inbound: ProductChangeEdge[];
+  // Cards people product-changed this card INTO.
+  outbound: ProductChangeEdge[];
+  inbound_total: number;
+  outbound_total: number;
+  // Distinct partner cards before the top-N slice — greater than the array
+  // length when the tail was truncated.
+  inbound_edge_count: number;
+  outbound_edge_count: number;
+}
+
+export const EMPTY_PRODUCT_CHANGES: CardProductChanges = {
+  card_id: 0,
+  inbound: [],
+  outbound: [],
+  inbound_total: 0,
+  outbound_total: 0,
+  inbound_edge_count: 0,
+  outbound_edge_count: 0,
+};
+
+// Pull the product-change graph around one card. Takes the numeric DB card id
+// (wallet_card_events stores ids, not slugs). Never throws: an empty graph and
+// a failed request render the same way, which is "no section".
+export async function getCardProductChanges(
+  cardId: number,
+  limit = 6,
+): Promise<CardProductChanges> {
+  try {
+    const res = await fetchWithRetry(
+      `${API_BASE}/card-product-changes?card_id=${cardId}&limit=${limit}`,
+      { next: { revalidate: 300 } },
+    );
+    if (!res.ok) return EMPTY_PRODUCT_CHANGES;
+    const data = await res.json();
+    return {
+      ...EMPTY_PRODUCT_CHANGES,
+      ...data,
+      inbound: Array.isArray(data.inbound) ? data.inbound : [],
+      outbound: Array.isArray(data.outbound) ? data.outbound : [],
+    };
+  } catch {
+    return EMPTY_PRODUCT_CHANGES;
+  }
+}
+
 export async function getAllCardWire(limit = 100): Promise<CardWireEntry[]> {
   const res = await fetchWithRetry(`${API_BASE}/card-wire?limit=${limit}`, {
     next: { revalidate: 300 },


### PR DESCRIPTION
Adds a **Product changes** section to `/card/[slug]`: a flow diagram with the card in the middle, cards people product-changed *into* it on the left, and cards they changed it *into* on the right. Connector thickness is set by each edge's share of its direction's total.

## Heads up on the data

`wallet_card_events` currently holds **3 product-change rows from 2 users**, covering 2 distinct edges (Citi Double Cash to Citi Custom Cash x2, Bilt to Wells Fargo Autograph). So on merge this section renders on ~4 card pages and stays hidden everywhere else. The feature is built to grow into the data rather than to look good today:

- The section is omitted entirely when a card has no logged changes.
- Every edge shows its raw report count next to the percentage, and the footnote says the sample is small.
- Section numbers are now derived from what renders, so the hidden section does not leave a numbering gap.

## Backend

New `CardProductChangesFunction` behind `GET /card-product-changes?card_id=N&limit=6`. One UNION query covers both directions and returns per-edge `count`, `users` (distinct wallets), `forced` (issuer-initiated), `share`, and `last_change_date`.

- Shares are computed over the direction's **full** total before the top-N slice, so a truncated list still reports honest percentages. `inbound_edge_count` vs `inbound.length` tells the client whether the tail was cut.
- `INNER JOIN cards` drops edges pointing at a card no longer in the catalog, keeping them out of the totals too.
- `old_card_id <> new_card_id` guards against a self-loop.

## Frontend

`ProductChangeFlow.tsx` renders two layouts of the same data:

- **Wide**: five-column grid with SVG connectors. Geometry is *computed*, not measured. Node rows are a fixed 62px with a 10px gap, so connector y-coordinates follow from the row index alone. No refs, no ResizeObserver, no post-hydration reflow. The CSS enforces the same row height the math assumes and both are commented to that effect.
- **Narrow (max-width 820px)**: stacked lists around the card, with the connector replaced by a bar whose length *and* thickness carry the share. Length was added because a 4px vs 9px bar is not comparable at phone size.

Edge rows come back keyed by `card_name` (the `cards` table has no slug column), so `page.tsx` resolves each against `cards.json` for the link target and canonical art. An edge whose card has left the catalog still renders, just without a link.

## Verification

- Wide and narrow layouts rendered and screenshotted against a temporary 3-in/3-out fixture (removed before commit).
- Connector geometry checked numerically in the browser: node row centres landed at 31 / 103 / 175 within a 206px gutter, matching the computed values exactly.
- Confirmed the section and its ToC entry disappear with no data, and that numbering stays contiguous (01-06) when it does.
- `tsc --noEmit`, `eslint`, `check:seo`, and `vitest` (88 tests) all pass. `sam validate --lint` passes.

## Notes

`/card-product-changes` does not exist until the API deploys, so the section will not appear on the frontend until `deploy-api.yml` runs on merge. `getCardProductChanges` swallows the failure and returns an empty graph, so there is no window where the page breaks.