### PR TITLE
news: drop closed-card tag from US Bank transfer partners item

### DIFF
--- a/data/news/2026-08-13-us-bank-altitude-reserve-transfer-partners.yaml
+++ b/data/news/2026-08-13-us-bank-altitude-reserve-transfer-partners.yaml
@@ -6,8 +6,6 @@ tags:
   - "benefit-change"
   - "policy-change"
 bank: "U.S. Bank"
-card_slug: "us-bank-altitude-reserve-visa-infinite"
-card_name: "US Bank Altitude Reserve Visa Infinite"
 source: "Doctor of Credit"
 source_url: "https://www.doctorofcredit.com/u-s-bank-finally-adds-transfer-partners-accor-flying-blue-qantas-ethiopian/"
 body: |


### PR DESCRIPTION
Follow-up to #2032.

The `us-bank-altitude-reserve-transfer-partners` news item tagged `card_slug: us-bank-altitude-reserve-visa-infinite`, a card with `accepting_applications: false`.

`card_slug` is not just metadata. It drives two user-facing surfaces:

- the **Related Cards** tile linking to `/card/...` (`src/components/ui/RelatedCards.tsx`)
- the **OG / Twitter hero image**, which uses card art when there is exactly one card (`src/app/news/[id]/opengraph-image.tsx:94`)

So the social unfurl led with art for a card no one can apply for.

The triage rules do allow tagging closed cards, but specifically as subjects of *discontinuation* news. This item is a benefit/policy change, so that carve-out did not apply.

## Change

Drops `card_slug` and `card_name`, keeps `bank: "U.S. Bank"`. The story is a rewards-program change rather than a card product change, so the bank tag carries it.

No factual detail is lost: the body still names the Altitude Reserve as the only card with transfers and states plainly that it stopped accepting applications.

## Verification

`node scripts/build-news.js` succeeds, 111 items. The rebuilt entry now resolves with `bank` only and no `card_slug` / `card_name` / `card_slugs`.

Note: the social post for this item already went to the queue and is not affected by this edit.