### PR TITLE
Auto: The Platinum Card rewards/benefits update — 2026-08-09

### DIFF
--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -29,6 +29,9 @@ rewards:
     value: 5
     unit: points_per_dollar
     note: "Booked directly with airlines or through Amex Travel, up to $500,000 per calendar year"
+    spend_cap: 500000
+    cap_period: annual
+    rate_after_cap: 1
   - category: hotels_portal
     value: 5
     unit: points_per_dollar


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **The Platinum Card**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/platinum/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
