### PR TITLE
Replace em dashes in the 87 new store intros

### DIFF
--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-05T22:02:17.706Z",
+  "generated_at": "2026-08-06T03:04:10.337Z",
   "count": 1043,
   "stores": [
     {
@@ -77,7 +77,7 @@
         "online_shopping"
       ],
       "website": "https://www.100percentpure.com",
-      "intro": "100% PURE built its clean-beauty reputation on fruit-pigmented makeup — color from actual fruit, cocoa, and tea rather than synthetic dyes — plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.\n\nClean-beauty carts respond well to an online category: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a restock to 5, and the brand's frequent gift-with-purchase promotions stack with whatever card you use.\n",
+      "intro": "100% PURE built its clean-beauty reputation on fruit-pigmented makeup (color from actual fruit, cocoa, and tea rather than synthetic dyes) plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.\n\nClean-beauty carts respond well to an online category: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a restock to 5, and the brand's frequent gift-with-purchase promotions stack with whatever card you use.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37229&trid=1552713.230391&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -353,7 +353,7 @@
         "select_clothing"
       ],
       "website": "https://www.aerosoles.com",
-      "intro": "Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s — its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.\n\nShoe orders sit comfortably in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both.\n",
+      "intro": "Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s. Its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.\n\nShoe orders sit comfortably in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9946&trid=1552713.175791&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -921,7 +921,7 @@
         "select_clothing"
       ],
       "website": "https://www.aninebing.com",
-      "intro": "ANINE BING bottles Scandinavian-meets-LA wardrobe staples — the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed — at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.\n\nAt this price tier the category margin is real money: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card still claws back a coffee's worth on every blazer.\n",
+      "intro": "ANINE BING bottles Scandinavian-meets-LA wardrobe staples (the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed) at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.\n\nAt this price tier the category margin is real money: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card still claws back a coffee's worth on every blazer.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46089&trid=1552713.203133&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -1844,7 +1844,7 @@
         "home_improvement"
       ],
       "website": "https://www.blendtec.com",
-      "intro": "Blendtec builds high-powered blenders in Utah — the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars — and famously ran the \"Will It Blend?\" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.\n\nA blender at this price point is a one-time considered purchase: Bank of America Customized Cash set to online shopping earns 3 percent, a Freedom Flex online-retail quarter can reach 5 percent, and flat 2 percent cards are the fallback if no category is live when yours dies mid-smoothie.\n",
+      "intro": "Blendtec builds high-powered blenders in Utah (the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars) and famously ran the \"Will It Blend?\" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.\n\nA blender at this price point is a one-time considered purchase: Bank of America Customized Cash set to online shopping earns 3 percent, a Freedom Flex online-retail quarter can reach 5 percent, and flat 2 percent cards are the fallback if no category is live when yours dies mid-smoothie.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.12057&trid=1552713.159184&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -1869,7 +1869,7 @@
         "online_shopping"
       ],
       "website": "https://www.blinkist.com",
-      "intro": "Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription — an online purchase, not a streaming service, so streaming credits and multipliers stay on the bench.\n\nA single annual charge favors whichever online category you have running: Bank of America Customized Cash set to online shopping earns 3 percent, and otherwise a flat 2 percent card like Citi Double Cash quietly does the job every year.\n",
+      "intro": "Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription (an online purchase, not a streaming service), so streaming credits and multipliers stay on the bench.\n\nA single annual charge favors whichever online category you have running: Bank of America Customized Cash set to online shopping earns 3 percent, and otherwise a flat 2 percent card like Citi Double Cash quietly does the job every year.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10732&trid=1552713.212952&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -2013,7 +2013,7 @@
         "online_shopping"
       ],
       "website": "https://www.hibobbie.com",
-      "intro": "Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase — not groceries — which changes which cards make sense.\n\nGrocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators — worth checking before optimizing card rewards.\n",
+      "intro": "Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase (not groceries), which changes which cards make sense.\n\nGrocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators; check that before optimizing card rewards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.33836&trid=1552713.249750&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -2208,7 +2208,7 @@
         "home_improvement"
       ],
       "website": "https://brinkshome.com",
-      "intro": "Brinks Home sells professionally monitored home-security systems — panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.\n\nNeither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on — security bundles are an easy few hundred dollars of qualifying spend.\n",
+      "intro": "Brinks Home sells professionally monitored home-security systems: panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.\n\nNeither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on; security bundles are an easy few hundred dollars of qualifying spend.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.41354&trid=1552713.247347&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -2253,7 +2253,7 @@
         "select_clothing"
       ],
       "website": "https://www.brunomagli.com",
-      "intro": "Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936 — cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.\n\nShoes at this tier reward a category match: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns a dependable 3 percent, and a flat 2 percent card on a pair of oxfords still returns enough for the shoe trees.\n",
+      "intro": "Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936: cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.\n\nShoes at this tier reward a category match: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns a dependable 3 percent, and a flat 2 percent card on a pair of oxfords still returns enough for the shoe trees.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18734&trid=1552713.216081&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -3116,7 +3116,7 @@
         "online_shopping"
       ],
       "website": "https://www.codecademy.com",
-      "intro": "Codecademy teaches programming through interactive browser-based courses, with free basics and a Pro subscription that unlocks career paths, projects, and certificates; it is now part of Skillsoft. Pro bills monthly or annually from codecademy.com and codes as an online education subscription.\n\nEducation subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends — worth asking before optimizing cents per dollar.\n",
+      "intro": "Codecademy teaches programming through interactive browser-based courses, with free basics and a Pro subscription that unlocks career paths, projects, and certificates; it is now part of Skillsoft. Pro bills monthly or annually from codecademy.com and codes as an online education subscription.\n\nEducation subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends; ask before optimizing cents per dollar.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9595&trid=1552713.209296&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -3453,7 +3453,7 @@
         "home_improvement"
       ],
       "website": "https://www.cubcadet.com",
-      "intro": "Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network — it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.\n\nA mower-sized charge deserves planning: it is ideal signup-bonus spend, and otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct. Buying the same machine through Home Depot or Lowe's instead can tap home-improvement category bonuses when you have one live.\n",
+      "intro": "Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network; it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.\n\nA mower-sized charge deserves planning: it is ideal signup-bonus spend, and otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct. Buying the same machine through Home Depot or Lowe's instead can tap home-improvement category bonuses when you have one live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9498&trid=1552713.212603&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -3710,7 +3710,7 @@
         "electronics_stores"
       ],
       "website": "https://www.denon.com",
-      "intro": "Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com — including refurbished receivers with full warranties — code as online electronics retail.\n\nReceiver upgrades are chunky spend, so aim a category at them: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is the steady 3 percent, and flat 2 percent cards cover the impulse subwoofer.\n",
+      "intro": "Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com (including refurbished receivers with full warranties) code as online electronics retail.\n\nReceiver upgrades are chunky spend, so aim a category at them: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is the steady 3 percent, and flat 2 percent cards cover the impulse subwoofer.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110005993&trid=1552713.228060&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -4415,7 +4415,7 @@
         "online_shopping"
       ],
       "website": "https://www.edx.org",
-      "intro": "edX hosts university-built online courses — MIT and Harvard founded it — spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.\n\nEducation charges sit outside consumer bonus categories, so treat them like any online purchase: Bank of America Customized Cash set to online shopping earns 3 percent on a certificate, flat 2 percent cards cover bigger program tuition without ceremony, and employer tuition-reimbursement programs frequently cover edX before rewards even enter the picture.\n",
+      "intro": "edX hosts university-built online courses (MIT and Harvard founded it) spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.\n\nEducation charges sit outside consumer bonus categories, so treat them like any online purchase: Bank of America Customized Cash set to online shopping earns 3 percent on a certificate, flat 2 percent cards cover bigger program tuition without ceremony, and employer tuition-reimbursement programs frequently cover edX before rewards even enter the picture.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.17728&trid=1552713.180112&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -4485,7 +4485,7 @@
         "online_shopping"
       ],
       "website": "https://www.elvie.com",
-      "intro": "Elvie makes discreet wearable breast pumps — the in-bra Elvie Pump and the value Stride line — plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.\n\nBefore optimizing rewards, exhaust the cheaper routes: Elvie pumps are frequently covered or subsidized through insurance DME suppliers and are broadly HSA/FSA-eligible. Paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a pump-sized purchase contributes meaningfully to a new card's signup-bonus minimum.\n",
+      "intro": "Elvie makes discreet wearable breast pumps (the in-bra Elvie Pump and the value Stride line) plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.\n\nBefore optimizing rewards, exhaust the cheaper routes: Elvie pumps are frequently covered or subsidized through insurance DME suppliers and are broadly HSA/FSA-eligible. Paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a pump-sized purchase contributes meaningfully to a new card's signup-bonus minimum.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.44020&trid=1552713.228006&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -4612,7 +4612,7 @@
         "travel"
       ],
       "website": "https://www.europcar.com",
-      "intro": "Europcar is one of Europe's largest car-rental networks, with counters across 130-plus countries; US travelers mostly meet it when booking European road trips, where its rates and one-way options frequently beat the American majors abroad. Rentals code as car rental agencies, squarely inside every travel category definition.\n\nCar rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry — genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.\n",
+      "intro": "Europcar is one of Europe's largest car-rental networks, with counters across 130-plus countries; US travelers mostly meet it when booking European road trips, where its rates and one-way options frequently beat the American majors abroad. Rentals code as car rental agencies, squarely inside every travel category definition.\n\nCar rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry, which is genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.5861&trid=1552713.189661&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -4628,7 +4628,7 @@
         "online_shopping"
       ],
       "website": "https://waxcenter.com",
-      "intro": "European Wax Center is the largest waxing-salon chain in the US, with over 1,000 franchised centers selling waxing services, the Wax Pass prepaid bundles, and its own skincare line. Charges are in-salon or prepaid packages booked through waxcenter.com and code as personal-care services.\n\nSalon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase — a few hundred dollars prepaid — into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.\n",
+      "intro": "European Wax Center is the largest waxing-salon chain in the US, with over 1,000 franchised centers selling waxing services, the Wax Pass prepaid bundles, and its own skincare line. Charges are in-salon or prepaid packages booked through waxcenter.com and code as personal-care services.\n\nSalon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase (a few hundred dollars prepaid) into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.30094&trid=1552713.245382&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -4946,7 +4946,7 @@
         "online_shopping"
       ],
       "website": "https://www.firstleaf.com",
-      "intro": "Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings — the algorithmic cousin of Naked Wines' funding model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.\n\nThat coding means grocery and dining multipliers stay quiet, and online categories do the work: Bank of America Customized Cash set to online shopping earns 3 percent per box, a Freedom Flex online-retail quarter can reach 5 percent on a stock-up order, and a flat 2 percent card suits the set-and-forget subscriber.\n",
+      "intro": "Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings. It is the algorithmic cousin of Naked Wines' model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.\n\nThat coding means grocery and dining multipliers stay quiet, and online categories do the work: Bank of America Customized Cash set to online shopping earns 3 percent per box, a Freedom Flex online-retail quarter can reach 5 percent on a stock-up order, and a flat 2 percent card suits the set-and-forget subscriber.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.38398&trid=1552713.249831&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5012,7 +5012,7 @@
         "online_shopping"
       ],
       "website": "https://www.shopflamingo.com",
-      "intro": "Flamingo is the women's body-care line from the team behind Harry's, selling razors, blade refills, and wax kits with the same design-forward, subscription-friendly model as its sibling brand. Orders and refill plans from shopflamingo.com code as online retail rather than drugstore purchases.\n\nThe card logic mirrors Harry's: direct subscriptions earn online-category rates — Bank of America Customized Cash set to online shopping pays 3 percent — while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.\n",
+      "intro": "Flamingo is the women's body-care line from the team behind Harry's, selling razors, blade refills, and wax kits with the same design-forward, subscription-friendly model as its sibling brand. Orders and refill plans from shopflamingo.com code as online retail rather than drugstore purchases.\n\nThe card logic mirrors Harry's: direct subscriptions earn online-category rates (Bank of America Customized Cash set to online shopping pays 3 percent) while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9412&trid=1552713.248795&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5173,7 +5173,7 @@
         "online_shopping"
       ],
       "website": "https://www.fragrancenet.com",
-      "intro": "FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes — plus skincare, haircare, and candles — at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.\n\nDiscount fragrance stacking works best with an online category on top: Bank of America Customized Cash set to online shopping adds 3 percent to already-marked-down bottles, rotating online-retail quarters push it to 5, and flat 2 percent cards handle gift-season hauls without planning.\n",
+      "intro": "FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes (plus skincare, haircare, and candles) at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.\n\nDiscount fragrance stacking works best with an online category on top: Bank of America Customized Cash set to online shopping adds 3 percent to already-marked-down bottles, rotating online-retail quarters push it to 5, and flat 2 percent cards handle gift-season hauls without planning.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.216&trid=1552713.455&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5205,7 +5205,7 @@
         "department_stores"
       ],
       "website": "https://www.francosarto.com",
-      "intro": "Franco Sarto delivers Italian-styled women's footwear — loafers, block heels, and knee boots — at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.\n\nFootwear categories cover the bases: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same styles through Macy's or DSW can catch department-store or rotating-category bonuses when live.\n",
+      "intro": "Franco Sarto delivers Italian-styled women's footwear (loafers, block heels, and knee boots) at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.\n\nFootwear categories cover the bases: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same styles through Macy's or DSW can catch department-store or rotating-category bonuses when live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41588&trid=1552713.178979&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5533,7 +5533,7 @@
         "online_shopping"
       ],
       "website": "https://www.gillette.com",
-      "intro": "Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor — the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.\n\nThat coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices — the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.\n",
+      "intro": "Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor, the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.\n\nThat coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices: the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23585&trid=1552713.196927&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5712,7 +5712,7 @@
         "secondhand_stores"
       ],
       "website": "https://www.grailed.com",
-      "intro": "Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout — the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.\n\nThat PayPal routing is the rewards angle: Chase Freedom Flex's recurring PayPal rotating quarters have historically covered Grailed checkouts at 5 percent, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card backstops off-quarter grail hunts.\n",
+      "intro": "Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout. It is the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.\n\nThat PayPal routing is the rewards angle: Chase Freedom Flex's recurring PayPal rotating quarters have historically covered Grailed checkouts at 5 percent, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card backstops off-quarter grail hunts.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13931&trid=1552713.227549&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5908,7 +5908,7 @@
         "online_shopping"
       ],
       "website": "https://www.hrblock.com",
-      "intro": "H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services — a category no consumer card bonuses.\n\nTwo angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution — paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.\n",
+      "intro": "H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services, a category no consumer card bonuses.\n\nTwo angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution: paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5683&trid=1552713.156923&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -6048,7 +6048,7 @@
         "online_shopping"
       ],
       "website": "https://www.healthlabs.com",
-      "intro": "HealthLabs sells direct-to-consumer lab testing — order a panel online, visit a local partner lab for the draw, and get results without a doctor's visit, the same model as Personalabs. The order is paid upfront on healthlabs.com and codes as an online health-services purchase, not a medical provider visit.\n\nLab panels are also commonly HSA/FSA-eligible, which beats any rewards rate — check that first. Paying by credit card, expect no medical category match; a flat 2 percent card or a Bank of America Customized Cash set to online shopping at 3 percent are the practical options.\n",
+      "intro": "HealthLabs sells direct-to-consumer lab testing: order a panel online, visit a local partner lab for the draw, and get results without a doctor's visit. It is the same model as Personalabs. The order is paid upfront on healthlabs.com and codes as an online health-services purchase, not a medical provider visit.\n\nLab panels are also commonly HSA/FSA-eligible, which beats any rewards rate; check that first. Paying by credit card, expect no medical category match; a flat 2 percent card or a Bank of America Customized Cash set to online shopping at 3 percent are the practical options.\n",
       "affiliate": {
         "url": "https://www.jdoqocy.com/click-101737824-13703022",
         "network": "cj"
@@ -6352,7 +6352,7 @@
         "sporting_goods"
       ],
       "website": "https://www.horizonfitness.com",
