### PR TITLE
Add the OG Chase Freedom and recover 14 product changes it was blocking

### DIFF
--- a/data/cards/chase-freedom.yaml
+++ b/data/cards/chase-freedom.yaml
@@ -1,0 +1,53 @@
+name: "Chase Freedom"
+bank: "Chase"
+slug: "chase-freedom"
+accepting_applications: false
+annual_fee: 0
+tags:
+  - cashback
+  - rewards
+reward_type: "cashback"
+rewards:
+  # Shares the quarterly calendar with the Freedom Flex: Chase announces the
+  # categories for "Freedom and Freedom Flex cardmembers" together, so this
+  # block must be kept in step with chase-freedom-flex.yaml each quarter.
+  - category: "rotating"
+    value: 5
+    unit: "percent"
+    mode: "quarterly_rotating"
+    current_categories:
+      - category: "gas"
+        note: "Gas stations (Q3 2026 rotation)"
+      - category: "ev_charging"
+        note: "EV charging (Q3 2026 rotation)"
+      - category: "transit"
+        note: "Public transit (Q3 2026 rotation)"
+      - category: "entertainment"
+        note: "Select live entertainment (Q3 2026 rotation)"
+    current_period: "Q3 2026"
+    note: "Q3 2026: gas stations and EV charging, public transit, select live entertainment, and donations to United Way"
+    spend_cap: 1500
+    cap_period: quarterly
+    rate_after_cap: 1
+  # Deliberately NO travel_portal entry. The permanent 5% on Chase Travel is a
+  # Freedom Flex benefit; this card only earns it when Chase Travel happens to
+  # be in the quarterly rotation, as it was in Q2 2026. The same goes for the
+  # Flex's 3% dining and drugstores and its cell phone protection, none of
+  # which this card carries.
+  - category: "everything_else"
+    value: 1
+    unit: "percent"
+foreign_transaction_fee: true
+network: "visa"
+our_take: >
+  The original Chase Freedom closed to new applications in 2020, when the
+  Freedom Flex replaced it, but plenty of people still hold one and it remains
+  a common product-change target. The reason is the network: it is a Visa,
+  where the Flex is a Mastercard, so cardholders who want a Visa in the Chase
+  lineup often downgrade into this card rather than the Flex. It earns the same
+  5% on the rotating quarterly categories, on up to $1,500 in spend once you
+  activate, and 1% on everything else. What it does not have is the rest of the
+  Flex's sheet: no permanent 5% on Chase Travel, no 3% on dining or drugstores,
+  and no cell phone protection. If you already hold one it is worth keeping for
+  the rotating categories and the account age, but there is no way to get one
+  today except by converting another Chase card.

--- a/data/reddit-product-changes/2024-11-t3_1gz8e16.yaml
+++ b/data/reddit-product-changes/2024-11-t3_1gz8e16.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1gz8e16
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1gz8e16/data_point_product_change_from_csp_to_og_freedom/
+posted: "2024-11-25"
+evidence: >-
+  Poster called to product change their Sapphire Preferred to the Freedom with Ultimate Rewards once
+  the annual fee hit and they were approaching 48 months from their intro offer.
+from_card: Chase Sapphire Preferred
+to_card: Chase Freedom
+change_month: 2024-11
+reason: voluntary

--- a/data/reddit-product-changes/2024-11-t3_1h0ena6.yaml
+++ b/data/reddit-product-changes/2024-11-t3_1h0ena6.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1h0ena6
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1h0ena6/data_point_product_change_chase_freedom_unlimited/
+posted: "2024-11-26"
+evidence: >-
+  Poster product changed a Freedom Unlimited held about nineteen months to the OG Freedom Visa by
+  calling support, wanting a Visa alongside their existing Mastercard Flex.
+from_card: Chase Freedom Unlimited
+to_card: Chase Freedom
+change_month: 2024-11
+reason: voluntary

--- a/data/reddit-product-changes/2024-12-t3_1hggxqs.yaml
+++ b/data/reddit-product-changes/2024-12-t3_1hggxqs.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1hggxqs
+permalink: https://www.reddit.com/r/CreditCards/comments/1hggxqs/product_change_from_csr_to_classic_freedom/
+posted: "2024-12-17"
+evidence: >-
+  Poster product changed a Sapphire Reserve to the original Chase Freedom after clarifying with the
+  representative that they meant the rotating-categories Visa rather than the Unlimited or Flex.
+from_card: Chase Sapphire Reserve
+to_card: Chase Freedom
+change_month: 2024-12
+reason: voluntary

