### PR TITLE
Mark PenFed Pathfinder annual fee waiver as ending 2026-09-28

### DIFF
--- a/data/cards/penfed-pathfinder-rewards.yaml
+++ b/data/cards/penfed-pathfinder-rewards.yaml
@@ -51,21 +51,31 @@ benefits:
     frequency: "annual"
     category: "lounge"
     enrollment_required: true
-  - name: "Annual Fee Waiver"
-    value: 95
-    description: "The $95 annual fee is waived for PenFed Honors Advantage members (current or former military, or Access America checking account holders)"
+  # Ending 2026-09-28: PenFed is mailing cardholders a change-in-terms notice
+  # saying the $95 fee is no longer eligible to be waived. Kept as a marked
+  # entry (value 0, so it stops counting toward Total Annual Credits) rather
+  # than deleted, because the live product page still advertises the waiver
+  # and the rewards checker would otherwise re-propose it. Delete this block
+  # after 2026-09-28.
+  - name: "Annual Fee Waiver (ends September 28, 2026)"
+    value: 0
+    description: "PenFed Honors Advantage members (current or former military, or Access America checking account holders) have had the $95 annual fee waived in full. PenFed is notifying cardholders that the fee is no longer eligible to be waived as of September 28, 2026, so plan on paying the $95."
     frequency: "annual"
     category: "other"
 our_take: >
-  The PenFed Pathfinder Rewards Visa Signature punches far above its weight
-  for military members and anyone willing to open a PenFed Access America
-  checking account: those Honors Advantage members get the $95 annual fee
-  waived entirely, plus 4x points on travel and 3x on dining. Even the $100
-  annual air travel incidental credit alone would justify a fee the eligible
-  cardholder is not paying. A 50,000-point bonus after $3,000 in spend, a
-  Global Entry credit every five years, and a Priority Pass membership round
-  out a travel package that few no-fee cards can match, though lounge visits
-  carry per-visit fees. Points redeem at roughly fixed value with a modest
-  catalog, so this is not a transferable-points powerhouse. For the Honors
-  Advantage crowd it is one of the best deals in travel cards; for everyone
-  else the math is merely decent.
+  The PenFed Pathfinder Rewards Visa Signature was built around a fee waiver
+  that is going away. PenFed is notifying cardholders that the $95 annual fee
+  is no longer eligible to be waived as of September 28, 2026, so Honors
+  Advantage members, meaning current or former military and Access America
+  checking customers, lose the perk that made this an effectively free travel
+  card. Judge it on the $95. The $100 annual domestic airline incidental
+  credit covers most of that by itself, and a Global Entry or TSA PreCheck
+  application credit every five years plus a Priority Pass membership fill out
+  a package that still holds up at this price, though lounge visits carry
+  per-visit fees. Honors Advantage members do keep the better earn rates, 4x
+  on travel and 3x on dining against 3x and 2x for everyone else, alongside
+  1.5x on everything else and no foreign transaction fees. The 50,000-point
+  bonus after $3,000 in the first 90 days is a fair start. Points redeem at
+  roughly fixed value through a modest catalog with no transfer partners, so
+  this is not a flexible-points powerhouse. It is a reasonable mid-fee travel
+  card now rather than the free-money play it used to be.


### PR DESCRIPTION
PenFed is mailing Pathfinder Rewards Visa Signature cardholders a change-in-terms notice saying the **$95 annual fee is no longer eligible to be waived as of September 28, 2026** ([Doctor of Credit](https://www.doctorofcredit.com/penfed-to-remove-annual-fee-waiver-on-pathfinder/), reported 2026-08-15). The news item shipped in #2053; this updates the card data, which still sold the card on the waiver.

## Changes to `data/cards/penfed-pathfinder-rewards.yaml`

**`Annual Fee Waiver` benefit** — renamed to `Annual Fee Waiver (ends September 28, 2026)`, `value` dropped `95` → `0`, description rewritten to state the end date.

Kept as a marked entry rather than deleted, for two reasons:
- The live product page still advertises the waiver as of August 2026, so the rewards/benefits checker would re-propose it. A code comment marks the block for deletion after 2026-09-28.
- Readers deciding in the next six weeks need to see the perk is going away, not just find it missing.

`value: 0` matters: `amortizedAnnualValue` counts an `annual` benefit at full value, so the old block was adding a phantom $95 to Total Annual Credits.

**`our_take`** — rewritten. It previously led with "those Honors Advantage members get the $95 annual fee waived entirely" and called the air travel credit worth "a fee the eligible cardholder is not paying." It now judges the card on the real $95: the $100 airline incidental credit covering most of it, Global Entry/TSA PreCheck, Priority Pass, and the Honors Advantage earn-rate edge that does survive.

## Live page verification

Checked https://www.penfed.org/credit-cards/pathfinder-rewards-visa directly (WebFetch and curl are 403'd by PenFed; read via the browser). Everything else in the YAML matches and is unchanged:

| Field | Live page | YAML |
|---|---|---|
| Annual fee | $95 | 95 ✓ |
| Purchase APR | 17.99% variable | 17.99 ✓ |
| Foreign transaction fee | None | false ✓ |
| Travel / dining | 4x / 3x Honors Advantage, 3x / 2x otherwise | ✓ |
| Everything else | 1.5x | 1.5 ✓ |
| Signup bonus | 50K points, $3,000 in first 90 days | 50000 / 3000 / 3mo ✓ |
| Air travel credit | $100 annual domestic air ancillary | 100 ✓ |
| Global Entry / TSA | $120 / $85 | 120 ✓ |
| Priority Pass | Complimentary, per-visit fees | ✓ |

Note: the product page still shows "Annual Fee: $95 (waived for existing PenFed Honors Advantage Members)" with no mention of the September date. PenFed has published no separate announcement, so the change is sourced from the mailed change-in-terms notice only.

## Validation

`npm run build:cards` passes clean (224 cards, no errors or warnings). Regenerated `cards.json` not committed (gitignored).

## Follow-up

Delete the marked benefit block after 2026-09-28.