-      "intro": "Horizon Fitness sells home treadmills, ellipticals, and exercise bikes — the value-focused sibling brand of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.\n\nBig fitness equipment is prime signup-bonus spend, clearing most minimums in one order. Otherwise, U.S. Bank Cash+ with sporting goods stores selected can pay 5 percent when the charge classifies that way, and Bank of America Customized Cash set to online shopping is the reliable 3 percent.\n",
+      "intro": "Horizon Fitness sells home treadmills, ellipticals, and exercise bikes. It is the value-focused sibling of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.\n\nBig fitness equipment is prime signup-bonus spend, clearing most minimums in one order. Otherwise, U.S. Bank Cash+ with sporting goods stores selected can pay 5 percent when the charge classifies that way, and Bank of America Customized Cash set to online shopping is the reliable 3 percent.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12130&trid=1552713.196086&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -6516,7 +6516,7 @@
         "home_improvement"
       ],
       "website": "https://www.hunterfan.com",
-      "intro": "Hunter has been making ceiling fans since 1886 and remains the name most Americans reach for when a room needs one, now spanning smart fans, outdoor-rated models, and the Casablanca premium line. Direct orders from hunterfan.com code as online retail rather than a hardware-store purchase.\n\nA fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there — worth a price check both ways.\n",
+      "intro": "Hunter has been making ceiling fans since 1886 and remains the name most Americans reach for when a room needs one, now spanning smart fans, outdoor-rated models, and the Casablanca premium line. Direct orders from hunterfan.com code as online retail rather than a hardware-store purchase.\n\nA fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there; price it both ways.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46207&trid=1552713.225483&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -6719,7 +6719,7 @@
         "electronics_stores"
       ],
       "website": "https://www.insta360.com",
-      "intro": "Insta360 makes the leading 360-degree action cameras — the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras — sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.\n\nCamera kits with mounts and accessories climb in price quickly, which suits an electronics category: U.S. Bank Cash+ set to electronics stores can return 5 percent when the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card covers accessory top-ups.\n",
+      "intro": "Insta360 makes the leading 360-degree action cameras (the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras) sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.\n\nCamera kits with mounts and accessories climb in price quickly, which suits an electronics category: U.S. Bank Cash+ set to electronics stores can return 5 percent when the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card covers accessory top-ups.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.46233&trid=1552713.248756&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -6746,7 +6746,7 @@
         "select_clothing"
       ],
       "website": "https://us.intimissimi.com",
-      "intro": "Intimissimi is the Italian lingerie chain — silk-and-lace bralettes, modal sleepwear, and seamless basics — that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.\n\nLingerie restocks fit apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 5-for deals on basics reward consolidating a haul onto whichever is live.\n",
+      "intro": "Intimissimi is the Italian lingerie chain (silk-and-lace bralettes, modal sleepwear, and seamless basics) that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.\n\nLingerie restocks fit apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 5-for deals on basics reward consolidating a haul onto whichever is live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41274&trid=1552713.189853&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -7317,7 +7317,7 @@
         "entertainment"
       ],
       "website": "https://www.klook.com",
-      "intro": "Klook is a travel-activities marketplace strongest in Asia — theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours — often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.\n\nActivity bookings are travel spend most cards recognize: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X's 2x applies everywhere including the odd booking that codes as ticketing instead. Klook runs frequent promo-code sales, so stack a discount with the multiplier rather than choosing between them.\n",
+      "intro": "Klook is a travel-activities marketplace strongest in Asia (theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours) often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.\n\nActivity bookings are travel spend most cards recognize: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X's 2x applies everywhere including the odd booking that codes as ticketing instead. Klook runs frequent promo-code sales, so stack a discount with the multiplier rather than choosing between them.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110006163&trid=1552713.230405&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -7335,7 +7335,7 @@
         "vacation_rentals"
       ],
       "website": "https://koa.com",
-      "intro": "KOA — Kampgrounds of America — runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.\n\nTravel cards are the natural fit: Chase Sapphire Preferred and Reserve count campground stays in their travel multipliers, Capital One Venture X earns its flat 2x everywhere, and annual-fee travel credits like the Sapphire Reserve's have been reported to apply to campground charges. KOA Rewards stacks on top regardless of card.\n",
+      "intro": "KOA (Kampgrounds of America) runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.\n\nTravel cards are the natural fit: Chase Sapphire Preferred and Reserve count campground stays in their travel multipliers, Capital One Venture X earns its flat 2x everywhere, and annual-fee travel credits like the Sapphire Reserve's have been reported to apply to campground charges. KOA Rewards stacks on top regardless of card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50482&trid=1552713.235147&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -7740,7 +7740,7 @@
         "sporting_goods"
       ],
       "website": "https://www.lifefitness.com",
-      "intro": "Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use — treadmills, ellipticals, bikes, and the Hammer Strength line — at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.\n\nPurchases this size are textbook signup-bonus spend, often clearing an entire minimum in one order. Absent a new card, U.S. Bank Cash+ with sporting goods selected can hit 5 percent where the charge classifies that way, with Bank of America Customized Cash's online shopping choice a dependable 3 percent.\n",
+      "intro": "Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use (treadmills, ellipticals, bikes, and the Hammer Strength line) at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.\n\nPurchases this size are textbook signup-bonus spend, often clearing an entire minimum in one order. Absent a new card, U.S. Bank Cash+ with sporting goods selected can hit 5 percent where the charge classifies that way, with Bank of America Customized Cash's online shopping choice a dependable 3 percent.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.17731&trid=1552713.189439&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -8205,7 +8205,7 @@
         "department_stores"
       ],
       "website": "https://www.makeupforever.com",
-      "intro": "Make Up For Ever is the LVMH-owned professional makeup house famous for the HD Skin foundation range, Aqua Resist liners, and artist-grade palettes born from its Paris pro heritage. US orders from makeupforever.com code as online beauty retail; the brand also sells through Sephora.\n\nDirect orders suit an online category — Bank of America Customized Cash set to online shopping earns 3 percent — while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.\n",
+      "intro": "Make Up For Ever is the LVMH-owned professional makeup house famous for the HD Skin foundation range, Aqua Resist liners, and artist-grade palettes born from its Paris pro heritage. US orders from makeupforever.com code as online beauty retail; the brand also sells through Sephora.\n\nDirect orders suit an online category (Bank of America Customized Cash set to online shopping earns 3 percent) while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.54284&trid=1552713.209548&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -8866,7 +8866,7 @@
         "dining"
       ],
       "website": "https://www.mrsfields.com",
-      "intro": "Mrs. Fields turned mall-kiosk chocolate-chip cookies into a national gifting business: tins, cookie cakes, and corporate gift baskets shipped nationwide from mrsfields.com, alongside its remaining bakery locations. Online gift orders code as internet retail or specialty food, while in-person bakery purchases can code as dining or fast food.\n\nFor shipped gifts, an online category does the work — Bank of America Customized Cash set to online shopping earns 3 percent — while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.\n",
+      "intro": "Mrs. Fields turned mall-kiosk chocolate-chip cookies into a national gifting business: tins, cookie cakes, and corporate gift baskets shipped nationwide from mrsfields.com, alongside its remaining bakery locations. Online gift orders code as internet retail or specialty food, while in-person bakery purchases can code as dining or fast food.\n\nFor shipped gifts, an online category does the work (Bank of America Customized Cash set to online shopping earns 3 percent) while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.7935&trid=1552713.158847&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -8927,7 +8927,7 @@
         "sporting_goods"
       ],
       "website": "https://www.nalgene.com",
-      "intro": "Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders — including the popular custom-printing option — ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.\n\nBottles are small-ticket, so rewards are more about which card is already in hand: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ sporting goods quarter can catch a team order at 5 percent, and REI stock of the same bottles earns REI-specific card bonuses instead.\n",
+      "intro": "Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders (including the popular custom-printing option) ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.\n\nBottles are small-ticket, so rewards are more about which card is already in hand: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ sporting goods quarter can catch a team order at 5 percent, and REI stock of the same bottles earns REI-specific card bonuses instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12848&trid=1552713.226006&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -9015,7 +9015,7 @@
         "department_stores"
       ],
       "website": "https://www.naturalizer.com",
-      "intro": "Naturalizer has sold comfort-first women's footwear since 1927 — pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.\n\nFootwear reliably lands in apparel categories: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the merchant classifies as apparel or shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and the same styles at Macy's or Nordstrom can pick up department-store bonuses when one is live.\n",
+      "intro": "Naturalizer has sold comfort-first women's footwear since 1927: pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.\n\nFootwear reliably lands in apparel categories: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the merchant classifies as apparel or shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and the same styles at Macy's or Nordstrom can pick up department-store bonuses when one is live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38505&trid=1552713.158953&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -9362,7 +9362,7 @@
         "department_stores"
       ],
       "website": "https://www.olehenriksen.com",
-      "intro": "Ole Henriksen bottles Scandinavian glow-first skincare — Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners — born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.\n\nDirect restocks favor an online category — Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5 — while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.\n",
+      "intro": "Ole Henriksen bottles Scandinavian glow-first skincare (Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners) born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.\n\nDirect restocks favor an online category (Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5) while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38834&trid=1552713.159748&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10003,7 +10003,7 @@
         "online_shopping"
       ],
       "website": "https://www.pgatoursuperstore.com",
-      "intro": "PGA TOUR Superstore is the big-box golf retailer — clubs, balls, apparel, launch-monitor fittings, and in-store simulators — with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.\n\nGolf spend adds up fast, and sporting-goods coverage is unusually good: U.S. Bank Cash+ with sporting goods stores selected pays 5 percent, rotating quarters occasionally cover the category too, and a driver-and-iron-set fitting bill makes clean signup-bonus spend. Bank of America Customized Cash's online shopping choice covers web orders at 3 percent.\n",
+      "intro": "PGA TOUR Superstore is the big-box golf retailer (clubs, balls, apparel, launch-monitor fittings, and in-store simulators) with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.\n\nGolf spend adds up fast, and sporting-goods coverage is unusually good: U.S. Bank Cash+ with sporting goods stores selected pays 5 percent, rotating quarters occasionally cover the category too, and a driver-and-iron-set fitting bill makes clean signup-bonus spend. Bank of America Customized Cash's online shopping choice covers web orders at 3 percent.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16839&trid=1552713.228946&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10062,7 +10062,7 @@
         "department_stores"
       ],
       "website": "https://www.philosophy.com",
-      "intro": "Philosophy is the feel-good skincare and bath brand behind Purity Made Simple cleanser, Hope in a Jar moisturizer, and the dessert-scented Amazing Grace shower gels, sold direct and through Ulta, Sephora, and department stores. Orders from philosophy.com code as online beauty retail.\n\nRoutine restocks favor an online category — Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5 — while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.\n",
+      "intro": "Philosophy is the feel-good skincare and bath brand behind Purity Made Simple cleanser, Hope in a Jar moisturizer, and the dessert-scented Amazing Grace shower gels, sold direct and through Ulta, Sephora, and department stores. Orders from philosophy.com code as online beauty retail.\n\nRoutine restocks favor an online category (Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5) while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50295&trid=1552713.169070&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10102,7 +10102,7 @@
         "online_shopping"
       ],
       "website": "https://www.physiciansformula.com",
-      "intro": "Physicians Formula has sold hypoallergenic drugstore makeup since 1937 — Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.\n\nThe drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter — Chase Freedom Flex has covered drugstores repeatedly — at 5 percent. Price-match against drugstore sales before ordering direct.\n",
+      "intro": "Physicians Formula has sold hypoallergenic drugstore makeup since 1937: Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.\n\nThe drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter (Chase Freedom Flex has covered drugstores repeatedly) at 5 percent. Price-match against drugstore sales before ordering direct.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43735&trid=1552713.247447&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10141,7 +10141,7 @@
         "home_improvement"
       ],
       "website": "https://pitboss-grills.com",
-      "intro": "Pit Boss is the value heavyweight of pellet grilling — bigger hoppers and lower prices than Traeger — spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.\n\nA grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories — compare, since Pit Boss runs aggressive direct-only bundle deals.\n",
+      "intro": "Pit Boss is the value heavyweight of pellet grilling (bigger hoppers and lower prices than Traeger) spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.\n\nA grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories; compare before buying, since Pit Boss runs aggressive direct-only bundle deals.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10421&trid=1552713.213540&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10977,7 +10977,7 @@
         "online_shopping"
       ],
       "website": "https://www.rocskincare.com",
-      "intro": "RoC pioneered stabilized retinol in drugstore skincare and remains the evidence-first pick for anti-aging staples like Retinol Correxion and the Multi Correxion vitamin-C line. Buying direct from rocskincare.com codes as online retail; the same products also sit on Walgreens, CVS, and Amazon shelves.\n\nDirect orders fit an online category — Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more — while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.\n",
+      "intro": "RoC pioneered stabilized retinol in drugstore skincare and remains the evidence-first pick for anti-aging staples like Retinol Correxion and the Multi Correxion vitamin-C line. Buying direct from rocskincare.com codes as online retail; the same products also sit on Walgreens, CVS, and Amazon shelves.\n\nDirect orders fit an online category (Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more) while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46883&trid=1552713.225417&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -11454,7 +11454,7 @@
         "electronics_stores"
       ],
       "website": "https://www.sennheiser.com",
-      "intro": "Sennheiser's consumer line — Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers — carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.\n\nHeadphone purchases in the $200–$400 band reward a live category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is a solid 3 percent, and open-box HD 6XX-adjacent deals on a flat 2 percent card still come out well.\n",
+      "intro": "Sennheiser's consumer line (Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers) carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.\n\nHeadphone purchases in the $200–$400 band reward a live category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is a solid 3 percent, and open-box HD 6XX-adjacent deals on a flat 2 percent card still come out well.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42592&trid=1552713.193918&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -12095,7 +12095,7 @@
         "online_shopping"
       ],
       "website": "https://www.spirithalloween.com",
-      "intro": "Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round — including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.\n\nCostume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter — which has historically covered Q4 — can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.\n",
+      "intro": "Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round, including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.\n\nCostume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter (which has historically covered Q4) can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8099&trid=1552713.161081&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -12244,7 +12244,7 @@
         "electronics_stores"
       ],
       "website": "https://steelseries.com",
-      "intro": "SteelSeries builds gaming peripherals — the Arctis headset line, Apex keyboards, Rival and Aerox mice, and QcK mousepads — sold direct from steelseries.com alongside retail channels. Direct orders code as online electronics retail and are where the brand runs its own refurb and bundle pricing.\n\nPeripheral refreshes are classic electronics-category spend: U.S. Bank Cash+ with electronics stores selected can hit 5 percent when the merchant classifies that way, Bank of America Customized Cash set to online shopping earns 3 percent, and PayPal-heavy checkout flows occasionally line up with a Chase Freedom Flex quarter.\n",
+      "intro": "SteelSeries builds gaming peripherals (the Arctis headset line, Apex keyboards, Rival and Aerox mice, and QcK mousepads) sold direct from steelseries.com alongside retail channels. Direct orders code as online electronics retail and are where the brand runs its own refurb and bundle pricing.\n\nPeripheral refreshes are classic electronics-category spend: U.S. Bank Cash+ with electronics stores selected can hit 5 percent when the merchant classifies that way, Bank of America Customized Cash set to online shopping earns 3 percent, and PayPal-heavy checkout flows occasionally line up with a Chase Freedom Flex quarter.\n",
       "affiliate": {
         "url": "https://www.tkqlhce.com/click-101737824-17028016",
         "network": "cj"
@@ -12452,7 +12452,7 @@
         "select_clothing"
       ],
       "website": "https://www.superdry.com",
-      "intro": "Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding — best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.\n\nApparel categories cover it: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both on a jacket-sized order.\n",
+      "intro": "Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding, best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.\n\nApparel categories cover it: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both on a jacket-sized order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.44521&trid=1552713.209552&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -12905,7 +12905,7 @@
         "travel"
       ],
       "website": "https://www.theparkingspot.com",