--- a/data/reddit-product-changes/2024-12-t3_1hjftet.yaml
+++ b/data/reddit-product-changes/2024-12-t3_1hjftet.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1hjftet
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1hjftet/dp_product_change_from_chase_freedom_flex_to_og/
+posted: "2024-12-21"
+evidence: >-
+  Poster switched from the Freedom Flex to the OG Freedom specifically to get a Visa rather than a
+  Mastercard, so the rotating wholesale-club quarter would work at Costco.
+from_card: Chase Freedom Flex
+to_card: Chase Freedom
+change_month: 2024-12
+reason: voluntary

--- a/data/reddit-product-changes/2025-03-t3_1j8eg6q.yaml
+++ b/data/reddit-product-changes/2025-03-t3_1j8eg6q.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1j8eg6q
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1j8eg6q/cfu_product_change_to_chase_freedom_ultimate/
+posted: "2025-03-11"
+evidence: >-
+  Poster product changed their Freedom Unlimited to the OG Freedom in a five-minute call, and
+  reports the rotating-category earnings backdated to purchases made in January and February.
+from_card: Chase Freedom Unlimited
+to_card: Chase Freedom
+change_month: 2025-03
+reason: voluntary

--- a/data/reddit-product-changes/2025-04-t3_1jtxpti.yaml
+++ b/data/reddit-product-changes/2025-04-t3_1jtxpti.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1jtxpti
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1jtxpti/og_chase_freedom_paired_with_the_chase_freedom/
+posted: "2025-04-07"
+evidence: >-
+  Poster updated their post to report successfully calling the Sapphire helpline and product
+  changing their household's second Sapphire Preferred to the OG Freedom Visa, to secure a second
+  rotating-category bucket.
+from_card: Chase Sapphire Preferred
+to_card: Chase Freedom
+change_month: 2025-04
+reason: voluntary

--- a/data/reddit-product-changes/2025-04-t3_1mmneom-1.yaml
+++ b/data/reddit-product-changes/2025-04-t3_1mmneom-1.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1mmneom#1
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1mmneom/am_i_able_to_downgrade_a_card_i_recently_upgraded/
+posted: "2025-08-10"
+evidence: >-
+  Poster's account history records downgrading a Sapphire Preferred opened in 2021 to an OG Freedom
+  in April 2025, before applying for a new Sapphire Preferred.
+from_card: Chase Sapphire Preferred
+to_card: Chase Freedom
+change_month: 2025-04
+reason: voluntary

--- a/data/reddit-product-changes/2025-06-t3_1lir1l9.yaml
+++ b/data/reddit-product-changes/2025-06-t3_1lir1l9.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1lir1l9
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1lir1l9/data_point_product_change_to_og_freedom_still/
+posted: "2025-06-23"
+evidence: >-
+  Poster product changed their Sapphire Preferred to the OG Freedom on 23 June 2025 to become
+  eligible for the new Sapphire Reserve bonus; the representative referred to the card as the
+  Freedom Classic.
+from_card: Chase Sapphire Preferred
+to_card: Chase Freedom
+change_month: 2025-06
+reason: voluntary

--- a/data/reddit-product-changes/2025-06-t3_1mmneom-2.yaml
+++ b/data/reddit-product-changes/2025-06-t3_1mmneom-2.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1mmneom#2
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1mmneom/am_i_able_to_downgrade_a_card_i_recently_upgraded/
+posted: "2025-08-10"
+evidence: >-
+  Same poster upgraded that same OG Freedom account to the new Sapphire Reserve on 27 June 2025,
+  forgoing the bonus because the credits would offset the annual fee.
+from_card: Chase Freedom
+to_card: Chase Sapphire Reserve
+change_month: 2025-06
+reason: voluntary

--- a/data/reddit-product-changes/2025-09-t3_1nffits.yaml
+++ b/data/reddit-product-changes/2025-09-t3_1nffits.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1nffits
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1nffits/dp_successful_product_change_to_og_chase_freedom/
+posted: "2025-09-12"
+evidence: >-
+  Poster called about product change options on an old Slate Edge, asked for the Freedom with
+  rotating categories by name, and the representative processed it within about five minutes.
+from_card: Chase Slate Edge
+to_card: Chase Freedom
+change_month: 2025-09
+reason: voluntary

--- a/data/reddit-product-changes/2025-12-t3_1q8kntr.yaml
+++ b/data/reddit-product-changes/2025-12-t3_1q8kntr.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1q8kntr
+permalink: https://www.reddit.com/r/CreditCards/comments/1q8kntr/dp_csr_downgrade_succesful/
+posted: "2026-01-09"
+evidence: >-
+  Poster called on 31 December intending to cancel the Sapphire Reserve, asked whether the Freedom
+  with Ultimate Rewards was available as a product change, and switched to it instead of closing the
+  account.
+from_card: Chase Sapphire Reserve
+to_card: Chase Freedom
+change_month: 2025-12
+reason: voluntary

