### PR TITLE
Add the ten-card Truist lineup

### DIFF
--- a/data/cards/truist-business-cash-rewards.yaml
+++ b/data/cards/truist-business-cash-rewards.yaml
@@ -1,0 +1,74 @@
+name: "Truist Business Cash Rewards"
+bank: "Truist"
+slug: "truist-business-cash-rewards"
+accepting_applications: true
+category: "business"
+annual_fee: 0
+network: "visa"
+reward_type: "cashback"
+tags:
+  - business
+  - cashback
+rewards:
+  - category: gas
+    value: 3
+    unit: percent
+    note: "$2,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 2000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: dining
+    value: 2
+    unit: percent
+    note: "$2,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 2000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: office_supplies
+    value: 2
+    unit: percent
+    note: "$2,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 2000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: everything_else
+    value: 1
+    unit: percent
+signup_bonus:
+  value: 300
+  type: "cash"
+  spend_requirement: 3000
+  timeframe_months: 3
+apr:
+  purchase_intro:
+    rate: 0
+    months: 9
+  regular:
+    min: 15.74
+    max: 24.74
+benefits:
+  - name: "Loyalty Cash Bonus"
+    value: 10
+    value_unit: "percent"
+    description: "10%, 25%, or 50% bonus on rewards redeemed into an eligible Truist business deposit account, with the tier set by your Truist relationship"
+    frequency: "per_redemption"
+    category: "rewards"
+  - name: "Free Employee Cards"
+    value: 0
+    description: "Add authorized cardholders at no additional charge"
+    frequency: "ongoing"
+    category: "business"
+apply_link: https://www.truist.com/small-business/credit-cards/business-cash-rewards
+our_take: >
+  The business version of Truist's cash back card pays 3% on gas and 2% at
+  restaurants and office supply stores, with those bonus rates sharing a
+  $2,000 monthly cap before everything falls to 1%. That is $24,000 a year of
+  bonus spending, roomier than the consumer card's cap but still modest for a
+  business with real fuel or supply costs. A $300 bonus after $3,000 in 90
+  days is easy to clear, there is no annual fee, employee cards are free, and
+  9 months of 0% on purchases helps if you are financing startup costs. Two
+  caveats: rewards expire five years after they are issued, which no flat rate
+  competitor imposes, and the headline value assumes you redeem into a Truist
+  business deposit account to collect the 10% to 50% Loyalty Cash Bonus.
+  Businesses without a Truist relationship, or with spending outside gas and
+  supplies, will do better on a flat 2% business card.

--- a/data/cards/truist-business-premium.yaml
+++ b/data/cards/truist-business-premium.yaml
@@ -1,0 +1,59 @@
+name: "Truist Business Premium"
+bank: "Truist"
+slug: "truist-business-premium"
+accepting_applications: true
+category: "business"
+annual_fee: 299
+annual_fee_intro:
+  value: 0
+  months: 12
+network: "visa"
+reward_type: "cashback"
+tags:
+  - business
+  - cashback
+  - premium
+rewards:
+  - category: everything_else
+    value: 2
+    unit: percent
+signup_bonus:
+  value: 1000
+  type: "cash"
+  spend_requirement: 15000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 15.74
+    max: 24.74
+benefits:
+  - name: "Annual Fee Waiver for High Spend"
+    value: 299
+    description: "The $299 annual fee is waived in any year the business puts $100,000 or more in eligible purchases on the card"
+    frequency: "annual"
+    category: "business"
+  - name: "Loyalty Cash Bonus"
+    value: 10
+    value_unit: "percent"
+    description: "10% bonus on rewards redeemed into an eligible Truist business deposit account"
+    frequency: "per_redemption"
+    category: "rewards"
+  - name: "Free Employee Cards"
+    value: 0
+    description: "Add authorized cardholders at no additional charge"
+    frequency: "ongoing"
+    category: "business"
+apply_link: https://www.truist.com/small-business/credit-cards/business-premium-rewards
+our_take: >
+  Truist Business Premium is a flat 2% card on a Visa Infinite Business chassis
+  with a $299 annual fee, and the fee is the whole question. It is waived the
+  first year and waived again in any year the business spends $100,000, which
+  is the spending level where the card is clearly meant to live. Below that,
+  paying $299 for 2% means you need roughly $15,000 a year in extra spending
+  versus a free 2% business card just to break even, and free flat rate
+  business cards are not scarce. The $1,000 bonus after $15,000 in 90 days is
+  real money and lands inside the waived first year, so a business with that
+  much near term spending can take the bonus, use the card for twelve months,
+  and decide later. Redeeming into a Truist business deposit account adds a
+  10% Loyalty Cash Bonus, lifting the effective rate to about 2.2%, which is
+  the version of the math Truist wants you to run.

