### PR TITLE
Reddit Data Points 2026-08-10

### DIFF
--- a/data/reddit-datapoints/2026-08-10-t3_1vh693i.yaml
+++ b/data/reddit-datapoints/2026-08-10-t3_1vh693i.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1vh693i"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vh693i/dp_langley_backtoback_rejections/"
+posted: "2026-08-06"
+evidence: "Poster reports a Discover it denial on July 7 with a 776 Equifax score and $68,000 income, after opening three cards earlier in the year."
+card_name: "Discover it Cash Back"
+result: "denied"
+credit_score: 776
+credit_score_source: 0
+listed_income: 68000
+date_applied: "2026-07"
+reason_denied_code: "not_specified"

--- a/data/reddit-datapoints/2026-08-10-t3_1vh8uws.yaml
+++ b/data/reddit-datapoints/2026-08-10-t3_1vh8uws.yaml
@@ -1,0 +1,14 @@
+source_id: "t3_1vh8uws"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vh8uws/dp_venture_x_approval_after_hard_inquiries_dropped/"
+posted: "2026-08-06"
+evidence: "Data point post reports a Venture X approval with a $20,000 limit on $70,000 income, citing an approval letter score of 751 Equifax after an inquiry aged off and took the poster from four to three in 24 months."
+card_name: "Capital One Venture X Rewards"
+result: "approved"
+credit_score: 751
+credit_score_source: 3
+listed_income: 70000
+starting_credit_limit: 20000
+total_open_cards: 5
+inquiries_24: 3
+bank_customer: true
+date_applied: "2026-08"

--- a/data/reddit-datapoints/2026-08-10-t3_1vhid0z.yaml
+++ b/data/reddit-datapoints/2026-08-10-t3_1vhid0z.yaml
@@ -1,0 +1,9 @@
+source_id: "t3_1vhid0z"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vhid0z/approved_for_chase_freedom_flex/"
+posted: "2026-08-06"
+evidence: "Recent graduate working part time reports approval for the Chase Freedom Flex and says the application pull left the score at 657."
+card_name: "Chase Freedom Flex"
+result: "approved"
+credit_score: 657
+credit_score_source: 0
+date_applied: "2026-08"

--- a/data/reddit-datapoints/2026-08-10-t3_1vhp9zi.yaml
+++ b/data/reddit-datapoints/2026-08-10-t3_1vhp9zi.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1vhp9zi"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vhp9zi/dp_chase_freedom_unlimited/"
+posted: "2026-08-07"
+evidence: "Data point post reports a Chase Freedom Unlimited approval with a $50,000 limit on roughly an 830 FICO and $200,000 income, alongside four existing Chase cards."
+card_name: "Chase Freedom Unlimited"
+result: "approved"
+credit_score: 830
+credit_score_source: 0
+listed_income: 200000
+starting_credit_limit: 50000
+bank_customer: true
+date_applied: "2026-08"

--- a/data/reddit-datapoints/2026-08-10-t3_1vi82ny.yaml
+++ b/data/reddit-datapoints/2026-08-10-t3_1vi82ny.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1vi82ny"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vi82ny/how_i_got_approved_for_cfu_today_with_less_that_1/"
+posted: "2026-08-07"
+evidence: "Poster reports a same-day Chase Freedom Unlimited approval with a $2,500 limit after opening a Chase checking account two weeks earlier, with about a year of credit history and a 756 Experian score just after the pull."
+card_name: "Chase Freedom Unlimited"
+result: "approved"
+credit_score: 756
+credit_score_source: 0
+length_credit: 1
+starting_credit_limit: 2500
+total_open_cards: 3
+bank_customer: true
+date_applied: "2026-08"

--- a/data/reddit-datapoints/2026-08-10-t3_1vilz18.yaml
+++ b/data/reddit-datapoints/2026-08-10-t3_1vilz18.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1vilz18"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vilz18/19_and_have_three_cards_already_what_steps_should/"
+posted: "2026-08-08"
+evidence: "Nineteen year old reports approval this month for the Elan-issued Fidelity Visa with a $500 limit, listing scores of 720 Experian, 719 TransUnion and 726 Equifax."
+card_name: "Fidelity Rewards Visa Signature"
+result: "approved"
+credit_score: 719
+credit_score_source: 0
+starting_credit_limit: 500
+date_applied: "2026-08"

