### PR TITLE
articles: add 14 scheduled articles publishing weekly Aug 6 to Nov 5

### DIFF
--- a/data/articles/drafts/amex-application-rules.yaml
+++ b/data/articles/drafts/amex-application-rules.yaml
@@ -1,0 +1,202 @@
+id: "amex-application-rules"
+slug: "amex-application-rules"
+title: "Amex Application Rules: 1/5, 2/90, and the 5-Card and 10-Charge-Card Limits"
+date: "2026-08-13"
+author: "CreditOdds"
+summary: "Every American Express application rule beyond once-per-lifetime: the 1/5 and 2/90 velocity caps, the 5-credit-card and 10-charge-card holding limits, and the pop-up."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - the-platinum-card
+  - american-express-gold-card
+  - american-express-green-card
+  - blue-business-plus-credit-card-from-american-express
+  - delta-skymiles-gold-american-express-card
+seo_title: "Amex Application Rules 2026: 1/5, 2/90, Card Limits | CreditOdds"
+seo_description: "Amex's velocity rules and holding limits explained: 1 card per 5 days, 2 per 90 days, 5 credit cards max, 10 charge cards max, and how the pop-up works."
+social_title: "Every Amex Application Rule"
+content: |
+  Most people learn one Amex rule and stop: [once per lifetime](/articles/amex-once-per-lifetime-rule), the policy that limits you to a single welcome bonus per card, ever. It is the most famous Amex rule and the most consequential one.
+
+  It is also not the rule that will actually block your next application. That job belongs to a separate set of constraints Amex has never published: two velocity caps and two holding limits. They determine whether you get approved at all, independent of whether you would have gotten a bonus.
+
+  Here is the full set as of August 2026.
+
+  ## The Rules at a Glance
+
+  | Rule | Limit | Applies to |
+  |---|---|---|
+  | **1/5** | 1 approval per 5 days | All Amex cards |
+  | **2/90** | 2 credit card approvals per 90 days | Amex credit cards only |
+  | **5-card limit** | 5 open Amex credit cards | Personal and business credit cards |
+  | **10-charge-card limit** | 10 open Amex charge cards | Charge cards only |
+  | **Once per lifetime** | 1 welcome bonus per card | Bonus eligibility, not approval |
+
+  The critical structural fact: **Amex treats credit cards and charge cards as separate populations.** Almost every confusing Amex outcome traces back to that split.
+
+  ## Credit Cards vs Charge Cards
+
+  Before the rules make sense, you need to know which bucket each product sits in.
+
+  **Charge cards** (no preset spending limit, balance due in full each month):
+
+  - The Platinum Card
+  - American Express Gold
+  - American Express Green
+  - The Business Platinum Card
+  - Business Gold
+
+  **Credit cards** (revolving, with a stated credit limit):
+
+  - Blue Cash Everyday and Blue Cash Preferred
+  - Blue Business Plus and Blue Business Cash
+  - Every Delta co-brand (Blue, Gold, Platinum, Reserve, and business versions)
+  - Every Hilton and Marriott Amex co-brand
+  - Amex EveryDay and EveryDay Preferred
+
+  Note that the co-brands are credit cards, not charge cards. This surprises people, because the Delta Reserve and Hilton Aspire feel premium. For rule purposes they sit in the credit card bucket, which is the tighter one.
+
+  ## Rule 1: The 1/5 Rule
+
+  Amex approves at most one card every five days.
+
+  This is the least restrictive rule on the list and the easiest to work with. It applies across the whole Amex lineup, credit and charge. If you are approved on the 1st, apply again on the 6th.
+
+  Some people report success at four days. Nobody reports success at two. Five days is the safe number, and there is rarely a reason to cut it closer.
+
+  ## Rule 2: The 2/90 Rule
+
+  Amex approves at most two **credit cards** in any rolling 90-day window.
+
+  This is the rule that constrains real strategies, and the charge card carve-out is what makes it interesting.
+
+  - **Counts toward 2/90**: Blue Cash, Blue Business, all Delta cards, all Hilton cards, all Marriott Amex cards
+  - **Does not count toward 2/90**: Platinum, Gold, Green, Business Platinum, Business Gold
+
+  So a 90-day window can hold two credit cards plus multiple charge cards. A realistic aggressive quarter looks like:
+
+  - **Day 0**: Delta SkyMiles Gold (credit card 1 of 2)
+  - **Day 6**: Amex Platinum (charge card, does not count)
+  - **Day 12**: Hilton Honors Surpass (credit card 2 of 2)
+  - **Day 18**: Amex Gold (charge card, does not count)
+  - **Day 91**: Credit card window resets
+
+  That is four Amex approvals in 18 days, entirely within the rules. It is also a good way to attract a financial review, which we get to below.
+
+  ## Rule 3: The 5-Credit-Card Limit
+
+  You can hold a maximum of five Amex credit cards at one time. Personal and business credit cards share the same pool.
+
+  When you are at five and apply for a sixth, the application is denied. The fix is straightforward: close or product change one of the five, wait for it to drop off your account, then apply.
+
+  A few practical notes:
+
+  - Closed cards free the slot fairly quickly, usually within a few days of the closure processing
+  - Product changing a credit card into a charge card moves it between pools, freeing a credit card slot
+  - Authorized user cards on someone else's account do not consume your slots
+
+  ## Rule 4: The 10-Charge-Card Limit
+
+  You can hold a maximum of ten Amex charge cards at one time. In practice almost nobody hits this, because there are not ten distinct charge cards most people would want. It matters mainly for people running several business entities with multiple Business Platinum and Business Gold accounts.
+
+  ## Rule 5: The Pop-Up
+
+  Separate from all of the above, Amex may show a message during the application saying you are not eligible for the welcome offer on that card. You can still submit and be approved. You simply will not get the bonus.
+
+  The pop-up is Amex enforcing once-per-lifetime and its family logic in real time. Triggers include:
+
+  - Having previously received the bonus on that exact card
+  - Having received a bonus on a card in the same family recently (the Platinum, Gold, and Green cards share family logic)
+  - Recent Delta card bonuses affecting other Delta card eligibility
+  - Sustained high application velocity, which can trigger it even on cards you have never held
+
+  **If you see the pop-up, close the application.** There is no reconsideration path for a pop-up. Submitting anyway buys you a hard inquiry and an account with no bonus.
+
+  You can check eligibility without applying by logging into your Amex account and browsing offers there. Amex will generally suppress or flag offers you are not eligible for, though this is not perfectly reliable.
+
+  ## Financial Review
+
+  The rule nobody plans for. Amex can freeze every account you hold and demand tax returns, bank statements, and a signed IRS Form 4506-C before unfreezing.
+
+  Common triggers:
+
+  - Rapid application velocity, especially several approvals in a short window
+  - Spending far in excess of your stated income
+  - Large or unusual payments, especially from accounts not in your name
+  - Stated income that does not match what Amex can verify
+
+  Financial review is not a rule you break. It is a risk you manage by keeping your stated income accurate (see [what income to put on a credit card application](/articles/credit-card-income-what-to-put)) and by not running a pace that looks abnormal.
+
+  If you are placed under review, cooperating is almost always better than closing accounts. Refusing typically ends with all Amex accounts closed and points forfeited.
+
+  ## What Amex Does Not Have
+
+  - **No 5/24 equivalent.** Amex does not auto-decline based on accounts opened at other issuers. Being at 9/24 does not lock you out.
+  - **No hard inquiry rule that blocks approvals outright.** Amex is relatively inquiry-tolerant compared to Citi or Barclays.
+  - **No published limit on total Amex relationship credit.** Amex does cap total exposure, but it manages it by lowering limits rather than by refusing new accounts.
+
+  Amex is unusually friendly on the front end and unusually harsh on the back end. Approvals are easy. Shutdowns and financial reviews are the real risk.
+
+  ## Amex and Your Credit Report
+
+  Amex charge cards report to your personal credit report, which means:
+
+  - They count toward [Chase 5/24](/articles/chase-5-24-rule-explained)
+  - They affect your average age of accounts
+  - Because they have no preset spending limit, most scoring models exclude them from utilization calculations, which is a small structural benefit
+
+  Amex business cards do not report to personal credit as long as they are in good standing, so they do not add to 5/24.
+
+  Amex pulls Experian in most cases, with occasional Equifax. See [credit freezes and applications](/articles/credit-freeze-and-applications) if you keep your reports locked.
+
+  ## Planning an Amex Year
+
+  A sane pace, not a maximum one:
+
+  - **Two Amex approvals per quarter**, mixing one credit card and one charge card
+  - **No more than four or five Amex approvals per year total**
+  - **Organic spend on everything you open.** The fastest route to a financial review is five cards with no activity on four of them.
+  - **Check the pop-up before every application**, and abandon rather than push through
+
+  Amex's velocity rules technically permit far more than this. The rules are not the binding constraint. Amex's risk system is.
+
+  ## FAQ
+
+  ### Does the 2/90 rule count business cards?
+  Yes, if they are credit cards. Blue Business Plus and Blue Business Cash count. Business Platinum and Business Gold are charge cards and do not.
+
+  ### If I close an Amex card, does it free a slot immediately?
+  Usually within a few days once the closure fully processes. If you are timing an application around it, wait a week.
+
+  ### Does the once-per-lifetime rule ever expire?
+  Officially it is permanent. In practice, people report new bonus eligibility after roughly 7 years on some products, and the pop-up is the only reliable test. See our [once-per-lifetime article](/articles/amex-once-per-lifetime-rule).
+
+  ### Do Amex cards count toward Chase 5/24?
+  Personal Amex cards and charge cards do. Amex business cards do not.
+
+  ### Can I have both a personal and business version of the same card?
+  Yes. The personal Platinum and Business Platinum are separate products with separate bonus eligibility.
+
+  ### Does an upgrade or product change count toward 2/90?
+  No. A product change is not a new approval, so it does not consume a velocity slot. It also does not generate a hard inquiry. See our [product change guide](/articles/product-change-guide).
+
+  ### Will Amex give me a credit limit increase without a hard pull?
+  Usually yes. Amex is the most generous major issuer on soft-pull limit increases, and the 3x CLI request is one of the most reliable moves in the hobby. See [credit limit increases](/articles/credit-limit-increases).
+
+  ### What triggers the pop-up on a card I have never held?
+  Most often family logic (the Platinum, Gold, and Green share it) or high recent velocity. Occasionally it appears with no clear cause and disappears weeks later.
+
+  ### Does Amex do a hard pull for every application?
+  Yes for new accounts. No for product changes, and usually no for limit increases.
+
+  ### How many total Amex cards can I hold?
+  Up to 5 credit cards plus up to 10 charge cards, so 15 in theory. Almost nobody gets close, and running more than 5 or 6 total invites a risk review.
+
+  ## The Bottom Line
+
+  Amex's approval rules are more permissive than any other major issuer's. The constraints that actually matter are different from the ones people worry about.
+
+  1. **Learn the credit card versus charge card split.** It explains 2/90, the holding limits, and most confusing Amex outcomes.
+  2. **Never push through the pop-up.** It costs you an inquiry and gets you nothing.
+  3. **Manage risk, not rules.** Amex will approve you faster than is good for you. Financial review and shutdown, not velocity denials, are what end most Amex relationships.

--- a/data/articles/drafts/are-credit-card-rewards-taxable.yaml
+++ b/data/articles/drafts/are-credit-card-rewards-taxable.yaml
@@ -1,0 +1,167 @@
+id: "are-credit-card-rewards-taxable"
+slug: "are-credit-card-rewards-taxable"
+title: "Are Credit Card Rewards Taxable? The Rebate Rule, and the Four Cases Where It Doesn't Apply"
+date: "2026-11-05"
+author: "CreditOdds"
+summary: "Points earned from spending are not taxable income. Referral bonuses, no-spend bonuses, and bank account bonuses generally are. Where the line sits and what a 1099 means."
+tags:
+  - guide
+  - analysis
+related_cards:
+  - chase-sapphire-preferred
+  - the-platinum-card
+  - citi-double-cash
+  - capital-one-venture-rewards
+  - discover-it-cash-back
+seo_title: "Are Credit Card Rewards Taxable? 2026 Guide | CreditOdds"
+seo_description: "Why points from spending are not taxable, when referral and bank bonuses are, what a 1099-MISC from your issuer means, and how business card rewards differ."
+social_title: "Are Credit Card Rewards Taxable?"
+content: |
+  Every January, a subset of people who earned a lot of points the previous year open an envelope from American Express or Chase containing a 1099-MISC, and have a bad afternoon.
+
+  The general rule is genuinely favorable: **rewards you earn by spending money are not taxable income.** But there are four well-defined exceptions, and they cover more situations than people expect.
+
+  This is general information rather than tax advice. If real money is at stake, talk to a CPA.
+
+  ## The General Rule: Rewards Are Rebates
+
+  The IRS's longstanding position is that credit card rewards earned through spending are a **purchase price adjustment**, not income. Economically, earning 2% back on a $100 purchase means you paid $98. You do not have income. You have a discount.
+
+  This covers the overwhelming majority of what most people earn:
+
+  - Cash back from ordinary spending
+  - Points and miles from ordinary spending
+  - Category bonuses and rotating 5% categories
+  - Welcome bonuses that require you to spend money to earn them
+
+  That last one surprises people, and it is the most valuable part of the rule. A 60,000-point bonus for spending $4,000 is a rebate on that $4,000 of spending. It is not taxable, no matter how large the bonus.
+
+  ## Exception 1: Bonuses That Require No Spending
+
+  If you receive a reward without spending anything, there is no purchase to rebate, so it is income.
+
+  This covers:
+
+  - Bonuses paid simply for opening an account
+  - Bonuses paid for setting up direct deposit
+  - Promotional payments for actions that are not purchases
+
+  Issuers typically report these on a **1099-MISC** when the annual total reaches $600. Below $600 you will not receive a form, but the income is technically still reportable.
+
+  Citi has historically issued 1099s for miles awarded without a spending requirement, which produced a wave of confused cardholders some years back. The reasoning was consistent with the rule: no spend, no rebate, therefore income.
+
+  ## Exception 2: Referral Bonuses
+
+  This is the one that catches active rewards users.
+
+  **Referral bonuses are income.** When you refer a friend and receive 15,000 points, you did not spend money to earn them. You performed a service, and you were compensated for it.
+
+  Practical details:
+
+  - Amex and Chase both issue **1099-MISC** forms for referral earnings, generally at the $600 annual threshold
+  - The issuer assigns a value to the points, commonly around one cent each, and that value appears on the form
+  - You owe tax on that stated value even if you think the points are worth less
+  - Below $600 you receive no form, but the income remains reportable
+
+  Someone who refers heavily can generate a five-figure 1099 without ever seeing a dollar of cash. Plan for it if referrals are a meaningful part of your strategy.
+
+  ## Exception 3: Bank Account Bonuses
+
+  Cash bonuses for opening a checking or savings account are unambiguously taxable. Banks report them on a **1099-INT**, treating them as interest.
+
+  These arrive reliably and are usually reported correctly. There is little ambiguity here.
+
+  ## Exception 4: Cash-Equivalent Purchases
+
+  This one is narrower and mostly relevant to a specific strategy.
+
+  In a 2021 Tax Court case, a taxpayer earned very large rewards by using cards to buy cash equivalents, primarily money orders and prepaid debit products, and then depositing the proceeds. The court held that rewards on ordinary purchases remained non-taxable rebates, but that rewards derived from buying **cash equivalents** were a different matter, because there was no consumption to rebate.
+
+  The practical takeaway for most readers: this does not affect normal spending, and it does not affect gift cards you buy and use. It does mean that manufactured spending through cash-equivalent instruments carries a tax question on top of the account closure risk already discussed in [hitting minimum spend](/articles/minimum-spend-strategies).
+
+  ## Business Cards Work Differently
+
+  If you use a business card for deductible business expenses, rewards do not become income. Instead, they **reduce your deductible expense**.
+
+  Example: you spend $10,000 on deductible business supplies and earn $200 in cash back. Your deductible expense is $9,800, not $10,000. The effect on your tax bill is similar to treating the $200 as income, but the mechanism is different, and it is handled on your business return rather than as a 1099.
+
+  In practice, many small business owners simply reduce the expense when the rewards are redeemed rather than tracking it purchase by purchase. Your accountant will have a preference.
+
+  This also means business card rewards are not "tax free" in the way personal rewards are. See [business credit cards without a business](/articles/business-card-no-business) if you are considering one.
+
+  ## What About Redemption?
+
+  Redeeming points is not a taxable event, regardless of how you do it.
+
+  - Transferring points to an airline: not taxable
+  - Booking a $4,000 flight with points: not taxable
+  - Cashing out points as a statement credit: not taxable
+  - Selling points for cash: this is a sale, and it may generate income, in addition to violating essentially every program's terms
+
+  The tax question attaches to how you **earned** the points, not to what you do with them afterward.
+
+  ## Sign-Up Bonuses on Cards With Annual Fees
+
+  A common question: if I pay a $695 annual fee and receive a 100,000-point bonus, is anything taxable?
+
+  No. The bonus required spending, so it is a rebate. The annual fee is a personal expense and is not deductible on a personal card. Neither side of that transaction produces a taxable event.
+
+  On a business card, the annual fee is generally a deductible business expense, and the rewards reduce other deductible expenses as described above.
+
+  ## If You Receive a 1099 You Think Is Wrong
+
+  It happens, most often when an issuer reports a spending-based bonus that should have been treated as a rebate.
+
+  1. **Contact the issuer first** and ask them to review and issue a corrected form. This is the cleanest path and it works reasonably often.
+  2. **Do not simply ignore the form.** The IRS received a copy. An unreported 1099 generates an automated notice.
+  3. **If the issuer will not correct it**, report the amount and take the position you believe is correct with your preparer's guidance. Document your reasoning.
+
+  ## Practical Planning
+
+  If rewards are a significant part of your financial picture:
+
+  - **Track referral earnings during the year.** Approaching $600 in referrals means a form is coming, and the value the issuer assigns may be higher than you expect.
+  - **Set aside a portion of bank bonus income.** These are reliably reported and reliably taxable.
+  - **Do not let tax treatment drive card strategy.** A spending-based bonus is not taxable, which means the overwhelming majority of rewards value in a normal strategy is untaxed.
+
+  ## FAQ
+
+  ### Are credit card sign-up bonuses taxable?
+  Not if they required spending. A bonus earned by meeting a minimum spend is a rebate on that spending. A bonus paid with no spending requirement is income.
+
+  ### Are cash back rewards taxable?
+  No, when earned by spending. Cash back is a purchase price adjustment.
+
+  ### Are referral bonuses taxable?
+  Yes. You did not spend money to earn them, so they are income. Issuers generally send a 1099-MISC at $600 or more per year.
+
+  ### What if my referral earnings were under $600?
+  You will not receive a 1099, but the income is technically still reportable.
+
+  ### Are bank account bonuses taxable?
+  Yes. Banks report them on a 1099-INT as interest income.
+
+  ### Do I owe tax when I redeem points?
+  No. Redemption is not a taxable event. The question is how the points were earned.
+
+  ### How does the issuer value points on a 1099?
+  Commonly around one cent per point, though the exact figure is the issuer's determination. You are taxed on the reported value.
+
+  ### Are business card rewards taxable?
+  Not as income. They reduce your deductible business expenses instead, which affects your return through a different mechanism.
+
+  ### Is the annual fee deductible?
+  On a personal card, no. On a business card used for business, generally yes as a business expense.
+
+  ### What if I earn points from a card in someone else's name as an authorized user?
+  Rewards accrue to the primary account holder in nearly all programs. Tax follows the same path. See [authorized user strategy](/articles/authorized-user-strategy).
+
+  ## The Bottom Line
+
+  The tax treatment of credit card rewards is more favorable than most people assume, and the exceptions are narrow enough to enumerate.
+
+  1. **If you spent money to earn it, it is a rebate and it is not taxable.** This covers cash back, category bonuses, and virtually every welcome bonus.
+  2. **If you did not spend money to earn it, it is income.** Referral bonuses, no-spend account bonuses, and bank account bonuses all fall here.
+  3. **Track referrals during the year.** A five-figure 1099 for points you never converted to cash is an unpleasant January surprise, and it is entirely predictable in advance.
+
+  For someone running a normal rewards strategy, essentially all of the value is untaxed. The exceptions matter mainly for heavy referrers and bank bonus chasers, and both groups can plan for them.

