### PR TITLE
api: stop trusting X-Forwarded-For from direct execute-api callers

### DIFF
--- a/apps/api/scripts/enable-origin-verify.sh
+++ b/apps/api/scripts/enable-origin-verify.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Enable (or rotate) the x-origin-verify shared secret between the API's
+# CloudFront distribution and the Lambda fleet.
+#
+# What it does, in order:
+#   1. Generates a fresh secret and sets it as a custom origin header
+#      (x-origin-verify) on the API Gateway origin of the CloudFront
+#      distribution.
+#   2. Waits for the distribution to finish deploying, so every origin
+#      request carries the header before enforcement starts.
+#   3. Sets the OriginVerifySecret stack parameter (all other parameters
+#      keep their previous values), which populates ORIGIN_VERIFY_SECRET
+#      on every function via Globals.
+#
+# First-time enable is seamless: until step 3 lands, the empty stack param
+# keeps getClientIp in legacy mode and the header is ignored.
+#
+# ROTATION CAVEAT: between step 1 and the end of step 3, CloudFront sends the
+# NEW secret while the stack still holds the OLD one, so getClientIp falls
+# back to sourceIp (a CloudFront edge address) for CloudFront-routed traffic.
+# That direction is safe (no forgery possible) but coarsens anonymous dedup
+# for the few minutes the rollout takes — e.g. two visitors behind the same
+# edge IP would collide on POST /ratings. Rotate during a quiet window.
+#
+# Requires: aws CLI with rights on cloudfront:GetDistributionConfig/
+# UpdateDistribution and cloudformation:UpdateStack, plus jq.
+set -euo pipefail
+
+DIST_ID="${DIST_ID:-E2IVU8Y8I7H6WK}"        # CloudFront in front of API Gateway (d2ojrhbh2dincr / api.creditodds.com)
+ORIGIN_ID="${ORIGIN_ID:-api-gateway-origin}"
+STACK="${STACK:-CreditCardOddsAPI}"
+REGION="${REGION:-us-east-1}"
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+# Refuse to run before the stack knows the parameter (i.e. before the PR
+# adding OriginVerifySecret to template.yml has deployed).
+aws cloudformation describe-stacks --stack-name "$STACK" --region "$REGION" \
+  --query "Stacks[0].Parameters[].ParameterKey" --output json | grep -q OriginVerifySecret || {
+  echo "Stack $STACK has no OriginVerifySecret parameter yet - deploy the template change first." >&2
+  exit 1
+}
+
+SECRET=$(openssl rand -hex 32)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "1/3 Setting x-origin-verify on CloudFront origin '$ORIGIN_ID' of $DIST_ID..."
+aws cloudfront get-distribution-config --id "$DIST_ID" > "$TMP/full.json"
+ETAG=$(jq -r .ETag "$TMP/full.json")
+jq --arg secret "$SECRET" --arg oid "$ORIGIN_ID" '
+  .DistributionConfig
+  | (.Origins.Items[] | select(.Id == $oid) | .CustomHeaders) =
+      {Quantity: 1, Items: [{HeaderName: "x-origin-verify", HeaderValue: $secret}]}
+' "$TMP/full.json" > "$TMP/updated.json"
+aws cloudfront update-distribution --id "$DIST_ID" --if-match "$ETAG" \
+  --distribution-config "file://$TMP/updated.json" \
+  --query Distribution.Status --output text
+
+echo "2/3 Waiting for the distribution to deploy (typically 3-10 minutes)..."
+aws cloudfront wait distribution-deployed --id "$DIST_ID"
+
+echo "3/3 Setting the OriginVerifySecret stack parameter on $STACK..."
+PARAMS=$(aws cloudformation describe-stacks --stack-name "$STACK" --region "$REGION" \
+  --query "Stacks[0].Parameters[].ParameterKey" --output json |
+  jq --arg secret "$SECRET" '[.[] | if . == "OriginVerifySecret"
+      then {ParameterKey: ., ParameterValue: $secret}
+      else {ParameterKey: ., UsePreviousValue: true} end]')
+aws cloudformation update-stack --stack-name "$STACK" --region "$REGION" \
+  --use-previous-template --parameters "$PARAMS" \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
+aws cloudformation wait stack-update-complete --stack-name "$STACK" --region "$REGION"
+
+echo "Done. Direct execute-api callers can no longer forge X-Forwarded-For."

