### PR TITLE
Auto: IHG One Rewards Premier Business — add DoorDash DashPass benefit

### DIFF
--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -39,6 +39,11 @@ benefits:
     frequency: "per_purchase"
     category: "rewards"
     enrollment_required: false
+  - name: "DoorDash DashPass"
+    description: "One-year complimentary DashPass membership for DoorDash and Caviar with unlimited deliveries and $0 delivery fees on eligible orders, when activated by Dec 31, 2027"
+    frequency: "annual"
+    category: "dining"
+    enrollment_required: true
 tags:
   - hotel
   - travel


### PR DESCRIPTION
Re-cut of #1865 on current `main`. **Closes #1865** once merged — please close that PR.

## Why re-cut

#1865 proposed two benefits. One of them, "Points Purchase Discount", has since landed on `main` via the 2026-08-02 rewards/benefits check, which left that branch conflicted. Only the **DoorDash DashPass** benefit is still new, so this branch carries just that hunk on top of current `main`.

## Verification

Checked against the live Chase page on 2026-08-03 ([apply page](https://creditcards.chase.com/business-credit-cards/IHG/business-premier) → "Partner Benefits" overlay), which reads:

> Get one-year complimentary DashPass, membership for both DoorDash and Caviar, that provides unlimited deliveries with $0 delivery fees and lower service fees on eligible orders. After that, you are automatically enrolled in DashPass at the current monthly rate. Activate by Dec 31, 2027.

Validated with `npm run build:cards` — 199 cards, no errors or warnings.

## Noted, not included

The same overlay lists an **Instacart** benefit that is absent from this card's YAML: a $10 monthly credit (up to $120/yr) plus a complimentary 3-month Instacart+ membership, benefits ending 12/31/27. Left out of this PR because it is a separate data question and sits near the small-benefit threshold — worth a call on whether to add it.