### PR TITLE
Stage the daily seen-state so the publish step can push it to main

### DIFF
--- a/scripts/check-reddit-product-changes-publish.sh
+++ b/scripts/check-reddit-product-changes-publish.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Publish step for the daily Reddit product-change check. Runs AFTER
+# `node scripts/sweep-reddit-product-changes.js --phase=finish` has written the
+# accepted changes to data/reddit-product-changes/.
+#
+# Two jobs, mirroring check-reddit-datapoints-publish.sh:
+#   1. Persist the seen-state (.github/reddit-product-change-state.json)
+#      straight to main via the contents API — it must survive even when the PR
+#      is closed unmerged, because "seen" means "presented for extraction", not
+#      "accepted". Routing it through the PR would lose exactly the rejections
+#      it needs to remember, and a rejected post would come back tomorrow.
+#   2. Open the auto-product-changes-* review PR from a branch based on
+#      origin/main.
+#
+# Usage: scripts/check-reddit-product-changes-publish.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+STATE_FILE=".github/reddit-product-change-state.json"
+STATE_UPDATED=".reddit-pc-work/state-updated.json"
+PR_BODY_FILE=".reddit-pc-work/pr-body.md"
+
+# ── 1. Seen-state → main (contents API; never through the PR) ────────────────
+if [ -f "$STATE_UPDATED" ] && ! cmp -s "$STATE_UPDATED" "$STATE_FILE"; then
+  echo "=== Persisting seen-state ==="
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+  SHA="$(gh api "repos/${REPO}/contents/${STATE_FILE}?ref=main" --jq '.sha' 2>/dev/null || true)"
+  ARGS=(-X PUT "repos/${REPO}/contents/${STATE_FILE}"
+    -f message='chore: update reddit product-change seen-state [skip ci]'
+    -f branch=main
+    -f content="$(base64 < "$STATE_UPDATED" | tr -d '\n')")
+  [ -n "$SHA" ] && ARGS+=(-f sha="$SHA")
+  gh api "${ARGS[@]}" --jq '.commit.sha' | sed 's/^/Committed state as /'
+  # The push went to origin/main; drop any local edit so the tree stays clean.
+  git checkout -q -- "$STATE_FILE" 2>/dev/null || true
+fi
+
+# ── 2. Review PR ─────────────────────────────────────────────────────────────
+if [ -z "$(git status --porcelain data/reddit-product-changes/)" ]; then
+  echo "No product changes to propose."
+  exit 0
+fi
+
+ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+BRANCH="auto-product-changes-$(date +%Y-%m-%d-%H%M%S)"
+
+# Base on origin/main, not HEAD: run locally this may start from a feature
+# branch, and the untracked data/reddit-product-changes/ files carry across the
+# checkout because they are the only modified paths.
+git fetch -q origin main
+git checkout -q -b "$BRANCH" origin/main
+git add data/reddit-product-changes/
+git commit -q -m "Reddit product changes for review — $(date +%Y-%m-%d)"
+git push -q -u origin "$BRANCH"
+
+PR_ARGS=(--head "$BRANCH" --base main --title "Reddit product changes for review — $(date +%Y-%m-%d)")
+if [ -f "$PR_BODY_FILE" ]; then
+  PR_ARGS+=(--body-file "$PR_BODY_FILE")
+else
+  PR_ARGS+=(--body "Product changes extracted from r/CreditCards.")
+fi
+gh pr create "${PR_ARGS[@]}"
+
+# Return to wherever the routine started so the checkout is left as found.
+git checkout -q "$ORIGINAL_BRANCH"

--- a/scripts/sweep-reddit-product-changes.js
+++ b/scripts/sweep-reddit-product-changes.js
@@ -471,6 +471,9 @@ function phaseFinish() {
 // rejecting a proposal is permanent: nothing re-proposes a post once it has
 // been seen, whether it became a data point or not.
 const DAILY_STATE_PATH = path.join(ROOT, '.github', 'reddit-product-change-state.json');
+// Staging copy the publish script reads; see saveDailyState for why the
+// committed file is never written directly.
+const DAILY_STATE_STAGED = path.join(OUT_DIR, 'state-updated.json');
 const DAILY_STATE_RETENTION_DAYS = 180;
 
 function loadDailyState() {
@@ -482,6 +485,12 @@ function loadDailyState() {
   }
 }
 
+// Writes to a STAGING file, not to the committed state. The publish script
+// pushes it straight to main via the contents API, because "seen" means
+// "presented for extraction", not "accepted" — a post whose PR was closed
+// unmerged must not come back tomorrow. Routing it through the review PR would
+// lose exactly the rejections it needs to remember. Same rationale as
+// check-reddit-datapoints-publish.sh.
 function saveDailyState(state) {
   // Prune well past any plausible re-surfacing so the file cannot grow forever.
   const cutoff = new Date(Date.now() - DAILY_STATE_RETENTION_DAYS * 86400000)
@@ -491,8 +500,8 @@ function saveDailyState(state) {
   for (const [id, date] of Object.entries(state.seen)) {
     if (date >= cutoff) seen[id] = date;
   }
-  fs.mkdirSync(path.dirname(DAILY_STATE_PATH), { recursive: true });
-  fs.writeFileSync(DAILY_STATE_PATH, `${JSON.stringify({ seen }, null, 1)}\n`);
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.writeFileSync(DAILY_STATE_STAGED, `${JSON.stringify({ seen }, null, 1)}\n`);
 }
 
 async function phaseDaily() {


### PR DESCRIPTION
Fixes a real bug in the daily routine before it is scheduled, and adds the publish step it needs.

## The bug

`--phase=daily` was writing `.github/reddit-product-change-state.json` directly. That file would then be picked up by the review PR — which loses the rejections.

"Seen" means **presented for extraction**, not **accepted**. If the seen-state only reaches main when a PR merges, then every post in a PR that gets closed unmerged comes back the next day, gets re-proposed, gets rejected again, forever.

## The fix

The daily phase now writes `.reddit-pc-work/state-updated.json`, and `scripts/check-reddit-product-changes-publish.sh` pushes that to main via the contents API *before* opening the `auto-product-changes-*` PR. That is the same split `check-reddit-datapoints-publish.sh` uses, for the same reason.

The publish script also opens the review PR from a branch based on `origin/main` rather than `HEAD`, so it behaves when the routine runs from a checkout sitting on some other branch — which, given how often scheduled tasks move this checkout around, is the normal case rather than the edge case.

## Verification

Live daily run against Reddit:

```
r/CreditCards new: 100 entries, 12 new with PC signal
product-change search: 13 entries, 13 new with PC signal
Daily scan: 21 new candidate(s)
```

Staged state written with 21 ids; `git status --porcelain .github/` clean afterwards, confirming the committed file is no longer touched by the scan.

`bash -n` and `node --check` both pass.