### PR TITLE
Add replacement-card modules to six more discontinuation articles

### DIFF
--- a/data/news/2026-02-07-bilt-card-transition.yaml
+++ b/data/news/2026-02-07-bilt-card-transition.yaml
@@ -7,5 +7,12 @@ tags:
   - "policy-change"
 bank: "Wells Fargo"
 card_name: "Bilt Mastercard"
+replacement_cards:
+  - slug: "bilt-blue"
+    reason: "Bilt's current no-fee card: rent still earns up to 1.25x, plus 3x on Bilt Travel hotels and 3x on Lyft."
+  - slug: "wells-fargo-autograph"
+    reason: "The card Wells Fargo moved many Bilt holders into: 3x on dining, travel, gas, transit, streaming, and phone, no annual fee."
+  - slug: "bilt-obsidian"
+    reason: "The $95 step up: choose 3x dining or groceries, keep the rent earning, and add travel rates."
 source: "Bloomberg"
 source_url: "https://www.bloomberg.com/news/articles/2026-02-07/bilt-customers-receive-wells-fargo-s-autograph-cards-they-didn-t-ask-for"

--- a/data/news/2026-02-23-sofi-credit-card-monthly-fee.yaml
+++ b/data/news/2026-02-23-sofi-credit-card-monthly-fee.yaml
@@ -6,6 +6,13 @@ tags:
   - "fee-change"
 bank: "SoFi"
 card_name: "SoFi Unlimited 2% Credit Card"
+replacement_cards:
+  - slug: "wells-fargo-active-cash"
+    reason: "Flat 2% on everything with no annual fee and no monthly charge to work around."
+  - slug: "citi-double-cash"
+    reason: "2% on everything, 1% when you buy and 1% when you pay, with no annual fee."
+  - slug: "fidelity-rewards-visa-signature"
+    reason: "2% back with no annual fee when rewards are deposited into an eligible Fidelity account."
 source: "Doctor of Credit"
 source_url: "https://www.doctorofcredit.com/sofi-adding-10-monthly-fee-for-some-credit-cardholders/"
 body: |

--- a/data/news/2026-04-13-amex-plum-card-discontinued.yaml
+++ b/data/news/2026-04-13-amex-plum-card-discontinued.yaml
@@ -4,6 +4,13 @@ summary: "American Express has discontinued the Business Plum Card and is no lon
 tags:
   - "discontinued"
 bank: "American Express"
+replacement_cards:
+  - slug: "blue-business-plus-credit-card-from-american-express"
+    reason: "The no-fee Amex business default: 2x Membership Rewards on the first $50,000 of spending each year, then 1x."
+  - slug: "blue-business-cash-card-from-american-express"
+    reason: "The same structure paid in cash back: 2% on the first $50,000 a year, no annual fee."
+  - slug: "chase-ink-business-unlimited"
+    reason: "Flat 1.5% on every business purchase, no annual fee, and no categories to manage."
 source: "r/churning"
 source_url: "https://www.reddit.com/r/churning/comments/1shh8qz/news_and_updates_thread_april_10_2026/ofi3piu/"
 date: "2026-04-13"

--- a/data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
+++ b/data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
@@ -7,6 +7,13 @@ tags:
 bank: "Citi"
 card_slug: "citi-custom-cash"
 card_name: "Citi Custom Cash"
+replacement_cards:
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "The closest structure left: pick two 5% categories each quarter on the first $2,000, no annual fee."
+  - slug: "chase-freedom-flex"
+    reason: "5% on rotating quarterly categories up to $1,500, plus 3% on dining and drugstores, no annual fee."
+  - slug: "citi-double-cash"
+    reason: "Citi's own suggestion for new cash back applicants: 2% on everything, no annual fee."
 source: "Citi"
 source_url: "https://www.citi.com/credit-cards/citi-custom-cash-credit-card"
 date: "2026-05-28"

--- a/data/news/2026-07-31-spirit-cards-converted-to-bofa-customized-cash.yaml
+++ b/data/news/2026-07-31-spirit-cards-converted-to-bofa-customized-cash.yaml
@@ -8,6 +8,13 @@ tags:
 bank: "Bank of America"
 card_slug: "bank-of-america-customized-cash-rewards"
 card_name: "Bank of America Customized Cash Rewards"
