### PR TITLE
Sync root lockfile with apps/api's @firebase/app dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "name": "@creditodds/api",
       "version": "1.0.0",
       "dependencies": {
+        "@firebase/app": "^0.14.13",
         "firebase-admin": "^13.6.0",
         "mysql2": "^3.16.2",
         "serverless-mysql": "^1.5.4",
@@ -37,6 +38,60 @@
       "devDependencies": {
         "dotenv": "^17.2.3",
         "jest": "^26.6.3"
+      }
+    },
+    "apps/api/node_modules/@firebase/app": {
+      "version": "0.14.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.13.tgz",
+      "integrity": "sha512-H89Jeyp31+EZk9GPu6vaeL9mEmoXgM3nASB7UPBYYS/lqAks21mO1BU1dF8NbsVTL6tgGZkGUtiGJgxtDiwHkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "apps/api/node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "apps/functions": {


### PR DESCRIPTION
## The break

PR #1923 added `"@firebase/app": "^0.14.13"` to `apps/api/package.json` to repair SAM builds. `apps/api` is a root workspace (`workspaces: ["apps/*"]`), so its dependencies must be represented in the root `package-lock.json` — and that file was not regenerated. `npm ci` at the repo root has failed ever since:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: @firebase/app@0.14.13 from lock file
npm error Missing: @firebase/component@0.7.3 from lock file
npm error Missing: @firebase/logger@0.5.1 from lock file
npm error Missing: @firebase/util@1.15.1 from lock file
```

## Why it went unnoticed

**Build and Deploy News** and **Build and Deploy Articles** have failed on every push since 12:58 UTC today. **Deploy Frontend** kept passing, because it only fires the Amplify webhook and never runs `npm ci`.

So code kept shipping while the data pipelines feeding it silently stopped. Concretely: `news.json` on the CDN is still the 12:26 UTC build. Anything merged into `data/news/**` or `data/articles/**` since then is live in code but absent from the data the site actually reads. That includes the replacement-card module from #1924, which renders nothing in production right now because `replacement_cards_info` never reached the published `news.json`.

The `apps/api/package.json` comment reasons about that directory as standalone ("This directory has no lockfile, so transitive versions float"), which is true for the SAM build but not for the root `npm ci` that every data workflow runs.

## The fix

Regenerated with `npm install --package-lock-only`. The diff is **purely additive** — 55 insertions, 0 deletions: the four missing `@firebase/*` packages plus the `apps/api` dependency entry. **No existing resolved version changes.**

Verified `npm ci` exits 0 against the new lockfile in a clean isolated tree containing only the root and workspace manifests.

## After merge

Both data workflows should go green on the next push. `build-news.yml` will republish `news.json` with the replacement-card data, at which point #1924 actually appears on the four backfilled articles. If nothing pushes to `data/news/**` soon, that workflow has a `workflow_dispatch` button to force it.