--- a/data/cards/truist-business-travel-rewards.yaml
+++ b/data/cards/truist-business-travel-rewards.yaml
@@ -1,0 +1,71 @@
+name: "Truist Business Travel Rewards"
+bank: "Truist"
+slug: "truist-business-travel-rewards"
+accepting_applications: true
+category: "business"
+annual_fee: 49
+annual_fee_intro:
+  value: 0
+  months: 12
+foreign_transaction_fee: false
+network: "visa"
+reward_type: "miles"
+tags:
+  - business
+  - travel
+  - rewards
+rewards:
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+  - category: hotels
+    value: 2
+    unit: points_per_dollar
+  - category: car_rentals
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 20000
+  type: "miles"
+  spend_requirement: 2000
+  timeframe_months: 3
+apr:
+  regular:
+    min: 15.74
+    max: 24.74
+benefits:
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 120
+    description: "Up to $120 statement credit per organization for a Global Entry or TSA PreCheck application fee, once every four years"
+    frequency: "multi_year"
+    frequency_years: 4
+    category: "security"
+  - name: "Loyalty Travel Bonus"
+    value: 10
+    value_unit: "percent"
+    description: "10%, 25%, or 50% bonus when miles are redeemed for travel, with the tier set by your Truist deposit relationship"
+    frequency: "per_redemption"
+    category: "rewards"
+  - name: "Free Employee Cards"
+    value: 0
+    description: "Add authorized cardholders at no additional charge"
+    frequency: "ongoing"
+    category: "business"
+apply_link: https://www.truist.com/small-business/credit-cards/business-travel-rewards
+our_take: >
+  A $49 business travel card, free the first year, earning 2 miles per dollar
+  on airfare, hotels, and car rentals and 1 mile on everything else. The
+  20,000 mile bonus after $2,000 in 90 days covers the fee for years at face
+  value, and no foreign transaction fees make it usable on trips abroad, which
+  is where a business travel card has to work. The limits are the same ones
+  that apply across Truist's lineup: miles redeem through Truist rather than
+  transferring to airline or hotel programs, so their value is capped around a
+  cent each, and they expire five years after they are issued. A Global Entry
+  or TSA PreCheck credit of up to $120 every four years, granted per
+  organization rather than per cardholder, is a decent extra at this fee. If
+  your business travel is heavy or you want transferable points, a $95 card
+  with real partners will out earn this one; if it is occasional, the low fee
+  and free first year make it easy to justify.

--- a/data/cards/truist-business.yaml
+++ b/data/cards/truist-business.yaml
@@ -1,0 +1,34 @@
+name: "Truist Business"
+bank: "Truist"
+slug: "truist-business"
+accepting_applications: true
+category: "business"
+annual_fee: 0
+network: "visa"
+tags:
+  - business
+  - balance_transfer
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 13.74
+    max: 22.74
+benefits:
+  - name: "Free Employee Cards"
+    value: 0
+    description: "Add authorized cardholders at no additional charge"
+    frequency: "ongoing"
+    category: "business"
+apply_link: https://www.truist.com/small-business/credit-cards/business-card
+our_take: >
+  This is Truist's no frills business card: no annual fee, no rewards, 12
+  months of 0% APR on purchases, and a regular range of 13.74% to 22.74% that
+  is the lowest in Truist's lineup by roughly two points. It exists for
+  businesses that expect to carry a balance, where a couple of points of APR
+  is worth more than 2% back that gets erased by interest anyway. If you pay
+  in full every month there is no argument for it over Truist's own Business
+  Cash Rewards, which costs the same nothing and actually earns. Employee
+  cards are free and it plugs into Truist's online banking and accounting
+  integrations like the rest of the lineup.

