### PR TITLE
Add replacement-card module to card-pulled news articles

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7044,6 +7044,93 @@
   padding: 32px clamp(20px, 3vw, 48px) 40px;
   box-shadow: var(--shadow-sm);
 }
+/* "What to get instead" — shown on articles about a card that is gone. Lives
+   inside .article-body, so it sits on --card and needs --paper-2 to separate
+   itself from the prose above it. */
+.landing-v2 .replacement-cards {
+  margin-top: 36px;
+  padding: 22px clamp(16px, 2.4vw, 26px) 24px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--paper-2);
+}
+.landing-v2 .replacement-cards-title {
+  font-family: var(--font-inter-tight), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  color: var(--ink);
+  margin: 0;
+}
+.landing-v2 .replacement-cards-intro {
+  margin: 6px 0 18px;
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+.landing-v2 .replacement-cards-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.landing-v2 .replacement-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--card);
+  text-decoration: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.landing-v2 .replacement-card:hover {
+  border-color: var(--ink);
+  box-shadow: var(--shadow-sm);
+}
+/* Fixed box so rows line up regardless of card art aspect ratio. */
+.landing-v2 .replacement-card-thumb {
+  position: relative;
+  flex: 0 0 auto;
+  width: 72px;
+  height: 46px;
+  border-radius: 5px;
+  overflow: hidden;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+}
+.landing-v2 .replacement-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.landing-v2 .replacement-card-name {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+.landing-v2 .replacement-card-meta {
+  font-size: 13px;
+  color: var(--muted);
+}
+.landing-v2 .replacement-card-reason {
+  margin-top: 2px;
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--ink-2);
+}
+@media (max-width: 520px) {
+  .landing-v2 .replacement-card-thumb {
+    width: 58px;
+    height: 37px;
+  }
+}
+
 .landing-v2 .article-follow {
   margin-top: 24px;
 }

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -8,6 +8,7 @@ import { ArticleContent } from "@/components/articles/ArticleContent";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { ReadingProgressBar } from "@/components/articles/ReadingProgressBar";
 import { RelatedCards } from "@/components/articles/RelatedCards";
+import { ReplacementCards } from "@/components/news/ReplacementCards";
 import { RelatedCardInfo } from "@/lib/articles";
 import CardImage from "@/components/ui/CardImage";
 import { V2Footer } from "@/components/landing-v2/Chrome";
@@ -243,6 +244,14 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
                 {item.summary}
               </p>
             )}
+
+            {/* Sits above Related Cards on purpose: on a story about a card
+                that is gone, "what can I get instead" is the reader's actual
+                next question, and Related Cards points at the dead card. */}
+            <ReplacementCards
+              cards={item.replacement_cards_info ?? []}
+              articleId={item.id}
+            />
 
             {relatedCards.length > 0 && <RelatedCards cards={relatedCards} />}
           </div>

