### PR TITLE
Auto: Delta SkyMiles Gold American Express rewards/benefits update — 2026-08-09

### DIFF
--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -65,6 +65,13 @@ benefits:
     frequency: "monthly"
     category: "rideshare"
     enrollment_required: true
+  - name: "Amex Venue Collection Concessions Credit"
+    value: 10
+    value_unit: "percent"
+    description: "10% back on qualifying concessions purchases at select stadiums and arenas, up to $250 per calendar year."
+    frequency: "per_purchase"
+    category: "entertainment"
+    enrollment_required: true
 tags:
   - airline
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Delta SkyMiles Gold American Express**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-gold-american-express-card/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
