### PR TITLE
Fix fetch phase starving the same cards every run

### DIFF
--- a/scripts/check-card-pages.js
+++ b/scripts/check-card-pages.js
@@ -146,6 +146,56 @@ function withTimeout(promise, ms, label) {
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
+// A gap between two budget checks longer than this cannot be work: the main
+// loop caps a card at PER_CARD_TIMEOUT_MS (60s) plus a FETCH_DELAY_MS host
+// wait, and the retry pass adds at most its longest backoff on top. Anything
+// beyond that is the machine having been suspended.
+const SUSPEND_GAP_MS = Number(process.env.CARD_PAGE_SUSPEND_GAP_MS || 5 * 60 * 1000);
+
+/**
+ * The run's time budget, measured in ACTIVE time rather than wall clock.
+ *
+ * This job runs on a laptop, and a laptop on battery sleeps. Date.now() keeps
+ * advancing through sleep while the script does nothing, so a wall-clock
+ * deadline gets spent while suspended and the run stops having checked a
+ * fraction of the catalog. On 2026-08-10 that meant 76 of 168 cards in a
+ * nominal 150 minutes — about 25 minutes of real work stretched across three
+ * system sleeps (`pmset -g log` shows a 902-second 'Maintenance Sleep' on
+ * battery partway through).
+ *
+ * So: whenever two consecutive checks are further apart than any amount of work
+ * could explain, treat the gap as suspend time and push the deadline out by it.
+ * Sleeps observed on this machine run 900s+, comfortably clear of the 5-minute
+ * threshold, and a genuinely slow stretch stays inside it and is still charged.
+ *
+ * Detecting the gap after the fact is deliberate — there is no portable way to
+ * ask "were we asleep?", and this needs no OS APIs and no privileges.
+ */
+function createTimeBudget(totalMs, now = Date.now()) {
+  let deadline = now + totalMs;
+  let lastTick = now;
+
+  const tick = (at) => {
+    const gap = at - lastTick;
+    if (gap > SUSPEND_GAP_MS) deadline += gap;
+    lastTick = at;
+  };
+
+  return {
+    // Call once per unit of work. Advances the suspend accounting as a side
+    // effect, so callers must not treat it as a pure predicate.
+    expired(at = Date.now()) {
+      tick(at);
+      return at > deadline;
+    },
+    remainingMs(at = Date.now()) {
+      tick(at);
+      return Math.max(0, deadline - at);
+    },
+    suspendAdjustedMs: () => deadline,
+  };
+}
+
 // ─── YAML helpers ────────────────────────────────────────────────────────────
 
 function replaceYamlField(yamlText, field, newValue) {
@@ -265,6 +315,39 @@ function filterCardsForCheck(allCards, slugFilter) {
     }
   }
   return cards;
+}
+
+/**
+ * Order cards oldest-verification-first, so a run that does exhaust its budget
+ * starves a DIFFERENT slice each time.
+ *
+ * loadAllCards() returns readdir order, which is stable across runs. Combined
+ * with a truncating deadline that made the cut deterministic: the same
+ * alphabetical tail was dropped every single time, so those cards were never
+ * checked at all rather than checked less often. Sam's Club Mastercard sat at
+ * last_ok:null through 12 consecutive runs that way, and Wells Fargo, World of
+ * Hyatt and Wyndham were all in the same permanently-unreached block.
+ *
+ * Sorting by last_ok makes truncation self-correcting: whatever a run drops has
+ * the oldest timestamp next time and goes to the front. Never-verified cards
+ * lead, since they are the ones with no known-good data at all.
+ *
+ * Cheap-to-skip cards (known blocks) also sort to the front and stay there,
+ * which is harmless — knownBlockedReason() short-circuits before any fetch.
+ */
+function orderCardsByStaleness(cards, state = {}) {
+  return [...cards].sort((a, b) => {
+    const aOk = state[a.slug]?.last_ok;
+    const bOk = state[b.slug]?.last_ok;
+    if (!aOk !== !bOk) return aOk ? 1 : -1;
+    if (aOk && bOk) {
+      const delta = Date.parse(aOk) - Date.parse(bOk);
+      if (delta) return delta;
+    }
+    // Stable tiebreak so a run is reproducible and two cards never swap places
+    // between runs for no reason.
+    return a.slug.localeCompare(b.slug);
+  });
 }
 
 // ─── Page fetching ────────────────────────────────────────────────────────────