--- a/apps/web-next/src/components/news/ReplacementCards.tsx
+++ b/apps/web-next/src/components/news/ReplacementCards.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import Link from 'next/link';
+import posthog from 'posthog-js';
+import CardImage from '@/components/ui/CardImage';
+import type { ReplacementCardInfo } from '@/lib/news';
+
+interface Props {
+  cards: ReplacementCardInfo[];
+  /** Article id, so clicks can be attributed to the story that drove them. */
+  articleId: string;
+}
+
+function feeLabel(annualFee: number | null): string | null {
+  if (annualFee === null) return null;
+  return annualFee === 0 ? 'No annual fee' : `$${annualFee.toLocaleString('en-US')} annual fee`;
+}
+
+export function ReplacementCards({ cards, articleId }: Props) {
+  if (!cards || cards.length === 0) return null;
+
+  // The intro deliberately names no card. On a straight pull the article's
+  // subject card is the dead one, but on a conversion story (Kroger to Smartly)
+  // card_slug points at the live replacement, so naming the subject would
+  // assert the opposite of the truth on half the articles that use this module.
+  return (
+    <aside className="replacement-cards" aria-labelledby="replacement-cards-title">
+      <h2 id="replacement-cards-title" className="replacement-cards-title">
+        What to get instead
+      </h2>
+      <p className="replacement-cards-intro">
+        These cards are open to new applicants and cover the same ground:
+      </p>
+      <ul className="replacement-cards-list">
+        {cards.map((card, index) => {
+          const fee = feeLabel(card.annual_fee);
+          return (
+            <li key={card.slug}>
+              <Link
+                href={`/card/${card.slug}`}
+                className="replacement-card"
+                onClick={() => {
+                  posthog.capture('replacement_card_clicked', {
+                    article_id: articleId,
+                    card_slug: card.slug,
+                    card_name: card.name,
+                    bank: card.bank,
+                    position: index + 1,
+                  });
+                }}
+              >
+                <span className="replacement-card-thumb">
+                  <CardImage
+                    cardImageLink={card.image}
+                    alt={card.name}
+                    fill
+                    sizes="72px"
+                    style={{ objectFit: 'contain' }}
+                  />
+                </span>
+                <span className="replacement-card-body">
+                  <span className="replacement-card-name">{card.name}</span>
+                  <span className="replacement-card-meta">
+                    {card.bank}
+                    {fee && (
+                      <>
+                        <span aria-hidden="true"> · </span>
+                        {fee}
+                      </>
+                    )}
+                  </span>
+                  {card.reason && (
+                    <span className="replacement-card-reason">{card.reason}</span>
+                  )}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </aside>
+  );
+}

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -12,6 +12,21 @@ export type NewsTag =
   | 'rumor'
   | 'general';
 
+/**
+ * A card readers can still apply for, offered on an article about a card that
+ * went away. Resolved at build time by scripts/build-news.js, which guarantees
+ * the slug exists in cards.json and is still accepting applications.
+ */
+export interface ReplacementCardInfo {
+  slug: string;
+  name: string;
+  image: string | null;
+  bank: string;
+  annual_fee: number | null;
+  /** One editorial line on why this card stands in for the one that went away. */
+  reason?: string;
+}
+
 export interface NewsItem {
   id: string;
   date: string;
@@ -27,6 +42,7 @@ export interface NewsItem {
   card_slugs?: string[];
   card_names?: string[];
   card_image_links?: string[];
+  replacement_cards_info?: ReplacementCardInfo[];
   source?: string;
   source_url?: string;
   body?: string;

--- a/data/news/2026-05-12-us-bank-kroger-cards-no-longer-accepting-applications.yaml
+++ b/data/news/2026-05-12-us-bank-kroger-cards-no-longer-accepting-applications.yaml
@@ -7,6 +7,13 @@ tags:
 bank: "U.S. Bank"
 card_slug: "us-bank-smartly-visa-signature"
 card_name: "Smartly Visa Signature"
+replacement_cards:
+  - slug: "blue-cash-preferred-card"
+    reason: "6% back at U.S. supermarkets on the first $6,000 a year, plus 3% on gas."
+  - slug: "blue-cash-everyday-card"
+    reason: "3% at U.S. supermarkets and 3% on gas with no annual fee, for lighter grocery baskets."
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "Keeps the rewards with U.S. Bank: two 5% categories of your choosing each quarter, no annual fee."
 source: "U.S. Bank"
 source_url: "https://www.usbank.com/credit-cards/splash/mysmartlyvisa.html"
 date: "2026-05-12"

--- a/data/news/2026-06-16-wells-fargo-attune-discontinued.yaml
+++ b/data/news/2026-06-16-wells-fargo-attune-discontinued.yaml
@@ -7,6 +7,13 @@ tags:
 bank: "Wells Fargo"
 card_slug: "wells-fargo-attune"
 card_name: "Wells Fargo Attune"
+replacement_cards:
+  - slug: "wells-fargo-autograph"
+    reason: "Wells Fargo's remaining no-fee category card: 3x on dining, travel, gas, transit, streaming, and phone plans."
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "Pick two 5% categories each quarter on the first $2,000 of spending, with no annual fee."
+  - slug: "wells-fargo-active-cash"
+    reason: "Flat 2% on everything, no annual fee, if you would rather not track categories at all."
 source: "NerdWallet"
 source_url: "https://www.nerdwallet.com/credit-cards/reviews/wells-fargo-attune"
 date: "2026-06-16"

--- a/data/news/2026-07-21-us-bank-shopper-cash-rewards-discontinued.yaml
+++ b/data/news/2026-07-21-us-bank-shopper-cash-rewards-discontinued.yaml
@@ -8,6 +8,13 @@ tags:
 bank: "U.S. Bank"
 card_slug: "us-bank-shopper"
 card_name: "US Bank Shopper Cash Rewards"
+replacement_cards:
+  - slug: "blue-cash-everyday-card"
+    reason: "3% on U.S. online retail up to $6,000 a year, covering the Shopper's core use with no annual fee."
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "Keeps the rewards with U.S. Bank: two 5% categories of your choosing each quarter, no annual fee."
+  - slug: "wells-fargo-active-cash"
+    reason: "Flat 2% on everything with no annual fee, and nothing to pick or track each quarter."
 source: "U.S. Bank"
 source_url: "https://www.usbank.com/credit-cards/shopper-cash-rewards-visa-signature-credit-card.html"
 body: |

--- a/data/news/2026-07-25-amex-green-card-pulled-renamed-classic-green.yaml
+++ b/data/news/2026-07-25-amex-green-card-pulled-renamed-classic-green.yaml
@@ -7,6 +7,13 @@ tags:
 bank: "American Express"
 card_slug: "american-express-green-card"
 card_name: "American Express Green"
+replacement_cards:
+  - slug: "wells-fargo-autograph"
+    reason: "Matches the Green's 3x on travel, transit, and dining, adds streaming and phone, and charges no annual fee."
+  - slug: "chase-sapphire-preferred"
+    reason: "3x dining and 5x on travel booked through Chase, with transferable points, for $95 instead of $150."
+  - slug: "american-express-gold-card"
+    reason: "The step up inside Amex: 4x at restaurants and 4x at U.S. supermarkets, if the spend clears the higher fee."
 source: "Doctor of Credit"
 source_url: "https://www.doctorofcredit.com/american-express-removes-green-card-from-website/"
 body: |

--- a/data/news/schema.json
+++ b/data/news/schema.json
@@ -77,6 +77,28 @@
       },
       "description": "Related card display names for multiple cards (optional)"
     },
+    "replacement_cards": {
+      "type": "array",
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "required": ["slug"],
+        "additionalProperties": false,
+        "properties": {
+          "slug": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$",
+            "description": "Slug of a card readers can still apply for"
+          },
+          "reason": {
+            "type": "string",
+            "maxLength": 160,
+            "description": "One short line on why this card stands in for the one that went away"
+          }
+        }
+      },
+      "description": "Cards to suggest when the article's subject card is gone (pulled, discontinued, converted, or shut down). Renders the 'What to get instead' module on the article. Every slug must exist in cards.json AND have accepting_applications: true — the build fails otherwise, since the whole point is to send readers somewhere they can actually apply. Distinct from card_slugs, which names the card the story is about."
+    },
     "source": {
       "type": "string",
       "description": "Source name (optional)"

--- a/scripts/build-news.js
+++ b/scripts/build-news.js
@@ -122,6 +122,50 @@ function validateNewsItem(item, schema) {
     }
   }
 
+  // Validate replacement_cards. Resolution against cards.json happens later in
+  // buildNews(), where the lookup is in scope — here we only check shape.
+  if (item.replacement_cards !== undefined) {
+    if (!Array.isArray(item.replacement_cards)) {
+      errors.push('replacement_cards must be an array');
+    } else if (item.replacement_cards.length > 4) {
+      errors.push('replacement_cards accepts at most 4 entries');
+    } else {
+      const seen = new Set();
+      for (const entry of item.replacement_cards) {
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+          errors.push('Each replacement_cards entry must be an object with a slug');
+          continue;
+        }
+        const extra = Object.keys(entry).filter(k => k !== 'slug' && k !== 'reason');
+        if (extra.length > 0) {
+          errors.push(`Unknown replacement_cards field(s): ${extra.join(', ')}`);
+        }
+        if (typeof entry.slug !== 'string' || !/^[a-z0-9-]+$/.test(entry.slug)) {
+          errors.push(`Invalid replacement_cards slug: ${entry.slug} (must be lowercase with hyphens only)`);
+          continue;
+        }
+        if (seen.has(entry.slug)) {
+          errors.push(`Duplicate replacement_cards slug: ${entry.slug}`);
+        }
+        seen.add(entry.slug);
+        if (entry.reason !== undefined) {
+          if (typeof entry.reason !== 'string') {
+            errors.push(`replacement_cards reason for ${entry.slug} must be a string`);
+          } else if (entry.reason.length > 160) {
+            errors.push(`replacement_cards reason for ${entry.slug} is ${entry.reason.length} chars (max 160)`);
+          }
+        }
+        // Pointing readers at the very card the article says is gone is the one
+        // mistake this module exists to prevent.
+        if (item.card_slugs && item.card_slugs.includes(entry.slug)) {
+          errors.push(`replacement_cards slug ${entry.slug} is also in card_slugs — a card cannot replace itself`);
+        } else if (item.card_slug === entry.slug) {
+          errors.push(`replacement_cards slug ${entry.slug} is also card_slug — a card cannot replace itself`);
+        }
+      }
+    }
+  }
+
   return errors;
 }
 
