### PR TITLE
Surface archived cards instead of hiding them (landing search, explore, card banner)

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -196,6 +196,9 @@ function formatNewsDate(dateStr: string): string {
   }
 }
 
+const MAX_SEARCH_RESULTS = 6;
+const MIN_ARCHIVED_RESULTS = 2;
+
 function Hero({ cards }: { cards: LandingCard[] }) {
   const router = useRouter();
   const [query, setQuery] = useState('');
@@ -206,13 +209,23 @@ function Hero({ cards }: { cards: LandingCard[] }) {
   const matches = useMemo(() => {
     const q = query.trim();
     if (!q) return [];
-    return cards
-      .filter((c) => c.accepting_applications)
+    const ranked = cards
       .filter((c) => cardMatchesSearch(c.card_name, c.bank, q))
       .map((c) => ({ c, s: searchRelevance(c, q) }))
       .sort((a, b) => b.s - a.s || a.c.card_name.localeCompare(b.c.card_name))
-      .slice(0, 6)
       .map(({ c }) => c);
+    const live = ranked.filter((c) => c.accepting_applications);
+    const archived = ranked.filter((c) => !c.accepting_applications);
+    // Archived cards always sit below the live ones, but they keep a couple of
+    // reserved slots so a pulled card (Citi Custom Cash, say) never gets pushed
+    // off the list entirely by cards that merely share a word with the query.
+    // When there are few live matches, archived cards fill the remaining space.
+    const archivedSlots = Math.min(
+      archived.length,
+      Math.max(MIN_ARCHIVED_RESULTS, MAX_SEARCH_RESULTS - live.length)
+    );
+    const liveShown = live.slice(0, MAX_SEARCH_RESULTS - archivedSlots);
+    return [...liveShown, ...archived.slice(0, MAX_SEARCH_RESULTS - liveShown.length)];
   }, [query, cards]);
 
   function go(slug: string) {
@@ -320,7 +333,9 @@ function Hero({ cards }: { cards: LandingCard[] }) {
                       href={`/card/${c.slug}`}
                       role="option"
                       aria-selected={idx === active}
-                      className={`opt${idx === active ? ' is-active' : ''}`}
+                      className={`opt${idx === active ? ' is-active' : ''}${
+                        c.accepting_applications ? '' : ' is-archived'
+                      }`}
                       onMouseEnter={() => setActive(idx)}
                       onMouseDown={(e) => e.preventDefault()}
                     >
@@ -329,7 +344,12 @@ function Hero({ cards }: { cards: LandingCard[] }) {
                       </div>
                       <div>
                         <div className="opt-name">{c.card_name}</div>
-                        <div className="opt-iss">{c.bank}</div>
+                        <div className="opt-iss">
+                          {c.bank}
+                          {!c.accepting_applications && (
+                            <span className="opt-tag">Not accepting applications</span>
+                          )}
+                        </div>
                       </div>
                     </Link>
                   ))

--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -865,27 +865,11 @@ export default function CardClient({
         </div>
       </div>
 
-      {/* Discontinued banner — card has been pulled entirely. */}
-      {card.active === false && (
-        <div
-          style={{
-            padding: "10px 24px",
-            background: "var(--ink)",
-            color: "#fff",
-            fontSize: 13,
-            fontWeight: 500,
-            display: "flex",
-            alignItems: "center",
-            gap: 10,
-          }}
-        >
-          <ExclamationTriangleIcon style={{ height: 16, width: 16 }} />
-          This card has been discontinued and is no longer offered.
-        </div>
-      )}
-
-      {/* Closed banner — card exists but isn't taking new applicants. */}
-      {card.active !== false && card.accepting_applications === false && (
+      {/* Pulled-card banner — discontinued outright, or still around but
+          closed to new applicants. Both use the same warn styling: the
+          discontinued one used to be ink-on-white, which blended into the
+          ink-colored breadcrumb bar directly above it. */}
+      {(card.active === false || card.accepting_applications === false) && (
         <div
           style={{
             padding: "10px 24px",
@@ -899,7 +883,9 @@ export default function CardClient({
           }}
         >
           <ExclamationTriangleIcon style={{ height: 16, width: 16 }} />
-          This card is no longer accepting applications.
+          {card.active === false
+            ? "This card has been discontinued and is no longer offered."
+            : "This card is no longer accepting applications."}
         </div>
       )}
 

--- a/apps/web-next/src/app/explore/ExploreV2Client.tsx
+++ b/apps/web-next/src/app/explore/ExploreV2Client.tsx
@@ -348,7 +348,6 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
   }, []);
   const [sort, setSort] = useState<SortKey>('trending');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const [includeArchived, setIncludeArchived] = useState(false);
   const [view, setView] = useState<ViewMode>('table');
   const [rewardType, setRewardType] = useState<RewardTypeFilter>('all');
   const [feeBucket, setFeeBucket] = useState<FeeBucket>('all');
@@ -367,10 +366,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
     }
   }
 
-  const totalCount = useMemo(
-    () => cards.filter((c) => includeArchived || c.accepting_applications).length,
-    [cards, includeArchived]
-  );
+  const totalCount = cards.length;
 
   const hasActiveFilters =
     query.trim() !== '' ||
@@ -379,8 +375,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
     network !== 'all' ||
     selectedBanks.size > 0 ||
     businessOnly ||
-    noForeignFeeOnly ||
-    includeArchived;
+    noForeignFeeOnly;
 
   function clearFilters() {
     setQuery('');
@@ -390,26 +385,24 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
     setSelectedBanks(new Set());
     setBusinessOnly(false);
     setNoForeignFeeOnly(false);
-    setIncludeArchived(false);
   }
 
   const banksList = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const c of cards) {
-      if (!includeArchived && !c.accepting_applications) continue;
       if (!c.bank) continue;
       counts[c.bank] = (counts[c.bank] ?? 0) + 1;
     }
     return Object.entries(counts)
       .map(([name, count]) => ({ name, count }))
       .sort((a, b) => a.name.localeCompare(b.name));
-  }, [cards, includeArchived]);
+  }, [cards]);
 
