### PR TITLE
cards: Delta SkyMiles Reserve Business SUB is now 80,000 miles

### DIFF
--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -37,7 +37,7 @@ rewards:
     unit: points_per_dollar
     note: "All purchases earn 1.5x after $150,000 in eligible purchases in a calendar year"
 signup_bonus:
-  value: 125000
+  value: 80000
   type: "miles"
   spend_requirement: 12000
   timeframe_months: 6


### PR DESCRIPTION
## What changed

`signup_bonus.value` on Delta SkyMiles Reserve Business American Express: **125,000 → 80,000 miles**.

Spend requirement (`$12,000`) and window (`6 months`) are unchanged. Nothing else in the file is touched.

## Why

The offer on the live issuer page really did drop. Verified in a clean browser session with no Amex cookies or prior session:

> WELCOME OFFER — Earn 80,000 Bonus Miles after you spend $12,000 in purchases on your new Card in your first 6 months of Card Membership.

Checks against the live DOM:

- `125,000` appears **nowhere** in the page HTML, including hidden and collapsed content.
- `80,000` is the **only** mileage figure on the page.
- **No** strikethrough / `<del>` / line-through elements, so this is not an expired-offer artifact.

Everything else on the page still matches the YAML: $650 annual fee, 19.49-28.49% APR, 3x Delta / 1.5x transit-shipping-office / 1x other.

## Why this needed a manual PR

The nightly card-page check found this change on the 2026-08-11 run and **suppressed it automatically**:

> proposed value 125000 → 80000 is a DECREASE on a host that serves session-targeted offers — the fetch may have been shown a smaller variant than the public one. Verify in a clean/incognito browser and apply by hand if real.

That guard is working as designed. This PR is the manual confirmation it asks for.

## Source

https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/

## Validation

`npm run build:cards` passes (209 cards). Regenerated `cards.json` intentionally not committed.