### PR TITLE
Auto: Hilton Honors American Express Surpass rewards/benefits update — 2026-08-09

### DIFF
--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -79,6 +79,13 @@ benefits:
     description: "Upgrade to Hilton Honors Diamond status through the end of the next calendar year after $40,000 in annual purchases"
     frequency: "ongoing"
     category: "hotel"
+  - name: "Venue Collection Concessions Rebate"
+    value: 10
+    value_unit: "percent"
+    description: "10% back on qualifying concessions purchases at select stadiums and arenas, up to $250 per calendar year, when the card is enrolled"
+    frequency: "per_purchase"
+    category: "entertainment"
+    enrollment_required: true
 tags:
   - hotel
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Hilton Honors American Express Surpass**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/hilton-honors-surpass/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
