### PR TITLE
Carry pending near-misses that a run never got to re-present

### DIFF
--- a/scripts/check-reddit-datapoints.js
+++ b/scripts/check-reddit-datapoints.js
@@ -1070,9 +1070,46 @@ ${buildPendingSection(pending)}
 
 // ── Pending reconciliation (finish phase) ────────────────────────────────────
 
+/**
+ * Fold the session's re-declarations back into the carried bucket.
+ *
+ * Silence drops an entry — but only when the session was actually SHOWN it.
+ * The revisit queue is capped (CAPS.revisitPosts) and draws from a request
+ * budget that Reddit's 429s regularly exhaust, so on a throttled run some
+ * pending entries never reach the prompt at all, and an entry that was never
+ * presented cannot be re-declared: validatePendingEntry rejects any source_id
+ * outside this run's candidates. Dropping those would make rate limiting look
+ * like a judgment call, and silently — their attempts counter was never even
+ * incremented, so they never spent a look. Seen live on 2026-08-06: three
+ * entries (two 429s, one cut by the request budget) fell out of the state file
+ * with attempts and days still left in their windows.
+ *
+ * So the split is by whether the entry was presented, not by whether it came
+ * back:
+ *   presented + re-declared  → keeps its history, attempts already bumped
+ *   presented + silent       → dropped, which is the session saying "give up"
+ *   never presented          → carried forward untouched
+ *
+ * Carrying forward is not a reprieve: firstSeen and attempts ride along
+ * unchanged, so pendingExpiry() ages the entry out on a later fetch phase
+ * exactly as it would have.
+ */
+function mergePending({ carried, declared, candidateById }) {
+  const pending = { ...declared };
+  const carriedForward = [];
+  for (const [id, entry] of Object.entries(carried)) {
+    if (pending[id] || candidateById.has(id)) continue;
+    // firstSeen is what bounds an entry's life, and a carried entry is never
+    // re-stamped, so a hand-edited state file missing it would otherwise live
+    // forever. Fill the hole once; every other field rides along as-is.
+    pending[id] = entry.firstSeen ? entry : { ...entry, firstSeen: TODAY };
+    carriedForward.push({ id, entry: pending[id] });
+  }
+  return { pending, carriedForward };
+}
+
 // The staged state is the fetch phase's output, so finish has to read it back,
-// fold in what the session decided, and rewrite it. Anything the session did NOT
-// re-declare falls out of the bucket: silence means "stop chasing this".
+// fold in what the session decided, and rewrite it.
 function reconcilePending(validationCtx) {
   const staged = fs.existsSync(STATE_UPDATED_FILE)
     ? JSON.parse(fs.readFileSync(STATE_UPDATED_FILE, 'utf8'))
@@ -1111,7 +1148,12 @@ function reconcilePending(validationCtx) {
     };
   }
 
