### PR TITLE
Spark Cash Plus: keep the repeatable bonus out of signup_bonus.note

### DIFF
--- a/data/cards/capital-one-spark-cash-plus.yaml
+++ b/data/cards/capital-one-spark-cash-plus.yaml
@@ -24,7 +24,7 @@ signup_bonus:
   type: "cash"
   spend_requirement: 30000
   timeframe_months: 3
-  note: "Earn a $2,000 cash bonus when you spend $30,000 in the first 3 months, plus an additional $2,000 cash bonus for every $500,000 spent during the first year (repeatable). Limited-time: also earn a one-time $500 Capital One Business Travel credit when you spend $30,000 in the first 3 months."
+  note: "For a limited time, also earns a one-time $500 Capital One Business Travel credit on the same $30,000 spend in the first 3 months"
 benefits:
   - name: "Volume Spend Bonus"
     value: 2000


### PR DESCRIPTION
Follow-up to #1991.

The note that landed there had three clauses, and only one of them belongs in `signup_bonus.note`:

| Clause | Verdict |
|---|---|
| "Earn a $2,000 cash bonus when you spend $30,000 in the first 3 months" | Restates `value` / `spend_requirement` / `timeframe_months` |
| "plus an additional $2,000 cash bonus for every $500,000 spent during the first year (repeatable)" | Already modeled as the card's `Volume Spend Bonus` benefit |
| "a one-time $500 Capital One Business Travel credit" | Genuine note content — the numeric fields cannot express it |

Recurring spend bonuses belong in `benefits`, not as a note on `signup_bonus`. `signup_bonus` represents the one-time opening offer; folding an ongoing earn into it misleads readers and breaks `signup_bonus_value` as a comparable scalar. The card already carries the repeatable tier correctly:

```yaml
benefits:
  - name: "Volume Spend Bonus"
    value: 2000
    description: "$2,000 cash bonus for every $500,000 spent in the first year, earnable multiple times"
```

So this restores the prior note, keeping only the $500 Business Travel credit. Numeric fields are untouched — they were already corrected on #1991 before merge.

```diff
-  note: "Earn a $2,000 cash bonus when you spend $30,000 in the first 3 months, plus an additional $2,000 cash bonus for every $500,000 spent during the first year (repeatable). Limited-time: also earn a one-time $500 Capital One Business Travel credit when you spend $30,000 in the first 3 months."
+  note: "For a limited time, also earns a one-time $500 Capital One Business Travel credit on the same $30,000 spend in the first 3 months"
```

The extractor rule added in #1995 now tells future runs to keep the repeating component out of `bonus_note`, so this should not come back.

`npm run build:cards` passes (209 cards); regenerated `cards.json` intentionally not committed.