### PR TITLE
Reddit product changes for review — 2026-08-05

### DIFF
--- a/data/reddit-product-changes/2026-07-t3_1vb6jfn.yaml
+++ b/data/reddit-product-changes/2026-07-t3_1vb6jfn.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vb6jfn
+permalink: https://www.reddit.com/r/CreditCards/comments/1vb6jfn/bcp_bce_bcp_cycle_not_working/
+posted: "2026-07-30"
+evidence: >-
+  Poster reports downgrading their Blue Cash Preferred to a Blue Cash Everyday shortly before
+  posting, then asks why no upgrade offer back to the Preferred has appeared. The only Amex offer
+  they are seeing is a personal loan pre-approval.
+from_card: Blue Cash Preferred
+to_card: Blue Cash Everyday
+change_month: 2026-07
+reason: voluntary

--- a/data/reddit-product-changes/2026-08-t3_1vd84s7.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vd84s7.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vd84s7
+permalink: https://www.reddit.com/r/CreditCards/comments/1vd84s7/advice_for_credit_card_set_up/
+posted: "2026-08-02"
+evidence: >-
+  Poster says they recently downgraded their own United Explorer to the no fee United Gateway,
+  mentioned while laying out the household card setup and asking what to apply for next. They note
+  they still qualify under Chase 5/24 and want to stay eligible for another bonus.
+from_card: United Explorer
+to_card: United Gateway
+change_month: 2026-08
+reason: voluntary

--- a/data/reddit-product-changes/2026-08-t3_1vfiqjx.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vfiqjx.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1vfiqjx
+permalink: https://www.reddit.com/r/CreditCards/comments/1vfiqjx/take_savor_for_good_credit_or_wait/
+posted: "2026-08-04"
+evidence: >-
+  Poster mentions the change while asking a separate question about whether to take a Savor offer.
+  They started building credit about six months ago with the Capital One Platinum and upgraded it to
+  the Quicksilver a few days before posting, and are now weighing whether the Savor categories would
+  suit them better.
+from_card: Capital One Platinum
+to_card: Capital One Quicksilver Cash Rewards
+change_month: 2026-08
+reason: voluntary

--- a/data/reddit-product-changes/2026-08-t3_1vgdf8e.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vgdf8e.yaml
@@ -1,0 +1,13 @@
+source_id: t3_1vgdf8e
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1vgdf8e/dp_cfu_to_freedom_og_with_shorter_age_and_lower/
+posted: "2026-08-05"
+evidence: >-
+  Data point posted the day the change went through: poster asked Chase to product change their
+  Freedom Unlimited to the original Freedom with Ultimate Rewards. The first rep only offered
+  Sapphire and Freedom Flex, so the poster hung up and called again, and a second rep completed it
+  quickly. Account was 4 months old with a $3,000 limit and was their only Chase relationship.
+from_card: Chase Freedom Unlimited
+to_card: Chase Freedom
+change_month: 2026-08
+reason: voluntary


### PR DESCRIPTION
Product changes extracted from r/CreditCards.

| From | To | Month | Reason | Source |
|---|---|---|---|---|
| Blue Cash Preferred | Blue Cash Everyday | 2026-07 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vb6jfn/bcp_bce_bcp_cycle_not_working/) |
| United Explorer | United Gateway | 2026-08 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vd84s7/advice_for_credit_card_set_up/) |
| Capital One Platinum | Capital One Quicksilver Cash Rewards | 2026-08 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vfiqjx/take_savor_for_good_credit_or_wait/) |
| Chase Freedom Unlimited | Chase Freedom | 2026-08 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vgdf8e/dp_cfu_to_freedom_og_with_shorter_age_and_lower/) |