-  // Per-option counts for the Network / Annual fee menus. Like banksList,
-  // these are counted against the archived-filtered pool only, so an option's
-  // number doesn't shift as other facets are toggled.
+  // Per-option counts for the Network / Annual fee menus. Counted against the
+  // whole catalog so an option's number doesn't shift as other facets are
+  // toggled.
   const facetCounts = useMemo(() => {
-    const pool = cards.filter((c) => includeArchived || c.accepting_applications);
+    const pool = cards;
     const network: Record<NetworkFilter, number> = {
       all: pool.length,
       visa: 0,
@@ -432,7 +425,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
       }
     }
     return { network, fee };
-  }, [cards, includeArchived]);
+  }, [cards]);
 
   function toggleBank(bank: string) {
     setSelectedBanks((prev) => {
@@ -450,13 +443,11 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
       ? [...selectedBanks][0]
       : `${selectedBanks.size} selected`;
 
-  const moreCount =
-    (businessOnly ? 1 : 0) + (noForeignFeeOnly ? 1 : 0) + (includeArchived ? 1 : 0);
+  const moreCount = (businessOnly ? 1 : 0) + (noForeignFeeOnly ? 1 : 0);
 
   const filtered = useMemo(() => {
     const q = query.trim();
     const pool = cards.filter((c) => {
-      if (!includeArchived && !c.accepting_applications) return false;
       if (businessOnly && cardCategory(c) !== 'Business') return false;
       if (rewardType !== 'all' && c.reward_type !== rewardType) return false;
       // Strict `=== false`: the field is optional, and a handful of cards omit
@@ -512,8 +503,14 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
         return sortDir === 'desc' ? bv - av : av - bv;
       });
     }
+    // Cards that stopped accepting applications sink to the bottom of every
+    // sort. They stay listed — people search for pulled cards — just last.
+    // Array.prototype.sort is stable, so each group keeps the order above.
+    sorted.sort(
+      (a, b) => Number(!a.accepting_applications) - Number(!b.accepting_applications)
+    );
     return sorted;
-  }, [cards, query, sort, sortDir, includeArchived, trendingViews, rewardType, feeBucket, selectedBanks, businessOnly, noForeignFeeOnly, network]);
+  }, [cards, query, sort, sortDir, trendingViews, rewardType, feeBucket, selectedBanks, businessOnly, noForeignFeeOnly, network]);
 
   return (
     <div className="landing-v2 explore-v2">
@@ -704,12 +701,6 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
                   >
                     No foreign transaction fee
                   </FacetSwitch>
-                  <FacetSwitch
-                    on={includeArchived}
-                    onToggle={() => setIncludeArchived((v) => !v)}
-                  >
-                    Include archived cards
-                  </FacetSwitch>
                 </>
               )}
             </Facet>
