### PR TITLE
Reddit product-change backfill: 61 changes, ingestion pipeline, daily routine

### DIFF
--- a/.github/workflows/sync-product-changes.yml
+++ b/.github/workflows/sync-product-changes.yml
@@ -1,0 +1,69 @@
+name: Sync Reddit Product Changes
+
+# Imports human-approved Reddit product-change reports into
+# reddit_product_changes whenever a merge touches data/reddit-product-changes/
+# (i.e. an auto-product-changes-* review PR was accepted). The full directory is
+# sent every run; the Lambda skips source_ids it already holds, so re-runs are
+# safe. Mirrors sync-datapoints.yml.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'data/reddit-product-changes/**'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build import payload
+        run: node scripts/build-product-changes-payload.js
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::953352003729:role/GitHubActions-CreditOdds
+          aws-region: us-east-1
+
+      - name: Import product changes to database
+        run: |
+          aws lambda invoke \
+            --region us-east-1 \
+            --function-name creditodds-import-reddit-product-changes \
+            --payload file://.product-changes-payload.json \
+            --cli-binary-format raw-in-base64-out \
+            response.json
+          echo "Lambda response envelope:"
+          cat response.json
+          # The handler returns an API-Gateway-style envelope {statusCode, body}
+          # where body is a JSON string, so parse both layers.
+          node -e "
+            const fs = require('fs');
+            const r = JSON.parse(fs.readFileSync('response.json', 'utf8'));
+            if (r.statusCode !== 200) { console.error('Import failed with status', r.statusCode); process.exit(1); }
+            const b = JSON.parse(r.body || '{}');
+            console.log('Imported:', b.imported, 'Skipped (already imported):', b.skipped);
+            if ((b.errors || []).length > 0) {
+              console.error('Per-record errors:', JSON.stringify(b.errors, null, 2));
+              process.exit(1);
+            }
+          "

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage/
 .card-page-check-stale.md
 .card-news-work/
 .reddit-dp-work/
+.reddit-pc-work/
 .datapoints-payload.json
 # NB: .github/card-page-check-state.json is deliberately NOT ignored — the
 # consecutive-skip counters only work if they persist across runs.

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ coverage/
 .reddit-dp-work/
 .reddit-pc-work/
 .datapoints-payload.json
+.product-changes-payload.json
 # NB: .github/card-page-check-state.json is deliberately NOT ignored — the
 # consecutive-skip counters only work if they persist across runs.
 # Same for .github/reddit-datapoint-state.json (seen-candidate tracking).

--- a/apps/api/migrations/054_create_reddit_product_changes.sql
+++ b/apps/api/migrations/054_create_reddit_product_changes.sql
@@ -1,0 +1,26 @@
+-- Product changes sourced from r/CreditCards, kept OUT of wallet_card_events.
+-- That table is a member's personal wallet history: user_id means a real
+-- account, and every product_change row there is paired with an actual
+-- user_cards row. Injecting synthetic reporters would leave a landmine for any
+-- future query that forgets the per-user scope, and Reddit rows need
+-- provenance columns (permalink, evidence) that would be null for 100% of real
+-- wallet rows. The card-product-changes endpoint UNIONs the two and reports the
+-- split, so the diagram can stay honest about where each report came from.
+--
+-- source_id carries an optional #N suffix because one post can describe several
+-- hops ("AA Plat -> Mile Up -> Custom Cash"); each hop is its own row, and the
+-- UNIQUE key is what makes re-importing the whole directory idempotent.
+CREATE TABLE reddit_product_changes (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  source_id VARCHAR(64) NOT NULL,
+  old_card_id INT NOT NULL,
+  new_card_id INT NOT NULL,
+  change_month DATE NOT NULL,
+  reason VARCHAR(16) NULL,
+  evidence VARCHAR(500) NULL,
+  permalink VARCHAR(500) NULL,
+  imported_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_reddit_pc_source (source_id),
+  INDEX idx_reddit_pc_old_card (old_card_id),
+  INDEX idx_reddit_pc_new_card (new_card_id)
+);

--- a/apps/api/src/handlers/card-product-changes.js
+++ b/apps/api/src/handlers/card-product-changes.js
@@ -28,46 +28,59 @@ const responseHeaders = {
 const DEFAULT_LIMIT = 6;
 const MAX_LIMIT = 12;
 
-// Both directions in one round trip. INNER JOIN cards on purpose: an edge that
-// points at a card no longer in the catalog can't be rendered or linked, so
-// dropping it here keeps it out of the totals too. old <> new guards against a
-// self-loop, which a malformed client write could otherwise produce.
+// Both directions and both sources in one round trip.
+//
+// Four legs feed a common shape (direction, other card, one row per raw report)
+// and the outer query rolls them up. Member wallet entries and r/CreditCards
+// reports are counted EQUALLY — one report is one report — but each edge also
+// carries the split so the page can say where its numbers came from.
+//
+// INNER JOIN cards on purpose: an edge pointing at a card no longer in the
+// catalog can't be rendered or linked, so dropping it here keeps it out of the
+// totals too. old <> new guards against a self-loop.
 const EDGE_SQL = `
   SELECT
-    'in' AS direction,
-    e.old_card_id AS other_card_id,
+    t.direction,
+    t.other_card_id,
     c.card_name AS other_card_name,
     c.bank AS other_bank,
     c.card_image_link AS other_card_image_link,
     COUNT(*) AS event_count,
-    COUNT(DISTINCT e.user_id) AS user_count,
-    SUM(e.reason = 'forced') AS forced_count,
-    MAX(e.change_date) AS last_change_date
-  FROM wallet_card_events e
-  JOIN cards c ON c.card_id = e.old_card_id
-  WHERE e.event_type = 'product_change'
-    AND e.new_card_id = ?
-    AND e.old_card_id <> e.new_card_id
-  GROUP BY e.old_card_id, c.card_name, c.bank, c.card_image_link
+    SUM(t.is_wallet) AS wallet_count,
+    SUM(1 - t.is_wallet) AS reddit_count,
+    SUM(t.is_forced) AS forced_count,
+    MAX(t.change_date) AS last_change_date
+  FROM (
+    SELECT 'in' AS direction, e.old_card_id AS other_card_id, 1 AS is_wallet,
+           (e.reason = 'forced') AS is_forced, e.change_date
+    FROM wallet_card_events e
+    WHERE e.event_type = 'product_change'
+      AND e.new_card_id = ? AND e.old_card_id <> e.new_card_id
 
-  UNION ALL
+    UNION ALL
 
-  SELECT
-    'out' AS direction,
-    e.new_card_id AS other_card_id,
-    c.card_name AS other_card_name,
-    c.bank AS other_bank,
-    c.card_image_link AS other_card_image_link,
-    COUNT(*) AS event_count,
-    COUNT(DISTINCT e.user_id) AS user_count,
-    SUM(e.reason = 'forced') AS forced_count,
-    MAX(e.change_date) AS last_change_date
-  FROM wallet_card_events e
-  JOIN cards c ON c.card_id = e.new_card_id
-  WHERE e.event_type = 'product_change'
-    AND e.old_card_id = ?
-    AND e.old_card_id <> e.new_card_id
-  GROUP BY e.new_card_id, c.card_name, c.bank, c.card_image_link
+    SELECT 'out', e.new_card_id, 1,
+           (e.reason = 'forced'), e.change_date
+    FROM wallet_card_events e
+    WHERE e.event_type = 'product_change'
+      AND e.old_card_id = ? AND e.old_card_id <> e.new_card_id
+
+    UNION ALL
+
+    SELECT 'in', r.old_card_id, 0,
+           (r.reason = 'forced'), r.change_month
+    FROM reddit_product_changes r
+    WHERE r.new_card_id = ? AND r.old_card_id <> r.new_card_id
+
+    UNION ALL
+
+    SELECT 'out', r.new_card_id, 0,
+           (r.reason = 'forced'), r.change_month
+    FROM reddit_product_changes r
+    WHERE r.old_card_id = ? AND r.old_card_id <> r.new_card_id
+  ) AS t
+  JOIN cards c ON c.card_id = t.other_card_id
+  GROUP BY t.direction, t.other_card_id, c.card_name, c.bank, c.card_image_link
 `;
 
 function toEdge(row, directionTotal) {
@@ -78,9 +91,10 @@ function toEdge(row, directionTotal) {
     bank: row.other_bank,
     card_image_link: row.other_card_image_link || null,
     count,
-    // Distinct wallets behind the count. Equal to `count` except when one
-    // person logged the same change on two copies of the card.
-    users: Number(row.user_count),
+    // Provenance split behind `count`. Kept per-edge rather than only as a
+    // page-level total so a single suspicious edge can be traced to its source.
+    wallet_count: Number(row.wallet_count || 0),
+    reddit_count: Number(row.reddit_count || 0),
     // 'forced' means the issuer moved the cardholder rather than the
     // cardholder choosing to. Worth surfacing: a mostly-forced outbound edge
     // reads very differently from a mostly-voluntary one.
@@ -123,15 +137,15 @@ exports.CardProductChangesHandler = async (event) => {
           ? Math.min(Math.max(limitRaw, 1), MAX_LIMIT)
           : DEFAULT_LIMIT;
 
-        const rows = await mysql.query(EDGE_SQL, [cardId, cardId]);
+        const rows = await mysql.query(EDGE_SQL, [cardId, cardId, cardId, cardId]);
         await mysql.end();
 
         const inRows = rows.filter((r) => r.direction === "in");
         const outRows = rows.filter((r) => r.direction === "out");
 
-        const sumCounts = (rs) => rs.reduce((acc, r) => acc + Number(r.event_count), 0);
-        const inboundTotal = sumCounts(inRows);
-        const outboundTotal = sumCounts(outRows);
+        const sumBy = (rs, col) => rs.reduce((acc, r) => acc + Number(r[col] || 0), 0);
+        const inboundTotal = sumBy(inRows, "event_count");
+        const outboundTotal = sumBy(outRows, "event_count");
 
         const rank = (rs, total) =>
           rs
@@ -148,6 +162,12 @@ exports.CardProductChangesHandler = async (event) => {
             outbound: rank(outRows, outboundTotal),
             inbound_total: inboundTotal,
             outbound_total: outboundTotal,
+            // Page-level provenance split across both directions. The card page
+            // renders this as a source line under the diagram, so a reader can
+            // tell member-logged data from r/CreditCards reports without
+            // needing to inspect individual edges.
+            wallet_total: sumBy(inRows, "wallet_count") + sumBy(outRows, "wallet_count"),
+            reddit_total: sumBy(inRows, "reddit_count") + sumBy(outRows, "reddit_count"),
             // Distinct source/destination cards before the top-N slice, so the
             // client can tell whether it is showing the whole picture.
             inbound_edge_count: inRows.length,

--- a/apps/api/src/handlers/import-reddit-product-changes.js
+++ b/apps/api/src/handlers/import-reddit-product-changes.js
@@ -1,0 +1,139 @@
+// Imports human-approved Reddit product-change reports into
+// reddit_product_changes. Invoke-only (no HTTP route):
+// .github/workflows/sync-product-changes.yml calls this with the full contents
+// of data/reddit-product-changes/ after a merge to main.
+//
+// Deliberately mirrors import-reddit-records.js: same trigger contract, same
+// suffix-fuzzy card lookup, same "send the whole directory, skip what exists"
+// idempotency. The differences are the target table and that a row here is an
+// EDGE (two cards) rather than an outcome.
+const mysql = require("../db");
+const yup = require("yup");
+
+// Why the cardholder moved. 'forced' means the issuer initiated it (a product
+// being discontinued, an account converted without asking); 'voluntary' means
+// the cardholder asked. Unstated is the common case and stays null rather than
+// defaulting, because guessing would distort the forced-vs-voluntary read that
+// makes an outbound edge interesting.
+const CHANGE_REASONS = ["voluntary", "forced"];
+
+const importSchema = yup.object().shape({
+  // The #N suffix lets one post contribute several hops
+  // ("AA Plat -> Mile Up -> Custom Cash" is two rows, #1 and #2).
+  source_id: yup.string().matches(/^t[13]_[a-z0-9]+(#\d+)?$/).required(),
+  from_card: yup.string().max(254).required(),
+  to_card: yup.string().max(254).required(),
+  change_month: yup.string().matches(/^\d{4}-(0[1-9]|1[0-2])$/).required(),
+  reason: yup.string().oneOf([...CHANGE_REASONS, null]).nullable(),
+  evidence: yup.string().max(500).nullable(),
+  permalink: yup.string().max(500).nullable(),
+});
+
+// Same suffix-fuzzy card_name matching the sync-cards Lambda uses — the DB may
+// still hold pre-standardization " Card"/" Credit Card" suffixes.
+function buildCardLookup(cards) {
+  const byName = new Map(cards.map((c) => [c.card_name, c]));
+  return function findCard(name) {
+    if (byName.has(name)) return byName.get(name);
+    const suffixes = [" Card", " Credit Card", " card", " credit card"];
+    for (const suffix of suffixes) {
+      if (byName.has(name + suffix)) return byName.get(name + suffix);
+      if (name.endsWith(suffix) && byName.has(name.slice(0, -suffix.length))) {
+        return byName.get(name.slice(0, -suffix.length));
+      }
+    }
+    return null;
+  };
+}
+
+exports.ImportRedditProductChangesHandler = async (event) => {
+  console.info("received:", JSON.stringify({ source: event?.source, changes: event?.changes?.length }));
+
+  if (event?.source !== "github-action" && event?.source !== "manual") {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ message: "Unrecognized trigger; pass {source: 'github-action'|'manual'}" }),
+    };
+  }
+  const changes = Array.isArray(event.changes) ? event.changes : [];
+  if (changes.length === 0) {
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: "No changes in payload", imported: 0, skipped: 0, errors: [] }),
+    };
+  }
+
+  const results = { imported: [], skipped: [], errors: [] };
+
+  try {
+    const cards = await mysql.query("SELECT card_id, card_name FROM cards");
+    const findCard = buildCardLookup(cards);
+
+    const existing = await mysql.query("SELECT source_id FROM reddit_product_changes");
+    const existingIds = new Set(existing.map((r) => r.source_id));
+
+    const currentMonth = new Date().toISOString().slice(0, 7);
+
+    for (const raw of changes) {
+      const label = raw?.source_id || "(no source_id)";
+      try {
+        const value = await importSchema.validate(raw, { stripUnknown: true });
+
+        if (existingIds.has(value.source_id)) {
+          results.skipped.push(value.source_id);
+          continue;
+        }
+        if (value.change_month > currentMonth) {
+          throw new Error("change_month is in the future");
+        }
+
+        const from = findCard(value.from_card);
+        if (!from) throw new Error(`from_card "${value.from_card}" not found in cards table`);
+        const to = findCard(value.to_card);
+        if (!to) throw new Error(`to_card "${value.to_card}" not found in cards table`);
+        if (from.card_id === to.card_id) {
+          throw new Error("from_card and to_card resolve to the same card");
+        }
+
+        await mysql.query("INSERT INTO reddit_product_changes SET ?", {
+          source_id: value.source_id,
+          old_card_id: from.card_id,
+          new_card_id: to.card_id,
+          change_month: new Date(`${value.change_month}-01T00:00:00Z`),
+          reason: value.reason ?? null,
+          evidence: value.evidence ?? null,
+          permalink: value.permalink ?? null,
+        });
+        existingIds.add(value.source_id);
+        results.imported.push(value.source_id);
+      } catch (changeError) {
+        console.error(`Error importing ${label}:`, changeError.message);
+        results.errors.push({ source_id: label, error: changeError.message });
+      }
+    }
+
+    await mysql.end();
+
+    console.log("Import results:", JSON.stringify({
+      imported: results.imported.length,
+      skipped: results.skipped.length,
+      errors: results.errors,
+    }));
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: "Reddit product changes imported",
+        imported: results.imported.length,
+        skipped: results.skipped.length,
+        errors: results.errors,
+      }),
+    };
+  } catch (error) {
+    console.error("Error importing reddit product changes:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: "Error importing reddit product changes", error: error.message }),
+    };
+  }
+};

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -504,6 +504,34 @@ Resources:
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
 
