### PR TITLE
news: drop unverified seaplane wording from Bilt Blade item

### DIFF
--- a/data/news/2026-08-14-bilt-blade-flights-bookable-in-app.yaml
+++ b/data/news/2026-08-14-bilt-blade-flights-bookable-in-app.yaml
@@ -1,7 +1,7 @@
 id: "bilt-blade-flights-bookable-in-app"
 date: "2026-08-14"
 title: "Bilt Adds Blade Helicopter Redemptions"
-summary: "Bilt turned on Blade bookings inside its app on August 13, 2026. Members can pay for helicopter and seaplane seats with Bilt Points, Bilt Cash, or a mix, with up to $350 in Bilt Cash per seat and a cap of two flights per calendar year."
+summary: "Bilt turned on Blade bookings inside its app on August 13, 2026. Members can pay for Blade seats with Bilt Points, Bilt Cash, or a mix, with up to $350 in Bilt Cash per seat and a cap of two flights per calendar year."
 tags:
   - "benefit-change"
 bank: "Bilt"


### PR DESCRIPTION
The Bilt/Blade item merged in #2043 said members can pay for "helicopter and seaplane seats." The sources ([The Points Guy](https://thepointsguy.com/news/bilt-cash-blade-flights/), [One Mile at a Time](https://onemileatatime.com/news/bilt-blade-partnership/)) describe the integration as Blade flight bookings and helicopter transfers. Neither confirms seaplane routes are in scope, so the summary now reads "Blade seats."

Summary line only. No other facts changed: the $350-per-seat Bilt Cash cap, the two-flights-per-calendar-year limit, and the August 13, 2026 date are all unchanged and verified.

Note: the auto-generated X post for this item (queue ID 358) went out with the original "helicopter and seaplane" phrasing and is not editable from this repo.