### PR TITLE
fix(auth): stop iOS Safari IndexedDB teardown from wedging auth state

### DIFF
--- a/apps/web-next/src/auth/AuthProvider.tsx
+++ b/apps/web-next/src/auth/AuthProvider.tsx
@@ -23,6 +23,25 @@ const newsletterRegisteredUids = new Set<string>();
 // Key for storing email in localStorage for email link sign-in
 const EMAIL_FOR_SIGN_IN_KEY = 'emailForSignIn';
 
+// How long to wait for Firebase's first auth-state emission before giving up
+// and treating the visitor as signed out.
+//
+// Firebase chains every onAuthStateChanged callback off its internal
+// _initializationPromise, and that promise rejects if reading the persisted
+// user throws — see the createAuth comment in firebase.ts for the iOS Safari
+// IndexedDB case. A rejection there means our callback is never invoked at all,
+// so isLoading would stay true forever and /profile, /admin and the store
+// personal row would sit on a skeleton for the rest of the page's life.
+// Firebase gives us no handle on that promise, so a timer is the only way to
+// notice.
+//
+// The failure is fast (a few synchronous storage retries, then it throws), so
+// this only has to outlast the slow-but-healthy case: a stored session whose
+// token gets refreshed over the network on load. 15s is comfortably past that,
+// and the subscription stays live afterwards, so a late emission still
+// corrects the state.
+const AUTH_INIT_TIMEOUT_MS = 15_000;
+
 // localStorage throws SecurityError in Safari when "Block all cookies" is
 // on. The email-link flow works without it — the user just gets prompted
 // for their email again — so storage failures are swallowed.
@@ -92,7 +111,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    const initTimeout = setTimeout(() => {
+      console.warn('Firebase auth did not initialize; treating as signed out');
+      setAuthState((prev) =>
+        prev.isLoading ? { ...prev, isLoading: false } : prev,
+      );
+    }, AUTH_INIT_TIMEOUT_MS);
+
     const unsubscribe = onAuthStateChanged(auth, (user) => {
+      clearTimeout(initTimeout);
       setAuthState({
         isAuthenticated: !!user,
         isLoading: false,
@@ -117,7 +144,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     });
 
-    return () => unsubscribe();
+    return () => {
+      clearTimeout(initTimeout);
+      unsubscribe();
+    };
   }, []);
 
   // Check for email link sign-in on mount

--- a/apps/web-next/src/auth/firebase.ts
+++ b/apps/web-next/src/auth/firebase.ts
@@ -1,5 +1,12 @@
 import { initializeApp, getApps, FirebaseApp } from 'firebase/app';