--- a/data/articles/drafts/azeo-explained.yaml
+++ b/data/articles/drafts/azeo-explained.yaml
@@ -1,0 +1,188 @@
+id: "azeo-explained"
+slug: "azeo-explained"
+title: "AZEO Explained: The All Zero Except One Trick, and When It Is Actually Worth Doing"
+date: "2026-09-17"
+author: "CreditOdds"
+summary: "AZEO means letting one card report a small balance and every other card report zero. How it works, how much it moves your score, and the timing that makes or breaks it."
+tags:
+  - strategy
+  - guide
+estimated_value: "10 to 30 FICO points"
+related_cards:
+  - chase-freedom-unlimited
+  - citi-double-cash
+  - wells-fargo-active-cash
+  - capital-one-quicksilver
+  - discover-it-cash-back
+seo_title: "AZEO Explained: All Zero Except One Credit Trick | CreditOdds"
+seo_description: "How the AZEO method works, why reporting one small balance beats reporting zero, the statement-date timing it depends on, and when it is worth the effort."
+social_title: "AZEO: All Zero Except One"
+content: |
+  There is a quirk in how FICO scores credit card balances that almost nobody outside the credit optimization community knows about: **reporting zero balances on every single card scores slightly worse than reporting a small balance on exactly one card.**
+
+  That quirk is the entire basis of AZEO, which stands for All Zero Except One. It is one of the few score optimization techniques that is both real and free, and it is worth 10 to 30 points for most people in the month you apply it.
+
+  It is also widely misapplied. Most people who try AZEO get the timing wrong and see nothing happen.
+
+  ## What AZEO Is
+
+  Let your statements close like this:
+
+  - **One credit card** reports a small balance, ideally 1% to 9% of that card's limit
+  - **Every other credit card** reports a $0 balance
+  - **Installment loans** are unaffected and can report normally
+
+  That is the whole method. The difficulty is entirely in the timing.
+
+  ## Why It Works
+
+  FICO's utilization calculation looks at two things: your aggregate utilization across all revolving accounts, and how many of your accounts carry a balance.
+
+  Reporting all zeros produces a strange result. Your aggregate utilization is 0%, which sounds ideal, but FICO's models penalize a total absence of revolving activity slightly. The scoring logic effectively wants evidence that you are using credit and managing it, not that you have stopped using it.
+
+  So the optimum is not zero. It is a small nonzero number on a single account, which produces:
+
+  - Very low aggregate utilization
+  - Only one account reporting a balance, which is the lowest nonzero count
+  - Demonstrated active use of revolving credit
+
+  The gap between "all zeros" and "AZEO" is usually small, on the order of a few points. The gap between "several cards reporting balances" and AZEO is much larger, and that is where most of the 10 to 30 points comes from.
+
+  ## The Timing, Which Is the Whole Game
+
+  Here is where most attempts fail.
+
+  **Credit card issuers report your statement balance to the bureaus, not your current balance.** They report it on or shortly after your statement closing date. If your statement closes on the 18th and you pay it off on the 25th, the balance that closed on the 18th is what your credit report shows for the next month.
+
+  This is the single most misunderstood mechanic in consumer credit, and we cover it fully in [statement balance vs current balance](/articles/statement-balance-vs-current-balance).
+
+  For AZEO, the consequence is:
+
+  **Paying off your cards after the statement closes does nothing for this month's score. You have to pay before the statement closes.**
+
+  ### The actual procedure
+
+  1. **Find every card's statement closing date.** It is on your statement and in your online account. It is not your due date, and for most cards it is roughly three weeks earlier.
+  2. **Pick your "one" card.** Ideally an older account with a high limit, so a small balance produces a small percentage.
+  3. **On every other card**, pay the balance to $0 two to three days before that card's statement closes, then stop using it until the statement closes.
+  4. **On your chosen card**, let a small balance sit through the statement close. Somewhere between 1% and 9% of the limit. If the limit is $10,000, aim for $100 to $500.
+  5. **Pay that card's statement balance in full** by the due date, as normal. You are optimizing what gets reported, not carrying debt.
+
+  Step 3 is where people trip. Paying to zero and then buying coffee the next day puts a balance back on before the statement closes, and the card reports that balance instead.
+
+  ### Timing the whole thing to an application
+
+  Statement dates are staggered across your cards, so a full AZEO cycle takes about 30 to 45 days from start to finish. Then the bureaus need a few days to reflect it.
+
+  Plan on **45 to 60 days from starting AZEO to applying.** Starting a week before your application does nothing.
+
+  ## How Much It Is Actually Worth
+
+  Honest numbers, because this technique gets oversold:
+
+  | Starting situation | Typical gain from AZEO |
+  |---|---|
+  | 4 cards reporting balances, 25% aggregate utilization | 20 to 40 points |
+  | 3 cards reporting small balances, 8% utilization | 10 to 20 points |
+  | All cards reporting $0 | 2 to 8 points |
+  | Already at AZEO | 0 |
+
+  The technique is most valuable for people who normally carry reported balances across several cards. If you already pay everything before statements close, AZEO gets you very little and is probably not worth the effort.
+
+  ## When AZEO Is Worth Doing
+
+  AZEO is a snapshot optimization. It moves your score for the month it is in effect and reverts as soon as you go back to normal spending. That makes it worth doing before a specific event and pointless as a lifestyle.
+
+  **Worth it before:**
+
+  - A mortgage application, where a 20-point move can change your rate tier
+  - An auto loan
+  - A credit card application at a score-sensitive issuer
+  - Any application where you are near a score threshold like 720 or 760
+
+  **Not worth it for:**
+
+  - Your general ongoing score, which nobody is looking at
+  - Situations where your denial risk is about [velocity or account count](/articles/velocity-rules-by-issuer) rather than score
+  - Anyone who already pays before statement close every month
+
+  ## What AZEO Does Not Fix
+
+  Worth being direct about this, because people try AZEO as a cure-all.
+
+  Utilization is roughly 30% of your FICO score and it is the fastest-moving component. But it is not the only one, and AZEO does nothing for:
+
+  - **Late payments.** These dominate your score and AZEO cannot touch them.
+  - **Average age of accounts.** Fixed by time only.
+  - **Hard inquiries.** See [hard inquiries explained](/articles/hard-inquiries-explained).
+  - **Issuer rules.** Chase 5/24 does not care about your score. A 850 at 6/24 is still denied.
+
+  If your problem is that you are over 5/24, AZEO is a distraction. Read [the 5/24 article](/articles/chase-5-24-rule-explained) instead.
+
+  ## Common Mistakes
+
+  ### Paying off cards on the due date
+  Too late. The statement already closed and already reported. Pay before the statement closing date.
+
+  ### Reporting zero on every card, including the "one"
+  This is the specific case AZEO exists to avoid. You need exactly one card with a balance.
+
+  ### Picking a low-limit card as the "one"
+  A $200 balance on a $500 store card is 40% utilization on that account, which is worse than what you were trying to fix. Use a high-limit card.
+
+  ### Forgetting charge cards
+  Amex charge cards have no preset limit and are generally excluded from utilization calculations, so they do not work as your "one" card. Use a revolving card.
+
+  ### Doing it a week before applying
+  Statement cycles take a month. Start 45 to 60 days out.
+
+  ### Using it every month
+  There is no cumulative benefit. Utilization has no memory in FICO scoring. Last month's utilization does not affect this month's score.
+
+  ## Checking That It Worked
+
+  Do not trust your bank's free score widget, which may use a VantageScore model that behaves differently. See [FICO vs VantageScore](/articles/fico-vs-vantagescore).
+
+  Instead, check the underlying data. Pull your reports from annualcreditreport.com and confirm the reported balance on each account. What you want to see is one account with a small balance and the rest at zero. If the data is right, the score follows.
+
+  ## FAQ
+
+  ### Does AZEO work on VantageScore too?
+  Partially. VantageScore also rewards low utilization but weights the "number of accounts with balances" factor differently. The gain is usually smaller. Lenders mostly use FICO anyway.
+
+  ### What percentage should the one card report?
+  Anywhere from 1% to 9% of that card's limit. There is no meaningful difference within that range. Do not aim for exactly 1%, which is not worth the precision.
+
+  ### Do I have to carry the balance and pay interest?
+  No. You let the balance report at statement close, then pay the statement in full by the due date. You pay zero interest. This is the most common misunderstanding about AZEO and it is the [carry-a-balance myth](/articles/credit-utilization-explained) in a different costume.
+
+  ### Does it matter which card I choose?
+  Pick a high-limit, well-established revolving account. Avoid low-limit store cards and Amex charge cards.
+
+  ### How long does the effect last?
+  Until the next statement closes. Utilization is a snapshot with no memory, so the benefit disappears as soon as your normal spending reports again.
+
+  ### Should I do AZEO before every credit card application?
+  Only if you are near a score threshold and the issuer is score-sensitive. If your constraint is 5/24 or velocity, it will not help.
+
+  ### Does paying twice a month accomplish the same thing?
+  It can, if the second payment lands before the statement closes. The mechanism is the same: control what balance is sitting there on the closing date.
+
+  ### What about authorized user cards?
+  AU accounts appear on your report and their balances count toward your utilization. If you are an AU on a card carrying a balance, that works against you. See [authorized user strategy](/articles/authorized-user-strategy).
+
+  ### Will the issuer notice or care?
+  No. Issuers do not track whether you are optimizing your statement balances, and there is nothing improper about paying early.
+
+  ### Is 0% utilization really worse than 3%?
+  Slightly, in FICO models. The difference is a handful of points, not a large one. It is real, but it is the smallest part of AZEO's value.
+
+  ## The Bottom Line
+
+  AZEO is a legitimate technique with an honest ceiling. It is not a credit repair method and it will not save an application that is failing for structural reasons.
+
+  1. **The timing is the technique.** Pay before statement close, not before the due date. Everything else is detail.
+  2. **Give it 45 to 60 days.** Statement cycles are staggered, and a rushed AZEO reports nothing different.
+  3. **Use it before something specific.** A mortgage, an auto loan, a borderline application. There is no value in maintaining it permanently.
+
+  If you currently let three or four cards report balances every month, this is one of the largest free score gains available to you. If you already pay before statements close, you are mostly there already.

--- a/data/articles/drafts/barclays-application-rules.yaml
+++ b/data/articles/drafts/barclays-application-rules.yaml
@@ -1,0 +1,168 @@
+id: "barclays-application-rules"
+slug: "barclays-application-rules"
+title: "Barclays Application Rules: 6/24, the Duplicate Card Rule, and Why Inquiries Matter More Here"
+date: "2026-09-03"
+author: "CreditOdds"
+summary: "Barclays US application rules in 2026: the soft 6/24 threshold, one card per six months, the rule against holding two of the same card, and their unusual inquiry sensitivity."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - jetblue-plus-card
+  - wyndham-rewards-earner-plus-card
+  - hawaiian-airlines-world-elite-mastercard
+  - samsung-galaxy-card
+  - princess-cruises-rewards-visa-card
+seo_title: "Barclays Credit Card Application Rules 2026 | CreditOdds"
+seo_description: "Barclays' 6/24 threshold, 1-card-per-6-months pacing, the no-duplicate-cards rule, and why inquiry count matters more at Barclays than most issuers."
+social_title: "Barclays' Application Rules"
+content: |
+  Barclays US is a co-brand shop. Almost their entire lineup is somebody else's brand: JetBlue, Hawaiian, Wyndham, Princess, and as of 2026, Samsung. That structure shapes their underwriting in a way worth understanding, because it means Barclays is underwriting a partner's customer base rather than building a direct relationship with you.
+
+  The result is an issuer that is unusually sensitive to how your credit report looks right now, and comparatively uninterested in your history with them.
+
+  Here are their rules as of September 2026.
+
+  ## The Rules at a Glance
+
+  | Rule | Type | Effect |
+  |---|---|---|
+  | **6/24** | Soft threshold | Denials rise sharply above 6 new accounts in 24 months |
+  | **1 card per 6 months** | Soft pacing | Second application inside the window often denied |
+  | **No duplicate cards** | Hard rule | Cannot hold two of the same product at once |
+  | **24-month bonus wait** | Bonus rule | Approved, but no bonus |
+  | **Total credit extended** | Underwriting cap | Denials once your Barclays exposure is maxed |
+
+  Only one of these is a hard rule. The rest are pressure, not walls.
+
+  ## Rule 1: The 6/24 Threshold
+
+  Barclays denies applicants with roughly six or more new accounts on their credit report in the past 24 months at a much higher rate than applicants below that line.
+
+  This is not [Chase 5/24](/articles/chase-5-24-rule-explained). Two important differences:
+
+  - **It is not a coded auto-decline.** Approvals at 6/24, 7/24, and higher are documented, especially on the entry-level cards.
+  - **It varies by product.** The premium co-brands (JetBlue Plus, the Wyndham Earner tiers) enforce it more tightly than the no-annual-fee versions.
+
+  What is consistent is the direction. Every new account on your report moves Barclays odds down, and the fall-off around six is steep enough that community shorthand treats it as a rule.
+
+  Practical read: below 5/24, Barclays is straightforward. At 6/24 and 7/24, it is a real gamble. Above 8/24, expect a denial on anything premium.
+
+  ## Rule 2: One Card Per Six Months
+
+  Barclays generally approves one new card per applicant per six months. Like the 6/24 threshold, this is soft. Approvals at three and four months happen, particularly when the second card is a lower-tier product.
+
+  Barclays is one of the issuers where applying too fast does more than get you denied. Rapid Barclays applications are a documented trigger for credit limit decreases on your existing Barclays accounts, and occasionally for account closure. This is a real difference from Chase or Amex, where a denial is just a denial.
+
+  ## Rule 3: No Duplicate Cards
+
+  This one is hard, and it is the rule most unique to Barclays.
+
+  **You cannot hold two of the same Barclays product at the same time.** If you already have a JetBlue Plus card, you cannot open a second JetBlue Plus card. You have to close the first one, and then apply.
+
+  This matters for bonus strategy. At Citi or Chase you can sometimes hold two of a product. At Barclays, re-earning a bonus on a card you like requires closing it, waiting out the bonus clock, and reapplying. That is a genuine cost, since closing shortens your average account age and drops the credit limit from your utilization calculation.
+
+  ## Rule 4: The 24-Month Bonus Wait
+
+  Barclays restricts welcome bonuses to once per 24 months per product, measured from when the prior bonus posted.
+
+  Combined with the duplicate card rule, the full re-earn cycle looks like:
+
+  1. Receive the bonus
+  2. Hold the card for at least a year, so the account does not look like pure bonus chasing
+  3. Close the card
+  4. Wait until 24 months have passed since the bonus posted
+  5. Reapply
+
+  As always, the offer terms on the application page are authoritative and vary by product.
+
+  ## Inquiry Sensitivity
+
+  Barclays weights hard inquiries more heavily than most major issuers. This is separate from the 6/24 account count, and it catches people who have applied a lot without being approved much.
+
+  A profile with four new accounts but twelve inquiries in 12 months can be denied at Barclays while sailing through at Amex. If you have been rate shopping or collecting denials elsewhere, let inquiries age before applying here.
+
+  Barclays pulls TransUnion in most cases, with Experian appearing regionally. Some applicants report double pulls. If you keep your reports frozen, thaw TransUnion first. See [credit freezes and applications](/articles/credit-freeze-and-applications).
+
+  ## Total Credit Extended
+
+  Like [U.S. Bank](/articles/us-bank-application-rules), Barclays caps total exposure per customer. Once you hold two or three Barclays cards with meaningful limits, further applications get denied on exposure rather than on credit quality.
+
+  The reconsideration fix is the same: offer to reallocate a limit from an existing Barclays card to the new account. Barclays recon agents have the authority to do this and it converts a real share of denials.
+
+  ## Reconsideration at Barclays
+
+  Barclays has a reconsideration line and it is moderately useful. What works:
+
+  - **Exposure denials**: offer to move credit from an existing card
+  - **Verification issues**: address or income mismatches are easy fixes
+  - **Explaining inquiries**: modestly effective if you have a clean narrative
+
+  What does not work: arguing a velocity or account-count denial. Barclays agents will not override a risk-model outcome driven by your report.
+
+  See our [reconsideration guide](/articles/credit-card-denied-reconsideration) for the general approach.
+
+  ## The 2026 Lineup
+
+  Barclays' portfolio has shifted meaningfully:
+
+  - **Samsung Galaxy Card** launched in July 2026, their newest major co-brand and the first big consumer-electronics partnership in the lineup
+  - **The Wyndham Earner family was refreshed** in June 2026, adding the $395 Earner Premier at the top
+  - **JetBlue** remains their flagship airline partnership, with the Plus and Premier tiers carrying the strongest bonuses and the tightest underwriting
+  - **Hawaiian Airlines** cards continue, though the Alaska merger has raised long-term questions about the program
+
+  Barclays also issues a number of smaller co-brands not covered here. The rules above apply across the lineup.
+
+  ## Where Barclays Fits in a Plan
+
+  Because Barclays is inquiry and velocity sensitive, it belongs early in an application sequence, not late.
+
+  The common mistake is treating Barclays as a filler issuer to hit after you have already opened four cards this year. By then their odds are poor. If a JetBlue or Wyndham card is on your list, apply for it while your report is clean.
+
+  A workable order for someone building a portfolio:
+
+  - **Chase first**, because [5/24](/articles/chase-5-24-rule-explained) is the least forgiving rule
+  - **Barclays and Citi next**, while inquiry counts are still low
+  - **Amex and Capital One later**, since both are more tolerant of a busy report
+
+  ## FAQ
+
+  ### Is Barclays 6/24 a hard rule?
+  No. It is a strong risk weighting. Approvals above 6/24 happen, more often on entry-level products than premium co-brands.
+
+  ### Can I have two JetBlue cards?
+  Not two of the same JetBlue product. You can hold the JetBlue Card and the JetBlue Plus Card simultaneously, since those are different products.
+
+  ### Do Barclays cards count toward Chase 5/24?
+  Yes. Barclays personal cards report to your personal credit report.
+
+  ### Will Barclays lower my limits if I apply too often?
+  It happens. Barclays is one of the few issuers where rapid application activity has triggered credit limit decreases and closures on existing accounts.
+
+  ### How long should I wait between Barclays applications?
+  Six months. Shorter intervals sometimes work but carry the account-review risk above.
+
+  ### Does Barclays do soft-pull credit limit increases?
+  Requested increases are typically hard pulls. Automatic increases are soft. See [credit limit increases](/articles/credit-limit-increases).
+
+  ### Can I product change a Barclays card?
+  Only within the same co-brand family, and options are limited because the lineup is mostly partner cards. Downgrade paths are narrower here than at Chase or Citi. See our [product change guide](/articles/product-change-guide).
+
+  ### What is the best way to improve Barclays odds?
+  Let inquiries age. Barclays reacts to inquiry count more than most issuers, and a six-month quiet period changes outcomes more than a score increase does.
+
+  ### Does Barclays have a 24-month or 48-month bonus rule?
+  24 months on most products, measured from when the bonus posted. Read the offer terms.
+
+  ### Does Barclays offer pre-qualification?
+  For some products, and it is a soft pull. It is less predictive than Capital One's tool. See [pre-approval vs pre-qualification](/articles/pre-approval-vs-pre-qualification).
+
+  ## The Bottom Line
+
+  Barclays is the issuer that punishes you for what you did in the last year rather than what you did in the last five.
+
+  1. **Apply while your report is clean.** Barclays odds decay faster with new accounts and inquiries than almost any other issuer, so put them early in your sequence.
+  2. **Remember you cannot hold two of the same card.** Re-earning a Barclays bonus means closing the original, which is a real cost.
+  3. **Do not stack Barclays applications.** Unlike most issuers, applying too fast here can cost you limits and accounts you already have.
+
+  Their co-brand bonuses are frequently the best value in their categories, particularly JetBlue and Wyndham. Getting them just requires applying at the right point in your credit cycle rather than whenever you happen to remember.