--- a/data/cards/truist-enjoy-beyond.yaml
+++ b/data/cards/truist-enjoy-beyond.yaml
@@ -1,0 +1,72 @@
+name: "Truist Enjoy Beyond"
+bank: "Truist"
+slug: "truist-enjoy-beyond"
+accepting_applications: true
+category: "travel"
+annual_fee: 95
+foreign_transaction_fee: false
+network: "visa"
+reward_type: "points"
+tags:
+  - travel
+  - rewards
+  - premium
+rewards:
+  - category: airlines
+    value: 3
+    unit: points_per_dollar
+  - category: hotels
+    value: 3
+    unit: points_per_dollar
+  - category: car_rentals
+    value: 3
+    unit: points_per_dollar
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 30000
+  type: "points"
+  spend_requirement: 1500
+  timeframe_months: 3
+apr:
+  regular:
+    min: 18.74
+    max: 27.74
+benefits:
+  - name: "Travel Experience Credit"
+    value: 100
+    description: "Up to $100 in annual statement credits for ground transportation, streaming services, and ticket agencies"
+    frequency: "annual"
+    category: "travel"
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 120
+    description: "Up to $120 statement credit for a Global Entry or TSA PreCheck application fee, once every four years"
+    frequency: "multi_year"
+    frequency_years: 4
+    category: "security"
+  - name: "Loyalty Cash Bonus"
+    value: 10
+    value_unit: "percent"
+    description: "10% to 50% bonus on points redeemed into an eligible Truist deposit account, with the tier set by your combined Truist balances"
+    frequency: "per_redemption"
+    category: "rewards"
+apply_link: https://www.truist.com/credit-cards/enjoy-beyond
+our_take: >
+  Enjoy Beyond is Truist's premium travel card at $95 a year: a metal card
+  earning 3x on airfare, hotels, and car rentals, 2x on dining, and 1x on
+  everything else, with 30,000 bonus points after $1,500 in 90 days. The
+  bonus threshold is low enough that most applicants will clear it on ordinary
+  spending. Two credits do most of the work on the fee, a $100 annual travel
+  experience credit covering ground transportation, streaming, and ticket
+  agencies, and up to $120 for Global Entry or TSA PreCheck every four years,
+  so the annual credit alone roughly covers the annual fee if you use it.
+  What you do not get is transfer partners: points redeem through Truist
+  rather than to airline or hotel programs, so the ceiling on their value is
+  fixed and the card cannot chase premium cabin redemptions the way a
+  transferable currency can. The 10% to 50% Loyalty Cash Bonus for redeeming
+  into a Truist account is the lever that makes this card competitive, and it
+  only pulls if Truist already holds your deposits.

--- a/data/cards/truist-enjoy-cash-1-5.yaml
+++ b/data/cards/truist-enjoy-cash-1-5.yaml
@@ -1,0 +1,50 @@
+name: "Truist Enjoy Cash 1.5%"
+bank: "Truist"
+slug: "truist-enjoy-cash-1-5"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0
+foreign_transaction_fee: false
+network: "visa"
+reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+rewards:
+  - category: everything_else
+    value: 1.5
+    unit: percent
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.74
+    max: 27.74
+benefits:
+  - name: "Loyalty Cash Bonus"
+    value: 10
+    value_unit: "percent"
+    description: "10% to 50% bonus on cash rewards redeemed into an eligible Truist deposit account, with the tier set by your combined Truist balances"
+    frequency: "per_redemption"
+    category: "rewards"
+apply_link: https://creditcard.digitalcommerce.truist.com/product/CRW
+page_check_url: https://www.truist.com/credit-cards/enjoy-cash
+our_take: >
+  This is the flat rate half of Truist Enjoy Cash: 1.5% on everything, no
+  categories, no caps, no annual fee. You choose between this and the tiered
+  3-2-1 version when you apply, and the choice is permanent, so it is worth
+  doing the arithmetic once. The tiered card caps its bonus rates at $1,000 of
+  combined monthly spending; if your gas, grocery, and utility spending runs
+  past that, or simply lands in categories the tiered version does not reward,
+  this version earns more. At 1.5% it is a middling flat rate card on its own,
+  since 2% cards with no annual fee are easy to find. What can move it is the
+  Loyalty Cash Bonus: redeem into an eligible Truist deposit account and 10% to
+  50% gets added, which at the top tier turns 1.5% into an effective 2.25%.
+  That upper tier takes a substantial Truist balance, so read the card as a
+  relationship product first and a flat rate card second. No foreign
+  transaction fees, and 12 months of 0% APR on purchases and on balance
+  transfers made in the first 90 days.

