### PR TITLE
Auto: Hilton Honors American Express Aspire rewards/benefits update — 2026-08-09

### DIFF
--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -98,6 +98,13 @@ benefits:
     frequency: "per_claim"
     category: "telecom"
     enrollment_required: false
+  - name: "Venue Collection Concessions Rebate"
+    value: 10
+    value_unit: "percent"
+    description: "Enroll your card and get 10% back on qualifying concessions purchases at select stadiums and arenas, up to $250 per calendar year"
+    frequency: "per_purchase"
+    category: "entertainment"
+    enrollment_required: true
 tags:
   - hotel
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Hilton Honors American Express Aspire**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/hilton-honors-aspire/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
