### PR TITLE
Add discontinued Kroger and Spirit cards, and resolve card-name aliases

### DIFF
--- a/data/cards/free-spirit-travel-mastercard.yaml
+++ b/data/cards/free-spirit-travel-mastercard.yaml
@@ -1,0 +1,50 @@
+name: "Free Spirit Travel Mastercard"
+bank: "Bank of America"
+slug: "free-spirit-travel-mastercard"
+accepting_applications: false
+category: "travel"
+annual_fee: 0
+reward_type: "points"
+network: "mastercard"
+foreign_transaction_fee: false
+tags:
+  - travel
+  - rewards
+rewards:
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+    merchant_specific: true
+    note: "Eligible Spirit Airlines purchases only"
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+benefits:
+  - name: "Anniversary bonus points"
+    description: "5,000 bonus points at each account anniversary after spending at least $10,000 in the prior anniversary year."
+    value: 5000
+    value_unit: points
+    category: "travel"
+  - name: "Inflight rebate"
+    description: "A 25% rebate on Spirit inflight food and beverage purchases paid for with the card."
+    value: 25
+    value_unit: percent
+    category: "travel"
+  - name: "Priority boarding"
+    description: "Zone 2 shortcut boarding on Spirit flights."
+    category: "travel"
+our_take: >
+  The no-fee Spirit card was the lighter version of the co-brand, and it asked
+  very little of you: no annual fee, no foreign transaction fees, 2x on Spirit
+  purchases and 1x on everything else. It kept the inflight rebate and shortcut
+  boarding, and paid 5,000 bonus points at your anniversary if you had put
+  $10,000 through it, which was a lot of spend for a small reward on a 1x
+  catch-all. It only ever made sense as a way to hold a Spirit relationship
+  without paying for it, and the Travel More tier was the better card for
+  anyone actually flying Spirit often. All of that is academic now. Spirit
+  ceased operations on May 2, 2026, Free Spirit points can no longer be
+  redeemed for flights or moved to another program, and Bank of America is
+  converting these accounts to the Customized Cash Rewards Mastercard with the
+  account number, APR and credit line unchanged. The conversion is a genuine
+  upgrade in earning terms, since a 1x airline card becomes a 3% category card,
+  and it is not something you can opt into by applying.

--- a/data/cards/free-spirit-travel-more-world-elite-mastercard.yaml
+++ b/data/cards/free-spirit-travel-more-world-elite-mastercard.yaml
@@ -1,0 +1,64 @@
+name: "Free Spirit Travel More World Elite Mastercard"
+bank: "Bank of America"
+slug: "free-spirit-travel-more-world-elite-mastercard"
+accepting_applications: false
+category: "travel"
+annual_fee: 79
+annual_fee_intro:
+  value: 0
+  months: 12
+reward_type: "points"
+network: "mastercard"
+foreign_transaction_fee: false
+tags:
+  - travel
+  - rewards
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+    merchant_specific: true
+    note: "Spirit Airlines tickets and inflight purchases only"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: groceries
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+benefits:
+  - name: "Two free checked bags"
+    description: "Two checked bags at no charge on Spirit flights, added to the card in September 2025."
+    category: "travel"
+  - name: "Companion flight voucher"
+    description: "A $100 companion flight voucher at each account anniversary after spending $5,000 in the prior anniversary year. Taxes and fees are not covered."
+    value: 100
+    category: "travel"
+  - name: "Inflight rebate"
+    description: "A 25% rebate on Spirit inflight food and beverage purchases paid for with the card, posted automatically within about a week."
+    value: 25
+    value_unit: percent
+    category: "travel"
+  - name: "Priority boarding"
+    description: "Shortcut boarding on Spirit flights."
+    category: "travel"
+  - name: "Points pooling"
+    description: "Free Spirit points could be pooled with up to eight friends or family members."
+    category: "travel"
+our_take: >
+  This was the paid tier of the Spirit co-brand, and for a Spirit regular who
+  checked bags it earned its keep: two free checked bags alone covered the $79
+  fee for anyone flying twice a year, and the first year was free. It paid 3x
+  on Spirit tickets and inflight purchases, 2x on dining and groceries, and 1x
+  elsewhere, with no foreign transaction fees and a $100 companion voucher at
+  renewal once you put $5,000 on the card. The catch was always that Free
+  Spirit points went nowhere else. There were no transfer partners, so the
+  rewards were only worth what Spirit charged for a seat. That became the whole
+  story when Spirit shut down on May 2, 2026 and the points stopped being
+  redeemable for flights. Bank of America has been converting these accounts to
+  the Customized Cash Rewards Mastercard, keeping the account number, APR and
+  credit line intact, and unusually letting the converted card keep its lack of
+  foreign transaction fees. If you hold one, it is now a cash back card with an
+  airline name on it, and there is no way to get one again.

