### PR TITLE
Delta SkyMiles Reserve Business: SUB 125,000 → 80,000 (incognito-verified)

### DIFF
--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -37,7 +37,7 @@ rewards:
     unit: points_per_dollar
     note: "All purchases earn 1.5x after $150,000 in eligible purchases in a calendar year"
 signup_bonus:
-  value: 125000
+  value: 80000
   type: "miles"
   spend_requirement: 12000
   timeframe_months: 6
@@ -127,11 +127,12 @@ our_take: >
   Earning is Delta-centric at 3 miles per dollar on Delta purchases, with 1.5
   miles on transit, U.S. shipping, and U.S. office supply stores, and 1 mile
   on the rest until you cross $150,000 in a calendar year, after which
-  everything earns 1.5 miles. The welcome offer of 125,000 miles is real money
-  but demands $12,000 of spend in six months, the steepest requirement in the
-  Delta lineup. Against a $650 annual fee, the credits help but come with
-  conditions: $250 in Delta Stays, up to $20 a month at Resy restaurants, and
-  up to $10 a month in rideshare, the latter two requiring enrollment. Skip it
+  everything earns 1.5 miles. The welcome offer of 80,000 miles demands
+  $12,000 of spend in six months, the steepest requirement in the Delta
+  lineup, so the miles are hard won. Against a $650 annual fee, the credits
+  help but come with conditions: $250 in Delta Stays, up to $20 a month at
+  Resy restaurants, and up to $10 a month in rideshare, the latter two
+  requiring enrollment. Skip it
   unless Delta lounges and Medallion qualification are things your travel
   schedule genuinely uses, because the $2,500 MQD headstart and $1 in MQDs per
   $10 spent are where the fee earns itself back.


### PR DESCRIPTION
## Change

| Field | Before | After |
|---|---|---|
| `signup_bonus.value` | 125,000 | **80,000** |
| `signup_bonus.spend_requirement` | \$12,000 | \$12,000 (unchanged) |
| `signup_bonus.timeframe_months` | 6 | 6 (unchanged) |

`our_take` updated to match. Annual fee \$650 confirmed correct against the live page, no change.

## Live page text (clean incognito, 2026-08-13)

> Annual Fee: \$650
> Delta SkyMiles® Reserve Business Card
> WELCOME OFFER
> Earn 80,000 Bonus Miles after you spend \$12,000 in purchases on your new Card in your first 6 months of Card Membership.

No "Special Welcome Offer" header, no struck-through previous number.

## Why this reverts yesterday's #2026

Three-day history on this field:

| Date | PR | Value | Verification |
|---|---|---|---|
| 08-11 | #2011 | 125,000 → 80,000 | none (hand-applied, no clean-browser step) |
| 08-12 | #2026 | 80,000 → 125,000 | incognito showed *"Special Welcome Offer / previously 80,000, now 125,000"* |
| 08-13 | this PR | 125,000 → 80,000 | incognito shows plain 80,000, no upgrade header |

The `previously 80,000, now 125,000` framing on 08-12 is how Amex presents a **targeted upgrade offer**, not a public offer change. The script's Playwright fetch saw 80,000 on both 08-12 and 08-13, and an independent clean incognito session now also sees 80,000.

Most likely reading: **80,000 has been the public baseline throughout, and the 125,000 seen on 08-12 was session-targeted.** That means #2026 wrote a targeted-*up* number into production for a day.

## The guard gap this exposes

`SESSION_TARGETED_OFFER_HOSTS` (`check-card-pages.js` ~line 289) suppresses signup_bonus **decreases** on americanexpress.com, on the premise that a targeted-down session cannot invent a number *higher* than the public offer. That premise was already documented as "not airtight" because Amex also serves targeted-*up* offers — this appears to be the first time it actually bit.

The asymmetry means increases on these hosts get **no** verification gate at all, while decreases get a hard one. Worth considering whether increases on session-targeted hosts should also be held for clean-browser confirmation rather than auto-applied.

`data/cards.json` intentionally not committed; CI rebuilds it.