### PR TITLE
Auto: Delta SkyMiles Blue American Express rewards/benefits update — 2026-08-09

### DIFF
--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -54,3 +54,10 @@ benefits:
     frequency: "per_purchase"
     category: "statement_credit"
     enrollment_required: false
+  - name: "Amex Venue Collection Concessions Credit"
+    value: 10
+    value_unit: "percent"
+    description: "10% back on qualifying concessions purchases at select stadiums and arenas, up to $250 per calendar year."
+    frequency: "per_purchase"
+    category: "entertainment"
+    enrollment_required: true


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Delta SkyMiles Blue American Express**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-blue-american-express-card/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
