### PR TITLE
api: declare @firebase/app so SAM builds resolve it again

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,9 @@
   "description": "CreditOdds API - AWS Lambda serverless backend",
   "version": "1.0.0",
   "private": true,
+  "comment_firebase_app": "Not imported by our code. @firebase/database-compat 2.1.5 (published 2026-07-30) moved @firebase/app from a transitive dependency to a peerDependency, so npm stopped installing it, and esbuild broke on the require() inside database-compat's standalone bundle. firebase-admin pulls database-compat in transitively, so every SAM build failed with 'Could not resolve @firebase/app'. Declaring it here puts it back in node_modules. This directory has no lockfile, so transitive versions float and a change like this lands on the next apps/api deploy with no code change of ours.",
   "dependencies": {
+    "@firebase/app": "^0.14.13",
     "firebase-admin": "^13.6.0",
     "mysql2": "^3.16.2",
     "serverless-mysql": "^1.5.4",


### PR DESCRIPTION
Fixes the red **Deploy API** run on #1920. The failure is not from that PR's code.

## What broke

`@firebase/database-compat@2.1.5` was published **2026-07-30 at 18:29 UTC**. The last green Deploy API ran that same day at **12:51**. That release moved `@firebase/app` from a transitive dependency to a `peerDependency`:

```
2.1.4 dependencies: tslib, @firebase/util, @firebase/logger, @firebase/database, @firebase/component, @firebase/database-types
2.1.5 same dependencies + peerDependencies: { "@firebase/app": "0.x", "@firebase/app-compat": "0.x" }
```

npm stopped installing it, and esbuild broke on the `require()` inside database-compat's standalone bundle:

```
Could not resolve "@firebase/app"
  node_modules/@firebase/database-compat/dist/index.standalone.js:15:25:
    15 | var require$$3 = require('@firebase/app');
```

We never import `@firebase/app` ourselves. `firebase-admin` pulls `database-compat` in transitively, so `UserRecordsFunction` (and every other function bundling firebase-admin) fails to build.

**This was going to hit whichever `apps/api/**` deploy ran next, regardless of its contents.** #1920 was simply the first push to `apps/api/**` since 07-30. `apps/api` has no lockfile, so transitive versions float and a publish like this lands on the next deploy with no change of ours involved.

## The fix

Declare `@firebase/app` explicitly in `apps/api/package.json` so npm installs it and esbuild can resolve it.

## Verification

- Reproduced the exact error in a scratch dir with a bare `firebase-admin: ^13.6.0` install: byte-identical esbuild message.
- Same scratch dir plus `@firebase/app`: bundles clean.
- Full `sam build` on this branch: **Build Succeeded**, all functions bundle including the new `CardProductChangesFunction` from #1920.

## Follow-up worth considering

The real exposure is that `apps/api` has **no lockfile**, so CI resolves dependencies fresh on every deploy and any upstream publish can turn a green pipeline red without a code change. Committing `apps/api/package-lock.json` and switching the workflow to `npm ci` would make these deploys reproducible. Happy to do that separately if you want it.