### PR TITLE
news: expand AAdvantage Executive refresh with full press release detail

### DIFF
--- a/data/news/2026-08-03-citi-aadvantage-executive-695-refresh.yaml
+++ b/data/news/2026-08-03-citi-aadvantage-executive-695-refresh.yaml
@@ -15,35 +15,69 @@ body: |
   Citi AAdvantage Executive Mastercard is getting a benefits refresh along with a
   higher price. The annual fee goes to **$695** effective **August 23, 2026**, up
   from the **$595** it has carried since the 2023 refresh. American says the
-  updated card carries up to **$2,300** in stated value, and the card is being
-  positioned on Mastercard's World Legend tier.
+  updated card carries up to **$2,300** in stated value, and it is now branded on
+  Mastercard's World Legend tier. The enhanced card becomes available to new
+  cardmembers on **August 23, 2026**.
 
-  ## What is being added
+  ## New credits
 
-  The largest new credit is up to **$500** back annually on eligible American
-  Airlines Vacations purchases. Cardmembers also get up to **$100** back on
-  inflight purchases and eligible Admirals Club purchases.
+  The largest addition is up to **$500** a year back on eligible American
+  Airlines Vacations packages and experiences. A second new credit covers up to
+  **$100** a year on inflight purchases and eligible Admirals Club purchases.
 
-  Two existing perks get bigger. Lyft credits rise to up to **$180** a year, up
-  from **$120**. Bookings through AAdvantage Hotels and AAdvantage Cars now earn
-  **12X** AAdvantage miles instead of **10X**.
+  ## Increased benefits
 
-  The status track also improves. New Loyalty Point milestones let cardmembers
-  earn up to **40,000** bonus Loyalty Points a year toward AAdvantage status,
-  double the previous **20,000** cap.
+  Lyft credits rise to up to **$180** a year, up from **$120**. The structure is
+  a **$15** credit after three eligible rides in a calendar month.
 
-  Two hotel and car partnerships join the card: Omni Hotels and Resorts Champion
-  status with an annual free night reward, and complimentary Avis President's
-  Club status.
+  Bookings through AAdvantage Hotels and AAdvantage Cars now earn **12X**
+  AAdvantage miles, up from **10X**.
 
-  ## What stays
+  The status track doubles. New milestones award **10,000** bonus Loyalty Points
+  at each of **50,000**, **90,000**, **165,000** and **240,000** Loyalty Points
+  in a qualification year, for up to **40,000** bonus Loyalty Points annually.
+  The previous cap was **20,000**.
 
-  Admirals Club membership remains included, covering unlimited lounge visits for
-  the primary cardmember plus up to two guests. American continues to describe it
-  as the only card that bundles Admirals Club membership.
+  ## New partner status
 
-  The announcement does not list any benefits being removed. Cardholders who
-  renew on or after August 23 will pay the new fee, so anyone weighing whether
-  the added credits cover the extra **$100** has until their next renewal date to
-  decide.
+  Omni Hotels and Resorts Champion status, the chain's second highest tier,
+  comes automatically and includes early check-in, late check-out and room
+  upgrades subject to availability, plus one Free Night reward each year after a
+  qualifying stay of two or more consecutive nights.
+
+  Avis President's Club status is complimentary through **August 31, 2028**, and
+  covers car upgrades, expedited service and complimentary additional drivers.
+
+  The Mastercard World Legend tier adds priority reservations at top
+  international restaurants and premium ticketing for global music, theater and
+  sporting events, alongside Mastercard priceless experiences.
+
+  ## What carries over
+
+  Admirals Club membership stays included and is valued by American at up to
+  **$1,400** a year. It covers unlimited visits for the primary cardmember plus
+  up to two guests or immediate family members at more than **100** Admirals Club
+  and partner lounges worldwide. Admirals Club membership rates are also being
+  updated on **August 23, 2026**.
+
+  Earning on everything else is unchanged: **4X** miles on eligible American
+  Airlines purchases, rising to **5X** for the rest of the calendar year once
+  spending passes **$150,000**, and **1X** on all other purchases.
+
+  The existing credits continue: up to **$120** a year on eligible prepaid Avis
+  and Budget rentals, and up to **$120** every four years for Global Entry or TSA
+  PreCheck. So do the free first checked bag for the primary cardmember and up to
+  eight companions on domestic itineraries, priority check-in, airport screening
+  and boarding, and no foreign transaction fees.
+
+  Travel protections stay in place, including trip delay protection, trip
+  cancellation and interruption protection, worldwide car rental insurance and
+  lost baggage protection.
+
+  ## Fees and what is not stated
+
+  Authorized users remain **$175** for up to three, then **$175** for each
+  additional user. The release does not mention a welcome bonus, and it does not
+  list any benefit as being removed or reduced. Cardholders who renew on or after
+  **August 23** will pay the new **$695** fee.
 


### PR DESCRIPTION
Expands the body of `2026-08-03-citi-aadvantage-executive-695-refresh` so the article carries every concrete detail from the official American Airlines newsroom release, which is already the item's `source_url`:

https://news.aa.com/news/news-details/2026/American-Airlines-and-Citi-elevate-premium-travel-with-enhanced-Citi-AAdvantage-Executive-World-Legend-Mastercard-AADV-08/default.aspx

Added since the first version:

- Loyalty Point milestone thresholds (10,000 bonus at each of 50,000 / 90,000 / 165,000 / 240,000, up to 40,000 total)
- Lyft credit structure ($15 after three eligible rides monthly)
- Omni Champion status details (early check-in, late check-out, upgrades, Free Night after a 2+ night stay)
- Avis President's Club terms and its August 31, 2028 end date
- Mastercard World Legend tier perks (restaurant reservations, premium ticketing, priceless experiences)
- Admirals Club stated value up to $1,400, 100+ lounges, and the August 23 membership rate update
- Carried-over earning: 4X American Airlines purchases, 5X past $150,000 calendar-year spend, 1X everything else
- Carried-over credits: $120 prepaid Avis/Budget, $120 Global Entry or TSA PreCheck every four years
- Free first checked bag for the cardmember plus up to eight companions, priority check-in/screening/boarding, no foreign transaction fees
- Travel protections (trip delay, cancellation and interruption, worldwide car rental insurance, lost baggage)
- Authorized user fee ($175 for up to three, then $175 each)
- New-cardmember availability date of August 23, 2026

Also notes explicitly that the release states no welcome bonus and lists no benefits as removed.

Title, summary, tags, slug and source are unchanged. `npm run build:news` passes and there are no em dashes.