+replacement_cards:
+  - slug: "capital-one-venture-rewards"
+    reason: "2x miles on everything and no foreign transaction fee, redeemable against any airline rather than one carrier."
+  - slug: "wells-fargo-autograph"
+    reason: "3x on travel, dining, gas, and transit with no annual fee and no foreign transaction fee."
+  - slug: "bank-of-america-travel-rewards"
+    reason: "Stays with Bank of America: 1.5x on every purchase, no annual fee, no foreign transaction fee."
 source: "Doctor of Credit"
 source_url: "https://www.doctorofcredit.com/bank-of-america-converting-spirit-airlines-cards-to-customized-cash-rewards-250-bonus-2-extra-cash-back-on-all-purchases-for-some/"
 body: |

--- a/data/news/2026-08-01-us-bank-kroger-cards-convert-to-smartly.yaml
+++ b/data/news/2026-08-01-us-bank-kroger-cards-convert-to-smartly.yaml
@@ -8,6 +8,13 @@ tags:
 bank: "U.S. Bank"
 card_slug: "us-bank-smartly-visa-signature"
 card_name: "Smartly Visa Signature"
+replacement_cards:
+  - slug: "blue-cash-preferred-card"
+    reason: "6% back at U.S. supermarkets on the first $6,000 a year, plus 3% on gas."
+  - slug: "blue-cash-everyday-card"
+    reason: "3% at U.S. supermarkets and 3% on gas with no annual fee, for lighter grocery baskets."
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "Keeps the rewards with U.S. Bank: two 5% categories of your choosing each quarter, no annual fee."
 source: "U.S. Bank"
 source_url: "https://www.usbank.com/about-us-bank/news-and-stories/article-library/us-bank-announces-transition-of-kroger-co-brand-card-program.html"
 body: |


### PR DESCRIPTION
Follows up #1924. The "What to get instead" module shipped 2026-08-03 on four articles, and the PostHog readout on 08-06 says it works:

| Article | onward rate before | after |
|---|---|---|
| Kroger | 27/1,147 = 2.35% | 9/39 = **23.1%** |
| Amex Green | 11/113 = 9.7% | 14/47 = **29.8%** |
| WF Attune | 2/19 = 10.5% | 1/7 = 14.3% |

`replacement_card_clicked` fired 12 times from 6 users in the first 3.5 days, from zero before. Articles without the module did not move (freedom-flex-cell-phone 1/32, amazon-prime-shutdown 2/27, platinum-peacock 0/15). Post-ship samples are small, so treat the level as provisional, but the direction is not in doubt.

## What this adds

`replacement_cards` on the six remaining articles whose subject card is genuinely gone:

| Article | Replacements |
|---|---|
| Kroger cards converting to Smartly | Blue Cash Preferred, Blue Cash Everyday, Cash+ |
| Spirit cards to BofA Customized Cash | Venture Rewards, Autograph, BofA Travel Rewards |
| Amex Business Plum discontinued | Blue Business Plus, Blue Business Cash, Ink Business Unlimited |
| Bilt / Wells Fargo partnership ends | Bilt Blue, Autograph, Bilt Obsidian |
| Citi Custom Cash closed | Cash+, Freedom Flex, Double Cash |
| SoFi Unlimited 2% $10 monthly fee | Active Cash, Double Cash, Fidelity Rewards |

Every rate quoted in a `reason` line was read off `cards.json` rather than written from memory. All 15 referenced card images return 200 from the CDN. `npm run build:news` passes and all six resolve into `replacement_cards_info` with images.

Two notes on specific picks. The Spirit and Kroger articles are conversion stories, so their `card_slug` names the *live* successor, not the dead card, and the successor is correctly absent from its own replacement list. On Bilt, `bilt-mastercard` is `accepting_applications: false` in the catalog, which is what makes that article eligible; Bilt Blue is the current no-fee Bilt card and Autograph is what Wells Fargo actually moved holders into.

## Deliberately not touched

Three articles matched the keyword sweep but their subject card is alive, so a "What to get instead" module would be wrong:

- **Chase Amazon Prime shutdown wave** — individual account closures for inactivity and limit cycling. The card is open and takes applications on this site.
- **Freedom Flex loses cell phone protection** — one benefit ends, the card is fine. The reader need here is "which card still has that perk," which is a different module.
- **Capital One replaces Spark Miles with Venture Business** — a rebrand whose successor is the article's own subject, already linked in the body.

## Verification

Rendered locally on `/news/amex-plum-card-discontinued` and `/news/bilt-wells-fargo-partnership-ends`; the module renders above Related Cards with correct names, fees, and reason lines.
