### PR TITLE
Update card count copy from 150+ to 200+

### DIFF
--- a/apps/web-next/src/app/LandingClient.tsx
+++ b/apps/web-next/src/app/LandingClient.tsx
@@ -815,7 +815,7 @@ function FinalCTA() {
         <h2>
           Open the <em>file</em> on every card.
         </h2>
-        <p>150+ cards. Thousands of records. Free, forever, no email required to read.</p>
+        <p>200+ cards. Thousands of records. Free, forever, no email required to read.</p>
         <div className="ctas-row">
           <Link
             href="/explore"

--- a/apps/web-next/src/components/landing-v2/Chrome.tsx
+++ b/apps/web-next/src/components/landing-v2/Chrome.tsx
@@ -73,7 +73,7 @@ export function V2Footer() {
                 maxWidth: 320,
               }}
             >
-              Community-powered approval odds for 150+ credit cards. Independent, free,
+              Community-powered approval odds for 200+ credit cards. Independent, free,
               and built on real data.
             </p>
           </div>


### PR DESCRIPTION
The landing page CTA and the site footer both advertised "150+ cards". The repo now has 224 card YAMLs (192 currently accepting applications), so both were understating coverage.

- `LandingClient.tsx` final CTA: "150+ cards" → "200+ cards"
- `landing-v2/Chrome.tsx` footer blurb: "150+ credit cards" → "200+ credit cards"

Used 200+ rather than the exact count so the claim holds under either definition (all tracked cards or only those accepting applications) and does not need updating on every card add.

Verified both strings render on the local dev server.