### PR TITLE
Scale product-change arrowheads, drop the source name, widen the lede

### DIFF
--- a/apps/web-next/src/app/card/[name]/ProductChangeFlow.tsx
+++ b/apps/web-next/src/app/card/[name]/ProductChangeFlow.tsx
@@ -56,6 +56,28 @@ function strokeFor(share: number): number {
   return STROKE_MIN + (clamped / 100) * (STROKE_MAX - STROKE_MIN);
 }
 
+// Arrowhead dimensions for a given share, derived from that flow's stroke.
+//
+// The head has to stay WIDER than the line it terminates or it stops reading as
+// an arrow — a fixed-size head on a 13px flow looked like the line had simply
+// been cut off. Width tracks the stroke at ~2.2x (the usual arrow proportion)
+// and is clamped at both ends: the floor keeps a hairline flow's head visible,
+// the ceiling keeps the heaviest head from eating the gutter.
+const ARROW_WIDTH_RATIO = 2.2;
+const ARROW_WIDTH_MIN = 9;
+const ARROW_WIDTH_MAX = 26;
+// Slightly shorter than it is wide, which reads as an arrow rather than a spike.
+const ARROW_LENGTH_RATIO = 0.85;
+
+function arrowFor(share: number): { headL: number; headW: number } {
+  const stroke = strokeFor(share);
+  const headW = Math.max(
+    ARROW_WIDTH_MIN,
+    Math.min(ARROW_WIDTH_MAX, stroke * ARROW_WIDTH_RATIO),
+  );
+  return { headL: headW * ARROW_LENGTH_RATIO, headW };
+}
+
 function columnHeight(count: number): number {
   return count > 0 ? count * PITCH - ROW_GAP : 0;
 }