@@ -1812,7 +1895,14 @@ async function main() {
 
   console.log('Loading cards...');
   const allCards = loadAllCards();
-  const cardsToCheck = filterCardsForCheck(allCards, slugFilter);
+  // Prior runs' per-card knowledge: which cards need the browser (see
+  // BROWSER_FIRST_TTL_MS) and when each was last verified. Loaded before the
+  // check list is built because last_ok decides the order cards are checked in.
+  const prevState = loadSkipState();
+  const cardsToCheck = orderCardsByStaleness(
+    filterCardsForCheck(allCards, slugFilter),
+    prevState
+  );
 
   if (cardsToCheck.length === 0) {
     console.log('No active cards with apply_link found. Exiting.');
@@ -1849,13 +1939,12 @@ async function main() {
       knownBlock: resolveKnownBlock(checkUrlFor(card), opts),
     });
 
-  const scriptDeadline = Date.now() + SCRIPT_TIMEOUT_MS;
+  const budget = createTimeBudget(SCRIPT_TIMEOUT_MS);
 
-  // Prior runs' per-card knowledge, read once up front: which cards are known
-  // to need the browser (see BROWSER_FIRST_TTL_MS). `browserFirstBySlug`
-  // collects the flags to persist for THIS run — a still-valid flag is carried
-  // forward with its original date so it eventually expires and re-probes.
-  const prevState = loadSkipState();
+  // `browserFirstBySlug` collects the flags to persist for THIS run — a
+  // still-valid flag is carried forward with its original date so it eventually
+  // expires and re-probes. (prevState itself is loaded above, before the check
+  // list is ordered.)
   const browserFirstBySlug = new Map();
 
   // Last time each hostname was actually hit; enforces FETCH_DELAY_MS per host.
@@ -1931,7 +2020,7 @@ async function main() {
   };
 
   for (const [i, card] of cardsToCheck.entries()) {
-    if (Date.now() > scriptDeadline) {
+    if (budget.expired()) {
       // Record the cards we never reached. Without this the loop just breaks and
       // they vanish — absent from both the checked set and the end-of-run skip
       // summary, so a truncated run is indistinguishable from a clean one.
@@ -2118,7 +2207,7 @@ async function main() {
       const pending = skippedCards.filter(s => !s.knownBlock && isTransientNetworkError(s.reason));
       if (pending.length === 0) break;
 
-      if (Date.now() + settleMs > scriptDeadline) {
+      if (settleMs > budget.remainingMs()) {
         console.warn(
           `\n⚠️  ${pending.length} network-error skip(s) left unretried — script deadline reached.`
         );
@@ -2133,7 +2222,7 @@ async function main() {
       await new Promise(r => setTimeout(r, settleMs));
 
       for (const entry of pending) {
-        if (Date.now() > scriptDeadline) {
+        if (budget.expired()) {
           console.warn('Script timeout reached — abandoning the remaining retries.');
           break;
         }
@@ -2403,6 +2492,8 @@ module.exports = {
   pageShowsSignupOffer,
   updateSkipState,
   resolveKnownBlock,
+  createTimeBudget,
+  orderCardsByStaleness,
   resolveSkipState,
   readSkipStateFromMain,
   staleCardsFrom,

--- a/scripts/check-card-pages.test.js
+++ b/scripts/check-card-pages.test.js
@@ -23,6 +23,8 @@ const {
   pageShowsSignupOffer,
   updateSkipState,
   resolveKnownBlock,
+  createTimeBudget,
+  orderCardsByStaleness,
   resolveSkipState,
   readSkipStateFromMain,
   staleCardsFrom,
@@ -1372,3 +1374,85 @@ test("run 2 preserves run 1's last_ok for cards it never looked at", () => {
 });
 
 console.log('');
+
+// ─── Fetch budget and card ordering ──────────────────────────────────────────
+//
+// Together these are why a truncated run used to drop the same cards forever:
+// the budget was spent while the laptop slept, and the cut always fell in the
+// same place. See createTimeBudget / orderCardsByStaleness.
+
+console.log('\nTime budget ignores suspend gaps:');
+
+const MIN = 60 * 1000;
+
+test('ordinary elapsed time is charged against the budget', () => {
+  const b = createTimeBudget(10 * MIN, 0);
+  assert.equal(b.expired(5 * MIN), false);
+  assert.equal(b.expired(9 * MIN), false);
+  assert.equal(b.expired(11 * MIN), true, 'real work must still exhaust the budget');
+});
+
+test('a suspend-sized gap is not charged', () => {
+  // The 2026-08-10 shape: a 15-minute system sleep inside a 10-minute budget.
+  const b = createTimeBudget(10 * MIN, 0);
+  assert.equal(b.expired(1 * MIN), false);
+  assert.equal(b.expired(16 * MIN), false, '15 minutes asleep must not spend the budget');
+  // The 9 minutes unspent before the sleep are still there afterwards...
+  assert.equal(b.remainingMs(16 * MIN), 9 * MIN, 'unspent budget survives the sleep');
+  // ...and are still finite. Ticking at a realistic cadence (the loop checks
+  // once per card, and a card is capped at ~1 minute), the run ends on the
+  // first tick past the suspend-adjusted deadline of t=25m.
+  let now = 16 * MIN;
+  while (!b.expired(now) && now < 60 * MIN) now += MIN;
+  assert.equal(now, 26 * MIN, 'the budget still ends, 9 working minutes later');
+});
+
+test('a slow-but-plausible gap stays charged', () => {
+  // Just under the threshold: a genuinely slow card must not buy free time.
+  const b = createTimeBudget(10 * MIN, 0);
+  assert.equal(b.expired(4 * MIN), false);
+  assert.equal(b.expired(8 * MIN), false);
+  assert.equal(b.expired(12 * MIN), true);
+});
+
+test('remainingMs also accounts for suspend', () => {
+  const b = createTimeBudget(10 * MIN, 0);
+  assert.equal(b.remainingMs(20 * MIN), 10 * MIN, 'a 20-minute sleep leaves the budget intact');
+});
+
+console.log('\nCards are ordered oldest-verification-first:');
+
+const card = slug => ({ slug, data: { name: slug } });
+
+test('never-verified cards lead, then oldest last_ok', () => {
+  const cards = [card('fresh'), card('never'), card('stale')];
+  const state = {
+    fresh: { last_ok: '2026-08-09T00:00:00Z' },
+    stale: { last_ok: '2026-08-01T00:00:00Z' },
+  };
+  assert.deepEqual(orderCardsByStaleness(cards, state).map(c => c.slug), ['never', 'stale', 'fresh']);
+});
+
+test('the cut rotates: what a truncated run drops leads the next one', () => {
+  // Run 1 checks the first two of three and runs out of budget.
+  const cards = [card('a'), card('b'), card('c')];
+  const afterRun1 = {
+    a: { last_ok: '2026-08-10T00:00:00Z' },
+    b: { last_ok: '2026-08-10T00:00:00Z' },
+    // c never reached — no last_ok
+  };
+  const order = orderCardsByStaleness(cards, afterRun1).map(x => x.slug);
+  assert.equal(order[0], 'c', 'the starved card must lead the next run');
+});
+
+test('ordering is stable and total with no state at all', () => {
+  const cards = [card('c'), card('a'), card('b')];
+  assert.deepEqual(orderCardsByStaleness(cards, {}).map(x => x.slug), ['a', 'b', 'c']);
+  assert.deepEqual(orderCardsByStaleness(cards).map(x => x.slug), ['a', 'b', 'c']);
+});
+
+test('ordering does not mutate its input', () => {
+  const cards = [card('c'), card('a')];
+  orderCardsByStaleness(cards, {});
+  assert.deepEqual(cards.map(x => x.slug), ['c', 'a']);
+});


### PR DESCRIPTION
The nightly fetch has been stopping early and dropping the *same* cards each time. Today's run reached 76 of 168 cards and left 92 unchecked — the same alphabetical tail as previous runs (US Bank, Venmo, Wells Fargo, World of Hyatt, Wyndham).

Two independent causes. Both need fixing: the budget bug is why runs truncate, the ordering bug is why truncation always lands on the same cards.

## 1. The budget was wall clock, on a laptop that sleeps

`Date.now()` keeps advancing through system sleep while the script does nothing, so the 150-minute deadline was being spent suspended.

Measured, the pages are not slow and nothing degrades:

| Sample | Result |
|---|---|
| 20 cards, mixed hosts | 212s total, ~10.6s/card, **no upward trend** (card 21 as fast as card 3) |
| 4 Amex cards (the heaviest) | ~16s each, all succeeded |
| Delta SkyMiles Platinum | timed out at 60s in the real run; **15.7s in isolation** |

168 cards is roughly 35 minutes of actual work. The run consumed 150 minutes of wall clock to do ~25 minutes of it. `pmset -g log` for the window shows why:

```
08:02:44 Entering Sleep state due to 'Maintenance Sleep' ... Using Batt  902 secs
```

plus further sleeps. It is also arithmetically impossible for 76 cards to take 150 minutes of *work*: `PER_CARD_TIMEOUT_MS` caps a card at 60s and the only await outside that cap is a ≤2s host gate, so 76 cards is ~78 minutes maximum.

`createTimeBudget()` charges active time. A gap between two budget checks longer than any amount of work could explain (5 minutes, against a 60s per-card cap) is treated as suspend and added back to the deadline. Observed sleeps are 900s+, comfortably clear of the threshold; a genuinely slow stretch stays under it and is still charged. Detecting the gap after the fact is deliberate — there is no portable "were we asleep?" API, and this needs no privileges.

## 2. Card order was `readdir` order, identical every run

So the cut always fell in the same place, and the tail was never checked rather than checked less often. That is how Sam's Club Mastercard reached `last_ok: null` across 12 consecutive runs (see #1992 / #2001).

`orderCardsByStaleness()` checks oldest-verified-first, making truncation self-correcting. Against the real state from the truncated run:

| Card | Before | After |
|---|---|---|
| us-bank-split | 181 | 129 |
| venmo-credit-card | 189 | 130 |
| wells-fargo-active-cash | 190 | 131 |
| world-of-hyatt-credit-card | 205 | 139 |
| wyndham-rewards-earner-card | 207 | 141 |
| aaa-daily-advantage (verified today) | 1 | 144 |
| chase-sapphire-preferred (verified today) | 66 | 193 |

Never-verified cards lead, then oldest `last_ok`, with a slug tiebreak so runs stay reproducible.

## Verification

- Unit tests for both helpers, including that ordinary elapsed time is still charged, a just-under-threshold slow stretch does not buy free time, and the budget still terminates after a sleep.
- One of my first budget tests was wrong (it ticked in 8-minute jumps, itself over the threshold, so it "proved" something the code never claimed). Rewritten to tick at the real per-card cadence and assert the substantive property via `remainingMs`.
- End-to-end scoped runs (`CARD_SLUG=…`) pass with ordering and budget wired in.
- Full existing suite green.

## Not included

`caffeinate` would stop some of these sleeps at the source, but only some — the log shows `Clamshell Sleep` too, which `caffeinate -i` does not prevent. The budget fix makes the run correct whether or not the machine sleeps, so I did not add a platform-specific half-measure. Worth considering separately for the scheduled task if runs stretching over many wall-clock hours becomes a problem.

Related: #2001, #1992.