### PR TITLE
Card page check: read skip state from main, not the reverted local file

### DIFF
--- a/scripts/check-card-pages-publish.sh
+++ b/scripts/check-card-pages-publish.sh
@@ -47,6 +47,11 @@ if [ -n "$(git status --porcelain "$STATE_FILE")" ]; then
     -f content="$(base64 < "$STATE_FILE" | tr -d '\n')")
   [ -n "$SHA" ] && ARGS+=(-f sha="$SHA")
   gh api "${ARGS[@]}" --jq '.commit.sha' | sed 's/^/Committed state as /'
+  # The push landed on main only, so the local copy is now behind — revert it so
+  # the checkout below sees nothing but the card edits. This is safe *because*
+  # check-card-pages.js reads the counters from origin/main, not from this file
+  # (see loadSkipState). Before that, a second run in the same working tree read
+  # the reverted copy and PUT an update that erased the first run's entries.
   git checkout -- "$STATE_FILE"
 fi
 

--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -40,8 +40,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 const yaml = require('js-yaml');
 
+const REPO_ROOT = path.join(__dirname, '..');
 const CARDS_DIR = path.join(__dirname, '..', 'data', 'cards');
 const SUMMARY_FILE = path.join(__dirname, '..', '.card-page-check-summary.md');
 // Consecutive-skip counters, committed to main by the workflow so the count
@@ -49,6 +51,8 @@ const SUMMARY_FILE = path.join(__dirname, '..', '.card-page-check-summary.md');
 // workflow either filters on data/** or (deploy-frontend) ignores it — dropping
 // this file anywhere under data/ would fire an Amplify build every night.
 const STATE_FILE = path.join(__dirname, '..', '.github', 'card-page-check-state.json');
+// Same file, repo-relative — the form `git show origin/main:<path>` needs.
+const STATE_FILE_REPO_PATH = '.github/card-page-check-state.json';
 // Written only when a card has been skipped too many runs in a row; the workflow
 // keys its Slack ping / GitHub issue / red build off this file's existence.
 const STALE_REPORT_FILE = path.join(__dirname, '..', '.card-page-check-stale.md');
