### PR TITLE
Sam's Club Mastercard: note EV charging on the 5% gas category

### DIFF
--- a/data/cards/sams-club-mastercard.yaml
+++ b/data/cards/sams-club-mastercard.yaml
@@ -16,7 +16,7 @@ rewards:
   - category: "gas"
     value: 5
     unit: "percent"
-    note: "Gas worldwide, including Sam's Club stations (first $6,000/year, then 1%)"
+    note: "Gas and EV charging worldwide, including Sam's Club stations (first $6,000/year, then 1%)"
     spend_cap: 6000
     cap_period: annual
     rate_after_cap: 1


### PR DESCRIPTION
The apply page advertises the top category as:

> 5% back in Sam's Cash™ on gas & EV charging (on first $6,000 per year, then 1%).

The stored note covered gas only, so EV charging read as earning the 1% base rate.

```diff
-    note: "Gas worldwide, including Sam's Club stations (first $6,000/year, then 1%)"
+    note: "Gas and EV charging worldwide, including Sam's Club stations (first $6,000/year, then 1%)"
```

Cap ($6,000/yr) and post-cap rate (1%) unchanged. Kept "worldwide" — the marketing page does not repeat it, but it is not contradicted there either, and it presumably came from the fuller rewards terms.

## Verification

Verified by hand against the live apply page on 2026-08-10. `samsclub.com` serves an automated client a JS shell with no terms in the markup (~374 chars of visible text from ~95KB of HTML), so it is in `KNOWN_BLOCKED_HOSTS` and the nightly check cannot pick this up.

Every other stored field was checked in the same pass and matches: no annual fee, $30 statement credit after $30 in club purchases within 30 days, purchase APR 20.15%/28.15%, 3% dining, 3% club purchases for Plus / 1% Club-tier, 1% everything else, $5,000/yr Sam's Cash cap. This note was the only gap.

`npm run build:cards` passes (209 cards); regenerated `cards.json` intentionally not committed.

## Not included

`our_take` also describes the category as gas-only. Left alone deliberately — it is regenerated twice monthly by the auto-`our_take` job, so a hand edit there would be overwritten.

Related: #2001 (the stale-alarm bug that surfaced this card), #1992.