### PR TITLE
Add /labs with the Paze Tracker

### DIFF
--- a/apps/web-next/src/app/labs/page.tsx
+++ b/apps/web-next/src/app/labs/page.tsx
@@ -1,0 +1,96 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { V2Footer } from '@/components/landing-v2/Chrome';
+import { PAZE_MERCHANTS } from './paze-tracker/merchants';
+import '../landing.css';
+
+export const metadata: Metadata = {
+  title: 'Labs',
+  description:
+    'Experiments from CreditOdds. Trackers and tools for the parts of the payments world nobody documents properly.',
+  openGraph: {
+    title: 'Labs | CreditOdds',
+    description: 'Experiments and trackers from CreditOdds.',
+    url: 'https://creditodds.com/labs',
+    type: 'website',
+  },
+  alternates: {
+    canonical: 'https://creditodds.com/labs',
+  },
+};
+
+interface Lab {
+  name: string;
+  description: string;
+  href: string;
+  /** Short right-aligned stat, the way /tools shows cents per point. */
+  stat: string;
+}
+
+const labs: Lab[] = [
+  {
+    name: 'Paze Tracker',
+    description:
+      'Every merchant that accepts Paze, plus how it actually works at each one: reload caps, timing rules, and live Paze offers.',
+    href: '/labs/paze-tracker',
+    stat: `${PAZE_MERCHANTS.length} merchants`,
+  },
+];
+
+export default function LabsPage() {
+  return (
+    <div className="landing-v2 labs-v2">
+      <BreadcrumbSchema
+        items={[
+          { name: 'Home', url: 'https://creditodds.com' },
+          { name: 'Labs', url: 'https://creditodds.com/labs' },
+        ]}
+      />
+
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <span className="cj-crumb cj-crumb-current" aria-current="page">Labs</span>
+        </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
+          <span><span className="cj-status-dot" />{labs.length} live</span>
+        </div>
+      </div>
+
+      <section className="page-hero wrap">
+        <h1 className="page-title">
+          Labs. <em>Work in progress.</em>
+        </h1>
+        <p className="page-sub">
+          Experiments we are building in the open. Rougher than the calculators in
+          Tools, and changing week to week.
+        </p>
+      </section>
+
+      <div className="wrap" style={{ paddingTop: 24, paddingBottom: 64 }}>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {labs.map((lab) => (
+            <Link
+              key={lab.href}
+              href={lab.href}
+              className="bg-white rounded-lg shadow p-5 hover:shadow-md transition-shadow group"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <h2 className="text-base font-semibold text-gray-900 group-hover:text-indigo-600 truncate">
+                  {lab.name}
+                </h2>
+                <span className="inline-flex items-center rounded-md px-2 py-1 text-sm font-semibold ring-1 ring-inset bg-indigo-50 text-indigo-700 ring-indigo-600/20 whitespace-nowrap">
+                  {lab.stat}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-gray-500">{lab.description}</p>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <V2Footer />
+    </div>
+  );
+}

--- a/apps/web-next/src/app/labs/paze-tracker/PazeTrackerClient.tsx
+++ b/apps/web-next/src/app/labs/paze-tracker/PazeTrackerClient.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  PAZE_CATEGORIES,
+  PAZE_MERCHANTS,
+  PAZE_DIRECTORY_CAPTURED,
+  type PazeCategory,
+} from './merchants';
+
+type Filter = PazeCategory | 'All';
+/** Merchants with field notes are the reason to visit, so they get their own filter. */
+type NotesFilter = 'all' | 'with-notes';
+
+export default function PazeTrackerClient() {
+  const [category, setCategory] = useState<Filter>('All');
+  const [notesOnly, setNotesOnly] = useState<NotesFilter>('all');
+  const [query, setQuery] = useState('');
+
+  const withNotesCount = useMemo(
+    () => PAZE_MERCHANTS.filter((m) => m.usage).length,
+    [],
+  );
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return PAZE_MERCHANTS.filter((m) => {
+      if (category !== 'All' && m.category !== category) return false;
+      if (notesOnly === 'with-notes' && !m.usage) return false;
+      if (q && !m.name.toLowerCase().includes(q)) return false;
+      return true;
+    }).sort((a, b) => {
+      // Merchants we know something about lead; the rest stay alphabetical so
+      // the list is still scannable as a directory.
+      if (Boolean(a.usage) !== Boolean(b.usage)) return a.usage ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [category, notesOnly, query]);
+
+  return (
+    <div className="labs-paze">
+      <div className="labs-controls">
+        <input
+          type="search"
+          className="labs-search"
+          placeholder="Search merchants"
+          aria-label="Search merchants"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <div className="labs-chips" role="group" aria-label="Filter by category">
+          <button
+            type="button"
+            className={`labs-chip${category === 'All' ? ' is-active' : ''}`}
+            onClick={() => setCategory('All')}
+          >
+            All ({PAZE_MERCHANTS.length})
+          </button>
+          {PAZE_CATEGORIES.map((c) => {
+            const n = PAZE_MERCHANTS.filter((m) => m.category === c).length;
+            if (n === 0) return null;
+            return (
+              <button
+                key={c}
+                type="button"
+                className={`labs-chip${category === c ? ' is-active' : ''}`}
+                onClick={() => setCategory(c)}
+              >
+                {c} ({n})
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            className={`labs-chip labs-chip-notes${notesOnly === 'with-notes' ? ' is-active' : ''}`}
+            onClick={() => setNotesOnly(notesOnly === 'with-notes' ? 'all' : 'with-notes')}
+            aria-pressed={notesOnly === 'with-notes'}
+          >
+            Has notes ({withNotesCount})
+          </button>
+        </div>
+      </div>
+
+      <p className="labs-count">
+        {visible.length} of {PAZE_MERCHANTS.length} merchants
+        {notesOnly === 'with-notes' && ' with field notes'}
+      </p>
+
+      {visible.length === 0 ? (
+        <p className="labs-empty">
+          No merchants match that. Clear the search or pick a different category.
+        </p>
+      ) : (
+        <ul className="labs-list">
+          {visible.map((m) => (
+            <li key={m.slug} className="labs-row">
+              <div className="labs-row-head">
+                <a
+                  href={m.url}
+                  className="labs-row-name"
+                  target="_blank"
+                  rel="noopener noreferrer nofollow"
+                >
+                  {m.name}
+                </a>
+                <span className="labs-row-cat">{m.category}</span>
+              </div>
+
+              {m.offer && (
+                <p className="labs-row-offer">
+                  <span className="labs-tag">Paze offer</span>
+                  {m.offer}
+                </p>
+              )}
+
+              {m.usage ? (
+                <p className="labs-row-usage">{m.usage}</p>
+              ) : (
+                <p className="labs-row-empty">
+                  No notes yet. If you have used Paze here, tell us how it works and we
+                  will add it.
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="labs-source">
+        Merchant list transcribed from Paze&apos;s own directory on {PAZE_DIRECTORY_CAPTURED}.
+        Field notes are ours and are only written where someone has confirmed the
+        behaviour, which is why most rows are still empty. Offers are quoted from Paze
+        and can end without notice.
+      </p>
+    </div>
+  );
+}

--- a/apps/web-next/src/app/labs/paze-tracker/merchants.ts
+++ b/apps/web-next/src/app/labs/paze-tracker/merchants.ts
@@ -1,0 +1,111 @@
+/**
+ * Merchants that accept Paze.
+ *
+ * TWO KINDS OF DATA LIVE HERE, and the difference matters:
+ *
+ *   1. `name`, `url`, `category` are transcribed from Paze's own merchant
+ *      directory (https://www.paze.com/merchant-directory), captured
+ *      2026-08-10. Paze paginates that page behind a "Load More" button; the
+ *      full list at capture time was 33 merchants.
+ *
+ *   2. `usage` is OURS. It is the field knowledge that makes this page worth
+ *      visiting: what you can actually do with Paze at that merchant, caps,
+ *      reload rules, gotchas. Paze does not publish any of it.
+ *
+ * Rule for `usage`: only write what someone has actually confirmed. An empty
+ * `usage` renders as "No notes yet" and that is the honest state for most of
+ * this list today. Do not infer a merchant's behaviour from another merchant's.
+ *
+ * `offer` is a Paze-run promotion quoted from Paze's own creative. Quote it,
+ * do not paraphrase it into a stronger claim, and drop it once it expires.
+ */
+
+export type PazeCategory =
+  | 'Apparel & Shoes'
+  | 'Beauty & Health'
+  | 'Electronics'
+  | 'Flowers & Gifts'
+  | 'Food & Grocery'
+  | 'Services'
+  | 'Travel & Entertainment';
+
+/** Paze's own filter taxonomy, in the order the directory lists it. */
+export const PAZE_CATEGORIES: PazeCategory[] = [
+  'Apparel & Shoes',
+  'Beauty & Health',
+  'Electronics',
+  'Flowers & Gifts',
+  'Food & Grocery',
+  'Services',
+  'Travel & Entertainment',
+];
+
+export interface PazeMerchant {
+  slug: string;
+  name: string;
+  /** Where Paze's directory sends you. Some carry Paze campaign parameters. */
+  url: string;
+  category: PazeCategory;
+  /** Our field notes. Empty until someone confirms how it actually works. */
+  usage?: string;
+  /** A live Paze promotion, quoted from Paze's own wording. */
+  offer?: string;
+}
+
+/** Captured from paze.com/merchant-directory on 2026-08-10. */
+export const PAZE_DIRECTORY_CAPTURED = '2026-08-10';
+
+export const PAZE_MERCHANTS: PazeMerchant[] = [
+  {
+    slug: 'dunkin',
+    name: 'Dunkin',
+    url: 'https://dunkin.app.link/dunkinxpaze_2026',
+    category: 'Food & Grocery',
+    usage:
+      'Gift card reload in the Dunkin app: $10 per reload, once every 24 hours. The clock is strict. Attempting another reload before the 24 hours is up restarts the 24 hour window rather than failing quietly, so a mistimed attempt costs you the next one too.',
+    offer: 'Check out in the Dunkin app with Paze and get up to $100 in statement credits.',
+  },
+  {
+    slug: 'dominos',
+    name: "Domino's",
+    url: 'https://www.dominos.com/en/restaurants?utm_campaign=Paze&utm_source=PazeLandingPage&utm_medium=other',
+    category: 'Food & Grocery',
+    offer: "Check out in the Domino's app with Paze and get up to $100 in statement credits.",
+  },
+  {
+    slug: 'newegg',
+    name: 'Newegg',
+    url: 'https://www.newegg.com/paze',
+    category: 'Electronics',
+  },
+  { slug: 'little-caesars', name: 'Little Caesars', url: 'https://littlecaesars.com/en-us/', category: 'Food & Grocery' },
+  { slug: 'whataburger', name: 'Whataburger', url: 'https://whataburger.com/home', category: 'Food & Grocery' },
+  { slug: 'shoprite', name: 'ShopRite', url: 'https://www.shoprite.com/', category: 'Food & Grocery' },
+  { slug: 'gnc', name: 'GNC', url: 'https://www.gnc.com/', category: 'Beauty & Health' },
+  { slug: 'sephora', name: 'Sephora', url: 'https://www.sephora.com/', category: 'Beauty & Health' },
+  { slug: 'pet-supermarket', name: 'Pet Supermarket', url: 'https://www.petsupermarket.com/', category: 'Food & Grocery' },
+  { slug: 'roku', name: 'Roku', url: 'https://www.roku.com/', category: 'Electronics' },
+  { slug: 'xsolla', name: 'Xsolla', url: 'https://xsolla.com/', category: 'Electronics' },
+  { slug: 'payrange', name: 'PayRange', url: 'https://payrange.com/', category: 'Services' },
+  { slug: 'usa-today', name: 'USA Today', url: 'https://www.usatoday.com/', category: 'Services' },
+  { slug: '1-800-flowers', name: '1-800-Flowers', url: 'https://www.1800flowers.com/', category: 'Flowers & Gifts' },
+  { slug: 'ftd', name: 'FTD', url: 'https://www.ftd.com/', category: 'Flowers & Gifts' },
+  { slug: 'proflowers', name: 'Proflowers', url: 'https://www.proflowers.com/', category: 'Flowers & Gifts' },
+  { slug: 'teleflora', name: 'Teleflora', url: 'https://www.teleflora.com/', category: 'Flowers & Gifts' },
+  { slug: 'harry-and-david', name: 'Harry & David', url: 'https://www.harryanddavid.com/', category: 'Flowers & Gifts' },
+  { slug: 'personalization-mall', name: 'Personalization Mall', url: 'https://www.personalizationmall.com/', category: 'Flowers & Gifts' },
+  { slug: 'banter-by-piercing-pagoda', name: 'Banter by Piercing Pagoda', url: 'https://www.banter.com/', category: 'Apparel & Shoes' },
+  { slug: 'jared', name: 'Jared', url: 'https://www.jared.com/', category: 'Apparel & Shoes' },
+  { slug: 'kay-jewelers', name: 'KAY Jewelers', url: 'https://www.kay.com/', category: 'Apparel & Shoes' },
+  { slug: 'zales', name: 'Zales', url: 'https://www.zales.com/', category: 'Apparel & Shoes' },
+  { slug: 'lids', name: 'Lids', url: 'https://www.lids.com/', category: 'Apparel & Shoes' },
+  { slug: 'fanatics', name: 'Fanatics', url: 'https://www.fanatics.com/pazepromo', category: 'Apparel & Shoes' },
+  { slug: 'durango', name: 'Durango', url: 'https://www.durangoboots.com/', category: 'Apparel & Shoes' },
+  { slug: 'georgia-boot', name: 'Georgia Boot', url: 'https://www.georgiaboot.com/', category: 'Apparel & Shoes' },
+  { slug: 'muck-boot-company', name: 'Muck Boot Company', url: 'https://www.muckbootcompany.com/', category: 'Apparel & Shoes' },
+  { slug: 'xtratuf', name: 'XTRATUF', url: 'https://www.xtratuf.com/', category: 'Apparel & Shoes' },
+  { slug: 'broadway-com', name: 'Broadway.com', url: 'https://www.broadway.com/', category: 'Travel & Entertainment' },
+  { slug: 'city-experiences', name: 'City Experiences', url: 'https://www.cityexperiences.com/', category: 'Travel & Entertainment' },
+  { slug: 'stubhub', name: 'StubHub', url: 'https://www.stubhub.com/', category: 'Travel & Entertainment' },
+  { slug: 'united-airlines', name: 'United Airlines', url: 'https://www.united.com/en/us', category: 'Travel & Entertainment' },
+];

--- a/apps/web-next/src/app/labs/paze-tracker/page.tsx
+++ b/apps/web-next/src/app/labs/paze-tracker/page.tsx
@@ -1,0 +1,65 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { BreadcrumbSchema } from '@/components/seo/JsonLd';
+import { V2Footer } from '@/components/landing-v2/Chrome';
+import PazeTrackerClient from './PazeTrackerClient';
+import { PAZE_MERCHANTS } from './merchants';
+import '../../landing.css';
+
+export const metadata: Metadata = {
+  title: 'Paze Tracker',
+  description:
+    'Every merchant that accepts Paze, plus how Paze actually works at each one: reload caps, timing rules, and current Paze offers.',
+  openGraph: {
+    title: 'Paze Tracker | CreditOdds',
+    description:
+      'Every merchant that accepts Paze, plus how Paze actually works at each one.',
+    url: 'https://creditodds.com/labs/paze-tracker',
+    type: 'website',
+  },
+  alternates: {
+    canonical: 'https://creditodds.com/labs/paze-tracker',
+  },
+};
+
+export default function PazeTrackerPage() {
+  return (
+    <div className="landing-v2 labs-v2">
+      <BreadcrumbSchema
+        items={[
+          { name: 'Home', url: 'https://creditodds.com' },
+          { name: 'Labs', url: 'https://creditodds.com/labs' },
+          { name: 'Paze Tracker', url: 'https://creditodds.com/labs/paze-tracker' },
+        ]}
+      />
+
+      <div className="cj-terminal">
+        <nav className="cj-crumbs" aria-label="Breadcrumb">
+          <Link href="/labs" className="cj-crumb">Labs</Link>
+          <span className="cj-crumb-sep">/</span>
+          <span className="cj-crumb cj-crumb-current" aria-current="page">Paze Tracker</span>
+        </nav>
+        <span className="cj-spacer" />
+        <div className="cj-term-actions">
+          <span><span className="cj-status-dot" />{PAZE_MERCHANTS.length} merchants</span>
+        </div>
+      </div>
+
+      <section className="page-hero wrap">
+        <h1 className="page-title">
+          Paze Tracker. <em>Where it works.</em>
+        </h1>
+        <p className="page-sub">
+          Paze publishes a list of merchants. It does not publish the part that
+          matters: what you can actually do once you are there. This tracks both.
+        </p>
+      </section>
+
+      <div className="wrap" style={{ paddingTop: 8, paddingBottom: 64 }}>
+        <PazeTrackerClient />
+      </div>
+
+      <V2Footer />
+    </div>
+  );
+}

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -6814,6 +6814,7 @@
 .landing-v2.bank-v2,
 .landing-v2.best-detail-v2,
 .landing-v2.tools-v2,
+.landing-v2.labs-v2,
 .landing-v2.auth-v2,
 .landing-v2.contact-v2 {
   background: var(--paper);
@@ -6826,6 +6827,7 @@
 .landing-v2.bank-v2 .bg-gray-50,
 .landing-v2.best-detail-v2 .bg-gray-50,
 .landing-v2.tools-v2 .bg-gray-50,
+.landing-v2.labs-v2 .bg-gray-50,
 .landing-v2.auth-v2 .bg-gray-50,
 .landing-v2.contact-v2 .bg-gray-50,
 .landing-v2.check-v2 .bg-gray-100,
@@ -6835,6 +6837,7 @@
 .landing-v2.bank-v2 .bg-gray-100,
 .landing-v2.best-detail-v2 .bg-gray-100,
 .landing-v2.tools-v2 .bg-gray-100,
+.landing-v2.labs-v2 .bg-gray-100,
 .landing-v2.auth-v2 .bg-gray-100,
 .landing-v2.contact-v2 .bg-gray-100 {
   background: var(--paper-2);
@@ -6846,6 +6849,7 @@
 .landing-v2.bank-v2 .bg-white,
 .landing-v2.best-detail-v2 .bg-white,
 .landing-v2.tools-v2 .bg-white,
+.landing-v2.labs-v2 .bg-white,
 .landing-v2.auth-v2 .bg-white,
 .landing-v2.contact-v2 .bg-white {
   background: var(--card);
@@ -6857,6 +6861,7 @@
 .landing-v2.bank-v2 .shadow,
 .landing-v2.best-detail-v2 .shadow,
 .landing-v2.tools-v2 .shadow,
+.landing-v2.labs-v2 .shadow,
 .landing-v2.auth-v2 .shadow,
 .landing-v2.contact-v2 .shadow,
 .landing-v2.check-v2 .shadow-sm,
@@ -6866,6 +6871,7 @@
 .landing-v2.bank-v2 .shadow-sm,
 .landing-v2.best-detail-v2 .shadow-sm,
 .landing-v2.tools-v2 .shadow-sm,
+.landing-v2.labs-v2 .shadow-sm,
 .landing-v2.auth-v2 .shadow-sm,
 .landing-v2.contact-v2 .shadow-sm,
 .landing-v2.check-v2 .shadow-md,
@@ -6875,6 +6881,7 @@
 .landing-v2.bank-v2 .shadow-md,
 .landing-v2.best-detail-v2 .shadow-md,
 .landing-v2.tools-v2 .shadow-md,
+.landing-v2.labs-v2 .shadow-md,
 .landing-v2.auth-v2 .shadow-md,
 .landing-v2.contact-v2 .shadow-md,
 .landing-v2.check-v2 .shadow-lg,
@@ -6884,6 +6891,7 @@
 .landing-v2.bank-v2 .shadow-lg,
 .landing-v2.best-detail-v2 .shadow-lg,
 .landing-v2.tools-v2 .shadow-lg,
+.landing-v2.labs-v2 .shadow-lg,
 .landing-v2.auth-v2 .shadow-lg,
 .landing-v2.contact-v2 .shadow-lg {
   box-shadow: var(--shadow-sm);
@@ -6896,6 +6904,7 @@
 .landing-v2.bank-v2 .text-indigo-600,
 .landing-v2.best-detail-v2 .text-indigo-600,
 .landing-v2.tools-v2 .text-indigo-600,
+.landing-v2.labs-v2 .text-indigo-600,
 .landing-v2.auth-v2 .text-indigo-600,
 .landing-v2.contact-v2 .text-indigo-600,
 .landing-v2.check-v2 .text-indigo-500,
@@ -6905,6 +6914,7 @@
 .landing-v2.bank-v2 .text-indigo-500,
 .landing-v2.best-detail-v2 .text-indigo-500,
 .landing-v2.tools-v2 .text-indigo-500,
+.landing-v2.labs-v2 .text-indigo-500,
 .landing-v2.auth-v2 .text-indigo-500,
 .landing-v2.contact-v2 .text-indigo-500 {
   color: var(--accent);
@@ -6916,6 +6926,7 @@
 .landing-v2.bank-v2 .bg-indigo-50,
 .landing-v2.best-detail-v2 .bg-indigo-50,
 .landing-v2.tools-v2 .bg-indigo-50,
+.landing-v2.labs-v2 .bg-indigo-50,
 .landing-v2.auth-v2 .bg-indigo-50,
 .landing-v2.contact-v2 .bg-indigo-50,
 .landing-v2.check-v2 .bg-indigo-100,
@@ -6925,6 +6936,7 @@
 .landing-v2.bank-v2 .bg-indigo-100,
 .landing-v2.best-detail-v2 .bg-indigo-100,
 .landing-v2.tools-v2 .bg-indigo-100,
+.landing-v2.labs-v2 .bg-indigo-100,
 .landing-v2.auth-v2 .bg-indigo-100,
 .landing-v2.contact-v2 .bg-indigo-100 {
   background: var(--accent-2);
@@ -6936,6 +6948,7 @@
 .landing-v2.bank-v2 .bg-indigo-600,
 .landing-v2.best-detail-v2 .bg-indigo-600,
 .landing-v2.tools-v2 .bg-indigo-600,
+.landing-v2.labs-v2 .bg-indigo-600,
 .landing-v2.auth-v2 .bg-indigo-600,
 .landing-v2.contact-v2 .bg-indigo-600 {
   background: var(--ink);
@@ -6947,6 +6960,7 @@
 .landing-v2.bank-v2 .hover\:bg-indigo-700:hover,
 .landing-v2.best-detail-v2 .hover\:bg-indigo-700:hover,
 .landing-v2.tools-v2 .hover\:bg-indigo-700:hover,
+.landing-v2.labs-v2 .hover\:bg-indigo-700:hover,
 .landing-v2.auth-v2 .hover\:bg-indigo-700:hover,
 .landing-v2.contact-v2 .hover\:bg-indigo-700:hover {
   background: var(--ink-2);
@@ -6958,6 +6972,7 @@
 .landing-v2.bank-v2 .focus\:ring-indigo-500:focus,
 .landing-v2.best-detail-v2 .focus\:ring-indigo-500:focus,
 .landing-v2.tools-v2 .focus\:ring-indigo-500:focus,
+.landing-v2.labs-v2 .focus\:ring-indigo-500:focus,
 .landing-v2.auth-v2 .focus\:ring-indigo-500:focus,
 .landing-v2.contact-v2 .focus\:ring-indigo-500:focus {
   --tw-ring-color: var(--accent);
@@ -6969,6 +6984,7 @@
 .landing-v2.bank-v2 .focus\:border-indigo-500:focus,
 .landing-v2.best-detail-v2 .focus\:border-indigo-500:focus,
 .landing-v2.tools-v2 .focus\:border-indigo-500:focus,
+.landing-v2.labs-v2 .focus\:border-indigo-500:focus,
 .landing-v2.auth-v2 .focus\:border-indigo-500:focus,
 .landing-v2.contact-v2 .focus\:border-indigo-500:focus {
   border-color: var(--accent);
@@ -11897,4 +11913,144 @@
 }
 .best-for-me-v2 a.bcfm-rec-img {
   display: block;
+}
+
+/* ── Labs: Paze Tracker ──────────────────────────────────────────────────── */
+.labs-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.labs-search {
+  width: 100%;
+  max-width: 340px;
+  padding: 9px 12px;
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.labs-search:focus {
+  outline: none;
+  border-color: var(--ink);
+}
+.labs-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.labs-chip {
+  padding: 6px 11px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.labs-chip:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+/* Filter state has to be obvious at a glance: the explore page's chips were
+   the site's one measured rage-click hotspot, and weak click feedback was the
+   suspected cause. Active is a full colour inversion, not a border tint. */
+.labs-chip.is-active {
+  color: var(--paper);
+  background: var(--ink);
+  border-color: var(--ink);
+}
+.labs-count {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.labs-empty {
+  margin: 28px 0;
+  font-size: 15px;
+  color: var(--muted);
+}
+.labs-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.labs-row {
+  padding: 14px 16px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+}
+.labs-row-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.labs-row-name {
+  font-size: 15.5px;
+  font-weight: 600;
+  color: var(--ink);
+  text-decoration: none;
+}
+.labs-row-name:hover {
+  text-decoration: underline;
+}
+.labs-row-cat {
+  flex-shrink: 0;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.labs-row-usage {
+  margin: 7px 0 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+/* Deliberately quiet. Most rows are empty today and a page of loud
+   placeholders would read as a broken page rather than an honest one. */
+.labs-row-empty {
+  margin: 7px 0 0;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--muted);
+  font-style: italic;
+}
+.labs-row-offer {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 8px 0 0;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+.labs-tag {
+  flex-shrink: 0;
+  padding: 2px 7px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-2);
+  border-radius: 4px;
+}
+.labs-source {
+  margin: 28px 0 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--muted);
+}
+@media (max-width: 560px) {
+  .labs-row-head {
+    flex-direction: column;
+    gap: 2px;
+  }
 }

--- a/apps/web-next/src/components/landing-v2/Chrome.tsx
+++ b/apps/web-next/src/components/landing-v2/Chrome.tsx
@@ -83,6 +83,7 @@ export function V2Footer() {
             <Link href="/check-odds">Check odds</Link>
             <Link href="/card-wire">Card wire</Link>
             <Link href="/tools">Tools</Link>
+            <Link href="/labs">Labs</Link>
           </div>
           <div>
             <h4>Content</h4>


### PR DESCRIPTION
New `/labs` section, mirroring the `/tools` index shell (cj-terminal, page-hero, card grid, V2Footer) with its own `.labs-v2` scope mirrored off every `.tools-v2` selector so the Tailwind utility remapping applies. Added to the footer's Product column after Tools; the navbar is left alone, matching `/tools`.

## Paze Tracker

All **33 merchants** from Paze's directory, with search, category filters on Paze's own taxonomy, and a "Has notes" filter. Merchants with field notes sort first; the rest stay alphabetical so it still reads as a directory.

Getting the full list needed the browser: paze.com paginates behind a "Load More" button, so a plain fetch returns only the first 12. The button was driven to exhaustion to capture all 33 with their destination URLs.

## The data model is the point

The data file keeps two kinds of fact apart, because they have very different reliability:

| Field | Source |
|---|---|
| `name`, `url`, `category` | Transcribed from paze.com/merchant-directory, captured 2026-08-10 |
| `usage` | **Ours.** What you can actually do there: reload caps, timing rules, gotchas |
| `offer` | Quoted verbatim from Paze's own promo wording |

Paze publishes where it works. It does not publish what you can do once you are there, and that second thing is the only reason this page is worth visiting.

**Only Dunkin has a `usage` note today** ($10 gift card reload per 24 hours, where an early retry restarts the window rather than failing). The other 32 are deliberately empty. Everything actually known about them is "Paze works here", and inventing plausible reload rules would poison the one field that gives the page its value. Empty rows render a quiet "No notes yet" rather than a loud placeholder, so the page reads as honest instead of broken.

The house rule is written into the file: only write `usage` where someone has confirmed the behaviour, and never infer one merchant's rules from another's. `offer` is quoted rather than paraphrased so a promo never gets talked up into a stronger claim than Paze made.

## Verification

`tsc` and `eslint` clean, `check-seo` passes, no console errors. Every filter exercised in the browser: Food & Grocery 6, Travel & Entertainment 4, "Has notes" 1, search "flow" returns 1-800-Flowers and Proflowers.

**`next build` could not be completed locally.** `/best-card-for/opengraph-image` prerender fails with `ETIMEDOUT` on a network fetch. I stashed these changes and built clean `origin/main` to check: it fails identically, so this is pre-existing and environmental, not from this branch. Worth a look separately if it also shows up in CI.