### PR TITLE
cards: refresh our_take prose to match corrected signup bonuses

### DIFF
--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -52,9 +52,9 @@ our_take: >
   The Savor packs an unusually wide 3% earn structure into a card with no
   annual fee: dining, entertainment, streaming, and groceries all pay the same
   rate, with 8% on Capital One Entertainment bookings and 5% on hotels and
-  rental cars booked through Capital One Travel. Capital One recently raised
-  the signup bonus from $200 to $250, still against a modest $500 spend in the
-  first three months, so the upfront value is easy to capture. You also get 12
+  rental cars booked through Capital One Travel. The signup bonus is $200
+  against a modest $500 spend in the first three months, so the upfront value
+  is easy to capture. You also get 12
   months of 0% intro APR on purchases and balance transfers and no foreign
   transaction fee. The honest limit is the 1% base rate: anything outside
   those four categories earns the bare minimum, so this works best as a

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -127,7 +127,7 @@ our_take: >
   Earning is Delta-centric at 3 miles per dollar on Delta purchases, with 1.5
   miles on transit, U.S. shipping, and U.S. office supply stores, and 1 mile
   on the rest until you cross $150,000 in a calendar year, after which
-  everything earns 1.5 miles. The welcome offer of 80,000 miles is real money
+  everything earns 1.5 miles. The welcome offer of 125,000 miles is real money
   but demands $12,000 of spend in six months, the steepest requirement in the
   Delta lineup. Against a $650 annual fee, the credits help but come with
   conditions: $250 in Delta Stays, up to $20 a month at Resy restaurants, and


### PR DESCRIPTION
Follow-up to #2026, which corrected four signup bonuses. `our_take` is authored prose and does not track the structured `signup_bonus.value`, so two card pages were contradicting their own hero copy.

| Card | Hero (live) | `our_take` said | Now |
|---|---|---|---|
| Delta SkyMiles Reserve Business | 125,000 miles | 80,000 miles | 125,000 miles |
| Capital One Savor | $200 | "recently raised the signup bonus from $200 to $250" | "The signup bonus is $200" |

The Savor sentence needed a rewrite rather than a number swap: it described an increase that has since been reversed, so it now just states the current value.

**Both Amtrak cards were deliberately left unchanged.** Their prose reads "up to 20,000 points" and "up to 30,000 points", which remains accurate: those totals include the 5,000-point authorized-user bonus, which by convention is excluded from `signup_bonus.value` (see the rule in `scripts/check-card-pages.js`). That is also why #2026 changed their values without those being real offer changes.

Validated with `npm run build:cards` (224 cards, clean); regenerated `data/cards.json` intentionally not committed.