### PR TITLE
Benefits triage: drop Venue Collection, split Ink 3x categories, remove expired Southwest promos

### DIFF
--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -15,9 +15,7 @@ our_take: >
   cover the fee if you fly often enough to use it, and the 40,000-point bonus
   after $3,000 in six months was reachable for anyone traveling regularly. The
   catch is how narrow the rest of it is: outside those three categories the
-  card earns a flat 1x, and the Venue Collection perk, 10% back on stadium
-  concessions up to $250 a year, only matters if you attend events at
-  participating venues. Existing cardholders who don't use CLEAR should run
+  card earns a flat 1x. Existing cardholders who don't use CLEAR should run
   the numbers before paying the fee again.
 annual_fee: 150
 reward_type: "points"
@@ -49,13 +47,6 @@ benefits:
     description: "Up to $219 in statement credits per calendar year for CLEAR Plus airport security membership"
     frequency: "annual"
     category: "security"
-    enrollment_required: true
-  - name: "American Express Venue Collection"
-    value: 10
-    value_unit: "percent"
-    description: "10% back on qualifying concessions purchases at select stadiums and arenas up to $250 per calendar year, plus access to dedicated entrances or fast lanes."
-    frequency: "annual"
-    category: "entertainment"
     enrollment_required: true
 tags:
   - travel

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -16,7 +16,28 @@ rewards:
   - category: travel
     value: 3
     unit: points_per_dollar
-    note: "Travel, shipping, internet/cable/phone, advertising on search engines and social media (combined)"
+    note: "Travel, shipping, internet/cable/phone, advertising on search engines and social media (combined $150,000/yr cap)"
+    spend_cap: 150000
+    cap_period: annual
+    rate_after_cap: 1
+  - category: shipping
+    value: 3
+    unit: points_per_dollar
+    note: "Shipping purchases (combined $150,000/yr cap with travel, internet/cable/phone, and advertising)"
+    spend_cap: 150000
+    cap_period: annual
+    rate_after_cap: 1
+  - category: utilities
+    value: 3
+    unit: points_per_dollar
+    note: "Internet and cable services (combined $150,000/yr cap with travel, shipping, phone, and advertising)"
+    spend_cap: 150000
+    cap_period: annual
+    rate_after_cap: 1
+  - category: phone
+    value: 3
+    unit: points_per_dollar
+    note: "Phone services (combined $150,000/yr cap with travel, shipping, internet/cable, and advertising)"
     spend_cap: 150000
     cap_period: annual
     rate_after_cap: 1

--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -54,10 +54,3 @@ benefits:
     frequency: "per_purchase"
     category: "statement_credit"
     enrollment_required: false
-  - name: "Amex Venue Collection"
-    value: 10
-    value_unit: "percent"
-    description: "10% back on qualifying concessions purchases at select stadiums and arenas up to $250 per calendar year."
-    frequency: "annual"
-    category: "entertainment"
-    enrollment_required: true

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -59,13 +59,6 @@ benefits:
     frequency: "annual"
     category: "hotel"
     enrollment_required: false
-  - name: "American Express Venue Collection"
-    value: 10
-    value_unit: "percent"
-    description: "Enhanced experience at select stadiums and arenas with dedicated entrances and 10% back on qualifying concessions purchases up to $250 per calendar year."
-    frequency: "annual"
-    category: "entertainment"
-    enrollment_required: true
   - name: "Rideshare Statement Credit"
     value: 120
     description: "Earn up to $10 in statement credits each month on U.S. rideshare purchases with select providers"

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -82,13 +82,6 @@ benefits:
     frequency: "per_purchase"
     category: "dining"
     enrollment_required: false
-  - name: "American Express Venue Collection"
-    value: 10
-    value_unit: "percent"
-    description: "On-site benefits such as dedicated entrances at select stadiums and arenas, plus 10% back on qualifying concessions purchases up to $250 per calendar year."
-    frequency: "annual"
-    category: "entertainment"
-    enrollment_required: true
   - name: "Cell Phone Protection"
     value: 800
     description: "Up to $800 per claim to repair or replace a damaged or stolen cell phone, limit 2 approved claims per 12 months with a $50 deductible, when the prior month's wireless bill was paid with the card."

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -93,13 +93,6 @@ benefits:
     frequency: "per_rental"
     category: "hotel"
     enrollment_required: false
