### PR TITLE
api: cache cards.json at module scope in the shared CDN fetcher

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,0 +1,8 @@
+// .aws-sam/build contains full copies of src + tests per zip-packaged
+// function; without these ignores, bare `jest` collects duplicate suites and
+// emits a haste-map naming collision on @creditodds/api.
+module.exports = {
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/.aws-sam/'],
+  modulePathIgnorePatterns: ['/.aws-sam/'],
+};

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "jest": "^26.6.3"
   },
   "scripts": {
+    "test": "jest",
     "test-get-all-cards": "sam build && sam local invoke AllCardsFunction --event events/event-get-all-cards.json --env-vars env.json",
     "test-get-card-by-id": "sam build && sam local invoke CardByIdFunction --event events/event-get-card-by-id.json --env-vars env.json",
     "test-get-card-graphs": "sam build && sam local invoke getCardGraphsFunction --event events/event-get-card-graphs.json --env-vars env.json",

--- a/apps/api/src/lib/cards-cdn.js
+++ b/apps/api/src/lib/cards-cdn.js
@@ -7,6 +7,12 @@
 // ("socket hang up"). A GET retry on a fresh connection is safe, so transient
 // socket errors get one retry, and each attempt carries an idle timeout
 // (https.get has none by default).
+//
+// Successful results are cached at module scope for 5 minutes (matching the
+// CDN's max-age=300 and the frontend's ISR revalidate), so warm invocations
+// skip the ~735KB download + JSON.parse entirely. cacheBust bypasses the
+// cache in both directions — it exists for the post-deploy sync, which must
+// read through the CDN, not this container's memory.
 const https = require('https');
 
 // Handlers historically read CARDS_JSON_URL but template.yml sets CardsJsonUrl;
@@ -18,6 +24,9 @@ const CARDS_URL =
 
 const REQUEST_TIMEOUT_MS = 5000;
 const TRANSIENT_CODES = new Set(['ECONNRESET', 'ETIMEDOUT', 'EPIPE']);
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+let cache = null; // { expiresAt, data }
 
 function requestCardsOnce(url) {
   return new Promise((resolve, reject) => {
@@ -50,16 +59,30 @@ function isTransientNetworkError(err) {
 // empty-array fallback apply `|| []` themselves). Pass cacheBust: true to
 // append a timestamp query param so a post-deploy sync bypasses the CDN cache.
 async function fetchCardsFromCDN({ cacheBust = false } = {}) {
+  if (!cacheBust && cache && cache.expiresAt > Date.now()) {
+    return cache.data;
+  }
   const url = cacheBust ? `${CARDS_URL}?t=${Date.now()}` : CARDS_URL;
+  let cards;
   try {
-    return await requestCardsOnce(url);
+    cards = await requestCardsOnce(url);
   } catch (err) {
     if (!isTransientNetworkError(err)) throw err;
     console.warn(
       `cards.json fetch failed (${err.code || err.message}); retrying on a fresh connection`
     );
-    return requestCardsOnce(url);
+    cards = await requestCardsOnce(url);
   }
+  // Only well-formed results are cached — a missing `cards` key stays a
+  // per-request anomaly rather than 5 minutes of empty responses.
+  if (!cacheBust && Array.isArray(cards)) {
+    cache = { expiresAt: Date.now() + CACHE_TTL_MS, data: cards };
+  }
+  return cards;
 }
 
-module.exports = { fetchCardsFromCDN };
+function _resetCacheForTests() {
+  cache = null;
+}
+
+module.exports = { fetchCardsFromCDN, _resetCacheForTests };

--- a/apps/api/src/lib/ranker/data-loaders.js
+++ b/apps/api/src/lib/ranker/data-loaders.js
@@ -5,38 +5,17 @@
 //   this directory). It must NOT be read as a loose file via fs/__dirname:
 //   under `BuildMethod: esbuild` the data file isn't copied next to the
 //   bundle, so a runtime read throws ENOENT and 500s every wallet-picks call.
-// - cards.json is fetched from CloudFront per cold start. The existing
-//   nearby-recommendations / card-by-id / all-cards handlers do the same
-//   per request; we cache at module scope here with a short TTL to keep
-//   warm-container wallet picks fast without holding stale data forever.
+// - cards.json comes from the shared CDN fetcher (../cards-cdn), which
+//   caches the raw card list at module scope for 5 minutes and handles the
+//   warm-container ECONNRESET retry + idle timeout. The cache below is a
+//   second, separate layer: it holds the DB-*enriched* card list so warm
+//   wallet-picks calls also skip the cards-table metadata query.
 
-const https = require("https");
 const mysql = require("../../db");
-
-const CARDS_URL =
-  process.env.CARDS_JSON_URL || "https://d2hxvzw7msbtvt.cloudfront.net/cards.json";
+const { fetchCardsFromCDN } = require("../cards-cdn");
 
 const CARDS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes — matches the CDN/ISR layers
 let cardsCache = null; // { expiresAt, data }
-
-function fetchCardsFromCDN() {
-  return new Promise((resolve, reject) => {
-    https
-      .get(CARDS_URL, (res) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => {
-          try {
-            const json = JSON.parse(data);
-            resolve(Array.isArray(json.cards) ? json.cards : []);
-          } catch (err) {
-            reject(new Error("Failed to parse cards.json"));
-          }
-        });
-      })
-      .on("error", reject);
-  });
-}
 
 // Merge in the same DB-sourced fields that `all-cards.js` exposes — the
 // frontend expects `card_image_link` (used by <CardImage>) and
@@ -76,10 +55,13 @@ async function getAllCards() {
   if (cardsCache && cardsCache.expiresAt > now) {
     return cardsCache.data;
   }
-  const [cdnCards, dbByName] = await Promise.all([
+  const [cdnCardsRaw, dbByName] = await Promise.all([
     fetchCardsFromCDN(),
     fetchCardDbMetadata(),
   ]);
+  // The shared fetcher returns json.cards as-is (undefined if the key is
+  // missing); the previous local fetcher guaranteed an array, so keep that.
+  const cdnCards = Array.isArray(cdnCardsRaw) ? cdnCardsRaw : [];
   const enriched = cdnCards.map((c) => {
     const db = dbByName.get(c.card_name) || dbByName.get(c.name) || {};
     return {

--- a/apps/api/tests/cards-cdn.test.js
+++ b/apps/api/tests/cards-cdn.test.js
@@ -10,7 +10,7 @@ const { EventEmitter } = require("events");
 
 jest.mock("https", () => ({ get: jest.fn() }));
 const https = require("https");
-const { fetchCardsFromCDN } = require("../src/lib/cards-cdn");
+const { fetchCardsFromCDN, _resetCacheForTests } = require("../src/lib/cards-cdn");
 
 const CARDS = [{ card_name: "Test Card" }];
 const BODY = JSON.stringify({ cards: CARDS });
@@ -54,6 +54,7 @@ function codedError(code, message) {
 
 beforeEach(() => {
   https.get.mockReset();
+  _resetCacheForTests();
   jest.spyOn(console, "warn").mockImplementation(() => {});
 });
 
@@ -134,4 +135,57 @@ test("cacheBust appends a timestamp query param", async () => {
 
   await fetchCardsFromCDN();
   expect(https.get.mock.calls[1][0]).toMatch(/cards\.json$/);
+});
+
+test("serves the module cache within the TTL without refetching", async () => {
+  https.get.mockImplementation(respondWith(BODY));
+
+  await expect(fetchCardsFromCDN()).resolves.toEqual(CARDS);
+  await expect(fetchCardsFromCDN()).resolves.toEqual(CARDS);
+  expect(https.get).toHaveBeenCalledTimes(1);
+});
+
+test("refetches after the 5-minute TTL expires", async () => {
+  let now = 1_000_000;
+  const nowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+  https.get.mockImplementation(respondWith(BODY));
+
+  await fetchCardsFromCDN();
+  now += 5 * 60 * 1000 - 1;
+  await fetchCardsFromCDN();
+  expect(https.get).toHaveBeenCalledTimes(1);
+
+  now += 2; // past expiry
+  await fetchCardsFromCDN();
+  expect(https.get).toHaveBeenCalledTimes(2);
+  nowSpy.mockRestore();
+});
+
+test("cacheBust bypasses the cache in both directions", async () => {
+  https.get.mockImplementation(respondWith(BODY));
+
+  await fetchCardsFromCDN(); // populates the cache
+  await fetchCardsFromCDN({ cacheBust: true }); // must hit the network
+  expect(https.get).toHaveBeenCalledTimes(2);
+
+  await fetchCardsFromCDN(); // original cached copy still serves
+  expect(https.get).toHaveBeenCalledTimes(2);
+});
+
+test("does not cache failures: a rejected fetch is retried by the next call", async () => {
+  https.get
+    .mockImplementationOnce(failWith(codedError("ENOTFOUND", "getaddrinfo ENOTFOUND")))
+    .mockImplementationOnce(respondWith(BODY));
+
+  await expect(fetchCardsFromCDN()).rejects.toThrow("getaddrinfo ENOTFOUND");
+  await expect(fetchCardsFromCDN()).resolves.toEqual(CARDS);
+  expect(https.get).toHaveBeenCalledTimes(2);
+});
+
+test("does not cache a malformed payload (missing cards key)", async () => {
+  https.get.mockImplementation(respondWith(JSON.stringify({ notCards: [] })));
+
+  await expect(fetchCardsFromCDN()).resolves.toBeUndefined();
+  await fetchCardsFromCDN();
+  expect(https.get).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
Fixes the highest-severity performance finding from the architecture review: every invocation of the hottest Lambdas re-downloaded and re-parsed the 735 KB cards.json from CloudFront.

## Changes
- **`src/lib/cards-cdn.js`**: successful fetches are cached at module scope for 5 minutes (matching the CDN's `max-age=300` and the ISR layer). Warm invocations of `all-cards`, `card-by-id`, `check-odds`, `card-records`, and `get-card-graphs` skip the download + parse — roughly 50–300 ms off warm p50/p95, and less NAT-instance egress. `cacheBust: true` (used by the post-deploy sync in `update-cards-github.js`) bypasses the cache in both directions. Failures and malformed payloads are never cached.
- **`src/lib/ranker/data-loaders.js`**: deletes its private `https.get` re-implementation (no timeout, no retry, and it read an env var the template never sets for the wallet-picks functions) and imports the shared fetcher — closing the warm-container `socket hang up` 500 risk the shared client was built to fix. Its own cache remains as a second layer holding the DB-*enriched* list.
- **Test infra**: `jest.config.js` ignores `.aws-sam/` (bare `jest` previously collected duplicate suites from function build copies and emitted a haste-map collision) and `package.json` gains the missing `"test": "jest"` script.

## Verification
`npm test` in apps/api: **35/35 green** — the 30 existing tests plus 5 new ones covering: cache hit within TTL, refetch after TTL expiry, cacheBust bypassing read and write, failed fetches not being cached, and malformed payloads (missing `cards` key) not being cached.

Deploys automatically via deploy-api.yml on merge.