### PR TITLE
Add news: Capital One rewrites Discover it terms ahead of October migration

### DIFF
--- a/data/news/2026-08-06-discover-it-capital-one-change-in-terms.yaml
+++ b/data/news/2026-08-06-discover-it-capital-one-change-in-terms.yaml
@@ -1,0 +1,80 @@
+id: "discover-it-capital-one-change-in-terms"
+date: "2026-08-06"
+title: "Capital One Rewrites Discover it Terms"
+summary: "Capital One is emailing Discover it cardholders a change-in-terms notice ahead of the October 19, 2026 move to the Capital One app and website. New account terms take effect October 16: a revised minimum payment formula, a new Prime Rate read date, rewards no longer counting toward the minimum payment, and Discover Identity Alerts shutting down in favor of CreditWise. Card numbers, rewards rates, and the no annual fee stay the same."
+tags:
+  - "policy-change"
+  - "benefit-change"
+bank: "Discover"
+card_slug: "discover-it-cash-back"
+card_name: "Discover it Cash Back"
+source: "Capital One"
+source_url: "https://www.capitalone.com/discover/card"
+body: |
+  Capital One has started sending Discover it cardholders a formal change-in-
+  terms notice for the next wave of the Discover integration. The notice,
+  landing in inboxes in early August 2026, confirms these accounts move to the
+  Capital One app and website on **October 19, 2026**, with a new set of
+  account terms taking effect a few days earlier on **October 16, 2026**.
+  Student cards got a similar email on August 2, and an earlier wave of
+  Discover accounts already transitioned on **July 27, 2026**.
+
+  ## New minimum payment formula
+
+  Under the new terms, if the balance is under **$35** the minimum payment is
+  the full balance. Otherwise it is the greater of **$35**, **2 percent** of
+  the balance, or **1 percent** of the balance plus new interest and late
+  payment fees, with any past due amount added on top. Notably, the notice
+  says the minimum payment structure is assigned **based on recent payment
+  history**, so different cardholders may see different formulas.
+
+  ## Rates update faster
+
+  Variable APRs will now key off the Prime Rate published in The Wall Street
+  Journal on the **25th of each month**, with changes taking effect on the
+  first day of the next month's billing cycle. Discover read the Prime Rate on
+  a different day, so this mostly changes how quickly rate moves show up on
+  the account. The variable APR is capped at **29.99 percent**. The billing
+  cycle also changes shape: the cycle will close **25 days** before the
+  payment due date, which means the closing date can shift by up to 3 days
+  month to month while the due date stays fixed.
+
+  ## Rewards rules tighten at the edges
+
+  Two rewards changes stand out. Starting **October 15, 2026** at 5 p.m. ET,
+  redeeming cash back as a statement credit will no longer count toward the
+  minimum monthly payment, so cardholders who leaned on rewards to cover the
+  minimum will need to make a real payment. And while rewards still never
+  expire for the life of the account, Capital One will no longer automatically
+  credit or mail out the rewards balance when an account is closed, so
+  cardholders should redeem before closing.
+
+  The earning side is untouched: **5 percent** cash back in rotating quarterly
+  categories up to the quarterly maximum with activation, **1 percent**
+  everywhere else, and Cashback Match for new cardmembers all carry over.
+  Capital One is also extending **5 percent** back on hotels, vacation rentals,
+  and rental cars booked through Capital One Travel and on Capital One
+  Entertainment purchases.
+
+  ## Identity Alerts shut down, FICO moves to CreditWise
+
+  Free Discover Identity Alerts will be discontinued as early as **October 1,
+  2026** and fully deactivated by October 16. Free FICO Score 8 access
+  survives, but cardholders will have to enroll in **CreditWise**, Capital
+  One's credit monitoring tool, to see it online and on statements.
+
+  ## Smaller print worth noting
+
+  The new customer agreement updates the arbitration provision and includes
+  instructions for rejecting it, which cardholders who care about preserving
+  court options should review. The minimum interest charge is being removed
+  entirely, a small win. Late fees run up to **$41**, returned payments up to
+  **$30**, and cash advances cost the greater of **$10** or **5 percent**.
+
+  ## What stays the same
+
+  The physical card and card number do not change, the card stays on the
+  Discover network, and there is still **no annual fee**. There is nothing for
+  cardholders to do right now, though it is worth confirming autopay and saved
+  payment details survive the October cutover and watching for the Capital One
+  login setup prompt.


### PR DESCRIPTION
Adds a news item covering the change-in-terms notice Capital One is emailing Discover it cardholders (received 2026-08-06).

## Summary
- Accounts move to the Capital One app/website on **October 19, 2026**; new account terms effective **October 16, 2026**
- New minimum payment formula (greater of $35 / 2% / 1% + interest and late fees), assigned per cardholder based on payment history
- Prime Rate now read from WSJ on the 25th of each month; billing cycle closes 25 days before the due date
- Rewards redemptions no longer count toward the minimum payment (from Oct 15, 5 p.m. ET); rewards no longer auto-credited at account closure
- Discover Identity Alerts discontinued (as early as Oct 1); FICO Score 8 requires CreditWise enrollment
- Minimum interest charge removed; card number, Discover network, rewards rates, Cashback Match, and no annual fee unchanged

Distinct from the 2026-08-03 student-card item, which only covered the student migration date. Validated with `npm run build:news` (107 items OK; title 38 chars, under the 47-char SEO budget).