@@ -132,6 +176,9 @@ function buildNews() {
   const cardsLookup = loadCardsLookup();
   const newsItems = [];
   const errors = [];
+  // Replacement-card failures found while resolving against cards.json, which
+  // only becomes possible after per-item validation has run.
+  const resolutionErrors = [];
 
   // Fail loud if cards.json didn't load. Without it, every related-card image
   // lookup below resolves to null and gets filtered to [], silently shipping a
@@ -198,6 +245,40 @@ function buildNews() {
         }
       }
 
+      // Resolve replacement cards into self-contained objects so the frontend
+      // never has to index parallel arrays. Failures are fatal rather than
+      // warnings: this module's whole job is to hand a reader a card they can
+      // still apply for, and a bad slug either 404s or points at another dead
+      // card — worse than rendering nothing at all.
+      if (item.replacement_cards) {
+        const resolved = [];
+        for (const entry of item.replacement_cards) {
+          const card = cardsLookup[entry.slug];
+          if (!card) {
+            resolutionErrors.push(
+              `${file}: replacement_cards slug "${entry.slug}" not found in cards.json`
+            );
+            continue;
+          }
+          if (card.accepting_applications === false) {
+            resolutionErrors.push(
+              `${file}: replacement_cards slug "${entry.slug}" (${card.name}) is not accepting ` +
+              'applications — it cannot be offered as a replacement'
+            );
+            continue;
+          }
+          resolved.push({
+            slug: entry.slug,
+            name: card.card_name || card.name,
+            image: card.image || null,
+            bank: card.bank || '',
+            annual_fee: typeof card.annual_fee === 'number' ? card.annual_fee : null,
+            ...(entry.reason ? { reason: entry.reason } : {}),
+          });
+        }
+        item.replacement_cards_info = resolved;
+      }
+
       newsItems.push(item);
       console.log(`  OK: ${item.title}`);
     } catch (err) {
@@ -216,6 +297,18 @@ function buildNews() {
         console.error(`    - ${err}`);
       }
     }
