### PR TITLE
ci: build cards.json before the best and articles builds

### DIFF
--- a/.github/workflows/build-articles.yml
+++ b/.github/workflows/build-articles.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # data/cards.json is generated and gitignored (#1599), so it does not
+      # exist in a fresh checkout. build:articles uses it to enrich
+      # related_cards into related_cards_info; without it the enrichment is
+      # silently empty and article pages lose their related-card module.
+      - name: Build cards.json
+        run: npm run build:cards
+
       - name: Build articles.json
         run: npm run build:articles
 

--- a/.github/workflows/build-best.yml
+++ b/.github/workflows/build-best.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # data/cards.json is generated and gitignored (#1599), so it does not
+      # exist in a fresh checkout. build:best resolves every card slug against
+      # it, so without this step every slug fails to resolve and the build exits
+      # 1. build-cards.yml and build-news.yml already do this.
+      - name: Build cards.json
+        run: npm run build:cards
+
       - name: Build best.json
         run: npm run build:best
 

--- a/scripts/build-articles.js
+++ b/scripts/build-articles.js
@@ -122,8 +122,10 @@ function buildArticles() {
 
   const schema = loadSchema();
   const cardsLookup = loadCardsLookup();
+  const cardsLookupEmpty = Object.keys(cardsLookup).length === 0;
   const articles = [];
   const errors = [];
+  let articlesWantingCards = 0;
 
   // Read all YAML files in the articles directory
   const files = fs.readdirSync(ARTICLES_DIR).filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
@@ -156,6 +158,7 @@ function buildArticles() {
 
       // Enrich related_cards with card info
       if (item.related_cards && item.related_cards.length > 0) {
+        articlesWantingCards++;
         item.related_cards_info = item.related_cards
           .filter(slug => cardsLookup[slug])
           .map(slug => ({
@@ -175,6 +178,20 @@ function buildArticles() {
   }
 
   console.log('\n---');
+
+  // cards.json is generated and gitignored, so a workflow that forgets to run
+  // build:cards first still produces a valid-looking articles.json with every
+  // related_cards_info silently empty. That regression shipped unnoticed from
+  // 2026-07-09 to 2026-08-03. Missing cards.json is only tolerable when no
+  // article actually references a card.
+  if (cardsLookupEmpty && articlesWantingCards > 0) {
+    console.error(
+      `\nBuild failed: ${articlesWantingCards} article(s) declare related_cards but ` +
+      `cards.json could not be loaded, so related_cards_info would be empty for all of them.\n` +
+      `Run \`npm run build:cards\` before \`npm run build:articles\`.`
+    );
+    process.exit(1);
+  }
 
   if (errors.length > 0) {
     console.error(`\nValidation failed with ${errors.length} error(s):`);


### PR DESCRIPTION
`data/cards.json` is generated and gitignored (#1599, merged 2026-07-09), so it does not exist in a fresh CI checkout. `build-cards.yml` and `build-news.yml` already run `build:cards` first. **`build-best.yml` and `build-articles.yml` never did.**

## build-best: failing loudly for a month

Last success 2026-07-01. First failure 2026-07-12, three days after #1599. Every run since has died with several hundred lines of:

```
ERROR: Card slug not found in cards.json: chase-sapphire-preferred, ...
```

`build-best.js` warns on the load failure, then hard-errors on every individual slug lookup and exits 1. `best.json` has not been rebuilt or uploaded since July 1.

## build-articles: failing quietly for the same month

This one is the reason the PR is worth reading. `loadCardsLookup()` catches the ENOENT and returns `{}`, so the build **succeeds** while every `related_cards_info` comes out empty. Article pages have been shipping without their related-card module since 2026-07-09, and the only evidence was a single line in the job log:

```
Warning: Could not load cards.json for card lookup: ENOENT: no such file or
directory, open '/home/runner/work/creditodds/creditodds/data/cards.json'
```

That line is present in today's otherwise-green run.

## Changes

1. `build-best.yml`: add a `Build cards.json` step before `build:best`.
2. `build-articles.yml`: same, before `build:articles`.
3. `build-articles.js`: exit 1 when articles declare `related_cards` but the lookup is empty. A silent month-long regression is worse than a failed build. Missing `cards.json` stays tolerable when no article references a card, so this only fires on the case that actually matters.

`post-best-rankings.js` and `post-weekly-top-cards.js` do not read `cards.json`, so their workflows need no change.

## Verification

| Case | Result |
|---|---|
| No `cards.json`, `build:articles` | exits 1 with a message naming the fix |
| No `cards.json`, `build:best` | exits 1 (unchanged, the original bug) |
| With `cards.json`, `build:articles` | exit 0, enriches **29/29** articles |
| With `cards.json`, `build:best` | exit 0, writes all **7** best pages |