### PR TITLE
Add trendline to income/limit chart and denial reasons to rejected tooltips

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -411,6 +411,22 @@ export default function CardClient({
     (s) => Array.isArray(s) && s.length > 0,
   );
 
+  // The graphs endpoint returns bare [x, y] pairs; match rejected points back
+  // to the raw records by coordinates to surface reason_denied in the tooltip.
+  const withDenialReasons = (
+    data: [number, number][],
+    x: (r: CardRecord) => number | null,
+    y: (r: CardRecord) => number | null,
+  ) =>
+    data.map(([px, py]) => {
+      const match = records.find(
+        (r) => r.result === 0 && r.reason_denied && x(r) === px && y(r) === py,
+      );
+      return match
+        ? { x: px, y: py, note: match.reason_denied as string }
+        : ([px, py] as [number, number]);
+    });
+
   const sortedRewards = useMemo<Reward[]>(
     () => (card.rewards ? [...card.rewards].sort((a, b) => b.value - a.value) : []),
     [card.rewards],
@@ -1448,7 +1464,15 @@ export default function CardClient({
                           yPrefix="$"
                           series={[
                             { name: "Accepted", color: "#6d3fe8", data: chartOne[0] || [] },
-                            { name: "Rejected", color: "#d23a62", data: chartOne[1] || [] },
+                            {
+                              name: "Rejected",
+                              color: "#d23a62",
+                              data: withDenialReasons(
+                                chartOne[1] || [],
+                                (r) => r.credit_score,
+                                (r) => r.listed_income,
+                              ),
+                            },
                           ]}
                         />
                       ),
@@ -1466,7 +1490,15 @@ export default function CardClient({
                           xSuffix=" yr"
                           series={[
                             { name: "Accepted", color: "#6d3fe8", data: chartTwo[0] || [] },
-                            { name: "Rejected", color: "#d23a62", data: chartTwo[1] || [] },
+                            {
+                              name: "Rejected",
+                              color: "#d23a62",
+                              data: withDenialReasons(
+                                chartTwo[1] || [],
+                                (r) => r.length_credit,
+                                (r) => r.credit_score,
+                              ),
+                            },
                           ]}
                         />
                       ),
@@ -1483,6 +1515,7 @@ export default function CardClient({
                           yAxis="Starting Credit Limit (USD)"
                           xPrefix="$"
                           yPrefix="$"
+                          trendline
                           series={[
                             { name: "Accepted", color: "#6d3fe8", data: chartThree[0] || [] },
                           ]}

--- a/apps/web-next/src/components/charts/ScatterPlot.tsx
+++ b/apps/web-next/src/components/charts/ScatterPlot.tsx
@@ -9,10 +9,26 @@ import { useMemo, useEffect } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 
+/** A bare [x, y] pair, or an object form carrying an optional tooltip note
+ *  (e.g. the denial reason on rejected data points). */
+export type ScatterPoint = [number, number] | { x: number; y: number; note?: string };
+
 interface SeriesData {
   name: string;
   color: string;
-  data: [number, number][];
+  data: ScatterPoint[];
+}
+
+function toPair(p: ScatterPoint): [number, number] {
+  return Array.isArray(p) ? p : [p.x, p.y];
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 interface ScatterPlotProps {
@@ -24,6 +40,34 @@ interface ScatterPlotProps {
   xSuffix?: string;
   yPrefix?: string;
   ySuffix?: string;
+  /** Fit a least-squares line to the first series and draw it dashed. */
+  trendline?: boolean;
+}
+
+function fitTrendline(points: [number, number][]): [number, number][] | null {
+  if (points.length < 2) return null;
+  const n = points.length;
+  let sumX = 0,
+    sumY = 0,
+    sumXY = 0,
+    sumX2 = 0;
+  for (const [x, y] of points) {
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumX2 += x * x;
+  }
+  const denom = n * sumX2 - sumX * sumX;
+  if (denom === 0) return null;
+  const slope = (n * sumXY - sumX * sumY) / denom;
+  const intercept = (sumY - slope * sumX) / n;
+  const xs = points.map(([x]) => x);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  return [
+    [minX, slope * minX + intercept],
+    [maxX, slope * maxX + intercept],
+  ];
 }
 
 // v2 editorial palette tokens. Highcharts can't read CSS custom props, so the
@@ -47,6 +91,7 @@ export default function ScatterPlot({
   xSuffix = "",
   yPrefix = "",
   ySuffix = "",
+  trendline = false,
 }: ScatterPlotProps) {
   useEffect(() => {
     Highcharts.setOptions({ lang: { thousandsSep: "," } });
@@ -164,7 +209,18 @@ export default function ScatterPlot({
         },
         headerFormat:
           `<div style="font-weight:600;letter-spacing:0.04em;text-transform:uppercase;font-size:10.5px;opacity:0.7;margin-bottom:2px">{series.name}</div>`,
-        pointFormat: `<div>${xPrefix}{point.x:,.0f}${xSuffix} · ${yPrefix}{point.y:,.0f}${ySuffix}</div>`,
+        pointFormatter: function (this: { x: number; y: number; note?: string }) {
+          const base =
+            `<div>${xPrefix}${Highcharts.numberFormat(this.x, 0, ".", ",")}${xSuffix}` +
+            ` · ${yPrefix}${Highcharts.numberFormat(this.y, 0, ".", ",")}${ySuffix}</div>`;
+          if (!this.note) return base;
+          return (
+            base +
+            `<div style="margin-top:3px;max-width:220px;white-space:normal;opacity:0.75;font-size:11px">` +
+            escapeHtml(this.note) +
+            `</div>`
+          );
+        },
       },
       plotOptions: {
         scatter: {
@@ -187,9 +243,29 @@ export default function ScatterPlot({
           },
         },
       },
-      series: series,
+      series: (() => {
+        if (!trendline) return series;
+        const fit = fitTrendline((series[0]?.data ?? []).map(toPair));
+        if (!fit) return series;
+        return [
+          ...series,
+          {
+            type: "line",
+            name: "Trend",
+            color: series[0].color,
+            dashStyle: "Dash",
+            lineWidth: 1.5,
+            opacity: 0.6,
+            data: fit,
+            marker: { enabled: false },
+            enableMouseTracking: false,
+            showInLegend: false,
+            states: { hover: { enabled: false } },
+          },
+        ];
+      })(),
     }),
-    [title, xAxis, yAxis, series, xPrefix, xSuffix, yPrefix, ySuffix],
+    [title, xAxis, yAxis, series, xPrefix, xSuffix, yPrefix, ySuffix, trendline],
   );
 
   return (


### PR DESCRIPTION
## What

Two improvements to the approval-odds scatter charts on card pages:

**Dashed trend line on Income vs Starting Credit Limit.** `ScatterPlot` gains an opt-in `trendline` prop that fits a least-squares regression over the first series and draws it as a dashed non-interactive line (no legend entry, no tooltip). Enabled only on the income/limit chart. Skips rendering with fewer than 2 points or zero x-variance.

**Denial reasons in rejected-point tooltips.** The graphs endpoint returns bare `[x, y]` pairs, so `CardClient` now matches rejected points back to the raw records (already fetched for the Raw-data tab) by coordinates and attaches `reason_denied` as a `note`. The tooltip shows it as a wrapped secondary line, HTML-escaped since reasons are user-submitted text. Points without a reason are unchanged.

## Verification

- Verified in local dev on /card/chase-sapphire-preferred: trendline renders through the accepted points; hovering the rejected point at (705, $70,000) shows "Existing credit limit too low"; points without reasons show the plain numeric tooltip.
- `tsc --noEmit` clean.