### PR TITLE
Stop crediting merchant-specific rates as generic spend in next-card ranker

### DIFF
--- a/apps/api/src/lib/ranker/nextCardRanking.js
+++ b/apps/api/src/lib/ranker/nextCardRanking.js
@@ -129,12 +129,14 @@ function travelGateSlug(card) {
 // and flexible (one of several eligible buckets). Each carries its cap and the
 // card name (so the analysis table can attribute the rate to a card).
 //
-// Travel is special: a co-brand card's elevated rate is tied to ONE airline or
-// hotel (merchant_specific, e.g. Choice Privileges' 10x at Choice Hotels, or
-// merchant_gate, e.g. United Gateway's 2x at United). We assume the user's
-// travel dollars go to the brand(s) they're loyal to, so those brand-specific
-// rates only count when the card matches a selected loyalty. Generic travel
-// rates (earn on all travel) always count.
+// Brand-locked rates (merchant_specific, or merchant_gate to one store) never
+// count as generic category spend. Travel is the one exception: we assume the
+// user's travel dollars go to the brand(s) they're loyal to, so a co-brand
+// rate (Choice Privileges' 10x hotels, United Gateway's 2x airlines) counts
+// when the card matches a selected loyalty. Outside travel the quiz has no
+// loyalty signal, so a merchant-limited rate (Intuit Business' 5% on Intuit
+// products, H-E-B's 5% groceries) is never credited — only the card's open
+// rates are. Generic travel rates (earn on all travel) always count.
 function cardOffers(card, allegiances) {
   const baseEff = flatRateEff(card);
   const direct = [];
@@ -144,7 +146,7 @@ function cardOffers(card, allegiances) {
   for (const bucket of SPEND_BUCKETS) {
     if (bucket === "everything_else") continue;
     const isTravel = TRAVEL_BUCKETS.has(bucket);
-    const includeMerchantSpecific = isTravel ? loyaltyMatch : true;
+    const includeMerchantSpecific = isTravel ? loyaltyMatch : false;
     const storeSlug = isTravel ? gateSlug : null;
     const m = findCategoryMatch(
       card,

--- a/apps/web-next/src/lib/nextCardRanking.test.ts
+++ b/apps/web-next/src/lib/nextCardRanking.test.ts
@@ -474,6 +474,32 @@ describe('rankNextCards — brand loyalty on travel', () => {
     expect(recommendations[0]?.card.slug).toBe('gt');
     expect(recommendations[0]?.rewardsValue).toBeCloseTo(180); // $6k × 3%
   });
+
+  it('never credits a merchant-specific rate outside travel (Intuit-style 5% online shopping)', () => {
+    // Intuit Business: 5% only on Intuit's own products (merchant_specific),
+    // 2% everything else. Against generic online-shopping spend it must earn
+    // its 2% base, not the 5%.
+    const intuit = card({
+      slug: 'intuit',
+      card_name: 'Intuit Business',
+      reward_type: 'cashback',
+      rewards: [
+        { category: 'online_shopping', value: 5, unit: 'percent', merchant_specific: true },
+        { category: 'everything_else', value: 2, unit: 'percent' },
+      ] as Reward[],
+    });
+    const { recommendations } = rankNextCards({
+      spend: { online_shopping: 6000 },
+      walletSlugs: [],
+      prefs: { rewardType: null },
+      cards: [intuit],
+    });
+    const rec = recommendations.find((r) => r.card.slug === 'intuit');
+    // $6k × 2% base = $120; the merchant-locked 5% would have been $300.
+    expect(rec?.rewardsValue).toBeCloseTo(120);
+    const shopping = rec?.categories.find((c) => c.category === 'online_shopping');
+    expect(shopping?.newRate).toBe(2);
+  });
 });
 
 describe('rankNextCards — cash vs points soft preference', () => {


### PR DESCRIPTION
## Problem

On /best-card-for-me, Intuit Business ranked #1 for online-shopping spend at a flat 5%, but that rate only applies to Intuit's own products (QuickBooks, TurboTax, Mailchimp). The YAML is flagged correctly (`merchant_specific: true`); the bug was in the ranker: `cardOffers` in `apps/api/src/lib/ranker/nextCardRanking.js` passed `includeMerchantSpecific=true` for every non-travel bucket, so brand-locked rates counted as open category rates.

Also affected: Samsung Galaxy Card 5% online shopping, PayPal Cashback 3% online shopping, H-E-B 5% / Kroger 2% groceries. Travel buckets were already handled (gated behind the loyalty quiz answer).

## Fix

Non-travel buckets now exclude `merchant_specific` rates entirely; the card is judged on its open rates (Intuit Business earns its 2% everything-else rate). This matches the API route, which already strips merchant-locked rates from the displayed reward list and whose comment claimed the ranking only credits them on brand loyalty.

## Verification

- New regression test: Intuit-style card earns 2% base on $6k online shopping ($120), not the merchant-locked 5% ($300); all 107 web-next tests and 60 api tests pass.
- Live check against the dev server: with online-shopping spend, recommendations are now genuine 3% cards; owning Intuit Business shows 2% "you earn now" and 3% cards correctly surface as upgrades.