### PR TITLE
Gate Sentry to production to stop local-dev noise

### DIFF
--- a/apps/web-next/sentry.edge.config.ts
+++ b/apps/web-next/sentry.edge.config.ts
@@ -6,7 +6,12 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  enabled: Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN),
+  // Production only (see instrumentation-client.ts); NEXT_PUBLIC_SENTRY_DEV=1
+  // re-enables locally for deliberate Sentry testing.
+  enabled:
+    Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN) &&
+    (process.env.NODE_ENV === 'production' ||
+      process.env.NEXT_PUBLIC_SENTRY_DEV === '1'),
 
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 1.0,
 

--- a/apps/web-next/sentry.server.config.ts
+++ b/apps/web-next/sentry.server.config.ts
@@ -7,8 +7,13 @@ import { isTransientNetworkError } from '@/lib/transientNetworkError';
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  // Only send events when a DSN is configured (i.e. in deployed environments).
-  enabled: Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN),
+  // Only send events when a DSN is configured, and only in production — local
+  // dev SSR errors (worktrees copy .env.local, so the DSN is present locally)
+  // are noise. Opt in locally with NEXT_PUBLIC_SENTRY_DEV=1 to test Sentry.
+  enabled:
+    Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN) &&
+    (process.env.NODE_ENV === 'production' ||
+      process.env.NEXT_PUBLIC_SENTRY_DEV === '1'),
 
   // Performance tracing. Tune down if event volume/cost grows.
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 1.0,

--- a/apps/web-next/src/instrumentation-client.ts
+++ b/apps/web-next/src/instrumentation-client.ts
@@ -27,7 +27,14 @@ posthog.init('phc_oPFKvUCGmpZdRPug7TvYDRRSZpJ9oUmLZphkjrSV3fCd', {
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  enabled: Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN),
+  // Production only: local dev servers (and Claude worktrees, which copy
+  // .env.local and therefore the DSN) would otherwise stream HMR/Fast-Refresh
+  // noise, mid-edit parse errors, and stale-chunk ReferenceErrors into Sentry.
+  // To deliberately test Sentry locally, opt in with NEXT_PUBLIC_SENTRY_DEV=1.
+  enabled:
+    Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN) &&
+    (process.env.NODE_ENV === 'production' ||
+      process.env.NEXT_PUBLIC_SENTRY_DEV === '1'),
 
   // Performance tracing. Tune down if event volume/cost grows.
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 1.0,


### PR DESCRIPTION
## Why

`instrumentation-client.ts` (and the server/edge configs) enabled Sentry whenever `NEXT_PUBLIC_SENTRY_DSN` was set. The worktree convention copies `.env.local` — which contains the DSN — into every Claude worktree, so every local dev server streamed HMR/Fast-Refresh noise, mid-edit parse errors, and stale-chunk ReferenceErrors into the `creditodds-javascript-nextjs` Sentry project (NEXTJS-19, NEXTJS-1A, NEXTJS-1C, NEXTJS-C were all dev-only noise triaged 2026-08-11).

## What

All three Sentry inits (`src/instrumentation-client.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts`) now require `NODE_ENV === 'production'` in addition to a DSN:

```ts
enabled:
  Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN) &&
  (process.env.NODE_ENV === 'production' ||
    process.env.NEXT_PUBLIC_SENTRY_DEV === '1'),
```

**Escape hatch:** set `NEXT_PUBLIC_SENTRY_DEV=1` to deliberately test Sentry against a local dev server. `tracesSampleRate`'s dev value of 1.0 and `debug: false` are unchanged — they only matter when enabled.

## Verification

- `npx vitest run` in `apps/web-next`: 107/107 passing
- Booted `next dev` in a worktree with the DSN present: client SDK reports `enabled: false`, zero network requests to Sentry, no Sentry console output client- or server-side; pages serve 200
- Production behavior unchanged: DSN + `NODE_ENV=production` → enabled, exactly as before