### PR TITLE
sentry: drop Firefox iOS foreign data-URI image-load rejections

### DIFF
--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -188,6 +188,24 @@ describe("isBenignClientError", () => {
     expect(isBenignClientError("something actually broke")).toBe(false);
   });
 
+  // Firefox iOS content scripts re-encode inline SVGs as data: URIs and
+  // reject with a bare string when the load fails inside their context.
+  it("drops Firefox iOS's data-URI image-load string rejection", () => {
+    expect(
+      isBenignClientError(
+        "Unable to load image data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQi",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps image-load failures pointing at a real URL", () => {
+    expect(
+      isBenignClientError(
+        "Unable to load image https://creditodds.com/cards/some-card.png",
+      ),
+    ).toBe(false);
+  });
+
   // An injected script stringifying a React-owned DOM node inside a patched
   // appendChild. Both halves of the message are required.
   it("drops circular-structure errors that walk a React fiber", () => {

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -40,7 +40,7 @@
 // ErrorEvent is deliberately NOT matched — it carries a real message/error
 // payload worth reporting.
 //
-// Two more shapes come from code that isn't ours at all:
+// Three more shapes come from code that isn't ours at all:
 //
 // 1. "Object Not Found Matching Id:N, MethodName:update, ParamCount:4"
 //    (CREDITODDS-JAVASCRIPT-NEXTJS-16), rejected as a bare STRING rather than
@@ -61,6 +61,20 @@
 //    genuine circular-structure bug in our own code would not be walking a
 //    React fiber.
 //
+// 3. "Unable to load image data:image/svg+xml;base64,..."
+//    (CREDITODDS-JAVASCRIPT-NEXTJS-1F), rejected as a bare STRING from
+//    Firefox iOS. The base64 payload decodes to one of our inline <svg>
+//    elements (the FollowXCallout X logo) — but we never serialise inline
+//    SVGs to data URIs or load them via Image(), and no code we ship says
+//    "Unable to load image" (nor could our chunks appear in a stack: string
+//    rejections carry no frames, which is also why hasOnlyForeignFrames
+//    can't catch this). Firefox iOS injects content scripts that walk the
+//    page's images (metadata/thumbnail extraction), and inline SVGs get
+//    re-encoded as data: URIs whose load can fail inside the injected
+//    context. The "data:" scheme is required in the signature so a
+//    hypothetical real image-load failure pointing at an https URL stays
+//    reportable.
+//
 // Finally, hasOnlyForeignFrames (below) drops exceptions by stack shape rather
 // than message: every frame lacks a resolvable script URL. See its comment.
 const BENIGN_CLIENT_SIGNATURES = [
@@ -78,6 +92,7 @@ const BENIGN_ANY_ERROR_SIGNATURES = [
   'Connection to Indexed Database server lost',
   'installations/app-offline',
   'Object Not Found Matching Id:',
+  'Unable to load image data:',
 ];
 
 // Every substring here must be present for the error to count as benign. Used


### PR DESCRIPTION
## Sentry issue

[CREDITODDS-JAVASCRIPT-NEXTJS-1F](https://sentry.io/organizations/creditodds/issues/?query=CREDITODDS-JAVASCRIPT-NEXTJS-1F) — `UnhandledRejection: Non-Error promise rejection captured with value: Unable to load image data:image/svg+xml;base64,...` on `/news/:id`, Firefox iOS 153.2 / iOS 18.7.

## Diagnosis

The base64 payload decodes to the inline X-logo `<svg>` from `FollowXCallout.tsx` (`class="x-follow-logo"`, `fill="currentColor"`). Our code never serialises inline SVGs to data URIs, never loads them via `Image()`, and nothing we ship contains the string "Unable to load image" (verified by grep across the app). Firefox iOS injects content scripts that walk the page's images for metadata/thumbnail extraction, re-encoding inline SVGs as `data:` URIs; when that load fails inside the injected context it rejects with a bare string, which Sentry's global handler captures.

The existing `hasOnlyForeignFrames` filter can't catch this shape: bare-string rejections carry no stack frames, and frame-less events are deliberately kept reportable.

## Fix

Adds `'Unable to load image data:'` to `BENIGN_ANY_ERROR_SIGNATURES` in `benignClientError.ts`, following the established foreign-code noise pattern (CefSharp bridge, React-fiber circular JSON). The `data:` scheme is part of the signature so a hypothetical real image-load failure pointing at an https URL would still be reported.

Tests: 2 new cases (drop the data-URI string, keep an https variant); all 32 pass.