### PR TITLE
Card Page Check 2026-08-05

### DIFF
--- a/data/cards/capital-one-spark-cash-plus.yaml
+++ b/data/cards/capital-one-spark-cash-plus.yaml
@@ -20,11 +20,11 @@ rewards:
     value: 2
     unit: percent
 signup_bonus:
-  value: 2000
+  value: 4000
   type: "cash"
-  spend_requirement: 30000
-  timeframe_months: 3
-  note: "Also earns a $500 credit for Capital One Business Travel bookings on the same $30,000 spend, plus an additional $2,000 for every $500,000 spent in the first year"
+  spend_requirement: 500000
+  timeframe_months: 12
+  note: "Earn a $2,000 cash bonus when you spend $30,000 in the first 3 months, plus an additional $2,000 cash bonus for every $500,000 spent in the first year (earnable multiple times). The two spend bonuses may be earned independently. For a limited time, also earn a one-time $500 Capital One Business Travel credit when you spend $30,000 in the first 3 months."
 benefits:
   - name: "Annual Fee Refund"
     value: 150

--- a/data/cards/capital-one-spark-cash-plus.yaml
+++ b/data/cards/capital-one-spark-cash-plus.yaml
@@ -20,12 +20,17 @@ rewards:
     value: 2
     unit: percent
 signup_bonus:
-  value: 4000
+  value: 2000
   type: "cash"
-  spend_requirement: 500000
-  timeframe_months: 12
-  note: "Earn a $2,000 cash bonus when you spend $30,000 in the first 3 months, plus an additional $2,000 cash bonus for every $500,000 spent in the first year (earnable multiple times). The two spend bonuses may be earned independently. For a limited time, also earn a one-time $500 Capital One Business Travel credit when you spend $30,000 in the first 3 months."
+  spend_requirement: 30000
+  timeframe_months: 3
+  note: "For a limited time, also earns a one-time $500 Capital One Business Travel credit on the same $30,000 spend in the first 3 months"
 benefits:
+  - name: "Volume Spend Bonus"
+    value: 2000
+    description: "$2,000 cash bonus for every $500,000 spent in the first year, earnable multiple times"
+    frequency: "annual"
+    category: "other"
   - name: "Annual Fee Refund"
     value: 150
     description: "The $150 annual fee is refunded every year you spend at least $150,000 on the card"

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -37,7 +37,7 @@ rewards:
     unit: points_per_dollar
     note: "All purchases earn 1.5x after $150,000 in eligible purchases in a calendar year"
 signup_bonus:
-  value: 125000
+  value: 80000
   type: "miles"
   spend_requirement: 12000
   timeframe_months: 6

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -37,7 +37,7 @@ rewards:
     unit: points_per_dollar
     note: "All purchases earn 1.5x after $150,000 in eligible purchases in a calendar year"
 signup_bonus:
-  value: 80000
+  value: 125000
   type: "miles"
   spend_requirement: 12000
   timeframe_months: 6


### PR DESCRIPTION
## Card Page Check — 2026-08-05

Detected by fetching official apply pages and extracting card terms with an LLM.
**Verify each change against the source page before merging.**

> **Note — this PR was corrected after it was opened.** The table below reflects
> what the branch actually contains now, not the original automated proposal.
> Two of the original changes were wrong and have been fixed; see
> "Corrections" at the bottom.

### Term Changes

| Card | Field | Current | Detected | Source |
|------|-------|---------|----------|--------|
| Capital One Spark Cash Plus | signup_bonus.note | Also earns a $500 credit for Capital One Business Travel bookings on the same $30,000 spend, plus an additional $2,000 for every $500,000 spent in the first year | For a limited time, also earns a one-time $500 Capital One Business Travel credit on the same $30,000 spend in the first 3 months | [apply page](https://www.capitalone.com/small-business/credit-cards/spark-cash-plus/) |
| Capital One Spark Cash Plus | benefits[] *(new)* | — | **Volume Spend Bonus** — $2,000 cash bonus for every $500,000 spent in the first year, earnable multiple times (`value: 2000`, `frequency: annual`) | [apply page](https://www.capitalone.com/small-business/credit-cards/spark-cash-plus/) |

`signup_bonus.value` (2000), `spend_requirement` (30000) and `timeframe_months` (3)
are **unchanged** on this branch.

### How to Review
1. Click each source link and verify the detected value on the issuer's page
2. Remove any YAML changes that look incorrect before merging
3. Run `npm run build:cards` to validate

---

### Corrections applied after the automated run

**1. Capital One Spark Cash Plus — annual spend bonus folded into the SUB.**
The run proposed value 2000 → 4000, spend_requirement 30000 → 500000 and
timeframe_months 3 → 12, treating the "$2,000 for every $500,000 spent in the
first year" volume bonus as a signup-bonus tier. It is recurring and earnable
multiple times, so it is an annual spend bonus and belongs in `benefits`
(convention: recurring spend bonuses never live in `signup_bonus`). The SUB is
restored to the real one-time offer and the volume bonus moved to a `benefits`
entry. The pre-existing note had the same problem, so this also cleans up state
that predated this run.

**2. Delta SkyMiles Reserve Business — reverted, stored value was correct.**
The run proposed 125,000 → 80,000. An incognito browser on the same URL shows a
"Special Welcome Offer" of **125,000** (`previously 80,000, now 125,000`), while
the headless fetch was served a flat 80,000 — the fetched HTML contained no
125,000 at all. This is offer targeting, not a parsing miss. That card is now
byte-identical to `main` and no longer appears in this diff.

The guard for #2 is in [#1957](https://github.com/CreditOdds/creditodds/pull/1957).

---
*Automated PR — review carefully before merging.*
