### PR TITLE
Card page: move the replacement rail to the bottom and add a banner shortcut

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -38,6 +38,9 @@ import posthog from "posthog-js";
 import { V2Footer } from "@/components/landing-v2/Chrome";
 import { ReplacementCards } from "@/components/ui/ReplacementCards";
 import CardRecordsTable from "./CardRecordsTable";
+
+/** Shared by the banner shortcut at the top and the rail it scrolls to. */
+const REPLACEMENTS_ANCHOR = "what-to-get-instead";
 import ProductChangeFlow, { ProductChangeNode } from "./ProductChangeFlow";
 import "../../landing.css";
 
@@ -298,6 +301,13 @@ export default function CardClient({
   bestRankings = [],
   productChanges,
 }: CardClientProps) {
+  // "What to get instead" is rendered at the bottom of the page but advertised
+  // in the pulled-card banner at the top, so both need the same id and the same
+  // answer to "does this card have replacements at all".
+  const replacementCards = card.replacement_cards_info ?? [];
+  const hasReplacements =
+    card.accepting_applications === false && replacementCards.length > 0;
+
   // ---------- State + chrome ----------
   const [showModal, setShowModal] = useState(false);
   // Approved/Denied prefill when the modal is opened from the post-apply
@@ -898,34 +908,45 @@ export default function CardClient({
             fontWeight: 500,
             display: "flex",
             alignItems: "center",
-            gap: 10,
+            justifyContent: "space-between",
+            gap: 12,
           }}
         >
-          <ExclamationTriangleIcon style={{ height: 16, width: 16 }} />
-          {card.active === false
-            ? "This card has been discontinued and is no longer offered."
-            : "This card is no longer accepting applications."}
+          <span style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+            <ExclamationTriangleIcon style={{ height: 16, width: 16, flexShrink: 0 }} />
+            {card.active === false
+              ? "This card has been discontinued and is no longer offered."
+              : "This card is no longer accepting applications."}
+          </span>
+
+          {/* Shortcut to the rail at the bottom of the page. The banner raises
+              the question and the answer is 3,000px away, so this carries the
+              reader there. Rendered only when that section actually exists. */}
+          {/* Plain anchor, no JS scroll handler: scrollIntoView with behavior
+              "smooth" silently no-ops in some engines (verified here: "auto"
+              scrolls, "smooth" leaves scrollY at 0), and the native jump
+              already honours the rail's scroll-margin-top. It also works
+              without JS and leaves a shareable hash. */}
+          {hasReplacements && (
+            <a href={`#${REPLACEMENTS_ANCHOR}`} className="cj-pulled-jump">
+              <span className="cj-pulled-jump-thumbs" aria-hidden="true">
+                {replacementCards.slice(0, 3).map((rc) => (
+                  <span className="cj-pulled-jump-thumb" key={rc.slug}>
+                    <CardImage
+                      cardImageLink={rc.image}
+                      alt={rc.name}
+                      fill
+                      sizes="34px"
+                      style={{ objectFit: "contain" }}
+                    />
+                  </span>
+                ))}
+              </span>
+              What to get instead
+            </a>
+          )}
         </div>
       )}
-
-      {/* "What to get instead", directly under the banner that just told the
-          reader this card is gone. Deliberately above the fold rather than down
-          with Related Cards: the banner creates the question, so the answer
-          belongs next to it. build-cards.js only populates
-          replacement_cards_info on closed cards, so no open-card guard is
-          needed here — but the rail is wrapped anyway to keep a data mistake
-          from rendering a competitor list on a live card. */}
-      {card.accepting_applications === false &&
-        (card.replacement_cards_info?.length ?? 0) > 0 && (
-          <div className="replacement-cards-banner-slot">
-            <ReplacementCards
-              cards={card.replacement_cards_info ?? []}
-              surface="card_page"
-              sourceId={card.slug}
-              intro="This card is closed to new applicants. These are open and cover the same ground:"
-            />
-          </div>
-        )}
 
       <div className="cj-layout">
         {/* Left ToC */}
