### PR TITLE
Paze Tracker: route merchant links through affiliate links where we have them

### DIFF
--- a/apps/web-next/src/app/labs/paze-tracker/PazeTrackerClient.tsx
+++ b/apps/web-next/src/app/labs/paze-tracker/PazeTrackerClient.tsx
@@ -1,19 +1,90 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import posthog from 'posthog-js';
+import { trackStoreEvent } from '@/lib/api';
 import {
   PAZE_CATEGORIES,
   PAZE_MERCHANTS,
   PAZE_DIRECTORY_CAPTURED,
   PAZE_PROMO,
   type PazeCategory,
+  type PazeMerchant,
 } from './merchants';
+
+/** Resolved on the server from data/stores; see resolveAffiliateLinks in page.tsx. */
+export interface AffiliateLink {
+  url: string;
+  network: string | null;
+  offer: string | null;
+}
+
+interface Props {
+  /** Keyed by store slug. Merchants without an entry keep their plain link. */
+  affiliateLinks: Record<string, AffiliateLink>;
+}
+
+/**
+ * The merchant name, pointed at our affiliate link where we hold one and at
+ * Paze's own destination otherwise.
+ *
+ * `rel="sponsored"` on the paid variant only, matching StoreAffiliateCta: it is
+ * the honest signal to search engines, and applying it to unpaid links would be
+ * a lie in the other direction. Both variants keep nofollow/noopener.
+ *
+ * Click tracking mirrors the store CTA so affiliate clicks from this page land
+ * in the same two places as everywhere else on the site: `trackStoreEvent` for
+ * the per-store aggregate and `affiliate_link_clicked` for PostHog. The
+ * `experiment_placement` value is what separates this surface in reporting.
+ */
+function MerchantLink({
+  merchant,
+  affiliate,
+}: {
+  merchant: PazeMerchant;
+  affiliate?: AffiliateLink;
+}) {
+  if (!affiliate) {
+    return (
+      <a
+        href={merchant.url}
+        className="labs-row-name"
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+      >
+        {merchant.name}
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={affiliate.url}
+      className="labs-row-name"
+      target="_blank"
+      rel="sponsored nofollow noopener noreferrer"
+      onClick={() => {
+        if (merchant.storeSlug) {
+          trackStoreEvent('affiliate_click', merchant.storeSlug).catch(() => {});
+        }
+        posthog.capture('affiliate_link_clicked', {
+          store_slug: merchant.storeSlug ?? null,
+          network: affiliate.network,
+          offer: affiliate.offer,
+          experiment_placement: 'paze_tracker',
+        });
+      }}
+    >
+      {merchant.name}
+    </a>
+  );
+}
 
 type Filter = PazeCategory | 'All';
 /** Merchants with field notes are the reason to visit, so they get their own filter. */
 type NotesFilter = 'all' | 'with-notes';
 
-export default function PazeTrackerClient() {
+export default function PazeTrackerClient({ affiliateLinks }: Props) {
   const [category, setCategory] = useState<Filter>('All');
   const [notesOnly, setNotesOnly] = useState<NotesFilter>('all');
   const [query, setQuery] = useState('');
@@ -107,14 +178,10 @@ export default function PazeTrackerClient() {
           {visible.map((m) => (
             <li key={m.slug} className="labs-row">
               <div className="labs-row-head">
-                <a
-                  href={m.url}
-                  className="labs-row-name"
-                  target="_blank"
-                  rel="noopener noreferrer nofollow"
-                >
-                  {m.name}
-                </a>
+                <MerchantLink
+                  merchant={m}
+                  affiliate={m.storeSlug ? affiliateLinks[m.storeSlug] : undefined}
+                />
                 <span className="labs-row-cat">{m.category}</span>
               </div>
 
@@ -160,7 +227,9 @@ export default function PazeTrackerClient() {
         the Dunkin reload throttle was reported lifted three days after it was written up
         as settled. Paze&apos;s directory also lags what people report actually working, so
         merchants can accept Paze without appearing above. Offers are quoted from Paze and
-        can end without notice.
+        can end without notice. Some merchant names link through our affiliate links,
+        which pay us if you buy; it costs you nothing and never changes what appears
+        here. See our <a href="/disclosures">disclosures</a>.
       </p>
     </div>
   );

--- a/apps/web-next/src/app/labs/paze-tracker/merchants.ts
+++ b/apps/web-next/src/app/labs/paze-tracker/merchants.ts
@@ -71,6 +71,15 @@ export interface PazeMerchant {
   offer?: string;
   /** Reported by users, not verified by us. Rendered with that caveat attached. */
   community?: CommunityNote;
+  /**
+   * Matching slug in data/stores, set ONLY where we hold an affiliate link for
+   * that exact merchant. The page swaps the outbound link for the tracking one
+   * when this resolves. Verified by comparing each store's `website` against
+   * the URL Paze's directory points at, because the near-misses are
+   * convincing: `caesars-rewards` is the casino, not Little Caesars, and
+   * `harrys` is the razor brand, not Harry & David.
+   */
+  storeSlug?: string;
 }
 
 /** Captured from paze.com/merchant-directory on 2026-08-10. */
@@ -145,6 +154,7 @@ export const PAZE_MERCHANTS: PazeMerchant[] = [
     name: 'GNC',
     url: 'https://www.gnc.com/',
     category: 'Beauty & Health',
+    storeSlug: 'gnc',
     community: {
       note: 'Two recurring complaints: Paze disappearing as a checkout option, and qualifying GNC purchases not generating the statement credit when every other merchant on the same card did. One user reports purchases from 10 July still uncredited a month later, with the items non-returnable.',
       asOf: '2026-08-09',
@@ -162,7 +172,7 @@ export const PAZE_MERCHANTS: PazeMerchant[] = [
       source: 'https://www.reddit.com/r/ChaseSapphire/comments/1vktslk/sephora_cfpb_update/',
     },
   },
-  { slug: 'pet-supermarket', name: 'Pet Supermarket', url: 'https://www.petsupermarket.com/', category: 'Food & Grocery' },
+  { slug: 'pet-supermarket', name: 'Pet Supermarket', url: 'https://www.petsupermarket.com/', category: 'Food & Grocery', storeSlug: 'pet-supermarket' },
   { slug: 'roku', name: 'Roku', url: 'https://www.roku.com/', category: 'Electronics' },
   { slug: 'xsolla', name: 'Xsolla', url: 'https://xsolla.com/', category: 'Electronics' },
   { slug: 'payrange', name: 'PayRange', url: 'https://payrange.com/', category: 'Services' },
@@ -182,15 +192,15 @@ export const PAZE_MERCHANTS: PazeMerchant[] = [
   { slug: 'proflowers', name: 'Proflowers', url: 'https://www.proflowers.com/', category: 'Flowers & Gifts' },
   { slug: 'teleflora', name: 'Teleflora', url: 'https://www.teleflora.com/', category: 'Flowers & Gifts' },
   { slug: 'harry-and-david', name: 'Harry & David', url: 'https://www.harryanddavid.com/', category: 'Flowers & Gifts' },
-  { slug: 'personalization-mall', name: 'Personalization Mall', url: 'https://www.personalizationmall.com/', category: 'Flowers & Gifts' },
+  { slug: 'personalization-mall', name: 'Personalization Mall', url: 'https://www.personalizationmall.com/', category: 'Flowers & Gifts', storeSlug: 'personalization-mall' },
   { slug: 'banter-by-piercing-pagoda', name: 'Banter by Piercing Pagoda', url: 'https://www.banter.com/', category: 'Apparel & Shoes' },
   { slug: 'jared', name: 'Jared', url: 'https://www.jared.com/', category: 'Apparel & Shoes' },
   { slug: 'kay-jewelers', name: 'KAY Jewelers', url: 'https://www.kay.com/', category: 'Apparel & Shoes' },
   { slug: 'zales', name: 'Zales', url: 'https://www.zales.com/', category: 'Apparel & Shoes' },
   { slug: 'lids', name: 'Lids', url: 'https://www.lids.com/', category: 'Apparel & Shoes' },
   { slug: 'fanatics', name: 'Fanatics', url: 'https://www.fanatics.com/pazepromo', category: 'Apparel & Shoes' },
-  { slug: 'durango', name: 'Durango', url: 'https://www.durangoboots.com/', category: 'Apparel & Shoes' },
-  { slug: 'georgia-boot', name: 'Georgia Boot', url: 'https://www.georgiaboot.com/', category: 'Apparel & Shoes' },
+  { slug: 'durango', name: 'Durango', url: 'https://www.durangoboots.com/', category: 'Apparel & Shoes', storeSlug: 'durango-boots' },
+  { slug: 'georgia-boot', name: 'Georgia Boot', url: 'https://www.georgiaboot.com/', category: 'Apparel & Shoes', storeSlug: 'georgia-boot' },
   { slug: 'muck-boot-company', name: 'Muck Boot Company', url: 'https://www.muckbootcompany.com/', category: 'Apparel & Shoes' },
   { slug: 'xtratuf', name: 'XTRATUF', url: 'https://www.xtratuf.com/', category: 'Apparel & Shoes' },
   { slug: 'broadway-com', name: 'Broadway.com', url: 'https://www.broadway.com/', category: 'Travel & Entertainment' },
@@ -200,6 +210,7 @@ export const PAZE_MERCHANTS: PazeMerchant[] = [
     name: 'StubHub',
     url: 'https://www.stubhub.com/',
     category: 'Travel & Entertainment',
+    storeSlug: 'stubhub',
     community: {
       note: 'Paze shows up at checkout on the web and mobile browser, but users report it missing in the StubHub app, and that the app and desktop show different ticket inventory. If the listing you want will not offer Paze, check the other surface before giving up. Stacks with a card StubHub credit for people who carry one.',
       asOf: '2026-08-07',

--- a/apps/web-next/src/app/labs/paze-tracker/page.tsx
+++ b/apps/web-next/src/app/labs/paze-tracker/page.tsx
@@ -5,6 +5,8 @@ import { BreadcrumbSchema } from '@/components/seo/JsonLd';
 import { V2Footer } from '@/components/landing-v2/Chrome';
 import PazeTrackerClient from './PazeTrackerClient';
 import { PAZE_MERCHANTS } from './merchants';
+import { getAllStores } from '@/lib/stores';
+import type { AffiliateLink } from './PazeTrackerClient';
 import '../../landing.css';
 
 export const metadata: Metadata = {
@@ -23,7 +25,42 @@ export const metadata: Metadata = {
   },
 };
 
-export default function PazeTrackerPage() {
+/**
+ * Resolve affiliate links for the merchants that have one, at request time on
+ * the server. Deliberately keyed off each merchant's explicit `storeSlug`
+ * rather than fuzzy-matching names against the store catalogue: a wrong match
+ * would send readers to a competitor under our tracking link.
+ *
+ * A slug that no longer resolves, or a store whose affiliate entry has been
+ * pulled, simply yields no link and the merchant falls back to its plain URL.
+ */
+async function resolveAffiliateLinks(): Promise<Record<string, AffiliateLink>> {
+  const wanted = new Set(
+    PAZE_MERCHANTS.map((m) => m.storeSlug).filter((s): s is string => Boolean(s)),
+  );
+  if (wanted.size === 0) return {};
+
+  try {
+    const stores = await getAllStores();
+    const out: Record<string, AffiliateLink> = {};
+    for (const store of stores) {
+      if (!wanted.has(store.slug) || !store.affiliate?.url) continue;
+      out[store.slug] = {
+        url: store.affiliate.url,
+        network: store.affiliate.network ?? null,
+        offer: store.affiliate.offer ?? null,
+      };
+    }
+    return out;
+  } catch {
+    // Monetization must never take the page down: fall back to plain links.
+    return {};
+  }
+}
+
+export default async function PazeTrackerPage() {
+  const affiliateLinks = await resolveAffiliateLinks();
+
   return (
     <div className="landing-v2 labs-v2">
       <BreadcrumbSchema
@@ -63,7 +100,7 @@ export default function PazeTrackerPage() {
       </section>
 
       <div className="wrap" style={{ paddingTop: 8, paddingBottom: 64 }}>
-        <PazeTrackerClient />
+        <PazeTrackerClient affiliateLinks={affiliateLinks} />
       </div>
 
       <V2Footer />


### PR DESCRIPTION
Six of the 33 Paze merchants have an affiliate link in `data/affiliates.yaml`. Their names now link through the tracking URL; the other 27 keep Paze's plain destination.

| Merchant | Store slug | Network |
|---|---|---|
| GNC | `gnc` | FlexOffers |
| StubHub | `stubhub` | FlexOffers |
| Pet Supermarket | `pet-supermarket` | FlexOffers |
| Personalization Mall | `personalization-mall` | FlexOffers |
| Georgia Boot | `georgia-boot` | CJ |
| Durango | `durango-boots` | CJ |

## Matching is explicit, never fuzzy

This is the part that needed care. Searching 644 affiliate merchants for Paze-merchant tokens turns up several convincing false friends:

- `caesars-rewards` is the casino, **not** Little Caesars
- `harrys` is the razor brand, **not** Harry & David
- `davids-bridal` is neither
- `flower-com` / `flowers-fast` are **not** 1-800-Flowers, FTD, Proflowers or Teleflora

Any of those would have pushed readers to a competitor under our own tracking link. So each merchant carries an explicit `storeSlug`, and every pair was verified by comparing the store's recorded `website` against the exact URL Paze's directory points at. All six line up (gnc.com, stubhub.com, petsupermarket.com, personalizationmall.com, georgiaboot.com, durangoboots.com). The rejected candidates are named in a code comment so the next person does not re-derive them.

## Behaviour

- **`rel="sponsored nofollow noopener noreferrer"` on paid links only.** Applying `sponsored` to unpaid links would be a lie in the other direction. Verified in the browser: exactly 6 links carry it, 0 of the 27 plain links do.
- **Click tracking mirrors the store CTA** so this surface reports alongside everything else: `trackStoreEvent('affiliate_click', slug)` for the per-store aggregate, and PostHog `affiliate_link_clicked` with `experiment_placement: 'paze_tracker'` so it can be separated in analysis.
- **Fails open.** Links resolve server-side from `stores.json` by slug, wrapped in a try/catch. A pulled affiliate entry or a renamed store yields no link and the merchant falls back to its plain URL. Monetization should never be able to take the page down.
- **Disclosure line added**, pointing at `/disclosures`. Store pages carry no inline disclosure because every link on them is paid; this list mixes paid and unpaid, so it says so.

## Verification

`tsc`, `eslint`, `check-seo` clean. Rendered locally and asserted on the DOM: 6 affiliate links with correct hosts and `sponsored`, 27 plain links without it, disclosure present.

## Follow-up, not in this PR

Of the 27 without links, the obvious revenue gaps are Sephora, Fanatics, Lids, Newegg, 1-800-Flowers, FTD, Harry & David, Zales, Jared and KAY — all large affiliate advertisers we simply do not have on file. Adding them to `data/affiliates.yaml` lights them up here automatically, no code change required.