### PR TITLE
Add twice-weekly "<card> approval odds?" Reddit draft

### DIFF
--- a/scripts/lib/card-approval-odds.js
+++ b/scripts/lib/card-approval-odds.js
@@ -1,0 +1,272 @@
+/**
+ * Shared logic for the twice-weekly r/creditodds "<card> approval odds?" post.
+ *
+ * One card per run, picked as the highest-record card that has not been posted
+ * before. The rotation deliberately does NOT loop: every eligible card gets
+ * exactly one post, and when the queue is empty the run is a no-op until new
+ * cards cross the record floor. Records accumulate over time, so the queue
+ * refills itself.
+ *
+ * Why a record floor at all: at the time this was written 175 of 209 cards had
+ * fewer than 5 data points. Publishing "approval odds" off 3 records would be
+ * a number nobody should act on, and the post exists to earn trust and pull in
+ * more data points, not to hit a cadence.
+ */
+
+// Reuses the roundup lib's retry wrapper (5xx/429 with exponential backoff)
+// rather than adding a second copy; that module is already the shared home for
+// this repo's social-post plumbing.
+const { fetchWithRetry } = require('./weekly-sub-changes');
+
+const API_BASE = process.env.CREDITODDS_API_BASE || 'https://d2ojrhbh2dincr.cloudfront.net';
+const SITE_BASE = 'https://creditodds.com';
+
+/** Below this many records the odds are not worth publishing. */
+const MIN_RECORDS = 10;
+
+/** `records.result` in the API: 1 approved, 0 denied. Nothing else is emitted. */
+const RESULT_APPROVED = 1;
+const RESULT_DENIED = 0;
+
+/**
+ * Every `credit_score_source` value the submit form offers is a FICO variant
+ * (0 unspecified, 1 Experian, 2 TransUnion, 3 Equifax), so labelling the
+ * aggregate "FICO" is accurate and needs no per-record filtering.
+ */
+function median(values) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Pull one numeric field off the records that actually carry it. Optional
+ * fields are sparse (income was present on 22 of 42 records on the card this
+ * was built against), so every stat reports its own n rather than implying the
+ * whole sample answered.
+ */
+function summarize(records, field) {
+  const values = records
+    .map(r => r[field])
+    .filter(v => typeof v === 'number' && Number.isFinite(v) && v > 0);
+  return { median: median(values), n: values.length };
+}
+
+async function fetchJson(url) {
+  const res = await fetchWithRetry(url, { headers: { Accept: 'application/json' } });
+  if (!res.ok) throw new Error(`GET ${url} failed: ${res.status}`);
+  return res.json();
+}
+
+/** Cache-bust the 300s CloudFront TTL so a run never reads yesterday's counts. */
+function bust(url) {
+  return `${url}${url.includes('?') ? '&' : '?'}_=${Date.now()}`;
+}
+
+async function fetchCards() {
+  return fetchJson(bust(`${API_BASE}/cards`));
+}
+
+async function fetchCardRecords(cardName) {
+  return fetchJson(bust(`${API_BASE}/card-records?card_name=${encodeURIComponent(cardName)}`));
+}
+
+/**
+ * Eligible = enough data to be worth publishing, still applicable for, and not
+ * already posted.
+ *
+ * Closed cards are excluded because the post asks "should you apply?" and links
+ * to a page that cannot take an application. Their data points are still
+ * valuable, they are just not the subject of this post.
+ */
+function selectCard(cards, postedSlugs, { minRecords = MIN_RECORDS } = {}) {
+  const eligible = cards.filter(c =>
+    (c.total_records || 0) >= minRecords &&
+    c.accepting_applications !== false &&
+    c.slug &&
+    !postedSlugs.has(c.slug)
+  );
+  if (eligible.length === 0) return null;
+  // Ties broken by name so a rerun with unchanged data picks the same card.
+  eligible.sort((a, b) =>
+    (b.total_records || 0) - (a.total_records || 0) ||
+    String(a.card_name || a.name).localeCompare(String(b.card_name || b.name))
+  );
+  return eligible[0];
+}
+
+function cardPageUrl(slug, campaign) {
+  const url = new URL(`${SITE_BASE}/card/${slug}`);
+  url.searchParams.set('utm_source', 'reddit');
+  url.searchParams.set('utm_medium', 'social');
+  url.searchParams.set('utm_campaign', campaign);
+  url.searchParams.set('utm_content', new Date().toISOString().slice(0, 10));
+  return url.toString();
+}
+
+function formatMoney(value) {
+  return `$${Math.round(value).toLocaleString('en-US')}`;
+}
+
+/**
+ * Split the records into the two outcomes and reduce each side to the stats
+ * worth printing. Denied-side medians are computed here rather than read from
+ * `card_stats`, which only stores the approved side.
+ */
+function computeStats(records) {
+  const approved = records.filter(r => r.result === RESULT_APPROVED);
+  const denied = records.filter(r => r.result === RESULT_DENIED);
+  const counted = approved.length + denied.length;
+
+  return {
+    total: records.length,
+    counted,
+    approvedCount: approved.length,
+    deniedCount: denied.length,
+    // Rate is over decided records only; a future pending/unknown result must
+    // not silently deflate the percentage.
+    approvalRate: counted > 0 ? approved.length / counted : null,
+    approvedScore: summarize(approved, 'credit_score'),
+    deniedScore: summarize(denied, 'credit_score'),
+    approvedIncome: summarize(approved, 'listed_income'),
+    deniedIncome: summarize(denied, 'listed_income'),
+    approvedLimit: summarize(approved, 'starting_credit_limit'),
+  };
+}
+
+/**
+ * Reddit body. Markdown is intentional and matches the weekly SUB roundup
+ * (PR #1993): links only render if the composer is in Markdown mode, so the
+ * caller prints that reminder next to the submit URL. Nothing else uses
+ * markdown syntax, so the text still reads correctly if it goes out rich-text.
+ *
+ * No em dashes anywhere in user-facing copy.
+ */
+function buildPostText(card, stats, link) {
+  const name = card.card_name || card.name;
+  const title = `${name} approval odds?`;
+
+  const lines = [];
+  lines.push(
+    `We track approval and denial data points on the [${name}](${link}). Here is what ${stats.counted} of them say so far.`
+  );
+  lines.push('');
+  lines.push(
+    `Approval rate: ${Math.round(stats.approvalRate * 100)}% (${stats.approvedCount} approved, ${stats.deniedCount} denied)`
+  );
+
+  const approvedRows = [];
+  if (stats.approvedScore.median !== null) {
+    approvedRows.push(`Median FICO: ${Math.round(stats.approvedScore.median)} (n=${stats.approvedScore.n})`);
+  }
+  if (stats.approvedIncome.median !== null) {
+    approvedRows.push(`Median income: ${formatMoney(stats.approvedIncome.median)} (n=${stats.approvedIncome.n})`);
+  }
+  if (stats.approvedLimit.median !== null) {
+    approvedRows.push(`Median starting limit: ${formatMoney(stats.approvedLimit.median)} (n=${stats.approvedLimit.n})`);
+  }
+  if (approvedRows.length > 0) {
+    lines.push('');
+    lines.push('Approved:');
+    lines.push('');
+    lines.push(approvedRows.join('\n'));
+  }
+
+  const denied = describeDeniedScore(stats);
+  if (denied) {
+    lines.push('');
+    lines.push(denied);
+  }
+
+  lines.push('');
+  lines.push(
+    `Each number is a median over the data points that reported that field, so the n varies by row. ${samplingCaveat(stats.counted)}`
+  );
+  lines.push('');
+  lines.push(
+    'If you have applied for this card, drop your data point in the comments: approved or denied, your FICO at the time, income, and the starting limit if you got one. We will fold it into the numbers.'
+  );
+  lines.push('');
+  lines.push(`Full data points and the odds calculator are on the card page: ${link}`);
+
+  return `${title}\n\n${lines.join('\n')}`;
+}
+
+/**
+ * How the denied side gets described.
+ *
+ * A bare "Approved median FICO 751 / Denied median FICO 750" table was the
+ * first draft, and it is a trap: across the 15 cards eligible at launch, the
+ * denied median was HIGHER than the approved median on 7 of them (Citi Strata
+ * Premier: denied 815 vs approved 759). Printed without context that reads as
+ * broken data and invites exactly the "your numbers are garbage" reply the post
+ * is trying to avoid.
+ *
+ * It is not broken, it is real: denials at high scores are driven by
+ * application velocity, thin files, and issuer rules rather than by score, and
+ * `reason_denied` is free text present on only ~14% of denials, so it cannot be
+ * aggregated to explain it. Saying so in a sentence is both honest and the most
+ * comment-worthy line in the post.
+ *
+ * Deliberately hedged ("often", "usually"): we are describing a pattern in a
+ * small self-reported sample, not asserting a cause.
+ */
+const SCORE_GAP_NOISE = 15;
+
+function describeDeniedScore(stats) {
+  const approved = stats.approvedScore.median;
+  const denied = stats.deniedScore.median;
+  if (approved === null || denied === null) return null;
+
+  const d = Math.round(denied);
+  const n = stats.deniedScore.n;
+  const gap = Math.round(approved - denied);
+
+  if (gap >= SCORE_GAP_NOISE) {
+    return `Denied applicants reported a median FICO of ${d} (n=${n}), about ${gap} points below the approved group.`;
+  }
+  if (gap <= -SCORE_GAP_NOISE) {
+    return (
+      `Denied applicants reported a median FICO of ${d} (n=${n}), which is actually ${Math.abs(gap)} points ` +
+      'higher than the approved group. On a sample this size that usually means denials came down to ' +
+      'application velocity, a thin file, or issuer rules rather than the score itself.'
+    );
+  }
+  return (
+    `Denied applicants reported a median FICO of ${d} (n=${n}), effectively the same as the approved group. ` +
+    'Score alone did not separate the two here, which often points at recent application velocity, ' +
+    'income, or an existing relationship with the bank.'
+  );
+}
+
+/**
+ * The honesty valve. These samples are small and the post should say so in
+ * proportion, rather than printing a confident percentage and moving on.
+ */
+function samplingCaveat(n) {
+  if (n < 20) {
+    return `At ${n} data points this is directional only, not a prediction.`;
+  }
+  if (n < 40) {
+    return `At ${n} data points treat this as directional.`;
+  }
+  return 'It is still a self-reported sample, so treat it as directional.';
+}
+
+module.exports = {
+  API_BASE,
+  MIN_RECORDS,
+  RESULT_APPROVED,
+  RESULT_DENIED,
+  median,
+  summarize,
+  computeStats,
+  selectCard,
+  cardPageUrl,
+  buildPostText,
+  describeDeniedScore,
+  samplingCaveat,
+  fetchCards,
+  fetchCardRecords,
+};