--- a/data/cards/truist-enjoy-cash-3-2-1.yaml
+++ b/data/cards/truist-enjoy-cash-3-2-1.yaml
@@ -1,6 +1,8 @@
-name: "Truist Enjoy Cash"
+name: "Truist Enjoy Cash 3-2-1"
 bank: "Truist"
-slug: "truist-enjoy-cash"
+slug: "truist-enjoy-cash-3-2-1"
+also_known_as:
+  - "Truist Enjoy Cash"
 accepting_applications: true
 category: "cashback"
 annual_fee: 0
@@ -42,7 +44,6 @@ rewards:
   - category: everything_else
     value: 1
     unit: percent
-    note: "A flat 1.5% on everything is offered as an alternative rewards structure chosen at application and locked in for the life of the account"
 apr:
   purchase_intro:
     rate: 0
@@ -60,19 +61,19 @@ benefits:
     description: "10% to 50% bonus on cash rewards redeemed into an eligible Truist deposit account, with the tier set by your combined Truist balances"
     frequency: "per_redemption"
     category: "rewards"
-apply_link: https://www.truist.com/credit-cards/enjoy-cash
+apply_link: https://creditcard.digitalcommerce.truist.com/product/CR3
+page_check_url: https://www.truist.com/credit-cards/enjoy-cash
 our_take: >
-  Truist Enjoy Cash asks you to pick a rewards structure at application and
-  live with it: either 3% on gas and EV charging plus 2% on groceries and
-  utilities, or a flat 1.5% on everything. The tiered option carries a
-  combined $1,000 monthly cap across both bonus tiers, so about $12,000 a year
-  of bonus spending, and everything past it earns 1%. That cap is what makes
-  the choice close, because a household putting more than a thousand dollars a
-  month through gas, groceries, and utilities is better off on the flat 1.5%.
-  There is no traditional welcome bonus, only the Loyalty Cash Bonus of 10% to
-  50% for redeeming into a Truist deposit account, which means the card pays
-  best if you already bank with Truist and worst if you do not. No annual fee
-  and no foreign transaction fees are genuine positives, and the 12 months of
-  0% APR on purchases and on balance transfers made in the first 90 days give
-  it some use as a payoff card. Outside the Truist relationship, a flat 2%
-  card beats every version of this one.
+  Truist sells one Enjoy Cash card with two rewards structures, and this is the
+  tiered one: 3% on gas and EV charging, 2% on groceries and utilities, and 1%
+  on everything else. You pick the structure when you apply and Truist does not
+  let you change it later, so the choice between this and the flat 1.5% version
+  is permanent. The deciding number is the cap: the 3% and 2% tiers share
+  $1,000 of spending a month, about $12,000 a year, and everything past it
+  earns 1%. Fill that cap with gas and groceries and this version wins
+  comfortably; go much beyond it and the flat card catches up and passes it.
+  There is no welcome bonus in either version, only the Loyalty Cash Bonus of
+  10% to 50% for redeeming into a Truist deposit account, so the card pays best
+  to existing Truist customers. No annual fee, no foreign transaction fees, and
+  12 months of 0% APR on purchases and on balance transfers made in the first
+  90 days round it out.