-      "intro": "The Parking Spot is the largest near-airport parking operator in the US, with covered and uncovered lots plus shuttle service at 25-plus airports, booked ahead on theparkingspot.com for member rates through its Spot Club program. Airport parking charges typically code as parking or travel merchants.\n\nParking spend near airports frequently counts toward travel multipliers — Chase Sapphire Preferred and Reserve both include parking in their travel definitions — and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.\n",
+      "intro": "The Parking Spot is the largest near-airport parking operator in the US, with covered and uncovered lots plus shuttle service at 25-plus airports, booked ahead on theparkingspot.com for member rates through its Spot Club program. Airport parking charges typically code as parking or travel merchants.\n\nParking spend near airports frequently counts toward travel multipliers (Chase Sapphire Preferred and Reserve both include parking in their travel definitions) and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10415&trid=1552713.211617&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -12960,7 +12960,7 @@
         "department_stores"
       ],
       "website": "https://www.theory.com",
-      "intro": "Theory built its name on precisely tailored workwear fundamentals — the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe — under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.\n\nSuiting-level price tags make categories worthwhile: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store bonuses apply when you shop Theory through Nordstrom instead.\n",
+      "intro": "Theory built its name on precisely tailored workwear fundamentals (the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe) under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.\n\nSuiting-level price tags make categories worthwhile: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store bonuses apply when you shop Theory through Nordstrom instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36186&trid=1552713.202068&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13384,7 +13384,7 @@
         "home_improvement"
       ],
       "website": "https://www.troybilt.com",
-      "intro": "Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points — corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.\n\nOutdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live — price both before buying.\n",
+      "intro": "Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points, corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.\n\nOutdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live; price both before buying.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9368&trid=1552713.203841&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13707,7 +13707,7 @@
         "entertainment"
       ],
       "website": "https://www.vegas.com",
-      "intro": "Vegas.com packages the whole Las Vegas trip — hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles — as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.\n\nOTA bookings are travel spend to most issuers: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X covers whatever coding comes back at 2x. One trade-off to know: booking through an OTA usually forfeits hotel-program elite credit, so weigh the bundle discount against booking the room direct.\n",
+      "intro": "Vegas.com packages the whole Las Vegas trip (hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles) as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.\n\nOTA bookings are travel spend to most issuers: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X covers whatever coding comes back at 2x. One trade-off to know: booking through an OTA usually forfeits hotel-program elite credit, so weigh the bundle discount against booking the room direct.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.4221&trid=1552713.159075&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13752,7 +13752,7 @@
         "online_shopping"
       ],
       "website": "https://versedskin.com",
-      "intro": "Versed distills clean-clinical skincare into sub-$25 staples — Dew Point moisturizer, the Auto Save retinol line, and single-minded serums — born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.\n\nThe Target-versus-direct choice drives rewards: direct earns online-category rates like Bank of America Customized Cash's 3 percent online shopping selection, while Target runs earn RedCard savings or Target-category promos. Direct-exclusive bundles and sets are usually the reason to order from the brand itself.\n",
+      "intro": "Versed distills clean-clinical skincare into sub-$25 staples (Dew Point moisturizer, the Auto Save retinol line, and single-minded serums) born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.\n\nThe Target-versus-direct choice drives rewards: direct earns online-category rates like Bank of America Customized Cash's 3 percent online shopping selection, while Target runs earn RedCard savings or Target-category promos. Direct-exclusive bundles and sets are usually the reason to order from the brand itself.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9474&trid=1552713.211622&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13810,7 +13810,7 @@
         "electronics_stores"
       ],
       "website": "https://victrola.com",
-      "intro": "Victrola revived the century-old phonograph name into the best-selling entry point for vinyl — suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.\n\nTurntable purchases fit neatly under an electronics selection: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a suitcase-player gift on a flat 2 percent card needs no planning at all.\n",
+      "intro": "Victrola revived the century-old phonograph name into the best-selling entry point for vinyl: suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.\n\nTurntable purchases fit neatly under an electronics selection: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a suitcase-player gift on a flat 2 percent card needs no planning at all.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18889&trid=1552713.207542&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13950,7 +13950,7 @@
         "home_improvement"
       ],
       "website": "https://www.vivint.com",
-      "intro": "Vivint sells professionally installed smart-home security — doorbell and outdoor cameras, smart locks, and thermostats wired into one app — with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.\n\nMonitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus — a full system easily covers a minimum-spend requirement in one go.\n",
+      "intro": "Vivint sells professionally installed smart-home security (doorbell and outdoor cameras, smart locks, and thermostats wired into one app) with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.\n\nMonitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus; a full system easily covers a minimum-spend requirement in one go.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.21822&trid=1552713.225643&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -14252,7 +14252,7 @@
         "online_shopping"
       ],
       "website": "https://www.wetnwildbeauty.com",
-      "intro": "Wet n Wild is the drugstore-beauty value icon — MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.\n\nAt these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent — the drugstore route usually wins when those are live.\n",
+      "intro": "Wet n Wild is the drugstore-beauty value icon: MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, all under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.\n\nAt these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent; the drugstore route usually wins when those are live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43590&trid=1552713.201598&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -14506,7 +14506,7 @@
         "electronics_stores"
       ],
       "website": "https://www.wyze.com",
-      "intro": "Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home — cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.\n\nWyze orders are frequent and small, which favors an always-on category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent on both hardware and Cam Plus renewals, and flat 2 percent covers the impulse camera.\n",
+      "intro": "Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home: cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.\n\nWyze orders are frequent and small, which favors an always-on category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent on both hardware and Cam Plus renewals, and flat 2 percent covers the impulse camera.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.27209&trid=1552713.249672&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -14535,7 +14535,7 @@
         "home_improvement"
       ],
       "website": "https://shopyalehome.com",
-      "intro": "Yale has made locks since 1840, and Yale Home is its smart-lock arm — the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa, sharing corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.\n\nA smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively — whichever category you have live decides the store.\n",
+      "intro": "Yale has made locks since 1840, and Yale Home is its smart-lock arm: the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa. It shares corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.\n\nA smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively; whichever category you have live decides the store.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37641&trid=1552713.247667&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -14557,7 +14557,7 @@
         "online_shopping"
       ],
       "website": "https://www.yarnspirations.com",
-      "intro": "Yarnspirations is the official online home of the big craft-yarn brands — Caron, Bernat, Red Heart, Patons, and Lily Sugar'n Cream — plus thousands of free knitting and crochet patterns. Unlike a Michaels or JOANN run, Yarnspirations orders ship direct and code as online retail rather than a craft-store purchase.\n\nStock-up orders during clearance events are where the money goes, so route them through an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter can lift a big cart to 5 percent.\n",
+      "intro": "Yarnspirations is the official online home of the big craft-yarn brands (Caron, Bernat, Red Heart, Patons, and Lily Sugar'n Cream) plus thousands of free knitting and crochet patterns. Unlike a Michaels or JOANN run, Yarnspirations orders ship direct and code as online retail rather than a craft-store purchase.\n\nStock-up orders during clearance events are where the money goes, so route them through an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter can lift a big cart to 5 percent.\n",
       "affiliate": {
         "url": "https://www.tkqlhce.com/click-101737824-13781226",
         "network": "cj"
@@ -14653,7 +14653,7 @@
         "online_shopping"
       ],
       "website": "https://www.zinio.com",
-      "intro": "Zinio is the largest digital newsstand, selling single issues and annual subscriptions to thousands of magazines readable across its apps, in the same digital-reading niche as Magzter. Subscriptions bill through zinio.com and code as an online digital purchase — notably not as a streaming service, so streaming-bundle credits will not apply.\n\nMagazine subscriptions are small recurring charges, ideal for a set-and-forget card: a flat 2 percent earner covers renewals without thought, while Bank of America Customized Cash set to online shopping stretches them to 3 percent.\n",
+      "intro": "Zinio is the largest digital newsstand, selling single issues and annual subscriptions to thousands of magazines readable across its apps, in the same digital-reading niche as Magzter. Subscriptions bill through zinio.com and code as an online digital purchase (not a streaming service), so streaming-bundle credits will not apply.\n\nMagazine subscriptions are small recurring charges, ideal for a set-and-forget card: a flat 2 percent earner covers renewals without thought, while Bank of America Customized Cash set to online shopping stretches them to 3 percent.\n",
       "affiliate": {
         "url": "https://www.dpbolvw.net/click-101737824-17177799",
         "network": "cj"

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-05T22:02:17.706Z",
+  "generated_at": "2026-08-06T03:04:10.337Z",
   "count": 1043,
   "stores": [
     {
@@ -77,7 +77,7 @@
         "online_shopping"
       ],
       "website": "https://www.100percentpure.com",
-      "intro": "100% PURE built its clean-beauty reputation on fruit-pigmented makeup — color from actual fruit, cocoa, and tea rather than synthetic dyes — plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.\n\nClean-beauty carts respond well to an online category: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a restock to 5, and the brand's frequent gift-with-purchase promotions stack with whatever card you use.\n",
+      "intro": "100% PURE built its clean-beauty reputation on fruit-pigmented makeup (color from actual fruit, cocoa, and tea rather than synthetic dyes) plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.\n\nClean-beauty carts respond well to an online category: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a restock to 5, and the brand's frequent gift-with-purchase promotions stack with whatever card you use.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37229&trid=1552713.230391&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -353,7 +353,7 @@
         "select_clothing"
       ],
       "website": "https://www.aerosoles.com",
-      "intro": "Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s — its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.\n\nShoe orders sit comfortably in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both.\n",
+      "intro": "Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s. Its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.\n\nShoe orders sit comfortably in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9946&trid=1552713.175791&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -921,7 +921,7 @@
         "select_clothing"
       ],
       "website": "https://www.aninebing.com",
-      "intro": "ANINE BING bottles Scandinavian-meets-LA wardrobe staples — the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed — at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.\n\nAt this price tier the category margin is real money: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card still claws back a coffee's worth on every blazer.\n",
+      "intro": "ANINE BING bottles Scandinavian-meets-LA wardrobe staples (the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed) at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.\n\nAt this price tier the category margin is real money: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card still claws back a coffee's worth on every blazer.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46089&trid=1552713.203133&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -1844,7 +1844,7 @@
         "home_improvement"
       ],
       "website": "https://www.blendtec.com",
-      "intro": "Blendtec builds high-powered blenders in Utah — the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars — and famously ran the \"Will It Blend?\" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.\n\nA blender at this price point is a one-time considered purchase: Bank of America Customized Cash set to online shopping earns 3 percent, a Freedom Flex online-retail quarter can reach 5 percent, and flat 2 percent cards are the fallback if no category is live when yours dies mid-smoothie.\n",
+      "intro": "Blendtec builds high-powered blenders in Utah (the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars) and famously ran the \"Will It Blend?\" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.\n\nA blender at this price point is a one-time considered purchase: Bank of America Customized Cash set to online shopping earns 3 percent, a Freedom Flex online-retail quarter can reach 5 percent, and flat 2 percent cards are the fallback if no category is live when yours dies mid-smoothie.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156099.12057&trid=1552713.159184&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -1869,7 +1869,7 @@
         "online_shopping"
       ],
       "website": "https://www.blinkist.com",
-      "intro": "Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription — an online purchase, not a streaming service, so streaming credits and multipliers stay on the bench.\n\nA single annual charge favors whichever online category you have running: Bank of America Customized Cash set to online shopping earns 3 percent, and otherwise a flat 2 percent card like Citi Double Cash quietly does the job every year.\n",
+      "intro": "Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription (an online purchase, not a streaming service), so streaming credits and multipliers stay on the bench.\n\nA single annual charge favors whichever online category you have running: Bank of America Customized Cash set to online shopping earns 3 percent, and otherwise a flat 2 percent card like Citi Double Cash quietly does the job every year.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10732&trid=1552713.212952&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -2013,7 +2013,7 @@
         "online_shopping"
       ],
       "website": "https://www.hibobbie.com",
-      "intro": "Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase — not groceries — which changes which cards make sense.\n\nGrocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators — worth checking before optimizing card rewards.\n",
+      "intro": "Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase (not groceries), which changes which cards make sense.\n\nGrocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators; check that before optimizing card rewards.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.33836&trid=1552713.249750&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -2208,7 +2208,7 @@
         "home_improvement"
       ],
       "website": "https://brinkshome.com",
-      "intro": "Brinks Home sells professionally monitored home-security systems — panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.\n\nNeither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on — security bundles are an easy few hundred dollars of qualifying spend.\n",
+      "intro": "Brinks Home sells professionally monitored home-security systems: panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.\n\nNeither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on; security bundles are an easy few hundred dollars of qualifying spend.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.41354&trid=1552713.247347&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -2253,7 +2253,7 @@
         "select_clothing"
       ],
       "website": "https://www.brunomagli.com",
-      "intro": "Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936 — cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.\n\nShoes at this tier reward a category match: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns a dependable 3 percent, and a flat 2 percent card on a pair of oxfords still returns enough for the shoe trees.\n",
+      "intro": "Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936: cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.\n\nShoes at this tier reward a category match: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns a dependable 3 percent, and a flat 2 percent card on a pair of oxfords still returns enough for the shoe trees.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18734&trid=1552713.216081&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -3116,7 +3116,7 @@
         "online_shopping"
       ],
       "website": "https://www.codecademy.com",
-      "intro": "Codecademy teaches programming through interactive browser-based courses, with free basics and a Pro subscription that unlocks career paths, projects, and certificates; it is now part of Skillsoft. Pro bills monthly or annually from codecademy.com and codes as an online education subscription.\n\nEducation subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends — worth asking before optimizing cents per dollar.\n",
+      "intro": "Codecademy teaches programming through interactive browser-based courses, with free basics and a Pro subscription that unlocks career paths, projects, and certificates; it is now part of Skillsoft. Pro bills monthly or annually from codecademy.com and codes as an online education subscription.\n\nEducation subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends; ask before optimizing cents per dollar.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9595&trid=1552713.209296&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -3453,7 +3453,7 @@
         "home_improvement"
       ],
       "website": "https://www.cubcadet.com",
-      "intro": "Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network — it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.\n\nA mower-sized charge deserves planning: it is ideal signup-bonus spend, and otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct. Buying the same machine through Home Depot or Lowe's instead can tap home-improvement category bonuses when you have one live.\n",
+      "intro": "Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network; it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.\n\nA mower-sized charge deserves planning: it is ideal signup-bonus spend, and otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct. Buying the same machine through Home Depot or Lowe's instead can tap home-improvement category bonuses when you have one live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9498&trid=1552713.212603&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -3710,7 +3710,7 @@
         "electronics_stores"
       ],
       "website": "https://www.denon.com",
-      "intro": "Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com — including refurbished receivers with full warranties — code as online electronics retail.\n\nReceiver upgrades are chunky spend, so aim a category at them: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is the steady 3 percent, and flat 2 percent cards cover the impulse subwoofer.\n",
+      "intro": "Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com (including refurbished receivers with full warranties) code as online electronics retail.\n\nReceiver upgrades are chunky spend, so aim a category at them: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is the steady 3 percent, and flat 2 percent cards cover the impulse subwoofer.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110005993&trid=1552713.228060&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -4415,7 +4415,7 @@
         "online_shopping"
       ],
       "website": "https://www.edx.org",
-      "intro": "edX hosts university-built online courses — MIT and Harvard founded it — spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.\n\nEducation charges sit outside consumer bonus categories, so treat them like any online purchase: Bank of America Customized Cash set to online shopping earns 3 percent on a certificate, flat 2 percent cards cover bigger program tuition without ceremony, and employer tuition-reimbursement programs frequently cover edX before rewards even enter the picture.\n",
+      "intro": "edX hosts university-built online courses (MIT and Harvard founded it) spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.\n\nEducation charges sit outside consumer bonus categories, so treat them like any online purchase: Bank of America Customized Cash set to online shopping earns 3 percent on a certificate, flat 2 percent cards cover bigger program tuition without ceremony, and employer tuition-reimbursement programs frequently cover edX before rewards even enter the picture.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.17728&trid=1552713.180112&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -4485,7 +4485,7 @@
         "online_shopping"
       ],
       "website": "https://www.elvie.com",
