### PR TITLE
Sync package-lock.json with the @firebase/app declaration (unbreaks all npm ci workflows)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "name": "@creditodds/api",
       "version": "1.0.0",
       "dependencies": {
+        "@firebase/app": "^0.14.13",
         "firebase-admin": "^13.6.0",
         "mysql2": "^3.16.2",
         "serverless-mysql": "^1.5.4",
@@ -37,6 +38,60 @@
       "devDependencies": {
         "dotenv": "^17.2.3",
         "jest": "^26.6.3"
+      }
+    },
+    "apps/api/node_modules/@firebase/app": {
+      "version": "0.14.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.13.tgz",
+      "integrity": "sha512-H89Jeyp31+EZk9GPu6vaeL9mEmoXgM3nASB7UPBYYS/lqAks21mO1BU1dF8NbsVTL6tgGZkGUtiGJgxtDiwHkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "apps/functions": {


### PR DESCRIPTION
## Urgent — `main` is currently red for 19 workflows

[#1923](https://github.com/CreditOdds/creditodds/pull/1923) added `@firebase/app` to `apps/api/package.json` to unbreak SAM builds. Its commit note says *"This directory has no lockfile, so transitive versions float"* — but `apps/api` **is** an npm workspace of the root `package-lock.json` (it is in there as `"apps/api"` with `link: true`). So the root lock went out of sync and every workflow running a root `npm ci` now fails:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @firebase/app@0.14.13 from lock file
npm error Missing: @firebase/component@0.7.3 from lock file
npm error Missing: @firebase/logger@0.5.1 from lock file
npm error Missing: @firebase/util@1.15.1 from lock file
```

19 workflows run a root `npm ci`, including `build-cards`, `build-news`, `build-articles`, `build-best`, `refresh-best-pages`, `check-card-pages`, `sync-datapoints`, and `queue-social`.

### Observed impact

`build-cards` last succeeded at 12:47 UTC on `625cc59a` (immediately before #1923) and has failed on every run since. Same story for `build-news` (last green 12:26 UTC). This is the silent-stall failure mode: **card and news YAML merged today is sitting on `main` but has not reached `cards.json`, S3, the CDN, or the DB.** Ten card PRs and four news items are affected.

## The fix

Regenerated with `npm install --package-lock-only`:

- **55 lines, all additions** — the four missing `apps/api/node_modules/@firebase/*` workspace entries
- **No version churn anywhere else** in the tree
- `npm ci --dry-run` resolves cleanly again

## After merging

The stalled data needs a re-run to actually publish — `build-cards` and `build-news` only fire on pushes that touch their paths, so they will not retrigger on their own. Re-run them from the Actions tab, or push any no-op change under `data/cards/` and `data/news/`.