--- a/data/cards/truist-enjoy-cash-secured.yaml
+++ b/data/cards/truist-enjoy-cash-secured.yaml
@@ -1,0 +1,75 @@
+name: "Truist Enjoy Cash Secured"
+bank: "Truist"
+slug: "truist-enjoy-cash-secured"
+accepting_applications: true
+category: "secured"
+annual_fee: 0
+foreign_transaction_fee: false
+network: "visa"
+reward_type: "cashback"
+tags:
+  - secured
+  - credit_builder
+  - cashback
+rewards:
+  - category: gas
+    value: 3
+    unit: percent
+    note: "$1,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 1000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: ev_charging
+    value: 3
+    unit: percent
+    note: "$1,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 1000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: groceries
+    value: 2
+    unit: percent
+    note: "$1,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 1000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: utilities
+    value: 2
+    unit: percent
+    note: "$1,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 1000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: everything_else
+    value: 1
+    unit: percent
+apr:
+  regular:
+    min: 26.74
+    max: 26.74
+benefits:
+  - name: "Loyalty Cash Bonus"
+    value: 10
+    value_unit: "percent"
+    description: "10% to 50% bonus on cash rewards redeemed into an eligible Truist deposit account, with the tier set by your combined Truist balances"
+    frequency: "per_redemption"
+    category: "rewards"
+  - name: "Credit Bureau Reporting"
+    value: 0
+    description: "Payment history reported monthly to all three major credit bureaus"
+    frequency: "monthly"
+    category: "security"
+apply_link: https://www.truist.com/credit-cards/enjoy-cash-secured
+our_take: >
+  Most secured cards give you nothing but a place to build history, so a
+  secured card earning 3% on gas and EV charging and 2% on groceries and
+  utilities is unusual, and Truist charges no annual fee to run it. The
+  security deposit starts at $400 and sets your credit limit, and payments
+  report to all three bureaus, which is the part that actually moves your
+  score. Read the limits before you get excited: the bonus rates share one
+  $1,000 monthly cap and drop to 1% past it, there is no intro APR, and the
+  rate is a flat 26.74%, so any balance you carry costs far more than the
+  rewards pay. Truist also publishes no automatic graduation path to an
+  unsecured card, so plan on asking for your deposit back rather than waiting
+  to be upgraded. Best used for a few small recurring charges paid in full
+  every month.

--- a/data/cards/truist-enjoy-cash.yaml
+++ b/data/cards/truist-enjoy-cash.yaml
@@ -1,0 +1,78 @@
+name: "Truist Enjoy Cash"
+bank: "Truist"
+slug: "truist-enjoy-cash"
+accepting_applications: true
+category: "cashback"
+annual_fee: 0
+foreign_transaction_fee: false
+network: "visa"
+reward_type: "cashback"
+tags:
+  - cashback
+  - rewards
+rewards:
+  - category: gas
+    value: 3
+    unit: percent
+    note: "$1,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 1000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: ev_charging
+    value: 3
+    unit: percent
+    note: "$1,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 1000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: groceries
+    value: 2
+    unit: percent
+    note: "$1,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 1000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: utilities
+    value: 2
+    unit: percent
+    note: "$1,000 combined monthly cap across the 3% and 2% categories; 1% thereafter"
+    spend_cap: 1000
+    cap_period: monthly
+    rate_after_cap: 1
+  - category: everything_else
+    value: 1
+    unit: percent
+    note: "A flat 1.5% on everything is offered as an alternative rewards structure chosen at application and locked in for the life of the account"
+apr:
+  purchase_intro:
+    rate: 0
+    months: 12
+  balance_transfer_intro:
+    rate: 0
+    months: 12
+  regular:
+    min: 18.74
+    max: 27.74
+benefits:
+  - name: "Loyalty Cash Bonus"
+    value: 10
+    value_unit: "percent"
+    description: "10% to 50% bonus on cash rewards redeemed into an eligible Truist deposit account, with the tier set by your combined Truist balances"
+    frequency: "per_redemption"
+    category: "rewards"
+apply_link: https://www.truist.com/credit-cards/enjoy-cash
+our_take: >
+  Truist Enjoy Cash asks you to pick a rewards structure at application and
+  live with it: either 3% on gas and EV charging plus 2% on groceries and
+  utilities, or a flat 1.5% on everything. The tiered option carries a
+  combined $1,000 monthly cap across both bonus tiers, so about $12,000 a year
+  of bonus spending, and everything past it earns 1%. That cap is what makes
+  the choice close, because a household putting more than a thousand dollars a
+  month through gas, groceries, and utilities is better off on the flat 1.5%.
+  There is no traditional welcome bonus, only the Loyalty Cash Bonus of 10% to
+  50% for redeeming into a Truist deposit account, which means the card pays
+  best if you already bank with Truist and worst if you do not. No annual fee
+  and no foreign transaction fees are genuine positives, and the 12 months of
+  0% APR on purchases and on balance transfers made in the first 90 days give
+  it some use as a payoff card. Outside the Truist relationship, a flat 2%
+  card beats every version of this one.