--- a/data/reddit-product-changes/2026-04-t3_1sif7ny.yaml
+++ b/data/reddit-product-changes/2026-04-t3_1sif7ny.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1sif7ny
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1sif7ny/successful_pc_from_chase_sapphire_preferred_to_og/
+posted: "2026-04-11"
+evidence: >-
+  Poster called the number on the back of their Sapphire Preferred and was offered a choice of
+  Freedom Unlimited or Freedom with Ultimate Rewards without having to ask; the change showed in the
+  app immediately.
+from_card: Chase Sapphire Preferred
+to_card: Chase Freedom
+change_month: 2026-04
+reason: voluntary

--- a/data/reddit-product-changes/2026-04-t3_1signs7.yaml
+++ b/data/reddit-product-changes/2026-04-t3_1signs7.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1signs7
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1signs7/product_changed_a_chase_freedom_unlimited_in_1/
+posted: "2026-04-11"
+evidence: >-
+  Poster product changed a Freedom Unlimited opened in August 2025 to the Freedom with Ultimate
+  Rewards at roughly six months, contradicting the widely repeated claim that Chase requires a full
+  year of tenure.
+from_card: Chase Freedom Unlimited
+to_card: Chase Freedom
+change_month: 2026-04
+reason: voluntary

--- a/data/reddit-product-changes/2026-06-t3_1ui76m6.yaml
+++ b/data/reddit-product-changes/2026-06-t3_1ui76m6.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1ui76m6
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1ui76m6/dp_product_change_cfu_to_chase_freedom_visa_with/
+posted: "2026-06-28"
+evidence: >-
+  Poster product changed their Freedom Unlimited to the Visa Freedom with Ultimate Rewards over the
+  phone in under ten minutes, after moving credit limit from another card to meet the $5k minimum
+  the rep required.
+from_card: Chase Freedom Unlimited
+to_card: Chase Freedom
+change_month: 2026-06
+reason: voluntary


### PR DESCRIPTION
Closes the largest recall gap in the r/CreditCards backfill.

The discontinued original Chase Freedom is the **most common product-change target on the subreddit**, and every change touching it was dropped because the card was not in the catalog.

## Result

**+14 changes, 61 → 75.** Chase Freedom lands as the third-highest-degree node:

| Node | Degree | |
|---|---|---|
| Citi Custom Cash | 23 | in 23, out 0 |
| Citi Double Cash | 17 | in 0, out 17 |
| **Chase Freedom** | **14** | **in 13, out 1** |
| Chase Freedom Unlimited | 8 | in 2, out 6 |

That 13-in / 1-out asymmetry is real and is rather the point: it is where people go, not where they leave.

By year: 2024 (13) · 2025 (29) · 2026 (33). No duplicate `source_id`s.

## Card details, verified not assumed

It shares the quarterly rotating calendar with the Freedom Flex — Chase announces categories for "Freedom **and** Freedom Flex cardmembers" together — so the two YAML files must be kept in step each quarter. That is a real recurring cost, not free.

What it does **not** carry, and I checked specifically because it would have been easy to copy across from the Flex:
- no permanent 5% on Chase Travel (Flex-only; this card gets it only when it rotates in, as in Q2 2026)
- no 3% dining or drugstores
- no cell phone protection

It is a **Visa** where the Flex is a Mastercard, which is the reason most posters give for converting into it — the rotating wholesale-club quarter then works at Costco. `accepting_applications: false` because it is genuinely closed to new applicants, which since #1939 surfaces it as archived rather than hiding it.

Sources: [Chase Q1 2026](https://media.chase.com/news/chase-freedom-2026-q1-categories), [Chase Q3 2026](https://media.chase.com/news/chase-freedom-2026-q3-categories)

## How the 14 were found

The re-sweep collected 244 candidates across all four Freedom cards (the `--cards` filter matches by substring). 8 were already accepted in the backfill and excluded so nothing is re-proposed. 77 mention the OG card, 16 scored as completed changes, 14 survived extraction.

The two dropped went on the same grounds used throughout the backfill: one where the poster reported the card being *offered* as an option without saying they took it, and one where Chase shipped the wrong card twice and the final state is genuinely unclear.

## Known gap

**No card art exists for this card**, so it renders the generic placeholder — visible, since it will now be a prominent node in the diagram. Needs an image dropped into the card-images CDN plus the `image:` field.