### PR TITLE
Add /newsletter-register: first-login Brevo upsert for instant welcome emails

### DIFF
--- a/apps/api/src/handlers/newsletter-register.js
+++ b/apps/api/src/handlers/newsletter-register.js
@@ -1,0 +1,54 @@
+// POST /newsletter-register — idempotent "this user exists" upsert into the
+// Brevo newsletter list, called by the frontend after sign-in. New signups
+// reach Brevo within seconds of their first login instead of waiting for the
+// nightly newsletter-sync pass, so the welcome-email automation (triggered by
+// list entry) fires the same hour they join, not the next morning.
+//
+// Safe to call on every login:
+//   - upsertContact never touches emailBlacklisted, so unsubscribes stick.
+//   - re-upserting an existing list member is not a list-entry event, so the
+//     welcome automation cannot fire twice (it is also once-per-contact).
+// The nightly sync remains the backstop for logins this call never reports
+// (closed tab, blocked request) and still prunes deleted accounts.
+
+const brevo = require('../lib/brevo');
+
+const responseHeaders = {
+  'Cache-Control': 'no-store',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS',
+};
+
+function reply(statusCode, body) {
+  return { statusCode, headers: responseHeaders, body: JSON.stringify(body) };
+}
+
+exports.NewsletterRegisterHandler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: responseHeaders, body: '' };
+  }
+  if (event.httpMethod !== 'POST') {
+    return reply(405, { error: 'Method not allowed' });
+  }
+
+  const email = event.requestContext?.authorizer?.email;
+  if (!email) {
+    return reply(401, { error: 'Unauthorized' });
+  }
+
+  if (!brevo.isConfigured()) {
+    return reply(200, { available: false });
+  }
+
+  try {
+    await brevo.upsertContact(email, {
+      attributes: brevo.nameAttributes(event.requestContext?.authorizer?.name),
+      listIds: [brevo.listId()],
+    });
+    return reply(200, { available: true });
+  } catch (error) {
+    console.error('newsletter-register error:', error);
+    return reply(500, { error: 'Internal server error' });
+  }
+};

--- a/apps/api/src/handlers/newsletter-sync.js
+++ b/apps/api/src/handlers/newsletter-sync.js
@@ -30,13 +30,6 @@ async function listAllFirebaseUsers(admin) {
   return users;
 }
 