@@ -1605,15 +1609,72 @@ function logFetchedText(name, url, usedBrowser, pageContent, extracted) {
 
 // ─── Consecutive-skip state ──────────────────────────────────────────────────
 
-function loadSkipState() {
+function parseSkipState(raw) {
+  if (typeof raw !== 'string') return null;
   try {
-    const parsed = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
-    return parsed && typeof parsed.cards === 'object' && parsed.cards ? parsed.cards : {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed.cards === 'object' && parsed.cards ? parsed.cards : null;
   } catch {
-    // Missing or corrupt state is not fatal — every card just starts at zero. The
-    // alarm re-arms after SKIP_ALERT_THRESHOLD runs rather than never firing.
-    return {};
+    return null;
   }
+}
+
+/**
+ * Pick which copy of the counters to fold this run into.
+ *
+ * The copy on main wins whenever it is readable. Both publish paths (the
+ * workflow's "Persist skip-tracking state" step and
+ * scripts/check-card-pages-publish.sh) commit this file straight to main through
+ * the contents API and never into the local branch, and the local script then
+ * `git checkout --`s its copy back to HEAD so the uncommitted data/cards/ edits
+ * survive for the PR step. So the local file is a run's *output*, reverted the
+ * moment it is pushed — reading it back as a run's *input* means a second run in
+ * the same working tree starts from pre-first-run state and PUTs an update that
+ * erases everything the first run recorded.
+ *
+ * Observed 2026-08-09: a full run verified 122 cards, then a CARD_SLUG-scoped
+ * recovery run over 44 of them pushed state again; main ended up with 43 cards
+ * at that day's last_ok and 123 still three days stale. Only last_ok was lost
+ * (consecutive_skips stayed 0 either way, so nothing was falsely flagged), but
+ * the file misreports verification recency, and chaining runs in CI would make
+ * it routine.
+ *
+ * Missing or corrupt state on both sides is not fatal — every card just starts
+ * at zero and the alarm re-arms after SKIP_ALERT_THRESHOLD runs.
+ */
+function resolveSkipState(mainRaw, localRaw) {
+  return parseSkipState(mainRaw) || parseSkipState(localRaw) || {};
+}
+
+// The pushed copy, read straight out of the remote-tracking ref. Returns null on
+// any failure — no network, no origin, file not on main yet (first ever run) —
+// which falls the caller back to the local file.
+function readSkipStateFromMain(cwd = REPO_ROOT) {
+  const run = (args) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  try {
+    run(['fetch', '-q', 'origin', 'main']);
+    return run(['show', `origin/main:${STATE_FILE_REPO_PATH}`]);
+  } catch {
+    return null;
+  }
+}
+
+function readSkipStateLocal() {
+  try {
+    return fs.readFileSync(STATE_FILE, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function loadSkipState() {
+  const mainRaw = readSkipStateFromMain();
+  if (parseSkipState(mainRaw)) {
+    console.log(`Skip-tracking state read from origin/main:${STATE_FILE_REPO_PATH}`);
+  } else {
+    console.log(`Skip-tracking state read from the local ${STATE_FILE_REPO_PATH} (main copy unavailable)`);
+  }
+  return resolveSkipState(mainRaw, readSkipStateLocal());
 }
 
 function writeSkipState(cards, checkedAt) {
@@ -2309,6 +2370,8 @@ module.exports = {
   normalizeBonusType,
   pageShowsSignupOffer,
   updateSkipState,
+  resolveSkipState,
+  readSkipStateFromMain,
   staleCardsFrom,
   isTransientNetworkError,
   redirectedToAncestor,

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -12,12 +12,18 @@
 // Run: `node scripts/check-card-pages.test.js`. Exits non-zero on any failure.
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 const {
   detectChanges,
   needsBrowserRetry,
   normalizeBonusType,
   pageShowsSignupOffer,
   updateSkipState,
+  resolveSkipState,
+  readSkipStateFromMain,
   staleCardsFrom,
   isTransientNetworkError,
   SKIP_ALERT_THRESHOLD,
@@ -1182,6 +1188,140 @@ test('a card with no URL at all does not crash the guard', () => {
   assert.doesNotThrow(() =>
     detectChanges(card, amexExtract(80000), new Date(), [], RENDERED_OFFER)
   );
+});
+
+// ─── Skip-state source: the pushed copy on main, not the reverted local file ──
+//
+// Both publish paths commit .github/card-page-check-state.json to main through
+// the contents API and then revert the local copy, so the local file is a run's
+// output and never its input. Reading it back made a second run in the same
+// working tree start from pre-first-run state and erase the first run's entries
+// (observed 2026-08-09 — 122 verified cards' last_ok lost to a 44-card recovery
+// run). These tests pin both halves: the source preference, and the full
+// two-sequential-runs cycle against a real git remote.
+
+console.log('\nSkip-state source preference:');
+
+const STATE_V0 = JSON.stringify({
+  updated_at: '2026-08-06T07:00:00.000Z',
+  cards: { 'card-a': { consecutive_skips: 0, last_ok: '2026-08-06T07:00:00.000Z' } },
+});
+const STATE_V1 = JSON.stringify({
+  updated_at: '2026-08-09T07:00:00.000Z',
+  cards: { 'card-a': { consecutive_skips: 0, last_ok: '2026-08-09T07:00:00.000Z' } },
+});
+
+test('the copy on main wins over a stale local file', () => {
+  assert.equal(resolveSkipState(STATE_V1, STATE_V0)['card-a'].last_ok, '2026-08-09T07:00:00.000Z');
+});
+
+test('an unreadable main copy falls back to the local file', () => {
+  assert.equal(resolveSkipState(null, STATE_V0)['card-a'].last_ok, '2026-08-06T07:00:00.000Z');
+});
+
+test('a corrupt main copy falls back to the local file', () => {
+  assert.equal(resolveSkipState('{not json', STATE_V0)['card-a'].last_ok, '2026-08-06T07:00:00.000Z');
+});
+
+test('a main copy missing the cards key falls back to the local file', () => {
+  assert.equal(resolveSkipState('{"updated_at":"x"}', STATE_V0)['card-a'].last_ok, '2026-08-06T07:00:00.000Z');
+});
+
+test('neither copy readable is not fatal — every card starts at zero', () => {
+  assert.deepEqual(resolveSkipState(null, null), {});
+});
+
+console.log('\nTwo sequential runs from one working tree:');
+
+const git = (cwd, args) =>
+  execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', ...args], {
+    cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+// Stand up origin + a clone, mirroring the real layout: the state file is
+// committed on main, and the checkout the run happens in tracks it.
+function makeRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'card-page-state-'));
+  const origin = path.join(root, 'origin.git');
+  const work = path.join(root, 'work');
+  execFileSync('git', ['init', '-q', '--bare', '-b', 'main', origin]);
+  git(root, ['clone', '-q', origin, work]);
+  fs.mkdirSync(path.join(work, '.github'), { recursive: true });
+  return { root, origin, work };
+}
+
+// What both publish paths do: PUT the file to main through the contents API
+// (never into the local branch), then `git checkout --` the local copy back to
+// HEAD so the uncommitted data/cards/ edits survive for the PR step.
+function publishToMain({ origin, work }, statePath, content) {
+  const pusher = fs.mkdtempSync(path.join(os.tmpdir(), 'card-page-push-'));
+  git(pusher, ['clone', '-q', origin, 'c']);
+  const clone = path.join(pusher, 'c');
+  fs.mkdirSync(path.join(clone, '.github'), { recursive: true });
+  fs.writeFileSync(path.join(clone, statePath), content);
+  git(clone, ['add', statePath]);
+  git(clone, ['commit', '-q', '-m', 'chore: update card-page skip-tracking state [skip ci]']);
+  git(clone, ['push', '-q', 'origin', 'main']);
+  fs.rmSync(pusher, { recursive: true, force: true });
+  git(work, ['checkout', '--', statePath]);
+}
+
+test("run 2 preserves run 1's last_ok for cards it never looked at", () => {
+  const STATE_PATH = '.github/card-page-check-state.json';
+  const repo = makeRepo();
+  const localFile = path.join(repo.work, STATE_PATH);
+  try {
+    // Baseline on main: 123 cards last verified three days ago.
+    const allSlugs = Array.from({ length: 123 }, (_, i) => `card-${String(i).padStart(3, '0')}`);
+    const baseline = {};
+    for (const slug of allSlugs) baseline[slug] = { consecutive_skips: 0, last_ok: '2026-08-06T07:00:00.000Z' };
+    fs.writeFileSync(localFile, JSON.stringify({ updated_at: '2026-08-06T07:00:00.000Z', cards: baseline }, null, 2) + '\n');
+    git(repo.work, ['add', STATE_PATH]);
+    git(repo.work, ['commit', '-q', '-m', 'baseline state']);
+    git(repo.work, ['push', '-q', '-u', 'origin', 'main']);
+
+    // Run 1 — full run, verifies all 123 (the last 44 skip, as on 2026-08-09).
+    const RUN_1_AT = '2026-08-09T07:30:00.000Z';
+    const skipped1 = allSlugs.slice(-44).map(slug => ({ slug, reason: 'fetch failed' }));
+    const state1 = updateSkipState(
+      resolveSkipState(readSkipStateFromMain(repo.work), fs.readFileSync(localFile, 'utf8')),
+      { checkedSlugs: new Set(allSlugs), skippedCards: skipped1, checkedAt: RUN_1_AT, isPartialRun: false }
+    );
+    fs.writeFileSync(localFile, JSON.stringify({ updated_at: RUN_1_AT, cards: state1 }, null, 2) + '\n');
+    publishToMain(repo, STATE_PATH, fs.readFileSync(localFile, 'utf8'));
+
+    // The local file is now back to the pre-run baseline — this is the trap.
+    assert.equal(
+      JSON.parse(fs.readFileSync(localFile, 'utf8')).cards['card-000'].last_ok,
+      '2026-08-06T07:00:00.000Z'
+    );
+
+    // Run 2 — CARD_SLUG-scoped recovery over the 44 that skipped.
+    const RUN_2_AT = '2026-08-09T09:00:00.000Z';
+    const recovered = allSlugs.slice(-44);
+    const state2 = updateSkipState(
+      resolveSkipState(readSkipStateFromMain(repo.work), fs.readFileSync(localFile, 'utf8')),
+      { checkedSlugs: new Set(recovered), skippedCards: [], checkedAt: RUN_2_AT, isPartialRun: true }
+    );
+    fs.writeFileSync(localFile, JSON.stringify({ updated_at: RUN_2_AT, cards: state2 }, null, 2) + '\n');
+    publishToMain(repo, STATE_PATH, fs.readFileSync(localFile, 'utf8'));
+
+    const onMain = JSON.parse(execFileSync('git', ['show', `main:${STATE_PATH}`], {
+      cwd: repo.origin, encoding: 'utf8',
+    })).cards;
+
+    // Every card carries a 2026-08-09 timestamp: run 1's for the 79 it verified,
+    // run 2's for the 44 it recovered. None is left back at the baseline.
+    assert.equal(Object.keys(onMain).length, 123);
+    const stillBaseline = allSlugs.filter(s => onMain[s].last_ok === '2026-08-06T07:00:00.000Z');
+    assert.deepEqual(stillBaseline, []);
+    for (const slug of allSlugs.slice(0, 79)) assert.equal(onMain[slug].last_ok, RUN_1_AT);
+    for (const slug of recovered) assert.equal(onMain[slug].last_ok, RUN_2_AT);
+    // And the recovery cleared the skip counters run 1 raised.
+    for (const slug of recovered) assert.equal(onMain[slug].consecutive_skips, 0);
+  } finally {
+    fs.rmSync(repo.root, { recursive: true, force: true });
+  }
 });
 
 console.log('');


### PR DESCRIPTION
## The bug

`scripts/check-card-pages-publish.sh` loses skip-tracking state when the card page check runs twice from the same working tree.

Both publish paths — the workflow's "Persist skip-tracking state" step and the local script — commit `.github/card-page-check-state.json` to main through the contents API (`-f branch=main`) and never into the local branch. The local script then runs `git checkout -- "$STATE_FILE"` so the uncommitted `data/cards/` edits survive for the PR step. That makes the local file a run's *output*, reverted the moment it is pushed — but `loadSkipState()` read it back as a run's *input*. A second run in the same session therefore started from pre-first-run state, applied only its own cards, and PUT the result to main, overwriting the first run's entries.

**Observed 2026-08-09:** a full run verified 122 cards and pushed state; a `CARD_SLUG`-scoped recovery run over 44 previously-skipped cards then pushed again. The file on main ended up with 43 cards at that day's `last_ok` and 123 still at 2026-08-06.

Severity is low — `consecutive_skips` drives the stale-card alarm and stayed 0 for every affected card, so nothing was falsely flagged. Only `last_ok` timestamps were lost. But the file silently misreports verification recency, and chaining runs in CI would make it routine.

## The fix

`loadSkipState()` now reads the pushed copy out of `origin/main` (`git fetch -q origin main` + `git show origin/main:<path>`) and falls back to the local file when the remote copy is unreachable or unparseable. It logs which source it used. Split into `readSkipStateFromMain()` / `resolveSkipState()` so both halves are testable.

The publish script's `git checkout -- "$STATE_FILE"` stays: with the read fixed it is the right behavior (it keeps the working tree clean for the PR branch checkout), and *not* reverting would break `git checkout -b … origin/main` once main carries a newer version of that file. Added a comment there recording why it is safe and what it used to cause.

## Verification

New test in `scripts/check-card-pages.test.js` simulates the exact two-run sequence against a real git remote: a bare origin plus a clone, a baseline of 123 cards at 2026-08-06, a full run (79 verified, 44 skipped) published to main by a separate clone and reverted locally, then a `CARD_SLUG`-scoped recovery run over those 44. It asserts main ends with all 123 cards carrying a 2026-08-09 timestamp and none left at baseline.

Full suite: **122 passing, 0 failing** (`node scripts/check-card-pages.test.js`).

Confirmed it is a real regression guard — swapping the state source back to the local file makes the test fail with the 79 wiped cards listed, matching the reported damage.

Plus five unit tests on source preference: main wins over a stale local file; unreadable / corrupt / `cards`-less main falls back to local; neither readable is not fatal.

## Not repaired

The current file on main still shows the damage (123 cards at 2026-08-06, 43 at 2026-08-09, 1 never). Run 1's per-card timestamps cannot be reconstructed, `consecutive_skips` is intact, and the next full nightly run rewrites every `last_ok`.