--- a/data/cards/truist-enjoy-travel.yaml
+++ b/data/cards/truist-enjoy-travel.yaml
@@ -1,0 +1,61 @@
+name: "Truist Enjoy Travel"
+bank: "Truist"
+slug: "truist-enjoy-travel"
+accepting_applications: true
+category: "travel"
+annual_fee: 0
+foreign_transaction_fee: false
+network: "visa"
+reward_type: "miles"
+tags:
+  - travel
+  - rewards
+rewards:
+  - category: airlines
+    value: 2
+    unit: points_per_dollar
+  - category: hotels
+    value: 2
+    unit: points_per_dollar
+  - category: car_rentals
+    value: 2
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 20000
+  type: "miles"
+  spend_requirement: 1500
+  timeframe_months: 3
+apr:
+  regular:
+    min: 18.74
+    max: 27.74
+benefits:
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 85
+    description: "Up to $85 statement credit for a Global Entry or TSA PreCheck application fee, once every four years"
+    frequency: "multi_year"
+    frequency_years: 4
+    category: "security"
+  - name: "Loyalty Travel Bonus"
+    value: 10
+    value_unit: "percent"
+    description: "10% to 50% bonus when miles are redeemed for travel, with the tier set by your combined Truist deposit balances"
+    frequency: "per_redemption"
+    category: "rewards"
+apply_link: https://www.truist.com/credit-cards/enjoy-travel
+our_take: >
+  Enjoy Travel is the no annual fee travel card in Truist's lineup: 2 miles per
+  dollar on airfare, hotels, and car rentals, 1 mile everywhere else, and
+  20,000 bonus miles after $1,500 of spending in 90 days. Miles redeem for
+  travel, cash back, gift cards, or merchandise rather than transferring to
+  airline or hotel programs, so treat them as roughly a cent each and judge
+  the card as a 2% travel earner, not as a points card. Two things push it
+  above a plain cash back card for occasional travelers: no foreign
+  transaction fees, and a Global Entry or TSA PreCheck credit of up to $85
+  every four years, which is rare at $0 a year. The Loyalty Travel Bonus of
+  10% to 50% on redemptions is only worth counting if you keep meaningful
+  balances at Truist. Without that relationship, a flat 2% card with no annual
+  fee does the same work with fewer strings.

--- a/data/cards/truist-future.yaml
+++ b/data/cards/truist-future.yaml
@@ -1,0 +1,34 @@
+name: "Truist Future"
+bank: "Truist"
+slug: "truist-future"
+accepting_applications: true
+category: "balance_transfer"
+annual_fee: 0
+foreign_transaction_fee: false
+network: "visa"
+tags:
+  - balance_transfer
+apr:
+  purchase_intro:
+    rate: 0
+    months: 15
+  balance_transfer_intro:
+    rate: 0
+    months: 15
+  regular:
+    min: 16.74
+    max: 25.74
+apply_link: https://www.truist.com/credit-cards/future
+our_take: >
+  Truist Future earns nothing, and that is the point: it is a low rate card
+  built for carrying a balance, with 15 months at 0% on purchases and on
+  balance transfers made within the first 90 days, then a regular range of
+  16.74% to 25.74% that starts about two points below Truist's rewards cards.
+  The balance transfer fee is 3% with a $10 minimum, so moving $8,000 costs
+  $240 up front and buys you more than a year of interest free runway. There
+  is no annual fee and no foreign transaction fee. The 90 day transfer window
+  is the trap to watch, since a transfer requested later pays the regular rate
+  from day one. Longer 0% windows exist elsewhere, but the low ongoing rate
+  after the intro period is what distinguishes this one, and it matters if you
+  expect to still be paying the balance down when the promo ends. Pay it off,
+  then move your spending to a card that actually earns.