-function splitName(displayName) {
-  const name = (displayName || '').trim();
-  if (!name) return { FIRSTNAME: '', LASTNAME: '' };
-  const parts = name.split(/\s+/);
-  return { FIRSTNAME: parts[0], LASTNAME: parts.slice(1).join(' ') };
-}
-
 exports.NewsletterSyncHandler = async () => {
   if (!brevo.isConfigured()) {
     console.info('newsletter-sync: BREVO_API_KEY / BREVO_LIST_ID not set, skipping');
@@ -64,7 +57,7 @@ exports.NewsletterSyncHandler = async () => {
     const results = await Promise.allSettled(
       batch.map((u) =>
         brevo.upsertContact(u.email, {
-          attributes: splitName(u.displayName),
+          attributes: brevo.nameAttributes(u.displayName),
           listIds: [listId],
         })
       )

--- a/apps/api/src/lib/brevo.js
+++ b/apps/api/src/lib/brevo.js
@@ -42,6 +42,16 @@ async function request(method, path, body) {
   return text ? JSON.parse(text) : null;
 }
 
+// Brevo contact attributes from a Firebase displayName: first word becomes
+// FIRSTNAME, the rest LASTNAME. Empty/missing names produce empty attributes
+// so a later real name can still fill them in via upsert.
+function nameAttributes(displayName) {
+  const name = (displayName || '').trim();
+  if (!name) return { FIRSTNAME: '', LASTNAME: '' };
+  const parts = name.split(/\s+/);
+  return { FIRSTNAME: parts[0], LASTNAME: parts.slice(1).join(' ') };
+}
+
 // Create-or-update a contact and link it to the given lists. Does NOT touch
 // emailBlacklisted, so contacts who unsubscribed via a campaign link stay
 // unsubscribed even though they remain list members.
@@ -113,6 +123,7 @@ async function removeFromList(id, emails) {
 module.exports = {
   isConfigured,
   listId,
+  nameAttributes,
   upsertContact,
   getContact,
   updateContact,

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -547,6 +547,48 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  # Idempotent upsert of the signed-in user into the Brevo newsletter list,
+  # called by the frontend on login so brand-new signups enter the list (and
+  # trigger the welcome-email automation) within seconds instead of waiting
+  # for the nightly NewsletterSyncFunction pass.
+  NewsletterRegisterFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/handlers/newsletter-register.js
+        Target: node22
+        Sourcemap: false
+        Minify: false
+    Properties:
+      Handler: src/handlers/newsletter-register.NewsletterRegisterHandler
+      Runtime: nodejs22.x
+      MemorySize: 256
+      Timeout: 15
+      Description: "POST the authenticated user into the Brevo newsletter list (welcome-email entry point)"
+      Environment:
+        Variables:
+          BREVO_API_KEY: !Ref BrevoApiKey
+          BREVO_LIST_ID: !Ref BrevoNewsletterListId
+      Events:
+        PostNewsletterRegister:
+          Type: Api
+          Properties:
+            Path: /newsletter-register
+            Method: POST
+            RestApiId:
+              Ref: CreditCardOddsAPI
+        NewsletterRegisterOptions:
+          Type: Api
+          Properties:
+            Path: /newsletter-register
+            Method: OPTIONS
+            RestApiId:
+              Ref: CreditCardOddsAPI
+            Auth:
+              Authorizer: NONE
+
   updateCardsGitHub:
     Type: AWS::Serverless::Function
     Properties:

--- a/apps/web-next/src/auth/AuthProvider.tsx
+++ b/apps/web-next/src/auth/AuthProvider.tsx
@@ -13,6 +13,12 @@ import {
 } from "firebase/auth";
 import { getFirebaseAuth } from "./firebase";
 import posthog from "posthog-js";
+import { registerNewsletterContact } from "@/lib/api";
+
+// Uids already reported to /newsletter-register this page load. The endpoint
+// is idempotent, so this only exists to avoid re-posting on every auth-state
+// emission; a fresh page load posting again is fine and intended.
+const newsletterRegisteredUids = new Set<string>();
 
 // Key for storing email in localStorage for email link sign-in
 const EMAIL_FOR_SIGN_IN_KEY = 'emailForSignIn';
@@ -97,6 +103,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           email: user.email,
           name: user.displayName,
         });
+        // Mirror the user into the Brevo newsletter audience so brand-new
+        // signups trigger the welcome email now, not after the nightly sync.
+        if (!newsletterRegisteredUids.has(user.uid)) {
+          newsletterRegisteredUids.add(user.uid);
+          user
+            .getIdToken()
+            .then((token) => registerNewsletterContact(token))
+            .catch(() => {
+              // Non-critical; the nightly newsletter sync is the backstop.
+            });
+        }
       }
     });
 

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -1398,6 +1398,21 @@ export async function updateNewsletterSettings(
   return res.json();
 }
 
+// Idempotent upsert of the signed-in user into the Brevo newsletter audience,
+// fired on login so new signups get the welcome email within minutes instead
+// of after the nightly sync. Fire-and-forget: never touches unsubscribe state
+// server-side, and a failure just means the nightly sync picks the user up.
+export async function registerNewsletterContact(token: string): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/newsletter-register`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    // Non-critical; the nightly newsletter sync is the backstop.
+  }
+}
+
 // Delete user account (removes referrals and wallet, keeps records anonymized)
 export async function deleteAccount(token: string): Promise<{ message: string }> {
   const res = await fetch(`${API_BASE}/account`, {


### PR DESCRIPTION
New signups currently reach the Brevo newsletter list (and its welcome-email automation) only via the nightly `NewsletterSyncFunction`, so their welcome email arrives up to a day after signup. This PR closes that gap: the welcome email now goes out within minutes of the first login.

## Changes

- **`POST /newsletter-register`** (new `NewsletterRegisterFunction`, esbuild, Firebase-authorized): idempotent upsert of the caller's email + name into the Brevo newsletter list. No-ops with `available: false` when Brevo params are unset, same as `/newsletter-settings`.
- **`AuthProvider`**: after sign-in, fires the endpoint once per uid per page load (module-level guard), fire-and-forget.
- **`lib/brevo.js`**: `splitName` moves here from `newsletter-sync.js` as `nameAttributes` so both callers share it.

## Why repeated calls are safe

- Upserts never touch `emailBlacklisted`, so unsubscribes stick.
- Re-upserting an existing list member is not a list-entry event, so the welcome automation cannot re-fire (it is also set to once-per-contact).
- The nightly sync remains the backstop for missed calls and still prunes deleted accounts.

## Validation

- `node --check` on all touched handlers/libs
- `sam validate --lint` passes
- `tsc --noEmit` clean on web-next