### PR TITLE
Card Page Check 2026-08-10

### DIFF
--- a/data/cards/capital-one-spark-cash-plus.yaml
+++ b/data/cards/capital-one-spark-cash-plus.yaml
@@ -20,10 +20,10 @@ rewards:
     value: 2
     unit: percent
 signup_bonus:
-  value: 4000
+  value: 2000
   type: "cash"
-  spend_requirement: 530000
-  timeframe_months: 12
+  spend_requirement: 30000
+  timeframe_months: 3
   note: "Earn a $2,000 cash bonus when you spend $30,000 in the first 3 months, plus an additional $2,000 cash bonus for every $500,000 spent during the first year (repeatable). Limited-time: also earn a one-time $500 Capital One Business Travel credit when you spend $30,000 in the first 3 months."
 benefits:
   - name: "Volume Spend Bonus"

--- a/data/cards/capital-one-spark-cash-plus.yaml
+++ b/data/cards/capital-one-spark-cash-plus.yaml
@@ -20,11 +20,11 @@ rewards:
     value: 2
     unit: percent
 signup_bonus:
-  value: 2000
+  value: 4000
   type: "cash"
-  spend_requirement: 30000
-  timeframe_months: 3
-  note: "For a limited time, also earns a one-time $500 Capital One Business Travel credit on the same $30,000 spend in the first 3 months"
+  spend_requirement: 530000
+  timeframe_months: 12
+  note: "Earn a $2,000 cash bonus when you spend $30,000 in the first 3 months, plus an additional $2,000 cash bonus for every $500,000 spent during the first year (repeatable). Limited-time: also earn a one-time $500 Capital One Business Travel credit when you spend $30,000 in the first 3 months."
 benefits:
   - name: "Volume Spend Bonus"
     value: 2000


### PR DESCRIPTION
## Card Page Check — 2026-08-10

Detected by fetching official apply pages and extracting card terms with an LLM.
**Verify each change against the source page before merging.**

### Term Changes

| Card | Field | Current | Detected | Source |
|------|-------|---------|----------|--------|
| Capital One Spark Cash Plus | signup_bonus.note | For a limited time, also earns a one-time $500 Capital One Business Travel credit on the same $30,000 spend in the first 3 months | Earn a $2,000 cash bonus when you spend $30,000 in the first 3 months, plus an additional $2,000 cash bonus for every $500,000 spent during the first year (repeatable). Limited-time: also earn a one-time $500 Capital One Business Travel credit when you spend $30,000 in the first 3 months. | [apply page](https://www.capitalone.com/small-business/credit-cards/spark-cash-plus/) |

### Extractor changes reverted before review

The automated run also proposed three numeric changes to the same card. They were
reverted in 7823ae2 and are **not** in this diff:

| Field | Stored (kept) | Extractor proposed | Why reverted |
|-------|---------------|--------------------|--------------|
| signup_bonus.value | 2000 | 4000 | Assumed exactly one repeat of an uncapped tier |
| signup_bonus.spend_requirement | 30000 | 530000 | 10x the catalog's next-highest spend requirement |
| signup_bonus.timeframe_months | 3 | 12 | Base $2,000 really is a 3-month window |

Spark Cash Plus pays $2,000 for $30,000 in the first 3 months, plus a **repeatable**
$2,000 for every additional $500,000 spent in year one. The
[headline-max convention](https://github.com/CreditOdds/creditodds/blob/main/CLAUDE.md)
for tiered bonuses assumes a bounded ladder with a maximum the issuer prints
(Delta Gold's 70K + 20K = 90K). This offer has no maximum, so the extractor picked an
arbitrary stopping point — two repeats would have given $6,000 / $1,030,000.

Capital One markets this as a $2,000 bonus, so the stored numeric fields now match the
marketed, attainable offer and the repeatable tier is fully disclosed in the note.

**Reviewer: the only thing to verify here is the note text against the apply page.**

### How to Review
1. Click the source link and verify the detected note on the issuer's page
2. Remove any YAML changes that look incorrect before merging
3. Run `npm run build:cards` to validate

---
*Automated PR — review carefully before merging.*