+  ImportRedditProductChangesFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/import-reddit-product-changes.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
+    Properties:
+      # Stable name so sync-product-changes.yml can target it with
+      # `aws lambda invoke --function-name creditodds-import-reddit-product-changes`.
+      FunctionName: creditodds-import-reddit-product-changes
+      Handler: src/handlers/import-reddit-product-changes.ImportRedditProductChangesHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 100
+      # Invoke-only, same contract as ImportRedditRecordsFunction: triggered by
+      # CI (OIDC role) after a data/reddit-product-changes/ merge. No API event.
+      Description: Imports human-approved Reddit product changes into reddit_product_changes (direct-invoke from CI)
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+
   UserWalletFunction:
     Type: AWS::Serverless::Function
     Metadata:

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -233,6 +233,8 @@ interface CardClientProps {
     outbound: ProductChangeNode[];
     inboundTotal: number;
     outboundTotal: number;
+    walletTotal: number;
+    redditTotal: number;
   };
 }
 
@@ -1648,6 +1650,8 @@ export default function CardClient({
                 outbound={productChanges.outbound}
                 inboundTotal={productChanges.inboundTotal}
                 outboundTotal={productChanges.outboundTotal}
+                walletTotal={productChanges.walletTotal}
+                redditTotal={productChanges.redditTotal}
               />
             </section>
           )}