-      "intro": "Elvie makes discreet wearable breast pumps — the in-bra Elvie Pump and the value Stride line — plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.\n\nBefore optimizing rewards, exhaust the cheaper routes: Elvie pumps are frequently covered or subsidized through insurance DME suppliers and are broadly HSA/FSA-eligible. Paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a pump-sized purchase contributes meaningfully to a new card's signup-bonus minimum.\n",
+      "intro": "Elvie makes discreet wearable breast pumps (the in-bra Elvie Pump and the value Stride line) plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.\n\nBefore optimizing rewards, exhaust the cheaper routes: Elvie pumps are frequently covered or subsidized through insurance DME suppliers and are broadly HSA/FSA-eligible. Paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a pump-sized purchase contributes meaningfully to a new card's signup-bonus minimum.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.44020&trid=1552713.228006&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -4612,7 +4612,7 @@
         "travel"
       ],
       "website": "https://www.europcar.com",
-      "intro": "Europcar is one of Europe's largest car-rental networks, with counters across 130-plus countries; US travelers mostly meet it when booking European road trips, where its rates and one-way options frequently beat the American majors abroad. Rentals code as car rental agencies, squarely inside every travel category definition.\n\nCar rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry — genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.\n",
+      "intro": "Europcar is one of Europe's largest car-rental networks, with counters across 130-plus countries; US travelers mostly meet it when booking European road trips, where its rates and one-way options frequently beat the American majors abroad. Rentals code as car rental agencies, squarely inside every travel category definition.\n\nCar rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry, which is genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.5861&trid=1552713.189661&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -4628,7 +4628,7 @@
         "online_shopping"
       ],
       "website": "https://waxcenter.com",
-      "intro": "European Wax Center is the largest waxing-salon chain in the US, with over 1,000 franchised centers selling waxing services, the Wax Pass prepaid bundles, and its own skincare line. Charges are in-salon or prepaid packages booked through waxcenter.com and code as personal-care services.\n\nSalon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase — a few hundred dollars prepaid — into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.\n",
+      "intro": "European Wax Center is the largest waxing-salon chain in the US, with over 1,000 franchised centers selling waxing services, the Wax Pass prepaid bundles, and its own skincare line. Charges are in-salon or prepaid packages booked through waxcenter.com and code as personal-care services.\n\nSalon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase (a few hundred dollars prepaid) into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.30094&trid=1552713.245382&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -4946,7 +4946,7 @@
         "online_shopping"
       ],
       "website": "https://www.firstleaf.com",
-      "intro": "Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings — the algorithmic cousin of Naked Wines' funding model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.\n\nThat coding means grocery and dining multipliers stay quiet, and online categories do the work: Bank of America Customized Cash set to online shopping earns 3 percent per box, a Freedom Flex online-retail quarter can reach 5 percent on a stock-up order, and a flat 2 percent card suits the set-and-forget subscriber.\n",
+      "intro": "Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings. It is the algorithmic cousin of Naked Wines' model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.\n\nThat coding means grocery and dining multipliers stay quiet, and online categories do the work: Bank of America Customized Cash set to online shopping earns 3 percent per box, a Freedom Flex online-retail quarter can reach 5 percent on a stock-up order, and a flat 2 percent card suits the set-and-forget subscriber.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.38398&trid=1552713.249831&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5012,7 +5012,7 @@
         "online_shopping"
       ],
       "website": "https://www.shopflamingo.com",
-      "intro": "Flamingo is the women's body-care line from the team behind Harry's, selling razors, blade refills, and wax kits with the same design-forward, subscription-friendly model as its sibling brand. Orders and refill plans from shopflamingo.com code as online retail rather than drugstore purchases.\n\nThe card logic mirrors Harry's: direct subscriptions earn online-category rates — Bank of America Customized Cash set to online shopping pays 3 percent — while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.\n",
+      "intro": "Flamingo is the women's body-care line from the team behind Harry's, selling razors, blade refills, and wax kits with the same design-forward, subscription-friendly model as its sibling brand. Orders and refill plans from shopflamingo.com code as online retail rather than drugstore purchases.\n\nThe card logic mirrors Harry's: direct subscriptions earn online-category rates (Bank of America Customized Cash set to online shopping pays 3 percent) while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.9412&trid=1552713.248795&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5173,7 +5173,7 @@
         "online_shopping"
       ],
       "website": "https://www.fragrancenet.com",
-      "intro": "FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes — plus skincare, haircare, and candles — at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.\n\nDiscount fragrance stacking works best with an online category on top: Bank of America Customized Cash set to online shopping adds 3 percent to already-marked-down bottles, rotating online-retail quarters push it to 5, and flat 2 percent cards handle gift-season hauls without planning.\n",
+      "intro": "FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes (plus skincare, haircare, and candles) at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.\n\nDiscount fragrance stacking works best with an online category on top: Bank of America Customized Cash set to online shopping adds 3 percent to already-marked-down bottles, rotating online-retail quarters push it to 5, and flat 2 percent cards handle gift-season hauls without planning.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.216&trid=1552713.455&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5205,7 +5205,7 @@
         "department_stores"
       ],
       "website": "https://www.francosarto.com",
-      "intro": "Franco Sarto delivers Italian-styled women's footwear — loafers, block heels, and knee boots — at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.\n\nFootwear categories cover the bases: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same styles through Macy's or DSW can catch department-store or rotating-category bonuses when live.\n",
+      "intro": "Franco Sarto delivers Italian-styled women's footwear (loafers, block heels, and knee boots) at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.\n\nFootwear categories cover the bases: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same styles through Macy's or DSW can catch department-store or rotating-category bonuses when live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41588&trid=1552713.178979&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5533,7 +5533,7 @@
         "online_shopping"
       ],
       "website": "https://www.gillette.com",
-      "intro": "Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor — the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.\n\nThat coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices — the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.\n",
+      "intro": "Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor, the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.\n\nThat coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices: the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.23585&trid=1552713.196927&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5712,7 +5712,7 @@
         "secondhand_stores"
       ],
       "website": "https://www.grailed.com",
-      "intro": "Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout — the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.\n\nThat PayPal routing is the rewards angle: Chase Freedom Flex's recurring PayPal rotating quarters have historically covered Grailed checkouts at 5 percent, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card backstops off-quarter grail hunts.\n",
+      "intro": "Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout. It is the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.\n\nThat PayPal routing is the rewards angle: Chase Freedom Flex's recurring PayPal rotating quarters have historically covered Grailed checkouts at 5 percent, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card backstops off-quarter grail hunts.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.13931&trid=1552713.227549&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -5908,7 +5908,7 @@
         "online_shopping"
       ],
       "website": "https://www.hrblock.com",
-      "intro": "H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services — a category no consumer card bonuses.\n\nTwo angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution — paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.\n",
+      "intro": "H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services, a category no consumer card bonuses.\n\nTwo angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution: paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.5683&trid=1552713.156923&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -6048,7 +6048,7 @@
         "online_shopping"
       ],
       "website": "https://www.healthlabs.com",
-      "intro": "HealthLabs sells direct-to-consumer lab testing — order a panel online, visit a local partner lab for the draw, and get results without a doctor's visit, the same model as Personalabs. The order is paid upfront on healthlabs.com and codes as an online health-services purchase, not a medical provider visit.\n\nLab panels are also commonly HSA/FSA-eligible, which beats any rewards rate — check that first. Paying by credit card, expect no medical category match; a flat 2 percent card or a Bank of America Customized Cash set to online shopping at 3 percent are the practical options.\n",
+      "intro": "HealthLabs sells direct-to-consumer lab testing: order a panel online, visit a local partner lab for the draw, and get results without a doctor's visit. It is the same model as Personalabs. The order is paid upfront on healthlabs.com and codes as an online health-services purchase, not a medical provider visit.\n\nLab panels are also commonly HSA/FSA-eligible, which beats any rewards rate; check that first. Paying by credit card, expect no medical category match; a flat 2 percent card or a Bank of America Customized Cash set to online shopping at 3 percent are the practical options.\n",
       "affiliate": {
         "url": "https://www.jdoqocy.com/click-101737824-13703022",
         "network": "cj"
@@ -6352,7 +6352,7 @@
         "sporting_goods"
       ],
       "website": "https://www.horizonfitness.com",
-      "intro": "Horizon Fitness sells home treadmills, ellipticals, and exercise bikes — the value-focused sibling brand of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.\n\nBig fitness equipment is prime signup-bonus spend, clearing most minimums in one order. Otherwise, U.S. Bank Cash+ with sporting goods stores selected can pay 5 percent when the charge classifies that way, and Bank of America Customized Cash set to online shopping is the reliable 3 percent.\n",
+      "intro": "Horizon Fitness sells home treadmills, ellipticals, and exercise bikes. It is the value-focused sibling of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.\n\nBig fitness equipment is prime signup-bonus spend, clearing most minimums in one order. Otherwise, U.S. Bank Cash+ with sporting goods stores selected can pay 5 percent when the charge classifies that way, and Bank of America Customized Cash set to online shopping is the reliable 3 percent.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12130&trid=1552713.196086&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -6516,7 +6516,7 @@
         "home_improvement"
       ],
       "website": "https://www.hunterfan.com",
-      "intro": "Hunter has been making ceiling fans since 1886 and remains the name most Americans reach for when a room needs one, now spanning smart fans, outdoor-rated models, and the Casablanca premium line. Direct orders from hunterfan.com code as online retail rather than a hardware-store purchase.\n\nA fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there — worth a price check both ways.\n",
+      "intro": "Hunter has been making ceiling fans since 1886 and remains the name most Americans reach for when a room needs one, now spanning smart fans, outdoor-rated models, and the Casablanca premium line. Direct orders from hunterfan.com code as online retail rather than a hardware-store purchase.\n\nA fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there; price it both ways.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46207&trid=1552713.225483&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -6719,7 +6719,7 @@
         "electronics_stores"
       ],
       "website": "https://www.insta360.com",
-      "intro": "Insta360 makes the leading 360-degree action cameras — the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras — sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.\n\nCamera kits with mounts and accessories climb in price quickly, which suits an electronics category: U.S. Bank Cash+ set to electronics stores can return 5 percent when the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card covers accessory top-ups.\n",
+      "intro": "Insta360 makes the leading 360-degree action cameras (the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras) sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.\n\nCamera kits with mounts and accessories climb in price quickly, which suits an electronics category: U.S. Bank Cash+ set to electronics stores can return 5 percent when the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card covers accessory top-ups.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.46233&trid=1552713.248756&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -6746,7 +6746,7 @@
         "select_clothing"
       ],
       "website": "https://us.intimissimi.com",
-      "intro": "Intimissimi is the Italian lingerie chain — silk-and-lace bralettes, modal sleepwear, and seamless basics — that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.\n\nLingerie restocks fit apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 5-for deals on basics reward consolidating a haul onto whichever is live.\n",
+      "intro": "Intimissimi is the Italian lingerie chain (silk-and-lace bralettes, modal sleepwear, and seamless basics) that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.\n\nLingerie restocks fit apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 5-for deals on basics reward consolidating a haul onto whichever is live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.41274&trid=1552713.189853&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -7317,7 +7317,7 @@
         "entertainment"
       ],
       "website": "https://www.klook.com",
-      "intro": "Klook is a travel-activities marketplace strongest in Asia — theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours — often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.\n\nActivity bookings are travel spend most cards recognize: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X's 2x applies everywhere including the odd booking that codes as ticketing instead. Klook runs frequent promo-code sales, so stack a discount with the multiplier rather than choosing between them.\n",
+      "intro": "Klook is a travel-activities marketplace strongest in Asia (theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours) often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.\n\nActivity bookings are travel spend most cards recognize: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X's 2x applies everywhere including the odd booking that codes as ticketing instead. Klook runs frequent promo-code sales, so stack a discount with the multiplier rather than choosing between them.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156085.110006163&trid=1552713.230405&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -7335,7 +7335,7 @@
         "vacation_rentals"
       ],
       "website": "https://koa.com",
-      "intro": "KOA — Kampgrounds of America — runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.\n\nTravel cards are the natural fit: Chase Sapphire Preferred and Reserve count campground stays in their travel multipliers, Capital One Venture X earns its flat 2x everywhere, and annual-fee travel credits like the Sapphire Reserve's have been reported to apply to campground charges. KOA Rewards stacks on top regardless of card.\n",
+      "intro": "KOA (Kampgrounds of America) runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.\n\nTravel cards are the natural fit: Chase Sapphire Preferred and Reserve count campground stays in their travel multipliers, Capital One Venture X earns its flat 2x everywhere, and annual-fee travel credits like the Sapphire Reserve's have been reported to apply to campground charges. KOA Rewards stacks on top regardless of card.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50482&trid=1552713.235147&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -7740,7 +7740,7 @@
         "sporting_goods"
       ],
       "website": "https://www.lifefitness.com",
-      "intro": "Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use — treadmills, ellipticals, bikes, and the Hammer Strength line — at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.\n\nPurchases this size are textbook signup-bonus spend, often clearing an entire minimum in one order. Absent a new card, U.S. Bank Cash+ with sporting goods selected can hit 5 percent where the charge classifies that way, with Bank of America Customized Cash's online shopping choice a dependable 3 percent.\n",
+      "intro": "Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use (treadmills, ellipticals, bikes, and the Hammer Strength line) at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.\n\nPurchases this size are textbook signup-bonus spend, often clearing an entire minimum in one order. Absent a new card, U.S. Bank Cash+ with sporting goods selected can hit 5 percent where the charge classifies that way, with Bank of America Customized Cash's online shopping choice a dependable 3 percent.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.17731&trid=1552713.189439&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -8205,7 +8205,7 @@
         "department_stores"
       ],
       "website": "https://www.makeupforever.com",
-      "intro": "Make Up For Ever is the LVMH-owned professional makeup house famous for the HD Skin foundation range, Aqua Resist liners, and artist-grade palettes born from its Paris pro heritage. US orders from makeupforever.com code as online beauty retail; the brand also sells through Sephora.\n\nDirect orders suit an online category — Bank of America Customized Cash set to online shopping earns 3 percent — while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.\n",
+      "intro": "Make Up For Ever is the LVMH-owned professional makeup house famous for the HD Skin foundation range, Aqua Resist liners, and artist-grade palettes born from its Paris pro heritage. US orders from makeupforever.com code as online beauty retail; the brand also sells through Sephora.\n\nDirect orders suit an online category (Bank of America Customized Cash set to online shopping earns 3 percent) while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.54284&trid=1552713.209548&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -8866,7 +8866,7 @@
         "dining"
       ],
       "website": "https://www.mrsfields.com",
-      "intro": "Mrs. Fields turned mall-kiosk chocolate-chip cookies into a national gifting business: tins, cookie cakes, and corporate gift baskets shipped nationwide from mrsfields.com, alongside its remaining bakery locations. Online gift orders code as internet retail or specialty food, while in-person bakery purchases can code as dining or fast food.\n\nFor shipped gifts, an online category does the work — Bank of America Customized Cash set to online shopping earns 3 percent — while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.\n",
+      "intro": "Mrs. Fields turned mall-kiosk chocolate-chip cookies into a national gifting business: tins, cookie cakes, and corporate gift baskets shipped nationwide from mrsfields.com, alongside its remaining bakery locations. Online gift orders code as internet retail or specialty food, while in-person bakery purchases can code as dining or fast food.\n\nFor shipped gifts, an online category does the work (Bank of America Customized Cash set to online shopping earns 3 percent) while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.7935&trid=1552713.158847&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -8927,7 +8927,7 @@
         "sporting_goods"
       ],
       "website": "https://www.nalgene.com",
