### PR TITLE
Reddit Data Points 2026-08-13

### DIFF
--- a/data/reddit-datapoints/2026-08-13-t3_1vlv2ug.yaml
+++ b/data/reddit-datapoints/2026-08-13-t3_1vlv2ug.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1vlv2ug"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vlv2ug/us_bank_no_cli_going_on_15_years/"
+posted: "2026-08-12"
+evidence: "Poster reports opening the Smartly in February 2025 at a score of 780+ with 0/1/1 inquiries and $110k total credit line, receiving a $500 starting limit, and being denied three credit limit increases since; they hold $100k+ in a US Bank brokerage and were grandfathered into the original Smartly requirements."
+card_name: "Smartly Visa Signature"
+result: "approved"
+credit_score: 780
+credit_score_source: 0
+starting_credit_limit: 500
+inquiries_3: 0
+inquiries_12: 1
+bank_customer: true
+date_applied: "2025-02"

--- a/data/reddit-datapoints/2026-08-13-t3_1vmyw3s.yaml
+++ b/data/reddit-datapoints/2026-08-13-t3_1vmyw3s.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1vmyw3s"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vmyw3s/should_i_get_a_chase_account_to_increase_approval/"
+posted: "2026-08-13"
+evidence: "Poster with a 720 Equifax score, one credit union card opened nine months earlier, and no other accounts reports an instant denial on the Sapphire Preferred; no issuer reason was quoted."
+card_name: "Chase Sapphire Preferred"
+result: "denied"
+credit_score: 720
+credit_score_source: 3
+length_credit: 1
+total_open_cards: 1
+date_applied: "2026-08"
+reason_denied_code: "not_specified"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-08-13

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vmyw3s](https://www.reddit.com/r/CreditCards/comments/1vmyw3s/should_i_get_a_chase_account_to_increase_approval/) | Chase Sapphire Preferred | denied | 720 | — | — | 1 | 2026-08 | `2026-08-13-t3_1vmyw3s.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (14)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [Approved for the U.S. Bank Triple Cash, only $3k credit limi…](https://www.reddit.com/r/CreditCards/comments/1vkjvqt/approved_for_the_us_bank_triple_cash_only_3k/) | Bank of America Travel Rewards · denied | credit_score | What was your score at the time, and which bureau? |
| [Just get approved for Chase CSR](https://www.reddit.com/r/CreditCards/comments/1vlxd8w/just_get_approved_for_chase_csr/) | Chase Sapphire Reserve · approved | credit_score | What was your score at the time, and which bureau? |
| [US Bank - No CLI - Going on 1.5 years.](https://www.reddit.com/r/CreditCards/comments/1vlv2ug/us_bank_no_cli_going_on_15_years/) | Smartly Visa Signature · approved | credit_score | What was your score at the time, and which bureau? |
| [Went on a bit of a Chase binge](https://www.reddit.com/r/CreditCards/comments/1vmyc67/went_on_a_bit_of_a_chase_binge/) | Ink Business Cash · approved | credit_score | What was your score at the time, and which bureau? |
| [Reapplication chances Robinhood gold](https://www.reddit.com/r/CreditCards/comments/1vmnx36/reapplication_chances_robinhood_gold/) | Robinhood Gold · denied | credit_score | What was your score at the time, and which bureau? |
| [Excellent credit, no credit history, and rejected](https://www.reddit.com/r/CreditCards/comments/1vmic66/excellent_credit_no_credit_history_and_rejected/) | Citi Double Cash · denied | credit_score | What was your score at the time, and which bureau? |
| [United Explorer Card Targeted 80k SUB](https://www.reddit.com/r/CreditCards/comments/1vjcakr/united_explorer_card_targeted_80k_sub/) | United Explorer · approved | credit_score | What was your score at the time, and which bureau? |
| [How is my credit card line up?](https://www.reddit.com/r/CreditCards/comments/1vhdp81/how_is_my_credit_card_line_up/) | Robinhood Gold · denied | credit_score | What was your score at the time, and which bureau? |
| [Got rejected for Savor Card!](https://www.reddit.com/r/CreditCards/comments/1vh8shb/got_rejected_for_savor_card/) | Capital One Savor Cash Rewards · denied | credit_score | What was your score at the time, and which bureau? |
| [Was approved for Chase Freedom Unlimited - Is this a good th…](https://www.reddit.com/r/CreditCards/comments/1viilrf/was_approved_for_chase_freedom_unlimited_is_this/) | Chase Freedom Unlimited · approved | credit_score | What was your score at the time, and which bureau? |
| [Got Venture X after getting denied from Bilt Palladium Yeste…](https://www.reddit.com/r/CreditCards/comments/1vhge0n/got_venture_x_after_getting_denied_from_bilt/) | Bilt Palladium · denied | credit_score | What was your score at the time, and which bureau? |
| [Looking for good first primary card after rejection](https://www.reddit.com/r/CreditCards/comments/1vl242g/looking_for_good_first_primary_card_after/) | denied | card_name | Which card exactly was it? |
| [Denied AAdvantage Platinum Select, When to Reapply?](https://www.reddit.com/r/CreditCards/comments/1vl1mtu/denied_aadvantage_platinum_select_when_to_reapply/) | Citi AAdvantage Platinum Select World Elite Mastercard · denied | credit_score | What was your score at the time, and which bureau? |
| [Chase United Explorer card taking forever to arrive — no USP…](https://www.reddit.com/r/CreditCards/comments/1vkw0tx/chase_united_explorer_card_taking_forever_to/) | United Explorer · approved | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_score` | 7 | Real outcome but no credit score anywhere, and below the pending bar |
| `no_outcome` | 5 | No stated approval or denial (odds question, recommendation request, chatter) |
| `other` | 1 | Anything else (a note is required) |
| `pre_qual` | 1 | Pre-qualification or pre-approval result, which is never an outcome |


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
