### PR TITLE
Auto: Hilton Honors rewards/benefits update — 2026-08-09

### DIFF
--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -66,6 +66,13 @@ benefits:
     description: "Upgrade to Hilton Honors Gold status after $20,000 in eligible purchases in a calendar year, valid for that year and the next"
     frequency: "ongoing"
     category: "hotel"
+  - name: "Venue Collection Concessions Rebate"
+    value: 10
+    value_unit: "percent"
+    description: "10% back on qualifying concessions purchases at select stadiums and arenas, up to $250 per calendar year, when the card is enrolled"
+    frequency: "per_purchase"
+    category: "entertainment"
+    enrollment_required: true
 tags:
   - hotel
   - travel


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Hilton Honors**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/hilton-honors/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