-      "intro": "Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders — including the popular custom-printing option — ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.\n\nBottles are small-ticket, so rewards are more about which card is already in hand: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ sporting goods quarter can catch a team order at 5 percent, and REI stock of the same bottles earns REI-specific card bonuses instead.\n",
+      "intro": "Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders (including the popular custom-printing option) ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.\n\nBottles are small-ticket, so rewards are more about which card is already in hand: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ sporting goods quarter can catch a team order at 5 percent, and REI stock of the same bottles earns REI-specific card bonuses instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.12848&trid=1552713.226006&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -9015,7 +9015,7 @@
         "department_stores"
       ],
       "website": "https://www.naturalizer.com",
-      "intro": "Naturalizer has sold comfort-first women's footwear since 1927 — pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.\n\nFootwear reliably lands in apparel categories: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the merchant classifies as apparel or shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and the same styles at Macy's or Nordstrom can pick up department-store bonuses when one is live.\n",
+      "intro": "Naturalizer has sold comfort-first women's footwear since 1927: pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.\n\nFootwear reliably lands in apparel categories: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the merchant classifies as apparel or shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and the same styles at Macy's or Nordstrom can pick up department-store bonuses when one is live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38505&trid=1552713.158953&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -9362,7 +9362,7 @@
         "department_stores"
       ],
       "website": "https://www.olehenriksen.com",
-      "intro": "Ole Henriksen bottles Scandinavian glow-first skincare — Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners — born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.\n\nDirect restocks favor an online category — Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5 — while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.\n",
+      "intro": "Ole Henriksen bottles Scandinavian glow-first skincare (Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners) born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.\n\nDirect restocks favor an online category (Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5) while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.38834&trid=1552713.159748&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10003,7 +10003,7 @@
         "online_shopping"
       ],
       "website": "https://www.pgatoursuperstore.com",
-      "intro": "PGA TOUR Superstore is the big-box golf retailer — clubs, balls, apparel, launch-monitor fittings, and in-store simulators — with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.\n\nGolf spend adds up fast, and sporting-goods coverage is unusually good: U.S. Bank Cash+ with sporting goods stores selected pays 5 percent, rotating quarters occasionally cover the category too, and a driver-and-iron-set fitting bill makes clean signup-bonus spend. Bank of America Customized Cash's online shopping choice covers web orders at 3 percent.\n",
+      "intro": "PGA TOUR Superstore is the big-box golf retailer (clubs, balls, apparel, launch-monitor fittings, and in-store simulators) with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.\n\nGolf spend adds up fast, and sporting-goods coverage is unusually good: U.S. Bank Cash+ with sporting goods stores selected pays 5 percent, rotating quarters occasionally cover the category too, and a driver-and-iron-set fitting bill makes clean signup-bonus spend. Bank of America Customized Cash's online shopping choice covers web orders at 3 percent.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.16839&trid=1552713.228946&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10062,7 +10062,7 @@
         "department_stores"
       ],
       "website": "https://www.philosophy.com",
-      "intro": "Philosophy is the feel-good skincare and bath brand behind Purity Made Simple cleanser, Hope in a Jar moisturizer, and the dessert-scented Amazing Grace shower gels, sold direct and through Ulta, Sephora, and department stores. Orders from philosophy.com code as online beauty retail.\n\nRoutine restocks favor an online category — Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5 — while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.\n",
+      "intro": "Philosophy is the feel-good skincare and bath brand behind Purity Made Simple cleanser, Hope in a Jar moisturizer, and the dessert-scented Amazing Grace shower gels, sold direct and through Ulta, Sephora, and department stores. Orders from philosophy.com code as online beauty retail.\n\nRoutine restocks favor an online category (Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5) while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.50295&trid=1552713.169070&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10102,7 +10102,7 @@
         "online_shopping"
       ],
       "website": "https://www.physiciansformula.com",
-      "intro": "Physicians Formula has sold hypoallergenic drugstore makeup since 1937 — Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.\n\nThe drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter — Chase Freedom Flex has covered drugstores repeatedly — at 5 percent. Price-match against drugstore sales before ordering direct.\n",
+      "intro": "Physicians Formula has sold hypoallergenic drugstore makeup since 1937: Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.\n\nThe drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter (Chase Freedom Flex has covered drugstores repeatedly) at 5 percent. Price-match against drugstore sales before ordering direct.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43735&trid=1552713.247447&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10141,7 +10141,7 @@
         "home_improvement"
       ],
       "website": "https://pitboss-grills.com",
-      "intro": "Pit Boss is the value heavyweight of pellet grilling — bigger hoppers and lower prices than Traeger — spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.\n\nA grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories — compare, since Pit Boss runs aggressive direct-only bundle deals.\n",
+      "intro": "Pit Boss is the value heavyweight of pellet grilling (bigger hoppers and lower prices than Traeger) spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.\n\nA grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories; compare before buying, since Pit Boss runs aggressive direct-only bundle deals.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10421&trid=1552713.213540&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -10977,7 +10977,7 @@
         "online_shopping"
       ],
       "website": "https://www.rocskincare.com",
-      "intro": "RoC pioneered stabilized retinol in drugstore skincare and remains the evidence-first pick for anti-aging staples like Retinol Correxion and the Multi Correxion vitamin-C line. Buying direct from rocskincare.com codes as online retail; the same products also sit on Walgreens, CVS, and Amazon shelves.\n\nDirect orders fit an online category — Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more — while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.\n",
+      "intro": "RoC pioneered stabilized retinol in drugstore skincare and remains the evidence-first pick for anti-aging staples like Retinol Correxion and the Multi Correxion vitamin-C line. Buying direct from rocskincare.com codes as online retail; the same products also sit on Walgreens, CVS, and Amazon shelves.\n\nDirect orders fit an online category (Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more) while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.46883&trid=1552713.225417&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -11454,7 +11454,7 @@
         "electronics_stores"
       ],
       "website": "https://www.sennheiser.com",
-      "intro": "Sennheiser's consumer line — Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers — carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.\n\nHeadphone purchases in the $200–$400 band reward a live category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is a solid 3 percent, and open-box HD 6XX-adjacent deals on a flat 2 percent card still come out well.\n",
+      "intro": "Sennheiser's consumer line (Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers) carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.\n\nHeadphone purchases in the $200–$400 band reward a live category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is a solid 3 percent, and open-box HD 6XX-adjacent deals on a flat 2 percent card still come out well.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.42592&trid=1552713.193918&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -12095,7 +12095,7 @@
         "online_shopping"
       ],
       "website": "https://www.spirithalloween.com",
-      "intro": "Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round — including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.\n\nCostume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter — which has historically covered Q4 — can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.\n",
+      "intro": "Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round, including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.\n\nCostume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter (which has historically covered Q4) can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.8099&trid=1552713.161081&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers",
@@ -12244,7 +12244,7 @@
         "electronics_stores"
       ],
       "website": "https://steelseries.com",
-      "intro": "SteelSeries builds gaming peripherals — the Arctis headset line, Apex keyboards, Rival and Aerox mice, and QcK mousepads — sold direct from steelseries.com alongside retail channels. Direct orders code as online electronics retail and are where the brand runs its own refurb and bundle pricing.\n\nPeripheral refreshes are classic electronics-category spend: U.S. Bank Cash+ with electronics stores selected can hit 5 percent when the merchant classifies that way, Bank of America Customized Cash set to online shopping earns 3 percent, and PayPal-heavy checkout flows occasionally line up with a Chase Freedom Flex quarter.\n",
+      "intro": "SteelSeries builds gaming peripherals (the Arctis headset line, Apex keyboards, Rival and Aerox mice, and QcK mousepads) sold direct from steelseries.com alongside retail channels. Direct orders code as online electronics retail and are where the brand runs its own refurb and bundle pricing.\n\nPeripheral refreshes are classic electronics-category spend: U.S. Bank Cash+ with electronics stores selected can hit 5 percent when the merchant classifies that way, Bank of America Customized Cash set to online shopping earns 3 percent, and PayPal-heavy checkout flows occasionally line up with a Chase Freedom Flex quarter.\n",
       "affiliate": {
         "url": "https://www.tkqlhce.com/click-101737824-17028016",
         "network": "cj"
@@ -12452,7 +12452,7 @@
         "select_clothing"
       ],
       "website": "https://www.superdry.com",
-      "intro": "Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding — best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.\n\nApparel categories cover it: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both on a jacket-sized order.\n",
+      "intro": "Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding, best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.\n\nApparel categories cover it: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both on a jacket-sized order.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.44521&trid=1552713.209552&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -12905,7 +12905,7 @@
         "travel"
       ],
       "website": "https://www.theparkingspot.com",
-      "intro": "The Parking Spot is the largest near-airport parking operator in the US, with covered and uncovered lots plus shuttle service at 25-plus airports, booked ahead on theparkingspot.com for member rates through its Spot Club program. Airport parking charges typically code as parking or travel merchants.\n\nParking spend near airports frequently counts toward travel multipliers — Chase Sapphire Preferred and Reserve both include parking in their travel definitions — and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.\n",
+      "intro": "The Parking Spot is the largest near-airport parking operator in the US, with covered and uncovered lots plus shuttle service at 25-plus airports, booked ahead on theparkingspot.com for member rates through its Spot Club program. Airport parking charges typically code as parking or travel merchants.\n\nParking spend near airports frequently counts toward travel multipliers (Chase Sapphire Preferred and Reserve both include parking in their travel definitions) and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.10415&trid=1552713.211617&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -12960,7 +12960,7 @@
         "department_stores"
       ],
       "website": "https://www.theory.com",
-      "intro": "Theory built its name on precisely tailored workwear fundamentals — the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe — under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.\n\nSuiting-level price tags make categories worthwhile: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store bonuses apply when you shop Theory through Nordstrom instead.\n",
+      "intro": "Theory built its name on precisely tailored workwear fundamentals (the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe) under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.\n\nSuiting-level price tags make categories worthwhile: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store bonuses apply when you shop Theory through Nordstrom instead.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.36186&trid=1552713.202068&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13384,7 +13384,7 @@
         "home_improvement"
       ],
       "website": "https://www.troybilt.com",
-      "intro": "Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points — corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.\n\nOutdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live — price both before buying.\n",
+      "intro": "Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points, corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.\n\nOutdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live; price both before buying.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9368&trid=1552713.203841&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13707,7 +13707,7 @@
         "entertainment"
       ],
       "website": "https://www.vegas.com",
-      "intro": "Vegas.com packages the whole Las Vegas trip — hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles — as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.\n\nOTA bookings are travel spend to most issuers: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X covers whatever coding comes back at 2x. One trade-off to know: booking through an OTA usually forfeits hotel-program elite credit, so weigh the bundle discount against booking the room direct.\n",
+      "intro": "Vegas.com packages the whole Las Vegas trip (hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles) as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.\n\nOTA bookings are travel spend to most issuers: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X covers whatever coding comes back at 2x. One trade-off to know: booking through an OTA usually forfeits hotel-program elite credit, so weigh the bundle discount against booking the room direct.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.4221&trid=1552713.159075&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13752,7 +13752,7 @@
         "online_shopping"
       ],
       "website": "https://versedskin.com",
-      "intro": "Versed distills clean-clinical skincare into sub-$25 staples — Dew Point moisturizer, the Auto Save retinol line, and single-minded serums — born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.\n\nThe Target-versus-direct choice drives rewards: direct earns online-category rates like Bank of America Customized Cash's 3 percent online shopping selection, while Target runs earn RedCard savings or Target-category promos. Direct-exclusive bundles and sets are usually the reason to order from the brand itself.\n",
+      "intro": "Versed distills clean-clinical skincare into sub-$25 staples (Dew Point moisturizer, the Auto Save retinol line, and single-minded serums) born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.\n\nThe Target-versus-direct choice drives rewards: direct earns online-category rates like Bank of America Customized Cash's 3 percent online shopping selection, while Target runs earn RedCard savings or Target-category promos. Direct-exclusive bundles and sets are usually the reason to order from the brand itself.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156052.9474&trid=1552713.211622&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13810,7 +13810,7 @@
         "electronics_stores"
       ],
       "website": "https://victrola.com",
-      "intro": "Victrola revived the century-old phonograph name into the best-selling entry point for vinyl — suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.\n\nTurntable purchases fit neatly under an electronics selection: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a suitcase-player gift on a flat 2 percent card needs no planning at all.\n",
+      "intro": "Victrola revived the century-old phonograph name into the best-selling entry point for vinyl: suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.\n\nTurntable purchases fit neatly under an electronics selection: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a suitcase-player gift on a flat 2 percent card needs no planning at all.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.18889&trid=1552713.207542&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -13950,7 +13950,7 @@
         "home_improvement"
       ],
       "website": "https://www.vivint.com",
-      "intro": "Vivint sells professionally installed smart-home security — doorbell and outdoor cameras, smart locks, and thermostats wired into one app — with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.\n\nMonitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus — a full system easily covers a minimum-spend requirement in one go.\n",
+      "intro": "Vivint sells professionally installed smart-home security (doorbell and outdoor cameras, smart locks, and thermostats wired into one app) with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.\n\nMonitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus; a full system easily covers a minimum-spend requirement in one go.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156178.21822&trid=1552713.225643&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -14252,7 +14252,7 @@
         "online_shopping"
       ],
       "website": "https://www.wetnwildbeauty.com",
-      "intro": "Wet n Wild is the drugstore-beauty value icon — MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.\n\nAt these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent — the drugstore route usually wins when those are live.\n",
+      "intro": "Wet n Wild is the drugstore-beauty value icon: MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, all under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.\n\nAt these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent; the drugstore route usually wins when those are live.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.43590&trid=1552713.201598&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -14506,7 +14506,7 @@
         "electronics_stores"
       ],
       "website": "https://www.wyze.com",
-      "intro": "Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home — cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.\n\nWyze orders are frequent and small, which favors an always-on category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent on both hardware and Cam Plus renewals, and flat 2 percent covers the impulse camera.\n",
+      "intro": "Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home: cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.\n\nWyze orders are frequent and small, which favors an always-on category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent on both hardware and Cam Plus renewals, and flat 2 percent covers the impulse camera.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.27209&trid=1552713.249672&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -14535,7 +14535,7 @@
         "home_improvement"
       ],
       "website": "https://shopyalehome.com",
-      "intro": "Yale has made locks since 1840, and Yale Home is its smart-lock arm — the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa, sharing corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.\n\nA smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively — whichever category you have live decides the store.\n",
+      "intro": "Yale has made locks since 1840, and Yale Home is its smart-lock arm: the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa. It shares corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.\n\nA smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively; whichever category you have live decides the store.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=156074.37641&trid=1552713.247667&foc=17&fot=9999&fos=6&url=",
         "network": "flexoffers"
@@ -14557,7 +14557,7 @@
         "online_shopping"
       ],
       "website": "https://www.yarnspirations.com",
-      "intro": "Yarnspirations is the official online home of the big craft-yarn brands — Caron, Bernat, Red Heart, Patons, and Lily Sugar'n Cream — plus thousands of free knitting and crochet patterns. Unlike a Michaels or JOANN run, Yarnspirations orders ship direct and code as online retail rather than a craft-store purchase.\n\nStock-up orders during clearance events are where the money goes, so route them through an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter can lift a big cart to 5 percent.\n",
+      "intro": "Yarnspirations is the official online home of the big craft-yarn brands (Caron, Bernat, Red Heart, Patons, and Lily Sugar'n Cream) plus thousands of free knitting and crochet patterns. Unlike a Michaels or JOANN run, Yarnspirations orders ship direct and code as online retail rather than a craft-store purchase.\n\nStock-up orders during clearance events are where the money goes, so route them through an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter can lift a big cart to 5 percent.\n",
       "affiliate": {
         "url": "https://www.tkqlhce.com/click-101737824-13781226",
         "network": "cj"
@@ -14653,7 +14653,7 @@
         "online_shopping"
       ],
       "website": "https://www.zinio.com",