+    process.exit(1);
+  }
+
+  if (resolutionErrors.length > 0) {
+    console.error(`\nReplacement-card resolution failed with ${resolutionErrors.length} error(s):`);
+    for (const err of resolutionErrors) {
+      console.error(`  - ${err}`);
+    }
+    console.error(
+      '\nFix the slug, or drop the entry. A replacement card must exist in cards.json\n' +
+      'and still be accepting applications.'
+    );
     process.exit(1);
   }
 


### PR DESCRIPTION
Ships R1 from the PostHog product review, which Max accepted on 2026-08-03.

## Why

Articles about a card being pulled, discontinued, or converted are the site's best-retaining news content, but they dead-end. Related Cards points at the card the story says is gone, which is the one card the reader cannot have.

The evidence from the 8/03 review:

- One inline link added to the Kroger article on 7/27 pulled 28 sessions out of `/news` and produced the Smartly Visa's first 3 applies, roughly a 4% CTR on a buried mid-article link.
- That effect has now saturated: beyond-news sessions moved 23 to 28 over four days and Smartly applies stayed flat at 3, while the article's 7-day traffic fell 28% (792 to 574 views).
- The pattern generalizes past Kroger. `/news/amex-green-card-pulled-renamed-classic-green` retains 12.9% of entry sessions past `/news` against Kroger's 2.4%, and 105 of its 135 views landed in the last 7 days.

## What changed

- **Schema**: new optional `replacement_cards` on news items, a list of `{slug, reason}` entries, max 4.
- **build-news.js**: resolves each slug against `cards.json` into a self-contained object (name, image, bank, annual_fee, reason) so the frontend never indexes parallel arrays. Resolution failures are **fatal, not warnings**. A replacement must exist in `cards.json`, must still have `accepting_applications: true`, and cannot be the article's own subject card. Handing a reader a second dead card is the one outcome this module has to rule out.
- **ReplacementCards**: renders above Related Cards inside the article body, and emits `replacement_card_clicked` with `article_id`, `card_slug`, and `position`, so the next review can measure the module directly instead of inferring it from session paths.
- **Backfill**: the four discontinued articles that carry the traffic (Kroger, Amex Green, Wells Fargo Attune, US Bank Shopper Cash Rewards). Together those are about 1,300 of roughly 1,400 discontinued-article entry sessions in the last 28 days.

The intro copy deliberately names no card. On a straight pull the subject card is the dead one, but on a conversion story (Kroger to Smartly) `card_slug` points at the live replacement, so naming the subject would assert the opposite of the truth on half these articles.

## Verification

- All four build guards confirmed to exit 1: closed replacement card, unknown slug, card replacing itself, duplicate slug / over-long reason.
- `build:news` clean at 98 items; `tsc --noEmit`, `eslint --max-warnings=0`, `check:seo`, and 88 vitest tests all pass.
- Rendered both backfilled articles on a dev server. The Kroger page now offers 4 distinct card destinations instead of 1, and "What to get instead" sits above Related Cards on both.
- `replacement_card_clicked` confirmed firing in the browser console.
- Mobile at 375px: no horizontal overflow, thumbnail drops to the 58x37 breakpoint, no clipped text.

## Notes

- `data/news.json` is gitignored; `build-news.yml` regenerates it on merge, syncs to S3, and fires the Amplify webhook. It builds cards before news, so the new guards run against fresh card data.
- Not merging without your say-so.