### PR TITLE
Unwire RunMigrationHandler now that 054 is applied

### DIFF
--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -1646,24 +1646,6 @@ Resources:
   #           USERNAME: !Ref USERNAME
   #           PASSWORD: !Ref PASSWORD
 
-  # TEMPORARILY WIRED to apply 054_create_reddit_product_changes.sql.
-  # Remove in the immediate follow-up PR — the handler reads an arbitrary file
-  # path from its invoke payload, so it must not sit deployed.
-  RunMigrationFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: src/handlers/run-migration.RunMigrationHandler
-      Runtime: nodejs22.x
-      MemorySize: 256
-      Timeout: 300
-      Description: One-shot migration runner; invoke with {"migration":"<file>"}
-      Environment:
-        Variables:
-          ENDPOINT: !Ref ENDPOINT
-          DATABASE: !Ref DATABASE
-          USERNAME: !Ref USERNAME
-          PASSWORD: !Ref PASSWORD
-
   # Referral validity check: paired Lambdas invoked by the
   # `check-referrals.yml` GitHub Action. List returns the due batch;
   # Complete writes back per-referral results. Not exposed via API Gateway.


### PR DESCRIPTION
Follow-up to #1942, as promised there. The one-shot migration runner comes back out — it reads an arbitrary file path from its invoke payload, so it must never sit deployed between migrations.

## Confirmed before removing

Migration applied:
```
{"statusCode":200,"body":"{\"message\":\"Migration completed\", ...}"}
```

Table exists with all nine columns (`id`, `source_id`, `old_card_id`, `new_card_id`, `change_month`, `reason`, `evidence`, `permalink`, `imported_at`).

Endpoint recovered — it was returning `{"error":"Failed to fetch product changes"}` for every card:
```
$ curl .../card-product-changes?card_id=74
{"card_id":74,"inbound":[{"card_name":"Citi Double Cash","count":19,
  "wallet_count":2,"reddit_count":17,"share":76, ...}], ...}
```

All 61 backfilled rows imported.

## One more thing this surfaced

The `sync-product-changes` workflow had failed twice with:

```
AccessDeniedException ... not authorized to perform: lambda:InvokeFunction on
arn:aws:lambda:us-east-1:...:function:creditodds-import-reddit-product-changes
```

Exactly the class of gotcha CLAUDE.md already documents for `InvokeSyncCards`: a new invoke-only Lambda needs its own inline policy on the `GitHubActions-CreditOdds` role. I added `InvokeImportRedditProductChanges` scoped to that single function ARN, mirroring `InvokeImportRedditRecords`, and the re-run went green.

Worth noting the failure mode: the workflow going red was the *only* signal. Nothing in the app surfaced it, and the endpoint had its own separate reason to be broken at the time, so the two faults masked each other.