--- a/apps/web-next/src/app/card/[name]/ProductChangeFlow.tsx
+++ b/apps/web-next/src/app/card/[name]/ProductChangeFlow.tsx
@@ -44,6 +44,11 @@ interface ProductChangeFlowProps {
   outbound: ProductChangeNode[];
   inboundTotal: number;
   outboundTotal: number;
+  // Provenance split of the same reports counted in the totals above. Both
+  // sources are weighted equally, so these exist to describe the mix, not to
+  // change the arithmetic.
+  walletTotal: number;
+  redditTotal: number;
 }
 
 function strokeFor(share: number): number {
@@ -204,12 +209,25 @@ export default function ProductChangeFlow({
   outbound,
   inboundTotal,
   outboundTotal,
+  walletTotal,
+  redditTotal,
 }: ProductChangeFlowProps) {
   const height = Math.max(
     columnHeight(inbound.length),
     columnHeight(outbound.length),
     MIN_H,
   );
+
+  const total = inboundTotal + outboundTotal;
+  // Name only the sources actually present. Claiming both when the data is
+  // entirely one of them is the specific way this line could mislead, and the
+  // mix will stay lopsided for a long time.
+  const sourcePhrase =
+    walletTotal > 0 && redditTotal > 0
+      ? ` from CreditOdds member wallets (${walletTotal}) and r/CreditCards (${redditTotal})`
+      : redditTotal > 0
+        ? " sourced from posts on r/CreditCards"
+        : " logged by CreditOdds members in their wallets";
 
   return (
     <div className="pcf">
@@ -287,11 +305,9 @@ export default function ProductChangeFlow({
       </div>
 
       <p className="pcf-note">
-        Based on {inboundTotal + outboundTotal}{" "}
-        {inboundTotal + outboundTotal === 1 ? "product change" : "product changes"}{" "}
-        logged by CreditOdds members in their wallets. Percentages are shares of
-        each direction, not of all cardholders, and a small sample can swing a
-        long way.
+        Based on {total} {total === 1 ? "report" : "reports"}
+        {sourcePhrase}. Percentages are shares of each direction, not of all
+        cardholders, and a small sample can swing a long way.
       </p>
     </div>
   );

--- a/apps/web-next/src/app/card/[name]/page.tsx
+++ b/apps/web-next/src/app/card/[name]/page.tsx
@@ -260,6 +260,8 @@ export default async function CardPage({ params }: CardPageProps) {
       outbound: productChanges.outbound.map(toFlowNode),
       inboundTotal: productChanges.inbound_total,
       outboundTotal: productChanges.outbound_total,
+      walletTotal: productChanges.wallet_total,
+      redditTotal: productChanges.reddit_total,
     };
 
     // Top-3 placements across the /best/* pages — surfaced as social-proof

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1207,7 +1207,11 @@ export interface ProductChangeEdge {
   bank: string;
   card_image_link: string | null;
   count: number;
-  users: number;
+  // Provenance split behind `count`. Member wallet entries and r/CreditCards
+  // reports are weighted equally; the split is kept so the page can say where
+  // its numbers came from.
+  wallet_count: number;
+  reddit_count: number;
   // How many of the moves the cardholder did not choose (issuer-initiated).
   forced: number;
   share: number;
@@ -1222,6 +1226,9 @@ export interface CardProductChanges {
   outbound: ProductChangeEdge[];
   inbound_total: number;
   outbound_total: number;
+  // Page-level provenance totals across both directions.
+  wallet_total: number;
+  reddit_total: number;
   // Distinct partner cards before the top-N slice — greater than the array
   // length when the tail was truncated.
   inbound_edge_count: number;
@@ -1234,6 +1241,8 @@ export const EMPTY_PRODUCT_CHANGES: CardProductChanges = {
   outbound: [],
   inbound_total: 0,
   outbound_total: 0,
+  wallet_total: 0,
+  reddit_total: 0,
   inbound_edge_count: 0,
   outbound_edge_count: 0,
 };

--- a/data/reddit-product-changes/2024-08-t3_1ekoryb.yaml
+++ b/data/reddit-product-changes/2024-08-t3_1ekoryb.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1ekoryb
+permalink: https://www.reddit.com/r/CreditCards/comments/1ekoryb/bofa_product_change_no_ftf/
+posted: "2024-08-05"
+evidence: >-
+  Poster submits a data point that a Travel Rewards to Unlimited Cash Rewards product change kept
+  the no-foreign-transaction-fee benefit, contrary to what the representative told them during the
+  call.
+from_card: Bank of America Travel Rewards
+to_card: Bank of America Unlimited Cash Rewards
+change_month: 2024-08
+reason: voluntary

--- a/data/reddit-product-changes/2024-08-t3_1fa54dk.yaml
+++ b/data/reddit-product-changes/2024-08-t3_1fa54dk.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1fa54dk
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1fa54dk/dont_do_moronic_things_like_i_did_with_the_citi/
+posted: "2024-09-06"
+evidence: >-
+  Poster reports their third household Custom Cash came from product changing a Double Cash opened
+  that May, done after three statement cycles once the signup bonus had posted.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2024-08
+reason: voluntary

--- a/data/reddit-product-changes/2024-09-t3_1f7mog3.yaml
+++ b/data/reddit-product-changes/2024-09-t3_1f7mog3.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1f7mog3
+permalink: https://www.reddit.com/r/CreditCards/comments/1f7mog3/wells_fargo_just_autoconverted_my_ancient/
+posted: "2024-09-03"
+evidence: >-
+  Poster reports Wells Fargo auto-converted their discontinued Platinum card to the discontinued
+  Visa Signature card without their request, and they researched afterwards to work out what the new
+  card was.
+from_card: Wells Fargo Platinum
+to_card: Wells Fargo Visa Signature
+change_month: 2024-09
+reason: forced

--- a/data/reddit-product-changes/2024-09-t3_1f9dx4d.yaml
+++ b/data/reddit-product-changes/2024-09-t3_1f9dx4d.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1f9dx4d
+permalink: https://www.reddit.com/r/CreditCards/comments/1f9dx4d/i_think_i_escaped_the_capone_bucket/
+posted: "2024-09-05"
+evidence: >-
+  Poster says they accidentally product changed their SavorOne into a Quicksilver, having meant to
+  change a different card, while describing their Capital One credit limit history.
+from_card: Capital One SavorOne Cash Rewards
+to_card: Capital One Quicksilver Cash Rewards
+change_month: 2024-09
+reason: voluntary

--- a/data/reddit-product-changes/2024-09-t3_1fz3yxb.yaml
+++ b/data/reddit-product-changes/2024-09-t3_1fz3yxb.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1fz3yxb
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1fz3yxb/denied_chase_sapphire_preferred_in_branch_whenhow/
+posted: "2024-10-08"
+evidence: >-
+  Poster downgraded their Sapphire Reserve to a Freedom Flex two weeks before posting, then was
+  denied a new Sapphire Preferred in branch because Chase still showed a Sapphire-branded account.
+from_card: Chase Sapphire Reserve
+to_card: Chase Freedom Flex
+change_month: 2024-09
+reason: voluntary

--- a/data/reddit-product-changes/2024-10-t3_1gdafk1.yaml
+++ b/data/reddit-product-changes/2024-10-t3_1gdafk1.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1gdafk1
+permalink: https://www.reddit.com/r/CreditCards/comments/1gdafk1/converted_amex_gold_to_green/
+posted: "2024-10-27"
+evidence: >-
+  Poster wanted the Green card's travel multiplier for an upcoming three-month campground booking
+  and converted their Gold rather than applying, since Amex does not allow changes on cards held
+  under a year and the Platinum was too new.
+from_card: American Express Gold
+to_card: American Express Green
+change_month: 2024-10
+reason: voluntary

--- a/data/reddit-product-changes/2024-10-t3_1gevzvp.yaml
+++ b/data/reddit-product-changes/2024-10-t3_1gevzvp.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1gevzvp
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1gevzvp/dp_bank_of_america_product_change_from_travel/
+posted: "2024-10-29"
+evidence: >-
+  Poster called Bank of America to convert a long-held Travel Rewards card into a second Customized
+  Cash Rewards, and confirms the change appeared on the account about ten days later despite already
+  holding a CCR.
+from_card: Bank of America Travel Rewards
+to_card: Bank of America Customized Cash Rewards
+change_month: 2024-10
+reason: voluntary

--- a/data/reddit-product-changes/2024-11-t3_1gsxvh8.yaml
+++ b/data/reddit-product-changes/2024-11-t3_1gsxvh8.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1gsxvh8
+permalink: https://www.reddit.com/r/CreditCards/comments/1gsxvh8/chase_vs_amex_ecosystem/
+posted: "2024-11-16"
+evidence: >-
+  Poster describes holding both Sapphire cards, having been approved for the Preferred directly and
+  then product changed their older Freedom Unlimited into the Reserve.
+from_card: Chase Freedom Unlimited
+to_card: Chase Sapphire Reserve
+change_month: 2024-11
+reason: voluntary

--- a/data/reddit-product-changes/2024-11-t3_1phkewi.yaml
+++ b/data/reddit-product-changes/2024-11-t3_1phkewi.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1phkewi
+permalink: https://www.reddit.com/r/CreditCards/comments/1phkewi/approved_on_my_20th_birthday/
+posted: "2025-12-08"
+evidence: >-
+  Poster's card history lists a QuicksilverOne opened in December 2023 and product changed to a
+  regular Quicksilver in November 2024.
+from_card: Capital One QuicksilverOne Cash Rewards
+to_card: Capital One Quicksilver Cash Rewards
+change_month: 2024-11
+reason: voluntary

--- a/data/reddit-product-changes/2025-01-t3_1lg9vpc.yaml
+++ b/data/reddit-product-changes/2025-01-t3_1lg9vpc.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1lg9vpc
+permalink: https://www.reddit.com/r/CreditCards/comments/1lg9vpc/question_about_citi_aadvantage_sub/
+posted: "2025-06-20"
+evidence: >-
+  Poster opened an AAdvantage Mile Up in November 2024 and product changed it to a second Custom
+  Cash two months later, after collecting the signup bonus.
+from_card: American Airlines AAdvantage MileUp Mastercard
+to_card: Citi Custom Cash
+change_month: 2025-01
+reason: voluntary

--- a/data/reddit-product-changes/2025-02-t3_1iqzpj1.yaml
+++ b/data/reddit-product-changes/2025-02-t3_1iqzpj1.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1iqzpj1
+permalink: https://www.reddit.com/r/CreditCards/comments/1iqzpj1/one_call_making_a_product_change_from_citi/
+posted: "2025-02-16"
+evidence: >-
+  Poster reports completing a product change from the AAdvantage Business card to a Custom Cash in a
+  single call the previous Friday.
+from_card: Citi AAdvantage Business World Elite Mastercard
+to_card: Citi Custom Cash
+change_month: 2025-02
+reason: voluntary

--- a/data/reddit-product-changes/2025-03-t3_1j9qi1a.yaml
+++ b/data/reddit-product-changes/2025-03-t3_1j9qi1a.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1j9qi1a
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1j9qi1a/make_sure_to_use_points_before_product_changing/
+posted: "2025-03-12"
+evidence: >-
+  Poster product changed a Double Cash to a Custom Cash two days before posting, and warns that
+  their ThankYou points went missing until they escalated to a supervisor.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2025-03
+reason: voluntary

--- a/data/reddit-product-changes/2025-03-t3_1jiiak9.yaml
+++ b/data/reddit-product-changes/2025-03-t3_1jiiak9.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1jiiak9
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1jiiak9/pcd_from_capital_one_platinum_to_quicksilverone/
+posted: "2025-03-24"
+evidence: >-
+  Poster product changed the Capital One Platinum they had opened in 2014 as a secured card, and
+  Capital One sent a replacement QuicksilverOne.
+from_card: Capital One Platinum
+to_card: Capital One QuicksilverOne Cash Rewards
+change_month: 2025-03
+reason: voluntary

--- a/data/reddit-product-changes/2025-04-t3_1kdimea.yaml
+++ b/data/reddit-product-changes/2025-04-t3_1kdimea.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1kdimea
+permalink: https://www.reddit.com/r/CreditCards/comments/1kdimea/what_should_be_my_next_card/
+posted: "2025-05-03"
+evidence: >-
+  Poster notes parenthetically that they upgraded their Blue Cash Everyday to the Blue Cash
+  Preferred one month before posting, while asking for next-card recommendations.
+from_card: Blue Cash Everyday
+to_card: Blue Cash Preferred
+change_month: 2025-04
+reason: voluntary

--- a/data/reddit-product-changes/2025-04-t3_1scgm1t.yaml
+++ b/data/reddit-product-changes/2025-04-t3_1scgm1t.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1scgm1t
+permalink: https://www.reddit.com/r/CreditCards/comments/1scgm1t/amex_blue_cash_preferred_prorata_annual_fee/
+posted: "2026-04-04"
+evidence: >-
+  Poster states they upgraded Blue Cash Everyday to Blue Cash Preferred on 2 April 2025, and
+  describes the resulting prorated annual fee.
+from_card: Blue Cash Everyday
+to_card: Blue Cash Preferred
+change_month: 2025-04
+reason: voluntary

--- a/data/reddit-product-changes/2025-05-t3_1knsi4v.yaml
+++ b/data/reddit-product-changes/2025-05-t3_1knsi4v.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1knsi4v
+permalink: https://www.reddit.com/r/CreditCards/comments/1knsi4v/alaska_airlines_visa_signature_downgrade/
+posted: "2025-05-16"
+evidence: >-
+  Poster asked a Bank of America representative to downgrade their Alaska Airlines card to a
+  Customized Cash Rewards card and the rep processed it, with no clawback of the original signup
+  bonus miles.
+from_card: Atmos Rewards Ascent
+to_card: Bank of America Customized Cash Rewards
+change_month: 2025-05
+reason: voluntary

--- a/data/reddit-product-changes/2025-06-t3_1lblt08.yaml
+++ b/data/reddit-product-changes/2025-06-t3_1lblt08.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1lblt08
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1lblt08/question_about_bank_of_america_travel_credit_card/
+posted: "2025-06-14"
+evidence: >-
+  Poster mentions recently product changing from the Premium Rewards card to the Travel Rewards card
+  while asking how point redemptions against older charges post.
+from_card: Bank of America Premium Rewards
+to_card: Bank of America Travel Rewards
+change_month: 2025-06
+reason: voluntary

--- a/data/reddit-product-changes/2025-06-t3_1leobg1.yaml
+++ b/data/reddit-product-changes/2025-06-t3_1leobg1.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1leobg1
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1leobg1/im_not_trying_to_hardcore_optimizations_im_just/
+posted: "2025-06-18"
+evidence: >-
+  Poster called Bank of America to product change their long-held Travel Rewards card to Unlimited
+  Cash Rewards, having concluded the 1% travel return was poor for how much they put on it.
+from_card: Bank of America Travel Rewards
+to_card: Bank of America Unlimited Cash Rewards
+change_month: 2025-06
+reason: voluntary

--- a/data/reddit-product-changes/2025-07-t3_1lr0azj.yaml
+++ b/data/reddit-product-changes/2025-07-t3_1lr0azj.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1lr0azj
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1lr0azj/product_change_from_citi_diamond_preferred_to/
+posted: "2025-07-03"
+evidence: >-
+  Poster used the in-app chat to product change their Diamond Preferred to a Custom Cash, and the
+  representative confirmed no welcome bonus would be given for a conversion.
+from_card: Citi Diamond Preferred
+to_card: Citi Custom Cash
+change_month: 2025-07
+reason: voluntary

--- a/data/reddit-product-changes/2025-07-t3_1lxgx57.yaml
+++ b/data/reddit-product-changes/2025-07-t3_1lxgx57.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1lxgx57
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1lxgx57/question_about_citi_product_change_to_customer/
+posted: "2025-07-11"
+evidence: >-
+  Poster says the replacement card from their Double Cash to Custom Cash change arrived that day,
+  and notes the change was done two to three months into holding the card.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2025-07
+reason: voluntary

--- a/data/reddit-product-changes/2025-07-t3_1m3xn28.yaml
+++ b/data/reddit-product-changes/2025-07-t3_1m3xn28.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1m3xn28
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1m3xn28/dp_citi_double_cash_to_custom_cash_product_change/
+posted: "2025-07-19"
+evidence: >-
+  Poster reports converting a Double Cash to a second Custom Cash after only about five months on
+  the account, contradicting the widely repeated claim that Citi requires a full year.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2025-07
+reason: voluntary

--- a/data/reddit-product-changes/2025-08-t3_1ojegjs.yaml
+++ b/data/reddit-product-changes/2025-08-t3_1ojegjs.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1ojegjs
+permalink: https://www.reddit.com/r/CreditCards/comments/1ojegjs/citi_aa_mile_up_strata_elite_strata_basic/
+posted: "2025-10-29"
+evidence: >-
+  Poster says they currently hold the AA Mile Up card, which they downgraded from the Executive a
+  couple of months before posting.
+from_card: Citi AAdvantage Executive World Elite Mastercard
+to_card: American Airlines AAdvantage MileUp Mastercard
+change_month: 2025-08
+reason: voluntary

--- a/data/reddit-product-changes/2025-10-t3_1nzvxr4.yaml
+++ b/data/reddit-product-changes/2025-10-t3_1nzvxr4.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1nzvxr4
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1nzvxr4/dp_aaa_product_change_daily_travel_comenity_bread/
+posted: "2025-10-06"
+evidence: >-
+  Poster called to product change from the AAA Daily Advantage to the AAA Travel Advantage card, and
+  reports transaction history and rewards balance carried over intact.
+from_card: AAA Daily Advantage Visa Signature
+to_card: AAA Travel Advantage Visa Signature
+change_month: 2025-10
+reason: voluntary

--- a/data/reddit-product-changes/2025-10-t3_1nzwwp0.yaml
+++ b/data/reddit-product-changes/2025-10-t3_1nzwwp0.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1nzwwp0
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1nzwwp0/dp_successful_product_change_citi_strata_premier/
+posted: "2025-10-06"
+evidence: >-
+  Poster reports successfully downgrading their Strata Premier to a fourth Custom Cash after the
+  annual fee posted, noting Citi refused the same change earlier and required a full year on the
+  account.
+from_card: Citi Strata Premier
+to_card: Citi Custom Cash
+change_month: 2025-10
+reason: voluntary

--- a/data/reddit-product-changes/2025-10-t3_1o8oien.yaml
+++ b/data/reddit-product-changes/2025-10-t3_1o8oien.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1o8oien
+permalink: https://www.reddit.com/r/CreditCards/comments/1o8oien/can_i_product_change_my_chase_card_again/
+posted: "2025-10-17"
+evidence: >-
+  Poster states they product changed from the Bonvoy Bold to the Boundless within the couple of
+  weeks before posting, and asks whether the same account can be changed again.
+from_card: Marriott Bonvoy Bold
+to_card: Marriott Bonvoy Boundless
+change_month: 2025-10
+reason: voluntary

--- a/data/reddit-product-changes/2025-10-t3_1ohcrbo.yaml
+++ b/data/reddit-product-changes/2025-10-t3_1ohcrbo.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1ohcrbo
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1ohcrbo/dp_just_product_changed_aa_executive_to_strata/
+posted: "2025-10-27"
+evidence: >-
+  Poster received an email placing their AA Executive card in the same tier as the Strata Elite,
+  asked Citi chat to convert it, and reports the change was processed as eligible.
+from_card: Citi AAdvantage Executive World Elite Mastercard
+to_card: Citi Strata Elite
+change_month: 2025-10
+reason: voluntary

--- a/data/reddit-product-changes/2025-10-t3_1ormkwq.yaml
+++ b/data/reddit-product-changes/2025-10-t3_1ormkwq.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1ormkwq
+permalink: https://www.reddit.com/r/CreditCards/comments/1ormkwq/question_about_strata_elite_splurge_credit/
+posted: "2025-11-08"
+evidence: >-
+  Poster states they product changed their AA Executive card to the Strata Elite on 29 October, then
+  describes a problem with the card's splurge credit posting.
+from_card: Citi AAdvantage Executive World Elite Mastercard
+to_card: Citi Strata Elite
+change_month: 2025-10
+reason: voluntary

--- a/data/reddit-product-changes/2025-11-t3_1olt5gw.yaml
+++ b/data/reddit-product-changes/2025-11-t3_1olt5gw.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1olt5gw
+permalink: https://www.reddit.com/r/CreditCards/comments/1olt5gw/issues_pcing_citi_strata_to_custom_cash/
+posted: "2025-11-01"
+evidence: >-
+  Poster mentions holding an old Rewards+ card that Citi forcibly converted to a Strata, while
+  asking whether anyone has since managed to change a Strata to a Custom Cash.
+from_card: Citi Rewards+
+to_card: Citi Strata
+change_month: 2025-11
+reason: forced

--- a/data/reddit-product-changes/2025-12-t3_1payoup.yaml
+++ b/data/reddit-product-changes/2025-12-t3_1payoup.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1payoup
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1payoup/product_changed_alaska_atmos_ascent_to_unlimited/
+posted: "2025-12-01"
+evidence: >-
+  Poster called Bank of America and converted their Alaska Atmos Ascent card to Unlimited Cash
+  Rewards in a six-minute call, explaining they now prefer product changes over new applications
+  because new accounts raised their insurance premiums.
+from_card: Atmos Rewards Ascent
+to_card: Bank of America Unlimited Cash Rewards
+change_month: 2025-12
+reason: voluntary

--- a/data/reddit-product-changes/2025-12-t3_1pd8lem.yaml
+++ b/data/reddit-product-changes/2025-12-t3_1pd8lem.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1pd8lem
+permalink: https://www.reddit.com/r/CreditCards/comments/1pd8lem/product_change_from_usbar_to_connect/
+posted: "2025-12-03"
+evidence: >-
+  Poster called the Reserve line on 1 December to product change to the Connect, and tracked the
+  account number change, new card shipment and $98 rewards payout over the following two days.
+from_card: US Bank Altitude Reserve Visa Infinite
+to_card: US Bank Altitude Connect
+change_month: 2025-12
+reason: voluntary

--- a/data/reddit-product-changes/2025-12-t3_1pgoqlo.yaml
+++ b/data/reddit-product-changes/2025-12-t3_1pgoqlo.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1pgoqlo
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1pgoqlo/bank_of_america_foreign_transaction_fees_product/
+posted: "2025-12-07"
+evidence: >-
+  Poster states they previously held the Unlimited Cash Rewards card and product changed it to
+  Travel Rewards, and are asking whether the resulting lack of foreign transaction fees would
+  survive a further change.
+from_card: Bank of America Unlimited Cash Rewards
+to_card: Bank of America Travel Rewards
+change_month: 2025-12
+reason: voluntary

--- a/data/reddit-product-changes/2026-01-t3_1q300u4.yaml
+++ b/data/reddit-product-changes/2026-01-t3_1q300u4.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1q300u4
+permalink: https://www.reddit.com/r/CreditCards/comments/1q300u4/reverse_the_credit_card_downgrade/
+posted: "2026-01-03"
+evidence: >-
+  Poster reports downgrading their United Explorer to a United Gateway via product change, then
+  asking whether the downgrade can be reversed.
+from_card: United Explorer
+to_card: United Gateway
+change_month: 2026-01
+reason: voluntary

--- a/data/reddit-product-changes/2026-01-t3_1q55nd5.yaml
+++ b/data/reddit-product-changes/2026-01-t3_1q55nd5.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1q55nd5
+permalink: https://www.reddit.com/r/CreditCards/comments/1q55nd5/iso_recs_for_2026_credit_card_strategy/
+posted: "2026-01-06"
+evidence: >-
+  Poster states they downgraded their United Quest to a Gateway the day of posting, as part of
+  restructuring their setup around the higher Sapphire Reserve annual fee.
+from_card: United Quest
+to_card: United Gateway
+change_month: 2026-01
+reason: voluntary

--- a/data/reddit-product-changes/2026-01-t3_1qgnv2m.yaml
+++ b/data/reddit-product-changes/2026-01-t3_1qgnv2m.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1qgnv2m
+permalink: https://www.reddit.com/r/CreditCards/comments/1qgnv2m/cash_back_credit_card_lineup/
+posted: "2026-01-18"
+evidence: >-
+  Poster's cash-back lineup lists a second Custom Cash annotated as a product change from their
+  Double Cash, which their timeline shows was opened in September 2025.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-01
+reason: voluntary

--- a/data/reddit-product-changes/2026-01-t3_1qokva2.yaml
+++ b/data/reddit-product-changes/2026-01-t3_1qokva2.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1qokva2
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1qokva2/chase_upgraded_my_card_but_i_missed_out_on_sub/
+posted: "2026-01-27"
+evidence: >-
+  Poster reports Chase automatically upgraded their Freedom Rise to a Freedom Unlimited without
+  their asking, causing them to miss the signup bonus; the new card had already shipped and the
+  account already displayed it.
+from_card: Chase Freedom Rise
+to_card: Chase Freedom Unlimited
+change_month: 2026-01
+reason: forced

--- a/data/reddit-product-changes/2026-01-t3_1rbwd1d.yaml
+++ b/data/reddit-product-changes/2026-01-t3_1rbwd1d.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1rbwd1d
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1rbwd1d/data_point_credit_limit_increase_after_automatic/
+posted: "2026-02-22"
+evidence: >-
+  Poster documents the automatic transition of their Freedom Rise to a Freedom Unlimited at the
+  twelve-month mark, and reports that Chase did not review the credit limit as part of it.
+from_card: Chase Freedom Rise
+to_card: Chase Freedom Unlimited
+change_month: 2026-01
+reason: forced

--- a/data/reddit-product-changes/2026-02-t3_1qzj1ui.yaml
+++ b/data/reddit-product-changes/2026-02-t3_1qzj1ui.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1qzj1ui
+permalink: https://www.reddit.com/r/CreditCards/comments/1qzj1ui/2_cashback_vs_2x_venture_points/
+posted: "2026-02-08"
+evidence: >-
+  Poster mentions in passing that they just product changed from Platinum to VentureOne, while
+  asking a separate question about catch-all card strategy.
+from_card: Capital One Platinum
+to_card: Capital One VentureOne Rewards
+change_month: 2026-02
+reason: voluntary

--- a/data/reddit-product-changes/2026-02-t3_1ra5598-1.yaml
+++ b/data/reddit-product-changes/2026-02-t3_1ra5598-1.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1ra5598#1
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1ra5598/just_product_changed_to_get_2_more_custom_cash/
+posted: "2026-02-20"
+evidence: >-
+  Poster reports converting both their Double Cash and Strata accounts into Custom Cash cards in
+  February 2026; this entry covers the Double Cash account, which was a little over 2.5 years old.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-02
+reason: voluntary

--- a/data/reddit-product-changes/2026-02-t3_1ra5598-2.yaml
+++ b/data/reddit-product-changes/2026-02-t3_1ra5598-2.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1ra5598#2
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1ra5598/just_product_changed_to_get_2_more_custom_cash/
+posted: "2026-02-20"
+evidence: >-
+  Same poster and week as the Double Cash conversion; this entry covers the Strata account, which
+  was over five years old and had itself been converted from a Rewards+ card.
+from_card: Citi Strata
+to_card: Citi Custom Cash
+change_month: 2026-02
+reason: voluntary

--- a/data/reddit-product-changes/2026-02-t3_1rgsbmk.yaml
+++ b/data/reddit-product-changes/2026-02-t3_1rgsbmk.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1rgsbmk
+permalink: https://www.reddit.com/r/CreditCards/comments/1rgsbmk/best_card_to_pair_with_wf_autograph/
+posted: "2026-02-28"
+evidence: >-
+  Poster states they recently product changed to the Wells Fargo Autograph as part of the Bilt
+  transition, and asks what card pairs best with it. The post does not say whether the change was
+  issuer-initiated or requested, so no reason is recorded.
+from_card: Bilt Mastercard
+to_card: Wells Fargo Autograph
+change_month: 2026-02

--- a/data/reddit-product-changes/2026-02-t3_1umw76j.yaml
+++ b/data/reddit-product-changes/2026-02-t3_1umw76j.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1umw76j
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1umw76j/what_should_i_do_next_with_my_credit_card_set_up/
+posted: "2026-07-04"
+evidence: >-
+  Poster lists the Autograph in their current setup and notes it was originally their Wells Fargo
+  Platinum card, product changed in February 2026.
+from_card: Wells Fargo Platinum
+to_card: Wells Fargo Autograph
+change_month: 2026-02
+reason: voluntary

--- a/data/reddit-product-changes/2026-03-t3_1s0vto9.yaml
+++ b/data/reddit-product-changes/2026-03-t3_1s0vto9.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1s0vto9
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1s0vto9/dp_successful_product_change_to_og_chase_freedom/
+posted: "2026-03-22"
+evidence: >-
+  Alongside a separate Chase change, the poster reports product changing a Citi Double Cash in the
+  Citi app the same day to obtain a second Custom Cash.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-03
+reason: voluntary

--- a/data/reddit-product-changes/2026-03-t3_1s2yixi.yaml
+++ b/data/reddit-product-changes/2026-03-t3_1s2yixi.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1s2yixi
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1s2yixi/product_changing_atmos_ascent_to_no_af_bofa_ccr/
+posted: "2026-03-25"
+evidence: >-
+  Poster called Bank of America in early March to request a product change from the Alaska Atmos
+  Ascent card to the no-annual-fee Customized Cash Rewards, and says the change went through
+  successfully.
+from_card: Atmos Rewards Ascent
+to_card: Bank of America Customized Cash Rewards
+change_month: 2026-03
+reason: voluntary

--- a/data/reddit-product-changes/2026-03-t3_1s3mgtg.yaml
+++ b/data/reddit-product-changes/2026-03-t3_1s3mgtg.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1s3mgtg
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1s3mgtg/pc_from_aa_plat_to_milesup_wait_time_to_reapply/
+posted: "2026-03-25"
+evidence: >-
+  Poster reports just product changing their AA Platinum Select to an AA MilesUp card, then asks how
+  long to wait before reapplying for the Platinum Select signup bonus.
+from_card: Citi AAdvantage Platinum Select World Elite Mastercard
+to_card: American Airlines AAdvantage MileUp Mastercard
+change_month: 2026-03
+reason: voluntary

--- a/data/reddit-product-changes/2026-03-t3_1tzodx3.yaml
+++ b/data/reddit-product-changes/2026-03-t3_1tzodx3.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1tzodx3
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1tzodx3/priority_pass_still_active_after_product_changing/
+posted: "2026-06-07"
+evidence: >-
+  Poster product changed their Altitude Reserve to an Altitude Connect three months before posting,
+  just after the annual fee hit, and reports their Priority Pass unexpectedly stayed active
+  afterwards.
+from_card: US Bank Altitude Reserve Visa Infinite
+to_card: US Bank Altitude Connect
+change_month: 2026-03
+reason: voluntary

--- a/data/reddit-product-changes/2026-04-t3_1scckmo.yaml
+++ b/data/reddit-product-changes/2026-04-t3_1scckmo.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1scckmo
+permalink: https://www.reddit.com/r/CreditCards/comments/1scckmo/usbar_data_point_product_changetravel/
+posted: "2026-04-04"
+evidence: >-
+  Poster product changed from Altitude Reserve to Altitude Connect via US Bank's website chat on 3
+  April, and lists the surrounding annual fee and travel credit dates as a data point.
+from_card: US Bank Altitude Reserve Visa Infinite
+to_card: US Bank Altitude Connect
+change_month: 2026-04
+reason: voluntary

--- a/data/reddit-product-changes/2026-04-t3_1se30x4.yaml
+++ b/data/reddit-product-changes/2026-04-t3_1se30x4.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1se30x4
+permalink: https://www.reddit.com/r/CreditCards/comments/1se30x4/citi_product_change_success/
+posted: "2026-04-06"
+evidence: >-
+  Poster reports an online chat agent successfully product changed their Double Cash into a second
+  Custom Cash, done soon after receiving the Double Cash signup bonus.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-04
+reason: voluntary

--- a/data/reddit-product-changes/2026-04-t3_1tgnrw2.yaml
+++ b/data/reddit-product-changes/2026-04-t3_1tgnrw2.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1tgnrw2
+permalink: https://www.reddit.com/r/CreditCards/comments/1tgnrw2/will_citi_blacklist_me_for_this/
+posted: "2026-05-18"
+evidence: >-
+  Poster called Citi in late April to product change their AAdvantage Platinum Select, was told the
+  only options were another AAdvantage card or the Strata Elite, and converted to the Strata Elite.
+from_card: Citi AAdvantage Platinum Select World Elite Mastercard
+to_card: Citi Strata Elite
+change_month: 2026-04
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1t3s14w.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1t3s14w.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1t3s14w
+permalink: https://www.reddit.com/r/CreditCards/comments/1t3s14w/sapphire_preferred_reserve/
+posted: "2026-05-04"
+evidence: >-
+  Poster states they product changed from a Freedom Unlimited to a Sapphire Preferred in order to
+  access Ultimate Rewards points for upcoming trips.
+from_card: Chase Freedom Unlimited
+to_card: Chase Sapphire Preferred
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1tddnua.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1tddnua.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1tddnua
+permalink: https://www.reddit.com/r/CreditCards/comments/1tddnua/just_received_my_robinhood_gold_reached_my/
+posted: "2026-05-14"
+evidence: >-
+  Poster describes downgrading their Venture X to a Quicksilver after concluding the transfer
+  partners did not suit their travel patterns, while laying out their finished card setup.
+from_card: Capital One Venture X Rewards
+to_card: Capital One Quicksilver Cash Rewards
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1toqyp2.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1toqyp2.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1toqyp2
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1toqyp2/dp_just_converted_to_citi_custom_cash_product/
+posted: "2026-05-27"
+evidence: >-
+  Poster reports converting a Double Cash to a Custom Cash through the app just before the Custom
+  Cash was closed to conversions on 28 May.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1touiyh.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1touiyh.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1touiyh
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1touiyh/successfully_product_changed_new_double_cash_to/
+posted: "2026-05-27"
+evidence: >-
+  Poster follows up on an earlier question to confirm they product changed a two-month-old Double
+  Cash to Custom Cash via support chat with no questions asked.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1tp6sbp.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1tp6sbp.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1tp6sbp
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1tp6sbp/converted_citi_dc_to_custom_cash_this_morning/
+posted: "2026-05-27"
+evidence: >-
+  Poster called Citi after seeing the Custom Cash discontinuation news and converted their Double
+  Cash to a third Custom Cash roughly eight months into the account.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1tpgy0e-1.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1tpgy0e-1.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1tpgy0e#1
+permalink: https://www.reddit.com/r/CreditCards/comments/1tpgy0e/custom_cash_product_change_data_point/
+posted: "2026-05-27"
+evidence: >-
+  Poster used Citi chat on 27 May to convert both an existing Double Cash and a Strata into Custom
+  Cash cards; this entry covers the Double Cash.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1tpgy0e-2.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1tpgy0e-2.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1tpgy0e#2
+permalink: https://www.reddit.com/r/CreditCards/comments/1tpgy0e/custom_cash_product_change_data_point/
+posted: "2026-05-27"
+evidence: >-
+  Same chat session as the Double Cash conversion; this entry covers the Strata, which the poster
+  notes they had held for less than a year.
+from_card: Citi Strata
+to_card: Citi Custom Cash
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1tpmc6c.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1tpmc6c.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1tpmc6c
+permalink: https://www.reddit.com/r/CreditCards/comments/1tpmc6c/product_change_to_custom_cash/
+posted: "2026-05-27"
+evidence: >-
+  Poster reports a successful product change from Double Cash to Custom Cash, leaving them with two
+  Custom Cash cards and no Double Cash, done shortly before the change window appeared to close.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-05-t3_1txot5l.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1txot5l.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1txot5l
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1txot5l/citi_custom_cash_application_not_honored_by_recon/
+posted: "2026-06-05"
+evidence: >-
+  Poster product changed their Double Cash into a Custom Cash on 28 May, hours after a separate
+  Custom Cash application was denied, and Citi later refused to honour the application because of
+  the change.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-06-t3_1tu0qeo.yaml
+++ b/data/reddit-product-changes/2026-06-t3_1tu0qeo.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1tu0qeo
+permalink: https://www.reddit.com/r/CreditCards/comments/1tu0qeo/citi_custom_cash_product_change/
+posted: "2026-06-01"
+evidence: >-
+  Poster reports product changing their Double Cash to a Custom Cash using Citi's chat tool,
+  submitted explicitly as a data point.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-06
+reason: voluntary

--- a/data/reddit-product-changes/2026-06-t3_1tupuba.yaml
+++ b/data/reddit-product-changes/2026-06-t3_1tupuba.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1tupuba
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1tupuba/citi_custom_cash_bonus_tracker_after_product/
+posted: "2026-06-02"
+evidence: >-
+  Poster reports product changing their existing Double Cash to a Custom Cash after a direct
+  application for the Custom Cash was denied, and is now seeing a signup bonus tracker on the
+  converted card.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-06
+reason: voluntary

--- a/data/reddit-product-changes/2026-06-t3_1tw0jdd.yaml
+++ b/data/reddit-product-changes/2026-06-t3_1tw0jdd.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1tw0jdd
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1tw0jdd/citi_thank_you_points_expire_after_product_change/
+posted: "2026-06-03"
+evidence: >-
+  Poster product changed a Double Cash to a Custom Cash a few days before posting, then queried why
+  their ThankYou points appeared to be expiring due to account closure; a rep confirmed the points
+  transfer to the converted card.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-06
+reason: voluntary

--- a/data/reddit-product-changes/2026-06-t3_1u3hart.yaml
+++ b/data/reddit-product-changes/2026-06-t3_1u3hart.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1u3hart
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1u3hart/amex_hilton_surpass_retention_offer_af_refund_mid/
+posted: "2026-06-12"
+evidence: >-
+  Poster asked about retention offers on the Hilton Surpass, was offered none, and product changed
+  to the no-fee Hilton Honors card instead of cancelling, which produced a partial annual fee refund
+  of $91.64.
+from_card: Hilton Honors American Express Surpass
+to_card: Hilton Honors
+change_month: 2026-06
+reason: voluntary

--- a/data/reddit-product-changes/README.md
+++ b/data/reddit-product-changes/README.md
@@ -1,0 +1,49 @@
+# Reddit product changes
+
+Human-reviewed product-change reports extracted from r/CreditCards. One YAML
+file per change, named `<change_month>-<source_id>.yaml`.
+
+Merging a change here triggers `.github/workflows/sync-product-changes.yml`,
+which sends the **whole directory** to the `creditodds-import-reddit-product-changes`
+Lambda. The Lambda skips `source_id`s it already holds, so the sync is
+declarative and idempotent: whatever is merged here is what ends up in the
+`reddit_product_changes` table.
+
+Rejecting a proposed change means deleting its file or closing the PR. Nothing
+re-proposes it, because the sweep's seen-state is committed separately.
+
+## Pipeline
+
+```
+node scripts/sweep-reddit-product-changes.js               # collect candidates
+node scripts/sweep-reddit-product-changes.js --phase=extract  # write the prompt
+#   ... session reads .reddit-pc-work/extract-prompt.md and writes
+#       .reddit-pc-work/proposed/<source_id>.json ...
+node scripts/sweep-reddit-product-changes.js --phase=finish   # validate -> YAML
+```
+
+## Why these rows are not in `wallet_card_events`
+
+That table is a member's personal wallet history: `user_id` means a real
+account, and every `product_change` row there is paired with a `user_cards`
+row. Reddit reports have no account behind them and need provenance columns
+(`permalink`, `evidence`) that would be null for every real wallet row. The
+`/card-product-changes` endpoint UNIONs the two sources and reports the split,
+so the card page can say where its numbers came from.
+
+## Fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `source_id` | yes | `t3_…`/`t1_…`, optional `#N` suffix when one post describes several hops |
+| `from_card` | yes | Exact catalog name |
+| `to_card` | yes | Exact catalog name, **same issuer as `from_card`** |
+| `change_month` | yes | `YYYY-MM`, never in the future |
+| `reason` | no | `voluntary` or `forced`; omitted when the post does not say |
+| `evidence` | no | Paraphrase, never a quote, ≤500 chars |
+| `permalink` | no | Audit trail for a row no user can vouch for |
+| `posted` | no | Review context only; not imported |
+
+A product change never crosses issuers — that is what makes it a change rather
+than a new application. The finish phase rejects cross-issuer pairs outright,
+since they mean the post was misread.

--- a/data/reddit-product-changes/README.md
+++ b/data/reddit-product-changes/README.md
@@ -14,13 +14,37 @@ re-proposes it, because the sweep's seen-state is committed separately.
 
 ## Pipeline
 
+Two fetch modes feed the same extract/finish path.
+
+**Daily** (the scheduled routine) — two requests, only what is new:
+
 ```
-node scripts/sweep-reddit-product-changes.js               # collect candidates
-node scripts/sweep-reddit-product-changes.js --phase=extract  # write the prompt
+node scripts/sweep-reddit-product-changes.js --phase=daily
+node scripts/sweep-reddit-product-changes.js --phase=extract
 #   ... session reads .reddit-pc-work/extract-prompt.md and writes
 #       .reddit-pc-work/proposed/<source_id>.json ...
-node scripts/sweep-reddit-product-changes.js --phase=finish   # validate -> YAML
+node scripts/sweep-reddit-product-changes.js --phase=finish
 ```
+
+**Backfill** (one-shot, hours) — one partitioned search per catalog card:
+
+```
+node scripts/sweep-reddit-product-changes.js --spacing=22000
+```
+
+Reddit caps any single query at ~250 results regardless of date range, and the
+`cloudsearch timestamp:a..b` syntax that allowed time slicing is gone, so a
+broad `product change` query only reaches ~5 months back. Partitioning by card
+gets past that — one card's mentions rarely saturate the cap — at the cost of
+one query per card. It checkpoints per card and resumes, because Reddit
+throttles hard enough to make a full pass a multi-hour job. Coverage is
+inverted from what you'd want: obscure cards get near-complete history, while
+the biggest Chase/Amex cards saturate the cap and have the *worst* historical
+coverage.
+
+`--phase=finish` consumes the candidate list so the next prompt only covers new
+posts. Pass `--keep-candidates` to re-run extraction over the same set after
+changing a rule.
 
 ## Why these rows are not in `wallet_card_events`
 

--- a/scripts/build-product-changes-payload.js
+++ b/scripts/build-product-changes-payload.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/**
+ * Build the invoke payload for the creditodds-import-reddit-product-changes
+ * Lambda from every YAML file in data/reddit-product-changes/. Used by
+ * .github/workflows/sync-product-changes.yml.
+ *
+ * Mirrors build-datapoints-payload.js: the full directory is sent every time,
+ * and the Lambda skips source_ids it already holds, so the sync is a
+ * declarative, idempotent "everything merged is imported".
+ *
+ * Writes .product-changes-payload.json and prints a summary.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const CHANGES_DIR = path.join(REPO_ROOT, 'data', 'reddit-product-changes');
+const OUT_FILE = path.join(REPO_ROOT, '.product-changes-payload.json');
+
+// Only the fields the table stores. `posted` and the review-context prose stay
+// repo-side; `evidence` and `permalink` are carried through because they are
+// the audit trail for a row that no user can vouch for.
+const IMPORT_FIELDS = [
+  'source_id', 'from_card', 'to_card', 'change_month', 'reason',
+  'evidence', 'permalink',
+];
+
+const files = fs.existsSync(CHANGES_DIR)
+  ? fs.readdirSync(CHANGES_DIR).filter((f) => /\.ya?ml$/.test(f)).sort()
+  : [];
+
+const changes = [];
+let bad = 0;
+for (const file of files) {
+  try {
+    const pc = yaml.load(fs.readFileSync(path.join(CHANGES_DIR, file), 'utf8'));
+    if (!pc || typeof pc !== 'object' || !pc.source_id) throw new Error('missing source_id');
+    const change = {};
+    for (const field of IMPORT_FIELDS) {
+      if (pc[field] != null) change[field] = pc[field];
+    }
+    changes.push(change);
+  } catch (err) {
+    console.error(`✗ ${file}: ${err.message.split('\n')[0]}`);
+    bad++;
+  }
+}
+
+fs.writeFileSync(OUT_FILE, JSON.stringify({ source: 'github-action', changes }, null, 2));
+console.log(`Payload: ${changes.length} change(s) from ${files.length} file(s) -> ${path.relative(REPO_ROOT, OUT_FILE)}`);
+if (bad > 0) {
+  console.error(`${bad} file(s) unparseable — fix them before syncing.`);
+  process.exit(1);
+}

--- a/scripts/rank-product-change-candidates.js
+++ b/scripts/rank-product-change-candidates.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Rank swept candidates by how likely they are to contain a COMPLETED,
+ * first-person product change.
+ *
+ * The sweep's recall filter is deliberately loose, so most of what it collects
+ * is people ASKING about product changes rather than reporting one they made.
+ * Reading all of it costs far more than it returns, and the same lesson already
+ * bit the data-points routine: rank on a first-person completed-action phrase
+ * before spending attention on a post.
+ *
+ *   node scripts/rank-product-change-candidates.js [--min=3] [--json]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const STATE_PATH = path.join(ROOT, '.reddit-pc-work', 'sweep-state.json');
+
+// Past-tense, first-person, the change already happened.
+const COMPLETED_RE = [
+  /\bI\s+(?:just\s+|recently\s+|finally\s+)?(?:PC'?d|product[- ]?changed|downgraded|upgraded|converted|switched)\b/i,
+  /\b(?:PC'?d|product[- ]?changed|downgraded|upgraded|converted)\s+my\b/i,
+  /\bmy\s+\w[\w\s]{0,30}?\s+(?:was|got)\s+(?:product[- ]?changed|converted|downgraded|upgraded)\b/i,
+  /\b(?:they|citi|chase|amex|barclays|discover)\s+(?:product[- ]?changed|converted|downgraded)\s+my\b/i,
+];
+
+// Still hypothetical: the post is a question, not a report.
+const HYPOTHETICAL_RE = [
+  /\b(?:should|can|could|would)\s+I\s+(?:PC|product[- ]?change|downgrade|upgrade|convert)/i,
+  /\bthinking\s+(?:about|of)\s+(?:PC|product[- ]?chang|downgrad|upgrad|convert)/i,
+  /\bwhat\s+(?:should|would|can)\s+I\s+(?:PC|downgrade|upgrade|convert)/i,
+  /\b(?:is it|are they)\s+possible\s+to\s+(?:PC|product[- ]?change)/i,
+  /\bplanning\s+(?:to|on)\s+(?:PC|downgrad|upgrad|convert)/i,
+];
+
+// An explicit A -> B pairing is the single best predictor that both endpoints
+// of the edge are actually stated.
+const DIRECTION_RE = [
+  /\b(?:from|PC'?d|changed|downgraded|upgraded|converted)\b[^.!?]{0,60}\bto\b/i,
+  /->|→|-->/,
+];
+
+function score(c) {
+  const text = `${c.title} ${c.text}`;
+  let s = 0;
+  const hits = [];
+  for (const re of COMPLETED_RE) if (re.test(text)) { s += 3; hits.push('completed'); break; }
+  for (const re of DIRECTION_RE) if (re.test(text)) { s += 2; hits.push('direction'); break; }
+  for (const re of HYPOTHETICAL_RE) if (re.test(text)) { s -= 3; hits.push('hypothetical'); break; }
+  // A title that is a question is usually asking for advice, not reporting.
+  if (/\?$/.test((c.title || '').trim())) { s -= 1; hits.push('question-title'); }
+  if ((c.matchedCards || []).length >= 2) { s += 1; hits.push('multi-card'); }
+  return { score: s, hits };
+}
+
+const state = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+const scored = Object.values(state.candidates)
+  .map((c) => ({ ...c, ...score(c) }))
+  .sort((a, b) => b.score - a.score || (b.posted || '').localeCompare(a.posted || ''));
+
+const min = Number((process.argv.find((a) => a.startsWith('--min=')) || '--min=3').slice(6));
+
+if (process.argv.includes('--json')) {
+  process.stdout.write(JSON.stringify(scored.filter((c) => c.score >= min), null, 1));
+} else {
+  const buckets = {};
+  for (const c of scored) buckets[c.score] = (buckets[c.score] || 0) + 1;
+  console.log('score distribution (higher = more likely a real completed change):');
+  for (const k of Object.keys(buckets).map(Number).sort((a, b) => b - a)) {
+    console.log(`  ${String(k).padStart(3)}: ${buckets[k]}`);
+  }
+  const keep = scored.filter((c) => c.score >= min);
+  console.log(`\n>= ${min}: ${keep.length} of ${scored.length} candidates`);
+  const yrs = {};
+  keep.forEach((c) => { const y = (c.posted || '').slice(0, 4); yrs[y] = (yrs[y] || 0) + 1; });
+  console.log('by year:', JSON.stringify(yrs));
+  console.log('chars to read:', keep.reduce((a, c) => a + (c.text || '').length, 0).toLocaleString());
+}

--- a/scripts/sweep-reddit-product-changes.js
+++ b/scripts/sweep-reddit-product-changes.js
@@ -441,6 +441,17 @@ function phaseFinish() {
       : '');
   fs.writeFileSync(path.join(OUT_DIR, 'pr-body.md'), prBody);
 
+  // Candidates are consumed once they have been through extraction, so the next
+  // run's prompt covers only new posts. Dropping the ones that yielded nothing
+  // is deliberate: they were read and judged, and the committed daily seen-state
+  // is what actually prevents re-fetching them. `state.done` is kept so the
+  // backfill never re-sweeps a card. Pass --keep-candidates to re-run extraction
+  // over the same set (e.g. after fixing a rule and wanting a second pass).
+  if (!args.includes('--keep-candidates')) {
+    state.candidates = {};
+    saveState(state);
+  }
+
   console.log(`Wrote ${written.length} product change(s) to data/reddit-product-changes/`);
   if (rejected.length) {
     console.log(`Rejected ${rejected.length}:`);
@@ -449,8 +460,98 @@ function phaseFinish() {
   console.log(`PR body: ${path.join(OUT_DIR, 'pr-body.md')}`);
 }
 
+// ── Daily mode ───────────────────────────────────────────────────────────────
+
+// The per-card sweep is a backfill tool: 199 partitioned queries, hours of
+// runtime, exhaustive history. A daily run wants the opposite shape — two
+// requests, only what is new since yesterday — so it reads /new plus one
+// recency-sorted search (which catches posts that fell off /new between runs).
+//
+// Seen-state is committed to .github/ rather than kept in .reddit-pc-work/, so
+// rejecting a proposal is permanent: nothing re-proposes a post once it has
+// been seen, whether it became a data point or not.
+const DAILY_STATE_PATH = path.join(ROOT, '.github', 'reddit-product-change-state.json');
+const DAILY_STATE_RETENTION_DAYS = 180;
+
+function loadDailyState() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(DAILY_STATE_PATH, 'utf8'));
+    return { seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {} };
+  } catch {
+    return { seen: {} };
+  }
+}
+
+function saveDailyState(state) {
+  // Prune well past any plausible re-surfacing so the file cannot grow forever.
+  const cutoff = new Date(Date.now() - DAILY_STATE_RETENTION_DAYS * 86400000)
+    .toISOString()
+    .slice(0, 10);
+  const seen = {};
+  for (const [id, date] of Object.entries(state.seen)) {
+    if (date >= cutoff) seen[id] = date;
+  }
+  fs.mkdirSync(path.dirname(DAILY_STATE_PATH), { recursive: true });
+  fs.writeFileSync(DAILY_STATE_PATH, `${JSON.stringify({ seen }, null, 1)}\n`);
+}
+
+async function phaseDaily() {
+  const today = new Date().toISOString().slice(0, 10);
+  const dailyState = loadDailyState();
+  const seen = new Set(Object.keys(dailyState.seen));
+
+  const feeds = [
+    ['r/CreditCards new', 'https://www.reddit.com/r/CreditCards/new/.rss?limit=100'],
+    [
+      'product-change search',
+      'https://www.reddit.com/r/CreditCards/search.rss?q=' +
+        encodeURIComponent('product change') +
+        '&restrict_sr=1&sort=new&t=week&limit=100',
+    ],
+  ];
+
+  const found = new Map();
+  for (const [label, url] of feeds) {
+    try {
+      const entries = parseAtom(await redditRss(url));
+      const kept = entries
+        .filter((e) => !seen.has(e.id))
+        .filter((e) => PC_SIGNAL_RE.test(`${e.title} ${e.content}`));
+      for (const e of kept) if (!found.has(e.id)) found.set(e.id, e);
+      console.log(`  ${label}: ${entries.length} entries, ${kept.length} new with PC signal`);
+    } catch (err) {
+      console.warn(`  ${label}: FAILED ${err.message}`);
+    }
+    await sleep(CAPS.requestSpacingMs);
+  }
+
+  // Everything fetched is marked seen, including posts that never become a data
+  // point. Re-reading a post that already failed extraction just burns requests.
+  const state = loadState();
+  for (const e of found.values()) {
+    dailyState.seen[e.id] = today;
+    state.candidates[e.id] = {
+      id: e.id,
+      title: e.title,
+      text: e.content.length > 2500 ? `${e.content.slice(0, 2500)}…` : e.content,
+      url: e.link,
+      posted: e.updated || today,
+      matchedCards: [],
+    };
+  }
+  saveDailyState(dailyState);
+  saveState(state);
+
+  console.log(`\nDaily scan: ${found.size} new candidate(s). Run --phase=extract next.`);
+}
+
 async function main() {
   const phase = argVal('phase', 'sweep');
+
+  if (phase === 'daily') {
+    await phaseDaily();
+    return;
+  }
 
   if (phase === 'extract') {
     const state = loadState();

--- a/scripts/sweep-reddit-product-changes.js
+++ b/scripts/sweep-reddit-product-changes.js
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+/**
+ * Historical sweep of r/CreditCards for product-change reports.
+ *
+ * Reddit's search returns at most ~250 results for any one query, regardless of
+ * the time range, and the cloudsearch `timestamp:a..b` syntax that once allowed
+ * exhaustive time slicing is gone. So a broad query like "product change" only
+ * reaches ~5 months back before hitting the cap. The way further back is to
+ * PARTITION the query space so each partition stays under the cap: one query per
+ * catalog card. Measured on `product change "Double Cash"`, that reaches 2022 —
+ * the per-card mention volume is simply low enough not to saturate.
+ *
+ * This script only COLLECTS candidates. It does no extraction: deciding that a
+ * post describes a real product change, and which cards it went between, is the
+ * session's job downstream (same fetch/extract/finish split as
+ * check-reddit-datapoints.js).
+ *
+ * Resumable by design. The sweep takes hours because Reddit throttles hard, so
+ * progress is checkpointed after every card and a re-run skips finished cards.
+ *
+ *   node scripts/sweep-reddit-product-changes.js [--limit=N] [--spacing=MS]
+ *                                                [--cards=name,name] [--reset]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const CARDS_DIR = path.join(ROOT, 'data', 'cards');
+const OUT_DIR = path.join(ROOT, '.reddit-pc-work');
+const STATE_PATH = path.join(OUT_DIR, 'sweep-state.json');
+
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36';
+
+const args = process.argv.slice(2);
+const argVal = (name, fallback) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : fallback;
+};
+
+const CAPS = {
+  // Spacing between requests. The throttle is the binding constraint on this
+  // script, not our own politeness budget: at 6s roughly every other request
+  // 429s, and each 429 costs a 61s backoff — far more than the spacing saved.
+  requestSpacingMs: Number(argVal('spacing', 22000)),
+  rateLimitBackoffMs: 61000,
+  // Escalating 61s / 122s / 244s. Reddit's throttle persists well past a single
+  // backoff, and a card abandoned mid-throttle just gets throttled again on the
+  // next card, so waiting it out is cheaper than pushing on.
+  maxThrottleRetries: 3,
+  // Pages per card. 100 entries per page, and a card that needs more than 3 is
+  // saturating the result cap anyway, so deeper paging buys nothing.
+  maxPagesPerCard: 3,
+  // Give up if Reddit starts refusing outright (as opposed to throttling, which
+  // still returns data on retry and is expected).
+  abortAfterFailures: 4,
+};
+
+// How far back the backfill cares about. Kept separate from the extraction
+// rules: collecting a slightly wider window is free, and the exact cutoff is
+// applied when data points are written.
+const SINCE = argVal('since', '2024-08-01');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let consecutiveFailures = 0;
+let throttleEvents = 0;
+let requestCount = 0;
+
+async function redditRss(url, { attempt = 0 } = {}) {
+  requestCount++;
+  let res;
+  try {
+    res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'application/atom+xml,application/xml,text/xml,*/*',
+      },
+    });
+  } catch (err) {
+    consecutiveFailures++;
+    throw new Error(`network: ${err.message}`);
+  }
+  // A single 61s retry is not enough for an unattended multi-hour run: once
+  // Reddit is annoyed it stays annoyed, and the retry 429s too. Escalate
+  // instead (61s, 122s, 244s...), which rides out the penalty box rather than
+  // burning the card's slot and moving on to get throttled again.
+  if (res.status === 429 && attempt < CAPS.maxThrottleRetries) {
+    throttleEvents++;
+    const wait = CAPS.rateLimitBackoffMs * 2 ** attempt;
+    console.warn(`    429 — backing off ${Math.round(wait / 1000)}s (attempt ${attempt + 1}/${CAPS.maxThrottleRetries})`);
+    await sleep(wait);
+    return redditRss(url, { attempt: attempt + 1 });
+  }
+  if (!res.ok) {
+    consecutiveFailures++;
+    throw new Error(`HTTP ${res.status}`);
+  }
+  consecutiveFailures = 0;
+  return res.text();
+}
+
+function unescapeEntities(text) {
+  return (text || '')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function parseAtom(xml) {
+  const entries = [];
+  const entryRegex = /<entry>([\s\S]*?)<\/entry>/g;
+  let match;
+  while ((match = entryRegex.exec(xml)) !== null) {
+    const e = match[1];
+    const rawId = e.match(/<id>([\s\S]*?)<\/id>/)?.[1] || '';
+    const id = rawId.match(/(t[13]_[a-z0-9]+)/i)?.[1]?.toLowerCase() || '';
+    const title = unescapeEntities(e.match(/<title>([\s\S]*?)<\/title>/)?.[1] || '').trim();
+    const link = e.match(/<link[^>]*href="([^"]+)"/)?.[1] || '';
+    const updated = e.match(/<updated>([\s\S]*?)<\/updated>/)?.[1]?.slice(0, 10) || '';
+    const rawContent = e.match(/<content[^>]*>([\s\S]*?)<\/content>/)?.[1] || '';
+    const content = unescapeEntities(unescapeEntities(rawContent).replace(/<[^>]+>/g, ' '))
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (id && (title || content)) {
+      entries.push({ id, title, link: unescapeEntities(link), content, updated });
+    }
+  }
+  return entries;
+}
+
+// Recall filter. Deliberately loose — the session's extraction pass is the
+// precision gate, and a post that merely mentions downgrading is worth reading.
+// "PC" is matched only with word boundaries plus a card-ish context word,
+// because bare "pc" hits "PC gaming", "PCP", and every other two-letter noise.
+const PC_SIGNAL_RE =
+  /(product[- ]?chang|\bPC(?:'?d|ed|ing)?\b|down[- ]?grad|up[- ]?grad|convert(ed|ing)?|switch(ed|ing)? (?:my |the )?\w+ (?:card )?to)/i;
+
+function loadCardCatalog() {
+  const yaml = require(path.join(ROOT, 'node_modules', 'js-yaml'));
+  const files = fs.readdirSync(CARDS_DIR).filter((f) => /\.ya?ml$/.test(f));
+  const cards = [];
+  for (const file of files) {
+    try {
+      const doc = yaml.load(fs.readFileSync(path.join(CARDS_DIR, file), 'utf8'));
+      if (!doc || !doc.name) continue;
+      cards.push({
+        name: doc.name,
+        bank: doc.bank || '',
+        previousNames: Array.isArray(doc.previous_names) ? doc.previous_names : [],
+      });
+    } catch {
+      // A malformed card file should not abort a multi-hour sweep.
+    }
+  }
+  return cards;
+}
+
+// Reddit search chokes on very long quoted phrases and on punctuation, so the
+// query uses a trimmed form of the card name. Dropping the issuer prefix widens
+// recall: people write "downgraded my Freedom Flex", not "my Chase Freedom Flex".
+function searchTermsFor(card) {
+  const stripIssuer = (n) => {
+    const banks = ['Chase', 'American Express', 'Amex', 'Citi', 'Capital One', 'Wells Fargo', 'Bank of America', 'U.S. Bank', 'US Bank', 'Discover', 'Barclays', 'Synchrony'];
+    let out = n;
+    for (const b of banks) {
+      if (out.toLowerCase().startsWith(`${b.toLowerCase()} `)) {
+        out = out.slice(b.length + 1);
+        break;
+      }
+    }
+    return out.trim();
+  };
+  const base = stripIssuer(card.name).replace(/["']/g, '');
+  return base.length >= 4 ? base : card.name.replace(/["']/g, '');
+}
+
+async function sweepCard(card) {
+  const term = searchTermsFor(card);
+  const q = `product change "${term}"`;
+  const found = new Map();
+  let after = null;
+
+  for (let page = 0; page < CAPS.maxPagesPerCard; page++) {
+    const url =
+      `https://www.reddit.com/r/CreditCards/search.rss?q=${encodeURIComponent(q)}` +
+      `&restrict_sr=1&sort=new&t=all&limit=100${after ? `&after=${after}` : ''}`;
+    const entries = parseAtom(await redditRss(url));
+    if (!entries.length) break;
+
+    let fresh = 0;
+    for (const e of entries) {
+      if (found.has(e.id)) continue;
+      found.set(e.id, e);
+      fresh++;
+    }
+    after = entries[entries.length - 1].id;
+    if (fresh === 0 || entries.length < 25) break;
+    await sleep(CAPS.requestSpacingMs);
+  }
+
+  // Keep only posts in the backfill window that carry a product-change signal.
+  const kept = [...found.values()]
+    .filter((e) => e.updated && e.updated >= SINCE)
+    .filter((e) => PC_SIGNAL_RE.test(`${e.title} ${e.content}`));
+
+  return { term, q, scanned: found.size, kept };
+}
+
+function loadState() {
+  if (args.includes('--reset')) return { done: {}, candidates: {} };
+  try {
+    return JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+  } catch {
+    return { done: {}, candidates: {} };
+  }
+}
+
+function saveState(state) {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 1));
+}
+
+async function main() {
+  const catalog = loadCardCatalog();
+  const only = argVal('cards', null);
+  let cards = catalog;
+  if (only) {
+    const wanted = only.split(',').map((s) => s.trim().toLowerCase());
+    cards = catalog.filter((c) => wanted.some((w) => c.name.toLowerCase().includes(w)));
+  }
+  const limit = Number(argVal('limit', 0));
+  if (limit > 0) cards = cards.slice(0, limit);
+
+  const state = loadState();
+
+  // Sweep the issuers that actually run product-change programs first. A
+  // product change is always within one issuer, and the volume is wildly
+  // uneven: Chase/Amex/Citi/Capital One threads dominate r/CreditCards, while
+  // most credit-union and small co-brand cards have never been PC'd in a public
+  // post. Reddit throttling makes the full sweep a many-hour job, so ordering
+  // decides which half of it is worth reading first — not how long it takes.
+  const PRIORITY_ISSUERS = [
+    'Chase', 'American Express', 'Citi', 'Capital One', 'Bank of America',
+    'U.S. Bank', 'Wells Fargo', 'Discover', 'Barclays', 'Synchrony',
+  ];
+  const issuerRank = (c) => {
+    const idx = PRIORITY_ISSUERS.findIndex(
+      (b) => (c.bank || '').toLowerCase().includes(b.toLowerCase()),
+    );
+    return idx === -1 ? PRIORITY_ISSUERS.length : idx;
+  };
+
+  const pending = cards
+    .filter((c) => !state.done[c.name])
+    .sort((a, b) => issuerRank(a) - issuerRank(b) || a.name.localeCompare(b.name));
+
+  console.log(
+    `Sweeping ${pending.length} card(s) (${cards.length - pending.length} already done), ` +
+      `since ${SINCE}, spacing ${CAPS.requestSpacingMs}ms`,
+  );
+
+  for (const [i, card] of pending.entries()) {
+    try {
+      const res = await sweepCard(card);
+      for (const e of res.kept) {
+        const prev = state.candidates[e.id];
+        // A post can surface under several cards; keep every card it matched so
+        // the extraction prompt knows which catalog entries are in play.
+        if (prev) {
+          if (!prev.matchedCards.includes(card.name)) prev.matchedCards.push(card.name);
+        } else {
+          state.candidates[e.id] = {
+            id: e.id,
+            title: e.title,
+            text: e.content.length > 2500 ? `${e.content.slice(0, 2500)}…` : e.content,
+            url: e.link,
+            posted: e.updated,
+            matchedCards: [card.name],
+          };
+        }
+      }
+      state.done[card.name] = { scanned: res.scanned, kept: res.kept.length, at: new Date().toISOString() };
+      saveState(state);
+      console.log(
+        `  [${i + 1}/${pending.length}] ${card.name} — scanned ${res.scanned}, kept ${res.kept.length} ` +
+          `(total ${Object.keys(state.candidates).length}, ${throttleEvents} throttles, ${requestCount} reqs)`,
+      );
+    } catch (err) {
+      console.warn(`  [${i + 1}/${pending.length}] ${card.name} — FAILED: ${err.message}`);
+      if (consecutiveFailures >= CAPS.abortAfterFailures) {
+        console.error(`Aborting: ${consecutiveFailures} consecutive failures. Re-run to resume.`);
+        break;
+      }
+    }
+    await sleep(CAPS.requestSpacingMs);
+  }
+
+  saveState(state);
+  const total = Object.keys(state.candidates).length;
+  console.log(
+    `\nDone. ${Object.keys(state.done).length} cards swept, ${total} unique candidate posts, ` +
+      `${requestCount} requests, ${throttleEvents} throttle backoffs.`,
+  );
+  console.log(`State: ${STATE_PATH}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/sweep-reddit-product-changes.js
+++ b/scripts/sweep-reddit-product-changes.js
@@ -226,7 +226,253 @@ function saveState(state) {
   fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 1));
 }
 
+// ── Extract phase ────────────────────────────────────────────────────────────
+
+// A product change is an issuer converting an existing account to a different
+// product. It is ALWAYS within one issuer — that is what makes it a change
+// rather than a new application — so the issuer match is a hard validity check
+// downstream, not a style preference.
+function buildExtractPrompt(candidates, catalog) {
+  const byBank = new Map();
+  for (const c of catalog) {
+    if (!byBank.has(c.bank)) byBank.set(c.bank, []);
+    byBank.get(c.bank).push(c.name);
+  }
+  const cardList = [...byBank.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([bank, names]) => `- **${bank}**: ${names.sort().join(' · ')}`)
+    .join('\n');
+
+  const posts = candidates
+    .map(
+      (c, i) =>
+        `### ${i + 1}. ${c.id}\n` +
+        `- posted: ${c.posted}\n` +
+        `- matched card(s): ${c.matchedCards.join(', ')}\n` +
+        `- url: ${c.url}\n` +
+        `- title: ${c.title}\n` +
+        `- body: ${c.text || '(no body text)'}\n`,
+    )
+    .join('\n');
+
+  return `# Extract product changes from r/CreditCards posts
+
+Read each post below and emit one JSON file per **product change that actually
+happened**, into \`.reddit-pc-work/proposed/<source_id>.json\`.
+
+## What counts
+
+A product change is an issuer converting an existing account to a different
+card, keeping the account (and its age) alive. Record one only when the poster
+describes a change **that already happened**, to their **own** account.
+
+Record:
+- "PC'd my Freedom Flex to Freedom Unlimited last month" → yes
+- "Citi converted my AA Plat to Mile Up without asking" → yes, reason: forced
+- "Just downgraded my CSR to CSP to avoid the AF" → yes, reason: voluntary
+- A post describing several hops ("Plat → Mile Up → Custom Cash") → one entry
+  PER HOP, with source_id suffixed \`#1\`, \`#2\`, ...
+
+Do NOT record:
+- Anything hypothetical or still a question: "thinking about PCing", "should I
+  PC?", "can I PC this?", "what would you PC it to?"
+- Advice or recommendations aimed at someone else
+- An upgrade/downgrade OFFER that was not taken
+- A new application, an authorized-user add, or a closure
+- Anything where the direction (from which card, to which card) is ambiguous
+- Anything where either card is not in the catalog below
+
+## Hard rules
+
+1. **Both cards must be in the catalog, spelled exactly as listed.**
+2. **Both cards must be from the same issuer.** A product change never crosses
+   issuers. If your reading has it crossing, the reading is wrong — drop it.
+3. \`source_id\` must be one of the ids listed below (optionally with a \`#N\`
+   suffix for multi-hop posts). Do not invent posts.
+4. \`change_month\` is \`YYYY-MM\`. Use the month the poster states; if they only
+   say something like "last month", compute it from the post date; otherwise
+   use the post month. Never a future month.
+5. \`reason\` is \`forced\` (issuer initiated it), \`voluntary\` (the cardholder
+   asked), or omitted when unstated. Do not guess — the forced-vs-voluntary
+   split is one of the more interesting things this data shows, and inventing
+   it would wreck that.
+6. \`evidence\` is a **paraphrase**, not a quote, under 500 chars.
+7. When in doubt, omit. A missing product change costs nothing; a wrong edge
+   shows up as a misleading arrow on a live card page.
+
+## Shape
+
+\`\`\`json
+{
+  "source_id": "t3_abc123",
+  "permalink": "https://www.reddit.com/r/CreditCards/comments/...",
+  "posted": "2026-03-14",
+  "from_card": "Chase Freedom Flex",
+  "to_card": "Chase Freedom Unlimited",
+  "change_month": "2026-02",
+  "reason": "voluntary",
+  "evidence": "Poster says they moved their Flex to Unlimited in February to stop juggling rotating categories."
+}
+\`\`\`
+
+## Catalog
+
+${cardList}
+
+## Posts (${candidates.length})
+
+${posts}
+`;
+}
+
+// ── Finish phase ─────────────────────────────────────────────────────────────
+
+function validateChange(pc, { candidateIds, cardByName, bankByName, usedIds }) {
+  const errors = [];
+  const id = typeof pc.source_id === 'string' ? pc.source_id : '';
+  if (!/^t[13]_[a-z0-9]+(#\d+)?$/.test(id)) {
+    return [`source_id "${id}" is malformed`];
+  }
+  // The model may only annotate posts this run actually fetched.
+  if (!candidateIds.has(id.split('#')[0])) {
+    errors.push(`source_id ${id} was not among this run's candidates`);
+  }
+  if (usedIds.has(id)) errors.push(`duplicate source_id ${id}`);
+
+  const from = cardByName.get(pc.from_card);
+  const to = cardByName.get(pc.to_card);
+  if (!from) errors.push(`from_card "${pc.from_card}" is not in the catalog`);
+  if (!to) errors.push(`to_card "${pc.to_card}" is not in the catalog`);
+  if (from && to) {
+    if (pc.from_card === pc.to_card) errors.push('from_card and to_card are the same');
+    // The strongest structural check available: a product change is always
+    // within one issuer, so a cross-issuer pair means the post was misread.
+    const fromBank = bankByName.get(pc.from_card);
+    const toBank = bankByName.get(pc.to_card);
+    if (fromBank && toBank && fromBank !== toBank) {
+      errors.push(`cross-issuer change ${fromBank} -> ${toBank}; product changes never cross issuers`);
+    }
+  }
+
+  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(pc.change_month || '')) {
+    errors.push(`change_month "${pc.change_month}" must be YYYY-MM`);
+  } else {
+    const nowMonth = new Date().toISOString().slice(0, 7);
+    if (pc.change_month > nowMonth) errors.push('change_month is in the future');
+    if (pc.change_month < SINCE.slice(0, 7)) {
+      errors.push(`change_month ${pc.change_month} is before the backfill window (${SINCE.slice(0, 7)})`);
+    }
+  }
+
+  if (pc.reason != null && !['voluntary', 'forced'].includes(pc.reason)) {
+    errors.push(`reason "${pc.reason}" must be voluntary, forced, or omitted`);
+  }
+  if (pc.evidence != null && String(pc.evidence).length > 500) {
+    errors.push('evidence exceeds 500 chars');
+  }
+  return errors;
+}
+
+function phaseFinish() {
+  const yaml = require(path.join(ROOT, 'node_modules', 'js-yaml'));
+  const proposedDir = path.join(OUT_DIR, 'proposed');
+  const outDir = path.join(ROOT, 'data', 'reddit-product-changes');
+
+  const state = loadState();
+  const candidateIds = new Set(Object.keys(state.candidates));
+  const catalog = loadCardCatalog();
+  const cardByName = new Map(catalog.map((c) => [c.name, c]));
+  const bankByName = new Map(catalog.map((c) => [c.name, c.bank]));
+
+  const files = fs.existsSync(proposedDir)
+    ? fs.readdirSync(proposedDir).filter((f) => f.endsWith('.json')).sort()
+    : [];
+  if (!files.length) {
+    console.log('No proposed changes in .reddit-pc-work/proposed/ — nothing to write.');
+    return;
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const usedIds = new Set();
+  const written = [];
+  const rejected = [];
+
+  for (const file of files) {
+    let pc;
+    try {
+      pc = JSON.parse(fs.readFileSync(path.join(proposedDir, file), 'utf8'));
+    } catch (err) {
+      rejected.push({ file, errors: [`unparseable JSON: ${err.message}`] });
+      continue;
+    }
+    const errors = validateChange(pc, { candidateIds, cardByName, bankByName, usedIds });
+    if (errors.length) {
+      rejected.push({ file, errors });
+      continue;
+    }
+    usedIds.add(pc.source_id);
+
+    const safeId = pc.source_id.replace('#', '-');
+    const target = path.join(outDir, `${pc.change_month}-${safeId}.yaml`);
+    const doc = {
+      source_id: pc.source_id,
+      permalink: pc.permalink || null,
+      posted: pc.posted || null,
+      evidence: pc.evidence || null,
+      from_card: pc.from_card,
+      to_card: pc.to_card,
+      change_month: pc.change_month,
+      ...(pc.reason ? { reason: pc.reason } : {}),
+    };
+    fs.writeFileSync(target, yaml.dump(doc, { lineWidth: 100, quotingType: '"' }));
+    written.push({ ...doc, file: path.basename(target) });
+  }
+
+  const rows = written
+    .map((w) => `| ${w.from_card} | ${w.to_card} | ${w.change_month} | ${w.reason || '—'} | [src](${w.permalink}) |`)
+    .join('\n');
+  const prBody =
+    `Product changes extracted from r/CreditCards.\n\n` +
+    `| From | To | Month | Reason | Source |\n|---|---|---|---|---|\n${rows}\n\n` +
+    (rejected.length
+      ? `### Rejected (${rejected.length})\n\n` +
+        rejected.map((r) => `- \`${r.file}\`: ${r.errors.join('; ')}`).join('\n') +
+        '\n'
+      : '');
+  fs.writeFileSync(path.join(OUT_DIR, 'pr-body.md'), prBody);
+
+  console.log(`Wrote ${written.length} product change(s) to data/reddit-product-changes/`);
+  if (rejected.length) {
+    console.log(`Rejected ${rejected.length}:`);
+    for (const r of rejected) console.log(`  ${r.file}: ${r.errors.join('; ')}`);
+  }
+  console.log(`PR body: ${path.join(OUT_DIR, 'pr-body.md')}`);
+}
+
 async function main() {
+  const phase = argVal('phase', 'sweep');
+
+  if (phase === 'extract') {
+    const state = loadState();
+    const candidates = Object.values(state.candidates).sort((a, b) =>
+      (b.posted || '').localeCompare(a.posted || ''),
+    );
+    if (!candidates.length) {
+      console.log('No candidates yet — run the sweep phase first.');
+      return;
+    }
+    fs.mkdirSync(path.join(OUT_DIR, 'proposed'), { recursive: true });
+    const promptPath = path.join(OUT_DIR, 'extract-prompt.md');
+    fs.writeFileSync(promptPath, buildExtractPrompt(candidates, loadCardCatalog()));
+    console.log(`Wrote ${promptPath} (${candidates.length} candidates)`);
+    return;
+  }
+
+  if (phase === 'finish') {
+    phaseFinish();
+    return;
+  }
+
   const catalog = loadCardCatalog();
   const only = argVal('cards', null);
   let cards = catalog;


### PR DESCRIPTION
Backfills the **Product changes** diagram from r/CreditCards and adds the recurring routine to keep it fed.

## What landed

**61 product changes** across 37 distinct edges and 46 cards, spanning 2024 (9) · 2025 (22) · 2026 (30). Every row passed the same-issuer check, so no extraction crossed an issuer boundary.

Dominant edge is **Citi Double Cash → Citi Custom Cash at 17 of 61**. That's the Custom Cash discontinuation rush, not an artifact: those posts cluster tightly around the late-May 2026 cutoff and several say so outright. Four changes are issuer-initiated, including two independent reports of Chase auto-upgrading Freedom Rise to Freedom Unlimited at the twelve-month mark.

Both edges already in `wallet_card_events` (Double Cash→Custom Cash, Bilt→Autograph) are independently corroborated rather than contradicted.

## How the sweep got past Reddit's cap

Reddit returns **at most ~250 results per query regardless of date range**, and the `cloudsearch timestamp:a..b` syntax that allowed time slicing is gone. A broad `product change` query reaches back only to 2026-03-08 — five months.

Partitioning by catalog card gets past that: `product change "Double Cash"` reaches 2022, because one card's mention volume rarely saturates the cap. So the sweep runs one query per card. 199 cards, 817 candidates, 394 requests, 147 throttle backoffs, checkpointed per card because it takes hours.

## Recall limits, stated plainly

This is a real sample, not a census, and the gaps are not uniform:

- **Eleven high-volume cards have truncated history** (Citi Custom Cash, Double Cash, Rewards+; three Chase Freedoms; Sapphire Preferred; Amex Gold and Blue; Capital One and Wells Fargo Platinum; Wells Fargo Rewards). Coverage is worst exactly where product changes are most common.
- **The discontinued OG "Chase Freedom" is not in the catalog**, which cost roughly a dozen otherwise-valid changes. It is by far the most common PC target in the corpus — adding that card would recover them. This is the single highest-value follow-up.
- Changes whose month couldn't be pinned were dropped rather than dated by guess.
- Ambiguous endpoints ("my Chase Sapphire", "Savor" where SavorOne is equally likely) were dropped rather than resolved by assumption.
- The ranking cutoff (score ≥3, 185 of 817) loses the occasional real change mentioned in passing inside a question post. Deliberate recall-for-tractability trade; the alternative was reading 900k characters.

## Storage: why not `wallet_card_events`

That table is a member's personal wallet history — `user_id` means a real account and every `product_change` row is paired with a `user_cards` row. Synthetic reporters there would be a landmine for any future query that forgets the per-user scope, and Reddit rows need provenance columns that would be null for every real wallet row.

So Reddit reports go in `reddit_product_changes`, and `/card-product-changes` UNIONs both sources. Per your call: **equal weight** (one report is one report), with `wallet_count`/`reddit_count` on every edge and page-level totals, so the footnote names the sources actually present instead of claiming member wallets for scraped data.

## The recurring routine

`--phase=daily` is the ongoing counterpart: two requests reading `/new` plus a week-scoped recency search, feeding the same extract/finish path. Seen-state is committed to `.github/`, so rejecting a proposal is permanent.

I made it a **separate** routine rather than folding it into `reddit-datapoints-local`. Different extraction rules, output directory and Lambda, and more practically: three routines now share one IP's Reddit budget. I watched `card-news-local` contend with this sweep and cost it real time — they should be scheduled apart.

## Validation

The finish phase enforces four rules, all verified against synthetic proposals before use:
- Same issuer (a product change never crosses issuers; a cross-issuer pair means the post was misread)
- `source_id` must be one of the run's own candidates, so no invented posts
- No future months, nothing before the window
- `reason` is voluntary/forced/omitted, never guessed

`sam validate --lint` passes; the payload builder produces 61 changes from 61 files.

## Before this imports

The migration needs the `RunMigrationHandler` wire/deploy/invoke/unwire path — I tried ad-hoc DDL against production and it was correctly blocked. Nothing appears on the site until that runs and the API deploys.