### PR TITLE
Unify follow-X callout size, match wire title to news, add wire CTA on news

### DIFF
--- a/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
+++ b/apps/web-next/src/app/card-wire/CardWireV2Client.tsx
@@ -234,10 +234,10 @@ export default function CardWireV2Client({ entries, slugMap, bonusTypeMap, bankM
         {/* Snapshot — title + sub, with follow callout on the right */}
         <div className="cj-snapshot wire-snapshot has-follow">
           <div className="wire-snapshot-text">
-            <h1 className="cj-snapshot-h1">
+            <h1 className="page-title">
               The wire. <em>Every change.</em>
             </h1>
-            <p className="wire-snapshot-sub">
+            <p className="page-sub">
               A chronological feed of every credit-card change we track — annual
               fees, sign-up bonuses, and application status.
             </p>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3081,22 +3081,27 @@
   font-variant-numeric: tabular-nums;
   font-feature-settings: 'ss01', 'cv11';
 }
+/* Top padding mirrors .page-hero on /news (4px mobile / 20px above 760px)
+   so the title sits at the same height on both pages. */
 .landing-v2.wire-v2 .wire-main {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 24px 18px 48px;
+  padding: 4px 18px 48px;
   min-width: 0;
 }
+@media (min-width: 761px) {
+  .landing-v2.wire-v2 .wire-main { padding-top: 20px; }
+}
 @media (min-width: 768px) {
-  .landing-v2.wire-v2 .wire-main { padding: 28px 24px 64px; }
+  .landing-v2.wire-v2 .wire-main { padding: 20px 24px 64px; }
 }
 @media (min-width: 1024px) {
-  .landing-v2.wire-v2 .wire-main { padding: 32px 32px 80px; }
+  .landing-v2.wire-v2 .wire-main { padding: 20px 32px 80px; }
 }
 
 /* Snapshot — title + sub */
 .landing-v2.wire-v2 .wire-snapshot {
-  padding: 6px 0 16px;
+  padding: 0 0 16px;
 }
 /* Title + sub use the shared .page-title / .page-sub styles so the hero
    matches /news exactly. */

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3098,30 +3098,8 @@
 .landing-v2.wire-v2 .wire-snapshot {
   padding: 6px 0 16px;
 }
-.landing-v2.wire-v2 .wire-snapshot .cj-snapshot-h1 {
-  font-family: var(--font-inter-tight), sans-serif;
-  font-weight: 500;
-  font-size: 32px;
-  letter-spacing: -0.03em;
-  line-height: 1;
-  margin: 0;
-  color: var(--ink);
-}
-@media (min-width: 768px) {
-  .landing-v2.wire-v2 .wire-snapshot .cj-snapshot-h1 { font-size: 44px; }
-}
-.landing-v2.wire-v2 .wire-snapshot .cj-snapshot-h1 em {
-  font-style: italic;
-  color: var(--accent);
-  font-weight: 400;
-}
-.landing-v2.wire-v2 .wire-snapshot-sub {
-  font-size: 15px;
-  line-height: 1.5;
-  color: var(--ink-2);
-  max-width: 620px;
-  margin: 12px 0 16px;
-}
+/* Title + sub use the shared .page-title / .page-sub styles so the hero
+   matches /news exactly. */
 .landing-v2.wire-v2 .wire-snapshot.has-follow {
   display: flex;
   flex-wrap: wrap;
@@ -3131,12 +3109,15 @@
 }
 
 /* Follow @creditodds callout — shared by the card-wire snapshot, the /news
-   hero, and news article footers (FollowXCallout component). */
+   hero, and news article footers (FollowXCallout component). Fixed width so
+   the box renders the same size everywhere regardless of sub-copy length. */
 .landing-v2 .x-follow {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
+  justify-content: space-between;
   gap: 14px;
+  width: 300px;
   margin-top: 4px;
   padding: 10px 10px 10px 14px;
   border: 1px solid var(--line-2);
@@ -3190,6 +3171,51 @@
     width: 100%;
     justify-content: space-between;
   }
+}
+
+/* News → Card Wire cross-link band (sits above the /news filters) */
+.landing-v2 .news-wire-cta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 20px;
+  padding: 12px 16px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: var(--paper);
+  text-decoration: none;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.landing-v2 .news-wire-cta:hover {
+  border-color: var(--muted-2);
+  box-shadow: var(--shadow);
+}
+.landing-v2 .news-wire-cta-dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #64d88a;
+}
+.landing-v2 .news-wire-cta-copy {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--ink-2);
+}
+.landing-v2 .news-wire-cta-copy strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+.landing-v2 .news-wire-cta-link {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--accent);
+  white-space: nowrap;
+}
+.landing-v2 .news-wire-cta:hover .news-wire-cta-link {
+  color: var(--accent-deep);
 }
 .landing-v2.wire-v2 .wire-snapshot .cj-readoff {
   margin-top: 4px;

--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -114,6 +114,14 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
       </section>
 
       <div className="wrap">
+        <Link href="/card-wire" className="news-wire-cta">
+          <span className="news-wire-cta-dot" aria-hidden="true" />
+          <span className="news-wire-cta-copy">
+            <strong>Don&apos;t miss a sign-up bonus or card change.</strong> The
+            Card Wire logs every fee, bonus, and application shift we track.
+          </span>
+          <span className="news-wire-cta-link">View the wire &rarr;</span>
+        </Link>
         <div className="filter-bar" style={{ paddingTop: 20 }}>
           <div className="filter-chip-row">
             {TAG_FILTERS.map((t) => (


### PR DESCRIPTION
## Changes

- **Same follow-@creditodds callout everywhere**: the `FollowXCallout` box now has a fixed 300px width (Follow button pinned right), so it renders at exactly the same size on /card-wire and /news (and the articles pages that share it). Previously the box width floated with the sub-copy length (~225px on /news vs ~299px on /card-wire).
- **/card-wire hero matches /news**: the wire title and sub now use the shared `.page-title` / `.page-sub` styles (large clamp size, non-italic purple accent) instead of the smaller wire-specific styles, which were removed.
- **New Card Wire CTA on /news**: a band above the filters — "Don't miss a sign-up bonus or card change." — linking to /card-wire.

Verified locally on both pages: callouts measure an identical 300×61, no console errors, ESLint clean.