### PR TITLE
admin: allow editing records that have no listed income

### DIFF
--- a/apps/api/src/handlers/admin.js
+++ b/apps/api/src/handlers/admin.js
@@ -246,7 +246,13 @@ exports.AdminRecordsHandler = async (event) => {
           credit_score: yup.number().integer().min(300).max(850),
           credit_score_source: yup.number().integer().min(0).max(4),
           result: yup.boolean(),
-          listed_income: yup.number().integer().min(0).max(1000000),
+          // .nullable() because income is optional on a record and the edit
+          // modal always sends every field, so a record with no income posts
+          // listed_income: null. Without this, yup coerces null to NaN and
+          // rejects the whole update — which made every income-less record
+          // uneditable, and surfaced only as a blocking alert() in the admin UI
+          // (72 of 133 imported Reddit data points were affected).
+          listed_income: yup.number().integer().min(0).max(1000000).nullable(),
           length_credit: yup.number().integer().min(0).max(100).nullable(),
           starting_credit_limit: yup.number().integer().min(0).max(1000000).nullable(),
           reason_denied: yup.string().max(254).nullable(),


### PR DESCRIPTION
admin: allow editing records that have no listed income

The admin record-edit PUT validated listed_income with a non-nullable
yup.number(). The edit modal always sends every field, so a record with no
income posts listed_income: null, yup coerces that to NaN, and the whole update
is rejected with "listed_income must be a `number` type".

Effect: any record without an income was uneditable. That is 72 of the 133
imported Reddit data points (income is omitted more often than not), plus any
user submission that left the field blank.

It was hard to see because the frontend reports failures through a native
alert(), which blocks the page's JS thread - the tab just stops responding
rather than showing an inline error. Found while trying to correct
bank_customer on record 4129.

Every other optional field in the schema was already .nullable(); this one was
the outlier.
