### PR TITLE
chore: sync package-lock for the apps/api @firebase/app declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "name": "@creditodds/api",
       "version": "1.0.0",
       "dependencies": {
+        "@firebase/app": "^0.14.13",
         "firebase-admin": "^13.6.0",
         "mysql2": "^3.16.2",
         "serverless-mysql": "^1.5.4",
@@ -37,6 +38,60 @@
       "devDependencies": {
         "dotenv": "^17.2.3",
         "jest": "^26.6.3"
+      }
+    },
+    "apps/api/node_modules/@firebase/app": {
+      "version": "0.14.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.13.tgz",
+      "integrity": "sha512-H89Jeyp31+EZk9GPu6vaeL9mEmoXgM3nASB7UPBYYS/lqAks21mO1BU1dF8NbsVTL6tgGZkGUtiGJgxtDiwHkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "apps/functions": {


### PR DESCRIPTION
Every workflow that runs `npm ci` has failed since #1923 merged at 12:52 UTC today. That is all 19 data-pipeline workflows: build-cards, build-news, build-articles, build-best, sync-datapoints, publish-scheduled-articles, and the rest.

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @firebase/app@0.14.13 from lock file
npm error Missing: @firebase/component@0.7.3 from lock file
npm error Missing: @firebase/logger@0.5.1 from lock file
npm error Missing: @firebase/util@1.15.1 from lock file
```

#1923 was correct about the underlying problem and its fix (declaring `@firebase/app` in `apps/api/package.json` so esbuild can resolve it during SAM builds). The gap is that its note says "apps/api has no lockfile", which is true of that directory but not of the repo: `apps/api` is a workspace of the **root** `package-lock.json`, so adding a dependency there requires regenerating it.

Regenerated with `npm install --package-lock-only`. Purely additive, 55 lines, no deletions: the four `@firebase/*` packages under `apps/api/node_modules`. No other dependency moved.

Verified with `npm ci --dry-run`, which now resolves 1510 packages cleanly.

Found while merging #1925, whose `Build and Deploy Articles` run failed on this. Unrelated to that PR's contents.