### PR TITLE
Weekly Reddit SUB roundup: retitle and link each card

### DIFF
--- a/scripts/lib/weekly-sub-changes.js
+++ b/scripts/lib/weekly-sub-changes.js
@@ -121,6 +121,9 @@ function collapsePerCard(rows) {
     // from it is a genuine change worth reporting.
     collapsed.push({
       cardName: shortenCardName(latest.card_name),
+      // The wire's own name, kept unshortened because it is what `/cards`
+      // matches on when resolving the card's page slug.
+      fullCardName: latest.card_name,
       unit: latest.unit,
       oldValue: first.old_value,
       newValue: latest.new_value,
@@ -133,6 +136,49 @@ function collapsePerCard(rows) {
     });
   }
   return collapsed;
+}
+
+/**
+ * Resolve each change's card page slug off `/cards`, matching on the wire's
+ * full card name first (the shortened display name misses cards whose stripped
+ * issuer suffix is part of the real name, e.g. Delta SkyMiles Reserve
+ * Business American Express).
+ *
+ * A card that resolves to nothing keeps `slug: null` rather than a guessed
+ * slug, so callers render it unlinked instead of shipping a 404.
+ */
+async function attachCardSlugs(changes) {
+  const res = await fetchWithRetry(`${API_BASE}/cards`);
+  if (!res.ok) throw new Error(`Failed to fetch cards: ${res.status}`);
+  const cards = await res.json();
+
+  const slugByName = new Map();
+  for (const card of cards) {
+    const name = card.card_name || card.name;
+    if (name && card.slug) slugByName.set(name, card.slug);
+  }
+
+  for (const change of changes) {
+    change.slug =
+      slugByName.get(change.fullCardName) || slugByName.get(change.cardName) || null;
+    if (!change.slug) {
+      console.log(`  Warning: no card page found for "${change.fullCardName}" — it will post unlinked.`);
+    }
+  }
+  return changes;
+}
+
+/**
+ * Card page link for a post body. Same UTM shape as buildCardWireLink so the
+ * weekly roundup's traffic groups under one campaign.
+ */
+function buildCardLink(slug, utmSource, campaign) {
+  const url = new URL(`https://creditodds.com/card/${slug}`);
+  url.searchParams.set('utm_source', utmSource);
+  url.searchParams.set('utm_medium', 'social');
+  url.searchParams.set('utm_campaign', campaign);
+  url.searchParams.set('utm_content', `weekly-${new Date().toISOString().slice(0, 10)}`);
+  return url.toString();
 }
 
 function buildCardWireLink(utmSource, campaign) {
@@ -176,6 +222,8 @@ module.exports = {
   formatBonus,
   fetchRecentSubChanges,
   collapsePerCard,
+  attachCardSlugs,
+  buildCardLink,
   buildCardWireLink,
   queueSocialPost,
 };

--- a/scripts/post-weekly-sub-changes-reddit.js
+++ b/scripts/post-weekly-sub-changes-reddit.js
@@ -29,9 +29,14 @@ const {
   formatBonus,
   fetchRecentSubChanges,
   collapsePerCard,
+  attachCardSlugs,
+  buildCardLink,
   buildCardWireLink,
   queueSocialPost,
 } = require('./lib/weekly-sub-changes');
+
+const UTM_SOURCE = 'reddit';
+const CAMPAIGN = 'weekly-sub-changes-reddit';
 
 /**
  * With no card-name column label next to it, a bare "75,000" is ambiguous, so
@@ -46,14 +51,22 @@ function formatBonusWithUnit(value, unit) {
 }
 
 /**
- * Deliberately markdown-free: Reddit's submit page opens in the rich-text
- * editor, which takes the pre-filled text literally — `**` and `|` table
- * syntax would post as visible asterisks and pipes. Plain lines read
- * correctly in both the rich-text and markdown editors.
+ * Card names link to their card page. Markdown links only render if the
+ * composer is in Markdown mode — Reddit's rich-text editor takes pre-filled
+ * text literally and would show the brackets — so the run prints that
+ * reminder alongside the submit URL.
+ *
+ * Everything else stays markdown-free (no `**`, no `|` tables) so the body
+ * degrades to readable plain text if it ever goes out rich-text.
  */
 function renderLines(changes) {
   return changes
-    .map(c => `${c.cardName}: ${formatBonusWithUnit(c.oldValue, c.unit)} → ${formatBonusWithUnit(c.newValue, c.unit)}`)
+    .map(c => {
+      const name = c.slug
+        ? `[${c.cardName}](${buildCardLink(c.slug, UTM_SOURCE, CAMPAIGN)})`
+        : c.cardName;
+      return `${name}: ${formatBonusWithUnit(c.oldValue, c.unit)} → ${formatBonusWithUnit(c.newValue, c.unit)}`;
+    })
     .join('\n');
 }
 
@@ -68,7 +81,7 @@ function formatShortDate(date) {
 function buildPostText(increases, decreases) {
   const now = new Date();
   const windowStart = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
-  const title = `Weekly Sign Up Bonus Changes (${formatShortDate(windowStart)} to ${formatShortDate(now)})`;
+  const title = `Weekly Credit Card Sign Up Bonus Changes (${formatShortDate(windowStart)} to ${formatShortDate(now)})`;
 
   const sections = [];
   if (increases.length > 0) {
@@ -98,6 +111,8 @@ async function main() {
     return;
   }
 
+  await attachCardSlugs(collapsed);
+
   const byWeight = (a, b) => b.weight - a.weight;
   const increases = collapsed.filter(c => c.newNum > c.oldNum).sort(byWeight);
   const decreases = collapsed.filter(c => c.newNum < c.oldNum).sort(byWeight);
@@ -106,7 +121,7 @@ async function main() {
   const text = buildPostText(increases, decreases);
   // utm_source gets rewritten to the platform name at publish time anyway;
   // set it to reddit so a dry-run prints the real link.
-  const linkUrl = buildCardWireLink('reddit', 'weekly-sub-changes-reddit');
+  const linkUrl = buildCardWireLink(UTM_SOURCE, CAMPAIGN);
   const dateStamp = new Date().toISOString().slice(0, 10);
 
   console.log(`\nPost text:\n\n${text}`);
@@ -134,6 +149,7 @@ async function main() {
   const redditResult = (result.results || []).find(r => r.platform === 'reddit');
   if (redditResult?.postUrl) {
     console.log(`\nPre-filled Reddit submit URL (also in the service UI under History):\n${redditResult.postUrl}`);
+    console.log('\nSwitch the composer to Markdown mode before submitting, otherwise the card links post as raw [text](url).');
   }
   if (result.status !== 'posted' && !result.deduped) {
     throw new Error(`Expected status 'posted', got '${result.status}' (${JSON.stringify(result.results)})`);


### PR DESCRIPTION
## What

Two changes to the Monday r/creditodds sign-up bonus roundup draft:

1. **Title** is now `Weekly Credit Card Sign Up Bonus Changes (<range>)` (was `Weekly Sign Up Bonus Changes (<range>)`), so the subject reads clearly from the subreddit feed.
2. **Every card name links to its card page**, per the standing rule that card and bank mentions in drafted copy get hyperlinked.

## Slug resolution

Card page slugs come from `/cards`, matched on the wire's **full** card name. The display name is shortened (`shortenCardName` strips ` American Express`), which would miss cards whose stripped suffix is part of the real name, so `collapsePerCard` now carries `fullCardName` alongside. A card that resolves to nothing posts **unlinked** rather than with a guessed slug that 404s, and the run logs a warning.

Card links reuse the weekly campaign's UTM shape, so their traffic groups with the CardWire link already in the body.

## Reddit composer caveat

Markdown links only render if the composer is in Markdown mode; the rich-text editor takes pre-filled text literally. The run now prints that reminder next to the submit URL. The body stays otherwise markdown-free (no bold, no tables) so it still degrades to readable plain text if it ever goes out rich-text.

## Verification

Dry run against this week's live data resolved all 6 cards, and every slug returns 200:

```
Weekly Credit Card Sign Up Bonus Changes (Aug 3 to Aug 10)

Increases:

[Delta SkyMiles Reserve Business](https://creditodds.com/card/delta-skymiles-reserve-business-american-express-card?...): 80,000 miles → 125,000 miles
[JetBlue Plus](https://creditodds.com/card/jetblue-plus-card?...): 60,000 points → 70,000 points
[Bank of America Unlimited Cash Rewards](https://creditodds.com/card/bank-of-america-unlimited-cash-rewards?...): $200 → $250
[Target Circle Card](https://creditodds.com/card/target-circle-card?...): $50 → $100

Decreases:

[Marriott Bonvoy Bold](https://creditodds.com/card/marriott-bonvoy-bold-credit-card?...): 60,000 points → 45,000 points
[JetBlue Premier](https://creditodds.com/card/jetblue-premier-card?...): 100,000 points → 90,000 points
```

Note: today's already-queued draft (post #331) still carries the old title and no links. Its idempotency key is per-day, so a rerun today dedupes to that same post rather than regenerating it.