### PR TITLE
Wire RunMigrationHandler to apply the reddit_product_changes migration

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -1646,6 +1646,24 @@ Resources:
   #           USERNAME: !Ref USERNAME
   #           PASSWORD: !Ref PASSWORD
 
+  # TEMPORARILY WIRED to apply 054_create_reddit_product_changes.sql.
+  # Remove in the immediate follow-up PR — the handler reads an arbitrary file
+  # path from its invoke payload, so it must not sit deployed.
+  RunMigrationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/run-migration.RunMigrationHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 300
+      Description: One-shot migration runner; invoke with {"migration":"<file>"}
+      Environment:
+        Variables:
+          ENDPOINT: !Ref ENDPOINT
+          DATABASE: !Ref DATABASE
+          USERNAME: !Ref USERNAME
+          PASSWORD: !Ref PASSWORD
+
   # Referral validity check: paired Lambdas invoked by the
   # `check-referrals.yml` GitHub Action. List returns the due batch;
   # Complete writes back per-referral results. Not exposed via API Gateway.


### PR DESCRIPTION
**Production regression fix.** The Product changes section is currently hidden on every card page, and this restores it.

## What broke

#1938 changed `/card-product-changes` to UNION the new `reddit_product_changes` table. That deployed before the table existed, so the endpoint now fails for **every** card:

```
ERROR Error fetching card product changes:
  ER_NO_SUCH_TABLE: Table 'creditodds.reddit_product_changes' doesn't exist
```

```
$ curl .../card-product-changes?card_id=74
{"error":"Failed to fetch product changes"}
```

The client swallows the failure and returns an empty graph, so the section hides itself rather than erroring visibly — which is why it looked like "no data yet" instead of a fault. It was previously rendering on Citi Custom Cash from wallet data, and that regressed too.

My mistake: I flagged the migration as outstanding but merged an endpoint change that depends on it. The migration needed to land first.

## This PR

Wires the one-shot `RunMigrationFunction` so `054_create_reddit_product_changes.sql` can be applied. Note it is deliberately defined **without** the esbuild `Metadata` block, matching the commented template — the handler does `fs.readFileSync` on `../../migrations`, which only resolves when the function ships as a plain directory zip rather than a bundle.

## Sequence

1. Merge this → `deploy-api.yml` deploys the runner
2. Invoke with `{"migration": "054_create_reddit_product_changes.sql"}`
3. Verify the endpoint returns data again
4. **Immediate follow-up PR removes this block** — the handler reads an arbitrary file path from its invoke payload, so it must not sit deployed

I'll drive 2–4 as soon as this lands.