### PR TITLE
Drop client errors whose stack never touches a named script

### DIFF
--- a/apps/web-next/src/instrumentation-client.ts
+++ b/apps/web-next/src/instrumentation-client.ts
@@ -10,7 +10,10 @@
 // the PostHog wizard's separate root-level file was merged in here.
 import * as Sentry from '@sentry/nextjs';
 import posthog from 'posthog-js';
-import { isBenignClientError } from '@/lib/benignClientError';
+import {
+  hasOnlyForeignFrames,
+  isBenignClientError,
+} from '@/lib/benignClientError';
 
 posthog.init('phc_oPFKvUCGmpZdRPug7TvYDRRSZpJ9oUmLZphkjrSV3fCd', {
   // Managed first-party reverse proxy configured in Route 53.
@@ -34,9 +37,14 @@ Sentry.init({
   // Drop benign teardown noise — chiefly Firebase Analytics' IndexedDB
   // AbortErrors when the user navigates/reloads mid-transaction. The page
   // loads fine; these aren't actionable (mirrors the server-side
-  // self-healing-network filter in sentry.server.config.ts).
+  // self-healing-network filter in sentry.server.config.ts). Also drop
+  // exceptions whose stack never touches a named script — foreign injected
+  // code (see hasOnlyForeignFrames in benignClientError.ts).
   beforeSend(event, hint) {
     if (isBenignClientError(hint?.originalException)) {
+      return null;
+    }
+    if (hasOnlyForeignFrames(event)) {
       return null;
     }
     return event;

--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { isBenignClientError } from "./benignClientError";
+import { hasOnlyForeignFrames, isBenignClientError } from "./benignClientError";
 
 // Mimics a browser DOMException without depending on the DOM lib in tests.
 const domException = (message: string, name = "AbortError", code = 20) =>
@@ -207,6 +207,103 @@ describe("isBenignClientError", () => {
           "Converting circular structure to JSON\n    --> starting at object with constructor 'Object'\n    --- property 'self' closes the circle",
         ),
       ),
+    ).toBe(false);
+  });
+});
+
+// Builds a minimal Sentry error event carrying the given stack frames.
+const eventWithFrames = (
+  frames: Array<Record<string, unknown>>,
+): Parameters<typeof hasOnlyForeignFrames>[0] => ({
+  exception: { values: [{ stacktrace: { frames } }] },
+});
+
+describe("hasOnlyForeignFrames", () => {
+  // CREDITODDS-JAVASCRIPT-NEXTJS-18: stack overflow from the Google iOS
+  // app's in-page translator — one frame, no filename at all.
+  it("drops an exception whose only frame has no filename", () => {
+    expect(
+      hasOnlyForeignFrames(
+        eventWithFrames([{ function: "?", lineno: 189, in_app: true }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops frames whose filenames are anonymous/native placeholders", () => {
+    expect(
+      hasOnlyForeignFrames(
+        eventWithFrames([
+          { filename: "<anonymous>", function: "e" },
+          { filename: "[native code]", function: "forEach" },
+          { filename: "native", function: "map" },
+          { filename: "", function: "?" },
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps an exception once any frame names a real script", () => {
+    expect(
+      hasOnlyForeignFrames(
+        eventWithFrames([
+          { filename: "<anonymous>", function: "wrapper" },
+          {
+            filename: "https://creditodds.com/_next/static/chunks/abc123.js",
+            function: "handleCardApplyClick",
+          },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a frame resolvable via abs_path alone", () => {
+    expect(
+      hasOnlyForeignFrames(
+        eventWithFrames([
+          {
+            filename: "<anonymous>",
+            abs_path: "https://creditodds.com/_next/static/chunks/abc123.js",
+          },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps frame-less events (e.g. bare 'Script error.')", () => {
+    expect(hasOnlyForeignFrames(eventWithFrames([]))).toBe(false);
+    expect(hasOnlyForeignFrames({ exception: { values: [{}] } })).toBe(false);
+    expect(hasOnlyForeignFrames({ exception: { values: [] } })).toBe(false);
+  });
+
+  it("handles missing/malformed event shapes safely", () => {
+    expect(hasOnlyForeignFrames(null)).toBe(false);
+    expect(hasOnlyForeignFrames(undefined)).toBe(false);
+    expect(hasOnlyForeignFrames({})).toBe(false);
+    expect(hasOnlyForeignFrames({ exception: null })).toBe(false);
+    expect(
+      hasOnlyForeignFrames({ exception: { values: [null, { stacktrace: null }] } }),
+    ).toBe(false);
+  });
+
+  it("checks frames across all exception values in a chain", () => {
+    expect(
+      hasOnlyForeignFrames({
+        exception: {
+          values: [
+            { stacktrace: { frames: [{ filename: "<anonymous>" }] } },
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      "https://creditodds.com/_next/static/chunks/abc123.js",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
     ).toBe(false);
   });
 });

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -60,6 +60,9 @@
 //    there is nothing to fix on our side. Both substrings are required: a
 //    genuine circular-structure bug in our own code would not be walking a
 //    React fiber.
+//
+// Finally, hasOnlyForeignFrames (below) drops exceptions by stack shape rather
+// than message: every frame lacks a resolvable script URL. See its comment.
 const BENIGN_CLIENT_SIGNATURES = [
   'The transaction was aborted',
   'database connection is closing',
@@ -149,4 +152,73 @@ export function isBenignClientError(error: unknown): boolean {
     current = e.cause;
   }
   return false;
+}
+
+// Drops exceptions where no stack frame carries a resolvable script URL —
+// code that reached the page without ever loading a script we ship or could
+// even name (injected webview scripts, translated-page rewriters, extension
+// eval blobs). First instance: CREDITODDS-JAVASCRIPT-NEXTJS-18, a
+// "RangeError: Maximum call stack size exceeded" from the Google iOS app with
+// in-page translation active (clicked element was `a > font > font` — the
+// translator's text-node wrappers), whose entire stack was one frame with no
+// filename ("Line 189" of undefined). Nothing in the apply-click path
+// recurses, and without a single named frame there is nothing to symbolicate
+// or fix.
+//
+// Deliberately NOT matched on the message: "Maximum call stack size exceeded"
+// is exactly what a genuine infinite recursion in our own code would say, and
+// such a bug would carry frames pointing at our chunks, so it passes this
+// filter untouched. At least one frame is required — frame-less events
+// ("Script error." and friends) are a different shape and stay reportable.
+
+// Filenames browsers substitute when a frame has no real script URL.
+const FOREIGN_FRAME_FILENAMES = new Set([
+  '',
+  '<anonymous>',
+  'native',
+  '[native code]',
+  'undefined',
+]);
+
+interface FrameLike {
+  filename?: unknown;
+  abs_path?: unknown;
+}
+
+interface SentryEventLike {
+  exception?: {
+    values?: Array<{ stacktrace?: { frames?: unknown[] } | null } | null>;
+  } | null;
+}
+
+function isForeignFrame(frame: FrameLike): boolean {
+  for (const value of [frame.filename, frame.abs_path]) {
+    if (typeof value === 'string' && !FOREIGN_FRAME_FILENAMES.has(value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function hasOnlyForeignFrames(
+  event: SentryEventLike | null | undefined,
+): boolean {
+  const values = event?.exception?.values;
+  if (!Array.isArray(values)) return false;
+  let frameCount = 0;
+  for (const value of values) {
+    const frames = value?.stacktrace?.frames;
+    if (!Array.isArray(frames)) continue;
+    for (const frame of frames) {
+      frameCount++;
+      if (
+        frame != null &&
+        typeof frame === 'object' &&
+        !isForeignFrame(frame as FrameLike)
+      ) {
+        return false;
+      }
+    }
+  }
+  return frameCount > 0;
 }


### PR DESCRIPTION
## Summary
Adds a stack-shape filter to the Sentry client `beforeSend`: exceptions where **every** frame lacks a resolvable script URL (no `filename`/`abs_path`, or only `<anonymous>` / `native` / `[native code]` placeholders) are dropped as foreign injected code.

First instance: CREDITODDS-JAVASCRIPT-NEXTJS-18 — `RangeError: Maximum call stack size exceeded` on `/card/aaa-daily-advantage-visa-signature` from the Google iOS app with in-page translation active (clicked element was `a.cj-apply-btn > font > font`, the translator's text-node wrappers). Its whole stack was one frame with no filename; nothing in the apply-click path recurses.

## Why not filter on the message
"Maximum call stack size exceeded" is exactly what a genuine infinite recursion in our own code would say — and that bug would carry frames naming our chunks, so it passes this filter and still reports. Frame-less events (bare "Script error.") also still report; at least one frame is required to drop.

## Testing
- 7 new unit tests covering the NEXTJS-18 shape, placeholder filenames, `abs_path`-only resolution, frame-less events, malformed events, and chained exceptions (30 total pass)
- `tsc --noEmit` clean