-  return { staged, pending: declared, rejected, carriedCount: Object.keys(carried).length };
+  const { pending, carriedForward } = mergePending({
+    carried,
+    declared,
+    candidateById: validationCtx.candidateById,
+  });
+  return { staged, pending, rejected, carriedForward, carriedCount: Object.keys(carried).length };
 }
 
 function resolvePendingFor(result, publishedIds) {
@@ -1125,11 +1167,31 @@ function resolvePendingFor(result, publishedIds) {
 
 // Rewrites the staged state and the follow-up list, then says what changed.
 function reportPending(result) {
-  const { staged, pending, rejected, resolved = 0 } = result;
+  const { staged, pending, rejected, resolved = 0, carriedForward = [] } = result;
   fs.writeFileSync(STATE_UPDATED_FILE, `${JSON.stringify({ seen: staged.seen || {}, pending }, null, 2)}\n`);
   fs.writeFileSync(FOLLOWUPS_FILE, buildFollowups(pending));
 
   rejected.forEach((r) => console.log(`✗ pending/${r}`));
+
+  // Say which entries the session never got to see. Left unsaid, a carried
+  // entry is indistinguishable from one the session read and kept — and the
+  // reason it was carried (the revisit cap, or Reddit throttling us out of the
+  // request) is the thing worth knowing about the run.
+  if (carriedForward.length > 0) {
+    console.log(
+      `\nPending carried forward (${carriedForward.length}): never re-presented this run ` +
+        `(revisit cap or Reddit throttling), so no look was spent and nothing was dropped.`
+    );
+    for (const { entry } of carriedForward) {
+      const known = [entry.card_name, entry.result].filter(Boolean).join(' ') || 'outcome';
+      const looksLeft = Math.max(0, PENDING_MAX_ATTEMPTS - (entry.attempts || 0));
+      console.log(
+        `  - ${known}, missing ${(entry.missing || []).join('/')} — ` +
+          `still ${looksLeft} look(s) left, first seen ${entry.firstSeen}`
+      );
+      console.log(`    ${entry.url}`);
+    }
+  }
 
   const count = Object.keys(pending).length;
   if (resolved > 0) console.log(`\nPending resolved: ${resolved} entr(ies) published after a revisit.`);
@@ -1378,6 +1440,7 @@ module.exports = {
   pendingExpiry,
   rankPending,
   validatePendingEntry,
+  mergePending,
   buildFollowups,
   buildExtractPrompt,
   buildPrBody,

--- a/scripts/check-reddit-datapoints.test.js
+++ b/scripts/check-reddit-datapoints.test.js
@@ -26,9 +26,11 @@ const {
   pendingExpiry,
   rankPending,
   validatePendingEntry,
+  mergePending,
   buildFollowups,
   CAPS,
   PENDING_MAX_ATTEMPTS,
+  PENDING_MAX_DAYS,
 } = require('./check-reddit-datapoints.js');
 
 // Shrink the real waits (8s between requests, 61s on a 429) so the loop tests
@@ -520,6 +522,70 @@ test('validatePendingEntry keeps junk out of the bucket', () => {
   assert.match(bad({ source_id: 't3_ok', missing: ['credit_score'], card_name: 'Chase Sapphire Preferred' }).join(), /result is required/);
   assert.match(bad({ source_id: 't3_ok', missing: ['credit_score'], result: 'denied' }).join(), /card_name is required/);
   assert.deepEqual(bad({ source_id: 't3_ok', missing: ['card_name'], result: 'denied' }), []);
+});
+
+// The revisit queue is capped and shares a budget with OP expansion, so on a
+// throttled run some pending entries never make it into the prompt. Before this
+// split, finish read their absence from pending/ as the session giving up on
+// them — three real entries were lost that way on 2026-08-06, two to 429s and
+// one to the request budget, each with attempts and days still left.
+test('an entry the session never saw is carried forward, not dropped', () => {
+  const carriedEntry = {
+    url: 'https://www.reddit.com/r/CreditCards/comments/never/x/',
+    title: 'Denied for Custom Cash',
+    card_name: 'Citi Custom Cash',
+    result: 'denied',
+    missing: ['credit_score'],
+    note: 'Denial with no score given.',
+    firstSeen: '2026-08-04',
+    attempts: 1,
+    lastChecked: '2026-08-05',
+  };
+  const { pending, carriedForward } = mergePending({
+    carried: { t3_unfetched: carriedEntry },
+    declared: {},
+    // Only the entries this run actually presented — t3_unfetched is not one.
+    candidateById: new Map([['t3_ok', { id: 't3_ok', kind: 'post' }]]),
+  });
+  assert.deepEqual(Object.keys(pending), ['t3_unfetched']);
+  // Untouched: a look it never got must not be charged to it, or Reddit
+  // throttling would quietly eat the entry's whole window.
+  assert.deepEqual(pending.t3_unfetched, carriedEntry);
+  assert.deepEqual(carriedForward.map((c) => c.id), ['t3_unfetched']);
+});
+
+test('an entry the session saw and did not re-declare is still dropped', () => {
+  const { pending, carriedForward } = mergePending({
+    carried: {
+      t3_shown: { url: 'https://reddit.com/x', missing: ['credit_score'], firstSeen: '2026-08-04', attempts: 2 },
+    },
+    declared: {},
+    candidateById: new Map([['t3_shown', { id: 't3_shown', kind: 'post' }]]),
+  });
+  assert.deepEqual(pending, {}, 'silence on a presented entry means give up on it');
+  assert.deepEqual(carriedForward, []);
+});
+
+test('a re-declared entry wins over the carried copy', () => {
+  const { pending, carriedForward } = mergePending({
+    carried: { t3_shown: { url: 'https://reddit.com/x', missing: ['credit_score'], firstSeen: '2026-08-04', attempts: 1 } },
+    declared: { t3_shown: { url: 'https://reddit.com/x', missing: ['credit_score'], firstSeen: '2026-08-04', attempts: 2, note: 'still no score' } },
+    candidateById: new Map([['t3_shown', { id: 't3_shown', kind: 'post' }]]),
+  });
+  assert.equal(pending.t3_shown.attempts, 2);
+  assert.equal(pending.t3_shown.note, 'still no score');
+  assert.deepEqual(carriedForward, [], 'a re-declared entry was presented, so it is not a carry');
+});
+
+// Carrying forward must not become immortality: the entry keeps its original
+// firstSeen, so the age half of pendingExpiry retires it on schedule even if
+// every single run gets throttled out of revisiting it.
+test('carried entries still age out of the bucket', () => {
+  const stale = { url: 'https://reddit.com/x', missing: ['credit_score'], firstSeen: '2026-07-28', attempts: 1 };
+  const { pending } = mergePending({ carried: { t3_stale: stale }, declared: {}, candidateById: new Map() });
+  assert.equal(pending.t3_stale.firstSeen, '2026-07-28', 'the clock must not restart on a carry');
+  assert.match(pendingExpiry(pending.t3_stale, '2026-08-05'), new RegExp(`past the ${PENDING_MAX_DAYS}-day window`));
+  assert.equal(pendingExpiry(pending.t3_stale, '2026-08-04'), null, 'and not before the window is up');
 });
 
 test('validatePendingEntry canonicalizes a previous card name', () => {


### PR DESCRIPTION
## The defect

The pending near-miss bucket drops an entry when the extraction session does not re-declare it, on the rule that silence means "give up on this one". `reconcilePending()` had no way to tell that silence apart from the entry never reaching the session at all:

- `revisitPending()` queues at most `Math.min(CAPS.revisitPosts, budget.remaining)` entries (`CAPS.revisitPosts` = 4), so anything past the cap is never queued.
- A queued entry whose comment feed 429s or fails drops out of the candidate list, and `fetchSnapshots()` aborts the whole revisit loop after 2 consecutive failures.
- Only successfully fetched revisits reach the `## Revisits` section of the extraction prompt.
- `validatePendingEntry()` rejects any `source_id` outside `candidateById`, so an entry that was never presented **cannot** be re-declared even if the session somehow knew about it.

Net effect: Reddit rate limiting was silently deciding what to stop chasing, and doing it for free. The dropped entries' `attempts` counters were never incremented, so they never spent a look, and they fell out of the state file with days left in their windows.

Observed live on the 2026-08-06 run, which lost three entries this way (two to 429s, one cut by the request budget):

| Entry | Attempts | First seen | Missing |
|---|---|---|---|
| `t3_1vfx27n` | 1/3 | 2026-08-05 | card_name |
| `t3_1vfjeba` | 1/3 | 2026-08-05 | credit_score |
| `t3_1vetc5m` | 2/3 | 2026-08-04 | credit_score |

## The fix

New `mergePending()` splits on **whether the entry was presented**, not on whether it came back:

| | Outcome |
|---|---|
| presented + re-declared | keeps its history, attempts already bumped by the revisit |
| presented + silent | dropped, unchanged behaviour: this is the session saying "give up" |
| never presented | carried forward with `firstSeen` / `attempts` / `note` untouched |

Carrying forward is not a reprieve. The entry keeps its original `firstSeen` and `attempts`, so `pendingExpiry()` retires it on the normal `PENDING_MAX_DAYS` / `PENDING_MAX_ATTEMPTS` schedule even if every subsequent run also gets throttled out of revisiting it. There is one belt-and-braces touch: an entry arriving with no `firstSeen` at all (only reachable via a hand-edited state file) gets stamped once, because a carried entry is never re-stamped and would otherwise have no clock to age out on.

Carried entries are also named in the finish-phase run output. Left unsaid, a carry is indistinguishable from an entry the session read and kept, and the reason it was carried is the thing worth knowing about the run.

## Verification

Four new cases in `scripts/check-reddit-datapoints.test.js` cover the carry, the still-drops case, re-declaration winning over the carried copy, and the aging check (`firstSeen` preserved → `pendingExpiry()` fires at the same day it always would, and not a day earlier). Full suite passes.

End-to-end run of `--phase=finish` against a synthetic staged state with all three shapes:

```
Pending carried forward (2): never re-presented this run (revisit cap or Reddit throttling), so no look was spent and nothing was dropped.
  - Citi Custom Cash denied, missing credit_score — still 2 look(s) left, first seen 2026-08-05
    https://www.reddit.com/r/CreditCards/comments/1vfx27n/x/
  - Citi Custom Cash denied, missing credit_score — still 1 look(s) left, first seen 2026-08-03
    https://www.reddit.com/r/CreditCards/comments/1vetc5m/x/
Pending: 3 entr(ies) awaiting a field.
```

The presented-and-silent entry dropped, the re-declared entry kept its bumped attempts, and the two never-presented entries survived with their counters intact.

## Not included

The three entries already lost on 2026-08-06 are still recoverable from the `2026-08-05` state snapshot (commit 32f71345) and all three are still inside their windows today. I left that restore out of this PR deliberately: `.github/reddit-datapoint-state.json` is rewritten and pushed to `main` wholesale by the daily routine, so an open PR editing it races with those pushes. Happy to restore them as a direct commit at merge time if you want them back.