-  - name: "American Express Venue Collection"
-    value: 10
-    value_unit: "percent"
-    description: "10% back on food and beverage concessions purchases at Amex Venue Collection stadiums and arenas, up to $250 per calendar year"
-    frequency: "annual"
-    category: "entertainment"
-    enrollment_required: true
   - name: "Cell Phone Protection"
     description: "Reimburses the lesser of repair or replacement cost after damage or theft, up to $800 per claim and 2 claims per 12 months, with a $50 deductible, when the wireless bill is paid with the card"
     frequency: "per_claim"

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -79,13 +79,6 @@ benefits:
     description: "Upgrade to Hilton Honors Diamond status through the end of the next calendar year after $40,000 in annual purchases"
     frequency: "ongoing"
     category: "hotel"
-  - name: "American Express Venue Collection"
-    value: 10
-    value_unit: "percent"
-    description: "10% back on food and beverage concessions purchases at Amex Venue Collection stadiums and arenas, up to $250 per calendar year"
-    frequency: "annual"
-    category: "entertainment"
-    enrollment_required: true
 tags:
   - hotel
   - travel

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -66,13 +66,6 @@ benefits:
     description: "Upgrade to Hilton Honors Gold status after $20,000 in eligible purchases in a calendar year, valid for that year and the next"
     frequency: "ongoing"
     category: "hotel"
-  - name: "American Express Venue Collection"
-    value: 10
-    value_unit: "percent"
-    description: "10% back on food and beverage concessions purchases at Amex Venue Collection stadiums and arenas, up to $250 per calendar year"
-    frequency: "annual"
-    category: "entertainment"
-    enrollment_required: true
 tags:
   - hotel
   - travel

--- a/data/cards/southwest-rapid-rewards-performance-business-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-performance-business-credit-card.yaml
@@ -33,10 +33,6 @@ rewards:
     value: 2
     unit: points_per_dollar
     note: "Local transit and commuting, including rideshare"
-  - category: phone
-    value: 2
-    unit: points_per_dollar
-    note: "Internet, cable, and phone services, plus social media and search engine advertising"
   - category: everything_else
     value: 1
     unit: points_per_dollar
@@ -110,7 +106,7 @@ our_take: >
   selection at booking, Group 5 boarding, and a free first checked bag for you
   and up to eight passengers on the same reservation. It earns 4 points per
   dollar on Southwest purchases and 2x across gas, dining, hotels booked
-  directly, transit, and internet, cable, phone, and advertising spend, with
+  directly, and transit, with
   80,000 points after $5,000 in the first three months. It also builds status
   faster than the rest of the family: 2,500 tier qualifying points toward
   A-List for every $5,000 spent, plus 10,000 Companion Pass qualifying points

--- a/data/cards/southwest-rapid-rewards-premier-business-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-business-credit-card.yaml
@@ -33,10 +33,6 @@ rewards:
     spend_cap: 8000
     cap_period: annual
     rate_after_cap: 1
-  - category: transit
-    value: 2
-    unit: points_per_dollar
-    note: "Local transit and commuting, including rideshare"
   - category: everything_else
     value: 1
     unit: points_per_dollar
@@ -104,8 +100,8 @@ our_take: >
   for the cardmember and up to eight passengers on the same reservation, Group
   5 boarding, complimentary Standard or Preferred seat selection within 48
   hours of departure, and free employee cards with individual spending limits.
-  It earns 3 points per dollar on Southwest purchases, 2x on transit, and 2x
-  on gas and restaurants up to a combined $8,000 a year before dropping to 1x,
+  It earns 3 points per dollar on Southwest purchases and 2x on gas and
+  restaurants up to a combined $8,000 a year before dropping to 1x,
   with 1x on everything else, so the spending categories are useful but
   capped. The welcome offer is 60,000 points after $3,000 in the first three
   months. For status chasers it delivers 2,000 tier qualifying points toward

--- a/data/review-declined.yaml
+++ b/data/review-declined.yaml
@@ -47,6 +47,12 @@ rewards_added:
       why: "the existing streaming row already covers cable and internet" }
   - { slug: united-quest, category: hotels,
       why: "the existing hotels_portal 5x row — Renowned Hotels via Chase Travel only; a bare `hotels` row would claim 5x on all hotel spend" }
