### PR TITLE
Hold signup-bonus downgrades from session-targeted offer hosts

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -216,6 +216,34 @@ function checkUrlFor(card) {
   return apply_link || special_apply_link;
 }
 
+// Hosts that serve SESSION-VARYING welcome offers: the same URL returns a
+// different bonus depending on session/cookies/IP, so an automated fetch can
+// legitimately render a SMALLER offer than a person sees in a clean browser.
+// This is not a parsing problem — there is no strikethrough to catch and the
+// fetched HTML contains only the lower number.
+//
+// Verified 2026-08-05 on Delta SkyMiles Reserve Business: the run's headless
+// fetch rendered a flat "Earn 80,000 Bonus Miles after you spend $12,000 ... in
+// your first 6 months" and the extractor correctly reported 80,000, while an
+// incognito browser on the same URL showed "<s>80,000</s> 125,000 Bonus Miles"
+// under a "Special Welcome Offer" header. The check proposed 125,000 → 80,000
+// and, because the stored entry had no note, no tier guard applied and the
+// downgrade was written straight into the YAML.
+//
+// Only DECREASES are suspect. A targeted-down session cannot invent a number
+// higher than the public offer, so increases still flow through normally.
+const SESSION_TARGETED_OFFER_HOSTS = ['americanexpress.com'];
+
+function isSessionTargetedOfferHost(url) {
+  if (!url) return false;
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return SESSION_TARGETED_OFFER_HOSTS.some(h => host === h || host.endsWith(`.${h}`));
+  } catch {
+    return false;
+  }
+}
+
 function filterCardsForCheck(allCards, slugFilter) {
   let cards = allCards.filter(
     c => c.data.accepting_applications !== false && checkUrlFor(c)
@@ -1223,9 +1251,37 @@ function detectChanges(card, extracted, now = new Date(), suppressions = [], pag
       cur.spend_requirement != null &&
       sb.spend_requirement > cur.spend_requirement;
 
-    const skipAsTieredBonus = tierCollapse || spendOvercount;
+    // A bonus DECREASE on a session-targeted host is unfalsifiable from the
+    // fetched text alone: the page really did say the smaller number to this
+    // client. Hold the stored value and make a human confirm in a clean browser
+    // rather than writing a possibly-targeted downgrade into production.
+    //
+    // Unlike the tier guards this one cannot self-disarm — the evidence it would
+    // need is not in the page. That is a deliberate trade: the suppression is
+    // reported at the end of every run, so a genuine Amex reduction shows up as
+    // a standing line item to apply by hand, whereas a silent downgrade reaches
+    // the live site and only gets caught if somebody happens to look.
+    const offerVariantDowngrade =
+      isSessionTargetedOfferHost(checkUrlFor(card)) &&
+      sb.value != null &&
+      cur.value != null &&
+      sb.value < cur.value;
 
-    if (skipAsTieredBonus) {
+    const skipAsTieredBonus = tierCollapse || spendOvercount || offerVariantDowngrade;
+
+    if (offerVariantDowngrade) {
+      const reason =
+        `proposed value ${cur.value} → ${sb.value} is a DECREASE on a host that serves ` +
+        `session-targeted offers — the fetch may have been shown a smaller variant than ` +
+        `the public one. Verify in a clean/incognito browser and apply by hand if real.`;
+      console.log(`  Ignoring signup_bonus changes: ${reason}`);
+      suppressions.push({
+        card_name: current.name,
+        guard: 'offer-variant-downgrade',
+        reason,
+        url: checkUrlFor(card),
+      });
+    } else if (skipAsTieredBonus) {
       const reason = tierCollapse
         ? `proposed value ${cur.value} → ${sb.value} looks like a base-tier-only misparse`
         : `proposed spend_requirement ${cur.spend_requirement} → ${sb.spend_requirement} looks like an overlapping-window double-count`;

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -1105,4 +1105,83 @@ test('an empty or missing reason is not retried', () => {
   assert.equal(isTransientNetworkError(undefined), false);
 });
 
+// ─── Session-targeted offer downgrades ──────────────────────────────────────
+//
+// Delta SkyMiles Reserve Business, 2026-08-05: the run's headless fetch was
+// served a flat 80,000 while an incognito browser showed 125,000. The stored
+// entry had no note, so no tier guard applied and the downgrade was written
+// into the YAML (caught in review on PR #1956). Only DECREASES on these hosts
+// are held — a targeted-down session cannot invent a higher number.
+
+const AMEX_URL =
+  'https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/';
+
+function amexCard(value, url = AMEX_URL) {
+  return {
+    name: 'Delta SkyMiles Reserve Business American Express',
+    data: {
+      name: 'Delta SkyMiles Reserve Business American Express',
+      apply_link: url,
+      signup_bonus: { value, type: 'miles', spend_requirement: 12000, timeframe_months: 6 },
+    },
+  };
+}
+
+const amexExtract = value => ({
+  signup_bonus: { value, spend_requirement: 12000, timeframe_months: 6, offer_is_tiered: null },
+});
+
+const RENDERED_OFFER =
+  'Earn Bonus Miles after you spend $12,000 in purchases in your first 6 months of Card Membership.';
+
+console.log('\nSession-targeted offer downgrade suppression:');
+
+test('Amex value downgrade 125000 → 80000 is suppressed and recorded', () => {
+  const suppressions = [];
+  const changes = detectChanges(
+    amexCard(125000), amexExtract(80000), new Date(), suppressions, RENDERED_OFFER
+  );
+  assert.deepEqual(fieldsChanged(changes), []);
+  assert.equal(suppressions.length, 1);
+  assert.equal(suppressions[0].guard, 'offer-variant-downgrade');
+});
+
+test('an Amex value INCREASE still flows through', () => {
+  const changes = detectChanges(
+    amexCard(80000), amexExtract(125000), new Date(), [], RENDERED_OFFER
+  );
+  assert.deepEqual(fieldsChanged(changes), ['signup_bonus.value']);
+});
+
+test('the host match covers subdomains', () => {
+  const changes = detectChanges(
+    amexCard(125000, 'https://cards.americanexpress.com/x'), amexExtract(80000),
+    new Date(), [], RENDERED_OFFER
+  );
+  assert.deepEqual(fieldsChanged(changes), []);
+});
+
+test('a lookalike host is NOT treated as Amex', () => {
+  const changes = detectChanges(
+    amexCard(125000, 'https://www.notamericanexpress.com/x'), amexExtract(80000),
+    new Date(), [], RENDERED_OFFER
+  );
+  assert.deepEqual(fieldsChanged(changes), ['signup_bonus.value']);
+});
+
+test('a downgrade on an unlisted host is unaffected', () => {
+  const changes = detectChanges(
+    amexCard(125000, 'https://creditcards.chase.com/x'), amexExtract(80000),
+    new Date(), [], RENDERED_OFFER
+  );
+  assert.deepEqual(fieldsChanged(changes), ['signup_bonus.value']);
+});
+
+test('a card with no URL at all does not crash the guard', () => {
+  const card = { name: 'No URL', data: { name: 'No URL', signup_bonus: { value: 125000 } } };
+  assert.doesNotThrow(() =>
+    detectChanges(card, amexExtract(80000), new Date(), [], RENDERED_OFFER)
+  );
+});
+
 console.log('');


### PR DESCRIPTION
## What happened

The 2026-08-05 card-page check ([#1956](https://github.com/CreditOdds/creditodds/pull/1956)) proposed `signup_bonus.value` 125,000 → 80,000 on Delta SkyMiles Reserve Business and applied it. The stored 125,000 was correct — Max caught it in review.

An incognito browser on the same URL renders:

> Earn, previously ~~80,000~~, now **125,000** Bonus Miles

while the run's headless fetch was served a flat `Earn 80,000 Bonus Miles`.

## Why the existing guards missed it

I initially assumed a strikethrough-parsing miss. It isn't:

- The live DOM node is a plain `<s>80,000</s>`, which `stripHtml` already handles.
- The strikethrough marking **works** — it fired 3 times on that very page's prompt, and all 166 prompts in the run carried markers.
- The fetched text contained **zero** occurrences of `125,000`.

So Amex served a genuinely different, smaller offer variant to the automated session. There is nothing in the fetched page to parse differently.

The card also had no `note`, so neither the tier-collapse nor the spend-overcount guard applied, and the downgrade was written straight to YAML.

## The fix

Hold `signup_bonus` changes when a host known to serve session-varying offers proposes a **decrease**, and record it in the existing suppression report for a human to confirm in a clean browser.

- **Decreases only.** A targeted-down session cannot invent a number higher than the public offer, so increases flow through untouched.
- **Host-scoped** (`americanexpress.com` + subdomains) rather than global, matching the file's existing precedent of explicit host lists.

### Trade-off, stated plainly

This guard **cannot self-disarm** the way the tier guards do, because the evidence it would need is absent from the page. That is deliberate, and it is the one thing worth pushing back on in review: a genuine Amex bonus reduction will now be suppressed every run and show up as a standing line item to apply by hand. The alternative is the failure this PR exists to fix — a silent downgrade reaching the live site, caught only if somebody happens to look.

## Tests

Six cases added to `scripts/check-card-pages.test.js`, covering the Delta regression, increases passing through, subdomain matching, a lookalike host (`notamericanexpress.com`) correctly **not** matching, unlisted hosts unaffected, and a card with no URL not crashing the guard. Full suite green (`node scripts/check-card-pages.test.js`, exit 0, 0 failures).

## Not covered

This does not detect targeting on any other issuer. If other hosts turn out to serve session-varying offers, they need adding to `SESSION_TARGETED_OFFER_HOSTS` — there's no automatic detection here.