### PR TITLE
migration 055: purge phantom CardWire rows on Delta SkyMiles Reserve Business

### DIFF
--- a/apps/api/migrations/055_purge_delta_reserve_business_phantom_wire_rows.sql
+++ b/apps/api/migrations/055_purge_delta_reserve_business_phantom_wire_rows.sql
@@ -1,0 +1,29 @@
+-- Purge four phantom CardWire rows on Delta SkyMiles Reserve Business American
+-- Express (card_id 375). The card's PUBLIC sign-up bonus never changed: it has
+-- been 80,000 miles after $12,000 in 6 months since the card was added on
+-- 2026-07-28.
+--
+-- What actually happened is that americanexpress.com serves a session-targeted
+-- 125,000 upgrade variant to some sessions, and the nightly page check's
+-- Playwright fetch was served that variant on some days and the public 80,000
+-- on others. Each flip wrote a wire row:
+--
+--   id 243  2026-08-03   80,000 -> 125,000   (#1898, fetch saw targeted variant)
+--   id 248  2026-08-11  125,000 ->  80,000   (#2011, hand-applied, unverified)
+--   id 252  2026-08-12   80,000 -> 125,000   (#2026, targeted variant confirmed
+--                                             in incognito as "Special Welcome
+--                                             Offer / previously 80,000, now
+--                                             125,000" — upgrade framing, i.e.
+--                                             targeting, not a public change)
+--   id 254  2026-08-13  125,000 ->  80,000   (#2040, corrects back to public)
+--
+-- All four are artifacts of one offer being read inconsistently, not four offer
+-- changes in eleven days. Leaving them shows visitors a bonus that ping-pongs
+-- weekly and, worse, two of them are INCREASES — which is what fires a CardWire
+-- tweet (see scripts/post-card-wire.js). Deleting the rows also removes them
+-- from the 48-hour --reconcile window so they cannot be re-posted.
+--
+-- Scoped by card_id + field + date so it cannot touch any other card or any of
+-- this card's non-SUB history (annual_fee, APR, rewards). The card's YAML is
+-- already correct at 80,000 as of #2040.
+DELETE FROM card_wire WHERE card_id = 375 AND field = 'signup_bonus_value' AND changed_at >= '2026-08-01 00:00:00';


### PR DESCRIPTION
## What is actually correct

**80,000 miles after \$12,000 in 6 months.** The card's public sign-up bonus has not changed since it was added on 2026-07-28.

## The evidence

| Date | Source | Read | Note |
|---|---|---|---|
| 07-28 → 08-02 | YAML baseline | 80,000 | stable for 5 days |
| 08-02 | automated fetch (#1898) | 125,000 | before the session-targeting guard existed |
| 08-11 | manual check (#2011) | 80,000 | "80,000 is the **only** mileage figure on the page" |
| 08-12 | automated fetch (#2026) | 125,000 | incognito showed *"Special Welcome Offer / previously 80,000, now 125,000"* |
| 08-13 | automated fetch + clean incognito (#2040) | 80,000 | plain "WELCOME OFFER", no upgrade header |

The automated fetch alternates 125k / 80k / 125k / 80k across eleven days. That is the signature of **session-targeted serving**, not four real offer changes. The decisive tell is the 08-12 framing: an offer that advertises itself as "previously 80,000, now 125,000" while 80,000 is what other sessions see is a **targeted upgrade**, not a public change.

## The rows being deleted

| id | date | change | origin |
|---|---|---|---|
| 243 | 08-03 | 80,000 → 125,000 | #1898, fetch got targeted variant |
| 248 | 08-11 | 125,000 → 80,000 | #2011, hand-applied unverified |
| 252 | 08-12 | 80,000 → 125,000 | #2026, targeted variant |
| 254 | 08-13 | 125,000 → 80,000 | #2040, correction back to public |

All four are artifacts of one unchanging offer being read inconsistently. Scoped by `card_id` + `field` + date so no other card and no non-SUB history on this card is touched.

## Deploy

Single-statement migration, runs through the usual `RunMigrationHandler` wire → deploy → invoke → unwire path.

## Related, not fixed here

- ⚠️ **A public tweet from 08-12 is live announcing the phantom increase** ("CardWire Update: Delta SkyMiles Reserve Business American Express ⬆️ Sign-up Bonus: 80,000 miles → 125,000 miles", ~24 views). Deleting the row stops it being re-posted by the 48-hour `--reconcile` window, but does not retract the tweet.
- The `SESSION_TARGETED_OFFER_HOSTS` guard in `check-card-pages.js` only suppresses **decreases**. Both phantom increases sailed through with no verification gate at all. Holding increases on those hosts for clean-browser confirmation would prevent a repeat.