### PR TITLE
Add 71 FlexOffers affiliate merchants, 70 with new store pages

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-28T18:15:39.962Z",
-  "count": 956,
+  "generated_at": "2026-08-05T22:01:44.676Z",
+  "count": 1026,
   "stores": [
     {
       "name": "1-800 Contacts",
@@ -65,6 +65,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9643.322259&trid=1552713.187444&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "40% off your first order with code NEW40"
+      }
+    },
+    {
+      "name": "100% PURE",
+      "slug": "100-pure",
+      "aliases": [
+        "100 Percent Pure"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.100percentpure.com",
+      "intro": "100% PURE built its clean-beauty reputation on fruit-pigmented makeup — color from actual fruit, cocoa, and tea rather than synthetic dyes — plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.\n\nClean-beauty carts respond well to an online category: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a restock to 5, and the brand's frequent gift-with-purchase promotions stack with whatever card you use.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37229&trid=1552713.230391&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "20% off your first order"
       }
     },
     {
@@ -313,6 +330,21 @@
       }
     },
     {
+      "name": "Aerosoles",
+      "slug": "aerosoles",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.aerosoles.com",
+      "intro": "Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s — its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.\n\nShoe orders sit comfortably in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9946&trid=1552713.175791&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping"
+      }
+    },
+    {
       "name": "Aesop",
       "slug": "aesop",
       "aliases": [
@@ -503,6 +535,23 @@
       ],
       "website": "https://www.aldoshoes.com",
       "intro": "ALDO is a global footwear and accessories brand selling dress shoes, boots, and handbags. Shopping online codes as online shopping or general retail and may earn via a portal, but in-store visits typically fall to a flat-rate card because shoes are seldom a standalone bonus category.\n"
+    },
+    {
+      "name": "Alibaba",
+      "slug": "alibaba",
+      "aliases": [
+        "Alibaba.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.alibaba.com",
+      "intro": "Alibaba.com is the world's largest business-to-business wholesale marketplace, where small businesses source inventory, packaging, and custom manufacturing directly from suppliers, mostly overseas. It is the wholesale sibling of AliExpress: order minimums are higher, unit prices far lower, and payments run through Alibaba's Trade Assurance escrow, coding as an online marketplace purchase.\n\nSourcing runs are business spend, so business cards shine here: Amex Blue Business Plus earns 2x on everything, and Chase Ink Business Unlimited pays a flat 1.5 percent. Watch for foreign-transaction fees on cards that charge them, since some supplier payments settle abroad.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156100.274315&trid=1552713.207736&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "$20 off"
+      }
     },
     {
       "name": "Alice + Olivia",
@@ -843,6 +892,23 @@
       "affiliate": {
         "url": "https://www.anrdoezrs.net/click-101737824-16960640",
         "network": "cj"
+      }
+    },
+    {
+      "name": "ANINE BING",
+      "slug": "anine-bing",
+      "aliases": [
+        "Anine Bing"
+      ],
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.aninebing.com",
+      "intro": "ANINE BING bottles Scandinavian-meets-LA wardrobe staples — the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed — at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.\n\nAt this price tier the category margin is real money: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card still claws back a coffee's worth on every blazer.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46089&trid=1552713.203133&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -1400,6 +1466,21 @@
       "intro": "Bartell Drugs is a Pacific Northwest pharmacy chain founded in 1890, with roughly 65\nlocations clustered in the Seattle metro and Puget Sound region. Owned by Rite Aid\nsince 2020, Bartell still operates under its own banner with its own pharmacy and\nloyalty program. Stores code as drugstores for credit card networks, so a drugstore\ncategory bonus card (Amex Blue Cash Preferred, Citi Custom Cash on drugstores, Chase\nFreedom Flex when activated) earns its full multiplier on prescriptions and front-of-\nstore purchases.\n"
     },
     {
+      "name": "Bartesian",
+      "slug": "bartesian",
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://bartesian.com",
+      "intro": "Bartesian makes capsule cocktail machines that mix a bar-quality drink from a pod plus your own base spirit, along with the recurring capsule packs that keep the machine running. The machine is a one-time kitchen-appliance purchase and the capsules are classic repeat spend, all coding as online retail from bartesian.com.\n\nTreat it like other countertop-appliance brands: Bank of America Customized Cash set to online shopping earns 3 percent on both machine and capsules, and a Chase Freedom Flex online-retail quarter is the moment to stock up on pods at 5 percent.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.15632&trid=1552713.227565&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping over $50"
+      }
+    },
+    {
       "name": "Baskin-Robbins",
       "slug": "baskin-robbins",
       "categories": [
@@ -1568,6 +1649,21 @@
       "intro": "Best Western Hotels & Resorts runs about 4,000 properties globally under a member-owned\ncooperative structure that's unusual in the major-chain landscape. The portfolio spans\nBest Western, Best Western Plus, and Best Western Premier on the core brand, with\nVīb, GLō, Aiden, Sadie, and Executive Residency rounding out boutique and extended-stay\nsegments, plus the SureStay budget brands. There's no Best Western co-brand credit\ncard in the U.S. market today, so the right play is a strong general hotel-category\ncard — Sapphire Reserve, Venture X, Amex Gold, or a flat-rate cashback card if you\nprefer simplicity. Best Western Rewards points are earned only on direct bookings at\nbestwestern.com or in-app; OTA stays earn nothing in the program.\n"
     },
     {
+      "name": "Betsey Johnson",
+      "slug": "betsey-johnson",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.betseyjohnson.com",
+      "intro": "Betsey Johnson is the famously whimsical fashion brand known for party dresses, novelty heels and handbags, and maximalist jewelry. Direct orders from betseyjohnson.com code as online apparel retail, while the brand also sells widely through department stores like Macy's and Bloomingdale's.\n\nApparel spend has good category coverage: U.S. Bank Cash+ offers a select clothing stores option that can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and buying through a department store instead can tap department-store bonus categories.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.37850&trid=1552713.159569&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "BevMo!",
       "slug": "bevmo",
       "aliases": [
@@ -1615,6 +1711,20 @@
       ],
       "website": "https://www.biggby.com",
       "intro": "Biggby Coffee is a Michigan-founded franchise known for flavored lattes and an upbeat, locally owned drive-thru vibe across the Midwest and beyond. Purchases code as dining or restaurants on most cards, so reach for a card with a coffee or dining bonus. Reloading a Biggby gift card in advance may not always trigger the dining category, so paying directly is safest.\n"
+    },
+    {
+      "name": "Biotherm",
+      "slug": "biotherm",
+      "categories": [
+        "online_shopping",
+        "department_stores"
+      ],
+      "website": "https://www.biotherm-usa.com",
+      "intro": "Biotherm is L'Oréal's aquatic-science skincare house, built around thermal plankton ferment in lines like Life Plankton and Aquasource, plus one of the most established men's skincare ranges in Biotherm Homme. US orders from biotherm-usa.com code as online beauty retail.\n\nSkincare replenishment favors whichever online category is live: Bank of America Customized Cash set to online shopping earns 3 percent, online-retail rotating quarters can push a serum restock to 5, and department-store bonuses apply when you pick Biotherm up through Macy's instead. Flat 2 percent covers the in-between months.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.53197&trid=1552713.180575&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Birkenstock",
@@ -1711,6 +1821,20 @@
       }
     },
     {
+      "name": "Blendtec",
+      "slug": "blendtec",
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.blendtec.com",
+      "intro": "Blendtec builds high-powered blenders in Utah — the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars — and famously ran the \"Will It Blend?\" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.\n\nA blender at this price point is a one-time considered purchase: Bank of America Customized Cash set to online shopping earns 3 percent, a Freedom Flex online-retail quarter can reach 5 percent, and flat 2 percent cards are the fallback if no category is live when yours dies mid-smoothie.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.12057&trid=1552713.159184&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Blick Art Materials",
       "slug": "blick-art-materials",
       "aliases": [
@@ -1721,6 +1845,19 @@
       ],
       "website": "https://www.dickblick.com",
       "intro": "Blick Art Materials, also known as Dick Blick, is a leading US art-supply retailer serving artists and schools online and in stores. Online orders code as online shopping, while in-store buys usually ring up as general retail, with no art-supply bonus on mainstream cards. A flat-rate or online-shopping card is the practical pick.\n"
+    },
+    {
+      "name": "Blinkist",
+      "slug": "blinkist",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.blinkist.com",
+      "intro": "Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription — an online purchase, not a streaming service, so streaming credits and multipliers stay on the bench.\n\nA single annual charge favors whichever online category you have running: Bank of America Customized Cash set to online shopping earns 3 percent, and otherwise a flat 2 percent card like Citi Double Cash quietly does the job every year.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10732&trid=1552713.212952&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Bloomingdale's",
@@ -1851,6 +1988,22 @@
       }
     },
     {
+      "name": "Bobbie",
+      "slug": "bobbie",
+      "aliases": [
+        "Bobbie Baby"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hibobbie.com",
+      "intro": "Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase — not groceries — which changes which cards make sense.\n\nGrocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators — worth checking before optimizing card rewards.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.33836&trid=1552713.249750&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Bojangles",
       "slug": "bojangles",
       "categories": [
@@ -1925,6 +2078,24 @@
       ],
       "website": "https://www.booksamillion.com",
       "intro": "Books-A-Million, branded as BAM!, is the second-largest brick-and-mortar bookstore\nchain in the United States with around 250 stores concentrated in the Southeast.\nThe retailer carries books, toys, gifts, magazines, and operates the Joe Muggs cafe\ninside larger stores. BAM! purchases generally code as bookstore or general retail\nrather than as a dedicated bonus category on most cards.\n\nCards with online shopping bonuses can earn better on booksamillion.com orders.\nBank of America Customized Cash and U.S. Bank Cash+ both offer selectable online\nshopping categories worth 3 to 5 percent, and Chase Freedom Flex sometimes features\nonline shopping in its rotating quarters. The Millionaire's Club membership stacks\nadditional discounts with credit card cash back for frequent buyers.\n"
+    },
+    {
+      "name": "Bowers & Wilkins",
+      "slug": "bowers-and-wilkins",
+      "aliases": [
+        "B&W"
+      ],
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.bowerswilkins.com",
+      "intro": "Bowers & Wilkins is the British high-end audio marque behind the 600–800 series loudspeakers, the Px7 and Px8 headphones, and the Zeppelin wireless speaker. Direct orders from bowerswilkins.com code as online electronics retail and are where the brand lists its own certified refurb stock.\n\nHi-fi purchases are large enough that category choice genuinely matters: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping is a safe 3 percent, and a pair of 700-series floorstanders on a flat 2 percent card still earns real money.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110005992&trid=1552713.228055&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping"
+      }
     },
     {
       "name": "Bowflex",
@@ -2011,6 +2182,23 @@
       "intro": "Brilliant Earth focuses on ethically sourced and lab-grown diamonds, selling rings and fine jewelry at brilliantearth.com that code as online shopping or general retail. Because a ring is often a four or five figure purchase, the card you choose matters more than the category. Jewelry has no bonus multiplier, so a strong flat-rate or online-shopping card maximizes the reward.\n"
     },
     {
+      "name": "Brinks Home",
+      "slug": "brinks-home",
+      "aliases": [
+        "Brinks Home Security"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://brinkshome.com",
+      "intro": "Brinks Home sells professionally monitored home-security systems — panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.\n\nNeither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on — security bundles are an easy few hundred dollars of qualifying spend.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.41354&trid=1552713.247347&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "British Airways",
       "slug": "british-airways",
       "aliases": [
@@ -2039,6 +2227,21 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.10113.589809&trid=1552713.245195&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Bruno Magli",
+      "slug": "bruno-magli",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.brunomagli.com",
+      "intro": "Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936 — cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.\n\nShoes at this tier reward a category match: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns a dependable 3 percent, and a flat 2 percent card on a pair of oxfords still returns enough for the shoe trees.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18734&trid=1552713.216081&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping on orders $200"
       }
     },
     {
@@ -2751,6 +2954,23 @@
       "intro": "Choice Hotels operates roughly 7,500 properties worldwide, dominated by mid-scale and\neconomy brands — Comfort Inn, Quality Inn, Sleep Inn, Clarion — with the Cambria and\nAscend Hotel Collection covering its upscale push. The 2022 acquisition of Radisson\nAmericas folded Country Inn & Suites and Park Plaza into Choice Privileges, broadening\nthe footprint considerably. Award nights start as low as 6,000 points, and the program\nis one of the better economy-tier values on a cents-per-point basis. The Wells Fargo\nChoice Privileges co-brand cards earn elevated points on Choice stays and gas, with\nthe Select tier adding automatic Platinum elite status and an annual bonus night.\nDirect bookings earn points; OTA stays do not.\n"
     },
     {
+      "name": "Chubbies",
+      "slug": "chubbies",
+      "aliases": [
+        "Chubbies Shorts"
+      ],
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.chubbiesshorts.com",
+      "intro": "Chubbies built a cult following on 5.5-inch-inseam weekend shorts and has since expanded into swim trunks, polos, and loungewear with the same retro-Americana streak. Orders from chubbiesshorts.com code as online apparel retail, with the brand's Fourth of July-adjacent drops driving most of its hype cycles.\n\nApparel categories cover it well: U.S. Bank Cash+ with select clothing stores chosen can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating-category quarters covering online retail occasionally beat both.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16759&trid=1552713.249484&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Church's Chicken",
       "slug": "churchs-chicken",
       "categories": [
@@ -2816,6 +3036,23 @@
       }
     },
     {
+      "name": "CLEAR",
+      "slug": "clear",
+      "aliases": [
+        "CLEAR Plus",
+        "CLEAR+"
+      ],
+      "categories": [
+        "travel"
+      ],
+      "website": "https://www.clearme.com",
+      "intro": "CLEAR Plus is the biometric identity lane at 50-plus US airports that lets members verify with eyes or fingerprints and skip to the front of security, stacking with TSA PreCheck rather than replacing it. The annual membership bills from clearme.com and codes as a travel purchase on most networks.\n\nBefore paying full freight, check your wallet: Amex Platinum and Amex Green carry statement credits that cover most or all of a CLEAR Plus membership, and several airline and hotel programs discount it. Paying out of pocket, a travel-category card like Chase Sapphire Preferred at 2x is the sensible vehicle.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23636&trid=1552713.245749&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Click & Grow",
       "slug": "click-and-grow",
       "aliases": [
@@ -2855,6 +3092,19 @@
       ],
       "website": "https://www.coach.com",
       "intro": "Coach is the flagship leather goods brand of Tapestry Inc, which also owns Kate Spade\nand Stuart Weitzman. The U.S. footprint includes around 360 full-price and outlet\nstores plus coach.com. Direct purchases typically code as department store in person\nand online shopping for web orders, while Coach handbags bought at Macy's, Nordstrom,\nor Bloomingdale's code under those host retailers. The free Coach Insider loyalty\nprogram stacks with credit card multipliers.\n"
+    },
+    {
+      "name": "Codecademy",
+      "slug": "codecademy",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.codecademy.com",
+      "intro": "Codecademy teaches programming through interactive browser-based courses, with free basics and a Pro subscription that unlocks career paths, projects, and certificates; it is now part of Skillsoft. Pro bills monthly or annually from codecademy.com and codes as an online education subscription.\n\nEducation subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends — worth asking before optimizing cents per dollar.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9595&trid=1552713.209296&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Cold Stone Creamery",
@@ -3180,6 +3430,20 @@
       "intro": "Crunch Fitness is a franchise gym chain known for budget pricing, group classes and a no-judgment vibe. As with most gyms, monthly dues seldom earn a bonus, so they typically code at the flat rate, and any value boost is more likely to come from a card offering a fitness or wellness credit than from a category multiplier.\n"
     },
     {
+      "name": "Cub Cadet",
+      "slug": "cub-cadet",
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.cubcadet.com",
+      "intro": "Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network — it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.\n\nA mower-sized charge deserves planning: it is ideal signup-bonus spend, and otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct. Buying the same machine through Home Depot or Lowe's instead can tap home-improvement category bonuses when you have one live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9498&trid=1552713.212603&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Cub Foods",
       "slug": "cub-foods",
       "categories": [
@@ -3251,6 +3515,20 @@
       ],
       "website": "https://www.dairyqueen.com",
       "intro": "Dairy Queen is the Berkshire Hathaway-owned QSR with more than 4,300 US locations split\nbetween traditional treat-only stores and full-menu DQ Grill & Chill outlets serving Blizzards,\nsoft-serve cones, dipped cones, burgers, and chicken strip baskets. Whether you order at a\nwalk-up window, drive-thru, or through the DQ Rewards mobile app, the transaction codes as\ndining/restaurants. Cards with strong dining multipliers (Amex Gold at 4x, Chase Sapphire\nPreferred at 3x, Capital One SavorOne at 3% cash) all earn at the full bonus rate on DQ.\n"
+    },
+    {
+      "name": "Dansko",
+      "slug": "dansko",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.dansko.com",
+      "intro": "Dansko's stapled clogs are the unofficial uniform of nurses, chefs, and anyone else on their feet twelve hours at a stretch, joined by walking shoes and sandals with the same all-day support. Direct orders from dansko.com code as online shoe retail.\n\nA clog replacement cycle pairs well with apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and employer scrub-and-shoe stipends cover Dansko at many hospital systems before rewards enter it.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9278&trid=1552713.202021&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "David's Bridal",
@@ -3407,6 +3685,21 @@
       ],
       "website": "https://www.dennys.com",
       "intro": "Denny's operates roughly 1,500 US diners famous for 24-hour service, the Grand Slam breakfast,\nMoons Over My Hammy, and a value-driven all-day menu that draws road-trippers, third-shift\nworkers, and late-night crowds. Most Denny's are highway-adjacent or in travel-corridor\nsuburbs. Denny's transactions code as dining/restaurants on every credit card, including\norders through the Denny's Rewards app and Denny's On Demand delivery portal. Dining-bonus\ncards earn full rate: Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne 3%.\n"
+    },
+    {
+      "name": "Denon",
+      "slug": "denon",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.denon.com",
+      "intro": "Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com — including refurbished receivers with full warranties — code as online electronics retail.\n\nReceiver upgrades are chunky spend, so aim a category at them: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is the steady 3 percent, and flat 2 percent cards cover the impulse subwoofer.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110005993&trid=1552713.228060&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping"
+      }
     },
     {
       "name": "Dermalogica",
@@ -3967,6 +4260,19 @@
       }
     },
     {
+      "name": "EarthLink",
+      "slug": "earthlink",
+      "categories": [
+        "tv_internet_streaming"
+      ],
+      "website": "https://www.earthlink.net",
+      "intro": "EarthLink, the dial-up pioneer turned modern ISP, resells fiber and wireless home internet across much of the US, often on the same physical lines as the big carriers but with its own pricing and no-data-cap positioning. Monthly bills code as internet service, the same bucket as Cox or Spectrum.\n\nInternet bills are one of the best recurring charges to optimize: U.S. Bank Cash+ with TV, internet, and streaming selected pays 5 percent on the monthly bill, Citi Custom Cash can hit 5 percent if internet is your top category that cycle, and a flat 2 percent card is the no-maintenance floor.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11979&trid=1552713.247913&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "EaseUS",
       "slug": "easeus",
       "aliases": [
@@ -4087,6 +4393,19 @@
       }
     },
     {
+      "name": "edX",
+      "slug": "edx",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.edx.org",
+      "intro": "edX hosts university-built online courses — MIT and Harvard founded it — spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.\n\nEducation charges sit outside consumer bonus categories, so treat them like any online purchase: Bank of America Customized Cash set to online shopping earns 3 percent on a certificate, flat 2 percent cards cover bigger program tuition without ceremony, and employer tuition-reimbursement programs frequently cover edX before rewards even enter the picture.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.17728&trid=1552713.180112&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Eileen Fisher",
       "slug": "eileen-fisher",
       "aliases": [
@@ -4141,6 +4460,19 @@
       "affiliate": {
         "url": "https://www.jdoqocy.com/click-101737824-16960092",
         "network": "cj"
+      }
+    },
+    {
+      "name": "Elvie",
+      "slug": "elvie",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.elvie.com",
+      "intro": "Elvie makes discreet wearable breast pumps — the in-bra Elvie Pump and the value Stride line — plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.\n\nBefore optimizing rewards, exhaust the cheaper routes: Elvie pumps are frequently covered or subsidized through insurance DME suppliers and are broadly HSA/FSA-eligible. Paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a pump-sized purchase contributes meaningfully to a new card's signup-bonus minimum.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.44020&trid=1552713.228006&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -4255,6 +4587,36 @@
       ],
       "website": "https://www.etsy.com",
       "intro": "Etsy is the marketplace for handmade, vintage, and craft goods sold by independent\nmakers, with checkout handled by Etsy itself. Purchases code as online shopping on every\ngeneral-purpose card we track, which means Etsy is a good fit for any card with a flat\nU.S. online retail bonus (Blue Cash Everyday, Hilton Surpass, etc.). Etsy doesn't have a\nco-branded card and rarely shows up in card-specific bonus lists.\n"
+    },
+    {
+      "name": "Europcar",
+      "slug": "europcar",
+      "categories": [
+        "car_rentals",
+        "travel"
+      ],
+      "website": "https://www.europcar.com",
+      "intro": "Europcar is one of Europe's largest car-rental networks, with counters across 130-plus countries; US travelers mostly meet it when booking European road trips, where its rates and one-way options frequently beat the American majors abroad. Rentals code as car rental agencies, squarely inside every travel category definition.\n\nCar rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry — genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.5861&trid=1552713.189661&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "European Wax Center",
+      "slug": "european-wax-center",
+      "aliases": [
+        "EWC"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://waxcenter.com",
+      "intro": "European Wax Center is the largest waxing-salon chain in the US, with over 1,000 franchised centers selling waxing services, the Wax Pass prepaid bundles, and its own skincare line. Charges are in-salon or prepaid packages booked through waxcenter.com and code as personal-care services.\n\nSalon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase — a few hundred dollars prepaid — into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.30094&trid=1552713.245382&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Eventbrite",
@@ -4559,6 +4921,22 @@
       "intro": "First Watch operates more than 540 daytime-only restaurants serving breakfast, brunch, and\nlunch, with menu staples like Avocado Toast, the Chickichanga, lemon-ricotta pancakes, and\nfresh-pressed juices. Locations close mid-afternoon, distinguishing First Watch from all-day\nbreakfast chains like IHOP and Denny's. First Watch transactions code as dining/restaurants\non every US card. Dining-bonus cards earn full rate: Amex Gold at 4x Membership Rewards,\nChase Sapphire Preferred at 3x, Chase Sapphire Reserve at 4x, Capital One SavorOne at 3% cash.\n"
     },
     {
+      "name": "Firstleaf",
+      "slug": "firstleaf",
+      "aliases": [
+        "Firstleaf Wine Club"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.firstleaf.com",
+      "intro": "Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings — the algorithmic cousin of Naked Wines' funding model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.\n\nThat coding means grocery and dining multipliers stay quiet, and online categories do the work: Bank of America Customized Cash set to online shopping earns 3 percent per box, a Freedom Flex online-retail quarter can reach 5 percent on a stock-up order, and a flat 2 percent card suits the set-and-forget subscriber.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.38398&trid=1552713.249831&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "FitFlop",
       "slug": "fitflop",
       "categories": [
@@ -4605,6 +4983,22 @@
       "intro": "Fjällräven is a Swedish outdoor brand best known for the boxy Kanken backpack and durable,\nwax-treated Greenland jacket, built on a design philosophy that favors long-lasting,\nrepairable gear over disposable fast fashion. It's part of the Fenix Outdoor group, which\nalso owns Hanwag and Primus. There is no Fjällräven co-brand credit card, so purchases\nthere are best matched to a card that bonuses sporting goods or outdoor retail, or a card\nthat rewards general online shopping, since Fjällräven's own e-commerce site is a common\nway U.S. shoppers buy its gear.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.29113.1175129&trid=1552713.235909&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Flamingo",
+      "slug": "flamingo",
+      "aliases": [
+        "Flamingo by Harry's"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.shopflamingo.com",
+      "intro": "Flamingo is the women's body-care line from the team behind Harry's, selling razors, blade refills, and wax kits with the same design-forward, subscription-friendly model as its sibling brand. Orders and refill plans from shopflamingo.com code as online retail rather than drugstore purchases.\n\nThe card logic mirrors Harry's: direct subscriptions earn online-category rates — Bank of America Customized Cash set to online shopping pays 3 percent — while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9412&trid=1552713.248795&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -4741,6 +5135,22 @@
       }
     },
     {
+      "name": "FragranceNet",
+      "slug": "fragrancenet",
+      "aliases": [
+        "FragranceNet.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.fragrancenet.com",
+      "intro": "FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes — plus skincare, haircare, and candles — at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.\n\nDiscount fragrance stacking works best with an online category on top: Bank of America Customized Cash set to online shopping adds 3 percent to already-marked-down bottles, rotating online-retail quarters push it to 5, and flat 2 percent cards handle gift-season hauls without planning.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.216&trid=1552713.455&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "FragranceShop.com",
       "slug": "fragranceshop",
       "aliases": [
@@ -4755,6 +5165,21 @@
       "affiliate": {
         "url": "https://www.tkqlhce.com/click-101737824-16942205",
         "network": "cj"
+      }
+    },
+    {
+      "name": "Franco Sarto",
+      "slug": "franco-sarto",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.francosarto.com",
+      "intro": "Franco Sarto delivers Italian-styled women's footwear — loafers, block heels, and knee boots — at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.\n\nFootwear categories cover the bases: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same styles through Macy's or DSW can catch department-store or rotating-category bonuses when live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41588&trid=1552713.178979&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -4787,6 +5212,23 @@
       ],
       "website": "https://www.freepeople.com",
       "intro": "Free People is the bohemian women's brand under URBN and includes the FP Movement\nactivewear line, with roughly 150 retail stores plus a sizeable online presence at\nfreepeople.com. Most credit cards code in-store transactions as department store and\nweb orders as online shopping. Free People does not currently issue a co-brand credit\ncard, so shoppers usually optimize with rotating category cards or a flat-rate\nonline-shopping multiplier.\n"
+    },
+    {
+      "name": "French Connection",
+      "slug": "french-connection",
+      "aliases": [
+        "FCUK"
+      ],
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.frenchconnection.com",
+      "intro": "French Connection is the London high-street label that rode the FCUK logo era and now trades on sharp dresses, tailoring, and knitwear at contemporary prices. US orders from frenchconnection.com code as online apparel retail, with an aggressive sale rotation.\n\nApparel category coverage applies cleanly: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and stacking the brand's sale pricing with either beats waiting for a better card.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.35448&trid=1552713.158807&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Freshly",
@@ -5052,6 +5494,23 @@
       }
     },
     {
+      "name": "Gillette",
+      "slug": "gillette",
+      "aliases": [
+        "The Gillette Company",
+        "Gillette Direct"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.gillette.com",
+      "intro": "Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor — the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.\n\nThat coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices — the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23585&trid=1552713.196927&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Gilt",
       "slug": "gilt-and-gilt-city",
       "aliases": [
@@ -5214,6 +5673,20 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12845.2840658&trid=1552713.224344&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "60% off"
+      }
+    },
+    {
+      "name": "Grailed",
+      "slug": "grailed",
+      "categories": [
+        "online_shopping",
+        "secondhand_stores"
+      ],
+      "website": "https://www.grailed.com",
+      "intro": "Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout — the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.\n\nThat PayPal routing is the rewards angle: Chase Freedom Flex's recurring PayPal rotating quarters have historically covered Grailed checkouts at 5 percent, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card backstops off-quarter grail hunts.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13931&trid=1552713.227549&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -5394,6 +5867,23 @@
       ],
       "website": "https://www2.hm.com",
       "intro": "H&M is a Swedish-headquartered fast-fashion chain with about 540 U.S. stores.\nIn-store charges code as department stores or apparel; hm.com codes as online\nshopping. The H&M Member program is free and issues birthday gifts plus tiered\nperks; H&M's co-branded U.S. credit card layers an additional discount on top\nof the loyalty program. For non-cardholders, an online-shopping-bonus card is\nthe strongest pairing.\n"
+    },
+    {
+      "name": "H&R Block",
+      "slug": "h-and-r-block",
+      "aliases": [
+        "H and R Block",
+        "HR Block"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hrblock.com",
+      "intro": "H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services — a category no consumer card bonuses.\n\nTwo angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution — paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5683&trid=1552713.156923&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Half Price Books",
@@ -5810,6 +6300,20 @@
       "intro": "HomeSense, the TJX off-price home brand and sister to HomeGoods, sells ever-changing decor and furniture that generally codes as general retail, not a home-improvement warehouse, so those bonuses often do not apply. Its US site at homesense.com is limited, but online orders code as online shopping. A flat-rate or online-shopping card is the dependable choice here.\n"
     },
     {
+      "name": "Horizon Fitness",
+      "slug": "horizon-fitness",
+      "categories": [
+        "online_shopping",
+        "sporting_goods"
+      ],
+      "website": "https://www.horizonfitness.com",
+      "intro": "Horizon Fitness sells home treadmills, ellipticals, and exercise bikes — the value-focused sibling brand of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.\n\nBig fitness equipment is prime signup-bonus spend, clearing most minimums in one order. Otherwise, U.S. Bank Cash+ with sporting goods stores selected can pay 5 percent when the charge classifies that way, and Bank of America Customized Cash set to online shopping is the reliable 3 percent.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12130&trid=1552713.196086&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Hot Topic",
       "slug": "hot-topic",
       "categories": [
@@ -5876,6 +6380,24 @@
       "intro": "HSN, the Home Shopping Network, is a multichannel retailer selling via 24-hour\ntelevision, hsn.com, and mobile, owned by Qurate Retail Group alongside sister\nbrand QVC. The product mix covers beauty, fashion, jewelry, kitchen, and home goods,\nwith a heavy emphasis on live demonstrations and host-led pitches. HSN purchases code\nas online shopping or general merchandise for credit card networks, so an\nonline-shopping category bonus card will earn its multiplier. The FlexPay installment\nprogram is available at checkout against the saved card.\n"
     },
     {
+      "name": "Hudson Jeans",
+      "slug": "hudson-jeans",
+      "aliases": [
+        "Hudson"
+      ],
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.hudsonjeans.com",
+      "intro": "Hudson Jeans is the Los Angeles premium-denim house known for its signature triangle back-flap pockets, mid-hundreds price points, and a steady rotation of skinny, straight, and barrel fits. Direct orders from hudsonjeans.com code as online apparel retail.\n\nPremium denim benefits from an apparel category: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 30-percent-off sales stack with either for the real savings.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.10023&trid=1552713.178072&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping over $200"
+      }
+    },
+    {
       "name": "Huel",
       "slug": "huel",
       "categories": [
@@ -5936,6 +6458,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53058.1000000002&trid=1552713.201413&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "30% off orders $99+"
+      }
+    },
+    {
+      "name": "Hunter Fan",
+      "slug": "hunter-fan",
+      "aliases": [
+        "Hunter Fan Company"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.hunterfan.com",
+      "intro": "Hunter has been making ceiling fans since 1886 and remains the name most Americans reach for when a room needs one, now spanning smart fans, outdoor-rated models, and the Casablanca premium line. Direct orders from hunterfan.com code as online retail rather than a hardware-store purchase.\n\nA fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there — worth a price check both ways.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46207&trid=1552713.225483&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -6128,6 +6667,20 @@
       }
     },
     {
+      "name": "Insta360",
+      "slug": "insta360",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.insta360.com",
+      "intro": "Insta360 makes the leading 360-degree action cameras — the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras — sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.\n\nCamera kits with mounts and accessories climb in price quickly, which suits an electronics category: U.S. Bank Cash+ set to electronics stores can return 5 percent when the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card covers accessory top-ups.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.46233&trid=1552713.248756&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Instacart",
       "slug": "instacart",
       "aliases": [
@@ -6139,6 +6692,20 @@
       ],
       "website": "https://www.instacart.com",
       "intro": "Instacart is the largest U.S. grocery delivery and pickup marketplace, partnering\nwith Costco, Wegmans, ALDI, Publix, and many regional chains. Orders placed through\nthe Instacart app or instacart.com generally code as groceries on most cards, but\nsome banks classify the charge as the underlying merchant — worth confirming on\na small order before relying on a 6% grocery card. Several premium cards (Sapphire\nReserve, Venture X) include Instacart+ memberships and statement credits.\n"
+    },
+    {
+      "name": "Intimissimi",
+      "slug": "intimissimi",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://us.intimissimi.com",
+      "intro": "Intimissimi is the Italian lingerie chain — silk-and-lace bralettes, modal sleepwear, and seamless basics — that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.\n\nLingerie restocks fit apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 5-for deals on basics reward consolidating a haul onto whichever is live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41274&trid=1552713.189853&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "iolo",
@@ -6681,6 +7248,38 @@
       "intro": "Kirkland's offers affordable home decor, wall art, and seasonal accents, with store purchases that usually code as general retail rather than a home-improvement warehouse, so hardware bonuses may not apply. Shopping kirklands.com normally codes as online shopping. For decor runs that add up, a card rewarding online spend or a flat everyday rate is the sensible pick.\n"
     },
     {
+      "name": "Klook",
+      "slug": "klook",
+      "categories": [
+        "travel",
+        "entertainment"
+      ],
+      "website": "https://www.klook.com",
+      "intro": "Klook is a travel-activities marketplace strongest in Asia — theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours — often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.\n\nActivity bookings are travel spend most cards recognize: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X's 2x applies everywhere including the odd booking that codes as ticketing instead. Klook runs frequent promo-code sales, so stack a discount with the multiplier rather than choosing between them.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110006163&trid=1552713.230405&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "KOA",
+      "slug": "koa",
+      "aliases": [
+        "Kampgrounds of America",
+        "KOA Campgrounds"
+      ],
+      "categories": [
+        "travel",
+        "vacation_rentals"
+      ],
+      "website": "https://koa.com",
+      "intro": "KOA — Kampgrounds of America — runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.\n\nTravel cards are the natural fit: Chase Sapphire Preferred and Reserve count campground stays in their travel multipliers, Capital One Venture X earns its flat 2x everywhere, and annual-fee travel credits like the Sapphire Reserve's have been reported to apply to campground charges. KOA Rewards stacks on top regardless of card.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50482&trid=1552713.235147&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Kobo",
       "slug": "kobo",
       "aliases": [
@@ -7057,6 +7656,20 @@
       ],
       "website": "https://www.lidl.com",
       "intro": "Lidl is a German discount grocer that has expanded across the U.S. East Coast since\n2017, with roughly 175 stores stretching from Georgia up to New York. The format is\nsmall-footprint and private-label-heavy, comparable to Aldi. Lidl codes as a U.S.\nsupermarket for credit card networks, so grocery category bonuses (Amex Gold, Blue\nCash Preferred, Citi Custom Cash) earn their full multiplier. The chain accepts mobile\nwallets and standard major networks.\n"
+    },
+    {
+      "name": "Life Fitness",
+      "slug": "life-fitness",
+      "categories": [
+        "online_shopping",
+        "sporting_goods"
+      ],
+      "website": "https://www.lifefitness.com",
+      "intro": "Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use — treadmills, ellipticals, bikes, and the Hammer Strength line — at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.\n\nPurchases this size are textbook signup-bonus spend, often clearing an entire minimum in one order. Absent a new card, U.S. Bank Cash+ with sporting goods selected can hit 5 percent where the charge classifies that way, with Bank of America Customized Cash's online shopping choice a dependable 3 percent.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.17731&trid=1552713.189439&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Life is Good",
@@ -7489,6 +8102,38 @@
       "affiliate": {
         "url": "https://www.anrdoezrs.net/click-101737824-17205347",
         "network": "cj"
+      }
+    },
+    {
+      "name": "Maidenform",
+      "slug": "maidenform",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.maidenform.com",
+      "intro": "Maidenform has been a mainstay of American intimates for a century, selling bras, shapewear, and underwear under a HanesBrands umbrella that keeps prices in the everyday range. Direct orders from maidenform.com code as online apparel retail, and the brand runs near-constant multi-buy promotions.\n\nIntimates restocks land in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store category bonuses apply when you buy Maidenform through Macy's or Kohl's instead.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43954&trid=1552713.205421&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Make Up For Ever",
+      "slug": "make-up-for-ever",
+      "aliases": [
+        "MUFE"
+      ],
+      "categories": [
+        "online_shopping",
+        "department_stores"
+      ],
+      "website": "https://www.makeupforever.com",
+      "intro": "Make Up For Ever is the LVMH-owned professional makeup house famous for the HD Skin foundation range, Aqua Resist liners, and artist-grade palettes born from its Paris pro heritage. US orders from makeupforever.com code as online beauty retail; the brand also sells through Sephora.\n\nDirect orders suit an online category — Bank of America Customized Cash set to online shopping earns 3 percent — while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.54284&trid=1552713.209548&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -8123,6 +8768,23 @@
       }
     },
     {
+      "name": "Mrs. Fields",
+      "slug": "mrs-fields",
+      "aliases": [
+        "Mrs Fields"
+      ],
+      "categories": [
+        "online_shopping",
+        "dining"
+      ],
+      "website": "https://www.mrsfields.com",
+      "intro": "Mrs. Fields turned mall-kiosk chocolate-chip cookies into a national gifting business: tins, cookie cakes, and corporate gift baskets shipped nationwide from mrsfields.com, alongside its remaining bakery locations. Online gift orders code as internet retail or specialty food, while in-person bakery purchases can code as dining or fast food.\n\nFor shipped gifts, an online category does the work — Bank of America Customized Cash set to online shopping earns 3 percent — while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.7935&trid=1552713.158847&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Munchkin",
       "slug": "munchkin",
       "aliases": [
@@ -8167,6 +8829,20 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13852.1723735&trid=1552713.163400&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "up to 60% off with code IMPACT12PK"
+      }
+    },
+    {
+      "name": "Nalgene",
+      "slug": "nalgene",
+      "categories": [
+        "online_shopping",
+        "sporting_goods"
+      ],
+      "website": "https://www.nalgene.com",
+      "intro": "Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders — including the popular custom-printing option — ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.\n\nBottles are small-ticket, so rewards are more about which card is already in hand: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ sporting goods quarter can catch a team order at 5 percent, and REI stock of the same bottles earns REI-specific card bonuses instead.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12848&trid=1552713.226006&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -8240,6 +8916,21 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14513.1998567&trid=1552713.234726&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "10% off with sign up"
+      }
+    },
+    {
+      "name": "Naturalizer",
+      "slug": "naturalizer",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.naturalizer.com",
+      "intro": "Naturalizer has sold comfort-first women's footwear since 1927 — pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.\n\nFootwear reliably lands in apparel categories: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the merchant classifies as apparel or shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and the same styles at Macy's or Nordstrom can pick up department-store bonuses when one is live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38505&trid=1552713.158953&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -8569,6 +9260,23 @@
       "intro": "Old Navy is Gap, Inc.'s value-priced apparel banner with about 1,200 U.S. stores and a\nstrong online catalog. Apparel doesn't have a dedicated reward category on most\ngeneral-purpose credit cards, so card choice usually comes down to whether you're\nshopping online (where online-shopping bonuses apply) or in-store (where you're\ntypically falling back to a strong flat-rate cashback card).\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5555.660845&trid=1552713.162751&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Ole Henriksen",
+      "slug": "ole-henriksen",
+      "aliases": [
+        "OLEHENRIKSEN"
+      ],
+      "categories": [
+        "online_shopping",
+        "department_stores"
+      ],
+      "website": "https://www.olehenriksen.com",
+      "intro": "Ole Henriksen bottles Scandinavian glow-first skincare — Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners — born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.\n\nDirect restocks favor an online category — Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5 — while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38834&trid=1552713.159748&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -9183,6 +9891,20 @@
       "intro": "PetSmart is the largest U.S. pet specialty retailer by store count at about 1,650\nlocations, with a sizable petsmart.com online catalog. Pet-supply purchases don't have a\ndedicated category on most credit cards, so in-store purchases generally fall back to a\nflat-rate cashback card. Online purchases at petsmart.com code as online shopping. The\nTreats Rewards loyalty program stacks on top of card cashback.\n"
     },
     {
+      "name": "PGA TOUR Superstore",
+      "slug": "pga-tour-superstore",
+      "categories": [
+        "sporting_goods",
+        "online_shopping"
+      ],
+      "website": "https://www.pgatoursuperstore.com",
+      "intro": "PGA TOUR Superstore is the big-box golf retailer — clubs, balls, apparel, launch-monitor fittings, and in-store simulators — with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.\n\nGolf spend adds up fast, and sporting-goods coverage is unusually good: U.S. Bank Cash+ with sporting goods stores selected pays 5 percent, rotating quarters occasionally cover the category too, and a driver-and-iron-set fitting bill makes clean signup-bonus spend. Bank of America Customized Cash's online shopping choice covers web orders at 3 percent.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16839&trid=1552713.228946&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Philips Hue",
       "slug": "philips-hue",
       "aliases": [
@@ -9228,6 +9950,20 @@
       }
     },
     {
+      "name": "Philosophy",
+      "slug": "philosophy",
+      "categories": [
+        "online_shopping",
+        "department_stores"
+      ],
+      "website": "https://www.philosophy.com",
+      "intro": "Philosophy is the feel-good skincare and bath brand behind Purity Made Simple cleanser, Hope in a Jar moisturizer, and the dessert-scented Amazing Grace shower gels, sold direct and through Ulta, Sephora, and department stores. Orders from philosophy.com code as online beauty retail.\n\nRoutine restocks favor an online category — Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5 — while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50295&trid=1552713.169070&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Philz Coffee",
       "slug": "philz-coffee",
       "categories": [
@@ -9255,6 +9991,19 @@
       }
     },
     {
+      "name": "Physicians Formula",
+      "slug": "physicians-formula",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.physiciansformula.com",
+      "intro": "Physicians Formula has sold hypoallergenic drugstore makeup since 1937 — Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.\n\nThe drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter — Chase Freedom Flex has covered drugstores repeatedly — at 5 percent. Price-match against drugstore sales before ordering direct.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43735&trid=1552713.247447&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Pick 'n Save",
       "slug": "pick-n-save",
       "categories": [
@@ -9275,6 +10024,39 @@
       ],
       "website": "https://pilotflyingj.com",
       "intro": "Pilot Flying J operates more than 750 travel centers across the U.S. and Canada,\nmaking it the largest truck stop network in North America. The chain serves both\nlong-haul truckers (with high-flow diesel lanes, showers, and driver lounges) and\npassenger drivers at standard gas pumps. Fuel at Pilot Flying J pumps codes as gas, so\nany card with a gas category bonus will earn its rate. The myRewards Plus loyalty\nprogram adds per-gallon discounts and points on in-store food, which can stack with a\nseparate gas rewards card.\n"
+    },
+    {
+      "name": "Pit Boss Grills",
+      "slug": "pit-boss-grills",
+      "aliases": [
+        "Pit Boss"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://pitboss-grills.com",
+      "intro": "Pit Boss is the value heavyweight of pellet grilling — bigger hoppers and lower prices than Traeger — spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.\n\nA grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories — compare, since Pit Boss runs aggressive direct-only bundle deals.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10421&trid=1552713.213540&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Pixi Beauty",
+      "slug": "pixi-beauty",
+      "aliases": [
+        "Pixi"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.pixibeauty.com",
+      "intro": "Pixi built a skincare empire on Glow Tonic, the glycolic toner with a permanent spot in affordable-skincare routines, plus flower-adorned tints and the collab-heavy Pretties palettes. Direct orders from pixibeauty.com code as online beauty retail; Target and Ulta carry core lines.\n\nGlow Tonic restocks reward whichever channel has a category live: direct orders earn Bank of America Customized Cash's 3 percent with online shopping selected, Target runs take the RedCard's 5 percent instead, and rotating online-retail quarters occasionally make direct the winner at 5. Flat 2 percent covers everything in between.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8883&trid=1552713.198431&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Pizza Hut",
@@ -9350,6 +10132,20 @@
       ],
       "website": "https://www.popeyes.com",
       "intro": "Popeyes is a U.S. Louisiana-style fried chicken chain with about 3,000 domestic\nlocations, owned by Restaurant Brands International. Charges code as dining on\nevery card we track. Any dining-bonus card (Amex Gold 4x, Sapphire Preferred 3x,\nSavorOne 3%) applies. The Popeyes Rewards app issues per-purchase points\nredeemable for free items, stackable with card bonuses.\n"
+    },
+    {
+      "name": "PopSockets",
+      "slug": "popsockets",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.popsockets.com",
+      "intro": "PopSockets turned the collapsible phone grip into an accessories empire, now spanning MagSafe grips, wallets, mounts, and endless licensed designs, sold direct from popsockets.com and through every electronics aisle in America. Direct orders code as online retail, sometimes classifying as electronics accessories.\n\nThese are small-ticket, high-frequency purchases where whatever category is live wins: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ electronics selection can catch a multi-grip order at 5 percent, and flat 2 percent cards cover the impulse checkout.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43682&trid=1552713.200566&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Portillo's",
@@ -9534,7 +10330,11 @@
         "airlines"
       ],
       "website": "https://www.qatarairways.com",
-      "intro": "Qatar Airways is the Doha-based Oneworld carrier celebrated for its Qsuite business class and a wide network from several US cities. Ticket purchases code as an airline or travel charge, the sweet spot for an airline or general travel bonus card. Points from flexible transferable-currency cards can move to its Privilege Club, often making transfers more rewarding than paying cash directly.\n"
+      "intro": "Qatar Airways is the Doha-based Oneworld carrier celebrated for its Qsuite business class and a wide network from several US cities. Ticket purchases code as an airline or travel charge, the sweet spot for an airline or general travel bonus card. Points from flexible transferable-currency cards can move to its Privilege Club, often making transfers more rewarding than paying cash directly.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25312&trid=1552713.249626&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Qdoba",
@@ -9643,6 +10443,23 @@
       ],
       "website": "https://www.racetrac.com",
       "intro": "RaceTrac is a family-owned Southeast U.S. convenience and fuel chain with more than\n800 stores across Georgia, Florida, Texas, Tennessee, Louisiana, and surrounding\nstates. Fuel pumps code as gas, so any gas category bonus card will earn its\nmultiplier. Inside-store food and drinks (the chain leans heavily on coffee and\nprepared foods) typically code as convenience store. The RaceTrac Rewards loyalty\nprogram adds per-gallon discounts and points on food that stack with a separate gas\nrewards card.\n"
+    },
+    {
+      "name": "RadioShack",
+      "slug": "radioshack",
+      "aliases": [
+        "Radio Shack"
+      ],
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.radioshack.com",
+      "intro": "RadioShack lives on as an online electronics retailer under new ownership, selling the batteries, adapters, components, and hobbyist parts the brand was always known for, plus consumer audio and smart-home gear. Orders from radioshack.com code as online electronics retail.\n\nComponent-drawer restocks and one-off adapter buys suit whichever electronics or online category is running: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card handles the odd soldering-iron emergency.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.32498&trid=1552713.248461&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Radisson Hotel Group",
@@ -10016,6 +10833,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14848.1705455&trid=1552713.240023&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "4% off"
+      }
+    },
+    {
+      "name": "RoC Skincare",
+      "slug": "roc-skincare",
+      "aliases": [
+        "RoC"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.rocskincare.com",
+      "intro": "RoC pioneered stabilized retinol in drugstore skincare and remains the evidence-first pick for anti-aging staples like Retinol Correxion and the Multi Correxion vitamin-C line. Buying direct from rocskincare.com codes as online retail; the same products also sit on Walgreens, CVS, and Amazon shelves.\n\nDirect orders fit an online category — Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more — while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46883&trid=1552713.225417&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -10478,6 +11311,20 @@
       "intro": "Segway makes personal electric transportation, including electric scooters, self-balancing\npersonal transporters, e-bikes, and off-road all-terrain vehicles, a lineup that grew well\nbeyond the original two-wheeled personal transporter that made the brand a household name.\nThe company has been owned by the Chinese mobility firm Ninebot since 2015, and the two\nbrands now operate under the combined Segway-Ninebot name. There's no Segway co-brand\ncredit card, so a purchase is best charged to an electronics or general online shopping\nrewards card, or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.31949.1241153&trid=1552713.240078&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Sennheiser",
+      "slug": "sennheiser",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.sennheiser.com",
+      "intro": "Sennheiser's consumer line — Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers — carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.\n\nHeadphone purchases in the $200–$400 band reward a live category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is a solid 3 percent, and open-box HD 6XX-adjacent deals on a flat 2 percent card still come out well.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42592&trid=1552713.193918&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -11090,6 +11937,23 @@
       "intro": "Spirit Airlines is a U.S. ultra-low-cost carrier known for stripped-down base fares\nwith à la carte pricing for bags, seat selection, and refreshments. Tickets code as\nairfare on every card we track, but for cards that offer trip-delay or trip-cancel\ninsurance the small base fare often falls below useful coverage thresholds. There's\nno widely-issued co-branded Spirit credit card, so general travel cards (Sapphire\nPreferred, Venture, Capital One Savor) are typically the best pairing.\n"
     },
     {
+      "name": "Spirit Halloween",
+      "slug": "spirit-halloween",
+      "aliases": [
+        "SpiritHalloween.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.spirithalloween.com",
+      "intro": "Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round — including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.\n\nCostume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter — which has historically covered Q4 — can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8099&trid=1552713.161081&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping over $60"
+      }
+    },
+    {
       "name": "Sportsman's Warehouse",
       "slug": "sportsmans-warehouse",
       "categories": [
@@ -11119,6 +11983,19 @@
       ],
       "website": "https://www.sprouts.com",
       "intro": "Sprouts Farmers Market is a natural-and-organic grocery chain with about 400 U.S.\nstores, leaning heavily on fresh produce and bulk foods. Sprouts codes cleanly as\ngroceries on every card we track. The strongest pairings are 6% Blue Cash Preferred\nand the U.S. Bank Shopper Cash Rewards (if Sprouts is selected as a chosen retailer);\nCapital One SavorOne earns 3% on groceries with no cap. Sprouts doesn't run a\nco-branded card, so general grocery cards are the standard answer.\n"
+    },
+    {
+      "name": "Stadium Goods",
+      "slug": "stadium-goods",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.stadiumgoods.com",
+      "intro": "Stadium Goods is the sneaker-and-streetwear consignment marketplace with a SoHo flagship and deep deadstock inventory, selling verified pairs through its own site alongside partners like Farfetch, its former parent. Purchases from stadiumgoods.com code as online retail.\n\nGrail-priced sneakers make the category math meaningful: Bank of America Customized Cash set to online shopping returns 3 percent on a $300 pair, rotating online-retail or PayPal quarters can reach 5, and a flat 2 percent card is the floor. Consignment pricing moves constantly, so the discount timing matters more than the card.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101104598&trid=1552713.195570&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Stamps.com",
@@ -11403,6 +12280,20 @@
       ],
       "website": "https://www.sunoco.com",
       "intro": "Sunoco-branded stations cover about 5,200 U.S. locations primarily across the East\nand Midwest. Pumps code cleanly as gas on every card we track. The Sunoco Rewards\napp stacks 5-10 cents per gallon savings on top of any card's bonus rate. There's\na Sunoco Rewards co-branded credit card, but in absolute cashback most 4-5%\ngeneral gas cards beat it.\n"
+    },
+    {
+      "name": "Superdry",
+      "slug": "superdry",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.superdry.com",
+      "intro": "Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding — best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.\n\nApparel categories cover it: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both on a jacket-sized order.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.44521&trid=1552713.209552&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Surfshark",
@@ -11828,6 +12719,19 @@
       "intro": "The North Face is a U.S. outdoor-apparel brand owned by VF Corporation, with\nabout 150 retail stores plus extensive third-party distribution at REI, Dick's,\nBackcountry, and more. Direct purchases at thenorthface.com code as online\nshopping; in-store charges code as department stores or apparel. The XPLR Pass\nloyalty program is free and issues spend rewards plus first-access to limited\ndrops. Pair with an online-shopping-bonus card or flat-rate cashback.\n"
     },
     {
+      "name": "The Parking Spot",
+      "slug": "the-parking-spot",
+      "categories": [
+        "travel"
+      ],
+      "website": "https://www.theparkingspot.com",
+      "intro": "The Parking Spot is the largest near-airport parking operator in the US, with covered and uncovered lots plus shuttle service at 25-plus airports, booked ahead on theparkingspot.com for member rates through its Spot Club program. Airport parking charges typically code as parking or travel merchants.\n\nParking spend near airports frequently counts toward travel multipliers — Chase Sapphire Preferred and Reserve both include parking in their travel definitions — and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10415&trid=1552713.211617&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "The RealReal",
       "slug": "the-realreal",
       "categories": [
@@ -11866,6 +12770,21 @@
       ],
       "website": "https://www.theupsstore.com",
       "intro": "The UPS Store is a franchise network of more than 5,000 U.S. locations offering\nshipping, printing, mailbox services, packing, notary, and small business support.\nMost The UPS Store locations code as office supplies or stationery on Visa,\nMastercard, and Amex networks, which makes shipping and print purchases eligible\nfor office supply bonus categories.\n\nBusiness cards with office supply bonuses are the natural fit. The Chase Ink\nBusiness Cash pays 5 percent on the first $25,000 in combined office supply and\ninternet, cable, and phone purchases each year, and the Amex Business Gold also\noffers office supplies as a top-two category. Personal cards with selectable office\nsupply categories, like U.S. Bank Cash+, can capture the same MCC.\n"
+    },
+    {
+      "name": "Theory",
+      "slug": "theory",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.theory.com",
+      "intro": "Theory built its name on precisely tailored workwear fundamentals — the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe — under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.\n\nSuiting-level price tags make categories worthwhile: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store bonuses apply when you shop Theory through Nordstrom instead.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36186&trid=1552713.202068&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Therabody",
@@ -12249,6 +13168,23 @@
       "intro": "Tropical Smoothie Cafe runs more than 1,400 US locations combining made-to-order smoothies\nwith a wraps, flatbreads, and bowls menu, distinguishing itself from pure smoothie chains\nwith a full lunch offering. Popular smoothies include the Sunrise Sunset, Mango Magic, and\nIsland Green. Tropical Smoothie Cafe transactions code as dining/restaurants on every\nnetwork, including app and curbside orders through Tropic Rewards. Cards with elevated dining\nrates (Amex Gold 4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3% cash) earn full bonus.\n"
     },
     {
+      "name": "Troy-Bilt",
+      "slug": "troy-bilt",
+      "aliases": [
+        "Troy Bilt"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.troybilt.com",
+      "intro": "Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points — corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.\n\nOutdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live — price both before buying.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9368&trid=1552713.203841&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "True Religion",
       "slug": "true-religion",
       "categories": [
@@ -12555,6 +13491,23 @@
       }
     },
     {
+      "name": "Vegas.com",
+      "slug": "vegas-com",
+      "aliases": [
+        "VEGAS.com"
+      ],
+      "categories": [
+        "travel",
+        "entertainment"
+      ],
+      "website": "https://www.vegas.com",
+      "intro": "Vegas.com packages the whole Las Vegas trip — hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles — as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.\n\nOTA bookings are travel spend to most issuers: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X covers whatever coding comes back at 2x. One trade-off to know: booking through an OTA usually forfeits hotel-program elite credit, so weigh the bundle discount against booking the room direct.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.4221&trid=1552713.159075&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Vera Bradley",
       "slug": "vera-bradley",
       "aliases": [
@@ -12581,6 +13534,23 @@
       ],
       "website": "https://www.verizon.com",
       "intro": "Verizon is the largest US wireless carrier, billing for phone plans, devices and home internet. Wireless and internet charges earn a bonus only on cards that specifically reward phone or internet bills, otherwise they fall to a flat rate, though some cards add cell-phone protection when you pay the bill with them.\n"
+    },
+    {
+      "name": "Versed",
+      "slug": "versed",
+      "aliases": [
+        "Versed Skin",
+        "VersedSkin.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://versedskin.com",
+      "intro": "Versed distills clean-clinical skincare into sub-$25 staples — Dew Point moisturizer, the Auto Save retinol line, and single-minded serums — born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.\n\nThe Target-versus-direct choice drives rewards: direct earns online-category rates like Bank of America Customized Cash's 3 percent online shopping selection, while Target runs earn RedCard savings or Target-category promos. Direct-exclusive bundles and sets are usually the reason to order from the brand itself.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9474&trid=1552713.211622&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Viagogo",
@@ -12623,6 +13593,20 @@
       "intro": "Victorinox is the Swiss manufacturer behind the original Swiss Army Knife, a family-owned\ncompany that has expanded well beyond pocket knives into watches, luggage, fragrances, and\ntravel gear. Its multitools and cutlery remain popular with outdoor and camping shoppers,\nwhile its luggage and accessories lines compete more broadly online. There's no Victorinox\nco-brand credit card, so a general online shopping rewards card or a sporting goods\ncategory card, where available, is the better fit than expecting a dedicated bonus.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43998.1000000019&trid=1552713.205647&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Victrola",
+      "slug": "victrola",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://victrola.com",
+      "intro": "Victrola revived the century-old phonograph name into the best-selling entry point for vinyl — suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.\n\nTurntable purchases fit neatly under an electronics selection: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a suitcase-player gift on a flat 2 percent card needs no planning at all.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18889&trid=1552713.207542&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -12746,6 +13730,23 @@
       "intro": "Vivid Seats is a ticket resale marketplace covering concerts, sports, and live theater, known for its loyalty program that hands back credit toward future orders. Purchases code as entertainment or ticketing, making a card with an entertainment bonus the best fit. Stacking its rewards credit with card points can compound value across repeat buyers.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12730.2851893&trid=1552713.159252&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Vivint",
+      "slug": "vivint",
+      "aliases": [
+        "Vivint Smart Home"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.vivint.com",
+      "intro": "Vivint sells professionally installed smart-home security — doorbell and outdoor cameras, smart locks, and thermostats wired into one app — with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.\n\nMonitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus — a full system easily covers a minimum-spend requirement in one go.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.21822&trid=1552713.225643&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -13036,6 +14037,22 @@
       }
     },
     {
+      "name": "Wet n Wild",
+      "slug": "wet-n-wild",
+      "aliases": [
+        "wet n wild"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.wetnwildbeauty.com",
+      "intro": "Wet n Wild is the drugstore-beauty value icon — MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.\n\nAt these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent — the drugstore route usually wins when those are live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43590&trid=1552713.201598&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Whataburger",
       "slug": "whataburger",
       "categories": [
@@ -13084,6 +14101,22 @@
       ],
       "website": "https://www.williams-sonoma.com",
       "intro": "Williams-Sonoma is the flagship kitchen and cookware banner of Williams-Sonoma Inc,\nthe parent company of Pottery Barn, West Elm, and Rejuvenation. The U.S. footprint\ncovers around 180 stores plus williams-sonoma.com. The Key Rewards Visa from Capital\nOne earns elevated points across all WSI brands and stacks with the free Key Rewards\nprogram. General-purpose cards typically code Williams-Sonoma as home improvement or\ndepartment store in person and online shopping for web orders.\n"
+    },
+    {
+      "name": "Willow",
+      "slug": "willow-pump",
+      "aliases": [
+        "Willow Pump"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://onewillow.com",
+      "intro": "Willow pioneered the in-bra wearable breast pump and now sells the Willow 360's spill-proof system alongside the tube-free Willow Go, competing head-on with Elvie for pumping parents who need mobility. Orders from onewillow.com code as online retail.\n\nInsurance first, rewards second: Willow pumps are frequently available through insurance DME channels at partial or no cost, and are broadly HSA/FSA-eligible. When paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a full-price pump purchase makes a healthy dent in a new card's signup-bonus minimum.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.27293&trid=1552713.216035&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "WinCo Foods",
@@ -13241,6 +14274,23 @@
       "intro": "Wyndham Hotels & Resorts is the largest U.S. hotel chain by property count — about\n9,000 hotels — concentrated in mid-scale and economy brands like Days Inn, Super 8,\nLa Quinta, and Ramada, with a smaller upscale presence under Wyndham Grand and the\nRegistry Collection. Wyndham Rewards uses a flat or tiered award chart with redemptions\nstarting at 7,500 points per night, and the program partners with Vacasa for full\nvacation-rental redemptions — a quirk that gives Wyndham points unusual reach for an\neconomy-leaning chain. Direct bookings at wyndhamhotels.com or in the app earn points;\nOTA stays do not. Co-brand cards run lower annual fees than the major chains' cards,\nmatching the program's value-tier identity.\n"
     },
     {
+      "name": "Wyze",
+      "slug": "wyze",
+      "aliases": [
+        "Wyze Labs"
+      ],
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.wyze.com",
+      "intro": "Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home — cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.\n\nWyze orders are frequent and small, which favors an always-on category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent on both hardware and Cam Plus renewals, and flat 2 percent covers the impulse camera.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.27209&trid=1552713.249672&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Xfinity",
       "slug": "xfinity",
       "aliases": [
@@ -13251,6 +14301,23 @@
       ],
       "website": "https://www.xfinity.com",
       "intro": "Xfinity, Comcast's consumer brand, sells home internet, cable TV, streaming and mobile service. These bills earn a bonus only on cards that specifically reward internet, cable or telecom spending, otherwise they fall to a flat rate, so check whether your card lists internet or cable as a bonus category before paying.\n"
+    },
+    {
+      "name": "Yale Home",
+      "slug": "yale-home",
+      "aliases": [
+        "Yale Locks"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://shopyalehome.com",
+      "intro": "Yale has made locks since 1840, and Yale Home is its smart-lock arm — the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa, sharing corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.\n\nA smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively — whichever category you have live decides the store.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37641&trid=1552713.247667&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Yard House",
@@ -13269,6 +14336,19 @@
       ],
       "website": "https://tv.youtube.com",
       "intro": "YouTube TV is Google's live-TV streaming service, bundling broadcast and cable channels with cloud DVR as a cord-cutting alternative. The monthly bill codes as streaming, so a card with a streaming category bonus earns at the elevated rate. Given the subscription has climbed in price over the years, putting it on a streaming-bonus card adds up across the year.\n"
+    },
+    {
+      "name": "Yves Rocher",
+      "slug": "yves-rocher",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.yvesrocherusa.com",
+      "intro": "Yves Rocher is the French botanical-beauty house that grows many of its own ingredients in La Gacilly, selling plant-based skincare, bath lines, and fragrance at accessible prices with famously generous promo codes. US orders from yvesrocherusa.com code as online retail.\n\nThe brand's constant stacked promotions do the heavy lifting on price, so the card's job is the margin: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a stock-up order to 5, and a flat 2 percent card suits the replenishment shopper.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.27010&trid=1552713.249667&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Zales",

--- a/data/affiliates.yaml
+++ b/data/affiliates.yaml
@@ -1811,3 +1811,232 @@ merchants:
   shipstation:
     url: "https://www.anrdoezrs.net/click-101737824-13896119"
     network: cj
+
+  # --- Added 2026-08-05 (FlexOffers approvals, Tier A+B new store pages) ---
+  # Deep links (foc=17) taken verbatim from the approved-programs sheet, with
+  # only the scheme upgraded http->https. `&url=` ships empty as provided —
+  # verified 2026-08-05 that the empty form still redirects to the merchant
+  # with the clickid attached. Every merchant except qatar-airways ships with
+  # a new data/stores/<slug>.yaml page in the same change.
+  # 100% PURE
+  100-pure:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.37229&trid=1552713.230391&foc=17&fot=9999&fos=6&url="
+    offer: "20% off your first order"
+  # Aerosoles
+  aerosoles:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9946&trid=1552713.175791&foc=17&fot=9999&fos=6&url="
+    offer: "free shipping"
+  # Alibaba US
+  alibaba:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156100.274315&trid=1552713.207736&foc=17&fot=9999&fos=6&url="
+    offer: "$20 off"
+  # ANINE BING
+  anine-bing:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.46089&trid=1552713.203133&foc=17&fot=9999&fos=6&url="
+  # Bartesian
+  bartesian:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.15632&trid=1552713.227565&foc=17&fot=9999&fos=6&url="
+    offer: "free shipping over $50"
+  # Betsey Johnson
+  betsey-johnson:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.37850&trid=1552713.159569&foc=17&fot=9999&fos=6&url="
+  # Biotherm USA
+  biotherm:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156178.53197&trid=1552713.180575&foc=17&fot=9999&fos=6&url="
+  # Blendtec
+  blendtec:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156099.12057&trid=1552713.159184&foc=17&fot=9999&fos=6&url="
+  # Blinkist (offer withheld pending verification)
+  blinkist:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10732&trid=1552713.212952&foc=17&fot=9999&fos=6&url="
+  # Bobbie
+  bobbie:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.33836&trid=1552713.249750&foc=17&fot=9999&fos=6&url="
+  # Bowers & Wilkins Global
+  bowers-and-wilkins:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110005992&trid=1552713.228055&foc=17&fot=9999&fos=6&url="
+    offer: "free shipping"
+  # Brinks Home
+  brinks-home:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.41354&trid=1552713.247347&foc=17&fot=9999&fos=6&url="
+  # Bruno Magli
+  bruno-magli:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.18734&trid=1552713.216081&foc=17&fot=9999&fos=6&url="
+    offer: "free shipping on orders $200"
+  # Chubbies
+  chubbies:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.16759&trid=1552713.249484&foc=17&fot=9999&fos=6&url="
+  # CLEAR+
+  clear:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.23636&trid=1552713.245749&foc=17&fot=9999&fos=6&url="
+  # Codecademy (offer withheld pending verification)
+  codecademy:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9595&trid=1552713.209296&foc=17&fot=9999&fos=6&url="
+  # Cub Cadet (offer withheld pending verification)
+  cub-cadet:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9498&trid=1552713.212603&foc=17&fot=9999&fos=6&url="
+  # Dansko
+  dansko:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9278&trid=1552713.202021&foc=17&fot=9999&fos=6&url="
+  # Denon Global
+  denon:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110005993&trid=1552713.228060&foc=17&fot=9999&fos=6&url="
+    offer: "free shipping"
+  # Earthlink
+  earthlink:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.11979&trid=1552713.247913&foc=17&fot=9999&fos=6&url="
+  # edX
+  edx:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.17728&trid=1552713.180112&foc=17&fot=9999&fos=6&url="
+  # Elvie US
+  elvie:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.44020&trid=1552713.228006&foc=17&fot=9999&fos=6&url="
+  # Europcar (US & Canada)
+  europcar:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156178.5861&trid=1552713.189661&foc=17&fot=9999&fos=6&url="
+  # European Wax Center
+  european-wax-center:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.30094&trid=1552713.245382&foc=17&fot=9999&fos=6&url="
+  # Firstleaf Wine Club
+  firstleaf:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.38398&trid=1552713.249831&foc=17&fot=9999&fos=6&url="
+  # Flamingo
+  flamingo:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.9412&trid=1552713.248795&foc=17&fot=9999&fos=6&url="
+  # FragranceNet.com
+  fragrancenet:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.216&trid=1552713.455&foc=17&fot=9999&fos=6&url="
+  # Franco Sarto
+  franco-sarto:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.41588&trid=1552713.178979&foc=17&fot=9999&fos=6&url="
+  # French Connection (US)
+  french-connection:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.35448&trid=1552713.158807&foc=17&fot=9999&fos=6&url="
+  # The Gillette Company
+  gillette:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.23585&trid=1552713.196927&foc=17&fot=9999&fos=6&url="
+  # Grailed
+  grailed:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.13931&trid=1552713.227549&foc=17&fot=9999&fos=6&url="
+  # H&R Block
+  h-and-r-block:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.5683&trid=1552713.156923&foc=17&fot=9999&fos=6&url="
+  # Horizon Fitness (offer withheld pending verification)
+  horizon-fitness:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12130&trid=1552713.196086&foc=17&fot=9999&fos=6&url="
+  # Hudson Jeans
+  hudson-jeans:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.10023&trid=1552713.178072&foc=17&fot=9999&fos=6&url="
+    offer: "free shipping over $200"
+  # Hunter Fan Company
+  hunter-fan:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.46207&trid=1552713.225483&foc=17&fot=9999&fos=6&url="
+  # Insta360
+  insta360:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.46233&trid=1552713.248756&foc=17&fot=9999&fos=6&url="
+  # Intimissimi
+  intimissimi:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.41274&trid=1552713.189853&foc=17&fot=9999&fos=6&url="
+  # Klook US
+  klook:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156085.110006163&trid=1552713.230405&foc=17&fot=9999&fos=6&url="
+  # Kampgrounds of America
+  koa:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.50482&trid=1552713.235147&foc=17&fot=9999&fos=6&url="
+  # Life Fitness (offer withheld pending verification)
+  life-fitness:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.17731&trid=1552713.189439&foc=17&fot=9999&fos=6&url="
+  # Maidenform
+  maidenform:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.43954&trid=1552713.205421&foc=17&fot=9999&fos=6&url="
+  # Make Up For Ever
+  make-up-for-ever:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.54284&trid=1552713.209548&foc=17&fot=9999&fos=6&url="
+  # Mrs. Fields
+  mrs-fields:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.7935&trid=1552713.158847&foc=17&fot=9999&fos=6&url="
+  # Nalgene
+  nalgene:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.12848&trid=1552713.226006&foc=17&fot=9999&fos=6&url="
+  # Naturalizer
+  naturalizer:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.38505&trid=1552713.158953&foc=17&fot=9999&fos=6&url="
+  # Ole Henriksen
+  ole-henriksen:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.38834&trid=1552713.159748&foc=17&fot=9999&fos=6&url="
+  # PGA TOUR Superstore
+  pga-tour-superstore:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.16839&trid=1552713.228946&foc=17&fot=9999&fos=6&url="
+  # Philosophy
+  philosophy:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.50295&trid=1552713.169070&foc=17&fot=9999&fos=6&url="
+  # Physicians Formula
+  physicians-formula:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.43735&trid=1552713.247447&foc=17&fot=9999&fos=6&url="
+  # Pit Boss Grills
+  pit-boss-grills:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10421&trid=1552713.213540&foc=17&fot=9999&fos=6&url="
+  # Pixi Beauty
+  pixi-beauty:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8883&trid=1552713.198431&foc=17&fot=9999&fos=6&url="
+  # PopSockets
+  popsockets:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.43682&trid=1552713.200566&foc=17&fot=9999&fos=6&url="
+  # Qatar Airways
+  qatar-airways:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.25312&trid=1552713.249626&foc=17&fot=9999&fos=6&url="
+  # Radioshack USA LLC (offer withheld pending verification)
+  radioshack:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.32498&trid=1552713.248461&foc=17&fot=9999&fos=6&url="
+  # Roc Skincare
+  roc-skincare:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.46883&trid=1552713.225417&foc=17&fot=9999&fos=6&url="
+  # Sennheiser
+  sennheiser:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.42592&trid=1552713.193918&foc=17&fot=9999&fos=6&url="
+  # SpiritHalloween.com
+  spirit-halloween:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.8099&trid=1552713.161081&foc=17&fot=9999&fos=6&url="
+    offer: "free shipping over $60"
+  # Stadium Goods
+  stadium-goods:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156085.101104598&trid=1552713.195570&foc=17&fot=9999&fos=6&url="
+  # Superdry (US)
+  superdry:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.44521&trid=1552713.209552&foc=17&fot=9999&fos=6&url="
+  # The Parking Spot
+  the-parking-spot:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.10415&trid=1552713.211617&foc=17&fot=9999&fos=6&url="
+  # Theory
+  theory:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.36186&trid=1552713.202068&foc=17&fot=9999&fos=6&url="
+  # Troy Bilt (offer withheld pending verification)
+  troy-bilt:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9368&trid=1552713.203841&foc=17&fot=9999&fos=6&url="
+  # VEGAS.com (offer withheld pending verification)
+  vegas-com:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.4221&trid=1552713.159075&foc=17&fot=9999&fos=6&url="
+  # VersedSkin.com (offer withheld pending verification)
+  versed:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156052.9474&trid=1552713.211622&foc=17&fot=9999&fos=6&url="
+  # Victrola
+  victrola:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.18889&trid=1552713.207542&foc=17&fot=9999&fos=6&url="
+  # Vivint (US)
+  vivint:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156178.21822&trid=1552713.225643&foc=17&fot=9999&fos=6&url="
+  # Wet n Wild
+  wet-n-wild:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=1.43590&trid=1552713.201598&foc=17&fot=9999&fos=6&url="
+  # Willow Pump
+  willow-pump:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.27293&trid=1552713.216035&foc=17&fot=9999&fos=6&url="
+  # Wyze Labs Inc.
+  wyze:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.27209&trid=1552713.249672&foc=17&fot=9999&fos=6&url="
+  # Yale Home
+  yale-home:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.37641&trid=1552713.247667&foc=17&fot=9999&fos=6&url="
+  # Yves Rocher
+  yves-rocher:
+    url: "https://track.flexlinkspro.com/g.ashx?foid=156074.27010&trid=1552713.249667&foc=17&fot=9999&fos=6&url="

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-28T18:15:39.962Z",
-  "count": 956,
+  "generated_at": "2026-08-05T22:01:44.676Z",
+  "count": 1026,
   "stores": [
     {
       "name": "1-800 Contacts",
@@ -65,6 +65,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9643.322259&trid=1552713.187444&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "40% off your first order with code NEW40"
+      }
+    },
+    {
+      "name": "100% PURE",
+      "slug": "100-pure",
+      "aliases": [
+        "100 Percent Pure"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.100percentpure.com",
+      "intro": "100% PURE built its clean-beauty reputation on fruit-pigmented makeup — color from actual fruit, cocoa, and tea rather than synthetic dyes — plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.\n\nClean-beauty carts respond well to an online category: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a restock to 5, and the brand's frequent gift-with-purchase promotions stack with whatever card you use.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37229&trid=1552713.230391&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "20% off your first order"
       }
     },
     {
@@ -313,6 +330,21 @@
       }
     },
     {
+      "name": "Aerosoles",
+      "slug": "aerosoles",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.aerosoles.com",
+      "intro": "Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s — its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.\n\nShoe orders sit comfortably in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9946&trid=1552713.175791&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping"
+      }
+    },
+    {
       "name": "Aesop",
       "slug": "aesop",
       "aliases": [
@@ -503,6 +535,23 @@
       ],
       "website": "https://www.aldoshoes.com",
       "intro": "ALDO is a global footwear and accessories brand selling dress shoes, boots, and handbags. Shopping online codes as online shopping or general retail and may earn via a portal, but in-store visits typically fall to a flat-rate card because shoes are seldom a standalone bonus category.\n"
+    },
+    {
+      "name": "Alibaba",
+      "slug": "alibaba",
+      "aliases": [
+        "Alibaba.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.alibaba.com",
+      "intro": "Alibaba.com is the world's largest business-to-business wholesale marketplace, where small businesses source inventory, packaging, and custom manufacturing directly from suppliers, mostly overseas. It is the wholesale sibling of AliExpress: order minimums are higher, unit prices far lower, and payments run through Alibaba's Trade Assurance escrow, coding as an online marketplace purchase.\n\nSourcing runs are business spend, so business cards shine here: Amex Blue Business Plus earns 2x on everything, and Chase Ink Business Unlimited pays a flat 1.5 percent. Watch for foreign-transaction fees on cards that charge them, since some supplier payments settle abroad.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156100.274315&trid=1552713.207736&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "$20 off"
+      }
     },
     {
       "name": "Alice + Olivia",
@@ -843,6 +892,23 @@
       "affiliate": {
         "url": "https://www.anrdoezrs.net/click-101737824-16960640",
         "network": "cj"
+      }
+    },
+    {
+      "name": "ANINE BING",
+      "slug": "anine-bing",
+      "aliases": [
+        "Anine Bing"
+      ],
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.aninebing.com",
+      "intro": "ANINE BING bottles Scandinavian-meets-LA wardrobe staples — the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed — at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.\n\nAt this price tier the category margin is real money: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card still claws back a coffee's worth on every blazer.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46089&trid=1552713.203133&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -1400,6 +1466,21 @@
       "intro": "Bartell Drugs is a Pacific Northwest pharmacy chain founded in 1890, with roughly 65\nlocations clustered in the Seattle metro and Puget Sound region. Owned by Rite Aid\nsince 2020, Bartell still operates under its own banner with its own pharmacy and\nloyalty program. Stores code as drugstores for credit card networks, so a drugstore\ncategory bonus card (Amex Blue Cash Preferred, Citi Custom Cash on drugstores, Chase\nFreedom Flex when activated) earns its full multiplier on prescriptions and front-of-\nstore purchases.\n"
     },
     {
+      "name": "Bartesian",
+      "slug": "bartesian",
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://bartesian.com",
+      "intro": "Bartesian makes capsule cocktail machines that mix a bar-quality drink from a pod plus your own base spirit, along with the recurring capsule packs that keep the machine running. The machine is a one-time kitchen-appliance purchase and the capsules are classic repeat spend, all coding as online retail from bartesian.com.\n\nTreat it like other countertop-appliance brands: Bank of America Customized Cash set to online shopping earns 3 percent on both machine and capsules, and a Chase Freedom Flex online-retail quarter is the moment to stock up on pods at 5 percent.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.15632&trid=1552713.227565&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping over $50"
+      }
+    },
+    {
       "name": "Baskin-Robbins",
       "slug": "baskin-robbins",
       "categories": [
@@ -1568,6 +1649,21 @@
       "intro": "Best Western Hotels & Resorts runs about 4,000 properties globally under a member-owned\ncooperative structure that's unusual in the major-chain landscape. The portfolio spans\nBest Western, Best Western Plus, and Best Western Premier on the core brand, with\nVīb, GLō, Aiden, Sadie, and Executive Residency rounding out boutique and extended-stay\nsegments, plus the SureStay budget brands. There's no Best Western co-brand credit\ncard in the U.S. market today, so the right play is a strong general hotel-category\ncard — Sapphire Reserve, Venture X, Amex Gold, or a flat-rate cashback card if you\nprefer simplicity. Best Western Rewards points are earned only on direct bookings at\nbestwestern.com or in-app; OTA stays earn nothing in the program.\n"
     },
     {
+      "name": "Betsey Johnson",
+      "slug": "betsey-johnson",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.betseyjohnson.com",
+      "intro": "Betsey Johnson is the famously whimsical fashion brand known for party dresses, novelty heels and handbags, and maximalist jewelry. Direct orders from betseyjohnson.com code as online apparel retail, while the brand also sells widely through department stores like Macy's and Bloomingdale's.\n\nApparel spend has good category coverage: U.S. Bank Cash+ offers a select clothing stores option that can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and buying through a department store instead can tap department-store bonus categories.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.37850&trid=1552713.159569&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "BevMo!",
       "slug": "bevmo",
       "aliases": [
@@ -1615,6 +1711,20 @@
       ],
       "website": "https://www.biggby.com",
       "intro": "Biggby Coffee is a Michigan-founded franchise known for flavored lattes and an upbeat, locally owned drive-thru vibe across the Midwest and beyond. Purchases code as dining or restaurants on most cards, so reach for a card with a coffee or dining bonus. Reloading a Biggby gift card in advance may not always trigger the dining category, so paying directly is safest.\n"
+    },
+    {
+      "name": "Biotherm",
+      "slug": "biotherm",
+      "categories": [
+        "online_shopping",
+        "department_stores"
+      ],
+      "website": "https://www.biotherm-usa.com",
+      "intro": "Biotherm is L'Oréal's aquatic-science skincare house, built around thermal plankton ferment in lines like Life Plankton and Aquasource, plus one of the most established men's skincare ranges in Biotherm Homme. US orders from biotherm-usa.com code as online beauty retail.\n\nSkincare replenishment favors whichever online category is live: Bank of America Customized Cash set to online shopping earns 3 percent, online-retail rotating quarters can push a serum restock to 5, and department-store bonuses apply when you pick Biotherm up through Macy's instead. Flat 2 percent covers the in-between months.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.53197&trid=1552713.180575&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Birkenstock",
@@ -1711,6 +1821,20 @@
       }
     },
     {
+      "name": "Blendtec",
+      "slug": "blendtec",
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.blendtec.com",
+      "intro": "Blendtec builds high-powered blenders in Utah — the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars — and famously ran the \"Will It Blend?\" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.\n\nA blender at this price point is a one-time considered purchase: Bank of America Customized Cash set to online shopping earns 3 percent, a Freedom Flex online-retail quarter can reach 5 percent, and flat 2 percent cards are the fallback if no category is live when yours dies mid-smoothie.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.12057&trid=1552713.159184&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Blick Art Materials",
       "slug": "blick-art-materials",
       "aliases": [
@@ -1721,6 +1845,19 @@
       ],
       "website": "https://www.dickblick.com",
       "intro": "Blick Art Materials, also known as Dick Blick, is a leading US art-supply retailer serving artists and schools online and in stores. Online orders code as online shopping, while in-store buys usually ring up as general retail, with no art-supply bonus on mainstream cards. A flat-rate or online-shopping card is the practical pick.\n"
+    },
+    {
+      "name": "Blinkist",
+      "slug": "blinkist",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.blinkist.com",
+      "intro": "Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription — an online purchase, not a streaming service, so streaming credits and multipliers stay on the bench.\n\nA single annual charge favors whichever online category you have running: Bank of America Customized Cash set to online shopping earns 3 percent, and otherwise a flat 2 percent card like Citi Double Cash quietly does the job every year.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10732&trid=1552713.212952&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Bloomingdale's",
@@ -1851,6 +1988,22 @@
       }
     },
     {
+      "name": "Bobbie",
+      "slug": "bobbie",
+      "aliases": [
+        "Bobbie Baby"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hibobbie.com",
+      "intro": "Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase — not groceries — which changes which cards make sense.\n\nGrocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators — worth checking before optimizing card rewards.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.33836&trid=1552713.249750&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Bojangles",
       "slug": "bojangles",
       "categories": [
@@ -1925,6 +2078,24 @@
       ],
       "website": "https://www.booksamillion.com",
       "intro": "Books-A-Million, branded as BAM!, is the second-largest brick-and-mortar bookstore\nchain in the United States with around 250 stores concentrated in the Southeast.\nThe retailer carries books, toys, gifts, magazines, and operates the Joe Muggs cafe\ninside larger stores. BAM! purchases generally code as bookstore or general retail\nrather than as a dedicated bonus category on most cards.\n\nCards with online shopping bonuses can earn better on booksamillion.com orders.\nBank of America Customized Cash and U.S. Bank Cash+ both offer selectable online\nshopping categories worth 3 to 5 percent, and Chase Freedom Flex sometimes features\nonline shopping in its rotating quarters. The Millionaire's Club membership stacks\nadditional discounts with credit card cash back for frequent buyers.\n"
+    },
+    {
+      "name": "Bowers & Wilkins",
+      "slug": "bowers-and-wilkins",
+      "aliases": [
+        "B&W"
+      ],
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.bowerswilkins.com",
+      "intro": "Bowers & Wilkins is the British high-end audio marque behind the 600–800 series loudspeakers, the Px7 and Px8 headphones, and the Zeppelin wireless speaker. Direct orders from bowerswilkins.com code as online electronics retail and are where the brand lists its own certified refurb stock.\n\nHi-fi purchases are large enough that category choice genuinely matters: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping is a safe 3 percent, and a pair of 700-series floorstanders on a flat 2 percent card still earns real money.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110005992&trid=1552713.228055&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping"
+      }
     },
     {
       "name": "Bowflex",
@@ -2011,6 +2182,23 @@
       "intro": "Brilliant Earth focuses on ethically sourced and lab-grown diamonds, selling rings and fine jewelry at brilliantearth.com that code as online shopping or general retail. Because a ring is often a four or five figure purchase, the card you choose matters more than the category. Jewelry has no bonus multiplier, so a strong flat-rate or online-shopping card maximizes the reward.\n"
     },
     {
+      "name": "Brinks Home",
+      "slug": "brinks-home",
+      "aliases": [
+        "Brinks Home Security"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://brinkshome.com",
+      "intro": "Brinks Home sells professionally monitored home-security systems — panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.\n\nNeither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on — security bundles are an easy few hundred dollars of qualifying spend.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.41354&trid=1552713.247347&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "British Airways",
       "slug": "british-airways",
       "aliases": [
@@ -2039,6 +2227,21 @@
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.10113.589809&trid=1552713.245195&foc=16&fot=9999&fos=6",
         "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Bruno Magli",
+      "slug": "bruno-magli",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.brunomagli.com",
+      "intro": "Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936 — cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.\n\nShoes at this tier reward a category match: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns a dependable 3 percent, and a flat 2 percent card on a pair of oxfords still returns enough for the shoe trees.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18734&trid=1552713.216081&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping on orders $200"
       }
     },
     {
@@ -2751,6 +2954,23 @@
       "intro": "Choice Hotels operates roughly 7,500 properties worldwide, dominated by mid-scale and\neconomy brands — Comfort Inn, Quality Inn, Sleep Inn, Clarion — with the Cambria and\nAscend Hotel Collection covering its upscale push. The 2022 acquisition of Radisson\nAmericas folded Country Inn & Suites and Park Plaza into Choice Privileges, broadening\nthe footprint considerably. Award nights start as low as 6,000 points, and the program\nis one of the better economy-tier values on a cents-per-point basis. The Wells Fargo\nChoice Privileges co-brand cards earn elevated points on Choice stays and gas, with\nthe Select tier adding automatic Platinum elite status and an annual bonus night.\nDirect bookings earn points; OTA stays do not.\n"
     },
     {
+      "name": "Chubbies",
+      "slug": "chubbies",
+      "aliases": [
+        "Chubbies Shorts"
+      ],
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.chubbiesshorts.com",
+      "intro": "Chubbies built a cult following on 5.5-inch-inseam weekend shorts and has since expanded into swim trunks, polos, and loungewear with the same retro-Americana streak. Orders from chubbiesshorts.com code as online apparel retail, with the brand's Fourth of July-adjacent drops driving most of its hype cycles.\n\nApparel categories cover it well: U.S. Bank Cash+ with select clothing stores chosen can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating-category quarters covering online retail occasionally beat both.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16759&trid=1552713.249484&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Church's Chicken",
       "slug": "churchs-chicken",
       "categories": [
@@ -2816,6 +3036,23 @@
       }
     },
     {
+      "name": "CLEAR",
+      "slug": "clear",
+      "aliases": [
+        "CLEAR Plus",
+        "CLEAR+"
+      ],
+      "categories": [
+        "travel"
+      ],
+      "website": "https://www.clearme.com",
+      "intro": "CLEAR Plus is the biometric identity lane at 50-plus US airports that lets members verify with eyes or fingerprints and skip to the front of security, stacking with TSA PreCheck rather than replacing it. The annual membership bills from clearme.com and codes as a travel purchase on most networks.\n\nBefore paying full freight, check your wallet: Amex Platinum and Amex Green carry statement credits that cover most or all of a CLEAR Plus membership, and several airline and hotel programs discount it. Paying out of pocket, a travel-category card like Chase Sapphire Preferred at 2x is the sensible vehicle.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23636&trid=1552713.245749&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Click & Grow",
       "slug": "click-and-grow",
       "aliases": [
@@ -2855,6 +3092,19 @@
       ],
       "website": "https://www.coach.com",
       "intro": "Coach is the flagship leather goods brand of Tapestry Inc, which also owns Kate Spade\nand Stuart Weitzman. The U.S. footprint includes around 360 full-price and outlet\nstores plus coach.com. Direct purchases typically code as department store in person\nand online shopping for web orders, while Coach handbags bought at Macy's, Nordstrom,\nor Bloomingdale's code under those host retailers. The free Coach Insider loyalty\nprogram stacks with credit card multipliers.\n"
+    },
+    {
+      "name": "Codecademy",
+      "slug": "codecademy",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.codecademy.com",
+      "intro": "Codecademy teaches programming through interactive browser-based courses, with free basics and a Pro subscription that unlocks career paths, projects, and certificates; it is now part of Skillsoft. Pro bills monthly or annually from codecademy.com and codes as an online education subscription.\n\nEducation subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends — worth asking before optimizing cents per dollar.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9595&trid=1552713.209296&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Cold Stone Creamery",
@@ -3180,6 +3430,20 @@
       "intro": "Crunch Fitness is a franchise gym chain known for budget pricing, group classes and a no-judgment vibe. As with most gyms, monthly dues seldom earn a bonus, so they typically code at the flat rate, and any value boost is more likely to come from a card offering a fitness or wellness credit than from a category multiplier.\n"
     },
     {
+      "name": "Cub Cadet",
+      "slug": "cub-cadet",
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.cubcadet.com",
+      "intro": "Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network — it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.\n\nA mower-sized charge deserves planning: it is ideal signup-bonus spend, and otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct. Buying the same machine through Home Depot or Lowe's instead can tap home-improvement category bonuses when you have one live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9498&trid=1552713.212603&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Cub Foods",
       "slug": "cub-foods",
       "categories": [
@@ -3251,6 +3515,20 @@
       ],
       "website": "https://www.dairyqueen.com",
       "intro": "Dairy Queen is the Berkshire Hathaway-owned QSR with more than 4,300 US locations split\nbetween traditional treat-only stores and full-menu DQ Grill & Chill outlets serving Blizzards,\nsoft-serve cones, dipped cones, burgers, and chicken strip baskets. Whether you order at a\nwalk-up window, drive-thru, or through the DQ Rewards mobile app, the transaction codes as\ndining/restaurants. Cards with strong dining multipliers (Amex Gold at 4x, Chase Sapphire\nPreferred at 3x, Capital One SavorOne at 3% cash) all earn at the full bonus rate on DQ.\n"
+    },
+    {
+      "name": "Dansko",
+      "slug": "dansko",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.dansko.com",
+      "intro": "Dansko's stapled clogs are the unofficial uniform of nurses, chefs, and anyone else on their feet twelve hours at a stretch, joined by walking shoes and sandals with the same all-day support. Direct orders from dansko.com code as online shoe retail.\n\nA clog replacement cycle pairs well with apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and employer scrub-and-shoe stipends cover Dansko at many hospital systems before rewards enter it.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9278&trid=1552713.202021&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "David's Bridal",
@@ -3407,6 +3685,21 @@
       ],
       "website": "https://www.dennys.com",
       "intro": "Denny's operates roughly 1,500 US diners famous for 24-hour service, the Grand Slam breakfast,\nMoons Over My Hammy, and a value-driven all-day menu that draws road-trippers, third-shift\nworkers, and late-night crowds. Most Denny's are highway-adjacent or in travel-corridor\nsuburbs. Denny's transactions code as dining/restaurants on every credit card, including\norders through the Denny's Rewards app and Denny's On Demand delivery portal. Dining-bonus\ncards earn full rate: Amex Gold at 4x, Chase Sapphire Preferred at 3x, Capital One SavorOne 3%.\n"
+    },
+    {
+      "name": "Denon",
+      "slug": "denon",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.denon.com",
+      "intro": "Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com — including refurbished receivers with full warranties — code as online electronics retail.\n\nReceiver upgrades are chunky spend, so aim a category at them: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is the steady 3 percent, and flat 2 percent cards cover the impulse subwoofer.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110005993&trid=1552713.228060&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping"
+      }
     },
     {
       "name": "Dermalogica",
@@ -3967,6 +4260,19 @@
       }
     },
     {
+      "name": "EarthLink",
+      "slug": "earthlink",
+      "categories": [
+        "tv_internet_streaming"
+      ],
+      "website": "https://www.earthlink.net",
+      "intro": "EarthLink, the dial-up pioneer turned modern ISP, resells fiber and wireless home internet across much of the US, often on the same physical lines as the big carriers but with its own pricing and no-data-cap positioning. Monthly bills code as internet service, the same bucket as Cox or Spectrum.\n\nInternet bills are one of the best recurring charges to optimize: U.S. Bank Cash+ with TV, internet, and streaming selected pays 5 percent on the monthly bill, Citi Custom Cash can hit 5 percent if internet is your top category that cycle, and a flat 2 percent card is the no-maintenance floor.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.11979&trid=1552713.247913&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "EaseUS",
       "slug": "easeus",
       "aliases": [
@@ -4087,6 +4393,19 @@
       }
     },
     {
+      "name": "edX",
+      "slug": "edx",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.edx.org",
+      "intro": "edX hosts university-built online courses — MIT and Harvard founded it — spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.\n\nEducation charges sit outside consumer bonus categories, so treat them like any online purchase: Bank of America Customized Cash set to online shopping earns 3 percent on a certificate, flat 2 percent cards cover bigger program tuition without ceremony, and employer tuition-reimbursement programs frequently cover edX before rewards even enter the picture.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.17728&trid=1552713.180112&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Eileen Fisher",
       "slug": "eileen-fisher",
       "aliases": [
@@ -4141,6 +4460,19 @@
       "affiliate": {
         "url": "https://www.jdoqocy.com/click-101737824-16960092",
         "network": "cj"
+      }
+    },
+    {
+      "name": "Elvie",
+      "slug": "elvie",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.elvie.com",
+      "intro": "Elvie makes discreet wearable breast pumps — the in-bra Elvie Pump and the value Stride line — plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.\n\nBefore optimizing rewards, exhaust the cheaper routes: Elvie pumps are frequently covered or subsidized through insurance DME suppliers and are broadly HSA/FSA-eligible. Paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a pump-sized purchase contributes meaningfully to a new card's signup-bonus minimum.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.44020&trid=1552713.228006&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -4255,6 +4587,36 @@
       ],
       "website": "https://www.etsy.com",
       "intro": "Etsy is the marketplace for handmade, vintage, and craft goods sold by independent\nmakers, with checkout handled by Etsy itself. Purchases code as online shopping on every\ngeneral-purpose card we track, which means Etsy is a good fit for any card with a flat\nU.S. online retail bonus (Blue Cash Everyday, Hilton Surpass, etc.). Etsy doesn't have a\nco-branded card and rarely shows up in card-specific bonus lists.\n"
+    },
+    {
+      "name": "Europcar",
+      "slug": "europcar",
+      "categories": [
+        "car_rentals",
+        "travel"
+      ],
+      "website": "https://www.europcar.com",
+      "intro": "Europcar is one of Europe's largest car-rental networks, with counters across 130-plus countries; US travelers mostly meet it when booking European road trips, where its rates and one-way options frequently beat the American majors abroad. Rentals code as car rental agencies, squarely inside every travel category definition.\n\nCar rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry — genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.5861&trid=1552713.189661&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "European Wax Center",
+      "slug": "european-wax-center",
+      "aliases": [
+        "EWC"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://waxcenter.com",
+      "intro": "European Wax Center is the largest waxing-salon chain in the US, with over 1,000 franchised centers selling waxing services, the Wax Pass prepaid bundles, and its own skincare line. Charges are in-salon or prepaid packages booked through waxcenter.com and code as personal-care services.\n\nSalon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase — a few hundred dollars prepaid — into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.30094&trid=1552713.245382&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Eventbrite",
@@ -4559,6 +4921,22 @@
       "intro": "First Watch operates more than 540 daytime-only restaurants serving breakfast, brunch, and\nlunch, with menu staples like Avocado Toast, the Chickichanga, lemon-ricotta pancakes, and\nfresh-pressed juices. Locations close mid-afternoon, distinguishing First Watch from all-day\nbreakfast chains like IHOP and Denny's. First Watch transactions code as dining/restaurants\non every US card. Dining-bonus cards earn full rate: Amex Gold at 4x Membership Rewards,\nChase Sapphire Preferred at 3x, Chase Sapphire Reserve at 4x, Capital One SavorOne at 3% cash.\n"
     },
     {
+      "name": "Firstleaf",
+      "slug": "firstleaf",
+      "aliases": [
+        "Firstleaf Wine Club"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.firstleaf.com",
+      "intro": "Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings — the algorithmic cousin of Naked Wines' funding model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.\n\nThat coding means grocery and dining multipliers stay quiet, and online categories do the work: Bank of America Customized Cash set to online shopping earns 3 percent per box, a Freedom Flex online-retail quarter can reach 5 percent on a stock-up order, and a flat 2 percent card suits the set-and-forget subscriber.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.38398&trid=1552713.249831&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "FitFlop",
       "slug": "fitflop",
       "categories": [
@@ -4605,6 +4983,22 @@
       "intro": "Fjällräven is a Swedish outdoor brand best known for the boxy Kanken backpack and durable,\nwax-treated Greenland jacket, built on a design philosophy that favors long-lasting,\nrepairable gear over disposable fast fashion. It's part of the Fenix Outdoor group, which\nalso owns Hanwag and Primus. There is no Fjällräven co-brand credit card, so purchases\nthere are best matched to a card that bonuses sporting goods or outdoor retail, or a card\nthat rewards general online shopping, since Fjällräven's own e-commerce site is a common\nway U.S. shoppers buy its gear.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.29113.1175129&trid=1552713.235909&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Flamingo",
+      "slug": "flamingo",
+      "aliases": [
+        "Flamingo by Harry's"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.shopflamingo.com",
+      "intro": "Flamingo is the women's body-care line from the team behind Harry's, selling razors, blade refills, and wax kits with the same design-forward, subscription-friendly model as its sibling brand. Orders and refill plans from shopflamingo.com code as online retail rather than drugstore purchases.\n\nThe card logic mirrors Harry's: direct subscriptions earn online-category rates — Bank of America Customized Cash set to online shopping pays 3 percent — while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9412&trid=1552713.248795&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -4741,6 +5135,22 @@
       }
     },
     {
+      "name": "FragranceNet",
+      "slug": "fragrancenet",
+      "aliases": [
+        "FragranceNet.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.fragrancenet.com",
+      "intro": "FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes — plus skincare, haircare, and candles — at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.\n\nDiscount fragrance stacking works best with an online category on top: Bank of America Customized Cash set to online shopping adds 3 percent to already-marked-down bottles, rotating online-retail quarters push it to 5, and flat 2 percent cards handle gift-season hauls without planning.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.216&trid=1552713.455&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "FragranceShop.com",
       "slug": "fragranceshop",
       "aliases": [
@@ -4755,6 +5165,21 @@
       "affiliate": {
         "url": "https://www.tkqlhce.com/click-101737824-16942205",
         "network": "cj"
+      }
+    },
+    {
+      "name": "Franco Sarto",
+      "slug": "franco-sarto",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.francosarto.com",
+      "intro": "Franco Sarto delivers Italian-styled women's footwear — loafers, block heels, and knee boots — at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.\n\nFootwear categories cover the bases: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same styles through Macy's or DSW can catch department-store or rotating-category bonuses when live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41588&trid=1552713.178979&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -4787,6 +5212,23 @@
       ],
       "website": "https://www.freepeople.com",
       "intro": "Free People is the bohemian women's brand under URBN and includes the FP Movement\nactivewear line, with roughly 150 retail stores plus a sizeable online presence at\nfreepeople.com. Most credit cards code in-store transactions as department store and\nweb orders as online shopping. Free People does not currently issue a co-brand credit\ncard, so shoppers usually optimize with rotating category cards or a flat-rate\nonline-shopping multiplier.\n"
+    },
+    {
+      "name": "French Connection",
+      "slug": "french-connection",
+      "aliases": [
+        "FCUK"
+      ],
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.frenchconnection.com",
+      "intro": "French Connection is the London high-street label that rode the FCUK logo era and now trades on sharp dresses, tailoring, and knitwear at contemporary prices. US orders from frenchconnection.com code as online apparel retail, with an aggressive sale rotation.\n\nApparel category coverage applies cleanly: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and stacking the brand's sale pricing with either beats waiting for a better card.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.35448&trid=1552713.158807&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Freshly",
@@ -5052,6 +5494,23 @@
       }
     },
     {
+      "name": "Gillette",
+      "slug": "gillette",
+      "aliases": [
+        "The Gillette Company",
+        "Gillette Direct"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.gillette.com",
+      "intro": "Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor — the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.\n\nThat coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices — the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23585&trid=1552713.196927&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Gilt",
       "slug": "gilt-and-gilt-city",
       "aliases": [
@@ -5214,6 +5673,20 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12845.2840658&trid=1552713.224344&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "60% off"
+      }
+    },
+    {
+      "name": "Grailed",
+      "slug": "grailed",
+      "categories": [
+        "online_shopping",
+        "secondhand_stores"
+      ],
+      "website": "https://www.grailed.com",
+      "intro": "Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout — the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.\n\nThat PayPal routing is the rewards angle: Chase Freedom Flex's recurring PayPal rotating quarters have historically covered Grailed checkouts at 5 percent, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card backstops off-quarter grail hunts.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13931&trid=1552713.227549&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -5394,6 +5867,23 @@
       ],
       "website": "https://www2.hm.com",
       "intro": "H&M is a Swedish-headquartered fast-fashion chain with about 540 U.S. stores.\nIn-store charges code as department stores or apparel; hm.com codes as online\nshopping. The H&M Member program is free and issues birthday gifts plus tiered\nperks; H&M's co-branded U.S. credit card layers an additional discount on top\nof the loyalty program. For non-cardholders, an online-shopping-bonus card is\nthe strongest pairing.\n"
+    },
+    {
+      "name": "H&R Block",
+      "slug": "h-and-r-block",
+      "aliases": [
+        "H and R Block",
+        "HR Block"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.hrblock.com",
+      "intro": "H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services — a category no consumer card bonuses.\n\nTwo angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution — paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5683&trid=1552713.156923&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Half Price Books",
@@ -5810,6 +6300,20 @@
       "intro": "HomeSense, the TJX off-price home brand and sister to HomeGoods, sells ever-changing decor and furniture that generally codes as general retail, not a home-improvement warehouse, so those bonuses often do not apply. Its US site at homesense.com is limited, but online orders code as online shopping. A flat-rate or online-shopping card is the dependable choice here.\n"
     },
     {
+      "name": "Horizon Fitness",
+      "slug": "horizon-fitness",
+      "categories": [
+        "online_shopping",
+        "sporting_goods"
+      ],
+      "website": "https://www.horizonfitness.com",
+      "intro": "Horizon Fitness sells home treadmills, ellipticals, and exercise bikes — the value-focused sibling brand of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.\n\nBig fitness equipment is prime signup-bonus spend, clearing most minimums in one order. Otherwise, U.S. Bank Cash+ with sporting goods stores selected can pay 5 percent when the charge classifies that way, and Bank of America Customized Cash set to online shopping is the reliable 3 percent.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12130&trid=1552713.196086&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Hot Topic",
       "slug": "hot-topic",
       "categories": [
@@ -5876,6 +6380,24 @@
       "intro": "HSN, the Home Shopping Network, is a multichannel retailer selling via 24-hour\ntelevision, hsn.com, and mobile, owned by Qurate Retail Group alongside sister\nbrand QVC. The product mix covers beauty, fashion, jewelry, kitchen, and home goods,\nwith a heavy emphasis on live demonstrations and host-led pitches. HSN purchases code\nas online shopping or general merchandise for credit card networks, so an\nonline-shopping category bonus card will earn its multiplier. The FlexPay installment\nprogram is available at checkout against the saved card.\n"
     },
     {
+      "name": "Hudson Jeans",
+      "slug": "hudson-jeans",
+      "aliases": [
+        "Hudson"
+      ],
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.hudsonjeans.com",
+      "intro": "Hudson Jeans is the Los Angeles premium-denim house known for its signature triangle back-flap pockets, mid-hundreds price points, and a steady rotation of skinny, straight, and barrel fits. Direct orders from hudsonjeans.com code as online apparel retail.\n\nPremium denim benefits from an apparel category: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 30-percent-off sales stack with either for the real savings.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.10023&trid=1552713.178072&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping over $200"
+      }
+    },
+    {
       "name": "Huel",
       "slug": "huel",
       "categories": [
@@ -5936,6 +6458,23 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.53058.1000000002&trid=1552713.201413&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "30% off orders $99+"
+      }
+    },
+    {
+      "name": "Hunter Fan",
+      "slug": "hunter-fan",
+      "aliases": [
+        "Hunter Fan Company"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.hunterfan.com",
+      "intro": "Hunter has been making ceiling fans since 1886 and remains the name most Americans reach for when a room needs one, now spanning smart fans, outdoor-rated models, and the Casablanca premium line. Direct orders from hunterfan.com code as online retail rather than a hardware-store purchase.\n\nA fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there — worth a price check both ways.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46207&trid=1552713.225483&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -6128,6 +6667,20 @@
       }
     },
     {
+      "name": "Insta360",
+      "slug": "insta360",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.insta360.com",
+      "intro": "Insta360 makes the leading 360-degree action cameras — the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras — sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.\n\nCamera kits with mounts and accessories climb in price quickly, which suits an electronics category: U.S. Bank Cash+ set to electronics stores can return 5 percent when the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card covers accessory top-ups.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.46233&trid=1552713.248756&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Instacart",
       "slug": "instacart",
       "aliases": [
@@ -6139,6 +6692,20 @@
       ],
       "website": "https://www.instacart.com",
       "intro": "Instacart is the largest U.S. grocery delivery and pickup marketplace, partnering\nwith Costco, Wegmans, ALDI, Publix, and many regional chains. Orders placed through\nthe Instacart app or instacart.com generally code as groceries on most cards, but\nsome banks classify the charge as the underlying merchant — worth confirming on\na small order before relying on a 6% grocery card. Several premium cards (Sapphire\nReserve, Venture X) include Instacart+ memberships and statement credits.\n"
+    },
+    {
+      "name": "Intimissimi",
+      "slug": "intimissimi",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://us.intimissimi.com",
+      "intro": "Intimissimi is the Italian lingerie chain — silk-and-lace bralettes, modal sleepwear, and seamless basics — that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.\n\nLingerie restocks fit apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 5-for deals on basics reward consolidating a haul onto whichever is live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41274&trid=1552713.189853&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "iolo",
@@ -6681,6 +7248,38 @@
       "intro": "Kirkland's offers affordable home decor, wall art, and seasonal accents, with store purchases that usually code as general retail rather than a home-improvement warehouse, so hardware bonuses may not apply. Shopping kirklands.com normally codes as online shopping. For decor runs that add up, a card rewarding online spend or a flat everyday rate is the sensible pick.\n"
     },
     {
+      "name": "Klook",
+      "slug": "klook",
+      "categories": [
+        "travel",
+        "entertainment"
+      ],
+      "website": "https://www.klook.com",
+      "intro": "Klook is a travel-activities marketplace strongest in Asia — theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours — often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.\n\nActivity bookings are travel spend most cards recognize: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X's 2x applies everywhere including the odd booking that codes as ticketing instead. Klook runs frequent promo-code sales, so stack a discount with the multiplier rather than choosing between them.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110006163&trid=1552713.230405&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "KOA",
+      "slug": "koa",
+      "aliases": [
+        "Kampgrounds of America",
+        "KOA Campgrounds"
+      ],
+      "categories": [
+        "travel",
+        "vacation_rentals"
+      ],
+      "website": "https://koa.com",
+      "intro": "KOA — Kampgrounds of America — runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.\n\nTravel cards are the natural fit: Chase Sapphire Preferred and Reserve count campground stays in their travel multipliers, Capital One Venture X earns its flat 2x everywhere, and annual-fee travel credits like the Sapphire Reserve's have been reported to apply to campground charges. KOA Rewards stacks on top regardless of card.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50482&trid=1552713.235147&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Kobo",
       "slug": "kobo",
       "aliases": [
@@ -7057,6 +7656,20 @@
       ],
       "website": "https://www.lidl.com",
       "intro": "Lidl is a German discount grocer that has expanded across the U.S. East Coast since\n2017, with roughly 175 stores stretching from Georgia up to New York. The format is\nsmall-footprint and private-label-heavy, comparable to Aldi. Lidl codes as a U.S.\nsupermarket for credit card networks, so grocery category bonuses (Amex Gold, Blue\nCash Preferred, Citi Custom Cash) earn their full multiplier. The chain accepts mobile\nwallets and standard major networks.\n"
+    },
+    {
+      "name": "Life Fitness",
+      "slug": "life-fitness",
+      "categories": [
+        "online_shopping",
+        "sporting_goods"
+      ],
+      "website": "https://www.lifefitness.com",
+      "intro": "Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use — treadmills, ellipticals, bikes, and the Hammer Strength line — at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.\n\nPurchases this size are textbook signup-bonus spend, often clearing an entire minimum in one order. Absent a new card, U.S. Bank Cash+ with sporting goods selected can hit 5 percent where the charge classifies that way, with Bank of America Customized Cash's online shopping choice a dependable 3 percent.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.17731&trid=1552713.189439&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Life is Good",
@@ -7489,6 +8102,38 @@
       "affiliate": {
         "url": "https://www.anrdoezrs.net/click-101737824-17205347",
         "network": "cj"
+      }
+    },
+    {
+      "name": "Maidenform",
+      "slug": "maidenform",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.maidenform.com",
+      "intro": "Maidenform has been a mainstay of American intimates for a century, selling bras, shapewear, and underwear under a HanesBrands umbrella that keeps prices in the everyday range. Direct orders from maidenform.com code as online apparel retail, and the brand runs near-constant multi-buy promotions.\n\nIntimates restocks land in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store category bonuses apply when you buy Maidenform through Macy's or Kohl's instead.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43954&trid=1552713.205421&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Make Up For Ever",
+      "slug": "make-up-for-ever",
+      "aliases": [
+        "MUFE"
+      ],
+      "categories": [
+        "online_shopping",
+        "department_stores"
+      ],
+      "website": "https://www.makeupforever.com",
+      "intro": "Make Up For Ever is the LVMH-owned professional makeup house famous for the HD Skin foundation range, Aqua Resist liners, and artist-grade palettes born from its Paris pro heritage. US orders from makeupforever.com code as online beauty retail; the brand also sells through Sephora.\n\nDirect orders suit an online category — Bank of America Customized Cash set to online shopping earns 3 percent — while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.54284&trid=1552713.209548&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -8123,6 +8768,23 @@
       }
     },
     {
+      "name": "Mrs. Fields",
+      "slug": "mrs-fields",
+      "aliases": [
+        "Mrs Fields"
+      ],
+      "categories": [
+        "online_shopping",
+        "dining"
+      ],
+      "website": "https://www.mrsfields.com",
+      "intro": "Mrs. Fields turned mall-kiosk chocolate-chip cookies into a national gifting business: tins, cookie cakes, and corporate gift baskets shipped nationwide from mrsfields.com, alongside its remaining bakery locations. Online gift orders code as internet retail or specialty food, while in-person bakery purchases can code as dining or fast food.\n\nFor shipped gifts, an online category does the work — Bank of America Customized Cash set to online shopping earns 3 percent — while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.7935&trid=1552713.158847&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Munchkin",
       "slug": "munchkin",
       "aliases": [
@@ -8167,6 +8829,20 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13852.1723735&trid=1552713.163400&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "up to 60% off with code IMPACT12PK"
+      }
+    },
+    {
+      "name": "Nalgene",
+      "slug": "nalgene",
+      "categories": [
+        "online_shopping",
+        "sporting_goods"
+      ],
+      "website": "https://www.nalgene.com",
+      "intro": "Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders — including the popular custom-printing option — ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.\n\nBottles are small-ticket, so rewards are more about which card is already in hand: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ sporting goods quarter can catch a team order at 5 percent, and REI stock of the same bottles earns REI-specific card bonuses instead.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12848&trid=1552713.226006&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -8240,6 +8916,21 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14513.1998567&trid=1552713.234726&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "10% off with sign up"
+      }
+    },
+    {
+      "name": "Naturalizer",
+      "slug": "naturalizer",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.naturalizer.com",
+      "intro": "Naturalizer has sold comfort-first women's footwear since 1927 — pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.\n\nFootwear reliably lands in apparel categories: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the merchant classifies as apparel or shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and the same styles at Macy's or Nordstrom can pick up department-store bonuses when one is live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38505&trid=1552713.158953&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -8569,6 +9260,23 @@
       "intro": "Old Navy is Gap, Inc.'s value-priced apparel banner with about 1,200 U.S. stores and a\nstrong online catalog. Apparel doesn't have a dedicated reward category on most\ngeneral-purpose credit cards, so card choice usually comes down to whether you're\nshopping online (where online-shopping bonuses apply) or in-store (where you're\ntypically falling back to a strong flat-rate cashback card).\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5555.660845&trid=1552713.162751&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Ole Henriksen",
+      "slug": "ole-henriksen",
+      "aliases": [
+        "OLEHENRIKSEN"
+      ],
+      "categories": [
+        "online_shopping",
+        "department_stores"
+      ],
+      "website": "https://www.olehenriksen.com",
+      "intro": "Ole Henriksen bottles Scandinavian glow-first skincare — Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners — born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.\n\nDirect restocks favor an online category — Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5 — while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38834&trid=1552713.159748&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -9183,6 +9891,20 @@
       "intro": "PetSmart is the largest U.S. pet specialty retailer by store count at about 1,650\nlocations, with a sizable petsmart.com online catalog. Pet-supply purchases don't have a\ndedicated category on most credit cards, so in-store purchases generally fall back to a\nflat-rate cashback card. Online purchases at petsmart.com code as online shopping. The\nTreats Rewards loyalty program stacks on top of card cashback.\n"
     },
     {
+      "name": "PGA TOUR Superstore",
+      "slug": "pga-tour-superstore",
+      "categories": [
+        "sporting_goods",
+        "online_shopping"
+      ],
+      "website": "https://www.pgatoursuperstore.com",
+      "intro": "PGA TOUR Superstore is the big-box golf retailer — clubs, balls, apparel, launch-monitor fittings, and in-store simulators — with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.\n\nGolf spend adds up fast, and sporting-goods coverage is unusually good: U.S. Bank Cash+ with sporting goods stores selected pays 5 percent, rotating quarters occasionally cover the category too, and a driver-and-iron-set fitting bill makes clean signup-bonus spend. Bank of America Customized Cash's online shopping choice covers web orders at 3 percent.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16839&trid=1552713.228946&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Philips Hue",
       "slug": "philips-hue",
       "aliases": [
@@ -9228,6 +9950,20 @@
       }
     },
     {
+      "name": "Philosophy",
+      "slug": "philosophy",
+      "categories": [
+        "online_shopping",
+        "department_stores"
+      ],
+      "website": "https://www.philosophy.com",
+      "intro": "Philosophy is the feel-good skincare and bath brand behind Purity Made Simple cleanser, Hope in a Jar moisturizer, and the dessert-scented Amazing Grace shower gels, sold direct and through Ulta, Sephora, and department stores. Orders from philosophy.com code as online beauty retail.\n\nRoutine restocks favor an online category — Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5 — while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50295&trid=1552713.169070&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Philz Coffee",
       "slug": "philz-coffee",
       "categories": [
@@ -9255,6 +9991,19 @@
       }
     },
     {
+      "name": "Physicians Formula",
+      "slug": "physicians-formula",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.physiciansformula.com",
+      "intro": "Physicians Formula has sold hypoallergenic drugstore makeup since 1937 — Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.\n\nThe drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter — Chase Freedom Flex has covered drugstores repeatedly — at 5 percent. Price-match against drugstore sales before ordering direct.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43735&trid=1552713.247447&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Pick 'n Save",
       "slug": "pick-n-save",
       "categories": [
@@ -9275,6 +10024,39 @@
       ],
       "website": "https://pilotflyingj.com",
       "intro": "Pilot Flying J operates more than 750 travel centers across the U.S. and Canada,\nmaking it the largest truck stop network in North America. The chain serves both\nlong-haul truckers (with high-flow diesel lanes, showers, and driver lounges) and\npassenger drivers at standard gas pumps. Fuel at Pilot Flying J pumps codes as gas, so\nany card with a gas category bonus will earn its rate. The myRewards Plus loyalty\nprogram adds per-gallon discounts and points on in-store food, which can stack with a\nseparate gas rewards card.\n"
+    },
+    {
+      "name": "Pit Boss Grills",
+      "slug": "pit-boss-grills",
+      "aliases": [
+        "Pit Boss"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://pitboss-grills.com",
+      "intro": "Pit Boss is the value heavyweight of pellet grilling — bigger hoppers and lower prices than Traeger — spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.\n\nA grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories — compare, since Pit Boss runs aggressive direct-only bundle deals.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10421&trid=1552713.213540&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Pixi Beauty",
+      "slug": "pixi-beauty",
+      "aliases": [
+        "Pixi"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.pixibeauty.com",
+      "intro": "Pixi built a skincare empire on Glow Tonic, the glycolic toner with a permanent spot in affordable-skincare routines, plus flower-adorned tints and the collab-heavy Pretties palettes. Direct orders from pixibeauty.com code as online beauty retail; Target and Ulta carry core lines.\n\nGlow Tonic restocks reward whichever channel has a category live: direct orders earn Bank of America Customized Cash's 3 percent with online shopping selected, Target runs take the RedCard's 5 percent instead, and rotating online-retail quarters occasionally make direct the winner at 5. Flat 2 percent covers everything in between.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8883&trid=1552713.198431&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Pizza Hut",
@@ -9350,6 +10132,20 @@
       ],
       "website": "https://www.popeyes.com",
       "intro": "Popeyes is a U.S. Louisiana-style fried chicken chain with about 3,000 domestic\nlocations, owned by Restaurant Brands International. Charges code as dining on\nevery card we track. Any dining-bonus card (Amex Gold 4x, Sapphire Preferred 3x,\nSavorOne 3%) applies. The Popeyes Rewards app issues per-purchase points\nredeemable for free items, stackable with card bonuses.\n"
+    },
+    {
+      "name": "PopSockets",
+      "slug": "popsockets",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.popsockets.com",
+      "intro": "PopSockets turned the collapsible phone grip into an accessories empire, now spanning MagSafe grips, wallets, mounts, and endless licensed designs, sold direct from popsockets.com and through every electronics aisle in America. Direct orders code as online retail, sometimes classifying as electronics accessories.\n\nThese are small-ticket, high-frequency purchases where whatever category is live wins: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ electronics selection can catch a multi-grip order at 5 percent, and flat 2 percent cards cover the impulse checkout.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43682&trid=1552713.200566&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Portillo's",
@@ -9534,7 +10330,11 @@
         "airlines"
       ],
       "website": "https://www.qatarairways.com",
-      "intro": "Qatar Airways is the Doha-based Oneworld carrier celebrated for its Qsuite business class and a wide network from several US cities. Ticket purchases code as an airline or travel charge, the sweet spot for an airline or general travel bonus card. Points from flexible transferable-currency cards can move to its Privilege Club, often making transfers more rewarding than paying cash directly.\n"
+      "intro": "Qatar Airways is the Doha-based Oneworld carrier celebrated for its Qsuite business class and a wide network from several US cities. Ticket purchases code as an airline or travel charge, the sweet spot for an airline or general travel bonus card. Points from flexible transferable-currency cards can move to its Privilege Club, often making transfers more rewarding than paying cash directly.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.25312&trid=1552713.249626&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Qdoba",
@@ -9643,6 +10443,23 @@
       ],
       "website": "https://www.racetrac.com",
       "intro": "RaceTrac is a family-owned Southeast U.S. convenience and fuel chain with more than\n800 stores across Georgia, Florida, Texas, Tennessee, Louisiana, and surrounding\nstates. Fuel pumps code as gas, so any gas category bonus card will earn its\nmultiplier. Inside-store food and drinks (the chain leans heavily on coffee and\nprepared foods) typically code as convenience store. The RaceTrac Rewards loyalty\nprogram adds per-gallon discounts and points on food that stack with a separate gas\nrewards card.\n"
+    },
+    {
+      "name": "RadioShack",
+      "slug": "radioshack",
+      "aliases": [
+        "Radio Shack"
+      ],
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.radioshack.com",
+      "intro": "RadioShack lives on as an online electronics retailer under new ownership, selling the batteries, adapters, components, and hobbyist parts the brand was always known for, plus consumer audio and smart-home gear. Orders from radioshack.com code as online electronics retail.\n\nComponent-drawer restocks and one-off adapter buys suit whichever electronics or online category is running: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card handles the odd soldering-iron emergency.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.32498&trid=1552713.248461&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Radisson Hotel Group",
@@ -10016,6 +10833,22 @@
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.14848.1705455&trid=1552713.240023&foc=16&fot=9999&fos=6",
         "network": "flexoffers",
         "offer": "4% off"
+      }
+    },
+    {
+      "name": "RoC Skincare",
+      "slug": "roc-skincare",
+      "aliases": [
+        "RoC"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.rocskincare.com",
+      "intro": "RoC pioneered stabilized retinol in drugstore skincare and remains the evidence-first pick for anti-aging staples like Retinol Correxion and the Multi Correxion vitamin-C line. Buying direct from rocskincare.com codes as online retail; the same products also sit on Walgreens, CVS, and Amazon shelves.\n\nDirect orders fit an online category — Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more — while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46883&trid=1552713.225417&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
       }
     },
     {
@@ -10478,6 +11311,20 @@
       "intro": "Segway makes personal electric transportation, including electric scooters, self-balancing\npersonal transporters, e-bikes, and off-road all-terrain vehicles, a lineup that grew well\nbeyond the original two-wheeled personal transporter that made the brand a household name.\nThe company has been owned by the Chinese mobility firm Ninebot since 2015, and the two\nbrands now operate under the combined Segway-Ninebot name. There's no Segway co-brand\ncredit card, so a purchase is best charged to an electronics or general online shopping\nrewards card, or a flat-rate cashback card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.31949.1241153&trid=1552713.240078&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Sennheiser",
+      "slug": "sennheiser",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.sennheiser.com",
+      "intro": "Sennheiser's consumer line — Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers — carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.\n\nHeadphone purchases in the $200–$400 band reward a live category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is a solid 3 percent, and open-box HD 6XX-adjacent deals on a flat 2 percent card still come out well.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42592&trid=1552713.193918&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -11090,6 +11937,23 @@
       "intro": "Spirit Airlines is a U.S. ultra-low-cost carrier known for stripped-down base fares\nwith à la carte pricing for bags, seat selection, and refreshments. Tickets code as\nairfare on every card we track, but for cards that offer trip-delay or trip-cancel\ninsurance the small base fare often falls below useful coverage thresholds. There's\nno widely-issued co-branded Spirit credit card, so general travel cards (Sapphire\nPreferred, Venture, Capital One Savor) are typically the best pairing.\n"
     },
     {
+      "name": "Spirit Halloween",
+      "slug": "spirit-halloween",
+      "aliases": [
+        "SpiritHalloween.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.spirithalloween.com",
+      "intro": "Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round — including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.\n\nCostume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter — which has historically covered Q4 — can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8099&trid=1552713.161081&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers",
+        "offer": "free shipping over $60"
+      }
+    },
+    {
       "name": "Sportsman's Warehouse",
       "slug": "sportsmans-warehouse",
       "categories": [
@@ -11119,6 +11983,19 @@
       ],
       "website": "https://www.sprouts.com",
       "intro": "Sprouts Farmers Market is a natural-and-organic grocery chain with about 400 U.S.\nstores, leaning heavily on fresh produce and bulk foods. Sprouts codes cleanly as\ngroceries on every card we track. The strongest pairings are 6% Blue Cash Preferred\nand the U.S. Bank Shopper Cash Rewards (if Sprouts is selected as a chosen retailer);\nCapital One SavorOne earns 3% on groceries with no cap. Sprouts doesn't run a\nco-branded card, so general grocery cards are the standard answer.\n"
+    },
+    {
+      "name": "Stadium Goods",
+      "slug": "stadium-goods",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.stadiumgoods.com",
+      "intro": "Stadium Goods is the sneaker-and-streetwear consignment marketplace with a SoHo flagship and deep deadstock inventory, selling verified pairs through its own site alongside partners like Farfetch, its former parent. Purchases from stadiumgoods.com code as online retail.\n\nGrail-priced sneakers make the category math meaningful: Bank of America Customized Cash set to online shopping returns 3 percent on a $300 pair, rotating online-retail or PayPal quarters can reach 5, and a flat 2 percent card is the floor. Consignment pricing moves constantly, so the discount timing matters more than the card.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.101104598&trid=1552713.195570&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Stamps.com",
@@ -11403,6 +12280,20 @@
       ],
       "website": "https://www.sunoco.com",
       "intro": "Sunoco-branded stations cover about 5,200 U.S. locations primarily across the East\nand Midwest. Pumps code cleanly as gas on every card we track. The Sunoco Rewards\napp stacks 5-10 cents per gallon savings on top of any card's bonus rate. There's\na Sunoco Rewards co-branded credit card, but in absolute cashback most 4-5%\ngeneral gas cards beat it.\n"
