### PR TITLE
Marriott Bonvoy Bevy: SUB 135,000 → 125,000 + $150 credit

### DIFF
--- a/data/cards/marriott-bonvoy-bevy-american-express.yaml
+++ b/data/cards/marriott-bonvoy-bevy-american-express.yaml
@@ -13,9 +13,9 @@ our_take: >
   most hotel co-brands manage. At Marriott Bonvoy properties it earns 6x, and
   complimentary Gold Elite status plus 15 Elite Night Credits each year move
   you toward higher tiers without any spending requirement. The current
-  135,000 point bonus arrives in two pieces, 85,000 after $5,000 and another
-  50,000 after $2,000 more, both within the first six months, and it climbed
-  back up in June after a sharp cut in May. The weak spot is a $250 annual fee
+  limited-time offer is 125,000 points plus a $150 statement credit after
+  $5,000 in the first six months, which replaces the two-part 135,000 point
+  deal and runs through September 30, 2026. The weak spot is a $250 annual fee
   against a free night award that only shows up after $15,000 of purchases in
   a calendar year, so there is no automatic anniversary night to lean on the
   way most hotel cards provide. Clear that threshold and stay at Marriott a
@@ -47,10 +47,11 @@ rewards:
     value: 2
     unit: points_per_dollar
 signup_bonus:
-  value: 135000
+  value: 125000
   type: "points"
-  spend_requirement: 7000
+  spend_requirement: 5000
   timeframe_months: 6
+  note: "Plus a $150 statement credit. Offer ends 2026-09-30."
 apr:
   regular:
     min: 19.49


### PR DESCRIPTION
## Change

Marriott Bonvoy Bevy welcome offer, verified against the live Amex page in a clean incognito browser.

| Field | Before | After |
|---|---|---|
| `signup_bonus.value` | 135,000 | **125,000** |
| `signup_bonus.spend_requirement` | \$7,000 | **\$5,000** |
| `signup_bonus.timeframe_months` | 6 | 6 (unchanged) |
| `signup_bonus.note` | *(none)* | **"Plus a \$150 statement credit. Offer ends 2026-09-30."** |

`our_take` updated to match: it described the retired two-part 85,000 + 50,000 structure.

## Live page text

> Limited Time Offer
> Earn 125,000 Marriott Bonvoy® Bonus Points Plus A \$150 Statement Credit
> after you use your new Card to make \$5,000 in purchases within the first 6 months of Card Membership. Offer ends 09/30/26.

## Why this needed a human

The 2026-08-13 card-page check suppressed this as an `offer-variant-downgrade`: americanexpress.com is on `SESSION_TARGETED_OFFER_HOSTS`, so a proposed **decrease** is held back on the theory that the fetch may have been served a targeted-down variant. That guard is working as designed.

Neither the script's Playwright fetch nor an automated browser can adjudicate an Amex offer (both are served the same session-targeted numbers), so this was confirmed by opening the apply link in a clean incognito consumer browser. The incognito reading matched the automated reading, which is what establishes 125,000 as the public offer rather than a targeted-down variant.

Note the spend requirement moved too — this is a full offer replacement, not just a point-total cut.

## Still unverified

**Delta SkyMiles Reserve Business** was suppressed by the same guard in the same run (125,000 → 80,000) and has **not** been checked in incognito. Deliberately not touched here. Given the 2026-08-11 incident where the targeted-down 80,000 was hand-applied without the clean-browser step, this one should stay at 125,000 until someone confirms it directly.

`data/cards.json` intentionally not committed; CI rebuilds it.