@@ -1783,6 +1804,26 @@ export default function CardClient({
                 })}
               </div>
             </section>
+          )}
+
+          {/* "What to get instead". Lives at the very bottom of the main
+              column: at the top it sat outside the .cj-layout grid, which left
+              a dead white gutter beside it and pushed the card itself below the
+              fold. Down here it inherits the column width and reads as a
+              closing recommendation, after the reader has seen what the card
+              actually was.
+
+              build-cards.js only populates replacement_cards_info on closed
+              cards, so the open-card guard is belt-and-braces against a data
+              mistake rendering a competitor list on a live card. */}
+          {hasReplacements && (
+            <ReplacementCards
+              cards={replacementCards}
+              surface="card_page"
+              sourceId={card.slug}
+              anchorId={REPLACEMENTS_ANCHOR}
+              intro="This card is closed to new applicants. These are open and cover the same ground:"
+            />
           )}
         </main>
 

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -7188,26 +7188,69 @@
   }
 }
 
-/* Card-page placement. The rail itself was styled for article prose inside
-   .article-body; on a card page it sits full-bleed directly under the
-   pulled-card banner, so the slot supplies the page gutter the card layout
-   would otherwise provide and caps line length on wide screens. The rail's own
-   36px margin-top is overridden because here it follows a banner, not
-   paragraphs. Longhand padding on purpose: a shorthand here would be
-   overwritten wholesale by the mobile override below. */
-.landing-v2.card-journal .replacement-cards-banner-slot {
-  padding-inline: 24px;
-  padding-bottom: 24px;
-  border-bottom: 1px solid var(--line);
+/* Card-page placement: last block in .cj-main, so it inherits the column's
+   width and padding and needs no gutter of its own. It previously sat
+   full-bleed under the pulled-card banner, which left a dead gutter beside its
+   720px cap and pushed the card below the fold.
+   The section rhythm on this page is heavier than article prose, so the rail's
+   own 36px top margin is opened up to match the gap between card sections. */
+.landing-v2.card-journal .cj-main > .replacement-cards {
+  margin-top: 44px;
+  margin-bottom: 8px;
+  /* Square on the card page. The rounded 12px box reads as a floating card,
+     which fights the hard-edged section rhythm this page uses. Scoped here so
+     the news article rail, which sits in rounded prose, keeps its radius. */
+  border-radius: 0;
+  /* Clears the 65px sticky navbar when the banner shortcut jumps here, so the
+     heading is not tucked underneath. Same allowance as the BCFM wizard. */
+  scroll-margin-top: 84px;
 }
-.landing-v2.card-journal .replacement-cards-banner-slot .replacement-cards {
-  margin-top: 20px;
-  max-width: 720px;
+/* Square all the way down: the tiles and their art boxes, so nothing inside
+   the squared container is still rounded. */
+.landing-v2.card-journal .cj-main > .replacement-cards .replacement-card,
+.landing-v2.card-journal .cj-main > .replacement-cards .replacement-card-thumb {
+  border-radius: 0;
 }
-@media (max-width: 767px) {
-  .landing-v2.card-journal .replacement-cards-banner-slot {
-    padding-inline: 16px;
-    padding-bottom: 20px;
+
+/* Pulled-card banner shortcut down to the rail. */
+.landing-v2.card-journal .cj-pulled-jump {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  /* Reads as part of the banner sentence, not as a button: same colour, same
+     13px/500 weight as the warning text, no underline. The card thumbnails
+     beside it are what signal it is clickable. */
+  color: inherit;
+  font-weight: inherit;
+  text-decoration: none;
+  line-height: 1.2;
+}
+.landing-v2.card-journal .cj-pulled-jump:hover {
+  opacity: 0.75;
+}
+.landing-v2.card-journal .cj-pulled-jump-thumbs {
+  display: inline-flex;
+  align-items: center;
+}
+/* Overlapped like a small stack so three cards cost ~60px, not ~110px. */
+.landing-v2.card-journal .cj-pulled-jump-thumb {
+  position: relative;
+  width: 34px;
+  height: 22px;
+  overflow: hidden;
+  background: var(--card);
+  border: 1px solid var(--line);
+  margin-right: -10px;
+}
+.landing-v2.card-journal .cj-pulled-jump-thumb:last-child {
+  margin-right: 0;
+}
+/* The banner is a single line of text on a narrow screen; the thumbnails are
+   the first thing to go, then the label wraps under the message. */
+@media (max-width: 640px) {
+  .landing-v2.card-journal .cj-pulled-jump-thumbs {
+    display: none;
   }
 }
 

--- a/apps/web-next/src/components/ui/ReplacementCards.tsx
+++ b/apps/web-next/src/components/ui/ReplacementCards.tsx
@@ -24,6 +24,11 @@ interface Props {
   sourceId: string;
   /** Optional override; each surface has a different natural lead-in. */
   intro?: string;
+  /**
+   * DOM id for in-page links. Only the card page sets it, so the news markup
+   * is unchanged and no id can ever collide across the two surfaces.
+   */
+  anchorId?: string;
 }
 
 function feeLabel(annualFee: number | null): string | null {
@@ -31,7 +36,7 @@ function feeLabel(annualFee: number | null): string | null {
   return annualFee === 0 ? 'No annual fee' : `$${annualFee.toLocaleString('en-US')} annual fee`;
 }
 
-export function ReplacementCards({ cards, surface, sourceId, intro }: Props) {
+export function ReplacementCards({ cards, surface, sourceId, intro, anchorId }: Props) {
   if (!cards || cards.length === 0) return null;
 
   // The intro deliberately names no card. On a straight pull the article's
@@ -39,7 +44,7 @@ export function ReplacementCards({ cards, surface, sourceId, intro }: Props) {
   // card_slug points at the live replacement, so naming the subject would
   // assert the opposite of the truth on half the articles that use this module.
   return (
-    <aside className="replacement-cards" aria-labelledby="replacement-cards-title">
+    <aside id={anchorId} className="replacement-cards" aria-labelledby="replacement-cards-title">
       <h2 id="replacement-cards-title" className="replacement-cards-title">
         What to get instead
       </h2>


### PR DESCRIPTION
Follow-up to #1996, all from looking at the rendered page.

## The problem

The rail sat outside the `.cj-layout` grid, directly under the pulled-card banner. Because it was capped at 720px inside a full-bleed container, everything to its right was dead white space, and the card itself was pushed below the fold.

## Changes

**Moved to the bottom of `.cj-main`.** It now inherits the content column instead of fighting it. Verified in the browser: left edge 240px and width 699px, exactly matching the card sections above it, with a 44px gap matching the page's section rhythm. The top of the page opens on the card again.

**Squared off**, per review: the container, the tiles, and the art boxes. Scoped to the card page, so the news rail keeps its 12px radius, which still suits the rounded prose it sits in.

**Banner shortcut.** The banner raises "this card is gone" and the answer is now ~3,000px away, so the banner gained a right-aligned link: three overlapped card thumbnails plus "What to get instead". Styled to match the warning text exactly rather than as a button (same colour, weight 500, 13px, no underline) — the thumbnails are what signal it is clickable. Rendered only when the section exists.

## Two implementation notes

**No JS scroll handler.** The first version used `scrollIntoView({behavior: 'smooth'})` and it silently did nothing. Verified locally: `behavior: 'auto'` scrolls, `'smooth'` leaves `scrollY` at 0. The plain anchor is better anyway — it honours the new `scroll-margin-top`, works without JS, and leaves a shareable hash. Confirmed the jump lands the rail 84px from the viewport top, clearing the 65px sticky navbar.

**Mobile.** The thumbnails hide under 640px so the banner stays a single line.

## Verification

`tsc` and `eslint` clean. Rendered and inspected on Citi Custom Cash, Amex Green and Chase Freedom; absent on live cards; news rail unchanged. Geometry, computed styles and the anchor jump all checked in the browser rather than by eye.