### PR DESCRIPTION
Truist had no cards in the catalog. That cost us a real data point in this morning's Reddit run: an approval for the Truist secured card with FICO 596/580/545 and a $1,000 line was skipped as `card_not_in_catalog`.

This adds the whole issuer, consumer and business, rather than just the secured card, so the gap does not come back the next time a Truist post shows up.

## Cards

| Card | AF | Headline earn | SUB | Notes |
|---|---|---|---|---|
| Truist Enjoy Cash 3-2-1 | $0 | 3% gas/EV, 2% groceries/utilities ($1k/mo combined cap), 1% else | none | 0% for 12 mo on purchases and BT |
| Truist Enjoy Cash 1.5% | $0 | flat 1.5%, no caps | none | same APRs and fees, different permanent rewards choice |
| Truist Enjoy Cash Secured | $0 | same rates as the 3-2-1 | none | $400 minimum deposit, flat 26.74% APR |
| Truist Enjoy Travel | $0 | 2x airfare/hotels/car rentals | 20k miles / $1,500 / 90 days | $85 Global Entry or PreCheck credit, no FTF |
| Truist Enjoy Beyond | $95 | 3x airfare/hotels/car rentals, 2x dining | 30k points / $1,500 / 90 days | $100 annual travel credit, $120 Global Entry credit |
| Truist Future | $0 | no rewards | none | 0% for 15 mo, 16.74–25.74% ongoing |
| Truist Business Cash Rewards | $0 | 3% gas, 2% dining/office supplies ($2k/mo combined cap) | $300 / $3,000 / 90 days | 0% for 9 mo on purchases |
| Truist Business Premium | $299 | flat 2% | $1,000 / $15,000 / 90 days | AF waived year one and in any $100k spend year |
| Truist Business Travel Rewards | $49 | 2x airfare/hotels/car rentals | 20k miles / $2,000 / 90 days | AF waived year one, $120 Global Entry credit, no FTF |
| Truist Business | $0 | no rewards | none | 0% for 12 mo, lowest ongoing APR in the lineup at 13.74–22.74% |

## Why Enjoy Cash is two cards

Truist markets one Enjoy Cash card with two rewards structures, chosen at application and, in their words, not changeable later. Since the choice is permanent, the two behave as separate products with different math: the tiered version caps its 3% and 2% rates at $1,000 of combined monthly spend, so past roughly $12k a year of gas, grocery, and utility spending the flat 1.5% version earns more.

- Names follow Truist's own apply-button labels, "Apply now (3%-2%-1%)" and "Apply now (1.5%)".
- `apply_link` points at each distinct product code (CR3 and CRW). Those pages render client side, so `page_check_url` sends check-card-pages to the shared marketing page instead.
- The 3-2-1 entry carries `also_known_as: Truist Enjoy Cash`, so a Reddit post that just says "Enjoy Cash" still resolves to a card rather than being dropped as unclear. It resolves to the option Truist leads with, which is a deliberate bias worth knowing about: an applicant who picked the flat version and did not say so gets attributed to the tiered entry. Underwriting is the same either way, so this only affects which card page the data point lands on.

## Verification

Every rate, fee, APR, and benefit was read off that product's own page on truist.com today (2026-08-11), not off blogs. `npm run build:cards` passes: 219 cards, all ten OK, no warnings. `cards.json` is gitignored and not included.

One remaining judgment call: **foreign transaction fee is omitted on three business cards** (Business Cash Rewards, Business Premium, Business) because Truist does not disclose it on those pages. Absent means unknown, not zero.

## Follow-ups

- **Card art is missing for all ten.** They render the generic-card fallback until you drop PNGs into `data/cards/images/` and run `compress-card-images.js`.
- `data/bank-twitter-handles.json` has no Truist entry, so new-card posts about these will not @mention the issuer. Left out rather than guessing the handle.
