### PR TITLE
Auto: Chase Sapphire Reserve rewards/benefits update — 2026-08-09

### DIFF
--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -94,6 +94,11 @@ benefits:
     frequency: "annual"
     category: "fitness"
     enrollment_required: true
+  - name: "Primary Rental Car Coverage"
+    description: "Primary auto rental collision damage waiver with reimbursement up to $75,000 for theft and collision damage in the U.S. and abroad."
+    frequency: "ongoing"
+    category: "car_rental"
+    enrollment_required: false
 tags:
   - travel
   - premium


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Chase Sapphire Reserve**.

**Apply link (verify against this):** https://creditcards.chase.com/rewards-credit-cards/sapphire/reserve

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
