### PR TITLE
Fix false stale-card alarm: timeout skips cleared the known-block flag

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -405,6 +405,26 @@ function knownBlockedReason(url) {
   return null;
 }
 
+// known_block is what keeps a permanent, deliberate skip out of the stale alarm,
+// so a skip that records it as false re-arms the alarm for a card that is
+// working exactly as designed. Only a caller that has actually formed a view of
+// the host should assert it; every other skip path derives it from the URL.
+//
+// This defaulting is centralized here rather than left to each call site because
+// the failure is silent: the counter keeps climbing either way, and the alarm
+// fires runs later with a reason string that points at whatever skipped last.
+// Sam's Club Mastercard filed a stale issue at 12 consecutive skips this way —
+// samsclub.com had been in KNOWN_BLOCKED_HOSTS since 2026-08-02, but the
+// script-timeout path recorded knownBlock:false for every card it never reached,
+// and a run that times out before the S's is now routine.
+//
+// Derived from the URL rather than carried over from prior state so that
+// dropping a host from KNOWN_BLOCKED_HOSTS still clears the flag on the next run.
+function resolveKnownBlock(url, opts = {}) {
+  if (opts.knownBlock !== undefined) return Boolean(opts.knownBlock);
+  return Boolean(knownBlockedReason(url));
+}
+
 // Transport-level failures that say nothing about the page itself: the request
 // never reached the origin, so the card is unchecked for a reason that may be
 // gone seconds later. These are the only skips the retry pass reopens.
@@ -1826,7 +1846,7 @@ async function main() {
       name: card.data.name,
       url: checkUrlFor(card),
       reason,
-      knownBlock: Boolean(opts.knownBlock),
+      knownBlock: resolveKnownBlock(checkUrlFor(card), opts),
     });
 
   const scriptDeadline = Date.now() + SCRIPT_TIMEOUT_MS;