--- a/scripts/lib/card-approval-odds.test.js
+++ b/scripts/lib/card-approval-odds.test.js
@@ -1,0 +1,252 @@
+// Tests for the "<card> approval odds?" Reddit post builder.
+//
+// Why this exists: this routine publishes approval statistics as fact. The two
+// ways it can embarrass us are picking a card that should not be posted (closed,
+// too thin, already covered) and printing a median that misrepresents its
+// sample. Both are pure functions, so both are pinned here.
+//
+// Run: `node scripts/lib/card-approval-odds.test.js`. Exits non-zero on failure.
+
+const assert = require('node:assert/strict');
+
+const {
+  median,
+  summarize,
+  computeStats,
+  selectCard,
+  buildPostText,
+  describeDeniedScore,
+  samplingCaveat,
+  cardPageUrl,
+} = require('./card-approval-odds');
+
+/** Build a stats object with just the two score medians the describer reads. */
+const scores = (approvedMedian, deniedMedian, n = 10) => ({
+  approvedScore: { median: approvedMedian, n },
+  deniedScore: { median: deniedMedian, n },
+});
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+console.log('median / summarize');
+
+test('median of an odd-length set is the middle value', () => {
+  assert.equal(median([700, 750, 800]), 750);
+});
+
+test('median of an even-length set averages the two middles', () => {
+  assert.equal(median([700, 750, 800, 850]), 775);
+});
+
+test('median is order-independent', () => {
+  assert.equal(median([800, 700, 750]), 750);
+});
+
+test('median of an empty set is null, not 0', () => {
+  // 0 would render as "Median FICO: 0" instead of omitting the row.
+  assert.equal(median([]), null);
+});
+
+test('summarize ignores missing and non-positive values and reports its own n', () => {
+  const records = [
+    { listed_income: 50000 },
+    { listed_income: null },
+    { listed_income: 0 },
+    { listed_income: 70000 },
+    {},
+  ];
+  assert.deepEqual(summarize(records, 'listed_income'), { median: 60000, n: 2 });
+});
+
+console.log('computeStats');
+
+const sample = [
+  { result: 1, credit_score: 780, listed_income: 90000, starting_credit_limit: 8000 },
+  { result: 1, credit_score: 740, listed_income: null, starting_credit_limit: 6000 },
+  { result: 1, credit_score: 760, listed_income: 70000, starting_credit_limit: null },
+  { result: 0, credit_score: 660, listed_income: 40000, starting_credit_limit: null },
+  { result: 0, credit_score: 700, listed_income: null, starting_credit_limit: null },
+];
+
+test('counts and approval rate use decided records only', () => {
+  const s = computeStats(sample);
+  assert.equal(s.approvedCount, 3);
+  assert.equal(s.deniedCount, 2);
+  assert.equal(s.counted, 5);
+  assert.equal(s.approvalRate, 0.6);
+});
+
+test('denied-side medians are computed, not taken from approved stats', () => {
+  const s = computeStats(sample);
+  assert.equal(s.approvedScore.median, 760);
+  assert.equal(s.deniedScore.median, 680);
+});
+
+test('each stat carries the n of the records that reported that field', () => {
+  const s = computeStats(sample);
+  assert.equal(s.approvedScore.n, 3);
+  assert.equal(s.approvedIncome.n, 2); // one approved record has no income
+  assert.equal(s.approvedLimit.n, 2); // one approved record has no limit
+});
+
+test('an unexpected result value is excluded from the rate rather than counted as denied', () => {
+  // Guards against a future "pending" status silently deflating the percentage.
+  const withPending = [...sample, { result: 2, credit_score: 720 }];
+  const s = computeStats(withPending);
+  assert.equal(s.counted, 5);
+  assert.equal(s.approvalRate, 0.6);
+  assert.equal(s.total, 6);
+});
+
+console.log('selectCard');
+
+const cards = [
+  { slug: 'big-closed', card_name: 'Big Closed', total_records: 40, accepting_applications: false },
+  { slug: 'top', card_name: 'Top Card', total_records: 30, accepting_applications: true },
+  { slug: 'mid', card_name: 'Mid Card', total_records: 20, accepting_applications: true },
+  { slug: 'thin', card_name: 'Thin Card', total_records: 4, accepting_applications: true },
+];
+
+test('picks the highest record count among eligible cards', () => {
+  assert.equal(selectCard(cards, new Set()).slug, 'top');
+});
+
+test('skips cards that are closed to applications', () => {
+  // Big Closed has the most records but cannot be applied for.
+  assert.notEqual(selectCard(cards, new Set()).slug, 'big-closed');
+});
+
+test('skips cards below the record floor', () => {
+  const picked = selectCard(cards, new Set(['top', 'mid']), { minRecords: 10 });
+  assert.equal(picked, null, 'Thin Card is under the floor and must not be picked');
+});
+
+test('never repeats a card that has already been posted', () => {
+  assert.equal(selectCard(cards, new Set(['top'])).slug, 'mid');
+});
+
+test('returns null when the rotation is exhausted rather than looping', () => {
+  assert.equal(selectCard(cards, new Set(['top', 'mid'])), null);
+});
+
+test('ties break by name so a rerun is deterministic', () => {
+  const tied = [
+    { slug: 'b', card_name: 'B Card', total_records: 15, accepting_applications: true },
+    { slug: 'a', card_name: 'A Card', total_records: 15, accepting_applications: true },
+  ];
+  assert.equal(selectCard(tied, new Set()).slug, 'a');
+  assert.equal(selectCard([...tied].reverse(), new Set()).slug, 'a');
+});
+
+test('a card with an undefined accepting_applications is still eligible', () => {
+  // The field is merged from the DB and can be absent; absence must not
+  // silently drop a card that is in fact open.
+  const unknown = [{ slug: 'u', card_name: 'U', total_records: 12 }];
+  assert.equal(selectCard(unknown, new Set()).slug, 'u');
+});
+
+console.log('buildPostText');
+
+const card = { slug: 'citi-double-cash', card_name: 'Citi Double Cash' };
+const text = buildPostText(card, computeStats(sample), 'https://creditodds.com/card/citi-double-cash?utm_source=reddit');
+
+test('first line is the title in the requested format', () => {
+  assert.equal(text.split('\n')[0], 'Citi Double Cash approval odds?');
+});
+
+test('body states the approval rate and both counts', () => {
+  assert.match(text, /Approval rate: 60% \(3 approved, 2 denied\)/);
+});
+
+test('body shows the approved profile and describes the denied side in prose', () => {
+  assert.match(text, /Approved:/);
+  assert.match(text, /Denied applicants reported a median FICO/);
+});
+
+console.log('describeDeniedScore');
+
+test('a real gap is stated plainly as points below approved', () => {
+  const s = describeDeniedScore(scores(760, 700));
+  assert.match(s, /median FICO of 700/);
+  assert.match(s, /60 points below/);
+});
+
+test('an inverted gap is called out rather than printed as-is', () => {
+  // The Citi Strata Premier case: denied 815 vs approved 759. Left bare this
+  // reads as broken data, which is the failure this framing exists to prevent.
+  const s = describeDeniedScore(scores(759, 815));
+  assert.match(s, /56 points higher/);
+  assert.match(s, /velocity|thin file|issuer rules/);
+  assert.ok(!/points below/.test(s));
+});
+
+test('a gap inside the noise band is described as effectively the same', () => {
+  const s = describeDeniedScore(scores(751, 750));
+  assert.match(s, /effectively the same/);
+  assert.ok(!/points below/.test(s), 'a 1-point gap must not be reported as a real difference');
+});
+
+test('the noise band is applied symmetrically', () => {
+  assert.match(describeDeniedScore(scores(760, 746)), /effectively the same/);
+  assert.match(describeDeniedScore(scores(746, 760)), /effectively the same/);
+  assert.match(describeDeniedScore(scores(760, 745)), /points below/);
+  assert.match(describeDeniedScore(scores(745, 760)), /points higher/);
+});
+
+test('no denied scores means no denied sentence at all', () => {
+  assert.equal(describeDeniedScore(scores(750, null)), null);
+  assert.equal(describeDeniedScore(scores(null, 750)), null);
+});
+
+test('body links the card page and repeats the URL for the CTA', () => {
+  assert.match(text, /\[Citi Double Cash\]\(https:\/\/creditodds\.com\/card\/citi-double-cash\?utm_source=reddit\)/);
+  assert.match(text, /card page: https:\/\/creditodds\.com\/card\/citi-double-cash/);
+});
+
+test('body asks for data points in the comments', () => {
+  assert.match(text, /drop your data point in the comments/);
+});
+
+test('copy contains no em dashes', () => {
+  assert.ok(!text.includes('—'), 'em dash found in user-facing copy');
+});
+
+test('rows omit themselves rather than printing a null median', () => {
+  const noIncome = [
+    { result: 1, credit_score: 780 },
+    { result: 0, credit_score: 660 },
+  ];
+  const t = buildPostText(card, computeStats(noIncome), 'https://example.com');
+  assert.ok(!t.includes('Median income'), 'income row should be absent when nothing reported it');
+  assert.match(t, /Median FICO/);
+});
+
+test('sampling caveat scales down as the sample shrinks', () => {
+  assert.match(samplingCaveat(12), /directional only, not a prediction/);
+  assert.match(samplingCaveat(30), /treat this as directional/);
+  assert.match(samplingCaveat(60), /self-reported sample/);
+});
+
+console.log('cardPageUrl');
+
+test('card link carries reddit UTM attribution', () => {
+  const url = new URL(cardPageUrl('citi-double-cash', 'card-approval-odds-reddit'));
+  assert.equal(url.pathname, '/card/citi-double-cash');
+  assert.equal(url.searchParams.get('utm_source'), 'reddit');
+  assert.equal(url.searchParams.get('utm_campaign'), 'card-approval-odds-reddit');
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll tests passed.');

--- a/scripts/post-card-approval-odds-reddit.js
+++ b/scripts/post-card-approval-odds-reddit.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+/**
+ * "<card> approval odds?" — twice-weekly Reddit draft for r/creditodds.
+ *
+ * Posts one card per run, highest record count first, working down. A card is
+ * posted at most ONCE: the rotation does not loop. When every eligible card has
+ * had its turn the run is a clean no-op, and the queue refills on its own as
+ * cards accumulate data points and cross the record floor.
+ *
+ * Nothing is auto-published. Like post-weekly-sub-changes-reddit.js, this hands
+ * the post to the Social Posting Service targeted at the manual `reddit`
+ * platform, which records a pre-filled reddit.com submit URL as
+ * `pending_manual`. Maxwell clicks "Post now" in the service UI and submits
+ * natively (see the no-self-hosted-Reddit-API constraint).
+ *
+ * The body uses markdown links, so the composer must be in MARKDOWN mode. The
+ * run prints that reminder next to the submit URL.
+ *
+ * Usage:
+ *   node scripts/post-card-approval-odds-reddit.js [--dry-run] [--state <path>]
+ *                                                  [--card <slug>] [--min-records <n>]
+ *
+ * Env vars: SOCIAL_API_URL, SOCIAL_API_KEY (not needed for --dry-run)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { queueSocialPost } = require('./lib/weekly-sub-changes');
+const {
+  MIN_RECORDS,
+  computeStats,
+  selectCard,
+  cardPageUrl,
+  buildPostText,
+  fetchCards,
+  fetchCardRecords,
+} = require('./lib/card-approval-odds');
+
+const CAMPAIGN = 'card-approval-odds-reddit';
+const DEFAULT_STATE_FILE = path.join(__dirname, '..', '.github', 'card-approval-odds-state.json');
+
+function parseArgs(argv) {
+  const flag = (name) => {
+    const i = argv.indexOf(name);
+    return i !== -1 && i + 1 < argv.length ? argv[i + 1] : null;
+  };
+  return {
+    dryRun: argv.includes('--dry-run'),
+    statePath: flag('--state') || DEFAULT_STATE_FILE,
+    cardSlug: flag('--card'),
+    minRecords: flag('--min-records') ? Number(flag('--min-records')) : MIN_RECORDS,
+  };
+}
+
+/**
+ * State is a flat list of slugs already posted, plus when. Corrupt or missing
+ * state is not fatal, but it IS loud: silently treating it as empty would
+ * re-post the whole rotation from the top, so the caller gets a warning.
+ */
+function loadState(statePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.posted)) {
+      console.warn(`WARNING: ${statePath} is not in the expected shape; treating as empty.`);
+      return { posted: [] };
+    }
+    return parsed;
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.warn(`WARNING: could not read ${statePath} (${err.message}); treating as empty.`);
+    }
+    return { posted: [] };
+  }
+}
+
+function saveState(statePath, state) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n');
+}
+
+async function main() {
+  const { dryRun, statePath, cardSlug, minRecords } = parseArgs(process.argv.slice(2));
+
+  console.log('=== Card approval odds (Reddit draft) ===\n');
+  console.log(`State file: ${statePath}`);
+
+  const state = loadState(statePath);
+  const postedSlugs = new Set(state.posted.map(p => p.slug));
+  console.log(`${postedSlugs.size} card(s) already posted.`);
+
+  const cards = await fetchCards();
+  console.log(`Fetched ${cards.length} cards.`);
+
+  let card;
+  if (cardSlug) {
+    // Manual override for a re-run or a one-off; still records state so the
+    // normal rotation does not repeat it later.
+    card = cards.find(c => c.slug === cardSlug);
+    if (!card) throw new Error(`No card with slug "${cardSlug}"`);
+    console.log(`Card forced via --card: ${card.card_name || card.name}`);
+  } else {
+    card = selectCard(cards, postedSlugs, { minRecords });
+  }
+
+  if (!card) {
+    const remaining = cards.filter(c =>
+      (c.total_records || 0) >= minRecords && c.accepting_applications !== false
+    ).length;
+    console.log(
+      `\nNo card left to post: all ${remaining} card(s) at or above ${minRecords} records have had their turn.`
+    );
+    console.log('The rotation does not loop. It resumes when another card crosses the floor.');
+    return;
+  }
+
+  const name = card.card_name || card.name;
+  console.log(`\nSelected: ${name} (${card.total_records} records, slug ${card.slug})`);
+
+  const records = await fetchCardRecords(name);
+  const stats = computeStats(records);
+  console.log(
+    `  ${stats.counted} decided records: ${stats.approvedCount} approved, ${stats.deniedCount} denied`
+  );
+
+  // The list endpoint's counts and the per-card records can drift by a few
+  // minutes of caching; the floor is re-checked against what will actually be
+  // published so a thin post never goes out on a stale count.
+  if (stats.counted < minRecords) {
+    console.log(
+      `\nSkipping: only ${stats.counted} decided record(s) once fetched, below the floor of ${minRecords}.`
+    );
+    return;
+  }
+
+  const link = cardPageUrl(card.slug, CAMPAIGN);
+  const text = buildPostText(card, stats, link);
+  const dateStamp = new Date().toISOString().slice(0, 10);
+
+  console.log(`\nPost text:\n\n${text}\n`);
+
+  if (dryRun) {
+    console.log('[DRY RUN] Not queueing and not recording state.');
+    return;
+  }
+
+  console.log('Sending to Social Posting Service (publish_now, reddit only)...');
+  const result = await queueSocialPost({
+    text_content: text,
+    source_type: 'card-approval-odds',
+    source_id: `approval-odds-${card.slug}`,
+    platforms: ['reddit'],
+    publish_now: true,
+    // Keyed on the card, not the date: a retry on any day must not create a
+    // second chore for the same card.
+    idempotency_key: `approval-odds-${card.slug}`,
+  });
+
+  console.log(`Post #${result.id} status: ${result.status}`);
+  const redditResult = (result.results || []).find(r => r.platform === 'reddit');
+  if (redditResult?.postUrl) {
+    console.log(`\nPre-filled Reddit submit URL (also in the service UI under History):\n${redditResult.postUrl}`);
+    console.log(
+      '\nIMPORTANT: switch the Reddit composer to Markdown mode before submitting,\n' +
+      'or the card links will post as literal [text](url).'
+    );
+  }
+  if (result.status !== 'posted' && !result.deduped) {
+    throw new Error(`Expected status 'posted', got '${result.status}' (${JSON.stringify(result.results)})`);
+  }
+
+  // Recorded only after a successful queue, so a failed run retries the same
+  // card rather than burning it.
+  state.posted.push({
+    slug: card.slug,
+    card_name: name,
+    records: stats.counted,
+    posted_at: dateStamp,
+  });
+  saveState(statePath, state);
+  console.log(`\nState updated: ${state.posted.length} card(s) posted to date.`);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Twice-weekly r/creditodds post: one card per run, highest data-point count first, working down. Posts the approval odds, the approved-applicant profile, asks readers to drop their data points in the comments, and links the card page.

Paired with a new local scheduled task `reddit-approval-odds-local` (Tue + Fri, 10:07 AM), which mirrors the existing `weekly-reddit-sub-changes-draft` routine: extracts the scripts from `origin/main` via `git show`, never touches the working tree, and resolves the social API creds at runtime.

## Rotation

- **Floor of 10 data points.** 175 of 209 cards have fewer than 5. Publishing "approval odds" off 3 records would be a number nobody should act on, and this post exists to earn trust and pull in more data, not to hit a cadence.
- **Cards closed to applications are skipped.** The post asks whether to apply and links a page that cannot take an application.
- **Each card posts at most once, and the rotation does not loop.** When every eligible card has had its turn the run is a clean no-op; the queue refills on its own as cards accumulate records and cross the floor.
- **Runway today is 15 cards**, so roughly 7 to 8 weeks before the rotation goes quiet.

State is a flat list of posted slugs. The scheduled task points `--state` at its own directory so nothing is written into the git checkout.

## The denied-side problem, and why the copy reads the way it does

The obvious format is an approved-vs-denied FICO table. It is a trap. Across the 15 cards eligible today, **the denied median FICO is higher than the approved median on 7 of them**:

| Card | Approved | Denied | Gap |
|---|---|---|---|
| Citi Strata Premier | 759 | 815 | **-56** |
| Capital One Venture X | 750 | 792 | **-42** |
| Blue Cash Everyday | 726 | 740 | -14 |
| Citi Double Cash | 751 | 750 | 1 |
| American Express Gold | 750 | 750 | 0 |
| Blue Cash Preferred | 737 | 680 | 57 |

That is not broken data. Denials at high scores are driven by application velocity, thin files and issuer rules rather than by score. But printed bare it *reads* as broken and invites the exact "your numbers are garbage" reply the post is trying to avoid. `reason_denied` cannot rescue it: it is free text present on only 9 of 64 denials, every value unique.

So `describeDeniedScore` states the comparison in prose with a 15-point noise band:

- Gap >= 15: "about N points below the approved group."
- Gap <= -15: "actually N points higher than the approved group. On a sample this size that usually means denials came down to application velocity, a thin file, or issuer rules rather than the score itself."
- Inside the band: "effectively the same as the approved group. Score alone did not separate the two here."

Hedged on purpose. We are describing a pattern in a small self-reported sample, not asserting a cause. It also turns the weakest part of the data into the most comment-worthy line, which serves the CTA.

Every stat carries its own `n`, because optional fields are sparse: on the top card, income is present on 14 of 42 records and starting limit on 19. A row with nothing behind it is omitted rather than printed as null.

## Sample output (live data, dry run)

```
Citi Double Cash approval odds?

We track approval and denial data points on the [Citi Double Cash](https://creditodds.com/card/citi-double-cash?utm_source=reddit&...). Here is what 42 of them say so far.

Approval rate: 57% (24 approved, 18 denied)

Approved:

Median FICO: 751 (n=24)
Median income: $57,500 (n=14)
Median starting limit: $4,300 (n=19)

Denied applicants reported a median FICO of 750 (n=18), effectively the same as the
approved group. Score alone did not separate the two here, which often points at recent
application velocity, income, or an existing relationship with the bank.

Each number is a median over the data points that reported that field, so the n varies by
row. It is still a self-reported sample, so treat it as directional.

If you have applied for this card, drop your data point in the comments: approved or
denied, your FICO at the time, income, and the starting limit if you got one. We will fold
it into the numbers.

Full data points and the odds calculator are on the card page: https://creditodds.com/card/...
```

## Publishing

Nothing auto-publishes. Queues to the Social Posting Service manual `reddit` platform (`publish_now`, per-card idempotency key), which records a pre-filled submit URL as `pending_manual`. The body uses markdown links, so the run prints the **Markdown-mode reminder** next to the submit URL, same convention as #1993.

## Verification

- 31 unit tests (`node scripts/lib/card-approval-odds.test.js`) covering selection, medians, sparse fields, all three denial framings, symmetry of the noise band, and the copy rules including the no-em-dash check.
- Dry-run against live data for the top card, the inverted-gap card (Strata Premier), and the exhausted-rotation case.
- Selection verified to skip the highest-record card overall (Wells Fargo Propel, 31 records) because it is closed to applications.