--- a/data/cards/kroger-rewards-world-elite-mastercard.yaml
+++ b/data/cards/kroger-rewards-world-elite-mastercard.yaml
@@ -2,6 +2,29 @@ name: "Kroger Rewards World Elite Mastercard"
 bank: "U.S. Bank"
 slug: "kroger-rewards-world-elite-mastercard"
 accepting_applications: false
+# One product, issued per Kroger Family of Companies banner. These are not
+# former names, they were concurrent brandings of this same card, which is why
+# they live here and not in previous_names. Reddit posters name the banner they
+# shop at, so without these every "my Harris Teeter card" report is dropped.
+also_known_as:
+  - "Harris Teeter Rewards World Elite Mastercard"
+  - "Ralphs Rewards World Elite Mastercard"
+  - "Fred Meyer Rewards World Elite Mastercard"
+  - "King Soopers Rewards World Elite Mastercard"
+  - "QFC Rewards World Elite Mastercard"
+  - "Smith's Rewards World Elite Mastercard"
+  - "Fry's Rewards World Elite Mastercard"
+  - "Dillons Rewards World Elite Mastercard"
+  - "Pick 'n Save Rewards World Elite Mastercard"
+  - "Mariano's Rewards World Elite Mastercard"
+  - "City Market Rewards World Elite Mastercard"
+  - "Metro Market Rewards World Elite Mastercard"
+  - "Baker's Rewards World Elite Mastercard"
+  - "Gerbes Rewards World Elite Mastercard"
+  - "Jay C Rewards World Elite Mastercard"
+  - "Pay Less Rewards World Elite Mastercard"
+  - "Owen's Rewards World Elite Mastercard"
+  - "Kroger Family of Companies Rewards World Elite Mastercard"
 category: "cashback"
 annual_fee: 0
 reward_type: "cashback"