@@ -128,27 +150,47 @@ function Connectors({
       focusable="false"
     >
       <defs>
-        {/* userSpaceOnUse (not strokeWidth) so a 13px-thick flow and a 2.5px
-            one get the same size arrowhead. Scaling with the stroke would make
-            the heaviest edge's head wider than the gutter. */}
-        <marker
-          id={`pcf-arrow-${direction}`}
-          markerUnits="userSpaceOnUse"
-          markerWidth="11"
-          markerHeight="11"
-          refX="9"
-          refY="5.5"
-          orient="auto"
-        >
-          <path d="M0,0 L11,5.5 L0,11 z" fill="var(--accent)" />
-        </marker>
+        {/* One marker per connector, sized from that connector's stroke.
+            A single shared marker cannot work here: markerUnits="strokeWidth"
+            scales linearly and would put a ~50px head on the heaviest flow,
+            while a fixed userSpaceOnUse head ends up NARROWER than a 13px line
+            and reads as a stub rather than an arrow. Sizing each head from its
+            own stroke keeps the classic arrow proportion at every weight. */}
+        {nodes.map((node) => {
+          const { headL, headW } = arrowFor(node.share);
+          return (
+            <marker
+              key={node.cardId}
+              id={`pcf-arrow-${direction}-${node.cardId}`}
+              markerUnits="userSpaceOnUse"
+              markerWidth={headL}
+              markerHeight={headW}
+              // refX 0 puts the head's BASE on the path's end vertex, so the
+              // head extends forward from there. The path is shortened by headL
+              // to compensate, which also stops the stroke before the triangle
+              // narrows — otherwise a thick line pokes out through the head's
+              // sides near the tip, since the triangle is thinner than the line
+              // over its front half.
+              refX={0}
+              refY={headW / 2}
+              orient="auto"
+            >
+              <path d={`M0,0 L${headL},${headW / 2} L0,${headW} z`} fill="var(--accent)" />
+            </marker>
+          );
+        })}
       </defs>
       {nodes.map((node, i) => {
         const y = rowCenterY(i, nodes.length, height);
+        const { headL } = arrowFor(node.share);
+        // The line stops where the head starts (less a 1px overlap that hides
+        // the seam), so the arrow tip still lands at GUTTER_W - INSET. The
+        // curve is flat at both ends, so subtracting along x is exact here.
+        const endX = GUTTER_W - INSET - headL + 1;
         const [x1, y1, x2, y2] =
           direction === "in"
-            ? [0, y, GUTTER_W - INSET, centerY]
-            : [INSET, centerY, GUTTER_W - INSET, y];
+            ? [0, y, endX, centerY]
+            : [INSET, centerY, endX, y];
         // Horizontal control points give an S-curve that leaves and arrives
         // flat, so connectors read as flows rather than straight-line joins.
         const cx = (x1 + x2) / 2;
@@ -161,8 +203,10 @@ function Connectors({
             strokeWidth={strokeFor(node.share)}
             strokeLinecap="butt"
             // Heavier flows read as more solid; the lightest still stay legible.
+            // Applied to the whole element, so the marker inherits it and the
+            // head never floats at a different weight from its line.
             opacity={0.42 + (Math.max(0, Math.min(100, node.share)) / 100) * 0.48}
-            markerEnd={`url(#pcf-arrow-${direction})`}
+            markerEnd={`url(#pcf-arrow-${direction}-${node.cardId})`}
           />
         );
       })}
@@ -219,15 +263,15 @@ export default function ProductChangeFlow({
   );
 
   const total = inboundTotal + outboundTotal;
-  // Name only the sources actually present. Claiming both when the data is
-  // entirely one of them is the specific way this line could mislead, and the
-  // mix will stay lopsided for a long time.
+  // Deliberately does not name the outside source. It also must not claim every
+  // report was logged by a member, because most were not — "cardholder reports"
+  // is the phrasing that stays true whatever the mix is. The per-edge and
+  // page-level provenance counts still come back from the API, so the split is
+  // available if this ever needs to be shown again.
   const sourcePhrase =
-    walletTotal > 0 && redditTotal > 0
-      ? ` from CreditOdds member wallets (${walletTotal}) and r/CreditCards (${redditTotal})`
-      : redditTotal > 0
-        ? " sourced from posts on r/CreditCards"
-        : " logged by CreditOdds members in their wallets";
+    walletTotal > 0 && redditTotal === 0
+      ? " logged by CreditOdds members in their wallets"
+      : "";
 
   return (
     <div className="pcf">
@@ -305,7 +349,8 @@ export default function ProductChangeFlow({
       </div>
 
       <p className="pcf-note">
-        Based on {total} {total === 1 ? "report" : "reports"}
+        Based on {total} reported product{" "}
+        {total === 1 ? "change" : "changes"}
         {sourcePhrase}. Percentages are shares of each direction, not of all
         cardholders, and a small sample can swing a long way.
       </p>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -8713,9 +8713,10 @@
    derives the SVG connector y-coordinates from those exact numbers. Changing
    either height here means changing ROW_H / ROW_GAP in that file too.
    `.pcf-stacked` is the narrow one and carries no such constraint. */
+/* No max-width: the lede spans the section like the diagram beneath it. A
+   620px measure left an odd ragged column against the full-width flow chart. */
 .landing-v2 .pcf-lede {
   margin: 0 0 24px;
-  max-width: 620px;
   font-size: 14px;
   line-height: 1.6;
   color: var(--muted);


### PR DESCRIPTION
Three fixes to the Product changes section, all spotted by Max on the live page.

## 1. Arrowheads didn't match their lines

I'd pinned the heads to a fixed 11px so they wouldn't blow up on heavy flows. At 13px stroke that makes the head **narrower than the line it terminates**, so it reads as the line being cut off rather than as an arrow.

Each head is now sized from its own connector's stroke at the usual ~2.2x arrow proportion, clamped at both ends — the floor keeps a hairline flow's head visible, the ceiling keeps the heaviest from eating the 96px gutter.

Measured on Citi Custom Cash:

| Flow | Stroke | Head width |
|---|---|---|
| Double Cash (76%) | 10.5px | 11px → **23.1px** |
| the 4% edges | 2.9px | 11px → 9.0px |

**Scaling the head alone would have introduced a new artifact.** A triangle is thinner than the line over its front half, so a thick stroke pokes out through the head's sides near the tip. The marker now anchors at its base (`refX=0`) and each path is shortened by the head length, so the line stops exactly where the head begins. Checked at 2.4x zoom — clean join, nothing protruding.

## 2. Footnote no longer names r/CreditCards

Per Max. Note it does **not** revert to "logged by CreditOdds members in their wallets" — only 2 of those 25 were, so that line would now be false. It reads:

> Based on 25 reported product changes. Percentages are shares of each direction, not of all cardholders, and a small sample can swing a long way.

"Reported product changes" stays true whatever the mix is. The member-specific wording still appears automatically when a card's data really is all member-logged, and the API still returns the provenance split per edge, so it can be surfaced again without a backend change.

## 3. Lede width

It carried `max-width: 620px` (mine), which wrapped it early against a full-width flow chart. Removed — it now measures exactly the section width.

## Verification

Ran against a local dev server with live production data. Confirmed via the DOM: marker dimensions scale as intended, the section contains no "reddit"/"r/Credit" string, and the lede width equals the section width. `tsc --noEmit` and `eslint` both clean.

## Known, not addressed here

Between roughly 820–1100px the node card names clip ("76…", "8%…") because the ToC and right rail squeeze the diagram. Pre-existing, not from this change — happy to take it separately.