-      "intro": "Zinio is the largest digital newsstand, selling single issues and annual subscriptions to thousands of magazines readable across its apps, in the same digital-reading niche as Magzter. Subscriptions bill through zinio.com and code as an online digital purchase — notably not as a streaming service, so streaming-bundle credits will not apply.\n\nMagazine subscriptions are small recurring charges, ideal for a set-and-forget card: a flat 2 percent earner covers renewals without thought, while Bank of America Customized Cash set to online shopping stretches them to 3 percent.\n",
+      "intro": "Zinio is the largest digital newsstand, selling single issues and annual subscriptions to thousands of magazines readable across its apps, in the same digital-reading niche as Magzter. Subscriptions bill through zinio.com and code as an online digital purchase (not a streaming service), so streaming-bundle credits will not apply.\n\nMagazine subscriptions are small recurring charges, ideal for a set-and-forget card: a flat 2 percent earner covers renewals without thought, while Bank of America Customized Cash set to online shopping stretches them to 3 percent.\n",
       "affiliate": {
         "url": "https://www.dpbolvw.net/click-101737824-17177799",
         "network": "cj"

--- a/data/stores/100-pure.yaml
+++ b/data/stores/100-pure.yaml
@@ -6,6 +6,6 @@ categories:
   - online_shopping
 website: "https://www.100percentpure.com"
 intro: |
-  100% PURE built its clean-beauty reputation on fruit-pigmented makeup — color from actual fruit, cocoa, and tea rather than synthetic dyes — plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.
+  100% PURE built its clean-beauty reputation on fruit-pigmented makeup (color from actual fruit, cocoa, and tea rather than synthetic dyes) plus natural skincare and the cult Coffee Bean eye cream. Direct orders from 100percentpure.com code as online beauty retail.
 
   Clean-beauty carts respond well to an online category: Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters can lift a restock to 5, and the brand's frequent gift-with-purchase promotions stack with whatever card you use.

--- a/data/stores/aerosoles.yaml
+++ b/data/stores/aerosoles.yaml
@@ -5,6 +5,6 @@ categories:
   - select_clothing
 website: "https://www.aerosoles.com"
 intro: |
-  Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s — its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.
+  Aerosoles has specialized in cushioned, walkable women's shoes since the 1980s. Its Core Comfort footbeds carry heels, flats, and boots that hold up to a commute. Direct orders from aerosoles.com code as online shoe retail, and the brand's sale section is deep most of the year.
 
   Shoe orders sit comfortably in apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both.

--- a/data/stores/anine-bing.yaml
+++ b/data/stores/anine-bing.yaml
@@ -7,6 +7,6 @@ categories:
   - select_clothing
 website: "https://www.aninebing.com"
 intro: |
-  ANINE BING bottles Scandinavian-meets-LA wardrobe staples — the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed — at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.
+  ANINE BING bottles Scandinavian-meets-LA wardrobe staples (the Sweatshirt with the AB logo, silk shirting, and denim that anchors the quiet-luxury feed) at contemporary-designer prices. Direct orders from aninebing.com code as online apparel retail.
 
   At this price tier the category margin is real money: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card still claws back a coffee's worth on every blazer.

--- a/data/stores/blendtec.yaml
+++ b/data/stores/blendtec.yaml
@@ -5,6 +5,6 @@ categories:
   - home_improvement
 website: "https://www.blendtec.com"
 intro: |
-  Blendtec builds high-powered blenders in Utah — the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars — and famously ran the "Will It Blend?" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.
+  Blendtec builds high-powered blenders in Utah (the Total Blend and Designer series for home kitchens plus the commercial units behind countless smoothie bars) and famously ran the "Will It Blend?" marketing era. Direct orders from blendtec.com, including certified refurbished units at steep discounts, code as online retail.
 
   A blender at this price point is a one-time considered purchase: Bank of America Customized Cash set to online shopping earns 3 percent, a Freedom Flex online-retail quarter can reach 5 percent, and flat 2 percent cards are the fallback if no category is live when yours dies mid-smoothie.

--- a/data/stores/blinkist.yaml
+++ b/data/stores/blinkist.yaml
@@ -4,6 +4,6 @@ categories:
   - online_shopping
 website: "https://www.blinkist.com"
 intro: |
-  Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription — an online purchase, not a streaming service, so streaming credits and multipliers stay on the bench.
+  Blinkist condenses nonfiction books into 15-minute text and audio summaries, sold as an annual subscription that now also bundles guided courses under Blinkist Go. The renewal bills from blinkist.com and codes as a digital subscription (an online purchase, not a streaming service), so streaming credits and multipliers stay on the bench.
 
   A single annual charge favors whichever online category you have running: Bank of America Customized Cash set to online shopping earns 3 percent, and otherwise a flat 2 percent card like Citi Double Cash quietly does the job every year.

--- a/data/stores/bobbie.yaml
+++ b/data/stores/bobbie.yaml
@@ -6,6 +6,6 @@ categories:
   - online_shopping
 website: "https://www.hibobbie.com"
 intro: |
-  Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase — not groceries — which changes which cards make sense.
+  Bobbie is an American-made, European-style infant formula company selling organic formula on a subscription that scales with a baby's age, plus one-off cans for supplementing. Subscriptions ship from hibobbie.com and code as an online purchase (not groceries), which changes which cards make sense.
 
-  Grocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators — worth checking before optimizing card rewards.
+  Grocery multipliers like the Amex Gold's 4x at US supermarkets will not trigger on direct formula subscriptions, so use online categories instead: Bank of America Customized Cash set to online shopping earns 3 percent on every shipment, and a flat 2 percent card covers it hands-off. Formula is also frequently HSA/FSA-eligible through certain administrators; check that before optimizing card rewards.

--- a/data/stores/brinks-home.yaml
+++ b/data/stores/brinks-home.yaml
@@ -7,6 +7,6 @@ categories:
   - home_improvement
 website: "https://brinkshome.com"
 intro: |
-  Brinks Home sells professionally monitored home-security systems — panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.
+  Brinks Home sells professionally monitored home-security systems: panels, sensors, and cameras installed DIY or professionally, paired with a monthly monitoring plan under one of the oldest names in the security business. Equipment purchases and monitoring bills come through brinkshome.com and code as security services rather than a utility.
 
-  Neither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on — security bundles are an easy few hundred dollars of qualifying spend.
+  Neither equipment nor monitoring reliably lands in a bonus category, so the practical play is a flat 2 percent card on the monthly plan, or putting the upfront equipment package on a card you are working toward a signup bonus on; security bundles are an easy few hundred dollars of qualifying spend.

--- a/data/stores/bruno-magli.yaml
+++ b/data/stores/bruno-magli.yaml
@@ -5,6 +5,6 @@ categories:
   - select_clothing
 website: "https://www.brunomagli.com"
 intro: |
-  Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936 — cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.
+  Bruno Magli has hand-finished Italian dress shoes in Bologna since 1936: cap-toe oxfords, driving mocs, and leather jackets that sit at the attainable end of true luxury footwear. US orders from brunomagli.com code as online apparel retail.
 
   Shoes at this tier reward a category match: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns a dependable 3 percent, and a flat 2 percent card on a pair of oxfords still returns enough for the shoe trees.

--- a/data/stores/codecademy.yaml
+++ b/data/stores/codecademy.yaml
@@ -6,4 +6,4 @@ website: "https://www.codecademy.com"
 intro: |
   Codecademy teaches programming through interactive browser-based courses, with free basics and a Pro subscription that unlocks career paths, projects, and certificates; it is now part of Skillsoft. Pro bills monthly or annually from codecademy.com and codes as an online education subscription.
 
-  Education subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends — worth asking before optimizing cents per dollar.
+  Education subscriptions sit outside every mainstream bonus category, so this is flat-rate territory: Citi Double Cash or Wells Fargo Active Cash at 2 percent, or 3 percent via a Bank of America Customized Cash set to online shopping. Many employers reimburse Codecademy under learning stipends; ask before optimizing cents per dollar.

--- a/data/stores/cub-cadet.yaml
+++ b/data/stores/cub-cadet.yaml
@@ -5,6 +5,6 @@ categories:
   - home_improvement
 website: "https://www.cubcadet.com"
 intro: |
-  Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network — it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.
+  Cub Cadet builds riding mowers, zero-turns, snow blowers, and utility vehicles, sold direct from cubcadet.com alongside its dealer network; it shares corporate parentage with Troy-Bilt under MTD, now part of Stanley Black & Decker. Direct equipment orders are four-figure purchases that code as online retail rather than a home-improvement store visit.
 
   A mower-sized charge deserves planning: it is ideal signup-bonus spend, and otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct. Buying the same machine through Home Depot or Lowe's instead can tap home-improvement category bonuses when you have one live.

--- a/data/stores/denon.yaml
+++ b/data/stores/denon.yaml
@@ -5,6 +5,6 @@ categories:
   - electronics_stores
 website: "https://www.denon.com"
 intro: |
-  Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com — including refurbished receivers with full warranties — code as online electronics retail.
+  Denon is the Japanese audio stalwart behind the AVR-X receiver line that anchors countless home theaters, plus the HEOS wireless ecosystem and a respected turntable and headphone catalog. Direct orders from denon.com (including refurbished receivers with full warranties) code as online electronics retail.
 
   Receiver upgrades are chunky spend, so aim a category at them: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is the steady 3 percent, and flat 2 percent cards cover the impulse subwoofer.

--- a/data/stores/edx.yaml
+++ b/data/stores/edx.yaml
@@ -4,6 +4,6 @@ categories:
   - online_shopping
 website: "https://www.edx.org"
 intro: |
-  edX hosts university-built online courses — MIT and Harvard founded it — spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.
+  edX hosts university-built online courses (MIT and Harvard founded it) spanning free audit tracks, paid verified certificates, MicroMasters, and full online degrees, now operated by 2U. Certificate and program payments run through edx.org and code as online education.
 
   Education charges sit outside consumer bonus categories, so treat them like any online purchase: Bank of America Customized Cash set to online shopping earns 3 percent on a certificate, flat 2 percent cards cover bigger program tuition without ceremony, and employer tuition-reimbursement programs frequently cover edX before rewards even enter the picture.

--- a/data/stores/elvie.yaml
+++ b/data/stores/elvie.yaml
@@ -4,6 +4,6 @@ categories:
   - online_shopping
 website: "https://www.elvie.com"
 intro: |
-  Elvie makes discreet wearable breast pumps — the in-bra Elvie Pump and the value Stride line — plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.
+  Elvie makes discreet wearable breast pumps (the in-bra Elvie Pump and the value Stride line) plus the Elvie Trainer pelvic-floor device, all app-connected and engineered in the femtech wave it helped start. US orders from elvie.com code as online retail.
 
   Before optimizing rewards, exhaust the cheaper routes: Elvie pumps are frequently covered or subsidized through insurance DME suppliers and are broadly HSA/FSA-eligible. Paying by card, Bank of America Customized Cash set to online shopping earns 3 percent, and a pump-sized purchase contributes meaningfully to a new card's signup-bonus minimum.

--- a/data/stores/europcar.yaml
+++ b/data/stores/europcar.yaml
@@ -7,4 +7,4 @@ website: "https://www.europcar.com"
 intro: |
   Europcar is one of Europe's largest car-rental networks, with counters across 130-plus countries; US travelers mostly meet it when booking European road trips, where its rates and one-way options frequently beat the American majors abroad. Rentals code as car rental agencies, squarely inside every travel category definition.
 
-  Car rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry — genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.
+  Car rentals reward the right card twice: earning, via Chase Sapphire Preferred or Reserve travel multipliers and Capital One Venture X's flat 2x, and coverage, via the primary rental CDW several of those cards carry, which is genuinely valuable on European rentals where damage waivers are pricey add-ons. Watch foreign-transaction fees on cards that still charge them.

--- a/data/stores/european-wax-center.yaml
+++ b/data/stores/european-wax-center.yaml
@@ -8,4 +8,4 @@ website: "https://waxcenter.com"
 intro: |
   European Wax Center is the largest waxing-salon chain in the US, with over 1,000 franchised centers selling waxing services, the Wax Pass prepaid bundles, and its own skincare line. Charges are in-salon or prepaid packages booked through waxcenter.com and code as personal-care services.
 
-  Salon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase — a few hundred dollars prepaid — into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.
+  Salon services sit outside standard bonus categories, so the dependable options are a flat 2 percent card on regular visits, or funneling a Wax Pass purchase (a few hundred dollars prepaid) into signup-bonus spend on a new card, which turns routine maintenance into an outsized return.

--- a/data/stores/firstleaf.yaml
+++ b/data/stores/firstleaf.yaml
@@ -6,6 +6,6 @@ categories:
   - online_shopping
 website: "https://www.firstleaf.com"
 intro: |
-  Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings — the algorithmic cousin of Naked Wines' funding model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.
+  Firstleaf is a personalized wine club that profiles your palate, ships six-bottle boxes at member pricing, and refines picks from your ratings. It is the algorithmic cousin of Naked Wines' model. Boxes bill per shipment from firstleaf.com and code as an online purchase, not a liquor-store visit.
 
   That coding means grocery and dining multipliers stay quiet, and online categories do the work: Bank of America Customized Cash set to online shopping earns 3 percent per box, a Freedom Flex online-retail quarter can reach 5 percent on a stock-up order, and a flat 2 percent card suits the set-and-forget subscriber.

--- a/data/stores/flamingo.yaml
+++ b/data/stores/flamingo.yaml
@@ -8,4 +8,4 @@ website: "https://www.shopflamingo.com"
 intro: |
   Flamingo is the women's body-care line from the team behind Harry's, selling razors, blade refills, and wax kits with the same design-forward, subscription-friendly model as its sibling brand. Orders and refill plans from shopflamingo.com code as online retail rather than drugstore purchases.
 
-  The card logic mirrors Harry's: direct subscriptions earn online-category rates — Bank of America Customized Cash set to online shopping pays 3 percent — while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.
+  The card logic mirrors Harry's: direct subscriptions earn online-category rates (Bank of America Customized Cash set to online shopping pays 3 percent) while grabbing Flamingo refills at Target instead can tap Target-specific savings. Small recurring charges also suit a flat 2 percent card left on autopilot.

--- a/data/stores/fragrancenet.yaml
+++ b/data/stores/fragrancenet.yaml
@@ -6,6 +6,6 @@ categories:
   - online_shopping
 website: "https://www.fragrancenet.com"
 intro: |
-  FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes — plus skincare, haircare, and candles — at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.
+  FragranceNet is one of the largest online discount fragrance retailers, moving genuine designer perfumes and colognes (plus skincare, haircare, and candles) at 30 to 70 percent under department-store prices, in the same lane as FragranceShop. Orders from fragrancenet.com code as straightforward online retail.
 
   Discount fragrance stacking works best with an online category on top: Bank of America Customized Cash set to online shopping adds 3 percent to already-marked-down bottles, rotating online-retail quarters push it to 5, and flat 2 percent cards handle gift-season hauls without planning.

--- a/data/stores/franco-sarto.yaml
+++ b/data/stores/franco-sarto.yaml
@@ -6,6 +6,6 @@ categories:
   - department_stores
 website: "https://www.francosarto.com"
 intro: |
-  Franco Sarto delivers Italian-styled women's footwear — loafers, block heels, and knee boots — at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.
+  Franco Sarto delivers Italian-styled women's footwear (loafers, block heels, and knee boots) at department-store-friendly prices under the Caleres portfolio alongside Naturalizer. Direct orders from francosarto.com code as online shoe retail.
 
   Footwear categories cover the bases: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as shoes or apparel, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same styles through Macy's or DSW can catch department-store or rotating-category bonuses when live.

--- a/data/stores/gillette.yaml
+++ b/data/stores/gillette.yaml
@@ -7,6 +7,6 @@ categories:
   - online_shopping
 website: "https://www.gillette.com"
 intro: |
-  Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor — the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.
+  Gillette sells razors, blade refills, and shave care direct from gillette.com, including subscription blade plans and the premium GilletteLabs line with the heated razor, the P&G giant's answer to the DTC model Harry's built. Direct orders and subscriptions code as online retail, not groceries or drugstores.
 
-  That coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices — the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.
+  That coding is the key decision: blade refills bought at a supermarket or drugstore can earn grocery or drugstore multipliers, while direct subscriptions earn online-category rates like Bank of America Customized Cash's 3 percent online shopping choice. Compare unit prices: the subscription discount versus a drugstore sale plus category bonus is a genuinely close call.

--- a/data/stores/grailed.yaml
+++ b/data/stores/grailed.yaml
@@ -5,6 +5,6 @@ categories:
   - secondhand_stores
 website: "https://www.grailed.com"
 intro: |
-  Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout — the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.
+  Grailed is the menswear resale marketplace where streetwear grails, archive designer pieces, and everyday secondhand fits change hands, with buyer protection riding on every checkout. It is the men's-fashion counterpart to StockX's sneaker exchange. Purchases code as an online marketplace, typically processed through PayPal's rails.
 
   That PayPal routing is the rewards angle: Chase Freedom Flex's recurring PayPal rotating quarters have historically covered Grailed checkouts at 5 percent, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card backstops off-quarter grail hunts.

--- a/data/stores/h-and-r-block.yaml
+++ b/data/stores/h-and-r-block.yaml
@@ -7,6 +7,6 @@ categories:
   - online_shopping
 website: "https://www.hrblock.com"
 intro: |
-  H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services — a category no consumer card bonuses.
+  H&R Block prepares taxes for millions of Americans through its do-it-yourself online software, virtual pro help, and thousands of walk-in offices. Whether you buy the online edition or pay an office invoice, the charge codes as tax-preparation services, a category no consumer card bonuses.
 
-  Two angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution — paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.
+  Two angles still pay: the charge is modest but annual, so a flat 2 percent card is the frictionless default, and the IRS-adjacent timing makes it easy signup-bonus spend in the spring. One caution: paying the taxes themselves by card through a processor adds a fee near 2 percent; run the math before chasing rewards on the tax bill itself.

--- a/data/stores/healthlabs.yaml
+++ b/data/stores/healthlabs.yaml
@@ -6,6 +6,6 @@ categories:
   - online_shopping
 website: "https://www.healthlabs.com"
 intro: |
-  HealthLabs sells direct-to-consumer lab testing — order a panel online, visit a local partner lab for the draw, and get results without a doctor's visit, the same model as Personalabs. The order is paid upfront on healthlabs.com and codes as an online health-services purchase, not a medical provider visit.
+  HealthLabs sells direct-to-consumer lab testing: order a panel online, visit a local partner lab for the draw, and get results without a doctor's visit. It is the same model as Personalabs. The order is paid upfront on healthlabs.com and codes as an online health-services purchase, not a medical provider visit.
 
-  Lab panels are also commonly HSA/FSA-eligible, which beats any rewards rate — check that first. Paying by credit card, expect no medical category match; a flat 2 percent card or a Bank of America Customized Cash set to online shopping at 3 percent are the practical options.
+  Lab panels are also commonly HSA/FSA-eligible, which beats any rewards rate; check that first. Paying by credit card, expect no medical category match; a flat 2 percent card or a Bank of America Customized Cash set to online shopping at 3 percent are the practical options.

--- a/data/stores/horizon-fitness.yaml
+++ b/data/stores/horizon-fitness.yaml
@@ -5,6 +5,6 @@ categories:
   - sporting_goods
 website: "https://www.horizonfitness.com"
 intro: |
-  Horizon Fitness sells home treadmills, ellipticals, and exercise bikes — the value-focused sibling brand of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.
+  Horizon Fitness sells home treadmills, ellipticals, and exercise bikes. It is the value-focused sibling of Matrix commercial gym equipment under Johnson Health Tech. A machine from horizonfitness.com is a several-hundred-to-few-thousand-dollar delivery that codes as online retail, sometimes classifying under sporting goods.
 
   Big fitness equipment is prime signup-bonus spend, clearing most minimums in one order. Otherwise, U.S. Bank Cash+ with sporting goods stores selected can pay 5 percent when the charge classifies that way, and Bank of America Customized Cash set to online shopping is the reliable 3 percent.

--- a/data/stores/hunter-fan.yaml
+++ b/data/stores/hunter-fan.yaml
@@ -9,4 +9,4 @@ website: "https://www.hunterfan.com"
 intro: |
   Hunter has been making ceiling fans since 1886 and remains the name most Americans reach for when a room needs one, now spanning smart fans, outdoor-rated models, and the Casablanca premium line. Direct orders from hunterfan.com code as online retail rather than a hardware-store purchase.
 
-  A fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there — worth a price check both ways.
+  A fan-or-two order fits neatly under online categories: Bank of America Customized Cash set to online shopping earns 3 percent direct. If you have a home-improvement bonus live instead, the same fans stocked at Home Depot or Lowe's can earn it there; price it both ways.

--- a/data/stores/insta360.yaml
+++ b/data/stores/insta360.yaml
@@ -5,6 +5,6 @@ categories:
   - electronics_stores
 website: "https://www.insta360.com"
 intro: |
-  Insta360 makes the leading 360-degree action cameras — the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras — sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.
+  Insta360 makes the leading 360-degree action cameras (the X-series one-shot-then-reframe cameras, the Ace Pro co-engineered with Leica, and the Go thumb cameras) sold direct from insta360.com with trade-in and bundle programs. Direct orders code as online electronics retail.
 
   Camera kits with mounts and accessories climb in price quickly, which suits an electronics category: U.S. Bank Cash+ set to electronics stores can return 5 percent when the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a flat 2 percent card covers accessory top-ups.

--- a/data/stores/intimissimi.yaml
+++ b/data/stores/intimissimi.yaml
@@ -5,6 +5,6 @@ categories:
   - select_clothing
 website: "https://us.intimissimi.com"
 intro: |
-  Intimissimi is the Italian lingerie chain — silk-and-lace bralettes, modal sleepwear, and seamless basics — that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.
+  Intimissimi is the Italian lingerie chain (silk-and-lace bralettes, modal sleepwear, and seamless basics) that has expanded from European high streets into US malls and a full e-commerce operation under the Calzedonia group. US orders from us.intimissimi.com code as online apparel retail.
 
   Lingerie restocks fit apparel categories: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the merchant classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and the brand's frequent 5-for deals on basics reward consolidating a haul onto whichever is live.

--- a/data/stores/klook.yaml
+++ b/data/stores/klook.yaml
@@ -5,6 +5,6 @@ categories:
   - entertainment
 website: "https://www.klook.com"
 intro: |
-  Klook is a travel-activities marketplace strongest in Asia — theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours — often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.
+  Klook is a travel-activities marketplace strongest in Asia (theme-park tickets, rail passes like the JR Pass, airport transfers, eSIMs, and tours) often at prices below the gate. Bookings run through klook.com or its app and generally code as travel or tour-agency merchants.
 
   Activity bookings are travel spend most cards recognize: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X's 2x applies everywhere including the odd booking that codes as ticketing instead. Klook runs frequent promo-code sales, so stack a discount with the multiplier rather than choosing between them.

--- a/data/stores/koa.yaml
+++ b/data/stores/koa.yaml
@@ -8,6 +8,6 @@ categories:
   - vacation_rentals
 website: "https://koa.com"
 intro: |
-  KOA — Kampgrounds of America — runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.
+  KOA (Kampgrounds of America) runs the largest network of private campgrounds in North America, over 500 locations spanning tent sites, RV hookups, and cabin rentals, bookable through koa.com and its Rewards program. Campground charges code as lodging or campground merchants, generally inside travel category definitions.
 
   Travel cards are the natural fit: Chase Sapphire Preferred and Reserve count campground stays in their travel multipliers, Capital One Venture X earns its flat 2x everywhere, and annual-fee travel credits like the Sapphire Reserve's have been reported to apply to campground charges. KOA Rewards stacks on top regardless of card.

--- a/data/stores/life-fitness.yaml
+++ b/data/stores/life-fitness.yaml
@@ -5,6 +5,6 @@ categories:
   - sporting_goods
 website: "https://www.lifefitness.com"
 intro: |
-  Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use — treadmills, ellipticals, bikes, and the Hammer Strength line — at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.
+  Life Fitness equips commercial gyms worldwide, and its consumer store sells the same DNA for home use (treadmills, ellipticals, bikes, and the Hammer Strength line) at four-figure price points. Home orders from lifefitness.com code as online retail, sometimes classifying under sporting or exercise equipment.
 
   Purchases this size are textbook signup-bonus spend, often clearing an entire minimum in one order. Absent a new card, U.S. Bank Cash+ with sporting goods selected can hit 5 percent where the charge classifies that way, with Bank of America Customized Cash's online shopping choice a dependable 3 percent.

--- a/data/stores/make-up-for-ever.yaml
+++ b/data/stores/make-up-for-ever.yaml
@@ -9,4 +9,4 @@ website: "https://www.makeupforever.com"
 intro: |
   Make Up For Ever is the LVMH-owned professional makeup house famous for the HD Skin foundation range, Aqua Resist liners, and artist-grade palettes born from its Paris pro heritage. US orders from makeupforever.com code as online beauty retail; the brand also sells through Sephora.
 
-  Direct orders suit an online category — Bank of America Customized Cash set to online shopping earns 3 percent — while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.
+  Direct orders suit an online category (Bank of America Customized Cash set to online shopping earns 3 percent) while buying the same products through Sephora can tap Sephora-adjacent promotions and rotating-category quarters. Flat 2 percent cards cover restocks when nothing better is live.

--- a/data/stores/mrs-fields.yaml
+++ b/data/stores/mrs-fields.yaml
@@ -9,4 +9,4 @@ website: "https://www.mrsfields.com"
 intro: |
   Mrs. Fields turned mall-kiosk chocolate-chip cookies into a national gifting business: tins, cookie cakes, and corporate gift baskets shipped nationwide from mrsfields.com, alongside its remaining bakery locations. Online gift orders code as internet retail or specialty food, while in-person bakery purchases can code as dining or fast food.
 
-  For shipped gifts, an online category does the work — Bank of America Customized Cash set to online shopping earns 3 percent — while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.
+  For shipped gifts, an online category does the work (Bank of America Customized Cash set to online shopping earns 3 percent) while a mall-kiosk cookie run may trigger dining or fast-food bonuses like the U.S. Bank Cash+ fast food selection. Holiday bulk gifting is also easy signup-bonus spend.

--- a/data/stores/nalgene.yaml
+++ b/data/stores/nalgene.yaml
@@ -5,6 +5,6 @@ categories:
   - sporting_goods
 website: "https://www.nalgene.com"
 intro: |
-  Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders — including the popular custom-printing option — ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.
+  Nalgene's wide-mouth bottles graduated from Rochester lab equipment to the default water bottle of trailheads and lecture halls, now sold in endless colors and the Sustain recycled line. Direct orders (including the popular custom-printing option) ship from nalgene.com and code as online retail, occasionally classifying as sporting goods.
 
   Bottles are small-ticket, so rewards are more about which card is already in hand: Bank of America Customized Cash set to online shopping earns 3 percent, a U.S. Bank Cash+ sporting goods quarter can catch a team order at 5 percent, and REI stock of the same bottles earns REI-specific card bonuses instead.

--- a/data/stores/naturalizer.yaml
+++ b/data/stores/naturalizer.yaml
@@ -6,6 +6,6 @@ categories:
   - department_stores
 website: "https://www.naturalizer.com"
 intro: |
-  Naturalizer has sold comfort-first women's footwear since 1927 — pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.
+  Naturalizer has sold comfort-first women's footwear since 1927: pumps, flats, boots, and sandals engineered around fit, under the Caleres umbrella alongside Famous Footwear and Franco Sarto. Direct orders from naturalizer.com code as online shoe retail.
 
   Footwear reliably lands in apparel categories: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the merchant classifies as apparel or shoes, Bank of America Customized Cash set to online shopping earns 3 percent, and the same styles at Macy's or Nordstrom can pick up department-store bonuses when one is live.

--- a/data/stores/ole-henriksen.yaml
+++ b/data/stores/ole-henriksen.yaml
@@ -7,6 +7,6 @@ categories:
   - department_stores
 website: "https://www.olehenriksen.com"
 intro: |
-  Ole Henriksen bottles Scandinavian glow-first skincare — Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners — born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.
+  Ole Henriksen bottles Scandinavian glow-first skincare (Banana Bright eye cream, Truth Serum vitamin C, and cold-plunge-inspired toners) born from the founder's Hollywood facial spa and now under Kendo, LVMH's beauty incubator. Direct orders from olehenriksen.com code as online beauty retail; Sephora carries the full line.
 
-  Direct restocks favor an online category — Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5 — while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.
+  Direct restocks favor an online category (Bank of America Customized Cash set to online shopping at 3 percent, online-retail rotating quarters at 5) while routing through Sephora can layer its sale events on top. A flat 2 percent card covers the serum emergency between promotions.

--- a/data/stores/pga-tour-superstore.yaml
+++ b/data/stores/pga-tour-superstore.yaml
@@ -5,6 +5,6 @@ categories:
   - online_shopping
 website: "https://www.pgatoursuperstore.com"
 intro: |
-  PGA TOUR Superstore is the big-box golf retailer — clubs, balls, apparel, launch-monitor fittings, and in-store simulators — with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.
+  PGA TOUR Superstore is the big-box golf retailer (clubs, balls, apparel, launch-monitor fittings, and in-store simulators) with 70-plus warehouses and a full e-commerce operation. Purchases code as sporting-goods retail whether in-store or from pgatoursuperstore.com.
 
   Golf spend adds up fast, and sporting-goods coverage is unusually good: U.S. Bank Cash+ with sporting goods stores selected pays 5 percent, rotating quarters occasionally cover the category too, and a driver-and-iron-set fitting bill makes clean signup-bonus spend. Bank of America Customized Cash's online shopping choice covers web orders at 3 percent.

--- a/data/stores/philosophy.yaml
+++ b/data/stores/philosophy.yaml
@@ -7,4 +7,4 @@ website: "https://www.philosophy.com"
 intro: |
   Philosophy is the feel-good skincare and bath brand behind Purity Made Simple cleanser, Hope in a Jar moisturizer, and the dessert-scented Amazing Grace shower gels, sold direct and through Ulta, Sephora, and department stores. Orders from philosophy.com code as online beauty retail.
 
-  Routine restocks favor an online category — Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5 — while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.
+  Routine restocks favor an online category (Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters lift a stock-up to 5) while buying through Ulta or a department store instead can catch retailer-specific bonuses. Flat 2 percent cards are the zero-thought floor.

--- a/data/stores/physicians-formula.yaml
+++ b/data/stores/physicians-formula.yaml
@@ -4,6 +4,6 @@ categories:
   - online_shopping
 website: "https://www.physiciansformula.com"
 intro: |
-  Physicians Formula has sold hypoallergenic drugstore makeup since 1937 — Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.
+  Physicians Formula has sold hypoallergenic drugstore makeup since 1937: Butter Bronzer, Murumuru glow products, and sensitive-skin formulas that undercut prestige dupes at a fraction of the price, under Markwins Beauty alongside Wet n Wild. Direct orders from physiciansformula.com code as online retail.
 
-  The drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter — Chase Freedom Flex has covered drugstores repeatedly — at 5 percent. Price-match against drugstore sales before ordering direct.
+  The drugstore-versus-direct split decides the card: direct orders earn online rates like Bank of America Customized Cash's 3 percent online shopping choice, while the same Butter Bronzer at CVS or Walgreens can ride a drugstore quarter (Chase Freedom Flex has covered drugstores repeatedly) at 5 percent. Price-match against drugstore sales before ordering direct.

--- a/data/stores/pit-boss-grills.yaml
+++ b/data/stores/pit-boss-grills.yaml
@@ -7,6 +7,6 @@ categories:
   - home_improvement
 website: "https://pitboss-grills.com"
 intro: |
-  Pit Boss is the value heavyweight of pellet grilling — bigger hoppers and lower prices than Traeger — spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.
+  Pit Boss is the value heavyweight of pellet grilling (bigger hoppers and lower prices than Traeger) spanning pellet, gas, and griddle lines plus the pellets and rubs that keep them fed, under Dansons alongside Louisiana Grills. Direct orders from pitboss-grills.com code as online retail.
 
-  A grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories — compare, since Pit Boss runs aggressive direct-only bundle deals.
+  A grill is mid-to-high three figures and lands well as signup-bonus spend. Otherwise Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same grills at Lowe's or Walmart can tap home-improvement or retailer categories; compare before buying, since Pit Boss runs aggressive direct-only bundle deals.

--- a/data/stores/roc-skincare.yaml
+++ b/data/stores/roc-skincare.yaml
@@ -8,4 +8,4 @@ website: "https://www.rocskincare.com"
 intro: |
   RoC pioneered stabilized retinol in drugstore skincare and remains the evidence-first pick for anti-aging staples like Retinol Correxion and the Multi Correxion vitamin-C line. Buying direct from rocskincare.com codes as online retail; the same products also sit on Walgreens, CVS, and Amazon shelves.
 
-  Direct orders fit an online category — Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more — while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.
+  Direct orders fit an online category (Bank of America Customized Cash set to online shopping earns 3 percent, rotating online-retail quarters more) while picking RoC up at an actual drugstore can trigger drugstore multipliers instead, like Chase Freedom Flex's frequent drugstore quarters. Compare prices; drugstore sales frequently undercut direct.

--- a/data/stores/sennheiser.yaml
+++ b/data/stores/sennheiser.yaml
@@ -5,6 +5,6 @@ categories:
   - electronics_stores
 website: "https://www.sennheiser.com"
 intro: |
-  Sennheiser's consumer line — Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers — carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.
+  Sennheiser's consumer line (Momentum headphones and earbuds, the audiophile HD 600 series, and Accentum mid-rangers) carries one of the most respected names in audio, with consumer operations now run by Sonova. Direct US orders code as online electronics retail and include certified refurb stock.
 
   Headphone purchases in the $200–$400 band reward a live category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the merchant classifies as electronics, Bank of America Customized Cash set to online shopping is a solid 3 percent, and open-box HD 6XX-adjacent deals on a flat 2 percent card still come out well.

--- a/data/stores/spirit-halloween.yaml
+++ b/data/stores/spirit-halloween.yaml
@@ -6,6 +6,6 @@ categories:
   - online_shopping
 website: "https://www.spirithalloween.com"
 intro: |
-  Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round — including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.
+  Spirit Halloween is the pop-up chain that materializes in vacant storefronts every fall, and its online store sells costumes, animatronics, and decor year-round, including the collector-grade animatronics that sell out before October. Online orders from spirithalloween.com code as internet retail; in-store purchases code as seasonal retail.
 
-  Costume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter — which has historically covered Q4 — can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.
+  Costume-season carts benefit from an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter (which has historically covered Q4) can push a family costume order to 5 percent. Flat 2 percent cards cover the in-store impulse skeleton.

--- a/data/stores/steelseries.yaml
+++ b/data/stores/steelseries.yaml
@@ -5,6 +5,6 @@ categories:
   - electronics_stores
 website: "https://steelseries.com"
 intro: |
-  SteelSeries builds gaming peripherals — the Arctis headset line, Apex keyboards, Rival and Aerox mice, and QcK mousepads — sold direct from steelseries.com alongside retail channels. Direct orders code as online electronics retail and are where the brand runs its own refurb and bundle pricing.
+  SteelSeries builds gaming peripherals (the Arctis headset line, Apex keyboards, Rival and Aerox mice, and QcK mousepads) sold direct from steelseries.com alongside retail channels. Direct orders code as online electronics retail and are where the brand runs its own refurb and bundle pricing.
 
   Peripheral refreshes are classic electronics-category spend: U.S. Bank Cash+ with electronics stores selected can hit 5 percent when the merchant classifies that way, Bank of America Customized Cash set to online shopping earns 3 percent, and PayPal-heavy checkout flows occasionally line up with a Chase Freedom Flex quarter.

--- a/data/stores/superdry.yaml
+++ b/data/stores/superdry.yaml
@@ -5,6 +5,6 @@ categories:
   - select_clothing
 website: "https://www.superdry.com"
 intro: |
-  Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding — best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.
+  Superdry is the British streetwear label that fuses Americana graphics with Japanese-inspired branding, best known for its Osaka tees, hoodies, and technical jackets. US orders from superdry.com code as online apparel retail, and the brand's outlet section runs deep discounts most of the year.
 
   Apparel categories cover it: U.S. Bank Cash+ with select clothing stores selected can pay 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and rotating online-retail quarters occasionally beat both on a jacket-sized order.

--- a/data/stores/the-parking-spot.yaml
+++ b/data/stores/the-parking-spot.yaml
@@ -6,4 +6,4 @@ website: "https://www.theparkingspot.com"
 intro: |
   The Parking Spot is the largest near-airport parking operator in the US, with covered and uncovered lots plus shuttle service at 25-plus airports, booked ahead on theparkingspot.com for member rates through its Spot Club program. Airport parking charges typically code as parking or travel merchants.
 
-  Parking spend near airports frequently counts toward travel multipliers — Chase Sapphire Preferred and Reserve both include parking in their travel definitions — and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.
+  Parking spend near airports frequently counts toward travel multipliers (Chase Sapphire Preferred and Reserve both include parking in their travel definitions) and Capital One Venture X's flat 2x applies regardless of coding. Book prepaid online rather than paying the gate rate: the member discount usually outweighs any category difference.

--- a/data/stores/theory.yaml
+++ b/data/stores/theory.yaml
@@ -6,6 +6,6 @@ categories:
   - department_stores
 website: "https://www.theory.com"
 intro: |
-  Theory built its name on precisely tailored workwear fundamentals — the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe — under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.
+  Theory built its name on precisely tailored workwear fundamentals (the Sylvain shirt, Good Wool suiting, and knits that anchor a capsule wardrobe) under Fast Retailing, the parent of Uniqlo. Direct orders from theory.com code as online apparel retail; the brand also runs a robust outlet channel and sells through Nordstrom and Bloomingdale's.
 
   Suiting-level price tags make categories worthwhile: U.S. Bank Cash+ with select clothing stores selected can return 5 percent when the charge classifies as apparel, Bank of America Customized Cash set to online shopping earns 3 percent, and department-store bonuses apply when you shop Theory through Nordstrom instead.

--- a/data/stores/troy-bilt.yaml
+++ b/data/stores/troy-bilt.yaml
@@ -7,6 +7,6 @@ categories:
   - home_improvement
 website: "https://www.troybilt.com"
 intro: |
-  Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points — corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.
+  Troy-Bilt has outfitted American yards since the first rototiller in 1937, selling walk-behind and riding mowers, tillers, snow blowers, and string trimmers at value price points, corporate sibling to Cub Cadet under Stanley Black & Decker's outdoor unit. Direct orders from troybilt.com code as online retail.
 
-  Outdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live — price both before buying.
+  Outdoor power equipment is chunky, plannable spend: a rider makes easy signup-bonus progress, Bank of America Customized Cash set to online shopping earns 3 percent direct, and the same machines at Lowe's or Home Depot can catch a home-improvement category bonus when one is live; price both before buying.

--- a/data/stores/vegas-com.yaml
+++ b/data/stores/vegas-com.yaml
@@ -7,6 +7,6 @@ categories:
   - entertainment
 website: "https://www.vegas.com"
 intro: |
-  Vegas.com packages the whole Las Vegas trip — hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles — as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.
+  Vegas.com packages the whole Las Vegas trip (hotel rooms, show and attraction tickets, tours, and flight-plus-hotel bundles) as an online travel agency focused on a single city. Bookings code as travel-agency or ticketing merchants depending on what is in the cart.
 
   OTA bookings are travel spend to most issuers: Chase Sapphire Preferred earns 2x and Reserve 3x on travel, and Capital One Venture X covers whatever coding comes back at 2x. One trade-off to know: booking through an OTA usually forfeits hotel-program elite credit, so weigh the bundle discount against booking the room direct.

--- a/data/stores/versed.yaml
+++ b/data/stores/versed.yaml
@@ -7,6 +7,6 @@ categories:
   - online_shopping
 website: "https://versedskin.com"
 intro: |
-  Versed distills clean-clinical skincare into sub-$25 staples — Dew Point moisturizer, the Auto Save retinol line, and single-minded serums — born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.
+  Versed distills clean-clinical skincare into sub-$25 staples (Dew Point moisturizer, the Auto Save retinol line, and single-minded serums) born from the Who What Wear media brand and stocked at Target alongside its own site. Direct orders from versedskin.com code as online retail.
 
   The Target-versus-direct choice drives rewards: direct earns online-category rates like Bank of America Customized Cash's 3 percent online shopping selection, while Target runs earn RedCard savings or Target-category promos. Direct-exclusive bundles and sets are usually the reason to order from the brand itself.

--- a/data/stores/victrola.yaml
+++ b/data/stores/victrola.yaml
@@ -5,6 +5,6 @@ categories:
   - electronics_stores
 website: "https://victrola.com"
 intro: |
-  Victrola revived the century-old phonograph name into the best-selling entry point for vinyl — suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.
+  Victrola revived the century-old phonograph name into the best-selling entry point for vinyl: suitcase turntables, the Sonos-ready Stream series, and retro radio-console hybrids. Direct orders from victrola.com code as online electronics retail.
 
   Turntable purchases fit neatly under an electronics selection: U.S. Bank Cash+ set to electronics stores can pay 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent, and a suitcase-player gift on a flat 2 percent card needs no planning at all.

--- a/data/stores/vivint.yaml
+++ b/data/stores/vivint.yaml
@@ -7,6 +7,6 @@ categories:
   - home_improvement
 website: "https://www.vivint.com"
 intro: |
-  Vivint sells professionally installed smart-home security — doorbell and outdoor cameras, smart locks, and thermostats wired into one app — with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.
+  Vivint sells professionally installed smart-home security (doorbell and outdoor cameras, smart locks, and thermostats wired into one app) with equipment financed or bought outright plus a monthly monitoring plan, now under NRG. Charges from vivint.com code as security services.
 
-  Monitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus — a full system easily covers a minimum-spend requirement in one go.
+  Monitoring bills and equipment payments rarely match a bonus category, so run the monthly plan on a flat 2 percent card, and consider timing an upfront equipment purchase against a new card's signup bonus; a full system easily covers a minimum-spend requirement in one go.

--- a/data/stores/wet-n-wild.yaml
+++ b/data/stores/wet-n-wild.yaml
@@ -6,6 +6,6 @@ categories:
   - online_shopping
 website: "https://www.wetnwildbeauty.com"
 intro: |
-  Wet n Wild is the drugstore-beauty value icon — MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.
+  Wet n Wild is the drugstore-beauty value icon: MegaGlo highlighters, PhotoFocus foundation, and $1-adjacent liners with a cult following far above their price point, all under Markwins Beauty. Direct orders from wetnwildbeauty.com code as online retail and carry web-exclusive shades and bundles.
 
-  At these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent — the drugstore route usually wins when those are live.
+  At these prices rewards are a rounding error per item but add up across hauls: Bank of America Customized Cash set to online shopping earns 3 percent direct, while grabbing the same SKUs at CVS or Walgreens can catch drugstore quarters like Chase Freedom Flex's at 5 percent; the drugstore route usually wins when those are live.

--- a/data/stores/wyze.yaml
+++ b/data/stores/wyze.yaml
@@ -7,6 +7,6 @@ categories:
   - electronics_stores
 website: "https://www.wyze.com"
 intro: |
-  Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home — cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.
+  Wyze made its name selling a competent $20 security camera and now covers the whole budget smart home: cams, video doorbells, locks, vacuums, and the Cam Plus subscription that unlocks cloud features. Hardware and subscriptions bill from wyze.com and code as online electronics retail.
 
   Wyze orders are frequent and small, which favors an always-on category: U.S. Bank Cash+ set to electronics stores can return 5 percent where the charge classifies as electronics, Bank of America Customized Cash set to online shopping earns 3 percent on both hardware and Cam Plus renewals, and flat 2 percent covers the impulse camera.

--- a/data/stores/yale-home.yaml
+++ b/data/stores/yale-home.yaml
@@ -7,6 +7,6 @@ categories:
   - home_improvement
 website: "https://shopyalehome.com"
 intro: |
-  Yale has made locks since 1840, and Yale Home is its smart-lock arm — the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa, sharing corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.
+  Yale has made locks since 1840, and Yale Home is its smart-lock arm: the Assure Lock 2 line, keypad deadbolts, and integrations across HomeKit, Google, and Alexa. It shares corporate lineage with August under ASSA ABLOY. Direct orders from shopyalehome.com code as online retail.
 
-  A smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively — whichever category you have live decides the store.
+  A smart-lock upgrade sits in the same category territory as Master Lock gear: Bank of America Customized Cash set to online shopping earns 3 percent direct, while buying the same lock at Home Depot or Best Buy can catch home-improvement or electronics bonuses respectively; whichever category you have live decides the store.

--- a/data/stores/yarnspirations.yaml
+++ b/data/stores/yarnspirations.yaml
@@ -4,6 +4,6 @@ categories:
   - online_shopping
 website: "https://www.yarnspirations.com"
 intro: |
-  Yarnspirations is the official online home of the big craft-yarn brands — Caron, Bernat, Red Heart, Patons, and Lily Sugar'n Cream — plus thousands of free knitting and crochet patterns. Unlike a Michaels or JOANN run, Yarnspirations orders ship direct and code as online retail rather than a craft-store purchase.
+  Yarnspirations is the official online home of the big craft-yarn brands (Caron, Bernat, Red Heart, Patons, and Lily Sugar'n Cream) plus thousands of free knitting and crochet patterns. Unlike a Michaels or JOANN run, Yarnspirations orders ship direct and code as online retail rather than a craft-store purchase.
 
   Stock-up orders during clearance events are where the money goes, so route them through an online category: Bank of America Customized Cash set to online shopping earns 3 percent, and a Chase Freedom Flex online-retail quarter can lift a big cart to 5 percent.

--- a/data/stores/zinio.yaml
+++ b/data/stores/zinio.yaml
@@ -6,6 +6,6 @@ categories:
   - online_shopping
 website: "https://www.zinio.com"
 intro: |
-  Zinio is the largest digital newsstand, selling single issues and annual subscriptions to thousands of magazines readable across its apps, in the same digital-reading niche as Magzter. Subscriptions bill through zinio.com and code as an online digital purchase — notably not as a streaming service, so streaming-bundle credits will not apply.
+  Zinio is the largest digital newsstand, selling single issues and annual subscriptions to thousands of magazines readable across its apps, in the same digital-reading niche as Magzter. Subscriptions bill through zinio.com and code as an online digital purchase (not a streaming service), so streaming-bundle credits will not apply.
 
   Magazine subscriptions are small recurring charges, ideal for a set-and-forget card: a flat 2 percent earner covers renewals without thought, while Bank of America Customized Cash set to online shopping stretches them to 3 percent.


### PR DESCRIPTION
The 2026-08 affiliate batch (#1960, #1962) shipped store intros written with em dashes, against the house copy rule (they read as AI-generated). My miss — the rule is in my feedback memory and I didn't apply it while writing.

- Paired dashes became parentheses; single dashes became commas, colons, or new sentences.
- Hand pass over every changed line to catch comma splices (29 manual rewrites on top of the mechanical transform).
- Zero em dashes remain across the 87 batch files; the ~39 pre-existing store files that contain em dashes are untouched (out of scope).
- `stores.json` + Lambda mirror regenerated; build green (1,043 stores, 576 affiliate links).