### PR TITLE
Retry apply-link 404s before flagging them as broken

### DIFF
--- a/scripts/check-apply-links.js
+++ b/scripts/check-apply-links.js
@@ -11,7 +11,9 @@
  * Fidelity's dead offer page survived a daily green check.
  *
  * A link is flagged as broken if any of these are true:
- *   - HTTP status is 4xx or 5xx (after retrying with a browser for 403/429)
+ *   - HTTP status is 4xx or 5xx, and it survives a stealth-browser retry plus a
+ *     second confirming attempt (see needsBrowserRetry — bank WAFs soft-block
+ *     the CI runner with a 404 as readily as a 403)
  *   - Final redirect URL matches an error path (e.g. /error/500, /404, /page-not-found)
  *   - Page title or body contains common error markers
  *
@@ -34,6 +36,7 @@ const CONCURRENCY = 8;
 const FETCH_TIMEOUT_MS = 20000;
 const BROWSER_TIMEOUT_MS = 30000;
 const REQUEST_DELAY_MS = 100;
+const RETRY_DELAY_MS = 3000;
 
 const USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
@@ -218,6 +221,27 @@ async function fetchWithBrowser(url) {
   }
 }
 
+// Statuses that may be a bank WAF blocking the CI runner rather than a real
+// verdict on the URL. The stealth-browser retry exists precisely to defeat these,
+// so the set decides whether that machinery ever runs.
+//
+// 404 is the important entry and the one that was missing. Akamai and Imperva
+// both soft-block with a plain 404, which at the status-code layer is
+// indistinguishable from a dead page — so the one status the script trusted
+// unconditionally was also a routine block response. Citi's /usc/lpaca/ offer
+// pages did exactly that on 2026-08-13 (issue #2037): a single run got a 404 on
+// the AAdvantage Executive apply link while every other citi.com URL in the same
+// run passed within the same second, and the page was live throughout — it had
+// checked OK on 8/9, 8/10 and 8/12, and checked OK again afterwards. Because 404
+// skipped the retry path, a live link with a live 70k offer was reported broken.
+//
+// 5xx and 410 are here for the same reason: transient edge failures that a real
+// browser or a few seconds later would not reproduce.
+function needsBrowserRetry(status) {
+  return status === 0 || status === 403 || status === 404 || status === 410 ||
+    status === 429 || status >= 500;
+}
+
 function classify(result, originalUrl) {
   if (!result) {
     return { ok: false, reason: 'No response' };
@@ -261,22 +285,54 @@ function classify(result, originalUrl) {
   return { ok: true, finalUrl };
 }
 
+// Surface what the server actually sent on a failure. Without this, a WAF denial
+// page and a real bank 404 are both just "HTTP 404" in the run log — which is
+// what made #2037 take a manual investigation to tell apart. Citi's genuine dead
+// page says "Page Not Found 404"; a block page reads nothing like it.
+function bodySnippetOf(result) {
+  if (!result?.body) return undefined;
+  const text = result.body
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text ? text.slice(0, 200) : undefined;
+}
+
+async function plainFetch(url) {
+  try {
+    return await fetchWithTimeout(url, FETCH_TIMEOUT_MS);
+  } catch (err) {
+    return { status: 0, finalUrl: url, body: '', error: err.message };
+  }
+}
+
 async function checkOne(card) {
-  let result = null;
+  let result = await plainFetch(card.apply_link);
   let usedBrowser = false;
 
-  try {
-    result = await fetchWithTimeout(card.apply_link, FETCH_TIMEOUT_MS);
-  } catch (err) {
-    result = { status: 0, finalUrl: card.apply_link, body: '', error: err.message };
-  }
-
-  // 403/429/0 may be bot blocks — retry with a real browser before flagging
-  if (result.status === 403 || result.status === 429 || result.status === 0) {
+  // A status a WAF might have invented deserves a real browser and a second look
+  // before we call the link dead. See needsBrowserRetry for why 404 is in that set.
+  if (needsBrowserRetry(result.status)) {
     const browserResult = await fetchWithBrowser(card.apply_link);
     if (browserResult) {
       result = browserResult;
       usedBrowser = true;
+    }
+
+    // Still bad. Edge blocks are usually rate- or reputation-based and clear
+    // within seconds, so give it one more attempt after a pause and only believe
+    // the failure if it repeats. A genuinely dead URL fails both times.
+    if (needsBrowserRetry(result.status)) {
+      await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+      const retry = await fetchWithBrowser(card.apply_link);
+      if (retry) {
+        result = retry;
+        usedBrowser = true;
+      } else {
+        result = await plainFetch(card.apply_link);
+        usedBrowser = false;
+      }
     }
   }
 
@@ -291,10 +347,17 @@ async function checkOne(card) {
       if (browserVerdict.ok) {
         return { ...card, ok: true, finalUrl: browserResult.finalUrl };
       }
-      return { ...card, ok: false, reason: browserVerdict.reason, finalUrl: browserResult.finalUrl };
+      return {
+        ...card,
+        ok: false,
+        reason: browserVerdict.reason,
+        finalUrl: browserResult.finalUrl,
+        bodySnippet: bodySnippetOf(browserResult),
+      };
     }
   }
 
+  if (!verdict.ok) verdict.bodySnippet = bodySnippetOf(result);
   return { ...card, ...verdict };
 }
 
@@ -324,6 +387,7 @@ async function main() {
     console.log(
       `[${idx + 1}/${cards.length}] ${tag} ${card.slug}${which} — ${r.reason || r.finalUrl || ''}`
     );
+    if (!r.ok && r.bodySnippet) console.log(`      body: ${r.bodySnippet}`);
     return r;
   });
 
@@ -360,7 +424,7 @@ async function main() {
   console.log(`Wrote ${RESULT_FILE}`);
 }
 
-module.exports = { checkOne, classify, loadActiveCards, targetsForCard };
+module.exports = { checkOne, classify, loadActiveCards, needsBrowserRetry, targetsForCard };
 
 if (require.main === module) {
   main()

--- a/scripts/check-apply-links.test.js
+++ b/scripts/check-apply-links.test.js
@@ -1,0 +1,93 @@
+// Smoke tests for the WAF-retry logic in check-apply-links.js.
+//
+// These guard the false-positive path that produced issue #2037: Citi's
+// /usc/lpaca/ offer landing page returned a 404 to one CI run while the page was
+// live, and because 404 was outside the retry set the check reported a working
+// apply link (and a live 70k SUB) as broken. A false "broken" here is expensive
+// twice over — it burns a manual investigation, and if acted on it strips a real
+// offer out of the card data.
+//
+// Run: `node scripts/check-apply-links.test.js`. Exits non-zero on any failure.
+
+const assert = require('node:assert/strict');
+const { classify, needsBrowserRetry } = require('./check-apply-links');
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+console.log('needsBrowserRetry');
+
+test('404 retries — the #2037 regression', () => {
+  assert.equal(needsBrowserRetry(404), true);
+});
+
+test('retries the other WAF-block and transient statuses', () => {
+  for (const status of [0, 403, 410, 429, 500, 502, 503, 504]) {
+    assert.equal(needsBrowserRetry(status), true, `expected retry for ${status}`);
+  }
+});
+
+test('does not retry a healthy or non-block response', () => {
+  for (const status of [200, 204, 301, 302, 304, 400, 401, 451]) {
+    assert.equal(needsBrowserRetry(status), false, `expected no retry for ${status}`);
+  }
+});
+
+console.log('classify');
+
+test('a live offer page passes', () => {
+  const verdict = classify(
+    {
+      status: 200,
+      finalUrl: 'https://www.citi.com/usc/lpaca/aa/aadvantage/exec/ps/index0.html',
+      body: '<title>Citi / AAdvantage Executive World Elite Mastercard</title>',
+    },
+    'https://www.citi.com/usc/lpaca/aa/aadvantage/exec/ps/index0.html'
+  );
+  assert.equal(verdict.ok, true);
+});
+
+test('an apply-page title containing "error" is not flagged on the word alone', () => {
+  // The title heuristic exempts pages whose title mentions apply/credit card, so
+  // a real product page cannot be failed by an incidental substring match.
+  const verdict = classify(
+    { status: 200, finalUrl: 'https://bank.example/apply', body: '<title>Apply for a credit card</title>' },
+    'https://bank.example/apply'
+  );
+  assert.equal(verdict.ok, true);
+});
+
+test('a genuine 404 is still broken', () => {
+  const verdict = classify(
+    { status: 404, finalUrl: 'https://bank.example/dead', body: '' },
+    'https://bank.example/dead'
+  );
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.reason, /404/);
+});
+
+test('a soft-404 body is still broken at HTTP 200', () => {
+  const verdict = classify(
+    {
+      status: 200,
+      finalUrl: 'https://bank.example/offer',
+      body: '<title>Offer</title><p>This page was moved or deleted.</p>',
+    },
+    'https://bank.example/offer'
+  );
+  assert.equal(verdict.ok, false);
+});
+
+if (failures) {
+  console.error(`\n${failures} test(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll tests passed.');


### PR DESCRIPTION
Fixes #2037.

## The report was a false positive

The daily check flagged the Citi AAdvantage Executive apply link as `HTTP 404`. The link works. `https://www.citi.com/usc/lpaca/aa/aadvantage/exec/ps/index0.html` returns 200 with the real offer page (70,000 miles / $7,000 in 3 months / $595 AF), which matches the stored `signup_bonus` exactly. Nothing was wrong with the card data.

What happened is an intermittent Akamai edge block on the runner:

- The same URL logged `OK` on the 8/9, 8/10 and 8/12 runs. Only 8/13 flagged it.
- On the 8/13 run **every other citi.com URL passed within the same second** from the same IP, so it wasn't a blanket Citi block — it was specific to the `/usc/lpaca/` offer-landing path, which sits behind a tighter policy than the `/credit-cards/` product pages.
- That path is demonstrably fingerprint-sensitive: a `HEAD` from a residential IP gets `403` from `AkamaiGHost` while a `GET` gets 200.

## The actual bug

`checkOne` only escalated to the stealth browser for `403`, `429`, and network errors:

```js
if (result.status === 403 || result.status === 429 || result.status === 0) {
```

A `404` went straight to broken with no browser retry and no second attempt. But Akamai and Imperva both soft-block datacenter IPs with a plain 404, so the one status the script trusted unconditionally is also a routine block response — and the whole stealth-Chrome apparatus that exists to defeat bank WAFs never ran for this URL.

## Changes

- `needsBrowserRetry(status)` — a named predicate matching the `check-card-pages.js` precedent — now covers `404`, `410` and `5xx` alongside `0`/`403`/`429`.
- A retryable status that survives the browser gets one more attempt after a 3s pause, and only a repeated failure is reported. Edge blocks are rate- or reputation-based and clear within seconds; a genuinely dead URL fails both times.
- Failures now log a 200-char text snippet of the response body. A WAF denial page and a real bank 404 were both just `HTTP 404` in the run log, which is precisely why #2037 needed a manual investigation to resolve.
- New `scripts/check-apply-links.test.js` covering the retry set and the `classify` verdicts.

## Verification

`node scripts/check-apply-links.test.js` — 7/7 pass.

End-to-end against live URLs:

| URL | Result |
|---|---|
| the real Citi exec link from #2037 | `OK` in 924ms, no retry triggered |
| a bogus `/usc/lpaca/` path | `BAD — HTTP 404` after both retries, logging Citi's real `Page Not Found 404` copy |

That second row is also the sanity check on the whole approach: a genuine Citi 404 says "Page not found", which reads nothing like a block page — so the new body snippet distinguishes the two cases directly in the log next time.

Cost is bounded: a real 404 now takes ~7s instead of ~1s, and broken links are normally 0-2 per run. Worst case (every URL blocked) is ~160s at `CONCURRENCY = 8`, well inside the 20-minute job timeout.

Note: the existing `scripts/*.test.js` files aren't wired into any workflow, so this one follows the same run-it-manually convention.