### PR TITLE
Filter foreign-script client noise out of Sentry

### DIFF
--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -165,4 +165,48 @@ describe("isBenignClientError", () => {
       false,
     );
   });
+
+  // CefSharp embedded-Chromium crawlers (Outlook SafeLinks) reject with a bare
+  // string; the id and method name vary per hit.
+  it("drops the CefSharp bridge string rejection", () => {
+    expect(
+      isBenignClientError(
+        "Object Not Found Matching Id:2, MethodName:update, ParamCount:4",
+      ),
+    ).toBe(true);
+  });
+
+  it("drops CefSharp bridge noise wrapped in an Error", () => {
+    expect(
+      isBenignClientError(
+        new Error("Object Not Found Matching Id:7, MethodName:getData, ParamCount:1"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps other bare-string rejections", () => {
+    expect(isBenignClientError("something actually broke")).toBe(false);
+  });
+
+  // An injected script stringifying a React-owned DOM node inside a patched
+  // appendChild. Both halves of the message are required.
+  it("drops circular-structure errors that walk a React fiber", () => {
+    expect(
+      isBenignClientError(
+        new TypeError(
+          "Converting circular structure to JSON\n    --> starting at object with constructor 'HTMLAnchorElement'\n    |     property '__reactFiber$n203s0946xd' -> object with constructor 'rg'\n    --- property 'stateNode' closes the circle",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps circular-structure errors from our own data", () => {
+    expect(
+      isBenignClientError(
+        new TypeError(
+          "Converting circular structure to JSON\n    --> starting at object with constructor 'Object'\n    --- property 'self' closes the circle",
+        ),
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -39,6 +39,27 @@
 // unactionable: a bare Event carries no stack, no message, and no URL.
 // ErrorEvent is deliberately NOT matched — it carries a real message/error
 // payload worth reporting.
+//
+// Two more shapes come from code that isn't ours at all:
+//
+// 1. "Object Not Found Matching Id:N, MethodName:update, ParamCount:4"
+//    (CREDITODDS-JAVASCRIPT-NEXTJS-16), rejected as a bare STRING rather than
+//    an Error. That wording is the CefSharp .NET/Chromium host bridge failing
+//    to resolve a JS object it registered — it is emitted by embedded-Chromium
+//    crawlers, chiefly Microsoft Outlook's SafeLinks scanner following a link
+//    from an email. No browser or library we ship produces it, the id and
+//    method name vary per hit, and there is no stack. Bot traffic, not users.
+//
+// 2. "Converting circular structure to JSON ... property '__reactFiber$...'"
+//    (CREDITODDS-JAVASCRIPT-NEXTJS-17): an injected script has monkey-patched
+//    Node.prototype.appendChild and JSON.stringify's the node React hands it
+//    during commit. React attaches its fiber to every DOM node it owns
+//    (`__reactFiber$<random>`), and a fiber points back at its stateNode, so
+//    stringifying any mounted node always cycles. The throw happens inside the
+//    extension's wrapper — every frame above our chunk is `<anonymous>` — so
+//    there is nothing to fix on our side. Both substrings are required: a
+//    genuine circular-structure bug in our own code would not be walking a
+//    React fiber.
 const BENIGN_CLIENT_SIGNATURES = [
   'The transaction was aborted',
   'database connection is closing',
@@ -53,6 +74,13 @@ const BENIGN_ANY_ERROR_SIGNATURES = [
   'Invalid call to runtime.sendMessage(). Tab not found.',
   'Connection to Indexed Database server lost',
   'installations/app-offline',
+  'Object Not Found Matching Id:',
+];
+
+// Every substring here must be present for the error to count as benign. Used
+// for shapes whose message alone is too generic to drop outright.
+const BENIGN_COMPOUND_SIGNATURES = [
+  ['Converting circular structure to JSON', '__reactFiber$'],
 ];
 
 // DOMException.ABORT_ERR — the numeric code carried by AbortErrors.
@@ -86,10 +114,25 @@ export function isBenignClientError(error: unknown): boolean {
       cause?: unknown;
     };
     const name = typeof e.name === 'string' ? e.name : '';
-    const message = typeof e.message === 'string' ? e.message : '';
+    // A promise can reject with a bare string (no Error wrapper), in which case
+    // the value itself is the only message we get.
+    const message =
+      typeof current === 'string'
+        ? current
+        : typeof e.message === 'string'
+          ? e.message
+          : '';
     const isAbort = name === 'AbortError' || e.code === ABORT_ERR_CODE;
 
     if (BENIGN_ANY_ERROR_SIGNATURES.some((sig) => message.includes(sig))) {
+      return true;
+    }
+
+    if (
+      BENIGN_COMPOUND_SIGNATURES.some((sigs) =>
+        sigs.every((sig) => message.includes(sig)),
+      )
+    ) {
       return true;
     }
 


### PR DESCRIPTION
Two new client issues are both produced by code we don't ship. Neither is actionable, so `beforeSend` drops them.

**[CREDITODDS-JAVASCRIPT-NEXTJS-16](https://creditodds.sentry.io/issues/7652461528/)** — `Object Not Found Matching Id:2, MethodName:update, ParamCount:4`, rejected as a bare string. That is the CefSharp .NET/Chromium host bridge failing to resolve a JS object it registered, emitted by embedded-Chromium crawlers, chiefly Outlook's SafeLinks scanner following a link from an email. The id and method name vary per hit and there is no stack. Bot traffic, not users.

**[CREDITODDS-JAVASCRIPT-NEXTJS-17](https://creditodds.sentry.io/issues/7652464450/)** — `Converting circular structure to JSON` starting at an `HTMLAnchorElement` via `property '__reactFiber$n203s0946xd'`. The stack is the tell: `HTMLDivElement.appendChild` resolves to `<anonymous> [Line 103]`, not native code, so an injected script has monkey-patched `appendChild` and stringifies the node React hands it during commit. React attaches a fiber to every node it owns and the fiber points back at its `stateNode`, so that always cycles. Every frame above our chunk is anonymous.

## Changes

- `isBenignClientError` now reads a bare **string** rejection reason as its own message. This was a real gap: issue 16 rejects with a string rather than an Error, so the old code looked for `.message`, found nothing, and would never have matched regardless of which signature was added.
- New `BENIGN_COMPOUND_SIGNATURES` list for messages too generic to drop outright. The circular-structure entry requires both `Converting circular structure to JSON` and `__reactFiber$`, so a genuine circular-structure bug in our own data still reports.

## Testing

23 unit tests pass, 6 of them new, including negative cases for an unrelated bare-string rejection and a non-fiber circular structure. `tsc --noEmit` and eslint clean.