--- a/apps/api/src/click-identity.js
+++ b/apps/api/src/click-identity.js
@@ -26,12 +26,43 @@ function getFirebaseAdmin() {
   }
 }
 
-// The API sits behind CloudFront, so requestContext.identity.sourceIp is a
-// CloudFront edge address, not the visitor. In the X-Forwarded-For chain the
-// last entry is CloudFront's own IP (appended by the API Gateway hop) and the
-// second-to-last is the address CloudFront saw as its TCP peer — the real
-// client. Anything earlier is client-supplied and spoofable.
+// The API sits behind CloudFront, so for CloudFront-routed traffic
+// requestContext.identity.sourceIp is an edge address, not the visitor: the
+// X-Forwarded-For chain reaching the Lambda is
+// "<client-supplied…>, <viewer IP>, <CloudFront edge IP>" — the last entry
+// appended by the API Gateway hop, the second-to-last being the address
+// CloudFront saw as its TCP peer, i.e. the real client.
+//
+// But the raw execute-api origin is also publicly reachable, and a direct
+// caller's chain is "<client-supplied…>, <caller IP>", which puts an
+// attacker-chosen value in the second-to-last slot — enough to forge the
+// ip_hash dedup on the anonymous ratings endpoint. So XFF is only trusted
+// when the request carries the x-origin-verify header the CloudFront
+// distribution attaches to origin requests (shared secret via the
+// OriginVerifySecret stack param). Anything else falls back to the
+// unforgeable TCP peer address in sourceIp. While ORIGIN_VERIFY_SECRET is
+// unset the legacy trust-XFF behavior applies unchanged — enable it with
+// apps/api/scripts/enable-origin-verify.sh.
+function timingSafeEqualStr(a, b) {
+  const ab = Buffer.from(String(a));
+  const bb = Buffer.from(String(b));
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
 function getClientIp(event) {
+  const sourceIp = event.requestContext?.identity?.sourceIp || null;
+
+  const secret = process.env.ORIGIN_VERIFY_SECRET;
+  if (secret) {
+    const originHeader =
+      event.headers?.["X-Origin-Verify"] || event.headers?.["x-origin-verify"];
+    if (!originHeader || !timingSafeEqualStr(originHeader, secret)) {
+      // Direct-to-API-Gateway caller: the XFF chain is attacker-controlled.
+      return sourceIp;
+    }
+  }
+
   const xff =
     event.headers?.["X-Forwarded-For"] || event.headers?.["x-forwarded-for"];
   if (xff) {
@@ -42,7 +73,7 @@ function getClientIp(event) {
     if (chain.length >= 2) return chain[chain.length - 2];
     if (chain.length === 1) return chain[0];
   }
-  return event.requestContext?.identity?.sourceIp || null;
+  return sourceIp;
 }
 
 function hashIp(ip) {

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -56,6 +56,11 @@ Parameters:
     Type: String
     Description: Server-side pepper used to hash visitor IPs into stable per-IP tokens for unique-click counting. Treat as a long-lived secret; rotating resets all uniqueness chains.
     NoEcho: true
+  OriginVerifySecret:
+    Type: String
+    Description: Shared secret the API's CloudFront distribution attaches to origin requests as the x-origin-verify header. When set, getClientIp trusts X-Forwarded-For only on requests carrying the matching header; direct execute-api callers fall back to their own TCP source address, closing the forged-XFF hole in anonymous dedup (ratings) and submitter-IP evidence. Empty keeps the legacy trust-XFF behavior. Enable/rotate with apps/api/scripts/enable-origin-verify.sh (CloudFront must send the header BEFORE this is set, or CloudFront-routed visitors all resolve to edge IPs).
+    NoEcho: true
+    Default: ""
   SentryDsn:
     Type: String
     Description: Sentry DSN for the backend project. Leave empty to disable error reporting (the SDK initializes but sends nothing). Not secret — the DSN only carries a public ingest key.
@@ -105,6 +110,7 @@ Globals:
         SENTRY_DSN: !Ref SentryDsn
         SENTRY_TRACES_SAMPLE_RATE: !Ref SentryTracesSampleRate
         SENTRY_ENVIRONMENT: !Ref SentryEnvironment
+        ORIGIN_VERIFY_SECRET: !Ref OriginVerifySecret
     # Every function runs in the shared us-east-1 default VPC, next to the
     # Aurora cluster. Database access comes from the default SG's
     # self-referencing rule, not from any allowlisted egress IP - there is no

--- a/apps/api/tests/click-identity.test.js
+++ b/apps/api/tests/click-identity.test.js
@@ -1,0 +1,127 @@
+// Unit tests for getClientIp / hashIp (src/click-identity.js). Written with
+// the x-origin-verify hardening: the raw execute-api origin is publicly
+// reachable, so a direct caller controls the second-to-last X-Forwarded-For
+// entry — the slot the legacy logic trusted as "the real client". When
+// ORIGIN_VERIFY_SECRET is set, XFF is only trusted on requests carrying the
+// matching header (attached by CloudFront as a custom origin header);
+// everything else must fall back to the unforgeable TCP peer address.
+
+const crypto = require("crypto");
+const { getClientIp, hashIp } = require("../src/click-identity");
+
+const SECRET = "0123456789abcdef0123456789abcdef";
+const SOURCE_IP = "203.0.113.50";
+
+function makeEvent({ xff, originVerify, sourceIp = SOURCE_IP } = {}) {
+  const headers = {};
+  if (xff !== undefined) headers["X-Forwarded-For"] = xff;
+  if (originVerify !== undefined) headers["x-origin-verify"] = originVerify;
+  return { headers, requestContext: { identity: { sourceIp } } };
+}
+
+const ENV_KEYS = ["ORIGIN_VERIFY_SECRET", "IP_HASH_PEPPER"];
+const savedEnv = {};
+
+beforeAll(() => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+});
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  console.warn.mockRestore();
+});
+
+afterAll(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe("getClientIp — legacy mode (no ORIGIN_VERIFY_SECRET)", () => {
+  test("trusts the second-to-last XFF entry (CloudFront-shaped chain)", () => {
+    const event = makeEvent({ xff: "198.51.100.7, 130.176.0.10" });
+    expect(getClientIp(event)).toBe("198.51.100.7");
+  });
+
+  test("single-entry XFF chain returns that entry", () => {
+    const event = makeEvent({ xff: "198.51.100.7" });
+    expect(getClientIp(event)).toBe("198.51.100.7");
+  });
+
+  test("no XFF header falls back to sourceIp", () => {
+    expect(getClientIp(makeEvent())).toBe(SOURCE_IP);
+  });
+
+  test("missing requestContext yields null without throwing", () => {
+    expect(getClientIp({ headers: {} })).toBeNull();
+  });
+});
+
+describe("getClientIp — enforcing mode (ORIGIN_VERIFY_SECRET set)", () => {
+  beforeEach(() => {
+    process.env.ORIGIN_VERIFY_SECRET = SECRET;
+  });
+
+  test("matching x-origin-verify header keeps the XFF-derived client IP", () => {
+    const event = makeEvent({
+      xff: "198.51.100.7, 130.176.0.10",
+      originVerify: SECRET,
+    });
+    expect(getClientIp(event)).toBe("198.51.100.7");
+  });
+
+  test("header name is accepted case-insensitively", () => {
+    const event = {
+      headers: {
+        "X-Forwarded-For": "198.51.100.7, 130.176.0.10",
+        "X-Origin-Verify": SECRET,
+      },
+      requestContext: { identity: { sourceIp: SOURCE_IP } },
+    };
+    expect(getClientIp(event)).toBe("198.51.100.7");
+  });
+
+  test("missing header ignores a forged XFF and returns the TCP peer", () => {
+    const event = makeEvent({ xff: "9.9.9.9, 10.0.0.1" });
+    expect(getClientIp(event)).toBe(SOURCE_IP);
+  });
+
+  test("wrong header value ignores the XFF chain", () => {
+    const event = makeEvent({
+      xff: "9.9.9.9, 10.0.0.1",
+      originVerify: "not-the-secret",
+    });
+    expect(getClientIp(event)).toBe(SOURCE_IP);
+  });
+
+  test("same-length wrong value still fails (timing-safe path)", () => {
+    const wrong = SECRET.slice(0, -1) + (SECRET.endsWith("f") ? "0" : "f");
+    const event = makeEvent({ xff: "9.9.9.9, 10.0.0.1", originVerify: wrong });
+    expect(getClientIp(event)).toBe(SOURCE_IP);
+  });
+});
+
+describe("hashIp", () => {
+  test("returns null (with a warning) when the pepper is unset", () => {
+    expect(hashIp("198.51.100.7")).toBeNull();
+  });
+
+  test("returns sha256(pepper + ip) when the pepper is set", () => {
+    process.env.IP_HASH_PEPPER = "pepper";
+    const expected = crypto
+      .createHash("sha256")
+      .update("pepper198.51.100.7")
+      .digest("hex");
+    expect(hashIp("198.51.100.7")).toBe(expected);
+  });
+
+  test("returns null for a null ip", () => {
+    process.env.IP_HASH_PEPPER = "pepper";
+    expect(hashIp(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes the security finding from the architecture review: anonymous-rating dedup was spoofable because the raw execute-api origin is publicly reachable and `getClientIp` trusted a forgeable X-Forwarded-For slot.

## The hole
Via CloudFront, the XFF chain reaching the Lambda is `<client-supplied…>, <viewer IP>, <CF edge IP>` — second-to-last is the real client, and that's what `getClientIp` returns. But a caller hitting `jy69cgjk02.execute-api.us-east-1.amazonaws.com` directly gets `<client-supplied…>, <caller IP>`, putting an **attacker-chosen value** in that same slot. Rotating the forged header = unlimited votes past the `(ip_hash, card_id)` unique key on the unauthenticated `POST /ratings`, plus poisoned `submitter_ip_address` evidence on records/referrals.

## The fix
- `click-identity.js`: when `ORIGIN_VERIFY_SECRET` is set, XFF is only trusted on requests carrying the matching `x-origin-verify` header (timing-safe compare). Everything else — i.e. direct execute-api traffic — falls back to `requestContext.identity.sourceIp`, the unforgeable TCP peer address, which for a direct caller **is** the real client. All 7 handlers using `getClientIp` are covered.
- `template.yml`: new `OriginVerifySecret` param (NoEcho, default `""`) wired to every function via Globals. **With the default empty value this PR deploys completely inert** — zero behavior change until enablement.
- `scripts/enable-origin-verify.sh`: one-command enablement/rotation — sets the CloudFront custom origin header, waits for the distribution to deploy, then flips the stack param (all other params keep previous values). Ordering matters and the script enforces it; the rotation caveat is documented in its header.

## After merge
Once deploy-api finishes, run:
```bash
apps/api/scripts/enable-origin-verify.sh
```
(needs aws CLI + jq; takes ~5–10 min, mostly waiting on CloudFront propagation. First-time enable has no traffic impact.)

## Verification
- 42/42 jest tests green, including 12 new ones: legacy mode unchanged, enforcing mode (header match keeps XFF client IP; missing/wrong/same-length-wrong header ignores forged XFF; case-insensitive header), and hashIp behavior.
- `sam validate --lint`: template valid.

Sidenote for reviewer: a stronger variant (API Gateway resource policy pinned to CloudFront origin-facing ranges) was considered and rejected — the range list rots, and the header check fully closes the dedup hole.