### PR TITLE
Fix United award-discount name collision; add missing 10% award booking discount

### DIFF
--- a/data/cards/united-business.yaml
+++ b/data/cards/united-business.yaml
@@ -122,7 +122,7 @@ benefits:
     description: "Employee cards at no additional cost"
     frequency: "ongoing"
     category: "business"
-  - name: "Award Flight Discount"
+  - name: "Award Booking Discount"
     value: 10
     value_unit: "percent"
     description: "Save 10% or more on the miles needed when booking United award flights with miles; Premier members save even more"

--- a/data/cards/united-club-business.yaml
+++ b/data/cards/united-club-business.yaml
@@ -108,7 +108,7 @@ benefits:
     description: "25% back as a statement credit on United inflight food, beverage, and Wi-Fi purchases and United Club premium drinks"
     frequency: "per_purchase"
     category: "travel"
-  - name: "Award Flight Discount"
+  - name: "Award Booking Discount"
     value: 10
     value_unit: "percent"
     description: "Save 10% or more on the miles needed when booking United award flights with miles; Premier members save even more"

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -62,11 +62,18 @@ benefits:
     frequency: "annual"
     category: "travel"
     enrollment_required: false
-  - name: "Award Flight Discounts"
+  - name: "Spending Award Flight Discount"
     value: 0
     description: "Earn a 10,000-mile award flight discount after $20,000 in purchases, up to two times each calendar year"
     frequency: "annual"
     category: "travel"
+  - name: "Award Booking Discount"
+    value: 10
+    value_unit: "percent"
+    description: "Save 10% or more on the miles needed when booking United award flights with miles; Premier members save even more"
+    frequency: "per_trip"
+    category: "travel"
+    enrollment_required: false
   - name: "Renowned Hotels Credit"
     value: 200
     description: "Up to $200 each anniversary year on prepaid Renowned Hotels and Resorts for United Cardmembers bookings"

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -52,11 +52,18 @@ benefits:
     description: "Priority boarding on United flights"
     frequency: "ongoing"
     category: "travel"
-  - name: "Award Flight Discount"
+  - name: "Spending Award Flight Discount"
     value: 0
     description: "Earn a 10,000-mile award flight discount after $20,000 in annual purchases"
     frequency: "annual"
     category: "travel"
+  - name: "Award Booking Discount"
+    value: 10
+    value_unit: "percent"
+    description: "Save 10% or more on the miles needed when booking United award flights with miles; Premier members save even more"
+    frequency: "per_trip"
+    category: "travel"
+    enrollment_required: false
   - name: "United Hotels Credit"
     value: 100
     description: "Up to $100 each anniversary year on prepaid hotel stays booked directly through United Hotels"

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -119,11 +119,11 @@ benefits:
     frequency: "per_purchase"
     category: "travel"
     enrollment_required: false
-  - name: "Award Flight Discount"
+  - name: "Award Booking Discount"
     value: 10
     value_unit: "percent"
     description: "At least 10% fewer miles when booking award flights on United or United Express (15% for cardmembers with MileagePlus Premier status)"
-    frequency: "per_purchase"
+    frequency: "per_trip"
     category: "travel"
     enrollment_required: false
 tags:


### PR DESCRIPTION
Fixes #1915.

All six United apply pages carry the new **"Save 10% or more when booking flights with miles"** perk, but United Explorer and Club Infinite were missing it because their unrelated fixed-mile perk (10,000-mile discount after $20k spend) shared the name `Award Flight Discount(s)` — so name-level dedupe silently skipped them every run.

## Changes

| Card | Change |
|---|---|
| United Explorer | Add `Award Booking Discount` (10%, per_trip); rename fixed-mile perk → `Spending Award Flight Discount` |
| United Club Infinite | Same as Explorer |
| United Quest | Rename 10% perk → `Award Booking Discount`; frequency `per_purchase` → `per_trip` |
| United Business | Rename 10% perk → `Award Booking Discount` |
| United Club Business | Rename 10% perk → `Award Booking Discount` |
| United Gateway | Unchanged — its 10% is genuinely gated on $10k/yr spend |

After this, `Award Booking Discount` consistently means the percentage perk and `Spending Award Flight Discount` the fixed-mile perk, so the weekly checker can no longer false-negative on the collision.

Verified against the live Chase United Explorer apply page today: "Save 10% or more when booking flights with miles. Premier members save even more."

`npm run build:cards` passes (cards.json regenerated then discarded per convention).