--- a/data/articles/drafts/business-card-no-business.yaml
+++ b/data/articles/drafts/business-card-no-business.yaml
@@ -1,0 +1,194 @@
+id: "business-card-no-business"
+slug: "business-card-no-business"
+title: "Business Credit Cards Without a Business: What Actually Qualifies, and What to Put on the Application"
+date: "2026-10-01"
+author: "CreditOdds"
+summary: "You do not need an LLC or an EIN to get a business card. What counts as a sole proprietorship, what to enter for revenue and business name, and where the real line is."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-ink-business-cash
+  - chase-ink-business-unlimited
+  - blue-business-plus-credit-card-from-american-express
+  - capital-one-venture-business
+  - wells-fargo-signify-business-cash
+seo_title: "Business Credit Card With No Business: What Qualifies | CreditOdds"
+seo_description: "How sole proprietors qualify for business credit cards without an LLC or EIN, what to enter for business name and revenue, and where the legal line is."
+social_title: "Business Cards Without a Business"
+content: |
+  The most common follow-up question to any article about business credit cards is some version of: I do not have a business, so this does not apply to me, right?
+
+  Usually it does apply. The bar for "business" on a credit card application is far lower than people assume, and a large share of business card holders are sole proprietors with modest side income and no formal entity at all.
+
+  But the bar is not zero, and the difference between "lower than you think" and "nonexistent" is the difference between a legitimate application and lying to a bank. This article covers both halves honestly.
+
+  ## What Actually Counts as a Business
+
+  A sole proprietorship is the default legal structure for any individual doing business activity for profit. You do not register it. You do not file anything. If you earn money from an activity with a profit motive, you are already operating one.
+
+  Things that genuinely qualify:
+
+  - Freelance or contract work of any kind
+  - Rideshare, delivery, or other gig platform driving
+  - Selling on eBay, Etsy, Poshmark, Mercari, or Facebook Marketplace
+  - Tutoring, lessons, coaching, consulting
+  - Photography, design, writing, editing
+  - Renting out property, including a room or a parking space
+  - Pet sitting, babysitting, lawn care, handyman work
+  - Content creation with any revenue, including affiliate or ad income
+  - Reselling of any kind
+
+  Scale is not the test. Intent to earn is. Someone who sold $400 of used gear on eBay last year with the intention of making money is running a sole proprietorship. Someone who has never earned a dollar and has no plans to is not.
+
+  ## Where the Line Is
+
+  Being direct about this, because it matters and most articles on this topic dodge it.
+
+  **A credit card application is a legal document. Materially false statements on one are fraud.** Not "against the terms of service." Fraud, under federal law.
+
+  What that means in practice:
+
+  - **Having a small or new business and applying is fine.** This is exactly who these products are for.
+  - **Reporting $0 or low revenue is fine.** Issuers approve businesses with no revenue constantly.
+  - **Inventing a business you do not have and do not intend to have is not fine.** Neither is inflating revenue by a factor of ten.
+
+  The good news is that honesty works here. Issuers approve genuine sole proprietors with $0 revenue and no business history routinely, because they underwrite these cards on your personal credit and your personal guarantee. You do not need to embellish anything to get approved.
+
+  ## Filling Out the Application
+
+  Here is what each field means for a sole proprietor.
+
+  ### Business name
+
+  Your own legal name. If you have a registered DBA ("doing business as"), you can use that instead, but your legal name is the correct and expected answer for an unregistered sole proprietorship.
+
+  ### Business type or structure
+
+  Select "Sole Proprietorship" or "Individual." Do not select LLC or Corporation unless you have actually formed one.
+
+  ### Tax ID
+
+  Your Social Security number. Sole proprietors without employees are not required to have an EIN, and issuers expect an SSN here.
+
+  You can get an EIN for free from the IRS website in about ten minutes if you prefer not to give out your SSN. It does not change your approval odds and it does not make the business more "real" in the issuer's eyes. It is purely a privacy choice.
+
+  ### Years in business
+
+  Count from when you actually started the activity. If you started last month, enter 0 years. If you have been freelancing for six years, enter 6. Issuers approve 0-year businesses regularly.
+
+  ### Annual business revenue
+
+  Your honest gross revenue from the activity over the past 12 months. If that is $0, enter $0. If it is $3,000, enter $3,000.
+
+  This is the field people most want to inflate and the one where inflation is least useful. These cards are underwritten primarily on your personal credit profile, because you are personally guaranteeing the debt. A large revenue number does not offset a weak personal file.
+
+  ### Number of employees
+
+  For most sole proprietors, 1 (yourself) or 0. Either is acceptable.
+
+  ### Estimated monthly spend
+
+  A reasonable estimate of what you would put on the card. This can include spend you would route through the card, and it is a forecast rather than a commitment.
+
+  ## What the Issuer Is Actually Underwriting
+
+  This is the part that makes everything above make sense.
+
+  For a small business card, the issuer is pulling your **personal** credit report, evaluating your **personal** score and income, and requiring your **personal** guarantee on the debt. The business details are context, not the decision.
+
+  Which means:
+
+  - A 750 personal score with a $0-revenue one-month-old sole proprietorship gets approved
+  - A 620 personal score with a five-year business doing $200,000 in revenue usually does not
+
+  If you want to know your odds, look at your personal credit profile, not your business.
+
+  ## Why Bother
+
+  Three concrete reasons, in order of how much they matter.
+
+  ### 1. Business cards do not count toward 5/24
+
+  Chase, Amex, Citi, U.S. Bank, Wells Fargo, and Barclays business cards do not report to your personal credit report in good standing. That means they do not add to your [Chase 5/24](/articles/chase-5-24-rule-explained) count, which is the single most valuable property they have.
+
+  Capital One and Discover business cards **do** report to personal credit and do count. See [business cards that don't report to personal credit](/articles/business-cards-not-on-personal-credit) for the full breakdown.
+
+  ### 2. The bonuses are large
+
+  Business card welcome bonuses are frequently the largest available. The Ink family in particular has carried some of the strongest offers in the market for years.
+
+  ### 3. They keep business spending off your utilization
+
+  Because they do not report to personal credit, a large balance on a business card does not affect your personal [utilization](/articles/credit-utilization-explained). For anyone with variable business expenses, this is a real structural benefit.
+
+  ## Which Issuers Are Easiest
+
+  Roughly, from most to least accommodating for a new sole proprietor:
+
+  | Issuer | Notes |
+  |---|---|
+  | **American Express** | Most accommodating. Approves $0 revenue and 0 years routinely. |
+  | **Chase (Ink)** | Very workable, but you must be under 5/24 to apply. |
+  | **Capital One** | Accessible, but reports to personal credit. |
+  | **Wells Fargo** | Reasonable, and runs on a separate track from personal applications. |
+  | **U.S. Bank** | Conservative, and a business deposit relationship helps. |
+  | **Bank of America** | Tends to want more established businesses. |
+
+  Amex is the standard starting point. Blue Business Plus has no annual fee, earns 2x on the first $50,000 of spend each year, and is one of the most commonly approved first business cards.
+
+  ## Common Mistakes
+
+  ### Forming an LLC because you think you need one
+  You do not. An LLC costs money, adds annual filing requirements in most states, and does not improve your approval odds on a card underwritten against your personal credit.
+
+  ### Applying for Chase Ink while over 5/24
+  Chase business cards do not add to your 5/24 count, but you still have to be **under** 5/24 to be approved for one. This trips people constantly.
+
+  ### Assuming the card will build business credit
+  Most of these cards do not report to business credit bureaus like Dun and Bradstreet either. They are personal-credit products with a business label. If building a business credit file is your goal, that is a different product category.
+
+  ### Inflating revenue
+  It does not help, because revenue is not the deciding input, and it is the field most likely to be scrutinized if anything goes wrong.
+
+  ## FAQ
+
+  ### Do I need an EIN?
+  No. Sole proprietors without employees can use their Social Security number. An EIN is free from the IRS if you want one for privacy reasons, but it does not change your odds.
+
+  ### Do I need an LLC?
+  No. Sole proprietorship is a valid business structure and is what most business card applicants use.
+
+  ### Can I put $0 for revenue?
+  Yes, and people are approved this way regularly. Approval is driven by your personal credit.
+
+  ### What if my business is brand new?
+  Enter 0 years in business. This is common and not disqualifying.
+
+  ### Will the issuer verify my business?
+  Rarely at application. Some issuers ask for documentation later, usually when something else has already triggered a review. Occupational and revenue details being accurate protects you here.
+
+  ### Do business cards affect my personal credit score?
+  The hard inquiry does. The account itself generally does not, at issuers that do not report business cards to personal credit. A default would report regardless, because you personally guaranteed it.
+
+  ### Which business cards report to personal credit?
+  Capital One and Discover report routinely. Most others report only if the account goes seriously delinquent. See our [detailed breakdown](/articles/business-cards-not-on-personal-credit).
+
+  ### Can I get a business card with a 650 score?
+  Sometimes, on entry-level products. Business cards are underwritten on personal credit, so a 650 faces the same constraints it would on a personal card.
+
+  ### Does business card spending count toward a personal card's welcome bonus?
+  No. Each card's spending counts only toward its own bonus. See [hitting minimum spend](/articles/minimum-spend-strategies).
+
+  ### Is it fraud to apply as a sole proprietor with a small side hustle?
+  No. That is a legitimate business. It becomes fraud when you invent activity that does not exist or materially misstate revenue.
+
+  ## The Bottom Line
+
+  The gap between "I have a business" and "I do not" is much smaller than most people think, and it is also a real line.
+
+  1. **If you earn money from any activity with a profit motive, you already qualify.** Enter your legal name, sole proprietorship, your SSN, and your actual revenue.
+  2. **Do not invent a business.** You do not need to, because these cards are approved on your personal credit anyway, and the downside is not a declined application.
+  3. **The real prize is 5/24 immunity.** Business cards from most major issuers let you keep opening accounts without spending your Chase eligibility.
+
+  For most people the right first step is a no-annual-fee business card from Amex, applied for honestly with whatever small numbers are true. The approval is usually easier than the personal card you already have.

--- a/data/articles/drafts/citi-application-rules.yaml
+++ b/data/articles/drafts/citi-application-rules.yaml
@@ -1,0 +1,181 @@
+id: "citi-application-rules"
+slug: "citi-application-rules"
+title: "Citi Application Rules: The 1/8, 2/65, and 48-Month Rules Explained"
+date: "2026-08-06"
+author: "CreditOdds"
+summary: "Citi's three application rules in 2026: one card per 8 days, two per 65 days, and a 48-month wait between welcome bonuses. What each one counts and how to sequence around them."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - citi-strata-premier
+  - citi-strata-elite
+  - citi-double-cash
+  - citi-aadvantage-platinum-select-world-elite-m
+  - costco-anywhere-visa-card-by-citi
+seo_title: "Citi Application Rules 2026: 1/8, 2/65, 48-Month | CreditOdds"
+seo_description: "How Citi's 1/8 and 2/65 velocity rules work, what the 48-month bonus rule actually counts, and how to plan Citi applications without wasting a bonus."
+social_title: "Citi's 1/8, 2/65, and 48-Month Rules"
+content: |
+  Citi is the issuer people misunderstand most. Chase's 5/24 rule is famous because it is brutal and simple: cross the line, get auto-declined. Citi's rules are quieter. They rarely stop you from being approved. They stop you from getting paid.
+
+  That distinction matters more than anything else in this article. Citi will happily approve a card and then decline to pay the welcome bonus, and you will not find out until the bonus fails to post two months later. Understanding the rules is the difference between a 75,000-point application and a free hard inquiry.
+
+  Here are all three rules as of August 2026, what each one actually counts, and how to sequence a Citi strategy around them.
+
+  ## The Three Rules at a Glance
+
+  | Rule | What it limits | Consequence of breaking it |
+  |---|---|---|
+  | **1/8** | 1 Citi card approval per 8 days | Application denied or held for review |
+  | **2/65** | 2 Citi card approvals per 65 days | Application denied |
+  | **48-month** | 1 welcome bonus per card per 48 months | Approved, but no bonus |
+
+  The first two are velocity rules. They govern approvals. The third is a bonus rule. It governs whether the application was worth making.
+
+  ## Rule 1: The 1/8 Rule
+
+  Citi will not approve more than one credit card application in any rolling 8-day window.
+
+  - **What counts**: Any Citi-branded credit card approval, personal or business, including co-brands like AAdvantage and Costco
+  - **What it measures**: Days between approvals, not days between applications
+  - **What happens if you break it**: The second application goes to pending, and is usually denied on review
+
+  The 8-day count is calendar days, and the community consensus is that it is measured from approval date to approval date. If you are approved for a Citi card on the 1st, your next Citi application should not go in until the 9th at the earliest. Most people wait 10 days to leave margin.
+
+  A denied application does not start the clock. Only an approval does. If your first application is denied, you are free to apply again immediately, though doing so is usually a bad idea for other reasons.
+
+  ## Rule 2: The 2/65 Rule
+
+  Citi will not approve more than two credit card applications in any rolling 65-day window.
+
+  This is the rule that actually constrains a Citi strategy. The 1/8 rule only forces you to space applications by a week. The 2/65 rule caps you at roughly two Citi cards per quarter, or about eight per year at maximum theoretical pace.
+
+  - **What counts**: Citi-branded credit card approvals, personal and business
+  - **What does not count**: Citi retail partner cards issued by other banks, and Citi bank account openings
+  - **How it stacks with 1/8**: Both apply simultaneously. Two approvals 8 days apart satisfies 1/8 but starts a 65-day clock before a third.
+
+  You will sometimes see this written as "8/65" or "1/8/65." Those are the same rule set described together, not a third separate rule. The clean way to hold it in your head is: 8 days between any two, 65 days before a third.
+
+  ### Sample Citi sequence
+
+  A maximum-pace Citi year, starting from zero:
+
+  - **Day 0**: Citi Strata Premier approved
+  - **Day 10**: Citi Double Cash approved (satisfies 1/8)
+  - **Day 75**: AAdvantage Platinum Select approved (satisfies 2/65 from day 0)
+  - **Day 85**: CitiBusiness AAdvantage approved
+  - **Day 150**: Fourth personal card
+
+  In practice, almost nobody should run at this pace. Citi is one of the more inquiry-sensitive issuers, and stacking four approvals in five months will suppress your credit limits and raise your odds of a manual review on the next one.
+
+  ## Rule 3: The 48-Month Bonus Rule
+
+  This is the important one, and the one that gets misreported constantly.
+
+  **You are not eligible for a welcome bonus on a Citi card if you have received a welcome bonus on that same card in the past 48 months.** The clock runs from the date the bonus posted, not the date you opened or closed the account.
+
+  Some Citi offers use a different construction, and the terms will say so explicitly: "if you have had this card open in the past 48 months, or received a bonus on it in the past 48 months." Read the offer terms on the actual application page. They are the only authoritative source.
+
+  ### The part everyone gets wrong: it is per card, not per family
+
+  Chase and Amex both use family rules. Getting the Sapphire Preferred bonus locks you out of the Sapphire Reserve bonus. Getting the Amex Gold bonus can affect Platinum eligibility.
+
+  Citi generally does not work this way. The 48-month clock attaches to the individual product. That means:
+
+  - You can hold the Strata Premier and still get a Double Cash bonus
+  - You can get the AAdvantage Platinum Select bonus and the AAdvantage MileUp bonus without waiting 48 months between them
+  - You can get a personal AAdvantage bonus and a CitiBusiness AAdvantage bonus in the same year
+
+  There have been periods where Citi applied stricter family logic to the ThankYou lineup, and the terms language has shifted over the years. The current 2026 behavior is per-product. Always verify against the offer terms rather than against a blog post, including this one.
+
+  ### Checking your own 48-month status
+
+  Citi does not give you a tool for this. You have to track it yourself:
+
+  1. Pull your credit reports from annualcreditreport.com and list every Citi account with its open date
+  2. Add closed Citi accounts, which stay on your report for up to 10 years
+  3. For each, estimate the bonus post date (usually 1 to 2 statement cycles after account opening)
+  4. Anything with a bonus that posted inside 48 months is ineligible
+
+  If you are close to the line, wait. A bonus denied for a 48-month violation is not recoverable through the reconsideration line.
+
+  ## How Citi Treats Inquiries
+
+  Separate from the written rules, Citi is meaningfully inquiry-sensitive. Community data points consistently show approval odds falling off with six or more inquiries in the past six months, regardless of score.
+
+  Citi pulls a single bureau in most states, and which one varies by region. Equifax is the most common, with Experian in some markets. This matters if you keep your reports frozen, which you should. See our guide to [credit freezes and applications](/articles/credit-freeze-and-applications) for the per-issuer thaw list.
+
+  ## What Citi Does Not Have
+
+  Worth stating clearly, because these myths circulate:
+
+  - **No 5/24 equivalent.** Citi does not care how many cards you have opened at other issuers. Being at 8/24 does not auto-decline you at Citi.
+  - **No hard cap on total Citi cards.** There is no "maximum 5 cards" rule. Citi limits total credit extended, not card count. If you are denied for having too much credit with them, you can often reallocate a limit from an existing card and get approved on reconsideration.
+  - **No 24-month rule.** The old 24-month bonus language was replaced by the 48-month rule years ago. Anyone citing 24 months is working from stale information.
+
+  ## Citi Lineup Notes for 2026
+
+  A few products have changed in ways that affect planning:
+
+  - **Custom Cash is closed to new applications** as of May 2026. If you already hold one, it keeps working. If you were planning a [multiple Custom Cash strategy](/articles/multiple-citi-custom-cash-cards), that door is shut for new applicants.
+  - **Strata Elite** is Citi's premium entry and carries its own 48-month clock, independent of Strata Premier.
+  - **Costco Anywhere Visa** behaves as its own product for bonus purposes and is not part of the ThankYou ecosystem.
+
+  ## Reconsideration at Citi
+
+  Citi's reconsideration line is one of the more productive ones. If you are denied for a reason that is not a hard rule violation, calling is worth it.
+
+  What works:
+
+  - **Too much credit extended**: Offer to move a limit from an existing Citi card to the new one. This is the single most effective Citi recon script.
+  - **Too many recent inquiries**: Explain what the inquiries were for. Rate shopping and a mortgage are sympathetic. Six card applications are not.
+  - **Unable to verify information**: Usually an address or income mismatch. Easy fix on the phone.
+
+  What does not work: asking for a 1/8 or 2/65 override, or asking for a bonus you are not eligible for under the 48-month rule. Those are coded into the system.
+
+  See our [reconsideration guide](/articles/credit-card-denied-reconsideration) for full scripts.
+
+  ## FAQ
+
+  ### Does the 1/8 rule count applications or approvals?
+  Approvals. A denial does not start the 8-day clock. That said, applying repeatedly after denials is a fast way to get flagged for review.
+
+  ### Do Citi business cards count toward 1/8 and 2/65?
+  Yes. Personal and business Citi approvals share the same velocity buckets.
+
+  ### Do Citi cards count toward Chase 5/24?
+  Citi personal cards do, because they report to your personal credit report. CitiBusiness cards do not report to personal credit, so they do not add to your 5/24 count. See [business cards that don't report to personal credit](/articles/business-cards-not-on-personal-credit).
+
+  ### If I close a Citi card, does the 48-month clock reset?
+  No. Closing changes nothing. The clock runs from when the bonus posted.
+
+  ### Can I get approved but not get the bonus?
+  Yes, and this is the most common Citi mistake. Citi will approve the account and simply not pay the bonus. There is no warning during the application.
+
+  ### How do I know if an offer uses the 48-month rule?
+  Read the offer terms on the application page before submitting. The exact language varies by product and by offer, and it is the only place the current rule is stated authoritatively.
+
+  ### Does a product change reset the 48-month clock?
+  A product change does not earn a bonus, so it does not start a clock. But product changing into a card can make you ineligible for that card's bonus later, depending on the offer's terms language. See our [product change guide](/articles/product-change-guide).
+
+  ### Does Citi do a hard pull for a credit limit increase?
+  Requested increases are typically a hard pull at Citi. Automatic increases are not. See [credit limit increases](/articles/credit-limit-increases).
+
+  ### How many Citi cards can I hold at once?
+  There is no published cap. People hold five or more. The binding constraint is total credit extended relative to your income, not the number of accounts.
+
+  ### Is Citi's 2/65 rule strictly enforced?
+  More consistently than most soft rules. Unlike Barclays' velocity guidance, which is fuzzy, 2/65 behaves like a coded rule. Plan around it rather than testing it.
+
+  ## The Bottom Line
+
+  Citi's rules are less punishing than Chase's, but they punish differently. Chase tells you no. Citi says yes and then quietly withholds the reward.
+
+  Three things to do:
+
+  1. **Space Citi applications 8 days apart, and cap yourself at two per 65 days.** These are the approval gates, and they are real.
+  2. **Track your own 48-month bonus history per card.** Citi will not check it for you before taking your inquiry.
+  3. **Read the offer terms on the application page every single time.** The 48-month language varies by product and shifts over time. It is the one source that is never stale.
+
+  Get those three right and Citi is one of the friendlier issuers to build around, with no 5/24-style lockout and a reconsideration line that actually helps.

--- a/data/articles/drafts/coupon-book-credits.yaml
+++ b/data/articles/drafts/coupon-book-credits.yaml
@@ -1,0 +1,188 @@
+id: "coupon-book-credits"
+slug: "coupon-book-credits"
+title: "The Coupon Book Problem: How to Actually Use the Credits on a Premium Card"
+date: "2026-10-29"
+author: "CreditOdds"
+summary: "Premium cards now carry a dozen credits on different clocks. Which reset monthly, quarterly, and semiannually, what enrollment they require, and how to avoid the December scramble."
+tags:
+  - strategy
+  - guide
+related_cards:
+  - the-platinum-card
+  - american-express-gold-card
+  - chase-sapphire-reserve
+  - capital-one-venture-x
+  - citi-strata-elite
+seo_title: "Premium Card Credits: How to Use Them All in 2026 | CreditOdds"
+seo_description: "Amex Platinum, Gold, Sapphire Reserve, Venture X, and Strata Elite credits by reset cadence, with the enrollment steps and deadlines that cause most breakage."
+social_title: "The Coupon Book Problem"
+content: |
+  The premium card business model changed. A decade ago you paid an annual fee for lounge access and a travel credit. Today you pay a much larger fee and receive a dozen separate credits, each with its own merchant, its own reset schedule, and in many cases its own enrollment requirement.
+
+  The Amex Platinum's $895 annual fee is nominally offset by well over $1,500 in stated credit value. That math only works if you actually use them, and the entire product is priced on the assumption that most people will not.
+
+  This is a logistics problem, not a financial one. Here is how to solve it.
+
+  ## Why Credits Go Unused
+
+  Three reasons, in order of how much value they destroy:
+
+  1. **Monthly credits do not roll over.** A $25 monthly credit is twelve separate $25 deadlines, not a $300 annual allowance. Miss March and March is gone.
+  2. **Enrollment is required and is not automatic.** Most Amex credits require you to click an enroll button in your account before they will pay out. Cardholders lose entire years of credits to this.
+  3. **The calendar is invisible.** Nothing in your statement tells you that a semiannual credit expires June 30. You have to know.
+
+  ## Sort Credits by Reset Cadence, Not by Card
+
+  This is the reframe that makes the problem tractable. Group every credit you hold by how often it resets, and manage each group differently.
+
+  ### Monthly credits: automate or lose
+
+  These are the highest-breakage category, because each one is twelve small deadlines.
+
+  | Card | Credit | Amount |
+  |---|---|---|
+  | Amex Platinum | Uber Cash | $15/month ($20 in December) |
+  | Amex Platinum | Digital Entertainment | $25/month |
+  | Amex Platinum | Equinox | $25/month |
+  | Amex Platinum | Walmart+ | Covers the monthly membership |
+  | Amex Platinum | Uber One | Up to $10/month |
+  | Amex Gold | Uber Cash | $10/month |
+  | Amex Gold | Dining Credit | $10/month |
+  | Amex Gold | Dunkin' | Up to $7/month |
+  | Sapphire Reserve | Lyft | Up to $10/month |
+  | Sapphire Reserve | Peloton | Up to $10/month |
+  | Sapphire Reserve | DoorDash | Up to $25/month in promos |
+
+  **The rule for monthly credits: attach them to a recurring charge and never think about them again.** Point your streaming subscriptions at the digital entertainment credit. Let the Walmart+ and Uber One memberships auto-renew on the card. A credit you have to remember is a credit you will miss.
+
+  The ones that resist automation, like the Amex Gold dining credit at a fixed list of merchants, are the ones worth putting a recurring calendar reminder on.
+
+  ### Quarterly credits: four reminders a year
+
+  | Card | Credit | Amount |
+  |---|---|---|
+  | Amex Platinum | Resy dining | Up to $100/quarter |
+  | Amex Platinum | Lululemon | $75/quarter |
+
+  Quarterly credits are the sweet spot for a calendar reminder set for the third week of the last month in each quarter. That gives you a week of runway.
+
+  Note that Amex tightened Resy credit eligibility in August 2026, and eligible restaurants now carry a badge in the Resy app. Check the badge before assuming a reservation qualifies. This is exactly the kind of quiet change that turns a reliable credit into a missed one.
+
+  ### Semiannual credits: the two deadlines people forget
+
+  | Card | Credit | Amount |
+  |---|---|---|
+  | Amex Platinum | Hotel credit (FHR and The Hotel Collection) | Up to $300 per half, $600/year |
+  | Amex Gold | Resy | Up to $50 per half |
+  | Sapphire Reserve | The Edit | Up to $250 per half |
+  | Sapphire Reserve | Dining at Sapphire Exclusive Tables | Up to $150 per half |
+  | Sapphire Reserve | StubHub and viagogo | Up to $150 per half |
+  | Citi Strata Elite | Blacklane | $100 Jan to Jun, $100 Jul to Dec |
+
+  Semiannual credits are the most commonly wasted category among people who otherwise pay attention, because "twice a year" feels like plenty of time until June 29.
+
+  **The two dates that matter are June 30 and December 31.** Put both on your calendar with a two-week lead.
+
+  ### Annual credits: one deadline, larger amounts
+
+  | Card | Credit | Amount |
+  |---|---|---|
+  | Amex Platinum | Airline fee credit (one selected airline) | Annual |
+  | Amex Platinum | CLEAR Plus | Up to $219/year |
+  | Amex Platinum | Oura Ring | Up to $200/year |
+  | Venture X | Travel credit via Capital One Travel | $300/year |
+  | Citi Strata Elite | Hotel credit via cititravel.com | Up to $300/year |
+  | Citi Strata Elite | Splurge credit (choice of brands) | Up to $200/year |
+  | Amex Gold | The Hotel Collection | $100 per stay |
+
+  Two things to watch on annual credits:
+
+  - **Some run on the calendar year and some on your cardmember year.** The Amex airline fee credit is calendar year. The Venture X travel credit is cardmember year. Getting this backwards costs you a full credit.
+  - **The airline fee credit requires selecting an airline**, once per calendar year, in your Amex account. If you never select one, you never get the credit.
+
+  ### Multi-year credits
+
+  Global Entry and TSA PreCheck credits appear on nearly every premium card and reset every four years. Set a reminder when you use one, and note that you can use a different card's credit for a family member's application.
+
+  ## The Enrollment Step
+
+  Worth its own section because it is the single largest source of lost value on Amex products.
+
+  **Most Amex credits do not pay out until you enroll.** Log into your account, find the benefits section, and click enroll on every applicable credit. Do this the day your card arrives and again each January, because some enrollments reset.
+
+  Chase, Capital One, and Citi are generally better about applying credits automatically, but a few still require activation. Check once per card per year.
+
+  ## Building the Calendar
+
+  A workable system, once, in about twenty minutes:
+
+  1. **List every credit you hold** across all your cards, with its amount and cadence
+  2. **Automate every monthly credit** by attaching it to a recurring charge
+  3. **Set four quarterly reminders** for the third week of March, June, September, and December
+  4. **Set two semiannual reminders** for mid-June and mid-December
+  5. **Set one annual reminder** in early January for airline selection and enrollment refreshes
+  6. **Check your issuer's benefits tracker monthly.** Amex and Chase both display credit usage in-app, and that display is authoritative.
+
+  The December reminder is the important one. Mid-December, not late December, because restaurants and hotels book up and a credit you cannot spend is a credit you lose.
+
+  ## The Honest Math
+
+  Here is the part most coverage of premium cards skips.
+
+  **A credit is only worth its face value if you would have made that purchase anyway.** A $25 monthly Equinox credit is worth $300 a year to an Equinox member and worth $0 to everyone else. A $200 Oura Ring credit is worth $200 once, to someone who wants an Oura Ring.
+
+  When you evaluate whether a premium card is worth its fee, do not add up the stated credit values. Add up only the credits you would spend money on regardless. That is usually a substantially smaller number, and it is the real one.
+
+  We work through this calculation properly in [annual fee math](/articles/annual-fee-math). The short version: if the credits you would genuinely use, plus the value of your ongoing earn rate, plus lounge access you would actually visit, does not exceed the fee, the card is not worth keeping regardless of what the marketing totals say.
+
+  ## Before You Cancel Over It
+
+  If the coupon book is more work than it is worth to you, that is a legitimate conclusion. But work through the sequence before closing:
+
+  1. **Let the annual fee post**, then call for a [retention offer](/articles/retention-offers-and-scripts)
+  2. **If declined, ask about a [product change](/articles/product-change-guide)** to a lower-fee card in the same family
+  3. **Close only if neither is available**
+
+  A Platinum downgraded to a Green keeps your account age and credit limit while eliminating the fee and the homework.
+
+  ## FAQ
+
+  ### Do monthly credits roll over?
+  No. Each month is a separate deadline and unused amounts are gone permanently.
+
+  ### Do I have to enroll in Amex credits?
+  Yes, for most of them. Credits do not pay out until you enroll in your online account, and some enrollments reset annually.
+
+  ### Are semiannual credits calendar-based or cardmember-year based?
+  The common semiannual credits run on the calendar, with deadlines of June 30 and December 31. Annual credits vary by card, so check each one.
+
+  ### What happens to unused credits if I downgrade?
+  You lose access to the remainder immediately. Use what you can before a product change takes effect.
+
+  ### Does the airline fee credit cover airfare?
+  No. It covers incidental fees like checked bags, seat selection, and lounge day passes on the one airline you select each calendar year. You have to make the selection in your account.
+
+  ### Can I use a Global Entry credit for someone else?
+  Yes. The credit applies to whatever application fee is charged to the card, including a family member's.
+
+  ### Why did my Resy credit not post?
+  Amex tightened eligibility in August 2026 and eligible venues now carry a badge in the Resy app. Unbadged restaurants may not trigger the credit.
+
+  ### Are the stated credit totals on premium cards realistic?
+  Rarely. They assume you use every credit at every merchant, which almost nobody does. Count only the credits you would spend on anyway.
+
+  ### Which premium card has the least homework?
+  Capital One Venture X, by a wide margin. A single $300 annual travel credit and 10,000 anniversary miles, both simple. It is the least coupon-book premium card in the market.
+
+  ### Do credits count toward minimum spend?
+  The purchase counts toward spend. The statement credit does not reduce it. See [hitting minimum spend](/articles/minimum-spend-strategies).
+
+  ## The Bottom Line
+
+  Premium card credits are worth real money and are structured so that a large share of them expire unused. That is not an accident.
+
+  1. **Sort by cadence, not by card.** Monthly credits get automated, quarterly and semiannual credits get calendar reminders, annual credits get a January checklist.
+  2. **Enroll in everything, then enroll again each January.** This is the largest single source of lost value on Amex products.
+  3. **Value only the credits you would use anyway.** The advertised total is a marketing number. Your number is smaller and it is the one that decides whether to keep the card.
+
+  Set the system up once and the coupon book becomes background noise. Leave it to memory and you will pay a $895 fee for a card that returned you $400.

--- a/data/articles/drafts/credit-freeze-and-applications.yaml
+++ b/data/articles/drafts/credit-freeze-and-applications.yaml
@@ -1,0 +1,171 @@
+id: "credit-freeze-and-applications"
+slug: "credit-freeze-and-applications"
+title: "Credit Freezes and Card Applications: Which Bureau to Thaw for Every Major Issuer"
+date: "2026-09-24"
+author: "CreditOdds"
+summary: "A frozen report is the most common cause of a denial that makes no sense. Which bureau each issuer pulls, how to thaw only what you need, and the timing that avoids delays."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - chase-sapphire-preferred
+  - the-platinum-card
+  - citi-strata-premier
+  - capital-one-venture-rewards
+  - us-bank-cash-plus-visa-signature
+seo_title: "Which Bureau Does Each Card Issuer Pull? 2026 | CreditOdds"
+seo_description: "Which credit bureau Chase, Amex, Citi, Capital One, Barclays, and others pull, and how to thaw the right one before applying without unfreezing everything."
+social_title: "Which Bureau Does Each Issuer Pull?"
+content: |
+  Everyone should keep their credit reports frozen. It is free, it is the single most effective protection against new-account identity fraud, and freezing has no effect on your credit score.
+
+  It does have one cost: if you forget to thaw before applying for a card, the application fails. Sometimes it is a clean "unable to verify" denial. Sometimes it sits in pending for a week. Sometimes it is a hard decline that burns the offer.
+
+  The fix is knowing which of the three bureaus each issuer actually pulls, so you can thaw one instead of all three.
+
+  ## The Issuer Table
+
+  Bureau selection varies by state, by product, and sometimes by applicant. This table reflects the most common pull for each issuer. Treat it as the first place to look, not a guarantee.
+
+  | Issuer | Most common | Also seen |
+  |---|---|---|
+  | **Chase** | Experian | Equifax, TransUnion |
+  | **American Express** | Experian | Equifax |
+  | **Citi** | Equifax | Experian |
+  | **Capital One** | All three | Triple pull is standard |
+  | **Bank of America** | Experian | TransUnion, Equifax |
+  | **Wells Fargo** | Experian | TransUnion, Equifax |
+  | **U.S. Bank** | TransUnion | Experian, Equifax |
+  | **Barclays** | TransUnion | Experian |
+  | **Discover** | TransUnion | Experian, Equifax |
+  | **Synchrony** | TransUnion | Rarely others |
+  | **Comenity (Bread)** | Experian | Equifax |
+  | **Navy Federal** | Equifax | TransUnion |
+  | **Goldman Sachs (Apple Card)** | TransUnion | Experian |
+
+  ### The one that is different: Capital One
+
+  Capital One pulls all three bureaus on nearly every application. There is no thawing strategy for Capital One. If you are applying there, unfreeze everything.
+
+  This is worth planning around. If you are doing several applications in a window and one of them is Capital One, do the Capital One application while all three are thawed and handle the others around it.
+
+  ## How Freezes Actually Work
+
+  A security freeze blocks new lenders from pulling your report. Existing creditors can still see your accounts, and your score is unaffected.
+
+  Freezing and thawing are free by federal law at all three bureaus, and each maintains a self-service portal:
+
+  - **Experian**: experian.com/freeze
+  - **Equifax**: equifax.com/personal/credit-report-services/credit-freeze
+  - **TransUnion**: transunion.com/credit-freeze
+
+  Thaws take effect within minutes online. You do not need to wait a day.
+
+  ### Temporary thaw versus permanent lift
+
+  Every bureau offers both:
+
+  - **Temporary thaw**: lift for a set window, commonly 1 to 7 days, and it refreezes automatically
+  - **Permanent lift**: stays open until you refreeze manually
+
+  Use temporary thaws. The whole point of a freeze is that it is on by default, and a permanent lift you forget to reverse is the same as not having a freeze.
+
+  ## The Timing Sequence
+
+  1. **Check the table above** for the issuer you are applying to
+  2. **Thaw that bureau for a short window**, 1 to 3 days is plenty
+  3. **Apply**
+  4. **If the application pends**, leave the thaw in place until it resolves, since the issuer may pull again during review
+  5. **Let it refreeze automatically**
+
+  If you get an instant "unable to verify your identity" response, the most likely cause is that you thawed the wrong bureau. Thaw a second one and call reconsideration rather than reapplying, which would cost you another inquiry.
+
+  ## The Other Freezes Nobody Mentions
+
+  Three credit bureaus is the well-known part. There are additional consumer reporting agencies that matter for specific applications, and they are the reason some applications fail even with all three thawed.
+
+  ### ChexSystems
+
+  Used for **deposit account** applications, not credit cards. If you are opening a checking account to build a relationship before applying at [U.S. Bank](/articles/us-bank-application-rules) or [Wells Fargo](/articles/wells-fargo-application-rules), a ChexSystems freeze will block it. Freeze and thaw at chexsystems.com.
+
+  ### NCTUE
+
+  The National Consumer Telecom and Utilities Exchange. Used by some issuers and by telecom providers. Comenity has been reported to check it.
+
+  ### Innovis
+
+  A fourth credit bureau, rarely used for card applications but occasionally checked.
+
+  For most card applications you will never encounter these. If you have all three main bureaus thawed and an application still fails identity verification, one of these is a likely culprit.
+
+  ## Why You Should Freeze Anyway
+
+  Given the friction, it is fair to ask whether it is worth it. It is, and the reasoning is simple:
+
+  - **A freeze stops new-account fraud at the source.** Someone with your Social Security number cannot open a card in your name if lenders cannot pull your report.
+  - **It costs nothing and does not affect your score.**
+  - **The inconvenience is about 90 seconds per application**, which is trivial next to the months it takes to clean up a fraudulent account.
+
+  Freezes are strictly better than fraud alerts for this purpose. A fraud alert asks lenders to take extra verification steps. A freeze prevents the pull entirely.
+
+  ## Freezes and Pre-Qualification
+
+  Pre-qualification tools use soft pulls, and soft pulls are generally not blocked by a freeze. In practice, results vary: some issuers' pre-qualification tools return nothing when your reports are frozen.
+
+  If a pre-qualification tool shows you no offers and you have frozen reports, thaw and check again before concluding you do not qualify. See [pre-approval vs pre-qualification](/articles/pre-approval-vs-pre-qualification).
+
+  ## Freezes and Existing Accounts
+
+  A freeze does not affect:
+
+  - Your existing cards, which keep working normally
+  - Automatic credit limit increases, which are soft pulls by your existing creditor
+  - Account review pulls by issuers you already have a relationship with
+  - Your credit score
+
+  It does affect:
+
+  - Requested credit limit increases that use a hard pull, which will fail. See [credit limit increases](/articles/credit-limit-increases).
+  - New account applications of any kind, including auto loans, mortgages, and rentals
+
+  ## FAQ
+
+  ### Does freezing my credit hurt my score?
+  No. A freeze is not visible to scoring models and has no effect whatsoever.
+
+  ### Which bureau does Chase pull?
+  Experian most often, though Equifax and TransUnion both appear regionally. Thaw Experian first.
+
+  ### Do I need to thaw for Capital One?
+  Yes, all three. Capital One pulls every bureau on nearly every application, with no practical way to narrow it.
+
+  ### How long does thawing take?
+  Minutes when done online. There is no need to thaw a day in advance.
+
+  ### Will a frozen report cause a denial or just a delay?
+  Either. Some issuers return an immediate "unable to verify" decline. Others hold the application pending. Both are avoidable.
+
+  ### If I am denied because of a freeze, can I fix it on the phone?
+  Usually yes. Thaw the correct bureau, then call reconsideration and ask them to re-pull. This avoids a second inquiry. See [reconsideration](/articles/credit-card-denied-reconsideration).
+
+  ### Does a hard pull still show up if the report was frozen and then thawed?
+  Yes. Thawing does not hide anything. The inquiry reports normally.
+
+  ### Should I freeze my kids' credit?
+  Yes. Minor credit fraud goes undetected for years because nobody checks. All three bureaus support minor freezes.
+
+  ### Are credit locks the same as freezes?
+  Functionally similar, legally different. Freezes are mandated and free by law. Locks are products offered by the bureaus, sometimes bundled with paid subscriptions. Use freezes.
+
+  ### Do I need to refreeze after each application?
+  If you used a temporary thaw, it refreezes on its own. If you used a permanent lift, you have to refreeze manually, which is the argument for always using temporary thaws.
+
+  ## The Bottom Line
+
+  A freeze is the highest-value free thing you can do for your credit, and the only cost is remembering to thaw.
+
+  1. **Thaw one bureau, not three.** The table above gets you to the right one most of the time.
+  2. **Use temporary thaws with short windows.** A permanent lift you forget about defeats the purpose entirely.
+  3. **Capital One is the exception.** All three, every time.
+
+  If an application ever fails for reasons that make no sense given your credit profile, check your freeze status before you check anything else. It is the most common cause of a denial that has nothing to do with your creditworthiness.

--- a/data/articles/drafts/deferred-interest-store-cards.yaml
+++ b/data/articles/drafts/deferred-interest-store-cards.yaml
@@ -1,0 +1,157 @@
+id: "deferred-interest-store-cards"
+slug: "deferred-interest-store-cards"
+title: "Deferred Interest: Why 'No Interest If Paid In Full' Is Not 0% APR"
+date: "2026-10-08"
+author: "CreditOdds"
+summary: "Store card financing charges you every dollar of back interest if any balance remains at the end. How deferred interest works, what it costs, and how to spot it before you sign."
+tags:
+  - guide
+  - beginner
+related_cards:
+  - amazon-store-card
+  - sams-club-mastercard
+  - playstation-visa
+  - wells-fargo-reflect
+  - citi-diamond-preferred
+seo_title: "Deferred Interest vs 0% APR: What It Really Costs | CreditOdds"
+seo_description: "Deferred interest charges all back interest if any balance remains at the promo end. How it differs from 0% APR, what it costs, and how to avoid the trap."
+social_title: "Deferred Interest Is Not 0% APR"
+content: |
+  You are buying a $2,400 mattress. The store offers 12 months special financing, no interest if paid in full. That sounds like a 0% APR promotion, and every reasonable person reads it that way.
+
+  It is not. It is deferred interest, and the difference costs money in a way that is designed to be invisible at the point of sale.
+
+  ## The Mechanical Difference
+
+  **0% APR** means no interest accrues during the promotional period. If a balance remains at the end, interest starts accruing from that point forward on whatever is left.
+
+  **Deferred interest** means interest accrues from day one, but the charges are held back. If you pay the balance to zero before the promotion ends, the accrued interest is waived. If any balance remains, even one dollar, **every dollar of accrued interest from the original purchase date is added to your account at once.**
+
+  The phrase to look for is "no interest if paid in full." That construction means deferred interest. A true 0% offer says "0% intro APR" and names a period.
+
+  ## What It Actually Costs
+
+  Take the $2,400 mattress on a 12-month deferred interest plan at a 29.99% APR.
+
+  You budget $200 a month. Life happens in month 10 and you pay $50 instead of $200. At month 12, you have paid $2,250 and have $150 left.
+
+  | | Deferred interest | True 0% APR |
+  |---|---|---|
+  | Balance at month 12 | $150 | $150 |
+  | Interest charged | About $390 | $0 |
+  | New balance | About $540 | $150 |
+
+  You missed the deadline by $150 and it cost you roughly $390. The retroactive charge is calculated on the **full original balance** across the entire promotional period, not on the $150 you still owe.
+
+  That asymmetry is the entire product. Get it exactly right and it is free. Miss by any margin and you pay as though the promotion never existed.
+
+  ## Where You Will Encounter It
+
+  Deferred interest is standard on retail credit cards, which are almost all issued by [Synchrony or Comenity](/articles/store-card-approvals-synchrony-comenity). Common venues:
+
+  - Furniture and mattress retailers
+  - Appliance and electronics stores
+  - Jewelry stores
+  - Home improvement retailers
+  - Medical and dental financing, especially Care Credit
+  - Tire and auto service chains
+
+  It also appears on some retailers' installment plans and on financing offered at checkout by third parties.
+
+  ## The Payment Allocation Problem
+
+  Here is the trap within the trap, and the part that catches careful people.
+
+  If your store card has both a promotional balance and a regular purchase balance, federal rules require issuers to apply payments above the minimum to the **highest-APR balance first**. That sounds protective, and usually it is.
+
+  With deferred interest, it works against you. The promotional balance is nominally at 0%, so it is the lowest-rate balance, so your extra payments go to the regular purchases instead. You can be paying aggressively every month and still arrive at the deadline with a promotional balance outstanding.
+
+  There is a partial protection: in the final two billing cycles of a deferred interest promotion, issuers are required to direct excess payments to the promotional balance. That helps, but two cycles is not much runway on a $2,000 balance.
+
+  **The practical rule: never mix regular purchases onto a card carrying a deferred interest balance.** Use the card for the financed purchase and nothing else until it is cleared.
+
+  ## How to Use It Safely
+
+  Deferred interest is not automatically a bad deal. Used precisely, it is genuinely free financing. The requirements are strict:
+
+  1. **Divide the balance by one less than the promotional term.** A 12-month promotion means dividing by 11, so you finish a full month early. That buffer month is the whole safety margin.
+  2. **Set up autopay for that fixed amount**, not for the minimum payment. The minimum payment on these cards is deliberately calibrated to leave a balance at the end.
+  3. **Make no other purchases on that card.** See the allocation problem above.
+  4. **Write down the exact promotion end date.** It is on your statement. It is often not 12 months from purchase, but 12 months from the account opening or the first statement.
+  5. **Check the balance at month 10.** If you are behind, you still have time to correct.
+
+  Do all five and it costs nothing. Skip any one and you are exposed.
+
+  ## The Minimum Payment Is Not Enough
+
+  Worth stating separately because it is the most common failure mode. The minimum payment on a deferred interest plan is frequently calculated so that following it exactly leaves a balance when the promotion expires.
+
+  If you set up autopay for the minimum and assume you are fine, you will very likely trigger the retroactive interest. The minimum payment and the payoff payment are different numbers, and only one of them protects you.
+
+  ## Better Alternatives
+
+  If you need to finance a purchase, there are cleaner instruments:
+
+  ### A true 0% intro APR card
+
+  Real 0% promotional periods run 12 to 21 months on purchases, and if a balance remains at the end you simply start paying interest going forward. No retroactive charge. Cards like Wells Fargo Reflect and Citi Diamond Preferred exist for exactly this.
+
+  The catch is that you need decent credit to be approved, and you need to apply before the purchase. See [balance transfer cards explained](/articles/balance-transfer-cards-explained) for the related mechanics.
+
+  ### A personal loan
+
+  Fixed rate, fixed term, no cliff. Often a lower effective cost than the risk-adjusted cost of deferred interest.
+
+  ### Paying cash
+
+  If the reason you are financing is that you cannot afford the purchase, deferred interest is the worst available way to bridge that gap, because the failure mode is a 30% retroactive charge at precisely the moment your budget was already tight.
+
+  ## If You Already Missed the Deadline
+
+  Not entirely hopeless:
+
+  - **Call and ask for a courtesy waiver.** Both Synchrony and Comenity will sometimes reverse the retroactive interest, particularly for a first occurrence and a small shortfall. Pay the remaining balance to zero first, then call. This works more often than people expect.
+  - **Escalate once if declined.** A supervisor has more authority than a first-line agent.
+  - **If it stands, pay it down fast.** The balance is now at the card's regular APR, which is typically near 30%.
+
+  ## FAQ
+
+  ### What is the difference between deferred interest and 0% APR?
+  0% APR accrues no interest during the promotion. Deferred interest accrues it the whole time and waives it only if you reach zero before the deadline. Miss by a dollar and all of it is charged.
+
+  ### How do I know which one I have?
+  Look at the language. "No interest if paid in full within X months" is deferred interest. "0% intro APR for X months" is a true promotion. The card agreement states it explicitly.
+
+  ### Does making the minimum payment protect me?
+  No. Minimum payments on these plans routinely leave a balance at the deadline. Divide the balance by the term yourself.
+
+  ### What happens if I am one dollar short?
+  You are charged all the interest that accrued on the original balance across the whole promotional period. The size of the shortfall does not matter.
+
+  ### Can I transfer the balance out before the deadline?
+  Yes, and this is a legitimate escape hatch. A balance transfer to a 0% card before the promotion expires clears the promotional balance and avoids the retroactive charge. Factor in the transfer fee.
+
+  ### Does the retroactive interest hurt my credit score?
+  Indirectly. The charge raises your balance, which raises your [utilization](/articles/credit-utilization-explained), which lowers your score. Store cards have low limits, so the effect can be large.
+
+  ### Is deferred interest legal?
+  Yes. It is disclosed, and the disclosures are required. The problem is that the disclosure language reads like a 0% offer to almost everyone.
+
+  ### Why do stores use it instead of 0% APR?
+  Because a meaningful share of customers miss the deadline, and that revenue funds the promotion.
+
+  ### Does Care Credit use deferred interest?
+  Yes, on its standard promotional plans. Medical and dental financing is one of the most common places people encounter it, often at a stressful moment.
+
+  ### Should I ever use deferred interest financing?
+  If you can pay it off with a month to spare, have the cash available, and will not use the card for anything else, it is free money. If any of those three is uncertain, use a true 0% card instead.
+
+  ## The Bottom Line
+
+  Deferred interest is a product that is free if you are precise and expensive if you are approximately right. Most consumer financial products do not have a cliff like that.
+
+  1. **Learn the phrase.** "No interest if paid in full" means deferred interest. "0% intro APR" does not.
+  2. **Divide by one less than the term and autopay that amount.** The minimum payment is designed to leave you short.
+  3. **Never put other purchases on the card.** Payment allocation rules will route your extra payments away from the balance you are trying to clear.
+
+  Used carefully it is genuinely useful financing. The risk is not the interest rate. It is that the penalty for a small mistake is the same as the penalty for a large one.

--- a/data/articles/drafts/minimum-spend-strategies.yaml
+++ b/data/articles/drafts/minimum-spend-strategies.yaml
@@ -1,0 +1,176 @@
+id: "minimum-spend-strategies"
+slug: "minimum-spend-strategies"
+title: "Hitting Minimum Spend: What Counts, What Doesn't, and How to Get There Without Overspending"
+date: "2026-10-15"
+author: "CreditOdds"
+summary: "Welcome bonuses require spend inside a deadline. Which transactions count, which quietly do not, when the clock actually starts, and legitimate ways to close a gap."
+tags:
+  - strategy
+  - guide
+related_cards:
+  - chase-sapphire-preferred
+  - the-platinum-card
+  - citi-strata-premier
+  - capital-one-venture-rewards
+  - chase-ink-business-preferred
+seo_title: "How to Hit Credit Card Minimum Spend Requirements | CreditOdds"
+seo_description: "What counts toward a credit card welcome bonus, what does not, when the spending clock starts, and how to close a gap without wasting money."
+social_title: "Hitting Minimum Spend"
+content: |
+  A welcome bonus is a contract with two terms: spend this much, by this date. Miss either and the bonus does not post, and there is no appeal.
+
+  Most people who miss a minimum spend do not miss it by a lot. They miss it because they misunderstood when the clock started, or because several thousand dollars of what they charged did not count. Both are avoidable.
+
+  ## When the Clock Starts
+
+  This is the most common source of lost bonuses.
+
+  **The window almost always runs from your account opening date, not from when the card arrives in the mail.** A "spend $4,000 in the first 3 months" offer on a card approved March 1 gives you until June 1, even if the card did not reach you until March 12 and you did not activate it until March 20.
+
+  That mailing delay can eat two full weeks of a 90-day window. Two practical responses:
+
+  - **Add the card to a mobile wallet immediately.** Most issuers make the card number available in your online account within a day or two of approval, and Apple Pay or Google Pay provisioning often works before the physical card arrives. Spend starting on day one.
+  - **Check the exact deadline in your account.** Most issuers now display bonus progress and the deadline directly in the app. That display is authoritative. Your mental math is not.
+
+  Some issuers use the first statement date instead of the account opening date. The offer terms specify which. Read them.
+
+  ## What Counts
+
+  Generally, **purchases** count. That means:
+
+  - Ordinary retail and online purchases
+  - Recurring subscriptions and bills charged to the card
+  - Travel bookings
+  - Charitable donations
+  - Tax payments made through an IRS-approved processor (with a fee, discussed below)
+  - Rent, when paid through a service that processes it as a purchase
+
+  ## What Does Not Count
+
+  This list costs people bonuses:
+
+  - **Balance transfers.** Never count.
+  - **Cash advances.** Never count.
+  - **Convenience checks.** Treated as cash advances.
+  - **Fees and interest**, including late fees and foreign transaction fees.
+  - **The annual fee itself**, at most issuers. A handful of issuers do count it. Do not assume.
+  - **Cash-equivalent purchases**: money orders, wire transfers, casino chips, cryptocurrency at most processors.
+  - **Peer-to-peer transfers** through Venmo, Cash App, Zelle, and similar, which typically code as cash advances when funded by a credit card.
+  - **Purchases that are later returned.** A $900 refund reduces your qualifying spend by $900, and this catches people at the end of the window.
+
+  ### The gift card question
+
+  Buying gift cards technically codes as a purchase at most merchants and usually counts. Issuers know this, and some explicitly exclude gift card purchases from bonus qualification in their terms, and some monitor for patterns of it.
+
+  Buying a $50 gift card for a gift is unremarkable. Buying $3,000 of Visa gift cards at a grocery store in one week to close a spending gap is a pattern issuers watch for, and it is a documented cause of bonus denial and account closure. This is the edge of manufactured spend, which is outside the scope of this article and carries real account risk.
+
+  ## Tracking Your Progress
+
+  Do not track this in your head.
+
+  1. **Use the issuer's own tracker.** Chase, Amex, Citi, and Capital One all display bonus progress in-app. This is the number that decides the outcome.
+  2. **If your issuer has no tracker**, add up posted transactions in your statement, not pending ones. Pending transactions are not final and can drop off.
+  3. **Build in a buffer.** Aim to exceed the requirement by 5% or so. A single unexpected return should not put you under.
+  4. **Finish two weeks early.** Transactions can take several days to post, and a purchase made on the last day of the window may post after it closes.
+
+  ## Legitimate Ways to Close a Gap
+
+  If you are genuinely short with time remaining, these are ordinary purchases that happen to be movable in time.
+
+  ### Prepay things you already owe
+
+  - **Insurance premiums.** Switching from monthly to a 6-month or annual payment often carries a discount and creates $600 to $2,000 of spend.
+  - **Utilities**, many of which accept prepayments held as a credit on your account.
+  - **Property taxes**, where the county accepts card payment.
+  - **Annual subscriptions** you currently pay monthly. Most services discount the annual plan.
+  - **Tuition or childcare**, where the provider accepts cards without an outsized fee.
+
+  ### Front-load recurring costs
+
+  - Stock up on non-perishables you will genuinely use
+  - Prepay a dentist or medical bill you know is coming
+  - Buy the flight or hotel for a trip you have already committed to
+
+  ### Pay taxes with a card
+
+  The IRS authorizes third-party processors that accept credit cards for roughly 1.75% to 2%. If you owe estimated taxes anyway, this generates large qualifying spend at a known cost.
+
+  The math: a $4,000 spend requirement met via tax payment at 1.85% costs $74 in fees. If the bonus is worth $900, that is an obvious trade. If you are only closing a $500 gap, the fee is proportionally worse than most alternatives.
+
+  ### Pay rent through a processing service
+
+  Services that pay your landlord by check or ACH while charging your card typically charge around 3%. That is expensive for routine use and reasonable as a one-time bonus-closing tool. Some rent-focused cards handle this natively without a fee.
+
+  ### Cover group expenses
+
+  Put the group dinner, the shared vacation rental, or the team purchase on your card and collect from everyone else. This is genuine spend that would have happened anyway, simply routed through one card. Just note that reimbursement through a peer-to-peer app is fine, while **charging your own card to fund a peer-to-peer transfer is not**, because that codes as a cash advance.
+
+  ## What Not to Do
+
+  ### Do not buy things you would not otherwise buy
+
+  This is the failure that turns a profitable bonus into a loss. A 60,000-point bonus is worth roughly $750. Spending $1,500 on things you did not need to earn it is a bad trade, and it is the most common way people lose money in this hobby.
+
+  If closing the gap requires genuine waste, consider letting the bonus go. The inquiry is spent either way, and the card may still be worth keeping on its ongoing earn rate.
+
+  ### Do not stack multiple minimum spends
+
+  Two cards with $4,000 requirements in overlapping windows means $8,000 in 90 days. Spend on one card does not count toward another card's bonus, ever, including between a personal and business version of the same product.
+
+  Open one card, complete its bonus, then open the next. This is also better for your [application velocity](/articles/velocity-rules-by-issuer).
+
+  ### Do not cut it close on timing
+
+  Posting delays are real. Finish early.
+
+  ## When the Bonus Does Not Post
+
+  If you met the requirement and the bonus has not appeared after two statement cycles:
+
+  1. **Check the issuer's tracker** to see what spend they credited. Sometimes the gap is a transaction you assumed counted.
+  2. **Call and ask them to review**, citing your qualifying transactions by date and amount.
+  3. **Escalate once** if the first agent cannot help.
+
+  Bonuses genuinely do fail to post through processing errors, and a phone call resolves it more often than not. Bonuses that fail because you were not eligible under a [48-month](/articles/citi-application-rules) or [once-per-lifetime](/articles/amex-once-per-lifetime-rule) rule are not recoverable, which is why eligibility should be confirmed before applying, not after.
+
+  ## FAQ
+
+  ### Does the annual fee count toward minimum spend?
+  At most issuers, no. A few count it. Check the offer terms rather than assuming.
+
+  ### Does spending on an authorized user card count?
+  Yes, at nearly every issuer. Adding an authorized user is a legitimate way to consolidate household spend onto the card during the bonus window.
+
+  ### Do returns reduce my qualifying spend?
+  Yes. A refund subtracts from your total, and this catches people who bought heavily and returned some of it near the deadline.
+
+  ### When exactly does the window start?
+  Usually the account opening date. Some issuers use the first statement date. The offer terms and your in-app tracker are authoritative.
+
+  ### Do Venmo, Cash App, or Zelle payments count?
+  Usually not. Funding a peer-to-peer transfer with a credit card typically codes as a cash advance, which never counts and carries immediate interest.
+
+  ### Can I use one card's spend toward another card's bonus?
+  No. Never, including between a personal card and its business counterpart.
+
+  ### Do gift card purchases count?
+  Usually they post as ordinary purchases, but some issuers exclude them in the terms and many monitor for patterns. Small, normal gift card buying is fine. Bulk buying to close a gap carries account risk.
+
+  ### What if I am short by a small amount on the last day?
+  Buy something you actually need, and understand that it may post after the window closes. Purchases made on the final day frequently post too late.
+
+  ### Does paying taxes with a card really work?
+  Yes, through IRS-authorized processors at roughly 1.75% to 2%. It is the cleanest large-spend option if you owe taxes anyway.
+
+  ### Should I take a bonus I cannot hit organically?
+  Usually not. If closing the gap requires buying things you do not need, the bonus is not worth what you would pay for it.
+
+  ## The Bottom Line
+
+  Minimum spend is a deadline problem more than a money problem, and the failures are almost always logistical.
+
+  1. **Start the clock on approval day, not delivery day.** Add the card to a mobile wallet and spend immediately. That recovered fortnight is often the difference.
+  2. **Know what does not count.** Balance transfers, cash advances, peer-to-peer transfers, fees, and returns are where qualifying spend quietly evaporates.
+  3. **Never buy something you would not otherwise buy.** The moment closing the gap costs real money, the bonus has stopped being free.
+
+  Apply for one card at a time, route your existing spending through it, and finish two weeks early. Done that way, minimum spend is a scheduling exercise rather than a financial one.

--- a/data/articles/drafts/product-change-guide.yaml
+++ b/data/articles/drafts/product-change-guide.yaml
@@ -1,0 +1,181 @@
+id: "product-change-guide"
+slug: "product-change-guide"
+title: "Product Changes: How to Downgrade a Card Without Losing Your Account History"
+date: "2026-10-22"
+author: "CreditOdds"
+summary: "A product change swaps your card for a different one without a hard pull, keeping your account age and credit limit. The rules at every major issuer and when to use one."
+tags:
+  - strategy
+  - guide
+related_cards:
+  - chase-sapphire-preferred
+  - chase-freedom-unlimited
+  - the-platinum-card
+  - american-express-green-card
+  - citi-double-cash
+seo_title: "Credit Card Product Change Rules by Issuer 2026 | CreditOdds"
+seo_description: "How to downgrade or product change a credit card at Chase, Amex, Citi, Capital One, and more. No hard pull, keeps account age, and the rules for each issuer."
+social_title: "How Product Changes Work"
+content: |
+  Your annual fee just posted on a card you no longer use enough to justify. The obvious move is to close it. The obvious move is usually wrong.
+
+  A product change converts your existing account into a different card from the same issuer. Same account number in many cases, same open date, same credit limit, no hard inquiry, no new account on your credit report. You stop paying the fee and keep everything the account was doing for your credit profile.
+
+  It is the most underused move in consumer credit, and the rules that govern it are not published anywhere by the issuers themselves.
+
+  ## Why It Beats Closing
+
+  Closing a card costs you three things:
+
+  1. **The credit limit**, which disappears from your total available credit and raises your [utilization](/articles/credit-utilization-explained) on everything else
+  2. **The account's contribution to average age of accounts**, eventually. A closed account in good standing stays on your report for about 10 years, so the loss is delayed rather than immediate, but it does arrive.
+  3. **The relationship**, including any pathway back to that product later
+
+  A product change costs you none of those. The account continues, aged and open, at a different annual fee.
+
+  See [how to close a credit card without tanking your score](/articles/closing-credit-cards-safely) for the cases where closing genuinely is correct.
+
+  ## The Universal Rules
+
+  Three things are true at essentially every issuer:
+
+  - **No hard inquiry.** Product changes do not generate a credit pull. This is the core benefit.
+  - **No new account.** Your report shows the same account, so it does not add to [Chase 5/24](/articles/chase-5-24-rule-explained) or any velocity count.
+  - **No welcome bonus.** You cannot product change into a card and receive its signup bonus. If the bonus is what you want, you have to apply.
+
+  That third point is the main tradeoff, and it is why product changes are a defensive move rather than an acquisitive one.
+
+  ## Rules by Issuer
+
+  | Issuer | Wait after opening | Change scope |
+  |---|---|---|
+  | **Chase** | 12 months | Within the same points family |
+  | **Citi** | 12 months | Broad, most current products |
+  | **American Express** | 12 months typical | Within credit or charge, family dependent |
+  | **Capital One** | 12 months | Narrow, limited paths |
+  | **Bank of America** | 12 months | Reasonably broad |
+  | **Wells Fargo** | 12 months | Within their lineup |
+  | **Barclays** | 12 months | Very narrow, co-brand bound |
+  | **U.S. Bank** | 12 months | Moderate |
+
+  ### Chase
+
+  Chase is the most structured. Changes stay inside a points family:
+
+  - **Sapphire Reserve to Sapphire Preferred to Freedom Unlimited or Freedom Flex.** All Ultimate Rewards products, all interchangeable.
+  - **Ink Business Preferred to Ink Business Cash or Ink Business Unlimited.** Same on the business side.
+  - **Airline and hotel co-brands** can generally only move within their own brand, if at all.
+
+  You cannot cross from a United card to a Sapphire card. The families are walls.
+
+  The classic Chase move is downgrading a Sapphire Preferred to a Freedom Unlimited after the bonus year. You keep the account and its age, you stop paying the annual fee, and you free up Sapphire bonus eligibility for later. Note that Chase's Sapphire bonus rules treat the family as one product, so holding any Sapphire card blocks a new Sapphire bonus.
+
+  ### Citi
+
+  The most permissive of the major issuers. Citi will generally let you change into most currently available products, including across what other issuers would consider family lines. An AAdvantage card into a Double Cash is a standard Citi move.
+
+  Citi's [48-month bonus rule](/articles/citi-application-rules) attaches to the product, so product changing into a card can affect your later bonus eligibility on it depending on the offer's terms language. Check before changing into a card you eventually want the bonus on.
+
+  ### American Express
+
+  Amex distinguishes upgrades from downgrades, and treats them differently:
+
+  - **Upgrades** (Green to Gold, Gold to Platinum) sometimes carry a targeted upgrade offer worth points. Check your account for these before upgrading, because they are real and frequently overlooked.
+  - **Downgrades** (Platinum to Green, Gold to a no-fee Blue product) are straightforward and usually processed on a single phone call or in chat.
+  - **Movement between credit cards and charge cards** is limited but possible, and it has a useful side effect: it can free a slot against Amex's [5-credit-card limit](/articles/amex-application-rules).
+
+  Amex also applies its once-per-lifetime rule to the card you change into. Product changing into a Gold card generally does not consume Gold bonus eligibility, but it also does not grant it, and pop-up behavior afterward is inconsistent.
+
+  ### Capital One
+
+  The most restrictive of the major issuers. Product change paths are narrow, and the answer is often that no change is available for your account. Venture to VentureOne is the standard workable path. Many Capital One cardholders find their only options are closing or keeping.
+
+  ### Barclays
+
+  Narrow, for structural reasons. Barclays' lineup is almost entirely [co-brands](/articles/barclays-application-rules), so there is rarely anywhere to go. A JetBlue Plus can typically become a JetBlue Card. It cannot become a Wyndham card.
+
+  ## When to Product Change
+
+  **Good reasons:**
+
+  - The annual fee no longer clears the value you get. Run the numbers first with [annual fee math](/articles/annual-fee-math).
+  - You want to keep an old account for age and limit but stop paying for it
+  - You want to reset bonus eligibility on a premium card by getting the current one off your account
+  - A no-fee card in the same family earns better on your actual spending
+
+  **Bad reasons:**
+
+  - You want the new card's welcome bonus. You will not get it.
+  - You want a card in a different family. Most issuers will not allow it.
+  - You are trying to escape a fee you can get waived. Try a [retention offer](/articles/retention-offers-and-scripts) first.
+
+  ## The Order of Operations
+
+  When an annual fee posts on a card you are reconsidering, work through this sequence:
+
+  1. **Wait for the fee to post.** Most issuers refund it in full if you act within 30 days of posting, and some allow up to 60. Acting before it posts forfeits the leverage.
+  2. **Call and ask for a retention offer.** Frequently a statement credit or bonus points that make keeping the card worthwhile for another year. This is free to ask and often the best outcome.
+  3. **If retention is declined, ask about product change options.** The same call, the same agent.
+  4. **Only close if there is no product change path**, which mainly happens at Capital One and Barclays.
+
+  Most people skip straight from step 1 to step 4 and give up an account for no reason.
+
+  ## Timing Details That Matter
+
+  - **The 12-month wait is close to universal** and is measured from account opening.
+  - **Changing before the annual fee posts** avoids paying it, but forfeits the retention offer conversation. If the card has real value, the retention offer is usually worth more than the timing convenience.
+  - **After a change, wait before changing again.** Most issuers want another 12 months.
+  - **Points usually transfer with you** inside the same currency family. Ultimate Rewards on a Sapphire Preferred survive a change to a Freedom card. Points on a co-brand generally do not survive a change out of that brand, so transfer or spend them first.
+
+  That last one costs people real value. **Before any product change, check what happens to your existing points balance.** If you are downgrading from a card that earns transferable points to one that does not, move the points out first.
+
+  ## What Happens to Benefits
+
+  A product change takes effect on the new card's terms immediately or at the next statement, depending on the issuer. Things to expect:
+
+  - **Ongoing credits stop.** If you had used $150 of a $300 annual credit, you lose access to the remainder.
+  - **Travel protections change** to whatever the new card carries, which is usually less.
+  - **Authorized users carry over** in most cases.
+  - **A new card number is sometimes issued** and sometimes not, varying by issuer and by product. If it changes, update your recurring charges.
+
+  ## FAQ
+
+  ### Does a product change hurt my credit score?
+  No. There is no hard inquiry and no new account. The credit limit and open date carry over, so the effect is neutral.
+
+  ### Will I get the new card's welcome bonus?
+  No. Product changes never earn welcome bonuses. If the bonus is the goal, apply for the card instead.
+
+  ### Does a product change count toward 5/24?
+  No. It is not a new account.
+
+  ### How long do I have to wait after opening?
+  12 months at essentially every major issuer, measured from account opening.
+
+  ### Can I product change to a card from a different issuer?
+  No. Product changes only happen within one issuer's lineup.
+
+  ### Do my points transfer?
+  Within the same currency family, yes. Ultimate Rewards survive a Sapphire to Freedom change. Co-brand miles generally do not survive a change out of that brand. Move points out first if you are unsure.
+
+  ### Should I product change or ask for a retention offer?
+  Ask for retention first. It is free, it is often generous, and you can still product change on the same call if it is declined.
+
+  ### Can I change back later?
+  Usually, after another 12 months. Do not count on being able to return to a product that has been discontinued in the meantime.
+
+  ### Will I keep my credit limit?
+  Yes, in almost all cases. Occasionally an issuer will adjust a limit when moving to a card with different underwriting, but the default is that it carries over.
+
+  ### Does product changing affect welcome bonus eligibility on that card later?
+  It can. Citi's 48-month language and Amex's once-per-lifetime rule both attach to the product, and how a product change interacts with them varies by offer. Check the terms of any offer you are eventually hoping to claim.
+
+  ## The Bottom Line
+
+  Closing a card is a permanent decision made to solve a temporary problem, which is that the annual fee stopped being worth it.
+
+  1. **Let the fee post, then call.** Retention offer first, product change second, closing only as a last resort.
+  2. **No hard pull, no new account, no lost history.** That combination makes a product change strictly better than closing whenever a path exists.
+  3. **Move your points out first** if you are leaving a currency behind. This is the one irreversible mistake in an otherwise reversible process.
+
+  Every issuer except Capital One and Barclays has usable downgrade paths. Most people never ask about them.

--- a/data/articles/drafts/store-card-approvals-synchrony-comenity.yaml
+++ b/data/articles/drafts/store-card-approvals-synchrony-comenity.yaml
@@ -1,0 +1,165 @@
+id: "store-card-approvals-synchrony-comenity"
+slug: "store-card-approvals-synchrony-comenity"
+title: "Store Card Approvals: How Synchrony and Comenity Actually Decide, and Which Bureau They Pull"
+date: "2026-09-10"
+author: "CreditOdds"
+summary: "Nearly every store card comes from Synchrony or Comenity. Which bureau each pulls, why approvals feel random, how store cards hit 5/24, and when they are worth an inquiry."
+tags:
+  - guide
+  - beginner
+related_cards:
+  - amazon-store-card
+  - sams-club-mastercard
+  - venmo-credit-card
+  - paypal-cashback-mastercard
+  - playstation-visa
+seo_title: "Synchrony and Comenity Store Card Approvals 2026 | CreditOdds"
+seo_description: "Synchrony pulls TransUnion, Comenity pulls Experian. How store card approvals really work, what limits to expect, and how they affect Chase 5/24."
+social_title: "How Store Card Approvals Work"
+content: |
+  When a cashier asks if you want to save 20% today, the card behind that offer is almost certainly issued by one of two banks. Synchrony and Comenity issue the overwhelming majority of retail credit cards in the United States, several hundred programs between them.
+
+  This is useful, because it means you do not need to research a hundred different store cards. You need to know how two banks make decisions.
+
+  ## The Single Most Useful Fact
+
+  | Issuer | Bureau pulled |
+  |---|---|
+  | **Synchrony** | TransUnion, nearly exclusively |
+  | **Comenity** | Experian primarily, Equifax sometimes |
+
+  Synchrony's reliance on TransUnion is close to absolute. Other bureau pulls exist but are rare enough to plan around. Comenity is less consistent, with Experian most common and Equifax appearing regularly enough that you should not assume.
+
+  Two consequences:
+
+  1. **If you freeze your reports**, thaw TransUnion for Synchrony and Experian for Comenity. A frozen report is the most common cause of a store card denial that "makes no sense." See [credit freezes and applications](/articles/credit-freeze-and-applications).
+  2. **If one bureau is weaker than the others**, you can steer. Someone with a clean TransUnion and a messy Experian will do noticeably better at Synchrony.
+
+  ## Who Issues What
+
+  Not exhaustive, but enough to recognize the pattern:
+
+  - **Synchrony**: Amazon Store Card, Sam's Club, PayPal, Venmo, Lowe's, TJX, Care Credit, Old Navy and the Gap brands, JCPenney, Belk, Ashley, Discount Tire
+  - **Comenity (Bread Financial)**: Victoria's Secret, Ulta, Torrid, Big Lots, AAA co-brands, PlayStation Visa, Wayfair, IKEA, Zales
+
+  Programs move between issuers periodically. If it matters for a freeze, check the card's terms page, which names the issuing bank.
+
+  ## Why Approvals Feel Random
+
+  Store card underwriting is genuinely different from major-issuer underwriting, and understanding why explains most of the confusion.
+
+  ### They approve much lower scores
+
+  Both banks approve in the low 600s routinely, and sometimes below. Retail partners want cardholders, and the economics work differently: high APRs and deferred interest subsidize higher default rates. A profile that Chase would decline instantly gets approved at Synchrony.
+
+  ### They start you small
+
+  Initial limits of $300 to $1,500 are typical, even for strong profiles. This is not a judgment on your credit. It is the product design. Limits grow, often quickly and often automatically.
+
+  ### They care about the relationship with that retailer
+
+  Both issuers weight your history with the specific merchant. Existing customers, especially ones with a loyalty account tied to the same identity, are approved at higher rates.
+
+  ### Store-only versus network versions
+
+  Many programs have two tiers: a closed-loop card usable only at that retailer, and a Visa or Mastercard version usable anywhere. The closed-loop version has looser underwriting. If you are declined for the network version, you are often auto-approved for the store-only one, sometimes in the same application flow.
+
+  ## The 5/24 Problem
+
+  This is the part that costs people real money.
+
+  **Store cards count toward [Chase 5/24](/articles/chase-5-24-rule-explained).** A $600 limit card you opened for a one-time 20% discount consumes one of five slots for two full years, and those slots are worth tens of thousands of points if you were planning Chase applications.
+
+  The math is worth stating plainly. A 20% discount on a $200 purchase saves $40. A Chase Sapphire Preferred bonus is worth several hundred dollars. If opening the store card pushes you to 5/24 and blocks that application, the discount cost you an order of magnitude more than it saved.
+
+  Store cards also count toward [Barclays' 6/24 threshold](/articles/barclays-application-rules) and factor into every issuer's velocity assessment.
+
+  ## The Deferred Interest Trap
+
+  Most store cards offer "no interest if paid in full within 12 months" promotions. This is not the same as 0% APR, and the difference is expensive. If any balance remains at the end of the promotional period, you are charged all the interest that accrued from the original purchase date, at rates typically approaching 30%.
+
+  We cover the mechanics in detail in [deferred interest store cards](/articles/deferred-interest-store-cards). If you are opening a store card for a financed purchase, read that first.
+
+  ## Credit Limit Increases
+
+  This is where store cards are genuinely good.
+
+  - **Synchrony** offers soft-pull increase requests through their online portal on most cards. They also grant automatic increases frequently, often every six months, and they can be large.
+  - **Comenity** offers soft-pull requests on many programs through their account portal, with similar automatic increase behavior.
+
+  For someone rebuilding credit, this is meaningful. A card that starts at $500 and reaches $5,000 in two years without a single hard inquiry does real work on your [utilization](/articles/credit-utilization-explained).
+
+  See [credit limit increases](/articles/credit-limit-increases) for the general playbook.
+
+  ## Inactivity Closures
+
+  Both issuers close inactive accounts more aggressively than major banks. Six to twelve months of no activity can trigger closure, sometimes without notice.
+
+  If you are keeping a store card open for account age or utilization, put a small recurring charge on it. A single transaction every few months is enough.
+
+  Note that a closed account still counts toward 5/24 for the full 24 months from opening. Closing it does not recover the slot.
+
+  ## When a Store Card Is Actually Worth It
+
+  There are real cases:
+
+  - **You are building or rebuilding credit.** Approval odds are high, the soft-pull limit increases are generous, and the 5/24 cost is irrelevant because you are not applying for Chase cards yet. See [best first credit card with no credit history](/articles/best-first-credit-card-no-history).
+  - **You genuinely shop there constantly.** A 5% back card at a store where you spend $3,000 a year returns $150 annually, which beats most general-purpose cards on that spend.
+  - **The signup discount is large and the purchase is large.** 20% off a $2,000 furniture purchase is $400, which changes the calculus entirely.
+
+  And the cases where it is not:
+
+  - You are under 5/24 and planning Chase applications
+  - You are opening it for a discount under $100
+  - You are financing a purchase you cannot pay off within the promotional window
+
+  ## Pre-Qualification
+
+  Both issuers offer pre-qualification, and unlike some major-issuer tools, these are reasonably predictive because the underwriting is more mechanical.
+
+  - Synchrony runs pre-qualification for many programs on the retailer's site
+  - Comenity offers it on their own portal for a subset of programs
+
+  Both are soft pulls. If you are unsure, use them. See [pre-approval vs pre-qualification](/articles/pre-approval-vs-pre-qualification).
+
+  ## FAQ
+
+  ### Which bureau does Synchrony pull?
+  TransUnion, in nearly all cases. Other bureaus appear rarely.
+
+  ### Which bureau does Comenity pull?
+  Experian most often, Equifax with some regularity. Less predictable than Synchrony.
+
+  ### Do store cards count toward Chase 5/24?
+  Yes. This is the most commonly overlooked cost of opening one.
+
+  ### Do store cards help or hurt my credit score?
+  Both. They add an account and a credit limit, which helps utilization over time. They also add a hard inquiry and lower your average account age in the short term. Net positive after about a year if you keep it open and unused.
+
+  ### Why was I approved for the store card but not the Visa version?
+  The closed-loop card has looser underwriting. Many applications automatically fall back to it when the network version is declined.
+
+  ### Can I get a store card with a 600 credit score?
+  Frequently, yes. Both issuers approve in the low 600s and sometimes below, which is why store cards are a common rebuilding tool.
+
+  ### How do I raise a low store card limit?
+  Use the issuer's online soft-pull increase request after six months of on-time payments. Both Synchrony and Comenity offer this on most programs.
+
+  ### Will they close my card if I stop using it?
+  Likely, after six to twelve months of inactivity. A small recurring charge prevents it.
+
+  ### Is "no interest for 12 months" the same as 0% APR?
+  No, and the difference matters. Store cards typically use deferred interest, which charges you all the back interest if any balance remains at the end. See [deferred interest store cards](/articles/deferred-interest-store-cards).
+
+  ### Should I close old store cards?
+  Usually not, if there is no annual fee. Closing costs you the credit limit and eventually the account age. See [how to close a credit card without tanking your score](/articles/closing-credit-cards-safely).
+
+  ## The Bottom Line
+
+  Store cards are not bad products. They are products with a cost that is invisible at the register.
+
+  1. **Know which bureau you are dealing with.** Synchrony is TransUnion, Comenity is Experian. That one fact resolves most unexplained denials.
+  2. **Price the 5/24 slot before you accept the discount.** If you are building toward Chase applications, a $40 savings can cost you a $900 bonus.
+  3. **If you do open one, use the soft-pull limit increases.** They are the best feature of these cards and almost nobody uses them.
+
+  For someone with a thin or damaged file, a store card is one of the easiest approvals available and one of the fastest ways to build a real credit limit. For someone optimizing rewards, it is usually the most expensive $40 they will ever save.

--- a/data/articles/drafts/us-bank-application-rules.yaml
+++ b/data/articles/drafts/us-bank-application-rules.yaml
@@ -1,0 +1,159 @@
+id: "us-bank-application-rules"
+slug: "us-bank-application-rules"
+title: "U.S. Bank Application Rules: Why Approvals Depend on Your Relationship, Not a Velocity Cap"
+date: "2026-08-20"
+author: "CreditOdds"
+summary: "U.S. Bank has no published 5/24-style rule, but it is one of the harder issuers to get approved by. How total credit exposure, deposit relationships, and the 5/12 pattern work."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - us-bank-altitude-reserve-visa-infinite
+  - us-bank-cash-plus-visa-signature
+  - us-bank-smartly-visa-signature
+  - us-bank-altitude-go-visa-signature
+  - us-bank-shield
+seo_title: "U.S. Bank Credit Card Application Rules 2026 | CreditOdds"
+seo_description: "U.S. Bank has no hard velocity rule but tight underwriting. How total credit exposure, the 5/12 pattern, and a deposit relationship drive approvals."
+social_title: "How U.S. Bank Actually Approves Cards"
+content: |
+  U.S. Bank is the issuer that breaks the usual framework. There is no 5/24. There is no 2/3/4. There is no 1/8. Ask what U.S. Bank's application rule is and the honest answer is that they do not really have one in the sense that Chase or Citi does.
+
+  What they have instead is a genuinely conservative underwriting model that cares about two things most other issuers weight lightly: how much total credit they have already extended to you, and whether you have any relationship with the bank at all.
+
+  That makes U.S. Bank harder to plan around than an issuer with a hard rule. A rule you can count against. A judgment call you have to influence.
+
+  ## What U.S. Bank Does Not Have
+
+  Clearing the myths first, because a lot of stale content says otherwise:
+
+  - **No 5/24 rule.** Accounts you opened at other issuers do not auto-decline you.
+  - **No published velocity cap.** There is no official "one card per six months" policy.
+  - **No hard cap on card count.** People hold four or five U.S. Bank cards.
+  - **No family-based bonus restriction.** Bonus eligibility is per product.
+
+  If you have read that U.S. Bank enforces a "2 in 12" rule, that was community shorthand from several years ago and it was never a coded rule. It described a pattern, not a policy.
+
+  ## The Two Things That Actually Decide It
+
+  ### 1. Total credit already extended
+
+  U.S. Bank underwrites to a total exposure number. Once the sum of your existing U.S. Bank credit limits reaches what their model thinks is appropriate for your income and profile, additional applications get denied, no matter how good your score is.
+
+  This is why the most effective U.S. Bank reconsideration script is not an explanation. It is an offer:
+
+  > "I understand you can't extend additional credit right now. Would you be able to move $5,000 of the limit from my existing Cash+ card to this new account instead?"
+
+  Reallocating an existing limit costs the bank nothing in additional exposure, and it converts a large share of denials into approvals. It is the single highest-value thing to know about applying at U.S. Bank.
+
+  ### 2. Whether you are already a customer
+
+  U.S. Bank is measurably more willing to approve people who bank with them. A checking or savings account, even a small one, changes outcomes. This shows up in data points constantly: identical profiles, one with a deposit account and one without, different results.
+
+  This is most pronounced on the premium end. The Altitude Reserve has historically been difficult or impossible to get without an existing U.S. Bank relationship, and while the requirement is not published, the pattern in approvals is unambiguous.
+
+  The practical move: if U.S. Bank cards are part of your plan, open a checking account 60 to 90 days before you apply. It is a soft pull or no pull, and it materially improves your odds.
+
+  ## The 5/12 Pattern
+
+  U.S. Bank does not have a velocity rule, but they do look at recent account openings, and the pattern people report is a rough sensitivity around five or more new accounts in the past 12 months.
+
+  This is not a coded auto-decline. It is a risk input. Applicants above that threshold get denied more often, get lower limits when approved, and get routed to manual review more frequently.
+
+  Treat it as guidance rather than a wall. Unlike [Chase 5/24](/articles/chase-5-24-rule-explained), being over it does not make an application pointless. It makes it worse odds.
+
+  ## Where to Apply From
+
+  U.S. Bank is one of the few remaining issuers where the application channel matters.
+
+  - **Branch applications** are handled by a banker who can add context and sometimes push a marginal file through. If you have a branch nearby and a borderline profile, this is the better channel.
+  - **Online applications** are more automated and less forgiving.
+  - **Pre-qualification** on the U.S. Bank site is a soft pull and reasonably predictive, more so than most issuers' tools. See [pre-approval vs pre-qualification](/articles/pre-approval-vs-pre-qualification).
+
+  If you do not live near a branch, U.S. Bank's footprint is a real constraint. Some products have historically been restricted or harder to obtain outside their core Midwest and Western markets.
+
+  ## Bonus Eligibility
+
+  U.S. Bank's restriction is simple and unusual: **you generally cannot receive a welcome bonus on a card you currently hold.** There is no long lookback window like Citi's 48 months or Amex's lifetime rule.
+
+  In practice this means:
+
+  - Close a card, wait, and reapply, and you are often bonus eligible again
+  - The commonly reported wait is around 12 months from closure
+  - Terms vary by product and offer, so read the offer page
+
+  This is one of the more permissive bonus structures among major issuers, and it is underused.
+
+  ## The 2026 Lineup, in Flux
+
+  U.S. Bank has been actively reshaping its cards, which affects planning:
+
+  - **Smartly Visa Signature** is now the centerpiece, with earn rates that scale by deposit and investment balances held at U.S. Bank. It is the clearest expression of their relationship-first strategy.
+  - **The Kroger family co-brands converted to Smartly** in May 2026.
+  - **Shopper Cash Rewards was discontinued** in July 2026.
+  - **Cash+** remains the most distinctive product in the lineup, with its rotating 5% category selection. Its category definitions are unusually literal, which we cover in [U.S. Bank Cash+ explained](/articles/us-bank-cash-plus-explained).
+  - **Altitude Reserve** is the premium option, with 3x on mobile wallet spend that remains one of the best broad-category earn rates available.
+
+  ## Business Cards
+
+  U.S. Bank business cards do not report to your personal credit report in good standing, which makes them useful for staying under [Chase 5/24](/articles/chase-5-24-rule-explained). They also do not consume personal-side capacity in the same way.
+
+  U.S. Bank business approvals lean on the same total-exposure logic, and a business deposit relationship helps for the same reason a personal one does.
+
+  ## Which Bureau
+
+  U.S. Bank pulls TransUnion most often, with Experian and Equifax appearing regionally. If you keep your reports frozen, thaw TransUnion first and be prepared to thaw a second. See [credit freezes and applications](/articles/credit-freeze-and-applications).
+
+  ## How to Actually Get Approved
+
+  A sequence that works, in order:
+
+  1. **Open a U.S. Bank checking account** and let it season for 60 to 90 days
+  2. **Check pre-qualification** on their site, which is a soft pull and more honest than most
+  3. **Apply for one card**, not several, and let it season for at least six months
+  4. **If denied, call reconsideration and offer to reallocate a limit** rather than arguing the denial
+  5. **Ask for a limit increase after six months**, which builds the exposure headroom for card two
+
+  This is a slower path than Amex or Capital One. U.S. Bank rewards patience and relationship depth in a way that most issuers no longer do.
+
+  ## FAQ
+
+  ### Does U.S. Bank have a 5/24 rule?
+  No. Accounts opened at other issuers do not trigger an automatic denial. Heavy recent velocity still hurts your odds as a risk factor.
+
+  ### How many U.S. Bank cards can I have?
+  There is no stated cap. The limit is total credit extended relative to your income, not account count.
+
+  ### Do I need a U.S. Bank account to get approved?
+  Not formally, and plenty of people are approved without one. It measurably improves your odds, and for the Altitude Reserve it is close to a practical requirement.
+
+  ### What is the best reconsideration script for U.S. Bank?
+  Offer to move credit from an existing U.S. Bank card to the new one. This addresses the actual denial reason in most cases. See our [reconsideration guide](/articles/credit-card-denied-reconsideration).
+
+  ### Can I get the bonus again on a card I closed?
+  Usually yes, after roughly 12 months. U.S. Bank's restriction is generally about currently holding the card, not a multi-year lookback.
+
+  ### Do U.S. Bank business cards report to personal credit?
+  Not in good standing. They are useful for staying under Chase 5/24.
+
+  ### Is applying in a branch better than online?
+  For borderline profiles, yes. A banker can add context and sometimes escalate. For clean profiles it makes little difference.
+
+  ### Does U.S. Bank do hard pulls for credit limit increases?
+  Requested increases are typically a hard pull. Automatic increases are not.
+
+  ### Why do so many people get denied with good scores?
+  Because U.S. Bank denies on total exposure, not on score. A 780 score with $60,000 of existing U.S. Bank credit gets denied where a 700 score with $0 gets approved.
+
+  ### Does U.S. Bank use pre-approval mailers?
+  Yes, and they are more predictive than their generic pre-qualification tool. A targeted mailer is a strong signal.
+
+  ## The Bottom Line
+
+  U.S. Bank is not a rules issuer. It is a relationship issuer, and it is a genuinely conservative one.
+
+  1. **Stop looking for the velocity rule.** There is not one. Your denial is almost certainly about total credit extended or a thin relationship.
+  2. **Bank with them before you apply.** A seasoned deposit account is the highest-leverage thing you can do, and it costs nothing.
+  3. **On denial, offer to reallocate a limit.** This converts more U.S. Bank denials than any argument you can make.
+
+  Handled that way, U.S. Bank has some of the most distinctive products available, including the 3x mobile wallet earn on Altitude Reserve and the category selection on Cash+. They are just gated behind more patience than most issuers ask for.

--- a/data/articles/drafts/wells-fargo-application-rules.yaml
+++ b/data/articles/drafts/wells-fargo-application-rules.yaml
@@ -1,0 +1,152 @@
+id: "wells-fargo-application-rules"
+slug: "wells-fargo-application-rules"
+title: "Wells Fargo Application Rules: The 1/6 Rule, the 6/24 Myth, and the 48-Month Bonus Clock"
+date: "2026-08-27"
+author: "CreditOdds"
+summary: "Wells Fargo's one-card-per-six-months rule, why the 6/24 rule is contested rather than confirmed, and the 48-month bonus restriction that catches most applicants."
+tags:
+  - guide
+  - strategy
+related_cards:
+  - wells-fargo-active-cash
+  - wells-fargo-autograph
+  - wells-fargo-autograph-journey
+  - wells-fargo-signify-business-cash
+  - bilt-mastercard
+seo_title: "Wells Fargo Card Application Rules 2026 | CreditOdds"
+seo_description: "Wells Fargo's 1/6 rule, the disputed 6/24 rule, and the 48-month bonus clock. What is confirmed, what is community guesswork, and how to sequence applications."
+social_title: "Wells Fargo's Application Rules"
+content: |
+  Wells Fargo is the major issuer with the least reliable public information. Search for their application rules and you will find two articles stating flatly that they enforce a 6/24 rule, and two stating flatly that they do not. Both cite data points. Neither is lying.
+
+  That contradiction is the actual story, and it is worth understanding rather than papering over. Wells Fargo runs a risk model rather than a coded rule set, and a risk model produces inconsistent outcomes on identical inputs. Here is what is confirmed, what is contested, and how to plan when the rules themselves are uncertain.
+
+  ## What Is Confirmed
+
+  | Rule | Status | Effect |
+  |---|---|---|
+  | **1 card per 6 months** | Stated by Wells Fargo | Usually denied, inconsistently enforced |
+  | **48-month bonus rule** | In offer terms | Approved, but no bonus |
+  | **Personal and business separate** | Confirmed by data points | One of each possible in a 6-month window |
+  | **6/24 rule** | Contested | See below |
+
+  ## Rule 1: One Card Per Six Months
+
+  Wells Fargo's own language says they may decline an application if you have opened a Wells Fargo credit card within the previous six months. This is the closest thing they have to a published rule.
+
+  Two things make it less absolute than it sounds:
+
+  - **It is enforced inconsistently.** Approvals inside the six-month window happen, particularly for people with an existing Wells Fargo banking relationship.
+  - **Personal and business cards are separate.** You can be approved for a personal card and a Signify Business Cash in the same six-month window, and this is well documented.
+
+  Plan on six months. Be unsurprised if someone else got through at four.
+
+  ## Rule 2: The 6/24 Question
+
+  Here is the contested one, stated honestly.
+
+  **The claim**: Wells Fargo auto-declines applicants with six or more new personal credit cards opened across all issuers in the past 24 months, functioning like a looser version of [Chase 5/24](/articles/chase-5-24-rule-explained).
+
+  **The evidence for**: A meaningful cluster of denials from applicants above that threshold with otherwise strong profiles, and denial letters citing "too many accounts recently opened."
+
+  **The evidence against**: A meaningful cluster of approvals from applicants well above that threshold, including people at 9/24 and 10/24.
+
+  **The most likely explanation**: Wells Fargo weights recent account velocity heavily as a risk input rather than enforcing a coded cutoff. Six new accounts in 24 months hurts. It does not disqualify. Other factors, especially an existing deposit relationship, can outweigh it.
+
+  What this means practically: do not skip a Wells Fargo application because you are at 7/24. Do lower your expectations, and do not burn the inquiry if the offer is marginal.
+
+  This is genuinely different from Chase, where being over 5/24 makes the application pointless. At Wells Fargo, being over the line makes it a coin flip.
+
+  ## Rule 3: The 48-Month Bonus Clock
+
+  Wells Fargo restricts welcome bonuses on a 48-month lookback for most products. If you received a bonus on a card within the past 48 months, you will not receive it again.
+
+  Exceptions exist and they matter:
+
+  - **Choice Privileges co-brands** have historically used a shorter window, around 15 months
+  - Terms vary by product and by offer, and the application page is the authoritative source
+
+  As with [Citi](/articles/citi-application-rules), Wells Fargo will approve the account and simply not pay the bonus. There is no warning during the application and no reconsideration path afterward.
+
+  ## Inquiry and Velocity Sensitivity
+
+  Beyond the written rules, Wells Fargo weights the last 6 to 12 months of your credit activity heavily. Clusters of inquiries hurt more here than at Amex or Capital One.
+
+  A pattern worth internalizing: at Wells Fargo, **recent activity can override the written rules in both directions.** A clean 12 months can get you approved inside the 6-month window. A messy 6 months can get you denied at 3/24.
+
+  ## The Deposit Relationship
+
+  Like [U.S. Bank](/articles/us-bank-application-rules), Wells Fargo treats existing customers differently. A checking account materially improves outcomes, and it is the most commonly cited factor in approvals that "should not" have happened under the 1/6 rule.
+
+  If Wells Fargo cards are part of a longer plan, open a checking account well ahead of applying.
+
+  ## The 2026 Lineup
+
+  Wells Fargo has narrowed its lineup, and a couple of changes affect planning:
+
+  - **Attune was discontinued** in June 2026
+  - **Autograph and Autograph Journey** are now the core rewards products, and Autograph Journey is the one with transferable points
+  - **Active Cash** remains one of the strongest flat-rate 2% cards with no annual fee
+  - **The Bilt Mastercard** is issued by Wells Fargo, which means it counts toward Wells Fargo's internal velocity considerations even though most people think of it as a Bilt product
+
+  That last point catches people. If you opened a Bilt Mastercard four months ago, you are inside Wells Fargo's 1/6 window.
+
+  ## Business Cards
+
+  Wells Fargo business cards do not report to your personal credit report in good standing, so they do not add to your [5/24 count](/articles/chase-5-24-rule-explained). They also run on a separate velocity track from personal cards.
+
+  Signify Business Cash is the main product, and it is a reasonable flat-rate business card for people who want to stay under 5/24 while still opening accounts.
+
+  ## Which Bureau
+
+  Wells Fargo pulls Experian most often, with TransUnion and Equifax appearing regionally. Multiple-bureau pulls are more common here than at most issuers, so if your reports are frozen, plan to thaw more than one. See [credit freezes and applications](/articles/credit-freeze-and-applications).
+
+  ## How to Sequence Wells Fargo
+
+  1. **Open a Wells Fargo checking account** and let it season if you are planning multiple cards
+  2. **Space personal applications six months apart**, and treat exceptions as luck rather than strategy
+  3. **Run one personal and one business card in the same window** if you want to move faster
+  4. **Check the 48-month clock** against your own bonus history before applying
+  5. **Skip the application if you are above 6/24 and the offer is only average**, since the odds are genuinely uncertain and the inquiry is not free
+
+  ## FAQ
+
+  ### Does Wells Fargo have a 5/24 or 6/24 rule?
+  Not as a coded auto-decline. Recent account velocity is a heavily weighted risk input, and applicants above roughly 6/24 are denied more often. Approvals well above that threshold are documented.
+
+  ### Can I get two Wells Fargo cards in six months?
+  One personal and one business, commonly. Two personal cards, occasionally, usually with an existing banking relationship.
+
+  ### Does the Bilt Mastercard count as a Wells Fargo card?
+  Yes. It is issued by Wells Fargo and factors into their internal velocity view.
+
+  ### How long until I can get a bonus again?
+  48 months on most products, measured from when the prior bonus posted. Some co-brands use shorter windows. Read the offer terms.
+
+  ### Do Wells Fargo cards count toward Chase 5/24?
+  Personal cards do. Business cards do not.
+
+  ### Will a denial letter tell me the real reason?
+  Partially. "Too many accounts recently opened" is the most common Wells Fargo denial reason and it is usually accurate. It does not tell you which threshold you crossed, because there may not be a fixed one.
+
+  ### Is reconsideration worth it at Wells Fargo?
+  Less productive than at Citi or Chase. Wells Fargo's recon line has limited authority to override risk-model denials. It is worth one call for a verification or income issue, not for a velocity denial.
+
+  ### Does Wells Fargo do soft-pull credit limit increases?
+  Automatic increases are soft. Requested increases are typically hard pulls. See [credit limit increases](/articles/credit-limit-increases).
+
+  ### Can I product change a Wells Fargo card?
+  Yes, generally after 12 months, within their lineup. See our [product change guide](/articles/product-change-guide).
+
+  ### Why is information about Wells Fargo's rules so inconsistent?
+  Because Wells Fargo runs a risk model rather than a rule set. Sites that report a hard 6/24 rule are describing a pattern as if it were a policy.
+
+  ## The Bottom Line
+
+  Wells Fargo is the issuer where confident advice is usually wrong.
+
+  1. **Treat 1/6 as real and 6/24 as a probability shift, not a wall.** The first is stated policy. The second is a risk weighting that other factors can outweigh.
+  2. **Bank with them.** An existing deposit relationship is the most consistent explanation for approvals that break the pattern.
+  3. **Check the 48-month bonus clock before you apply.** It is the rule most likely to cost you real money, because Wells Fargo approves the card either way.
+
+  The products are worth the trouble. Active Cash is a top-tier no-annual-fee 2% card, and Autograph Journey is a genuinely competitive transferable-points option. You just have to accept more uncertainty at the application step than any other major issuer requires.

--- a/scripts/build-articles.js
+++ b/scripts/build-articles.js
@@ -187,6 +187,31 @@ function buildArticles() {
     process.exit(1);
   }
 
+  // Unlink cross-references to articles that haven't published yet.
+  //
+  // Scheduled articles (data/articles/drafts/) are written as a batch that
+  // cross-links freely, but they publish one at a time over weeks. Until a
+  // target lands in data/articles/, a link to it would 404. Rather than hand-
+  // editing links on each publish, strip any /articles/<slug> link whose slug
+  // isn't in this build, leaving the anchor text in place. Each weekly publish
+  // rebuilds, so inbound links to the new article re-activate on their own.
+  const publishedSlugs = new Set(articles.map(a => a.slug));
+  let unlinked = 0;
+  for (const article of articles) {
+    article.content = article.content.replace(
+      /\[([^\]]+)\]\(\/articles\/([a-z0-9-]+)\)/g,
+      (match, text, slug) => {
+        if (publishedSlugs.has(slug)) return match;
+        unlinked++;
+        console.log(`  Unlinked (not yet published): /articles/${slug} in ${article.slug}`);
+        return text;
+      }
+    );
+  }
+  if (unlinked > 0) {
+    console.log(`\nUnlinked ${unlinked} cross-reference(s) to unpublished articles`);
+  }
+
   // Sort articles by date (newest first)
   articles.sort((a, b) => new Date(b.date) - new Date(a.date));
 


### PR DESCRIPTION
Fills the gaps found in an audit of the 29 live articles. Two groups:

**Completes the per-issuer application-rules franchise.** We had Chase 5/24, Chase pop-up, BofA 2/3/4, Cap One buckets, and Amex once-per-lifetime, but nothing for Citi, Amex velocity, U.S. Bank, Wells Fargo, Barclays, or store cards. These are the highest-intent searches on the site's core topic.

**Seven high-volume evergreen guides** covering AZEO, credit freezes by issuer, sole-proprietor business cards, deferred interest, minimum spend, product changes, and rewards taxability.

## Schedule

All 14 land in `data/articles/drafts/` on a 7-day cadence, promoted by the existing `publish-scheduled-articles` cron:

| Date | Slug |
|---|---|
| 2026-08-06 | citi-application-rules |
| 2026-08-13 | amex-application-rules |
| 2026-08-20 | us-bank-application-rules |
| 2026-08-27 | wells-fargo-application-rules |
| 2026-09-03 | barclays-application-rules |
| 2026-09-10 | store-card-approvals-synchrony-comenity |
| 2026-09-17 | azeo-explained |
| 2026-09-24 | credit-freeze-and-applications |
| 2026-10-01 | business-card-no-business |
| 2026-10-08 | deferred-interest-store-cards |
| 2026-10-15 | minimum-spend-strategies |
| 2026-10-22 | product-change-guide |
| 2026-10-29 | coupon-book-credits |
| 2026-11-05 | are-credit-card-rewards-taxable |

Ordering is deliberate: the six issuer pieces run as a consecutive series, deferred interest lands before holiday financing, and the credits and taxes pieces land ahead of their seasonal peaks.

## build-articles.js change

The drafts cross-link heavily and the link graph is **cyclic**, so no publish order avoids linking to an article that has not landed yet. 12 links would have 404'd for up to 13 weeks.

`build-articles.js` now strips `/articles/<slug>` links whose target is not in the current build, keeping the anchor text. Each weekly rebuild re-activates inbound links to whatever just published, so it self-heals with no manual intervention, and it protects future scheduled batches.

Verified against three states: baseline (29 live, 0 stripped, so no existing article is affected), first publish (2 stripped in the Citi article), and all 14 published (0 stripped).

## Merge safety

Drafts live under `data/articles/**`, so this fires `build-articles.yml`, but nothing publishes early:

- New-article detection uses `:(glob)data/articles/*.yaml`, which does not cross `/`, so drafts are excluded from social posting.
- `sync-article-images.js` reads `articles.json`, which excludes drafts, so no hero images are generated until each article actually publishes.

## Validation

Schema-valid, no em dashes in user-facing fields, all `related_cards` slugs resolve against cards.json, all internal links resolve, and all 14 markdown tables parse against the custom parser in `ArticleContent.tsx`. About 1,600 words each.

## Follow-ups, not in this PR

- `multiple-citi-custom-cash-cards` is stale now that Custom Cash is closed to new applications. Flagged in two of the new articles.
- `best-no-annual-fee-cashback-2026` predates the Discover/Capital One merger and the Intuit 2% launch.