+    },
+    {
+      "name": "Superdry",
+      "slug": "superdry",
+      "categories": [
+        "online_shopping",
+        "select_clothing"
+      ],
+      "website": "https://www.superdry.com",
+      "intro": "Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding — best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.\n\nApparel categories cover it: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both on a jacket-sized order.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.44521&trid=1552713.209552&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Surfshark",
@@ -11828,6 +12719,19 @@
       "intro": "The North Face is a U.S. outdoor-apparel brand owned by VF Corporation, with\nabout 150 retail stores plus extensive third-party distribution at REI, Dick's,\nBackcountry, and more. Direct purchases at thenorthface.com code as online\nshopping; in-store charges code as department stores or apparel. The XPLR Pass\nloyalty program is free and issues spend rewards plus first-access to limited\ndrops. Pair with an online-shopping-bonus card or flat-rate cashback.\n"
     },
     {
+      "name": "The Parking Spot",
+      "slug": "the-parking-spot",
+      "categories": [
+        "travel"
+      ],
+      "website": "https://www.theparkingspot.com",
+      "intro": "The Parking Spot is the largest near-airport parking operator in the US, with covered and uncovered lots plus shuttle service at 25-plus airports, booked ahead on theparkingspot.com for member rates through its Spot Club program. Airport parking charges typically code as parking or travel merchants.\n\nParking spend near airports frequently counts toward travel multipliers — Chase Sapphire Preferred and Reserve both include parking in their travel definitions — and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10415&trid=1552713.211617&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "The RealReal",
       "slug": "the-realreal",
       "categories": [
@@ -11866,6 +12770,21 @@
       ],
       "website": "https://www.theupsstore.com",
       "intro": "The UPS Store is a franchise network of more than 5,000 U.S. locations offering\nshipping, printing, mailbox services, packing, notary, and small business support.\nMost The UPS Store locations code as office supplies or stationery on Visa,\nMastercard, and Amex networks, which makes shipping and print purchases eligible\nfor office supply bonus categories.\n\nBusiness cards with office supply bonuses are the natural fit. The Chase Ink\nBusiness Cash pays 5 percent on the first $25,000 in combined office supply and\ninternet, cable, and phone purchases each year, and the Amex Business Gold also\noffers office supplies as a top-two category. Personal cards with selectable office\nsupply categories, like U.S. Bank Cash+, can capture the same MCC.\n"
+    },
+    {
+      "name": "Theory",
+      "slug": "theory",
+      "categories": [
+        "online_shopping",
+        "select_clothing",
+        "department_stores"
+      ],
+      "website": "https://www.theory.com",
+      "intro": "Theory built its name on precisely tailored workwear fundamentals — the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe — under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.\n\nSuiting-level price tags make categories worthwhile: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store bonuses apply when you shop Theory through Nordstrom instead.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36186&trid=1552713.202068&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Therabody",
@@ -12249,6 +13168,23 @@
       "intro": "Tropical Smoothie Cafe runs more than 1,400 US locations combining made-to-order smoothies\nwith a wraps, flatbreads, and bowls menu, distinguishing itself from pure smoothie chains\nwith a full lunch offering. Popular smoothies include the Sunrise Sunset, Mango Magic, and\nIsland Green. Tropical Smoothie Cafe transactions code as dining/restaurants on every\nnetwork, including app and curbside orders through Tropic Rewards. Cards with elevated dining\nrates (Amex Gold 4x, Chase Sapphire Preferred 3x, Capital One SavorOne 3% cash) earn full bonus.\n"
     },
     {
+      "name": "Troy-Bilt",
+      "slug": "troy-bilt",
+      "aliases": [
+        "Troy Bilt"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.troybilt.com",
+      "intro": "Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points — corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.\n\nOutdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live — price both before buying.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9368&trid=1552713.203841&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "True Religion",
       "slug": "true-religion",
       "categories": [
@@ -12555,6 +13491,23 @@
       }
     },
     {
+      "name": "Vegas.com",
+      "slug": "vegas-com",
+      "aliases": [
+        "VEGAS.com"
+      ],
+      "categories": [
+        "travel",
+        "entertainment"
+      ],
+      "website": "https://www.vegas.com",
+      "intro": "Vegas.com packages the whole Las Vegas trip — hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles — as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.\n\nOTA bookings are travel spend to most issuers: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X covers whatever coding comes back at 2x. One trade-off to know: booking through an OTA usually forfeits hotel-program elite credit, so weigh the bundle discount against booking the room direct.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.4221&trid=1552713.159075&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Vera Bradley",
       "slug": "vera-bradley",
       "aliases": [
@@ -12581,6 +13534,23 @@
       ],
       "website": "https://www.verizon.com",
       "intro": "Verizon is the largest US wireless carrier, billing for phone plans, devices and home internet. Wireless and internet charges earn a bonus only on cards that specifically reward phone or internet bills, otherwise they fall to a flat rate, though some cards add cell-phone protection when you pay the bill with them.\n"
+    },
+    {
+      "name": "Versed",
+      "slug": "versed",
+      "aliases": [
+        "Versed Skin",
+        "VersedSkin.com"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://versedskin.com",
+      "intro": "Versed distills clean-clinical skincare into sub-$25 staples — Dew Point moisturizer, the Auto Save retinol line, and single-minded serums — born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.\n\nThe Target-versus-direct choice drives rewards: direct earns online-category rates like Bank of America Customized Cash's 3 percent online shopping selection, while Target runs earn RedCard savings or Target-category promos. Direct-exclusive bundles and sets are usually the reason to order from the brand itself.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9474&trid=1552713.211622&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Viagogo",
@@ -12623,6 +13593,20 @@
       "intro": "Victorinox is the Swiss manufacturer behind the original Swiss Army Knife, a family-owned\ncompany that has expanded well beyond pocket knives into watches, luggage, fragrances, and\ntravel gear. Its multitools and cutlery remain popular with outdoor and camping shoppers,\nwhile its luggage and accessories lines compete more broadly online. There's no Victorinox\nco-brand credit card, so a general online shopping rewards card or a sporting goods\ncategory card, where available, is the better fit than expecting a dedicated bonus.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43998.1000000019&trid=1552713.205647&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Victrola",
+      "slug": "victrola",
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://victrola.com",
+      "intro": "Victrola revived the century-old phonograph name into the best-selling entry point for vinyl — suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.\n\nTurntable purchases fit neatly under an electronics selection: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a suitcase-player gift on a flat 2 percent card needs no planning at all.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18889&trid=1552713.207542&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -12746,6 +13730,23 @@
       "intro": "Vivid Seats is a ticket resale marketplace covering concerts, sports, and live theater, known for its loyalty program that hands back credit toward future orders. Purchases code as entertainment or ticketing, making a card with an entertainment bonus the best fit. Stacking its rewards credit with card points can compound value across repeat buyers.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12730.2851893&trid=1552713.159252&foc=16&fot=9999&fos=6",
+        "network": "flexoffers"
+      }
+    },
+    {
+      "name": "Vivint",
+      "slug": "vivint",
+      "aliases": [
+        "Vivint Smart Home"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://www.vivint.com",
+      "intro": "Vivint sells professionally installed smart-home security — doorbell and outdoor cameras, smart locks, and thermostats wired into one app — with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.\n\nMonitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus — a full system easily covers a minimum-spend requirement in one go.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.21822&trid=1552713.225643&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
       }
     },
@@ -13036,6 +14037,22 @@
       }
     },
     {
+      "name": "Wet n Wild",
+      "slug": "wet-n-wild",
+      "aliases": [
+        "wet n wild"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.wetnwildbeauty.com",
+      "intro": "Wet n Wild is the drugstore-beauty value icon — MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.\n\nAt these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent — the drugstore route usually wins when those are live.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43590&trid=1552713.201598&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Whataburger",
       "slug": "whataburger",
       "categories": [
@@ -13084,6 +14101,22 @@
       ],
       "website": "https://www.williams-sonoma.com",
       "intro": "Williams-Sonoma is the flagship kitchen and cookware banner of Williams-Sonoma Inc,\nthe parent company of Pottery Barn, West Elm, and Rejuvenation. The U.S. footprint\ncovers around 180 stores plus williams-sonoma.com. The Key Rewards Visa from Capital\nOne earns elevated points across all WSI brands and stacks with the free Key Rewards\nprogram. General-purpose cards typically code Williams-Sonoma as home improvement or\ndepartment store in person and online shopping for web orders.\n"
+    },
+    {
+      "name": "Willow",
+      "slug": "willow-pump",
+      "aliases": [
+        "Willow Pump"
+      ],
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://onewillow.com",
+      "intro": "Willow pioneered the in-bra wearable breast pump and now sells the Willow 360's spill-proof system alongside the tube-free Willow Go, competing head-on with Elvie for pumping parents who need mobility. Orders from onewillow.com code as online retail.\n\nInsurance first, rewards second: Willow pumps are frequently available through insurance DME channels at partial or no cost, and are broadly HSA/FSA-eligible. When paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a full-price pump purchase makes a healthy dent in a new card's signup-bonus minimum.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.27293&trid=1552713.216035&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "WinCo Foods",
@@ -13241,6 +14274,23 @@
       "intro": "Wyndham Hotels & Resorts is the largest U.S. hotel chain by property count — about\n9,000 hotels — concentrated in mid-scale and economy brands like Days Inn, Super 8,\nLa Quinta, and Ramada, with a smaller upscale presence under Wyndham Grand and the\nRegistry Collection. Wyndham Rewards uses a flat or tiered award chart with redemptions\nstarting at 7,500 points per night, and the program partners with Vacasa for full\nvacation-rental redemptions — a quirk that gives Wyndham points unusual reach for an\neconomy-leaning chain. Direct bookings at wyndhamhotels.com or in the app earn points;\nOTA stays do not. Co-brand cards run lower annual fees than the major chains' cards,\nmatching the program's value-tier identity.\n"
     },
     {
+      "name": "Wyze",
+      "slug": "wyze",
+      "aliases": [
+        "Wyze Labs"
+      ],
+      "categories": [
+        "online_shopping",
+        "electronics_stores"
+      ],
+      "website": "https://www.wyze.com",
+      "intro": "Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home — cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.\n\nWyze orders are frequent and small, which favors an always-on category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent on both hardware and Cam Plus renewals, and flat 2 percent covers the impulse camera.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.27209&trid=1552713.249672&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
+    },
+    {
       "name": "Xfinity",
       "slug": "xfinity",
       "aliases": [
@@ -13251,6 +14301,23 @@
       ],
       "website": "https://www.xfinity.com",
       "intro": "Xfinity, Comcast's consumer brand, sells home internet, cable TV, streaming and mobile service. These bills earn a bonus only on cards that specifically reward internet, cable or telecom spending, otherwise they fall to a flat rate, so check whether your card lists internet or cable as a bonus category before paying.\n"
+    },
+    {
+      "name": "Yale Home",
+      "slug": "yale-home",
+      "aliases": [
+        "Yale Locks"
+      ],
+      "categories": [
+        "online_shopping",
+        "home_improvement"
+      ],
+      "website": "https://shopyalehome.com",
+      "intro": "Yale has made locks since 1840, and Yale Home is its smart-lock arm — the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa, sharing corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.\n\nA smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively — whichever category you have live decides the store.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37641&trid=1552713.247667&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Yard House",
@@ -13269,6 +14336,19 @@
       ],
       "website": "https://tv.youtube.com",
       "intro": "YouTube TV is Google's live-TV streaming service, bundling broadcast and cable channels with cloud DVR as a cord-cutting alternative. The monthly bill codes as streaming, so a card with a streaming category bonus earns at the elevated rate. Given the subscription has climbed in price over the years, putting it on a streaming-bonus card adds up across the year.\n"
+    },
+    {
+      "name": "Yves Rocher",
+      "slug": "yves-rocher",
+      "categories": [
+        "online_shopping"
+      ],
+      "website": "https://www.yvesrocherusa.com",
+      "intro": "Yves Rocher is the French botanical-beauty house that grows many of its own ingredients in La Gacilly, selling plant-based skincare, bath lines, and fragrance at accessible prices with famously generous promo codes. US orders from yvesrocherusa.com code as online retail.\n\nThe brand's constant stacked promotions do the heavy lifting on price, so the card's job is the margin: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a stock-up order to 5, and a flat 2 percent card suits the replenishment shopper.\n",
+      "affiliate": {
+        "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.27010&trid=1552713.249667&foc=17&fot=9999&fos=6&url=",
+        "network": "flexoffers"
+      }
     },
     {
       "name": "Zales",

--- a/data/stores/100-pure.yaml
+++ b/data/stores/100-pure.yaml
@@ -1,0 +1,11 @@
+name: "100% PURE"
+slug: "100-pure"
+aliases:
+  - "100 Percent Pure"
+categories:
+  - online_shopping
+website: "https://www.100percentpure.com"
+intro: |
+  100% PURE built its clean-beauty reputation on fruit-pigmented makeup — color from actual fruit, cocoa, and tea rather than synthetic dyes — plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.
+
+  Clean-beauty carts respond well to an online category: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a restock to 5, and the brand's frequent gift-with-purchase promotions stack with whatever card you use.

--- a/data/stores/aerosoles.yaml
+++ b/data/stores/aerosoles.yaml
@@ -1,0 +1,10 @@
+name: "Aerosoles"
+slug: "aerosoles"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://www.aerosoles.com"
+intro: |
+  Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s — its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.
+
+  Shoe orders sit comfortably in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both.

--- a/data/stores/alibaba.yaml
+++ b/data/stores/alibaba.yaml
@@ -1,0 +1,11 @@
+name: "Alibaba"
+slug: "alibaba"
+aliases:
+  - "Alibaba.com"
+categories:
+  - online_shopping
+website: "https://www.alibaba.com"
+intro: |
+  Alibaba.com is the world's largest business-to-business wholesale marketplace, where small businesses source inventory, packaging, and custom manufacturing directly from suppliers, mostly overseas. It is the wholesale sibling of AliExpress: order minimums are higher, unit prices far lower, and payments run through Alibaba's Trade Assurance escrow, coding as an online marketplace purchase.
+
+  Sourcing runs are business spend, so business cards shine here: Amex Blue Business Plus earns 2x on everything, and Chase Ink Business Unlimited pays a flat 1.5 percent. Watch for foreign-transaction fees on cards that charge them, since some supplier payments settle abroad.

--- a/data/stores/anine-bing.yaml
+++ b/data/stores/anine-bing.yaml
@@ -1,0 +1,12 @@
+name: "ANINE BING"
+slug: "anine-bing"
+aliases:
+  - "Anine Bing"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://www.aninebing.com"
+intro: |
+  ANINE BING bottles Scandinavian-meets-LA wardrobe staples — the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed — at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.
+
+  At this price tier the category margin is real money: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card still claws back a coffee's worth on every blazer.

--- a/data/stores/bartesian.yaml
+++ b/data/stores/bartesian.yaml
@@ -1,0 +1,10 @@
+name: "Bartesian"
+slug: "bartesian"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://bartesian.com"
+intro: |
+  Bartesian makes capsule cocktail machines that mix a bar-quality drink from a pod plus your own base spirit, along with the recurring capsule packs that keep the machine running. The machine is a one-time kitchen-appliance purchase and the capsules are classic repeat spend, all coding as online retail from bartesian.com.
+
+  Treat it like other countertop-appliance brands: Bank of America Customized Cash set to online shopping earns 3 percent on both machine and capsules, and a Chase Freedom Flex online-retail quarter is the moment to stock up on pods at 5 percent.

--- a/data/stores/betsey-johnson.yaml
+++ b/data/stores/betsey-johnson.yaml
@@ -1,0 +1,11 @@
+name: "Betsey Johnson"
+slug: "betsey-johnson"
+categories:
+  - online_shopping
+  - select_clothing
+  - department_stores
+website: "https://www.betseyjohnson.com"
+intro: |
+  Betsey Johnson is the famously whimsical fashion brand known for party dresses, novelty heels and handbags, and maximalist jewelry. Direct orders from betseyjohnson.com code as online apparel retail, while the brand also sells widely through department stores like Macy's and Bloomingdale's.
+
+  Apparel spend has good category coverage: U.S. Bank Cash+ offers a select clothing stores option that can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and buying through a department store instead can tap department-store bonus categories.

--- a/data/stores/biotherm.yaml
+++ b/data/stores/biotherm.yaml
@@ -1,0 +1,10 @@
+name: "Biotherm"
+slug: "biotherm"
+categories:
+  - online_shopping
+  - department_stores
+website: "https://www.biotherm-usa.com"
+intro: |
+  Biotherm is L'Oréal's aquatic-science skincare house, built around thermal plankton ferment in lines like Life Plankton and Aquasource, plus one of the most established men's skincare ranges in Biotherm Homme. US orders from biotherm-usa.com code as online beauty retail.
+
+  Skincare replenishment favors whichever online category is live: Bank of America Customized Cash set to online shopping earns 3 percent, online-retail rotating quarters can push a serum restock to 5, and department-store bonuses apply when you pick Biotherm up through Macy's instead. Flat 2 percent covers the in-between months.

--- a/data/stores/blendtec.yaml
+++ b/data/stores/blendtec.yaml
@@ -1,0 +1,10 @@
+name: "Blendtec"
+slug: "blendtec"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://www.blendtec.com"
+intro: |
+  Blendtec builds high-powered blenders in Utah — the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars — and famously ran the "Will It Blend?" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.
+
+  A blender at this price point is a one-time considered purchase: Bank of America Customized Cash set to online shopping earns 3 percent, a Freedom Flex online-retail quarter can reach 5 percent, and flat 2 percent cards are the fallback if no category is live when yours dies mid-smoothie.

--- a/data/stores/blinkist.yaml
+++ b/data/stores/blinkist.yaml
@@ -1,0 +1,9 @@
+name: "Blinkist"
+slug: "blinkist"
+categories:
+  - online_shopping
+website: "https://www.blinkist.com"
+intro: |
+  Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription — an online purchase, not a streaming service, so streaming credits and multipliers stay on the bench.
+
+  A single annual charge favors whichever online category you have running: Bank of America Customized Cash set to online shopping earns 3 percent, and otherwise a flat 2 percent card like Citi Double Cash quietly does the job every year.

--- a/data/stores/bobbie.yaml
+++ b/data/stores/bobbie.yaml
@@ -1,0 +1,11 @@
+name: "Bobbie"
+slug: "bobbie"
+aliases:
+  - "Bobbie Baby"
+categories:
+  - online_shopping
+website: "https://www.hibobbie.com"
+intro: |
+  Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase — not groceries — which changes which cards make sense.
+
+  Grocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators — worth checking before optimizing card rewards.

--- a/data/stores/bowers-and-wilkins.yaml
+++ b/data/stores/bowers-and-wilkins.yaml
@@ -1,0 +1,12 @@
+name: "Bowers & Wilkins"
+slug: "bowers-and-wilkins"
+aliases:
+  - "B&W"
+categories:
+  - online_shopping
+  - electronics_stores
+website: "https://www.bowerswilkins.com"
+intro: |
+  Bowers & Wilkins is the British high-end audio marque behind the 600–800 series loudspeakers, the Px7 and Px8 headphones, and the Zeppelin wireless speaker. Direct orders from bowerswilkins.com code as online electronics retail and are where the brand lists its own certified refurb stock.
+
+  Hi-fi purchases are large enough that category choice genuinely matters: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping is a safe 3 percent, and a pair of 700-series floorstanders on a flat 2 percent card still earns real money.

--- a/data/stores/brinks-home.yaml
+++ b/data/stores/brinks-home.yaml
@@ -1,0 +1,12 @@
+name: "Brinks Home"
+slug: "brinks-home"
+aliases:
+  - "Brinks Home Security"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://brinkshome.com"
+intro: |
+  Brinks Home sells professionally monitored home-security systems — panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.
+
+  Neither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on — security bundles are an easy few hundred dollars of qualifying spend.

--- a/data/stores/bruno-magli.yaml
+++ b/data/stores/bruno-magli.yaml
@@ -1,0 +1,10 @@
+name: "Bruno Magli"
+slug: "bruno-magli"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://www.brunomagli.com"
+intro: |
+  Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936 — cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.
+
+  Shoes at this tier reward a category match: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns a dependable 3 percent, and a flat 2 percent card on a pair of oxfords still returns enough for the shoe trees.

--- a/data/stores/chubbies.yaml
+++ b/data/stores/chubbies.yaml
@@ -1,0 +1,12 @@
+name: "Chubbies"
+slug: "chubbies"
+aliases:
+  - "Chubbies Shorts"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://www.chubbiesshorts.com"
+intro: |
+  Chubbies built a cult following on 5.5-inch-inseam weekend shorts and has since expanded into swim trunks, polos, and loungewear with the same retro-Americana streak. Orders from chubbiesshorts.com code as online apparel retail, with the brand's Fourth of July-adjacent drops driving most of its hype cycles.
+
+  Apparel categories cover it well: U.S. Bank Cash+ with select clothing stores chosen can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating-category quarters covering online retail occasionally beat both.

--- a/data/stores/clear.yaml
+++ b/data/stores/clear.yaml
@@ -1,0 +1,12 @@
+name: "CLEAR"
+slug: "clear"
+aliases:
+  - "CLEAR Plus"
+  - "CLEAR+"
+categories:
+  - travel
+website: "https://www.clearme.com"
+intro: |
+  CLEAR Plus is the biometric identity lane at 50-plus US airports that lets members verify with eyes or fingerprints and skip to the front of security, stacking with TSA PreCheck rather than replacing it. The annual membership bills from clearme.com and codes as a travel purchase on most networks.
+
+  Before paying full freight, check your wallet: Amex Platinum and Amex Green carry statement credits that cover most or all of a CLEAR Plus membership, and several airline and hotel programs discount it. Paying out of pocket, a travel-category card like Chase Sapphire Preferred at 2x is the sensible vehicle.

--- a/data/stores/codecademy.yaml
+++ b/data/stores/codecademy.yaml
@@ -1,0 +1,9 @@
+name: "Codecademy"
+slug: "codecademy"
+categories:
+  - online_shopping
+website: "https://www.codecademy.com"
+intro: |
+  Codecademy teaches programming through interactive browser-based courses, with free basics and a Pro subscription that unlocks career paths, projects, and certificates; it is now part of Skillsoft. Pro bills monthly or annually from codecademy.com and codes as an online education subscription.
+
+  Education subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends — worth asking before optimizing cents per dollar.

--- a/data/stores/cub-cadet.yaml
+++ b/data/stores/cub-cadet.yaml
@@ -1,0 +1,10 @@
+name: "Cub Cadet"
+slug: "cub-cadet"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://www.cubcadet.com"
+intro: |
+  Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network — it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.
+
+  A mower-sized charge deserves planning: it is ideal signup-bonus spend, and otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct. Buying the same machine through Home Depot or Lowe's instead can tap home-improvement category bonuses when you have one live.

--- a/data/stores/dansko.yaml
+++ b/data/stores/dansko.yaml
@@ -1,0 +1,10 @@
+name: "Dansko"
+slug: "dansko"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://www.dansko.com"
+intro: |
+  Dansko's stapled clogs are the unofficial uniform of nurses, chefs, and anyone else on their feet twelve hours at a stretch, joined by walking shoes and sandals with the same all-day support. Direct orders from dansko.com code as online shoe retail.
+
+  A clog replacement cycle pairs well with apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and employer scrub-and-shoe stipends cover Dansko at many hospital systems before rewards enter it.

--- a/data/stores/denon.yaml
+++ b/data/stores/denon.yaml
@@ -1,0 +1,10 @@
+name: "Denon"
+slug: "denon"
+categories:
+  - online_shopping
+  - electronics_stores
+website: "https://www.denon.com"
+intro: |
+  Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com — including refurbished receivers with full warranties — code as online electronics retail.
+
+  Receiver upgrades are chunky spend, so aim a category at them: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is the steady 3 percent, and flat 2 percent cards cover the impulse subwoofer.

--- a/data/stores/earthlink.yaml
+++ b/data/stores/earthlink.yaml
@@ -1,0 +1,9 @@
+name: "EarthLink"
+slug: "earthlink"
+categories:
+  - tv_internet_streaming
+website: "https://www.earthlink.net"
+intro: |
+  EarthLink, the dial-up pioneer turned modern ISP, resells fiber and wireless home internet across much of the US, often on the same physical lines as the big carriers but with its own pricing and no-data-cap positioning. Monthly bills code as internet service, the same bucket as Cox or Spectrum.
+
+  Internet bills are one of the best recurring charges to optimize: U.S. Bank Cash+ with TV, internet, and streaming selected pays 5 percent on the monthly bill, Citi Custom Cash can hit 5 percent if internet is your top category that cycle, and a flat 2 percent card is the no-maintenance floor.

--- a/data/stores/edx.yaml
+++ b/data/stores/edx.yaml
@@ -1,0 +1,9 @@
+name: "edX"
+slug: "edx"
+categories:
+  - online_shopping
+website: "https://www.edx.org"
+intro: |
+  edX hosts university-built online courses — MIT and Harvard founded it — spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.
+
+  Education charges sit outside consumer bonus categories, so treat them like any online purchase: Bank of America Customized Cash set to online shopping earns 3 percent on a certificate, flat 2 percent cards cover bigger program tuition without ceremony, and employer tuition-reimbursement programs frequently cover edX before rewards even enter the picture.

--- a/data/stores/elvie.yaml
+++ b/data/stores/elvie.yaml
@@ -1,0 +1,9 @@
+name: "Elvie"
+slug: "elvie"
+categories:
+  - online_shopping
+website: "https://www.elvie.com"
+intro: |
+  Elvie makes discreet wearable breast pumps — the in-bra Elvie Pump and the value Stride line — plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.
+
+  Before optimizing rewards, exhaust the cheaper routes: Elvie pumps are frequently covered or subsidized through insurance DME suppliers and are broadly HSA/FSA-eligible. Paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a pump-sized purchase contributes meaningfully to a new card's signup-bonus minimum.

--- a/data/stores/europcar.yaml
+++ b/data/stores/europcar.yaml
@@ -1,0 +1,10 @@
+name: "Europcar"
+slug: "europcar"
+categories:
+  - car_rentals
+  - travel
+website: "https://www.europcar.com"
+intro: |
+  Europcar is one of Europe's largest car-rental networks, with counters across 130-plus countries; US travelers mostly meet it when booking European road trips, where its rates and one-way options frequently beat the American majors abroad. Rentals code as car rental agencies, squarely inside every travel category definition.
+
+  Car rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry — genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.

--- a/data/stores/european-wax-center.yaml
+++ b/data/stores/european-wax-center.yaml
@@ -1,0 +1,11 @@
+name: "European Wax Center"
+slug: "european-wax-center"
+aliases:
+  - "EWC"
+categories:
+  - online_shopping
+website: "https://waxcenter.com"
+intro: |
+  European Wax Center is the largest waxing-salon chain in the US, with over 1,000 franchised centers selling waxing services, the Wax Pass prepaid bundles, and its own skincare line. Charges are in-salon or prepaid packages booked through waxcenter.com and code as personal-care services.
+
+  Salon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase — a few hundred dollars prepaid — into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.

--- a/data/stores/firstleaf.yaml
+++ b/data/stores/firstleaf.yaml
@@ -1,0 +1,11 @@
+name: "Firstleaf"
+slug: "firstleaf"
+aliases:
+  - "Firstleaf Wine Club"
+categories:
+  - online_shopping
+website: "https://www.firstleaf.com"
+intro: |
+  Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings — the algorithmic cousin of Naked Wines' funding model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.
+
+  That coding means grocery and dining multipliers stay quiet, and online categories do the work: Bank of America Customized Cash set to online shopping earns 3 percent per box, a Freedom Flex online-retail quarter can reach 5 percent on a stock-up order, and a flat 2 percent card suits the set-and-forget subscriber.

--- a/data/stores/flamingo.yaml
+++ b/data/stores/flamingo.yaml
@@ -1,0 +1,11 @@
+name: "Flamingo"
+slug: "flamingo"
+aliases:
+  - "Flamingo by Harry's"
+categories:
+  - online_shopping
+website: "https://www.shopflamingo.com"
+intro: |
+  Flamingo is the women's body-care line from the team behind Harry's, selling razors, blade refills, and wax kits with the same design-forward, subscription-friendly model as its sibling brand. Orders and refill plans from shopflamingo.com code as online retail rather than drugstore purchases.
+
+  The card logic mirrors Harry's: direct subscriptions earn online-category rates — Bank of America Customized Cash set to online shopping pays 3 percent — while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.

--- a/data/stores/fragrancenet.yaml
+++ b/data/stores/fragrancenet.yaml
@@ -1,0 +1,11 @@
+name: "FragranceNet"
+slug: "fragrancenet"
+aliases:
+  - "FragranceNet.com"
+categories:
+  - online_shopping
+website: "https://www.fragrancenet.com"
+intro: |
+  FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes — plus skincare, haircare, and candles — at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.
+
+  Discount fragrance stacking works best with an online category on top: Bank of America Customized Cash set to online shopping adds 3 percent to already-marked-down bottles, rotating online-retail quarters push it to 5, and flat 2 percent cards handle gift-season hauls without planning.

--- a/data/stores/franco-sarto.yaml
+++ b/data/stores/franco-sarto.yaml
@@ -1,0 +1,11 @@
+name: "Franco Sarto"
+slug: "franco-sarto"
+categories:
+  - online_shopping
+  - select_clothing
+  - department_stores
+website: "https://www.francosarto.com"
+intro: |
+  Franco Sarto delivers Italian-styled women's footwear — loafers, block heels, and knee boots — at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.
+
+  Footwear categories cover the bases: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same styles through Macy's or DSW can catch department-store or rotating-category bonuses when live.

--- a/data/stores/french-connection.yaml
+++ b/data/stores/french-connection.yaml
@@ -1,0 +1,12 @@
+name: "French Connection"
+slug: "french-connection"
+aliases:
+  - "FCUK"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://www.frenchconnection.com"
+intro: |
+  French Connection is the London high-street label that rode the FCUK logo era and now trades on sharp dresses, tailoring, and knitwear at contemporary prices. US orders from frenchconnection.com code as online apparel retail, with an aggressive sale rotation.
+
+  Apparel category coverage applies cleanly: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and stacking the brand's sale pricing with either beats waiting for a better card.

--- a/data/stores/gillette.yaml
+++ b/data/stores/gillette.yaml
@@ -1,0 +1,12 @@
+name: "Gillette"
+slug: "gillette"
+aliases:
+  - "The Gillette Company"
+  - "Gillette Direct"
+categories:
+  - online_shopping
+website: "https://www.gillette.com"
+intro: |
+  Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor — the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.
+
+  That coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices — the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.

--- a/data/stores/grailed.yaml
+++ b/data/stores/grailed.yaml
@@ -1,0 +1,10 @@
+name: "Grailed"
+slug: "grailed"
+categories:
+  - online_shopping
+  - secondhand_stores
+website: "https://www.grailed.com"
+intro: |
+  Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout — the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.
+
+  That PayPal routing is the rewards angle: Chase Freedom Flex's recurring PayPal rotating quarters have historically covered Grailed checkouts at 5 percent, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card backstops off-quarter grail hunts.

--- a/data/stores/h-and-r-block.yaml
+++ b/data/stores/h-and-r-block.yaml
@@ -1,0 +1,12 @@
+name: "H&R Block"
+slug: "h-and-r-block"
+aliases:
+  - "H and R Block"
+  - "HR Block"
+categories:
+  - online_shopping
+website: "https://www.hrblock.com"
+intro: |
+  H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services — a category no consumer card bonuses.
+
+  Two angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution — paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.

--- a/data/stores/horizon-fitness.yaml
+++ b/data/stores/horizon-fitness.yaml
@@ -1,0 +1,10 @@
+name: "Horizon Fitness"
+slug: "horizon-fitness"
+categories:
+  - online_shopping
+  - sporting_goods
+website: "https://www.horizonfitness.com"
+intro: |
+  Horizon Fitness sells home treadmills, ellipticals, and exercise bikes — the value-focused sibling brand of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.
+
+  Big fitness equipment is prime signup-bonus spend, clearing most minimums in one order. Otherwise, U.S. Bank Cash+ with sporting goods stores selected can pay 5 percent when the charge classifies that way, and Bank of America Customized Cash set to online shopping is the reliable 3 percent.

--- a/data/stores/hudson-jeans.yaml
+++ b/data/stores/hudson-jeans.yaml
@@ -1,0 +1,12 @@
+name: "Hudson Jeans"
+slug: "hudson-jeans"
+aliases:
+  - "Hudson"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://www.hudsonjeans.com"
+intro: |
+  Hudson Jeans is the Los Angeles premium-denim house known for its signature triangle back-flap pockets, mid-hundreds price points, and a steady rotation of skinny, straight, and barrel fits. Direct orders from hudsonjeans.com code as online apparel retail.
+
+  Premium denim benefits from an apparel category: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 30-percent-off sales stack with either for the real savings.

--- a/data/stores/hunter-fan.yaml
+++ b/data/stores/hunter-fan.yaml
@@ -1,0 +1,12 @@
+name: "Hunter Fan"
+slug: "hunter-fan"
+aliases:
+  - "Hunter Fan Company"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://www.hunterfan.com"
+intro: |
+  Hunter has been making ceiling fans since 1886 and remains the name most Americans reach for when a room needs one, now spanning smart fans, outdoor-rated models, and the Casablanca premium line. Direct orders from hunterfan.com code as online retail rather than a hardware-store purchase.
+
+  A fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there — worth a price check both ways.

--- a/data/stores/insta360.yaml
+++ b/data/stores/insta360.yaml
@@ -1,0 +1,10 @@
+name: "Insta360"
+slug: "insta360"
+categories:
+  - online_shopping
+  - electronics_stores
+website: "https://www.insta360.com"
+intro: |
+  Insta360 makes the leading 360-degree action cameras — the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras — sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.
+
+  Camera kits with mounts and accessories climb in price quickly, which suits an electronics category: U.S. Bank Cash+ set to electronics stores can return 5 percent when the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card covers accessory top-ups.

--- a/data/stores/intimissimi.yaml
+++ b/data/stores/intimissimi.yaml
@@ -1,0 +1,10 @@
+name: "Intimissimi"
+slug: "intimissimi"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://us.intimissimi.com"
+intro: |
+  Intimissimi is the Italian lingerie chain — silk-and-lace bralettes, modal sleepwear, and seamless basics — that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.
+
+  Lingerie restocks fit apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 5-for deals on basics reward consolidating a haul onto whichever is live.

--- a/data/stores/klook.yaml
+++ b/data/stores/klook.yaml
@@ -1,0 +1,10 @@
+name: "Klook"
+slug: "klook"
+categories:
+  - travel
+  - entertainment
+website: "https://www.klook.com"
+intro: |
+  Klook is a travel-activities marketplace strongest in Asia — theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours — often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.
+
+  Activity bookings are travel spend most cards recognize: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X's 2x applies everywhere including the odd booking that codes as ticketing instead. Klook runs frequent promo-code sales, so stack a discount with the multiplier rather than choosing between them.

--- a/data/stores/koa.yaml
+++ b/data/stores/koa.yaml
@@ -1,0 +1,13 @@
+name: "KOA"
+slug: "koa"
+aliases:
+  - "Kampgrounds of America"
+  - "KOA Campgrounds"
+categories:
+  - travel
+  - vacation_rentals
+website: "https://koa.com"
+intro: |
+  KOA — Kampgrounds of America — runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.
+
+  Travel cards are the natural fit: Chase Sapphire Preferred and Reserve count campground stays in their travel multipliers, Capital One Venture X earns its flat 2x everywhere, and annual-fee travel credits like the Sapphire Reserve's have been reported to apply to campground charges. KOA Rewards stacks on top regardless of card.

--- a/data/stores/life-fitness.yaml
+++ b/data/stores/life-fitness.yaml
@@ -1,0 +1,10 @@
+name: "Life Fitness"
+slug: "life-fitness"
+categories:
+  - online_shopping
+  - sporting_goods
+website: "https://www.lifefitness.com"
+intro: |
+  Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use — treadmills, ellipticals, bikes, and the Hammer Strength line — at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.
+
+  Purchases this size are textbook signup-bonus spend, often clearing an entire minimum in one order. Absent a new card, U.S. Bank Cash+ with sporting goods selected can hit 5 percent where the charge classifies that way, with Bank of America Customized Cash's online shopping choice a dependable 3 percent.

--- a/data/stores/maidenform.yaml
+++ b/data/stores/maidenform.yaml
@@ -1,0 +1,11 @@
+name: "Maidenform"
+slug: "maidenform"
+categories:
+  - online_shopping
+  - select_clothing
+  - department_stores
+website: "https://www.maidenform.com"
+intro: |
+  Maidenform has been a mainstay of American intimates for a century, selling bras, shapewear, and underwear under a HanesBrands umbrella that keeps prices in the everyday range. Direct orders from maidenform.com code as online apparel retail, and the brand runs near-constant multi-buy promotions.
+
+  Intimates restocks land in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store category bonuses apply when you buy Maidenform through Macy's or Kohl's instead.

--- a/data/stores/make-up-for-ever.yaml
+++ b/data/stores/make-up-for-ever.yaml
@@ -1,0 +1,12 @@
+name: "Make Up For Ever"
+slug: "make-up-for-ever"
+aliases:
+  - "MUFE"
+categories:
+  - online_shopping
+  - department_stores
+website: "https://www.makeupforever.com"
+intro: |
+  Make Up For Ever is the LVMH-owned professional makeup house famous for the HD Skin foundation range, Aqua Resist liners, and artist-grade palettes born from its Paris pro heritage. US orders from makeupforever.com code as online beauty retail; the brand also sells through Sephora.
+
+  Direct orders suit an online category — Bank of America Customized Cash set to online shopping earns 3 percent — while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.

--- a/data/stores/mrs-fields.yaml
+++ b/data/stores/mrs-fields.yaml
@@ -1,0 +1,12 @@
+name: "Mrs. Fields"
+slug: "mrs-fields"
+aliases:
+  - "Mrs Fields"
+categories:
+  - online_shopping
+  - dining
+website: "https://www.mrsfields.com"
+intro: |
+  Mrs. Fields turned mall-kiosk chocolate-chip cookies into a national gifting business: tins, cookie cakes, and corporate gift baskets shipped nationwide from mrsfields.com, alongside its remaining bakery locations. Online gift orders code as internet retail or specialty food, while in-person bakery purchases can code as dining or fast food.
+
+  For shipped gifts, an online category does the work — Bank of America Customized Cash set to online shopping earns 3 percent — while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.

--- a/data/stores/nalgene.yaml
+++ b/data/stores/nalgene.yaml
@@ -1,0 +1,10 @@
+name: "Nalgene"
+slug: "nalgene"
+categories:
+  - online_shopping
+  - sporting_goods
+website: "https://www.nalgene.com"
+intro: |
+  Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders — including the popular custom-printing option — ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.
+
+  Bottles are small-ticket, so rewards are more about which card is already in hand: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ sporting goods quarter can catch a team order at 5 percent, and REI stock of the same bottles earns REI-specific card bonuses instead.

--- a/data/stores/naturalizer.yaml
+++ b/data/stores/naturalizer.yaml
@@ -1,0 +1,11 @@
+name: "Naturalizer"
+slug: "naturalizer"
+categories:
+  - online_shopping
+  - select_clothing
+  - department_stores
+website: "https://www.naturalizer.com"
+intro: |
+  Naturalizer has sold comfort-first women's footwear since 1927 — pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.
+
+  Footwear reliably lands in apparel categories: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the merchant classifies as apparel or shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and the same styles at Macy's or Nordstrom can pick up department-store bonuses when one is live.

--- a/data/stores/ole-henriksen.yaml
+++ b/data/stores/ole-henriksen.yaml
@@ -1,0 +1,12 @@
+name: "Ole Henriksen"
+slug: "ole-henriksen"
+aliases:
+  - "OLEHENRIKSEN"
+categories:
+  - online_shopping
+  - department_stores
+website: "https://www.olehenriksen.com"
+intro: |
+  Ole Henriksen bottles Scandinavian glow-first skincare — Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners — born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.
+
+  Direct restocks favor an online category — Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5 — while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.

--- a/data/stores/pga-tour-superstore.yaml
+++ b/data/stores/pga-tour-superstore.yaml
@@ -1,0 +1,10 @@
+name: "PGA TOUR Superstore"
+slug: "pga-tour-superstore"
+categories:
+  - sporting_goods
+  - online_shopping
+website: "https://www.pgatoursuperstore.com"
+intro: |
+  PGA TOUR Superstore is the big-box golf retailer — clubs, balls, apparel, launch-monitor fittings, and in-store simulators — with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.
+
+  Golf spend adds up fast, and sporting-goods coverage is unusually good: U.S. Bank Cash+ with sporting goods stores selected pays 5 percent, rotating quarters occasionally cover the category too, and a driver-and-iron-set fitting bill makes clean signup-bonus spend. Bank of America Customized Cash's online shopping choice covers web orders at 3 percent.

--- a/data/stores/philosophy.yaml
+++ b/data/stores/philosophy.yaml
@@ -1,0 +1,10 @@
+name: "Philosophy"
+slug: "philosophy"
+categories:
+  - online_shopping
+  - department_stores
+website: "https://www.philosophy.com"
+intro: |
+  Philosophy is the feel-good skincare and bath brand behind Purity Made Simple cleanser, Hope in a Jar moisturizer, and the dessert-scented Amazing Grace shower gels, sold direct and through Ulta, Sephora, and department stores. Orders from philosophy.com code as online beauty retail.
+
+  Routine restocks favor an online category — Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5 — while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.

--- a/data/stores/physicians-formula.yaml
+++ b/data/stores/physicians-formula.yaml
@@ -1,0 +1,9 @@
+name: "Physicians Formula"
+slug: "physicians-formula"
+categories:
+  - online_shopping
+website: "https://www.physiciansformula.com"
+intro: |
+  Physicians Formula has sold hypoallergenic drugstore makeup since 1937 — Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.
+
+  The drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter — Chase Freedom Flex has covered drugstores repeatedly — at 5 percent. Price-match against drugstore sales before ordering direct.

--- a/data/stores/pit-boss-grills.yaml
+++ b/data/stores/pit-boss-grills.yaml
@@ -1,0 +1,12 @@
+name: "Pit Boss Grills"
+slug: "pit-boss-grills"
+aliases:
+  - "Pit Boss"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://pitboss-grills.com"
+intro: |
+  Pit Boss is the value heavyweight of pellet grilling — bigger hoppers and lower prices than Traeger — spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.
+
+  A grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories — compare, since Pit Boss runs aggressive direct-only bundle deals.

--- a/data/stores/pixi-beauty.yaml
+++ b/data/stores/pixi-beauty.yaml
@@ -1,0 +1,11 @@
+name: "Pixi Beauty"
+slug: "pixi-beauty"
+aliases:
+  - "Pixi"
+categories:
+  - online_shopping
+website: "https://www.pixibeauty.com"
+intro: |
+  Pixi built a skincare empire on Glow Tonic, the glycolic toner with a permanent spot in affordable-skincare routines, plus flower-adorned tints and the collab-heavy Pretties palettes. Direct orders from pixibeauty.com code as online beauty retail; Target and Ulta carry core lines.
+
+  Glow Tonic restocks reward whichever channel has a category live: direct orders earn Bank of America Customized Cash's 3 percent with online shopping selected, Target runs take the RedCard's 5 percent instead, and rotating online-retail quarters occasionally make direct the winner at 5. Flat 2 percent covers everything in between.

--- a/data/stores/popsockets.yaml
+++ b/data/stores/popsockets.yaml
@@ -1,0 +1,10 @@
+name: "PopSockets"
+slug: "popsockets"
+categories:
+  - online_shopping
+  - electronics_stores
+website: "https://www.popsockets.com"
+intro: |
+  PopSockets turned the collapsible phone grip into an accessories empire, now spanning MagSafe grips, wallets, mounts, and endless licensed designs, sold direct from popsockets.com and through every electronics aisle in America. Direct orders code as online retail, sometimes classifying as electronics accessories.
+
+  These are small-ticket, high-frequency purchases where whatever category is live wins: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ electronics selection can catch a multi-grip order at 5 percent, and flat 2 percent cards cover the impulse checkout.

--- a/data/stores/radioshack.yaml
+++ b/data/stores/radioshack.yaml
@@ -1,0 +1,12 @@
+name: "RadioShack"
+slug: "radioshack"
+aliases:
+  - "Radio Shack"
+categories:
+  - online_shopping
+  - electronics_stores
+website: "https://www.radioshack.com"
+intro: |
+  RadioShack lives on as an online electronics retailer under new ownership, selling the batteries, adapters, components, and hobbyist parts the brand was always known for, plus consumer audio and smart-home gear. Orders from radioshack.com code as online electronics retail.
+
+  Component-drawer restocks and one-off adapter buys suit whichever electronics or online category is running: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card handles the odd soldering-iron emergency.

--- a/data/stores/roc-skincare.yaml
+++ b/data/stores/roc-skincare.yaml
@@ -1,0 +1,11 @@
+name: "RoC Skincare"
+slug: "roc-skincare"
+aliases:
+  - "RoC"
+categories:
+  - online_shopping
+website: "https://www.rocskincare.com"
+intro: |
+  RoC pioneered stabilized retinol in drugstore skincare and remains the evidence-first pick for anti-aging staples like Retinol Correxion and the Multi Correxion vitamin-C line. Buying direct from rocskincare.com codes as online retail; the same products also sit on Walgreens, CVS, and Amazon shelves.
+
+  Direct orders fit an online category — Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more — while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.

--- a/data/stores/sennheiser.yaml
+++ b/data/stores/sennheiser.yaml
@@ -1,0 +1,10 @@
+name: "Sennheiser"
+slug: "sennheiser"
+categories:
+  - online_shopping
+  - electronics_stores
+website: "https://www.sennheiser.com"
+intro: |
+  Sennheiser's consumer line — Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers — carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.
+
+  Headphone purchases in the $200–$400 band reward a live category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is a solid 3 percent, and open-box HD 6XX-adjacent deals on a flat 2 percent card still come out well.

--- a/data/stores/spirit-halloween.yaml
+++ b/data/stores/spirit-halloween.yaml
@@ -1,0 +1,11 @@
+name: "Spirit Halloween"
+slug: "spirit-halloween"
+aliases:
+  - "SpiritHalloween.com"
+categories:
+  - online_shopping
+website: "https://www.spirithalloween.com"
+intro: |
+  Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round — including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.
+
+  Costume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter — which has historically covered Q4 — can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.

--- a/data/stores/stadium-goods.yaml
+++ b/data/stores/stadium-goods.yaml
@@ -1,0 +1,9 @@
+name: "Stadium Goods"
+slug: "stadium-goods"
+categories:
+  - online_shopping
+website: "https://www.stadiumgoods.com"
+intro: |
+  Stadium Goods is the sneaker-and-streetwear consignment marketplace with a SoHo flagship and deep deadstock inventory, selling verified pairs through its own site alongside partners like Farfetch, its former parent. Purchases from stadiumgoods.com code as online retail.
+
+  Grail-priced sneakers make the category math meaningful: Bank of America Customized Cash set to online shopping returns 3 percent on a $300 pair, rotating online-retail or PayPal quarters can reach 5, and a flat 2 percent card is the floor. Consignment pricing moves constantly, so the discount timing matters more than the card.

--- a/data/stores/superdry.yaml
+++ b/data/stores/superdry.yaml
@@ -1,0 +1,10 @@
+name: "Superdry"
+slug: "superdry"
+categories:
+  - online_shopping
+  - select_clothing
+website: "https://www.superdry.com"
+intro: |
+  Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding — best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.
+
+  Apparel categories cover it: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both on a jacket-sized order.

--- a/data/stores/the-parking-spot.yaml
+++ b/data/stores/the-parking-spot.yaml
@@ -1,0 +1,9 @@
+name: "The Parking Spot"
+slug: "the-parking-spot"
+categories:
+  - travel
+website: "https://www.theparkingspot.com"
+intro: |
+  The Parking Spot is the largest near-airport parking operator in the US, with covered and uncovered lots plus shuttle service at 25-plus airports, booked ahead on theparkingspot.com for member rates through its Spot Club program. Airport parking charges typically code as parking or travel merchants.
+
+  Parking spend near airports frequently counts toward travel multipliers — Chase Sapphire Preferred and Reserve both include parking in their travel definitions — and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.

--- a/data/stores/theory.yaml
+++ b/data/stores/theory.yaml
@@ -1,0 +1,11 @@
+name: "Theory"
+slug: "theory"
+categories:
+  - online_shopping
+  - select_clothing
+  - department_stores
+website: "https://www.theory.com"
+intro: |
+  Theory built its name on precisely tailored workwear fundamentals — the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe — under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.
+
+  Suiting-level price tags make categories worthwhile: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store bonuses apply when you shop Theory through Nordstrom instead.

--- a/data/stores/troy-bilt.yaml
+++ b/data/stores/troy-bilt.yaml
@@ -1,0 +1,12 @@
+name: "Troy-Bilt"
+slug: "troy-bilt"
+aliases:
+  - "Troy Bilt"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://www.troybilt.com"
+intro: |
+  Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points — corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.
+
+  Outdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live — price both before buying.

--- a/data/stores/vegas-com.yaml
+++ b/data/stores/vegas-com.yaml
@@ -1,0 +1,12 @@
+name: "Vegas.com"
+slug: "vegas-com"
+aliases:
+  - "VEGAS.com"
+categories:
+  - travel
+  - entertainment
+website: "https://www.vegas.com"
+intro: |
+  Vegas.com packages the whole Las Vegas trip — hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles — as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.
+
+  OTA bookings are travel spend to most issuers: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X covers whatever coding comes back at 2x. One trade-off to know: booking through an OTA usually forfeits hotel-program elite credit, so weigh the bundle discount against booking the room direct.

--- a/data/stores/versed.yaml
+++ b/data/stores/versed.yaml
@@ -1,0 +1,12 @@
+name: "Versed"
+slug: "versed"
+aliases:
+  - "Versed Skin"
+  - "VersedSkin.com"
+categories:
+  - online_shopping
+website: "https://versedskin.com"
+intro: |
+  Versed distills clean-clinical skincare into sub-$25 staples — Dew Point moisturizer, the Auto Save retinol line, and single-minded serums — born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.
+
+  The Target-versus-direct choice drives rewards: direct earns online-category rates like Bank of America Customized Cash's 3 percent online shopping selection, while Target runs earn RedCard savings or Target-category promos. Direct-exclusive bundles and sets are usually the reason to order from the brand itself.

--- a/data/stores/victrola.yaml
+++ b/data/stores/victrola.yaml
@@ -1,0 +1,10 @@
+name: "Victrola"
+slug: "victrola"
+categories:
+  - online_shopping
+  - electronics_stores
+website: "https://victrola.com"
+intro: |
+  Victrola revived the century-old phonograph name into the best-selling entry point for vinyl — suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.
+
+  Turntable purchases fit neatly under an electronics selection: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a suitcase-player gift on a flat 2 percent card needs no planning at all.

--- a/data/stores/vivint.yaml
+++ b/data/stores/vivint.yaml
@@ -1,0 +1,12 @@
+name: "Vivint"
+slug: "vivint"
+aliases:
+  - "Vivint Smart Home"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://www.vivint.com"
+intro: |
+  Vivint sells professionally installed smart-home security — doorbell and outdoor cameras, smart locks, and thermostats wired into one app — with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.
+
+  Monitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus — a full system easily covers a minimum-spend requirement in one go.

--- a/data/stores/wet-n-wild.yaml
+++ b/data/stores/wet-n-wild.yaml
@@ -1,0 +1,11 @@
+name: "Wet n Wild"
+slug: "wet-n-wild"
+aliases:
+  - "wet n wild"
+categories:
+  - online_shopping
+website: "https://www.wetnwildbeauty.com"
+intro: |
+  Wet n Wild is the drugstore-beauty value icon — MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.
+
+  At these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent — the drugstore route usually wins when those are live.

--- a/data/stores/willow-pump.yaml
+++ b/data/stores/willow-pump.yaml
@@ -1,0 +1,11 @@
+name: "Willow"
+slug: "willow-pump"
+aliases:
+  - "Willow Pump"
+categories:
+  - online_shopping
+website: "https://onewillow.com"
+intro: |
+  Willow pioneered the in-bra wearable breast pump and now sells the Willow 360's spill-proof system alongside the tube-free Willow Go, competing head-on with Elvie for pumping parents who need mobility. Orders from onewillow.com code as online retail.
+
+  Insurance first, rewards second: Willow pumps are frequently available through insurance DME channels at partial or no cost, and are broadly HSA/FSA-eligible. When paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a full-price pump purchase makes a healthy dent in a new card's signup-bonus minimum.

--- a/data/stores/wyze.yaml
+++ b/data/stores/wyze.yaml
@@ -1,0 +1,12 @@
+name: "Wyze"
+slug: "wyze"
+aliases:
+  - "Wyze Labs"
+categories:
+  - online_shopping
+  - electronics_stores
+website: "https://www.wyze.com"
+intro: |
+  Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home — cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.
+
+  Wyze orders are frequent and small, which favors an always-on category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent on both hardware and Cam Plus renewals, and flat 2 percent covers the impulse camera.

--- a/data/stores/yale-home.yaml
+++ b/data/stores/yale-home.yaml
@@ -1,0 +1,12 @@
+name: "Yale Home"
+slug: "yale-home"
+aliases:
+  - "Yale Locks"
+categories:
+  - online_shopping
+  - home_improvement
+website: "https://shopyalehome.com"
+intro: |
+  Yale has made locks since 1840, and Yale Home is its smart-lock arm — the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa, sharing corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.
+
+  A smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively — whichever category you have live decides the store.

--- a/data/stores/yves-rocher.yaml
+++ b/data/stores/yves-rocher.yaml
@@ -1,0 +1,9 @@
+name: "Yves Rocher"
+slug: "yves-rocher"
+categories:
+  - online_shopping
+website: "https://www.yvesrocherusa.com"
+intro: |
+  Yves Rocher is the French botanical-beauty house that grows many of its own ingredients in La Gacilly, selling plant-based skincare, bath lines, and fragrance at accessible prices with famously generous promo codes. US orders from yvesrocherusa.com code as online retail.
+
+  The brand's constant stacked promotions do the heavy lifting on price, so the card's job is the margin: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a stock-up order to 5, and a flat 2 percent card suits the replenishment shopper.


### PR DESCRIPTION
Wires up the FlexOffers portion of the 113 approved affiliate programs from `CreditOdds_Ready_To_Build.xlsx` (75 rows).

## What's in
- **70 new store pages** in `data/stores/` (every FlexOffers merchant that clearly warrants one), each with a distinctive intro, category mapping derived from comparable existing stores, and canonical website.
- **71 affiliate entries** appended to `data/affiliates.yaml` as a dated section (house convention since 2026-07-10). Qatar Airways already had a store page, so it's entry-only.
- Regenerated `data/stores.json` + the Lambda ranker mirror.

## Field handling
- **URLs verbatim** from the sheet except the scheme, upgraded `http://` → `https://` (the build rejects non-https; all 488 existing entries use https on the same host). All tracking params, including the empty trailing `&url=`, are untouched. **Redirect verified in a real browser**: the empty `&url=` form lands on the merchant with the affiliate `clickid` attached.
- **Offers** only where the sheet's evergreen offer column was populated AND the Verify column was empty. The 9 Verify-flagged rows (Blinkist, Codecademy, Cub Cadet, Horizon Fitness, Life Fitness, RadioShack, Troy-Bilt, VEGAS.com, Versed) ship url-only. No `cta` overrides, no seasonal/dated offers.

## Skipped FlexOffers rows (4)
| Merchant | Reason |
|---|---|
| APMEX | Bullion dealers surcharge credit cards; rewards-hostile purchase, poor page fit |
| Remitly | Card-funded remittances cost extra / can code as cash advance; poor rewards fit |
| WorldRemit | Same as Remitly |
| ROKA | Niche performance eyewear, thin brand recognition |

## Verification
- `npm run build:stores`: all 1,026 stores build, 576 affiliate links attach, zero errors from this change. The one validation failure (`my-best-buy-visa` dead gate on `best-buy`) **pre-exists on main** (from #1950) and reproduces with this branch's changes stashed — flagged separately.
- All 71 pages spot-checked live on a dev server: 200s across the board, CTA renders with `rel="sponsored nofollow noopener noreferrer"`, offer phrasing reads correctly between "See … at {name}".

The 38 CJ rows ship separately in #1961 (held until CJ onboarding is verified).