@@ -1919,6 +1939,9 @@ async function main() {
       const mins = SCRIPT_TIMEOUT_MS / 60000;
       console.warn(`\nScript timeout reached (${mins} min) — stopping early; ${unreached.length} card(s) never checked.`);
       for (const c of unreached) {
+        // knownBlock is deliberately not passed: running out of clock is not a
+        // verdict on the host, so recordSkip derives it from the URL. See
+        // resolveKnownBlock.
         recordSkip(c, `script timeout (${mins} min) reached before this card was checked`);
       }
       break;
@@ -2379,6 +2402,7 @@ module.exports = {
   normalizeBonusType,
   pageShowsSignupOffer,
   updateSkipState,
+  resolveKnownBlock,
   resolveSkipState,
   readSkipStateFromMain,
   staleCardsFrom,

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -22,6 +22,7 @@ const {
   normalizeBonusType,
   pageShowsSignupOffer,
   updateSkipState,
+  resolveKnownBlock,
   resolveSkipState,
   readSkipStateFromMain,
   staleCardsFrom,
@@ -971,6 +972,52 @@ test('known bot-blocks never alarm, however long they persist', () => {
   const after = fold({ pnc: { consecutive_skips: 99 } }, ['pnc'], [skip('pnc', 'known block: akamai', true)]);
   assert.equal(after.pnc.consecutive_skips, 100);
   assert.deepEqual(staleCardsFrom(after), []);
+});
+
+// ─── known_block defaulting ──────────────────────────────────────────────────
+
+test('a skip that states no opinion on the host derives known_block from the URL', () => {
+  // This is the actual regression. The script-timeout path records every
+  // unreached card without a knownBlock opt, because running out of clock says
+  // nothing about the host. If that defaults to false it clears the flag that
+  // keeps a deliberate skip out of the stale alarm, and the card alarms on a
+  // counter it has been climbing since it was first blocked.
+  assert.equal(
+    resolveKnownBlock('https://www.samsclub.com/credit'),
+    true,
+    'a blocked host must stay blocked when the caller states nothing'
+  );
+  assert.equal(resolveKnownBlock('https://creditcards.chase.com/anything'), false);
+});
+
+test('an explicit knownBlock opt always wins over the URL', () => {
+  // A caller that has actually formed a view of the host — the known-block skip
+  // path asserting true, the no-extraction path asserting false — must not have
+  // it silently overridden by the default.
+  assert.equal(resolveKnownBlock('https://creditcards.chase.com/x', { knownBlock: true }), true);
+  assert.equal(resolveKnownBlock('https://www.samsclub.com/credit', { knownBlock: false }), false);
+});
+
+test('a timeout skip on a known-blocked card must not re-arm the alarm', () => {
+  // A run that hits the script deadline records every unreached card as a
+  // timeout skip. That skip is not a verdict on the host, so it must carry the
+  // known-block status forward — otherwise a permanent, deliberate skip flips
+  // known_block to false and alarms on the counter it has been climbing all
+  // along. Sam's Club Mastercard filed a stale issue at 12 skips this way,
+  // despite samsclub.com being in KNOWN_BLOCKED_HOSTS the whole time.
+  const timeoutSkip = skip('sams', 'script timeout (150 min) reached before this card was checked', true);
+  const after = fold({ sams: { consecutive_skips: 11, known_block: true } }, ['sams'], [timeoutSkip]);
+  assert.equal(after.sams.consecutive_skips, 12);
+  assert.equal(after.sams.known_block, true, 'timeout must not clear the known-block flag');
+  assert.deepEqual(staleCardsFrom(after), [], 'a known-blocked card must never alarm');
+});
+
+test('a timeout skip on an ordinary card still alarms normally', () => {
+  // The converse guard: carrying known-block through must not blanket-suppress
+  // real staleness on cards that simply never got reached.
+  const timeoutSkip = skip('ordinary', 'script timeout (150 min) reached before this card was checked', false);
+  const after = fold({ ordinary: { consecutive_skips: SKIP_ALERT_THRESHOLD - 1 } }, ['ordinary'], [timeoutSkip]);
+  assert.deepEqual(staleCardsFrom(after).map(c => c.slug), ['ordinary']);
 });
 
 test('a full run prunes cards that no longer exist', () => {


### PR DESCRIPTION
Fixes #1992.

## What #1992 actually was

Not a data problem, and not a missing block entry. Sam's Club Mastercard reported 12 consecutive skips with `last_ok: null`, but `samsclub.com` has been in `KNOWN_BLOCKED_HOSTS` since 2026-08-02 — it was already registered as a permanent, deliberate skip, which is supposed to be excluded from the alarm.

The exclusion in `staleCardsFrom()` reads `!s.known_block`. That field was written by `recordSkip` as `Boolean(opts.knownBlock)`, so **any caller that passed no opinion recorded `false`** — clearing a flag that was previously true.

The script-timeout path is exactly such a caller. When the run hits its 150-minute deadline it records every unreached card, and running out of clock says nothing about whether the host is walled. So each timed-out run cleared `known_block` on every blocked card past the cutoff, while `consecutive_skips` kept climbing. Once it crossed the threshold, the alarm fired with the timeout as its reason string — pointing at the wrong cause.

Timed-out runs are no longer rare: today's fetch left 92 cards unreached, and Sam's sorts well past the cutoff.

## The fix

Centralized the defaulting in a new `resolveKnownBlock(url, opts)` rather than patching the timeout call site, since the failure is silent and any future skip path could reintroduce it:

- Callers that have genuinely formed a view of the host still win (the known-block path asserting `true`, the no-extraction path asserting `false`).
- Everything else derives it from the URL.
- Derived from the URL, not carried over from prior state, so dropping a host from `KNOWN_BLOCKED_HOSTS` still clears the flag on the next run.

## Verification

The new `resolveKnownBlock` test fails against the old `Boolean(opts.knownBlock)` behaviour and passes with the fix (checked by reverting the body in place). Also added coverage for the state-machine consequence in both directions: a timeout skip on a known-blocked card must not alarm, and a timeout skip on an ordinary card still must.

Card data was independently re-verified by hand against the live apply page today — no annual fee, $30 statement credit after $30 in club purchases within 30 days, purchase APR 20.15%/28.15%, $6,000/yr gas cap, $5,000/yr Sam's Cash cap. All match what is stored, so no YAML change is needed.

## Note on the underlying page

`samsclub.com/credit` returns HTTP 200 with ~95KB of HTML but only ~374 chars of visible text — a client-side-rendered shell with no terms in the markup. `samsclub.com/content/credit` and `samsclub.com/credit-cards` are the same shell; `syf.com/credit-cards/sams-club` 404s. The existing block entry is the correct call; this card genuinely needs periodic hand-verification.