### PR TITLE
Auto: The Platinum Card rewards/benefits update — 2026-08-16

### DIFF
--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -194,6 +194,11 @@ benefits:
     frequency: "ongoing"
     category: "hotel"
     enrollment_required: false
+  - name: "Car Rental Privileges"
+    description: "Complimentary premium status for select car rental programs with Avis, Hertz, and National"
+    frequency: "ongoing"
+    category: "car_rental"
+    enrollment_required: true
 tags:
   - travel
   - premium

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -195,6 +195,7 @@ benefits:
     category: "hotel"
     enrollment_required: false
   - name: "Car Rental Privileges"
+    value: 0
     description: "Complimentary premium status for select car rental programs with Avis, Hertz, and National"
     frequency: "ongoing"
     category: "car_rental"


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **The Platinum Card**.

**Apply link (verify against this):** https://www.americanexpress.com/us/credit-cards/card/platinum/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