+  - { slug: heb-visa-signature, category: dining,
+      why: "the 5% is Favor delivery only, already covered by the groceries row's note; all other dining earns the 1.5% base rate (issue #1914)" }
+  - { slug: southwest-rapid-rewards-performance-business-credit-card, category: phone,
+      why: "internet/cable/phone + advertising 2x expired 2025-12-31; Chase still quotes the dated text on the page. Delete this entry if Chase renews with a new date" }
+  - { slug: southwest-rapid-rewards-premier-business-credit-card, category: transit,
+      why: "local transit 2x expired 2025-12-31; Chase still quotes the dated text on the page. Delete this entry if Chase renews with a new date" }
   - { slug: world-of-hyatt-business-credit-card, category: selected_categories,
       why: "the same bucket as the existing top_category row" }
 
@@ -55,6 +61,10 @@ rewards_added:
 # detector could not read the earn table (JS-rendered or bot-blocked).
 rewards_removed:
   - { slug: aaa-daily-advantage-visa-signature, category: ev_charging }
+  - { slug: robinhood-platinum, category: hotels_portal }
+  - { slug: robinhood-platinum, category: car_rentals_portal }
+  - { slug: southwest-rapid-rewards-performance-business-credit-card, category: hotels }
+  - { slug: united-explorer, category: hotels }
   - { slug: aaa-travel-advantage-visa-signature, category: ev_charging }
   - { slug: atmos-rewards-business, category: ev_charging }
   - { slug: capital-one-quicksilver-secured, category: hotels_car_portal }
@@ -99,4 +109,8 @@ benefits:
 # Benefit names declined on EVERY card. Prefer benefit-policy.yaml's
 # `exclude` list for anything the team will never want; this is for names
 # that are merely not worth re-litigating each week.
-benefits_global: []
+benefits_global:
+  - { name: "American Express Venue Collection",
+      why: "10% back on stadium concessions capped at $250/yr is at most $25 of value, below the small-benefits bar; removed from all 7 carrying cards (issue #1916)" }
+  - { name: "Amex Venue Collection",
+      why: "name variant of the same perk (was on Delta SkyMiles Blue)" }


### PR DESCRIPTION
Resolves #1916, #1914, and #1879 (the full triage of the two weekly review queues plus the Venue Collection consistency issue).

Every item was verified against the live issuer page today before deciding.

## Venue Collection (#1916)
Removed **American Express Venue Collection** from all 7 carrying cards (Amex Green + our_take mention, Delta Blue/Gold/Platinum, Hilton Honors/Surpass/Aspire). The perk caps at $250 of concessions spend, so it's worth at most **$25/yr** — below the small-benefits bar (same call as the JetBlue Business rebate in #1332). Added `benefits_global` decline entries under both name spellings so the checker never re-proposes it.

## Review queue items (#1914 / #1879)

| Item | Live-page verdict | Action |
|---|---|---|
| Ink Preferred: shipping/utilities/phone 3x | Real: page lists all four 3x categories, combined $150k cap | **Added** as split rows so store rankings surface them |
| H-E-B: dining 5% | Favor delivery only; other dining earns the 1.5% base | **Declined** — already covered by the groceries row's note |
| Robinhood Platinum: hotels_portal / car_rentals_portal removals | Page plainly shows "10% cash back on hotels & cars" booked in-app | **Kept**, removals declined (extraction false positive) |
| SW Performance: hotels 2x removal | Page still lists "2 points per $1 on hotel accommodations booked directly" | **Kept**, removal declined |
| SW Performance: phone 2x removal | Page dates internet/cable/phone + advertising "until December 31, 2025" — expired | **Removed** (+ our_take updated) |
| SW Premier: transit 2x removal | Same expired 12/31/2025 dating | **Removed** (+ our_take updated) |
| United Explorer: hotels 2x removal | Page still lists "2x miles on hotel stays when booked with the hotel" | **Kept**, removal declined |

The two expired Southwest categories got `rewards_added` decline entries too, since Chase still quotes the dated text on the page and the extractor would otherwise re-propose them weekly; the entries say to delete them if Chase renews.

`npm run build:cards` passes (cards.json regenerated then discarded per convention); `review-declined.yaml` parses.