--- a/data/cards/kroger-rewards-world-elite-mastercard.yaml
+++ b/data/cards/kroger-rewards-world-elite-mastercard.yaml
@@ -1,0 +1,58 @@
+name: "Kroger Rewards World Elite Mastercard"
+bank: "U.S. Bank"
+slug: "kroger-rewards-world-elite-mastercard"
+accepting_applications: false
+category: "cashback"
+annual_fee: 0
+reward_type: "cashback"
+network: "mastercard"
+foreign_transaction_fee: false
+tags:
+  - cashback
+  - rewards
+rewards:
+  # The 5% is on mobile wallet spend generally, not just Kroger Pay inside a
+  # store, which is what made this card worth holding for anyone who tapped to
+  # pay everywhere. Kroger Pay counts toward the same $3,000 calendar-year cap.
+  - category: mobile_wallet
+    value: 5
+    unit: percent
+    note: "Mobile wallet and Kroger Pay purchases; $3,000 calendar-year cap, then 1%"
+    spend_cap: 3000
+    cap_period: annual
+    rate_after_cap: 1
+  # Kroger Family of Companies stores only, so this must not match generic
+  # grocery-store queries: the card paid 1% at a supermarket it did not own.
+  - category: groceries
+    value: 2
+    unit: percent
+    merchant_specific: true
+    note: "Purchases inside Kroger Family of Companies stores only (Kroger, Harris Teeter, Ralphs, Fred Meyer, King Soopers, QFC, Smith's, Fry's, Dillons, Pick 'n Save, Mariano's and the other banners); excludes fuel centers"
+  - category: everything_else
+    value: 1
+    unit: percent
+benefits:
+  - name: "Kroger fuel discount"
+    description: "An extra 5 cents per gallon off at Kroger Family of Companies Fuel Centers on top of earned fuel points, rising to 25 cents per gallon after $6,000 in calendar-year spend when redeeming at least 100 fuel points."
+    category: "shopping"
+  - name: "Boost Essential membership"
+    description: "Complimentary Kroger Boost Essential membership, which includes free grocery delivery on qualifying orders and doubled fuel points."
+    category: "shopping"
+our_take: >
+  The Kroger card was one of the better mobile wallet plays available, and its
+  ending is the reason people are still talking about it. U.S. Bank issued it
+  across the Kroger Family of Companies, so the same product appeared as a
+  Harris Teeter, Ralphs, Fred Meyer, King Soopers, QFC, Smith's, Fry's,
+  Dillons, Pick 'n Save or Mariano's card depending on which banner you shopped
+  at. All of them earned 5% back on mobile wallet purchases up to $3,000 a
+  calendar year, which was a rare uncapped-by-category rate for anyone who
+  tapped to pay, plus 2% inside Kroger-owned stores and 1% everywhere else.
+  U.S. Bank stopped taking applications in April 2026 and confirmed that
+  July that the partnership was ending. Existing accounts are being converted
+  to the Smartly Visa Signature between August and October 2026, with balances,
+  APRs, credit limits and rewards carrying over, so nobody has to reapply. What
+  does not survive is the part that made the card worth holding: the 5% mobile
+  wallet rate becomes a flat 2%, and the fuel discount stops the moment the new
+  card is activated. Converted cardholders get an extra 1% at groceries and gas
+  for 12 months as a consolation, which softens the first year and nothing
+  after that.

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -12,6 +12,11 @@
       "items": { "type": "string" },
       "description": "Prior names this card was known by, e.g. before a rebrand. Rendered on the card detail page."
     },