@@ -783,7 +774,11 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
               const archived = !c.accepting_applications;
               const bonus = formatBonus(c);
               return (
-                <Link key={c.slug} href={`/card/${c.slug}`} className="cc">
+                <Link
+                  key={c.slug}
+                  href={`/card/${c.slug}`}
+                  className={'cc' + (archived ? ' is-archived' : '')}
+                >
                   <div className="cc-top">
                     <div className="cc-thumb">
                       <CardImage
@@ -880,7 +875,7 @@ export default function ExploreV2Client({ cards, trendingViews }: ExploreV2Clien
                   const bonus = formatBonus(c);
                   const feeLabel = `$${c.annual_fee ?? 0}`;
                   return (
-                    <tr key={c.slug}>
+                    <tr key={c.slug} className={archived ? 'is-archived' : undefined}>
                       <td>
                         <Link href={`/card/${c.slug}`} className="ct-card">
                           <div className="ct-thumb">

--- a/apps/web-next/src/app/landing-v3.css
+++ b/apps/web-next/src/app/landing-v3.css
@@ -222,6 +222,29 @@
   color: var(--muted);
   margin-top: 2px;
 }
+/* Cards that stopped accepting applications: dimmed but still clickable. */
+.landing-v3 .search-results .opt.is-archived .opt-thumb {
+  filter: grayscale(1);
+  opacity: 0.7;
+}
+.landing-v3 .search-results .opt.is-archived .opt-name {
+  color: var(--muted);
+  font-weight: 500;
+}
+.landing-v3 .search-results .opt.is-archived:hover .opt-name,
+.landing-v3 .search-results .opt.is-archived.is-active .opt-name {
+  color: var(--ink);
+}
+.landing-v3 .search-results .opt-tag {
+  margin-left: 6px;
+  padding: 1px 6px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  color: var(--muted);
+}
 .landing-v3 .search-results .opt-empty {
   padding: 18px 14px;
   font-size: 13px;

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2141,6 +2141,20 @@
   background: var(--warn-2);
   color: var(--warn);
 }
+/* Cards that stopped accepting applications sort to the bottom of Explore and
+   read as inactive — dimmed, but still a normal link. */
+.landing-v2 .cc.is-archived {
+  opacity: 0.62;
+}
+.landing-v2 .cc.is-archived:hover {
+  opacity: 1;
+}
+.landing-v2 .cc.is-archived .cc-thumb {
+  filter: grayscale(1);
+}
+.landing-v2 .cc.is-archived:hover .cc-thumb {
+  filter: none;
+}
 
 /* ---------- Search row (search + view toggle inline) ---------- */
 .landing-v2 .search-row {
@@ -2224,6 +2238,18 @@
 }
 .landing-v2 .card-table tbody tr:hover {
   background: color-mix(in oklab, var(--accent) 4%, transparent);
+}
+.landing-v2 .card-table tbody tr.is-archived {
+  opacity: 0.6;
+}
+.landing-v2 .card-table tbody tr.is-archived:hover {
+  opacity: 1;
+}
+.landing-v2 .card-table tbody tr.is-archived .ct-thumb {
+  filter: grayscale(1);
+}
+.landing-v2 .card-table tbody tr.is-archived:hover .ct-thumb {
+  filter: none;
 }
 .landing-v2 .card-table td.num {
   text-align: right;


### PR DESCRIPTION
## Problem

Cards that stopped accepting applications were hidden in two places and easy to miss in a third:

- The landing hero search filtered to `accepting_applications: true`, so searching for a pulled card (Citi Custom Cash, Citi Prestige) returned "No cards match" even though the card page exists.
- Explore hid them behind an "Include archived cards" switch buried in the More facet.
- On the card page, the discontinued banner was ink-on-white, sitting right under the ink-colored breadcrumb bar so the two read as one dark block (e.g. Bilt Mastercard).

## Changes

**Landing search** — archived cards are now included, ranked below every live match, rendered with a grayscale thumbnail, muted name, and a "Not accepting applications" pill. Still clickable; the name brightens on hover/keyboard focus. They hold up to two reserved slots in the 6-result list so a broad query like "citi" can't push them off, and they fill the remaining space when few live cards match. Typing "citi custom" now leaves Citi Custom Cash as the only result, and Enter goes straight to it.

**Explore** — the "Include archived cards" switch is gone. Archived cards always appear, sorted last under every sort key (the partition runs after the chosen sort, and `Array.prototype.sort` is stable, so order within each group holds). Both table rows and grid cards drop to 0.6 opacity with a grayscale thumbnail, back to full opacity on hover. Facet counts and the header count now cover the whole catalog (199).

**Card page** — the discontinued banner uses the same warn red as the "no longer accepting applications" banner. The two branches collapse into one block that swaps only the copy.

## Verification

Ran the dev server and checked each surface:
- Landing: "citi" → four live Citi cards, then Citi Custom Cash and Citi Prestige grayed at the bottom; "citi custom" → Citi Custom Cash alone.
- Explore: 199 rows, 171 live then 28 archived; archived rows compute to `opacity: 0.6` with `grayscale(1)` thumbs in table view and 0.62 in grid view; the More facet now lists only the two remaining switches.
- Card page: `/card/bilt-mastercard` banner computes to `#ffe6ed` on `#d23a62`, clearly separated from the breadcrumb bar.

`tsc --noEmit` and eslint clean.

Note: the bank pages (`/bank/[name]`) still have their own "Show archived" toggle, and so does the wallet. Left alone since this was scoped to landing + explore.