### PR TITLE
Add "What to get instead" rail to discontinued card pages

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -36,6 +36,7 @@ import { categoryLabels, CategoryIcon } from "@/lib/cardDisplayUtils";
 import { resolveApplyLink, withApplySource } from "@/lib/applyLink";
 import posthog from "posthog-js";
 import { V2Footer } from "@/components/landing-v2/Chrome";
+import { ReplacementCards } from "@/components/ui/ReplacementCards";
 import CardRecordsTable from "./CardRecordsTable";
 import ProductChangeFlow, { ProductChangeNode } from "./ProductChangeFlow";
 import "../../landing.css";
@@ -906,6 +907,25 @@ export default function CardClient({
             : "This card is no longer accepting applications."}
         </div>
       )}
+
+      {/* "What to get instead", directly under the banner that just told the
+          reader this card is gone. Deliberately above the fold rather than down
+          with Related Cards: the banner creates the question, so the answer
+          belongs next to it. build-cards.js only populates
+          replacement_cards_info on closed cards, so no open-card guard is
+          needed here — but the rail is wrapped anyway to keep a data mistake
+          from rendering a competitor list on a live card. */}
+      {card.accepting_applications === false &&
+        (card.replacement_cards_info?.length ?? 0) > 0 && (
+          <div className="replacement-cards-banner-slot">
+            <ReplacementCards
+              cards={card.replacement_cards_info ?? []}
+              surface="card_page"
+              sourceId={card.slug}
+              intro="This card is closed to new applicants. These are open and cover the same ground:"
+            />
+          </div>
+        )}
 
       <div className="cj-layout">
         {/* Left ToC */}

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7188,6 +7188,29 @@
   }
 }
 
+/* Card-page placement. The rail itself was styled for article prose inside
+   .article-body; on a card page it sits full-bleed directly under the
+   pulled-card banner, so the slot supplies the page gutter the card layout
+   would otherwise provide and caps line length on wide screens. The rail's own
+   36px margin-top is overridden because here it follows a banner, not
+   paragraphs. Longhand padding on purpose: a shorthand here would be
+   overwritten wholesale by the mobile override below. */
+.landing-v2.card-journal .replacement-cards-banner-slot {
+  padding-inline: 24px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--line);
+}
+.landing-v2.card-journal .replacement-cards-banner-slot .replacement-cards {
+  margin-top: 20px;
+  max-width: 720px;
+}
+@media (max-width: 767px) {
+  .landing-v2.card-journal .replacement-cards-banner-slot {
+    padding-inline: 16px;
+    padding-bottom: 20px;
+  }
+}
+
 .landing-v2 .article-follow {
   margin-top: 24px;
 }

--- a/apps/web-next/src/app/news/[id]/page.tsx
+++ b/apps/web-next/src/app/news/[id]/page.tsx
@@ -8,7 +8,7 @@ import { ArticleContent } from "@/components/articles/ArticleContent";
 import { BreadcrumbSchema } from "@/components/seo/JsonLd";
 import { ReadingProgressBar } from "@/components/articles/ReadingProgressBar";
 import { RelatedCards } from "@/components/articles/RelatedCards";
-import { ReplacementCards } from "@/components/news/ReplacementCards";
+import { ReplacementCards } from "@/components/ui/ReplacementCards";
 import { RelatedCardInfo } from "@/lib/articles";
 import CardImage from "@/components/ui/CardImage";
 import { V2Footer } from "@/components/landing-v2/Chrome";
@@ -246,7 +246,8 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
                 next question, and Related Cards points at the dead card. */}
             <ReplacementCards
               cards={item.replacement_cards_info ?? []}
-              articleId={item.id}
+              surface="news"
+              sourceId={item.id}
             />
 
             {relatedCards.length > 0 && <RelatedCards cards={relatedCards} />}

--- a/apps/web-next/src/components/ui/ReplacementCards.tsx
+++ b/apps/web-next/src/components/ui/ReplacementCards.tsx
@@ -3,12 +3,27 @@
 import Link from 'next/link';
 import posthog from 'posthog-js';
 import CardImage from '@/components/ui/CardImage';