--- a/data/reddit-datapoints/2026-08-10-t3_1vj07k3.yaml
+++ b/data/reddit-datapoints/2026-08-10-t3_1vj07k3.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1vj07k3"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vj07k3/capital_one_quicksilver_approval_odds/"
+posted: "2026-08-08"
+evidence: "Poster, 23, reports a recent Chase Freedom Unlimited denial for insufficient own credit history; cites TransUnion 767 and Equifax 755, with roughly 10 years of file age almost entirely as an authorized user."
+card_name: "Chase Freedom Unlimited"
+result: "denied"
+credit_score: 755
+credit_score_source: 0
+length_credit: 10
+date_applied: "2026-08"
+reason_denied: "Chase cited not enough established credit history in his own name."
+reason_denied_code: "length_of_credit_too_short"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-08-10

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vj07k3](https://www.reddit.com/r/CreditCards/comments/1vj07k3/capital_one_quicksilver_approval_odds/) | Chase Freedom Unlimited | denied | 755 | — | — | 10 | 2026-08 | `2026-08-10-t3_1vj07k3.yaml` |
| [t3_1vilz18](https://www.reddit.com/r/CreditCards/comments/1vilz18/19_and_have_three_cards_already_what_steps_should/) | Fidelity Rewards Visa Signature | approved | 719 | — | $500 | — | 2026-08 | `2026-08-10-t3_1vilz18.yaml` |
| [t3_1vi82ny](https://www.reddit.com/r/CreditCards/comments/1vi82ny/how_i_got_approved_for_cfu_today_with_less_that_1/) | Chase Freedom Unlimited | approved | 756 | — | $2,500 | 1 | 2026-08 | `2026-08-10-t3_1vi82ny.yaml` |
| [t3_1vhp9zi](https://www.reddit.com/r/CreditCards/comments/1vhp9zi/dp_chase_freedom_unlimited/) | Chase Freedom Unlimited | approved | 830 | $200,000 | $50,000 | — | 2026-08 | `2026-08-10-t3_1vhp9zi.yaml` |
| [t3_1vhid0z](https://www.reddit.com/r/CreditCards/comments/1vhid0z/approved_for_chase_freedom_flex/) | Chase Freedom Flex | approved | 657 | — | — | — | 2026-08 | `2026-08-10-t3_1vhid0z.yaml` |
| [t3_1vh8uws](https://www.reddit.com/r/CreditCards/comments/1vh8uws/dp_venture_x_approval_after_hard_inquiries_dropped/) | Capital One Venture X Rewards | approved | 751 | $70,000 | $20,000 | — | 2026-08 | `2026-08-10-t3_1vh8uws.yaml` |
| [t3_1vh693i](https://www.reddit.com/r/CreditCards/comments/1vh693i/dp_langley_backtoback_rejections/) | Discover it Cash Back | denied | 776 | $68,000 | — | — | 2026-07 | `2026-08-10-t3_1vh693i.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (5)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [United Explorer Card Targeted 80k SUB](https://www.reddit.com/r/CreditCards/comments/1vjcakr/united_explorer_card_targeted_80k_sub/) | United Explorer · approved | credit_score | What was your score at the time, and which bureau? |
| [Was approved for Chase Freedom Unlimited - Is this a good th…](https://www.reddit.com/r/CreditCards/comments/1viilrf/was_approved_for_chase_freedom_unlimited_is_this/) | Chase Freedom Unlimited · approved | credit_score | What was your score at the time, and which bureau? |
| [Got Venture X after getting denied from Bilt Palladium Yeste…](https://www.reddit.com/r/CreditCards/comments/1vhge0n/got_venture_x_after_getting_denied_from_bilt/) | Bilt Palladium · denied | credit_score | What was your score at the time, and which bureau? |
| [How is my credit card line up?](https://www.reddit.com/r/CreditCards/comments/1vhdp81/how_is_my_credit_card_line_up/) | Robinhood Gold · denied | credit_score | What was your score at the time, and which bureau? |
| [Got rejected for Savor Card!](https://www.reddit.com/r/CreditCards/comments/1vh8shb/got_rejected_for_savor_card/) | Capital One Savor Cash Rewards · denied | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 26 | No stated approval or denial (odds question, recommendation request, chatter) |
| `no_score` | 14 | Real outcome but no credit score anywhere, and below the pending bar |
| `pre_qual` | 4 | Pre-qualification or pre-approval result, which is never an outcome |
| `not_datable` | 3 | Application cannot be placed in a specific month |
| `card_unclear` | 1 | Real outcome but which card was applied for cannot be pinned down |

**Cards in real data points but missing from the catalog:** `OnePay Walmart Cash Rewards`. Adding one turns every future post about it into publishable odds data.


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
