### PR TITLE
Reddit product changes for review — 2026-08-12

### DIFF
--- a/data/reddit-product-changes/2026-08-t3_1vh8shb.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vh8shb.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vh8shb
+permalink: https://www.reddit.com/r/CreditCards/comments/1vh8shb/got_rejected_for_savor_card/
+posted: "2026-08-06"
+evidence: >-
+  In a post about a Capital One denial, the poster mentions in passing that they recently upgraded
+  their Cash Magnet to a Blue Cash Preferred, taking a statement credit offer with the first year
+  fee waived and no hard pull.
+from_card: Cash Magnet
+to_card: Blue Cash Preferred
+change_month: 2026-08
+reason: voluntary

--- a/data/reddit-product-changes/2026-08-t3_1vji20h.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vji20h.yaml
@@ -1,0 +1,12 @@
+source_id: t3_1vji20h
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1vji20h/dp_amex_downgrade_did_not_refund_full_annual_fee/
+posted: "2026-08-09"
+evidence: >-
+  Poster shares a data point: they called Amex and downgraded their Blue Cash Preferred to Blue Cash
+  Everyday the day after the annual fee posted. No retention offer was mentioned, and the refund
+  they received was partial rather than the full annual fee.
+from_card: Blue Cash Preferred
+to_card: Blue Cash Everyday
+change_month: 2026-08
+reason: voluntary


### PR DESCRIPTION
Product changes extracted from r/CreditCards.

| From | To | Month | Reason | Source |
|---|---|---|---|---|
| Cash Magnet | Blue Cash Preferred | 2026-08 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vh8shb/got_rejected_for_savor_card/) |
| Blue Cash Preferred | Blue Cash Everyday | 2026-08 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vji20h/dp_amex_downgrade_did_not_refund_full_annual_fee/) |