-import { getAuth, Auth } from 'firebase/auth';
+import {
+  getAuth,
+  initializeAuth,
+  browserLocalPersistence,
+  indexedDBLocalPersistence,
+  browserPopupRedirectResolver,
+  Auth,
+} from 'firebase/auth';
 import { getAnalytics, Analytics, isSupported } from 'firebase/analytics';
 
 const firebaseConfig = {
@@ -17,6 +24,42 @@ let app: FirebaseApp | undefined;
 let auth: Auth | undefined;
 let analytics: Analytics | undefined;
 
+// getAuth() puts IndexedDB first in the persistence hierarchy, and on iOS
+// Safari that is a wedge risk. WebKit tears the page's IndexedDB connection
+// down whenever the tab is backgrounded or hidden, so an open during that
+// window rejects with "InvalidStateError: Database is closing/hidden". Firebase
+// retries four times with no backoff, then lets the rejection escape from
+// initializeCurrentUser -> _initializationPromise. Nothing in the SDK holds a
+// handler for that promise, so two things happen: Sentry records an unhandled
+// rejection (CREDITODDS-JAVASCRIPT-NEXTJS-1G), and — worse — every
+// onAuthStateChanged callback is chained off that same promise and therefore
+// never fires. AuthProvider's isLoading would stay true for the rest of the
+// page's life.
+//
+// localStorage first avoids the whole path: the selected persistence is read
+// synchronously and cannot reject. IndexedDB stays in the hierarchy so an
+// existing session stored there is still found and migrated to localStorage on
+// first load (PersistenceUserManager.create wraps those reads in try/catch), so
+// nobody gets signed out by this change. If localStorage is unavailable —
+// Safari with "Block all cookies" — Firebase drops it from the hierarchy and
+// falls back to IndexedDB, matching the previous behaviour.
+//
+// browserPopupRedirectResolver has to be passed explicitly: getAuth() supplies
+// it by default, and signInWithPopup throws auth/operation-not-supported
+// without it.
+function createAuth(firebaseApp: FirebaseApp): Auth {
+  try {
+    return initializeAuth(firebaseApp, {
+      persistence: [browserLocalPersistence, indexedDBLocalPersistence],
+      popupRedirectResolver: browserPopupRedirectResolver,
+    });
+  } catch {
+    // auth/already-initialized — another module (or a Fast Refresh reload)
+    // got here first. Reuse whatever instance exists.
+    return getAuth(firebaseApp);
+  }
+}
+
 function getFirebaseAuth(): Auth | undefined {
   if (typeof window === 'undefined') {
     return undefined;
@@ -30,7 +73,7 @@ function getFirebaseAuth(): Auth | undefined {
   if (!app) {
     try {
       app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
-      auth = getAuth(app);
+      auth = createAuth(app);
 
       // Initialize Analytics (only in browser, if supported, and not in development)
       if (process.env.NODE_ENV === 'production') {

--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -69,6 +69,22 @@ describe("isBenignClientError", () => {
     ).toBe(true);
   });
 
+  it("drops WebKit's closing/hidden IDB-open noise (DOMException shape)", () => {
+    expect(
+      isBenignClientError(
+        domException("Database is closing/hidden", "InvalidStateError", 11),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops WebKit's closing/hidden IDB-open noise (Firebase rethrow shape)", () => {
+    // Firebase's _withRetries rethrows the DOMException as a plain Error once
+    // the retry budget is spent, which is the shape Sentry actually recorded.
+    expect(isBenignClientError(new Error('Database is closing/hidden'))).toBe(
+      true,
+    );
+  });
+
   it("drops Firebase Installations app-offline noise", () => {
     // FirebaseError shape: name "FirebaseError", code "installations/app-offline".
     expect(

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -17,6 +17,18 @@
 // page to try again" — name/code don't match the AbortError gate below, so
 // that signature is matched unconditionally. The page itself is unaffected.
 //
+// WebKit has a second, distinct teardown signature: "InvalidStateError:
+// Database is closing/hidden" (CREDITODDS-JAVASCRIPT-NEXTJS-1G), raised when a
+// page opens IndexedDB while Mobile Safari is suspending the tab. It is neither
+// an AbortError nor a connection-lost error, so it needs its own entry.
+// The auth-side consequence of this one was real rather than cosmetic —
+// Firebase let it escape from initializeCurrentUser and wedged
+// onAuthStateChanged — and that is fixed at the source in auth/firebase.ts by
+// putting localStorage ahead of IndexedDB. What survives is the rejection
+// itself: Firebase Analytics/Installations still touch IndexedDB, and their
+// internal promises have no handler we can attach to, so the same message can
+// still surface as unhandled noise with nothing to act on.
+//
 // Firebase Installations also rejects with "installations/app-offline" when
 // navigator.onLine is false during Analytics init. getAnalytics() never awaits
 // that internal registration promise, so a visitor who loses connectivity
@@ -90,6 +102,7 @@ const BENIGN_CLIENT_SIGNATURES = [
 const BENIGN_ANY_ERROR_SIGNATURES = [
   'Invalid call to runtime.sendMessage(). Tab not found.',
   'Connection to Indexed Database server lost',
+  'Database is closing/hidden',
   'installations/app-offline',
   'Object Not Found Matching Id:',
   'Unable to load image data:',


### PR DESCRIPTION
## What this is

Sentry [CREDITODDS-JAVASCRIPT-NEXTJS-1G](https://creditodds.sentry.io/issues/7672678319/) — `Error: Database is closing/hidden`, unhandled rejection, Mobile Safari / iOS 18.7.

## Why it is not just noise

The stack is `_openDb → _withRetries → _get → getCurrentUser → initializeCurrentUser`. WebKit tears the page's IndexedDB connection down while suspending a backgrounded tab, so the open rejects. Firebase retries 4x with no backoff, then rethrows out of `initializeCurrentUser` into `_initializationPromise`.

`registerStateListener` chains every `onAuthStateChanged` callback off that same promise with a `.then()` and no rejection handler. So when it rejects, our callback is **never invoked** — `AuthProvider`'s `isLoading` stays `true` for the life of the page. Affected surfaces:

| Surface | Stuck state |
| --- | --- |
| `/profile` | `ProfileSkeleton` forever |
| `/admin` | loading forever |
| `/best-card-for/[slug]` | personal row never renders (this is the page in the report) |
| `/check-odds`, `/profile/history` | prefill / load never runs |

## The fix

**1. `auth/firebase.ts` — build auth with `initializeAuth`, localStorage first.**
`getAuth()` puts IndexedDB at the head of the persistence hierarchy. With `browserLocalPersistence` first, the persisted user is read synchronously from localStorage and cannot reject, so the failing path is gone.

`indexedDBLocalPersistence` stays in the hierarchy: `PersistenceUserManager.create` scans **all** listed persistences for an existing user (in a `try/catch`) and migrates what it finds to the selected one, so signed-in users are carried across rather than logged out. If localStorage is unavailable (Safari "Block all cookies"), Firebase drops it and falls back to IndexedDB, i.e. today's behaviour.

`browserPopupRedirectResolver` is passed explicitly — `initializeAuth` does not supply `getAuth`'s default, and `signInWithPopup` throws `auth/operation-not-supported-in-this-environment` without it.

**2. `auth/AuthProvider.tsx` — 15s watchdog.**
Firebase exposes no handle on `_initializationPromise` (`authStateReady()` is itself built on `onAuthStateChanged`, so it hangs too). A timer is the only way to notice. If the first emission has not arrived in 15s, settle `isLoading: false` and treat the visitor as signed out. The failure mode is fast (a few synchronous retries), so 15s clears the slow-but-healthy case of a stored session refreshing its token over the network; the subscription stays live so a late emission still corrects the state.

**3. `lib/benignClientError.ts` — filter the message.**
It is neither an `AbortError` nor a connection-lost error, so it slipped past both existing gates. Analytics and Installations still touch IndexedDB through promises we cannot attach a handler to, and the rejection itself carries nothing actionable.

## Verification

- `benignClientError.test.ts`: 34 passing, 2 new cases (DOMException + Firebase rethrow shapes).
- `tsc --noEmit` and `eslint` clean on the changed files.
- Dev server: `/best-card-for/buffalo-wild-wings` loads with `Firebase initialized successfully` and no console errors — confirming no `auth/already-initialized` fallback.
- `/profile` while signed out redirects to `/login`, which only happens on `!isLoading && !isAuthenticated` — so the auth state settles under the new persistence config.