+    "also_known_as": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Other names this SAME product was issued under at the same time, e.g. the per-banner brandings of a co-brand (Kroger's card also shipped as the Harris Teeter and Ralphs card). Unlike `previous_names` these are concurrent siblings, not a rebrand history, so they are NOT rendered as former names. Reserve it for names NOT derivable from the canonical one: an extractor can match a dropped tier word (\"Travel More Mastercard\" -> \"Travel More World Elite Mastercard\") on its own, but nothing in \"Kroger\" tells it that the Harris Teeter card is the same product. Build-time only, stripped from cards.json; today the only consumer is sweep-reddit-product-changes.js, which shows them to the extractor so a post naming a sibling brand still resolves to this card."
+    },
     "our_take": {
       "type": "string",
       "description": "Editorial paragraph rendered in the 'Our take' block on the card detail page. Optional; when omitted the block is hidden (only the Featured-in chips render, if the card is top-3 on a /best/ list)."

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -348,6 +348,7 @@ function buildCards() {
       card.card_id = card.slug;
       card.card_name = card.name; // Alias for compatibility
       delete card.check_ignore;
+      delete card.also_known_as;
 
       cards.push(card);
       cardsWithFiles.push({ file, card });

--- a/scripts/sweep-reddit-product-changes.js
+++ b/scripts/sweep-reddit-product-changes.js
@@ -152,16 +152,53 @@ function loadCardCatalog() {
     try {
       const doc = yaml.load(fs.readFileSync(path.join(CARDS_DIR, file), 'utf8'));
       if (!doc || !doc.name) continue;
+      // Both fields are extraction aliases even though they mean different
+      // things on the card page: a rebrand's old name and a co-brand's sibling
+      // banner name are equally likely to be what the poster actually typed.
+      const aliases = [
+        ...(Array.isArray(doc.previous_names) ? doc.previous_names : []),
+        ...(Array.isArray(doc.also_known_as) ? doc.also_known_as : []),
+      ].filter((a) => typeof a === 'string' && a.trim());
       cards.push({
         name: doc.name,
         bank: doc.bank || '',
-        previousNames: Array.isArray(doc.previous_names) ? doc.previous_names : [],
+        aliases,
       });
     } catch {
       // A malformed card file should not abort a multi-hour sweep.
     }
   }
   return cards;
+}
+
+// Maps every name the extractor might legitimately emit onto the one canonical
+// card name, so a sibling-branded post ("my Harris Teeter card") lands on the
+// same edge as the canonical one instead of being rejected as uncatalogued.
+//
+// Canonical names always win: an alias is only registered when nothing real
+// already holds that name, which stops a careless alias on one card from
+// hijacking another card's identity. Collisions are reported rather than
+// silently resolved, because two cards claiming one alias means the data is
+// wrong and picking a winner would hide that.
+function buildNameResolver(catalog) {
+  const byLower = new Map();
+  const collisions = [];
+  for (const c of catalog) byLower.set(c.name.toLowerCase(), c.name);
+  for (const c of catalog) {
+    for (const alias of c.aliases) {
+      const key = alias.toLowerCase();
+      const held = byLower.get(key);
+      if (held === undefined) {
+        byLower.set(key, c.name);
+      } else if (held !== c.name) {
+        collisions.push(`"${alias}" claimed by both "${held}" and "${c.name}"`);
+      }
+    }
+  }
+  return {
+    canonical: (name) => byLower.get(String(name || '').trim().toLowerCase()) || name,
+    collisions,
+  };
 }
 
 // Reddit search chokes on very long quoted phrases and on punctuation, so the
@@ -239,11 +276,22 @@ function buildExtractPrompt(candidates, catalog) {
   const byBank = new Map();
   for (const c of catalog) {
     if (!byBank.has(c.bank)) byBank.set(c.bank, []);
-    byBank.get(c.bank).push(c.name);
+    // A card with aliases is listed as "Canonical [= alias, alias]". The
+    // canonical name still leads, because that is what must be emitted.
+    byBank.get(c.bank).push({
+      sort: c.name,
+      label: c.aliases.length ? `${c.name} [= ${c.aliases.join(', ')}]` : c.name,
+    });
   }
   const cardList = [...byBank.entries()]
     .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([bank, names]) => `- **${bank}**: ${names.sort().join(' · ')}`)
+    .map(
+      ([bank, entries]) =>
+        `- **${bank}**: ${entries
+          .sort((a, b) => a.sort.localeCompare(b.sort))
+          .map((e) => e.label)
+          .join(' · ')}`,
+    )
     .join('\n');
 
   const posts = candidates
@@ -287,9 +335,15 @@ Do NOT record:
 
 ## Hard rules
 
-1. **Both cards must be in the catalog, spelled exactly as listed.**
+1. **Both cards must be in the catalog, spelled exactly as listed.** A catalog
+   entry written \`Canonical [= other, other]\` is one product that shipped
+   under several names, usually a co-brand rebranded per store banner. A post
+   naming any of them counts, but **always emit the canonical name** (the part
+   before the \`[\`), never the alias.
 2. **Both cards must be from the same issuer.** A product change never crosses
    issuers. If your reading has it crossing, the reading is wrong — drop it.
+   Aliases do not change this: a sibling brand has the same issuer as its
+   canonical card, so "Harris Teeter card to Smartly" is a U.S. Bank change.
 3. \`source_id\` must be one of the ids listed below (optionally with a \`#N\`
    suffix for multi-hop posts). Do not invent posts.
 4. \`change_month\` is \`YYYY-MM\`. Use the month the poster states; if they only
@@ -386,6 +440,11 @@ function phaseFinish() {
   const catalog = loadCardCatalog();
   const cardByName = new Map(catalog.map((c) => [c.name, c]));
   const bankByName = new Map(catalog.map((c) => [c.name, c.bank]));
+  const resolver = buildNameResolver(catalog);
+  if (resolver.collisions.length) {
+    console.warn(`Alias collisions in data/cards (aliases ignored for these):`);
+    for (const c of resolver.collisions) console.warn(`  - ${c}`);
+  }
 
   const files = fs.existsSync(proposedDir)
     ? fs.readdirSync(proposedDir).filter((f) => f.endsWith('.json')).sort()
@@ -408,6 +467,12 @@ function phaseFinish() {
       rejected.push({ file, errors: [`unparseable JSON: ${err.message}`] });
       continue;
     }
+    // Fold aliases onto canonical names before validating, so the rest of the
+    // pipeline — the catalog check, the same-issuer check, the written YAML,
+    // and the row the Lambda imports — only ever sees one name per product.
+    pc.from_card = resolver.canonical(pc.from_card);
+    pc.to_card = resolver.canonical(pc.to_card);
+
     const errors = validateChange(pc, { candidateIds, cardByName, bankByName, usedIds });
     if (errors.length) {
       rejected.push({ file, errors });
@@ -688,7 +753,16 @@ async function main() {
   console.log(`State: ${STATE_PATH}`);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  buildNameResolver,
+  buildExtractPrompt,
+  loadCardCatalog,
+  validateChange,
+};

--- a/scripts/sweep-reddit-product-changes.test.js
+++ b/scripts/sweep-reddit-product-changes.test.js
@@ -1,0 +1,201 @@
+// Tests for card-name alias resolution in sweep-reddit-product-changes.js.
+//
+// Why this exists: a product change is stored as an edge between two exact
+// catalog names, so anything that lets a second name for one product through
+// splits that product's arrows in two on the card page. Aliases exist because
+// co-brands ship under several banner names at once (the Kroger card was also
+// the Harris Teeter card), and the extractor sees only names — nothing in
+// "Kroger" tells it those are one product. The risks worth pinning down are
+// that an alias must never shadow a real card, and that whatever the extractor
+// emits must be folded to the canonical name before it reaches the YAML.
+//
+// Run: `node scripts/sweep-reddit-product-changes.test.js`. Exits non-zero on failure.
+
+const assert = require('node:assert/strict');
+
+const {
+  buildNameResolver,
+  buildExtractPrompt,
+  loadCardCatalog,
+  validateChange,
+} = require('./sweep-reddit-product-changes.js');
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+const CATALOG = [
+  { name: 'Kroger Rewards World Elite Mastercard', bank: 'U.S. Bank', aliases: ['Harris Teeter Rewards World Elite Mastercard', "Ralphs Rewards World Elite Mastercard"] },
+  { name: 'Smartly Visa Signature', bank: 'U.S. Bank', aliases: [] },
+  { name: 'Citi Strata Premier', bank: 'Citi', aliases: ['Citi Premier'] },
+  { name: 'Chase Freedom', bank: 'Chase', aliases: [] },
+];
+
+console.log('buildNameResolver');
+
+test('canonical names pass through untouched', () => {
+  const { canonical } = buildNameResolver(CATALOG);
+  assert.equal(canonical('Chase Freedom'), 'Chase Freedom');
+});
+
+test('a sibling banner name resolves to the canonical card', () => {
+  const { canonical } = buildNameResolver(CATALOG);
+  assert.equal(
+    canonical('Harris Teeter Rewards World Elite Mastercard'),
+    'Kroger Rewards World Elite Mastercard',
+  );
+});
+
+test('a previous name resolves to the current card', () => {
+  const { canonical } = buildNameResolver(CATALOG);
+  assert.equal(canonical('Citi Premier'), 'Citi Strata Premier');
+});
+
+test('resolution is case and whitespace insensitive', () => {
+  const { canonical } = buildNameResolver(CATALOG);
+  assert.equal(
+    canonical('  ralphs rewards world elite mastercard '),
+    'Kroger Rewards World Elite Mastercard',
+  );
+});
+
+test('an unknown name is returned unchanged so validation can reject it', () => {
+  const { canonical } = buildNameResolver(CATALOG);
+  assert.equal(canonical('Aven Rewards Visa'), 'Aven Rewards Visa');
+});
+
+test('empty and missing names do not throw', () => {
+  const { canonical } = buildNameResolver(CATALOG);
+  assert.equal(canonical(''), '');
+  assert.equal(canonical(undefined), undefined);
+});
+
+test('an alias never shadows a real card name', () => {
+  // The nightmare case: a careless alias on card B silently rewrites every
+  // report about card A onto B, and nothing downstream can tell.
+  const withHijack = [
+    ...CATALOG,
+    { name: 'Some Other Card', bank: 'Chase', aliases: ['Chase Freedom'] },
+  ];
+  const { canonical, collisions } = buildNameResolver(withHijack);
+  assert.equal(canonical('Chase Freedom'), 'Chase Freedom');
+  assert.equal(collisions.length, 1);
+  assert.match(collisions[0], /Chase Freedom/);
+});
+
+test('two cards claiming one alias is reported, not silently resolved', () => {
+  const dupes = [
+    { name: 'Card A', bank: 'Citi', aliases: ['Shared Name'] },
+    { name: 'Card B', bank: 'Citi', aliases: ['Shared Name'] },
+  ];
+  const { collisions } = buildNameResolver(dupes);
+  assert.equal(collisions.length, 1);
+  assert.match(collisions[0], /Card A.*Card B|Card B.*Card A/);
+});
+
+test('a card aliasing its own name is not a collision', () => {
+  const { collisions } = buildNameResolver([
+    { name: 'Chase Freedom', bank: 'Chase', aliases: ['Chase Freedom'] },
+  ]);
+  assert.deepEqual(collisions, []);
+});
+
+console.log('buildExtractPrompt');
+
+test('aliased cards render as "Canonical [= alias, alias]"', () => {
+  const prompt = buildExtractPrompt([], CATALOG);
+  assert.match(
+    prompt,
+    /Kroger Rewards World Elite Mastercard \[= Harris Teeter Rewards World Elite Mastercard, Ralphs Rewards World Elite Mastercard\]/,
+  );
+});
+
+test('cards without aliases render as a bare name', () => {
+  const prompt = buildExtractPrompt([], CATALOG);
+  assert.match(prompt, /\*\*Chase\*\*: Chase Freedom(?!\s*\[)/);
+});
+
+test('the catalog stays grouped by issuer and sorted by canonical name', () => {
+  const prompt = buildExtractPrompt([], CATALOG);
+  const usBank = prompt.match(/- \*\*U\.S\. Bank\*\*: (.+)/)[1];
+  assert.ok(
+    usBank.indexOf('Kroger') < usBank.indexOf('Smartly'),
+    'alias label must not change sort position',
+  );
+});
+
+test('the prompt tells the model to emit the canonical name', () => {
+  const prompt = buildExtractPrompt([], CATALOG);
+  assert.match(prompt, /always emit the canonical name/i);
+});
+
+console.log('real catalog');
+
+test('the shipped catalog has no alias collisions', () => {
+  const { collisions } = buildNameResolver(loadCardCatalog());
+  assert.deepEqual(collisions, [], `collisions: ${collisions.join('; ')}`);
+});
+
+test('the Kroger banner names resolve in the shipped catalog', () => {
+  const { canonical } = buildNameResolver(loadCardCatalog());
+  for (const banner of ['Harris Teeter', 'Ralphs', "Pick 'n Save", 'QFC']) {
+    assert.equal(
+      canonical(`${banner} Rewards World Elite Mastercard`),
+      'Kroger Rewards World Elite Mastercard',
+      `${banner} did not resolve`,
+    );
+  }
+});
+
+console.log('validateChange after resolution');
+
+test('a resolved sibling pair passes the same-issuer check', () => {
+  // "My Harris Teeter card became a Smartly" is a U.S. Bank change once the
+  // alias is folded in; before folding it would fail as uncatalogued.
+  const { canonical } = buildNameResolver(CATALOG);
+  const pc = {
+    source_id: 't3_abc123',
+    from_card: canonical('Harris Teeter Rewards World Elite Mastercard'),
+    to_card: canonical('Smartly Visa Signature'),
+    change_month: '2026-08',
+  };
+  const errors = validateChange(pc, {
+    candidateIds: new Set(['t3_abc123']),
+    cardByName: new Map(CATALOG.map((c) => [c.name, c])),
+    bankByName: new Map(CATALOG.map((c) => [c.name, c.bank])),
+    usedIds: new Set(),
+  });
+  assert.deepEqual(errors, []);
+});
+
+test('an unresolved alias is still rejected as uncatalogued', () => {
+  const errors = validateChange(
+    {
+      source_id: 't3_abc123',
+      from_card: 'Harris Teeter Rewards World Elite Mastercard',
+      to_card: 'Smartly Visa Signature',
+      change_month: '2026-08',
+    },
+    {
+      candidateIds: new Set(['t3_abc123']),
+      cardByName: new Map(CATALOG.map((c) => [c.name, c])),
+      bankByName: new Map(CATALOG.map((c) => [c.name, c.bank])),
+      usedIds: new Set(),
+    },
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /not in the catalog/);
+});
+
+if (failures) {
+  console.error(`\n${failures} test(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll tests passed.');


### PR DESCRIPTION
Adds three discontinued cards that were missing from the catalog, plus the alias resolution needed to make them actually usable by the product-change sweep.

Both programs were converted into other cards this year and show up repeatedly in r/CreditCards product-change reports, but because neither card existed in the catalog, every one of those reports was dropped for having an unrecognized `from_card`. This week's run alone dropped five posts to this gap.

## Cards added

| Card | Bank | Fate |
|---|---|---|
| Kroger Rewards World Elite Mastercard | U.S. Bank | Converting to Smartly Visa Signature, Aug to Oct 2026 |
| Free Spirit Travel More World Elite Mastercard | Bank of America | Converting to Customized Cash Rewards |
| Free Spirit Travel Mastercard | Bank of America | Converting to Customized Cash Rewards |

All three are `accepting_applications: false` with no `apply_link` (these programs are closed, the cards exist here as an artifact of the conversions), so `check-card-pages` skips them. Each already has a news article on the site covering its conversion; this fills in the card pages those articles point at.

## Alias resolution

Adding the Kroger card alone would not have captured the reports, because the extractor sees a flat list of exact names and nothing in "Kroger" tells it that the Harris Teeter card is the same product. U.S. Bank issued it under eighteen banner names.

New `also_known_as` field for names the same product shipped under **concurrently**, kept distinct from `previous_names` (a rebrand history, which renders on the card page as former names, and would be factually wrong here). Both now feed one resolver:

- The extract prompt lists a card as `Canonical [= alias, alias]` and instructs the model to emit the canonical name.
- The finish phase folds whatever comes back onto the canonical name **before** validation, so the catalog check, the same-issuer check, and the stored YAML only ever see one name per product. Splitting one product across two names would split its arrows on the card page.

`previous_names` was already being loaded by the sweep and then never used, so wiring it in picks up four rebranded cards for free: Air France KLM, Chase Freedom Rise, Citi AAdvantage Business, Princess Rewards.

Aliases can never shadow a real card name, and two cards claiming one alias is reported rather than silently resolved.

## Decisions worth a look

**One Kroger card, not eighteen.** The banners are one product rebranded per store. Adding a page per banner would have put ~18 near-identical dead cards into `/explore`, the sitemap and every future extract prompt. The banner names live in `also_known_as` instead, which solves extraction without the page bloat.

**Two Spirit cards, not one.** These were genuinely different products ($79 vs $0 annual fee, 3x vs 2x on Spirit). Deliberately given no aliases: Bank of America's conversion letter calls both "Spirit Airlines Mastercard", and that phrasing is genuinely ambiguous, so those posts should keep being dropped rather than guessed at. Aliases are reserved for names not derivable from the canonical one.

**The 5% was mobile wallet, not Kroger-gated.** The Kroger card paid 5% on mobile wallet purchases anywhere, capped at $3,000 per calendar year, which is the thing people are actually mourning on the subreddit. Modeled as `mobile_wallet` with `everything_else` as the ungated 1% floor. The 2% is `groceries` with `merchant_specific: true` so it does not falsely match generic grocery-store queries.

## Verification

- `node scripts/sweep-reddit-product-changes.test.js` — 17 tests, all passing. Covers alias resolution, the shadowing and collision guards, prompt rendering, and that the shipped catalog is collision-free.
- `npm run build:cards` — 208 cards, all three new ones OK, `also_known_as` stripped from `cards.json` the way `check_ignore` is.
- No card art yet, so they fall back to `generic-card.svg` like the existing Blue and Serve entries. Real art can be dropped in later via the `image` field.