-import type { ReplacementCardInfo } from '@/lib/news';
+import type { ReplacementCardInfo } from '@/lib/api';
+
+/**
+ * Which page the rail is rendered on. Both surfaces emit the same
+ * `replacement_card_clicked` event, so this is what lets the two be read apart
+ * in PostHog — without it the card-page clicks would silently pollute the
+ * per-article readout the news rail has been measured on since #1924.
+ */
+export type ReplacementSurface = 'news' | 'card_page';
 
 interface Props {
   cards: ReplacementCardInfo[];
-  /** Article id, so clicks can be attributed to the story that drove them. */
-  articleId: string;
+  surface: ReplacementSurface;
+  /**
+   * What drove the click: the article id on news, the dead card's slug on a
+   * card page. Emitted under a per-surface property name so the existing
+   * `article_id` breakdown keeps meaning exactly what it always meant.
+   */
+  sourceId: string;
+  /** Optional override; each surface has a different natural lead-in. */
+  intro?: string;
 }
 
 function feeLabel(annualFee: number | null): string | null {
@@ -16,7 +31,7 @@ function feeLabel(annualFee: number | null): string | null {
   return annualFee === 0 ? 'No annual fee' : `$${annualFee.toLocaleString('en-US')} annual fee`;
 }
 
-export function ReplacementCards({ cards, articleId }: Props) {
+export function ReplacementCards({ cards, surface, sourceId, intro }: Props) {
   if (!cards || cards.length === 0) return null;
 
   // The intro deliberately names no card. On a straight pull the article's
@@ -29,7 +44,7 @@ export function ReplacementCards({ cards, articleId }: Props) {
         What to get instead
       </h2>
       <p className="replacement-cards-intro">
-        These cards are open to new applicants and cover the same ground:
+        {intro ?? 'These cards are open to new applicants and cover the same ground:'}
       </p>
       <ul className="replacement-cards-list">
         {cards.map((card, index) => {
@@ -41,7 +56,10 @@ export function ReplacementCards({ cards, articleId }: Props) {
                 className="replacement-card"
                 onClick={() => {
                   posthog.capture('replacement_card_clicked', {
-                    article_id: articleId,
+                    surface,
+                    ...(surface === 'news'
+                      ? { article_id: sourceId }
+                      : { source_card_slug: sourceId }),
                     card_slug: card.slug,
                     card_name: card.name,
                     bank: card.bank,

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -132,6 +132,24 @@ export interface CardBenefit {
   merchants?: string[];
 }
 
+/**
+ * A card a reader can still apply for, offered in place of one that went away.
+ * Resolved at build time — by scripts/build-news.js for the news surface and
+ * scripts/build-cards.js for the card-page surface. Both guarantee the slug
+ * exists and is still accepting applications, so the frontend never has to
+ * re-check. Self-contained on purpose: the image travels with its own slug and
+ * name, so a card missing from the source data blanks only itself.
+ */
+export interface ReplacementCardInfo {
+  slug: string;
+  name: string;
+  image: string | null;
+  bank: string;
+  annual_fee: number | null;
+  /** One editorial line on why this card stands in for the one that went away. */
+  reason?: string;
+}
+
 export interface Card {
   card_id: string | number;
   db_card_id?: number;
@@ -168,6 +186,11 @@ export interface Card {
   apr?: CardAPR;
   benefits?: CardBenefit[];
   our_take?: string;
+  /**
+   * Populated by build-cards.js only on cards with accepting_applications:
+   * false. Drives the "What to get instead" rail under the pulled-card banner.
+   */
+  replacement_cards_info?: ReplacementCardInfo[];
 }
 
 // GraphData is an array of series data

--- a/apps/web-next/src/lib/news.ts
+++ b/apps/web-next/src/lib/news.ts
@@ -1,5 +1,6 @@
 // News API types and fetching
 import { fetchWithRetry } from './fetchWithRetry';
+import type { ReplacementCardInfo } from './api';
 
 export type NewsTag =
   | 'new-card'
@@ -12,20 +13,10 @@ export type NewsTag =
   | 'rumor'
   | 'general';
 
-/**
- * A card readers can still apply for, offered on an article about a card that
- * went away. Resolved at build time by scripts/build-news.js, which guarantees
- * the slug exists in cards.json and is still accepting applications.
- */
-export interface ReplacementCardInfo {
-  slug: string;
-  name: string;
-  image: string | null;
-  bank: string;
-  annual_fee: number | null;
-  /** One editorial line on why this card stands in for the one that went away. */
-  reason?: string;
-}
+// Shared with the card-page surface, so the definition lives next to `Card`.
+// Re-exported here because news consumers have imported it from this module
+// since the rail shipped (#1924).
+export type { ReplacementCardInfo };
 
 /**
  * A card a news item is about, resolved at build time by scripts/build-news.js.

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -3,6 +3,14 @@ bank: "American Express"
 slug: "american-express-green-card"
 image: "amex_green_card.png"
 accepting_applications: false
+# Reused verbatim from data/news/2026-07-25-amex-green-card-pulled-renamed-classic-green.yaml
+replacement_cards:
+  - slug: "wells-fargo-autograph"
+    reason: "Matches the Green's 3x on travel, transit, and dining, adds streaming and phone, and charges no annual fee."
+  - slug: "chase-sapphire-preferred"
+    reason: "3x dining and 5x on travel booked through Chase, with transferable points, for $95 instead of $150."
+  - slug: "american-express-gold-card"
+    reason: "The step up inside Amex: 4x at restaurants and 4x at U.S. supermarkets, if the spend clears the higher fee."
 apply_link: https://www.americanexpress.com/us/credit-cards/card/green/
 foreign_transaction_fee: false
 network: "amex"

--- a/data/cards/bilt-mastercard.yaml
+++ b/data/cards/bilt-mastercard.yaml
@@ -3,6 +3,14 @@ bank: "Wells Fargo"
 slug: "bilt-mastercard"
 image: "bilt_mastercard.png"
 accepting_applications: false
+# Reused verbatim from data/news/2026-02-07-bilt-card-transition.yaml
+replacement_cards:
+  - slug: "bilt-blue"
+    reason: "Bilt's current no-fee card: rent still earns up to 1.25x, plus 3x on Bilt Travel hotels and 3x on Lyft."
+  - slug: "wells-fargo-autograph"
+    reason: "The card Wells Fargo moved many Bilt holders into: 3x on dining, travel, gas, transit, streaming, and phone, no annual fee."
+  - slug: "bilt-obsidian"
+    reason: "The $95 step up: choose 3x dining or groceries, keep the rent earning, and add travel rates."
 active: false
 category: "rewards"
 annual_fee: 0

--- a/data/cards/chase-freedom.yaml
+++ b/data/cards/chase-freedom.yaml
@@ -3,6 +3,14 @@ bank: "Chase"
 slug: "chase-freedom"
 image: "chase-freedom.png"
 accepting_applications: false
+# Not from a news article: the original Freedom was retired before this site
+# covered it, so the copy below is written against the successors' current
+# YAML terms rather than reused.
+replacement_cards:
+  - slug: "chase-freedom-flex"
+    reason: "The direct successor: 5% on rotating quarterly categories up to $1,500, plus 3% on dining and drugstores, no annual fee."
+  - slug: "chase-freedom-unlimited"
+    reason: "Flat 1.5% on everything with no annual fee, if you would rather not activate categories each quarter."
 annual_fee: 0
 tags:
   - cashback

--- a/data/cards/citi-custom-cash.yaml
+++ b/data/cards/citi-custom-cash.yaml
@@ -3,6 +3,14 @@ bank: "Citi"
 slug: "citi-custom-cash"
 image: "citi_custom_cash.png"
 accepting_applications: false
+# Reused verbatim from data/news/2026-05-27-citi-custom-cash-discontinuation-rumor.yaml
+replacement_cards:
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "The closest structure left: pick two 5% categories each quarter on the first $2,000, no annual fee."
+  - slug: "chase-freedom-flex"
+    reason: "5% on rotating quarterly categories up to $1,500, plus 3% on dining and drugstores, no annual fee."
+  - slug: "citi-double-cash"
+    reason: "Citi's own suggestion for new cash back applicants: 2% on everything, no annual fee."
 annual_fee: 0
 reward_type: "cashback"
 tags:

--- a/data/cards/kroger-rewards-world-elite-mastercard.yaml
+++ b/data/cards/kroger-rewards-world-elite-mastercard.yaml
@@ -3,6 +3,17 @@ bank: "U.S. Bank"
 slug: "kroger-rewards-world-elite-mastercard"
 image: "kroger-rewards-world-elite.png"
 accepting_applications: false
+# Reused verbatim from the Kroger conversion coverage
+# (data/news/2026-05-12-us-bank-kroger-cards-no-longer-accepting-applications.yaml).
+# Note that article's `card_slug` is the LIVE Smartly card, not this dead one —
+# the replacements belong to this page, which is the one readers land on.
+replacement_cards:
+  - slug: "blue-cash-preferred-card"
+    reason: "6% back at U.S. supermarkets on the first $6,000 a year, plus 3% on gas."
+  - slug: "blue-cash-everyday-card"
+    reason: "3% at U.S. supermarkets and 3% on gas with no annual fee, for lighter grocery baskets."
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "Keeps the rewards with U.S. Bank: two 5% categories of your choosing each quarter, no annual fee."
 # One product, issued per Kroger Family of Companies banner. These are not
 # former names, they were concurrent brandings of this same card, which is why
 # they live here and not in previous_names. Reddit posters name the banner they

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -38,6 +38,20 @@
       "type": "boolean",
       "description": "Whether the card is currently accepting new applications"
     },
+    "replacement_cards": {
+      "type": "array",
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "required": ["slug"],
+        "properties": {
+          "slug": { "type": "string" },
+          "reason": { "type": "string", "maxLength": 160 }
+        },
+        "additionalProperties": false
+      },
+      "description": "Cards to offer a reader who lands on this card's page after it closed to applications. Renders the 'What to get instead' rail below the pulled-card banner. ONLY legal on a card whose `accepting_applications` is false — build-cards.js rejects it on a live card, because on a live card the rail would push readers away from a product they can still get. Each slug must exist in cards.json and itself be accepting applications; the build fails otherwise, since a dead replacement is worse than no rail. Same shape as the news `replacement_cards` field (data/news/schema.json); where a news article covers this exact card, reuse its curated list verbatim rather than writing new copy."
+    },
     "category": {
       "type": "string",
       "enum": ["travel", "cashback", "business", "student", "secured", "rewards", "balance_transfer", "other"],

--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -3,6 +3,14 @@ bank: "U.S. Bank"
 slug: "us-bank-shopper"
 image: "us-bank-shopper.png"
 accepting_applications: false
+# Reused verbatim from data/news/2026-07-21-us-bank-shopper-cash-rewards-discontinued.yaml
+replacement_cards:
+  - slug: "blue-cash-everyday-card"
+    reason: "3% on U.S. online retail up to $6,000 a year, covering the Shopper's core use with no annual fee."
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "Keeps the rewards with U.S. Bank: two 5% categories of your choosing each quarter, no annual fee."
+  - slug: "wells-fargo-active-cash"
+    reason: "Flat 2% on everything with no annual fee, and nothing to pick or track each quarter."
 annual_fee: 95
 annual_fee_intro:
   value: 0

--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -2,6 +2,14 @@ name: "Wells Fargo Attune"
 bank: "Wells Fargo"
 slug: "wells-fargo-attune"
 accepting_applications: false
+# Reused verbatim from data/news/2026-06-16-wells-fargo-attune-discontinued.yaml
+replacement_cards:
+  - slug: "wells-fargo-autograph"
+    reason: "Wells Fargo's remaining no-fee category card: 3x on dining, travel, gas, transit, streaming, and phone plans."
+  - slug: "us-bank-cash-plus-visa-signature"
+    reason: "Pick two 5% categories each quarter on the first $2,000 of spending, with no annual fee."
+  - slug: "wells-fargo-active-cash"
+    reason: "Flat 2% on everything, no annual fee, if you would rather not track categories at all."
 category: "cashback"
 image: "wells-fargo-attune.png"
 annual_fee: 0

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -237,6 +237,57 @@ function validateCard(card, schema, categoryIds, storeSlugs) {
     }
   }
 
+  // Validate replacement_cards shape. Cross-card resolution (does the slug
+  // exist, is it still open) needs every card loaded, so it happens in a second
+  // pass in buildCards() — this only covers what one card can check alone.
+  if (card.replacement_cards !== undefined) {
+    if (!Array.isArray(card.replacement_cards)) {
+      errors.push('replacement_cards must be an array');
+    } else if (card.replacement_cards.length > 4) {
+      errors.push('replacement_cards accepts at most 4 entries');
+    } else {
+      // Guard the whole point of the field: it answers "this card is gone, now
+      // what?". On a card still taking applications the rail would steer a
+      // ready-to-apply reader at a competitor, so treat it as an authoring bug
+      // rather than silently hiding it at render time.
+      if (card.accepting_applications !== false) {
+        errors.push(
+          'replacement_cards is only valid on a card with accepting_applications: false ' +
+          `(${card.slug} is still accepting applications)`
+        );
+      }
+      const seen = new Set();
+      for (const entry of card.replacement_cards) {
+        if (typeof entry !== 'object' || entry === null || Array.isArray(entry) || !entry.slug) {
+          errors.push('Each replacement_cards entry must be an object with a slug');
+          continue;
+        }
+        const extra = Object.keys(entry).filter(k => !['slug', 'reason'].includes(k));
+        if (extra.length > 0) {
+          errors.push(`Unknown replacement_cards field(s): ${extra.join(', ')}`);
+        }
+        if (typeof entry.slug !== 'string' || !/^[a-z0-9-]+$/.test(entry.slug)) {
+          errors.push(`Invalid replacement_cards slug: ${entry.slug} (must be lowercase with hyphens only)`);
+          continue;
+        }
+        if (seen.has(entry.slug)) {
+          errors.push(`Duplicate replacement_cards slug: ${entry.slug}`);
+        }
+        seen.add(entry.slug);
+        if (entry.slug === card.slug) {
+          errors.push(`replacement_cards slug ${entry.slug} is this card — a card cannot replace itself`);
+        }
+        if (entry.reason !== undefined) {
+          if (typeof entry.reason !== 'string') {
+            errors.push(`replacement_cards reason for ${entry.slug} must be a string`);
+          } else if (entry.reason.length > 160) {
+            errors.push(`replacement_cards reason for ${entry.slug} is ${entry.reason.length} chars (max 160)`);
+          }
+        }
+      }
+    }
+  }
+
   // Validate APR
   if (card.apr) {
     if (typeof card.apr !== 'object' || Array.isArray(card.apr)) {
@@ -369,6 +420,58 @@ function buildCards() {
         console.error(`    - ${err}`);
       }
     }
+    process.exit(1);
+  }
+
+  // Resolve replacement cards into self-contained objects, so the frontend
+  // never indexes parallel arrays (the bug this shape was chosen to avoid on
+  // the news side). Runs only once every card has parsed, because a slug can
+  // point at any other card in the set.
+  //
+  // Failures are fatal, matching build-news.js: the rail's whole job is to hand
+  // someone a card they can actually still get, and a bad slug either 404s or
+  // points at a second dead card — worse than rendering nothing.
+  const cardsLookup = Object.fromEntries(cards.map(c => [c.slug, c]));
+  const resolutionErrors = [];
+  for (const card of cards) {
+    if (!card.replacement_cards) continue;
+    const resolved = [];
+    for (const entry of card.replacement_cards) {
+      const target = cardsLookup[entry.slug];
+      if (!target) {
+        resolutionErrors.push(
+          `${card.slug}: replacement_cards slug "${entry.slug}" not found in data/cards`
+        );
+        continue;
+      }
+      if (target.accepting_applications === false) {
+        resolutionErrors.push(
+          `${card.slug}: replacement_cards slug "${entry.slug}" (${target.name}) is not accepting ` +
+          'applications — it cannot be offered as a replacement'
+        );
+        continue;
+      }
+      resolved.push({
+        slug: entry.slug,
+        name: target.card_name || target.name,
+        image: target.image || null,
+        bank: target.bank || '',
+        annual_fee: typeof target.annual_fee === 'number' ? target.annual_fee : null,
+        ...(entry.reason ? { reason: entry.reason } : {}),
+      });
+    }
+    card.replacement_cards_info = resolved;
+  }
+
+  if (resolutionErrors.length > 0) {
+    console.error(`\nReplacement-card resolution failed with ${resolutionErrors.length} error(s):`);
+    for (const err of resolutionErrors) {
+      console.error(`  - ${err}`);
+    }
+    console.error(
+      '\nFix the slug, or drop the entry. A replacement card must exist in data/cards\n' +
+      'and still be accepting applications.\n'
+    );
     process.exit(1);
   }
 


### PR DESCRIPTION
Implements **R13** from the 2026-08-10 PostHog product review.

## Why

The news rail from #1924 works, but its ceiling is the article's traffic. The 8/10 readout made that concrete:

- All 16 `replacement_card_clicked` events sit on the **three original** articles (Kroger 8, Amex Green 6, WF Attune 2).
- The **six articles backfilled in #1975 produced zero clicks** in four days, because `us-bank-kroger-cards-convert-to-smartly` drew 7 entry sessions in a week and the other five did not clear 3 each.
- The mechanism is fine; the denominator is not.

Card pages accumulate steady search traffic instead of decaying like a news post, and the rail sits one click from apply there rather than two.

**Honest sizing, up front:** discontinued card pages are not a big surface either. All 32 closed cards together drew ~130 views/28d, led by Amex Green (40) and Citi Custom Cash (35, with 31 of those in the last 7 days). Expect a handful of clicks a week, not another 10x headline. The case is that it is cheap, it reuses proven machinery, and every future discontinuation gets it automatically instead of needing a backfill.

## What changed

**Data**
- `data/cards/schema.json`: optional `replacement_cards: [{slug, reason}]`, max 4, mirroring the news field.
- `scripts/build-cards.js`: per-card shape validation, then a cross-card resolution pass producing `replacement_cards_info`.

Three guards, all fatal (matching `build-news.js`, where a bad slug is worse than rendering nothing):

| Guard | Message |
|---|---|
| Rail on a live card | `replacement_cards is only valid on a card with accepting_applications: false` |
| Unknown slug | `replacement_cards slug "..." not found in data/cards` |
| Replacement itself closed | `replacement_cards slug "..." (...) is not accepting applications` |

**Frontend**
- `ReplacementCards` moves `components/news/` → `components/ui/` (it now serves two page types) and takes `surface` + `sourceId`.
- `ReplacementCardInfo` moves to `lib/api.ts` next to `Card`; `lib/news.ts` re-exports it so existing imports are untouched.
- Rail renders directly under the pulled-card banner. The banner raises the question, so the answer belongs beside it, not down with Related Cards.

**Analytics** — both surfaces emit `replacement_card_clicked`. News keeps `article_id`; card pages send `source_card_slug`; both now carry `surface`. The existing per-article breakdown keeps meaning exactly what it always meant, so the #1924 readout stays comparable.

## Cards authored (7)

Six reuse the curated copy **verbatim** from the news article covering that same card, so there is no new editorial risk:

| Card | Views/28d | Replacements | Copy source |
|---|---|---|---|
| American Express Green | 40 | Autograph, Sapphire Preferred, Amex Gold | amex-green-card-pulled |
| Citi Custom Cash | 35 | Cash+, Freedom Flex, Double Cash | citi-custom-cash-discontinuation-rumor |
| Chase Freedom | 9 | Freedom Flex, Freedom Unlimited | **new** (written against successors' current YAML) |
| Bilt Mastercard | 9 | Bilt Blue, Autograph, Bilt Obsidian | bilt-card-transition |
| US Bank Shopper | 8 | Blue Cash Everyday, Cash+, Active Cash | us-bank-shopper-discontinued |
| Kroger Rewards World Elite | 3 | Blue Cash Preferred, Blue Cash Everyday, Cash+ | kroger conversion coverage |
| Wells Fargo Attune | 2 | Autograph, Cash+, Active Cash | wells-fargo-attune-discontinued |

Selection is on `accepting_applications: false` on the subject card, not headline wording — the lesson from #1975. Note the Kroger article's `card_slug` is the *live* Smartly card, so the replacements belong to the dead Kroger card's page, not the article's subject.

The other 25 closed cards are left without a rail for now; they can be added as cheap YAML whenever someone wants to, and the build refuses to let a bad one through.

## Verification

- `npm run build:cards` green; all 7 resolve with correct name/bank/fee.
- Each of the three guards was deliberately tripped and failed the build with the expected message.
- `tsc --noEmit` clean, `eslint --max-warnings=0` clean, `next build` green (including the `check-seo` prebuild), 107/107 unit tests pass.
- Rendered locally: rail present on Amex Green / Citi Custom Cash / Chase Freedom, **absent** on a live card, news rail unchanged. Desktop and mobile (375px) both checked; no new console errors.

`data/cards.json` is gitignored and deliberately not committed.

## How to read the result

Compare `replacement_card_clicked` where `surface = 'card_page'` against the news surface from the next review onward. Card pages that stay module-free act as the control.