### PR TITLE
Fix benefits with no value rendering nowhere

### DIFF
--- a/apps/web-next/src/app/card/[name]/CardClient.tsx
+++ b/apps/web-next/src/app/card/[name]/CardClient.tsx
@@ -23,7 +23,7 @@ import {
   CardWireEntry,
 } from "@/lib/api";
 import { getValuationDetails } from "@/lib/valuations";
-import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, frequencyLabel } from "@/lib/cardDisplayUtils";
+import { DEFAULT_MULTI_YEAR_CYCLE, formatBenefitValue, formatRewardCapCaveat, frequencyLabel, isCreditBenefit } from "@/lib/cardDisplayUtils";
 import { NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { Article } from "@/lib/articles";
 import SubmitRecordModal from "@/components/forms/SubmitRecordModal";
@@ -443,7 +443,7 @@ export default function CardClient({
     [card.rewards],
   );
 
-  const creditBenefits = (card.benefits || []).filter((b) => b.value > 0);
+  const creditBenefits = (card.benefits || []).filter(isCreditBenefit);
   // Mirrors amortizedAnnualValue() but supports unit filtering so we can
   // roll up USD / points / miles totals separately. Convention: `value` is
   // the annual total; `frequency` is just a display hint (monthly/quarterly

--- a/apps/web-next/src/app/compare/CompareClient.tsx
+++ b/apps/web-next/src/app/compare/CompareClient.tsx
@@ -12,7 +12,7 @@ import {
   InformationCircleIcon,
 } from '@heroicons/react/24/outline';
 import { Card, Reward, trackCardCompareEvent } from '@/lib/api';
-import { amortizedAnnualValue, formatBenefitValue } from '@/lib/cardDisplayUtils';
+import { amortizedAnnualValue, formatBenefitValue, isCreditBenefit, isPerkBenefit } from '@/lib/cardDisplayUtils';
 import { cardMatchesSearch } from '@/lib/searchAliases';
 import {
   categoryLabels,
@@ -539,8 +539,8 @@ export default function CompareClient({ allCards }: CompareClientProps) {
 
                   {/* Benefits */}
                   {card.benefits && card.benefits.length > 0 && (() => {
-                    const credits = card.benefits.filter(b => b.value > 0);
-                    const perks = card.benefits.filter(b => b.value === 0);
+                    const credits = card.benefits.filter(isCreditBenefit);
+                    const perks = card.benefits.filter(isPerkBenefit);
                     const totalAnnual = credits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0);
                     return (
                       <div className="px-4 py-2.5 text-sm">
@@ -829,7 +829,7 @@ export default function CompareClient({ allCards }: CompareClientProps) {
               {activeCards.some(c => c.benefits && c.benefits.length > 0) && (() => {
                 const totalCredits = activeCards.map(c => {
                   if (!c.benefits) return 0;
-                  return c.benefits.filter(b => b.value > 0).reduce(
+                  return c.benefits.filter(isCreditBenefit).reduce(
                     (sum, b) => sum + amortizedAnnualValue(b),
                     0
                   );
@@ -848,12 +848,12 @@ export default function CompareClient({ allCards }: CompareClientProps) {
                               </div>
                             )}
                             <div className="text-xs text-gray-500 space-y-0.5">
-                              {card.benefits.filter(b => b.value > 0).map(b => (
+                              {card.benefits.filter(isCreditBenefit).map(b => (
                                 <div key={b.name}>{b.name} ({formatBenefitValue(b)}{b.frequency === 'annual' ? '/yr' : b.frequency === 'monthly' ? '/mo' : b.frequency === 'quarterly' ? '/qtr' : ''})</div>
                               ))}
-                              {card.benefits.filter(b => b.value === 0).length > 0 && (
+                              {card.benefits.filter(isPerkBenefit).length > 0 && (
                                 <div className="text-gray-400 mt-1">
-                                  +{card.benefits.filter(b => b.value === 0).length} perk{card.benefits.filter(b => b.value === 0).length !== 1 ? 's' : ''}
+                                  +{card.benefits.filter(isPerkBenefit).length} perk{card.benefits.filter(isPerkBenefit).length !== 1 ? 's' : ''}
                                 </div>
                               )}
                             </div>

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -14,7 +14,7 @@ import "../landing.css";
 import { getNews, getNewsCards, NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
 import ProfileLoader from "./ProfileLoader";
-import { amortizedAnnualValue, categoryLabels } from "@/lib/cardDisplayUtils";
+import { amortizedAnnualValue, categoryLabels, isCreditBenefit } from "@/lib/cardDisplayUtils";
 import { TrashIcon, DocumentTextIcon, LinkIcon, ExclamationTriangleIcon, PencilIcon } from "@heroicons/react/24/outline";
 import { calculateApplicationRules, countCardsMissingDates } from "@/lib/applicationRules";
 import posthog from "posthog-js";
@@ -311,7 +311,7 @@ export default function ProfileClient() {
       if (!card?.benefits?.length) continue;
       let cardTotal = 0;
       for (const b of card.benefits) {
-        if (b.value > 0) cardTotal += amortizedAnnualValue(b);
+        if (isCreditBenefit(b)) cardTotal += amortizedAnnualValue(b);
       }
       if (cardTotal > 0) {
         total += cardTotal;

--- a/apps/web-next/src/components/ui/CardBenefits.tsx
+++ b/apps/web-next/src/components/ui/CardBenefits.tsx
@@ -5,7 +5,7 @@ import {
   CheckCircleIcon,
 } from "@heroicons/react/24/outline";
 import { CardBenefit } from "@/lib/api";
-import { amortizedAnnualValue, formatBenefitValue, frequencyLabel } from "@/lib/cardDisplayUtils";
+import { amortizedAnnualValue, formatBenefitValue, frequencyLabel, isCreditBenefit, isPerkBenefit } from "@/lib/cardDisplayUtils";
 
 const categoryIcons: Record<string, string> = {
   dining: "🍽️",
@@ -31,8 +31,8 @@ interface CardBenefitsProps {
 }
 
 export default function CardBenefits({ benefits, cardName }: CardBenefitsProps) {
-  const credits = benefits.filter((b) => b.value > 0);
-  const perks = benefits.filter((b) => b.value === 0);
+  const credits = benefits.filter(isCreditBenefit);
+  const perks = benefits.filter(isPerkBenefit);
   // Only sum USD-valued credits — points/miles can't be meaningfully added in dollars.
   const totalAnnualValue = credits.reduce((sum, b) => sum + amortizedAnnualValue(b), 0);
 

--- a/apps/web-next/src/components/wallet/WalletBenefits.tsx
+++ b/apps/web-next/src/components/wallet/WalletBenefits.tsx
@@ -8,7 +8,9 @@ import {
   amortizedAnnualValue,
   DEFAULT_MULTI_YEAR_CYCLE,
   formatBenefitValue,
+  isCreditBenefit,
   isMonetaryBenefit,
+  isPerkBenefit,
 } from "@/lib/cardDisplayUtils";
 import { dedupeWalletByCardName } from "@/app/profile/profileSelectors";
 
@@ -123,7 +125,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
   const allCredits = useMemo<DecoratedBenefit[]>(() => {
     return cardsWithBenefits.flatMap(c =>
       c.benefits
-        .filter(b => b.value > 0)
+        .filter(isCreditBenefit)
         .map(b => ({ ...b, cardName: c.cardData.card_name, cardSlug: c.cardData.slug, cardImage: c.cardData.card_image_link }))
     ).sort((a, b) => amortizedAnnualValue(b) - amortizedAnnualValue(a));
   }, [cardsWithBenefits]);
@@ -131,7 +133,7 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
   const allPerks = useMemo<DecoratedBenefit[]>(() => {
     return cardsWithBenefits.flatMap(c =>
       c.benefits
-        .filter(b => b.value === 0)
+        .filter(isPerkBenefit)
         .map(b => ({ ...b, cardName: c.cardData.card_name, cardSlug: c.cardData.slug, cardImage: c.cardData.card_image_link }))
     );
   }, [cardsWithBenefits]);
@@ -153,9 +155,9 @@ export default function WalletBenefits({ walletCards, allCards }: WalletBenefits
           cardSlug: c.cardData.slug,
           cardImage: c.cardData.card_image_link,
         });
-        const credits = c.benefits.filter(b => b.value > 0).map(decorate)
+        const credits = c.benefits.filter(isCreditBenefit).map(decorate)
           .sort((a, b) => amortizedAnnualValue(b) - amortizedAnnualValue(a));
-        const perks = c.benefits.filter(b => b.value === 0).map(decorate);
+        const perks = c.benefits.filter(isPerkBenefit).map(decorate);
         const annualTotal = Math.round(credits.reduce((s, b) => s + amortizedAnnualValue(b), 0));
         return { card: c.cardData, credits, perks, annualTotal };
       })

--- a/apps/web-next/src/lib/cardDisplayUtils.test.ts
+++ b/apps/web-next/src/lib/cardDisplayUtils.test.ts
@@ -3,7 +3,9 @@ import {
   formatBenefitValue,
   creditAmountLabel,
   amortizedAnnualValue,
+  isCreditBenefit,
   isMonetaryBenefit,
+  isPerkBenefit,
   spendableValue,
 } from './cardDisplayUtils';
 
@@ -89,5 +91,44 @@ describe('creditAmountLabel', () => {
 
   it('returns nothing for a zero-value perk', () => {
     expect(creditAmountLabel(0, 'annual')).toBe('');
+  });
+});
+
+// A benefit with no `value` at all used to render NOWHERE. Every surface
+// splits benefits into `value > 0` credits and `value === 0` perks, and
+// undefined satisfies neither test, so 163 perks across 67 cards (Amex
+// Platinum's Marriott Gold status, Delta Sky Club visits, free checked bags)
+// were dropped from the compare table, the wallet view and the card page.
+// The YAMLs are backfilled and build-cards.js now rejects a benefit without
+// a value; these guard the runtime half, since cards.json is CDN-cached and
+// an older payload can still reach the browser.
+describe('benefits with a missing value', () => {
+  const statusPerk = { name: 'Marriott Bonvoy Gold Elite Status', frequency: 'ongoing' } as never;
+
+  it('counts as a perk, not a credit', () => {
+    expect(isCreditBenefit(statusPerk)).toBe(false);
+    expect(isPerkBenefit(statusPerk)).toBe(true);
+  });
+
+  it('lands in exactly one bucket for every benefit', () => {
+    const benefits = [
+      { name: 'Hotel Credit', value: 600, frequency: 'annual' },
+      { name: 'Lounge Access', value: 0, frequency: 'ongoing' },
+      statusPerk,
+    ] as never[];
+    expect(benefits.filter(isCreditBenefit).length + benefits.filter(isPerkBenefit).length)
+      .toBe(benefits.length);
+  });
+
+  it('never turns an annual credits rollup into NaN', () => {
+    expect(amortizedAnnualValue(statusPerk)).toBe(0);
+    expect(
+      amortizedAnnualValue({ name: 'Delta Sky Club Visits', frequency: 'annual' } as never)
+    ).toBe(0);
+  });
+
+  it('formats as $0 rather than $NaN', () => {
+    expect(formatBenefitValue({ name: 'x', frequency: 'monthly' } as never)).toBe('$0');
+    expect(spendableValue({ name: 'x', frequency: 'quarterly' } as never)).toBe(0);
   });
 });

--- a/apps/web-next/src/lib/cardDisplayUtils.tsx
+++ b/apps/web-next/src/lib/cardDisplayUtils.tsx
@@ -171,6 +171,32 @@ export function isMonetaryBenefit(benefit: { value_unit?: string }): boolean {
   return !benefit.value_unit || benefit.value_unit === 'usd';
 }
 
+// A benefit's `value`, defaulting a missing one to 0 (the repo's marker for a
+// non-dollar perk).
+//
+// CardBenefit types `value` as required and build-cards now enforces it, but
+// cards.json is served from a CDN and older payloads can still be in a
+// browser/ISR cache, so nothing at runtime guarantees the field is there. The
+// default matters because the UI partitions benefits into exactly two buckets
+// — `value > 0` credits and `value === 0` perks. An undefined value satisfies
+// neither test, so the benefit silently vanished from every list instead of
+// rendering as a perk (163 benefits across 67 cards were hidden this way), and
+// it turned annual totals into NaN wherever it reached the sum.
+export function benefitValue(benefit: { value?: number }): number {
+  return benefit.value ?? 0;
+}
+
+// The two buckets the UI renders. Kept here rather than inlined at each call
+// site so the "credits vs perks" split can never drift apart or leave a
+// benefit in neither bucket.
+export function isCreditBenefit(benefit: { value?: number }): boolean {
+  return benefitValue(benefit) > 0;
+}
+
+export function isPerkBenefit(benefit: { value?: number }): boolean {
+  return benefitValue(benefit) === 0;
+}
+
 // Smallest spendable denomination per cycle — what we headline in the UI.
 //
 // Why not just `benefit.value`? Because `value` is the ANNUAL TOTAL by
@@ -186,11 +212,12 @@ export function isMonetaryBenefit(benefit: { value_unit?: string }): boolean {
 //   3. `value` itself for annual / multi_year / ongoing / per-event
 export function spendableValue(benefit: CardBenefit): number {
   if (typeof benefit.value_per_cycle === 'number') return benefit.value_per_cycle;
+  const value = benefitValue(benefit);
   switch (benefit.frequency) {
-    case 'monthly': return Math.round(benefit.value / 12);
-    case 'quarterly': return Math.round(benefit.value / 4);
-    case 'semi_annual': return Math.round(benefit.value / 2);
-    default: return benefit.value;
+    case 'monthly': return Math.round(value / 12);
+    case 'quarterly': return Math.round(value / 4);
+    case 'semi_annual': return Math.round(value / 2);
+    default: return value;
   }
 }
 
@@ -198,7 +225,7 @@ export function formatBenefitValue(benefit: CardBenefit): string {
   // `percent` is a RATE, not an amount, so it must not be divided down by
   // frequency the way a dollar total is — a 20% inflight rebate is 20% on
   // every purchase, not 20/12 of anything. Read `value` directly.
-  if (benefit.value_unit === 'percent') return `${benefit.value.toLocaleString()}%`;
+  if (benefit.value_unit === 'percent') return `${benefitValue(benefit).toLocaleString()}%`;
   const v = spendableValue(benefit).toLocaleString();
   if (benefit.value_unit === 'points') return `${v} points`;
   if (benefit.value_unit === 'miles') return `${v} miles`;
@@ -243,10 +270,10 @@ export function amortizedAnnualValue(benefit: CardBenefit): number {
     case 'quarterly':
     case 'semi_annual':
     case 'annual':
-      return benefit.value;
+      return benefitValue(benefit);
     case 'multi_year': {
       const years = benefit.frequency_years || DEFAULT_MULTI_YEAR_CYCLE;
-      return Math.round(benefit.value / years);
+      return Math.round(benefitValue(benefit) / years);
     }
     case 'ongoing': return 0;
     // per_purchase, per_flight, per_trip, per_visit, per_rental, per_claim,

--- a/data/cards/aaa-daily-advantage-visa-signature.yaml
+++ b/data/cards/aaa-daily-advantage-visa-signature.yaml
@@ -73,9 +73,11 @@ our_take: >
   way.
 benefits:
   - name: "AAA Redemption Bonus"
+    value: 0
     description: "5% more cash back when redeeming with AAA Northeast Counselors and Advisors"
     category: "rewards"
   - name: "3% on AAA Purchases"
+    value: 0
     description: "3% cash back on AAA memberships and AAA Travel agency bookings"
     frequency: "ongoing"
     category: "rewards"

--- a/data/cards/aaa-travel-advantage-visa-signature.yaml
+++ b/data/cards/aaa-travel-advantage-visa-signature.yaml
@@ -61,5 +61,6 @@ our_take: >
   rate will not do much for you.
 benefits:
   - name: "AAA Redemption Bonus"
+    value: 0
     description: "5% more cash back when redeeming with AAA Northeast Counselors and Advisors"
     category: "rewards"

--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -40,16 +40,19 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Priority Boarding"
+    value: 0
     description: "Priority boarding for the cardmember and authorized users on Aer Lingus flights between the US and Ireland"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "10% Flight Discount"
+    value: 0
     description: "10% off Aer Lingus flights from the US to Europe when booking via the designated cardmember website"
     frequency: "per_purchase"
     category: "travel"
     enrollment_required: false
   - name: "DashPass Membership"
+    value: 0
     description: "Complimentary DashPass for at least one year when activated by Dec 31, 2027"
     frequency: "annual"
     category: "rewards"
@@ -57,14 +60,17 @@ benefits:
     merchants:
       - doordash
   - name: "Baggage Delay Insurance"
+    value: 0
     description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false
   - name: "Lost Luggage Reimbursement"
+    value: 0
     description: "Reimbursement up to $3,000 per covered traveler for lost, damaged, or stolen checked or carry-on baggage during a covered trip"
     category: "travel"
     enrollment_required: false
   - name: "Purchase Protection"
+    value: 0
     description: "Covers eligible new purchases for 120 days from purchase date against damage or theft, up to $500 per item"
     category: "protection"
     enrollment_required: false

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -64,18 +64,22 @@ our_take: >
   make it easy to keep around even when you are not shopping.
 benefits:
   - name: "Purchase Protection"
+    value: 0
     description: "Covers eligible new purchases for 120 days from purchase date against damage or theft up to $500 per item"
     category: "protection"
     enrollment_required: false
   - name: "Baggage Delay Insurance"
+    value: 0
     description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false
   - name: "Travel Accident Insurance"
+    value: 0
     description: "Provides up to $500,000 in accidental death or dismemberment coverage when you pay for air, bus, train or cruise transportation with your card"
     category: "travel"
     enrollment_required: false
   - name: "Lost Luggage Reimbursement"
+    value: 0
     description: "Provides reimbursement up to $3,000 per covered traveler for lost, damaged or stolen checked or carry-on baggage during a covered trip"
     category: "travel"
     enrollment_required: false

--- a/data/cards/amazon-store-card.yaml
+++ b/data/cards/amazon-store-card.yaml
@@ -16,10 +16,13 @@ rewards:
     note: "Amazon and Whole Foods Market (In-Store Code required) with an eligible Prime membership; no 5% without Prime"
 benefits:
   - name: "0% APR Equal Monthly Payments"
+    value: 0
     description: "6 months on Amazon purchases $50–$599.99, 12 months on $600+, 24 months on select purchases"
   - name: "10%+ back limited-time offers"
+    value: 0
     description: "Rotating selection of items and categories on Amazon for eligible Prime cardmembers"
   - name: "Amazon-only acceptance"
+    value: 0
     description: "Closed-loop store card usable at Amazon.com, select physical Amazon stores, Whole Foods Market (via in-store code), and merchants accepting Amazon Pay"
 signup_bonus:
   value: 0

--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -50,6 +50,7 @@ benefits:
     frequency: "annual"
     category: "travel"
   - name: "Free Checked Bag and Preferred Boarding"
+    value: 0
     description: "First checked bag free and preferred boarding for the cardmember and up to 6 guests on the same reservation"
     frequency: "per_flight"
     category: "travel"

--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -61,16 +61,19 @@ signup_bonus:
   note: "Get 70,000 bonus points and a $99 Companion Fare (plus taxes and fees from $23) after you make $4,000 or more in purchases within the first 90 days of opening your account."
 benefits:
   - name: "Coach Companion Fare"
+    value: 0
     description: "$99 Companion Fare (plus taxes and fees from $23) every year that you spend at least $6,000 on purchases with the card"
     frequency: "annual"
     category: "travel"
     enrollment_required: false
   - name: "Free Checked Bag"
+    value: 0
     description: "First checked bag free for the cardmember on Alaska Airlines flights when paid with the card"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "Priority Boarding"
+    value: 0
     description: "Priority boarding on Alaska Airlines flights when paid with the card"
     frequency: "per_flight"
     category: "travel"
@@ -82,6 +85,7 @@ benefits:
     category: "lounge"
     enrollment_required: false
   - name: "No Personal Credit Reporting"
+    value: 0
     description: "Card activity does not report to personal credit bureaus, helpful for managing personal credit utilization and 5/24-style limits"
     frequency: "annual"
     category: "other"

--- a/data/cards/atmos-rewards-summit.yaml
+++ b/data/cards/atmos-rewards-summit.yaml
@@ -69,6 +69,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Free Checked Bag and Preferred Boarding"
+    value: 0
     description: "First checked bag free and priority boarding for the cardmember and up to 6 guests on the same reservation when paid with the card"
     frequency: "per_flight"
     category: "travel"
@@ -86,6 +87,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Same-Day Confirmed Change Fee Waiver"
+    value: 0
     description: "Same-day confirmed flight change fees waived (excludes Saver fares)"
     frequency: "per_flight"
     category: "travel"
@@ -103,6 +105,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "20% Inflight Purchase Rebate"
+    value: 0
     description: "20% back on Alaska and Hawaiian Airlines inflight purchases when paid with the card"
     frequency: "per_purchase"
     category: "statement_credit"

--- a/data/cards/att-points-plus-from-citi.yaml
+++ b/data/cards/att-points-plus-from-citi.yaml
@@ -69,10 +69,12 @@ benefits:
     category: "statement_credit"
     enrollment_required: false
   - name: "No Foreign Transaction Fees"
+    value: 0
     description: "No foreign transaction fees on purchases abroad"
     category: "travel"
     enrollment_required: false
   - name: "ThankYou Points Pooling"
+    value: 0
     description: "Pool points with other Citi ThankYou cards to access transfer partners"
     category: "rewards"
     enrollment_required: false

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -57,6 +57,7 @@ benefits:
     category: "lounge"
     enrollment_required: false
   - name: "Gold Status"
+    value: 0
     description: "Gold Status awarded after meeting $4,000 spend requirement on purchases (excluding rent or mortgage) in first 90 days"
     frequency: "one_time"
     category: "rewards"

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -78,6 +78,7 @@ benefits:
       - hulu
       - espn-plus
   - name: "Purchase Protection"
+    value: 0
     description: "Coverage up to $50,000 per calendar year (maximum $1,000 per purchase) for stolen or accidentally damaged covered purchases within 90 days"
     category: "protection"
     enrollment_required: false

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -74,14 +74,17 @@ benefits:
       - hulu
       - espn-plus
   - name: "Purchase Protection"
+    value: 0
     description: "Coverage up to $1,000 per covered purchase and $50,000 per account per calendar year if a charged item is stolen or accidentally damaged within 90 days"
     category: "protection"
     enrollment_required: false
   - name: "Return Protection"
+    value: 0
     description: "Return eligible purchases to American Express for refund if the seller won't accept returns, up to $300 per item and $1,000 per calendar year"
     category: "protection"
     enrollment_required: false
   - name: "Extended Warranty"
+    value: 0
     description: "Up to one extra year added to the original manufacturer's warranty on covered purchases (up to $10,000 per item, $50,000 per account per calendar year)"
     category: "protection"
     enrollment_required: false

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -46,11 +46,13 @@ benefits:
     category: "statement_credit"
     enrollment_required: false
   - name: "10% Flight Discount"
+    value: 0
     description: "10% off British Airways flights from the US to London booked via the designated cardmember website"
     frequency: "per_purchase"
     category: "travel"
     enrollment_required: false
   - name: "DashPass Membership"
+    value: 0
     description: "Complimentary DashPass for at least one year when activated by Dec 31, 2027"
     frequency: "annual"
     category: "rewards"
@@ -58,14 +60,17 @@ benefits:
     merchants:
       - doordash
   - name: "Baggage Delay Insurance"
+    value: 0
     description: "Reimbursement up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false
   - name: "Lost Luggage Reimbursement"
+    value: 0
     description: "Reimbursement up to $3,000 per covered traveler for repair or replacement of lost, damaged, or stolen baggage during a covered trip"
     category: "travel"
     enrollment_required: false
   - name: "Purchase Protection"
+    value: 0
     description: "Coverage for eligible new purchases against damage or theft up to $500 per item for 120 days from purchase date"
     category: "protection"
     enrollment_required: false

--- a/data/cards/capital-one-quicksilver.yaml
+++ b/data/cards/capital-one-quicksilver.yaml
@@ -53,6 +53,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Price Match Guarantee"
+    value: 0
     description: "Travel credit for the difference if you find a better price on flights, hotels, or rental cars within 24 hours of booking."
     frequency: "per_trip"
     category: "travel"

--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -68,6 +68,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Price Match Guarantee"
+    value: 0
     description: "Travel credit for the difference if you find a better price on eligible flights, hotels, or rental cars within 24 hours of booking."
     frequency: "per_trip"
     category: "travel"

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -20,6 +20,7 @@ benefits:
     category: "hotel"
     enrollment_required: false
   - name: "50% Off Handcrafted Beverages"
+    value: 0
     description: "50% off all handcrafted beverages every day at any Capital One Café nationwide."
     frequency: "per_purchase"
     category: "dining"

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -44,6 +44,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Price Match Guarantee"
+    value: 0
     description: "Travel credit for price difference on flights, hotels, or rental cars if better price found within 24 hours of booking"
     frequency: "per_trip"
     category: "travel"
@@ -55,17 +56,20 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Capital One Entertainment 5x"
+    value: 0
     description: "5x miles on ticket purchases through the Capital One Entertainment platform (concerts, sports, dining experiences). Excludes dining reservations and Capital One Dining."
     frequency: "per_purchase"
     category: "entertainment"
     enrollment_required: false
   - name: "Discounted Cultivist Membership"
+    value: 0
     description: "50% off the Enthusiast membership to The Cultivist for up to 2 years"
     frequency: "multi_year"
     frequency_years: 2
     category: "entertainment"
     enrollment_required: false
   - name: "Enhanced Hotel Benefits"
+    value: 0
     description: "Includes up to $100 hotel credit, daily breakfast, room upgrades, and more at Premier and Lifestyle Collection hotels"
     frequency: "per_trip"
     category: "hotel"

--- a/data/cards/capital-one-ventureone-rewards.yaml
+++ b/data/cards/capital-one-ventureone-rewards.yaml
@@ -50,6 +50,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Price Match Guarantee"
+    value: 0
     description: "Travel credit for the difference if you find a better price on eligible flight, hotel, or rental car within 24 hours of booking."
     frequency: "per_trip"
     category: "travel"

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -81,6 +81,7 @@ benefits:
     category: "other"
     enrollment_required: false
   - name: "DashPass Complimentary Membership"
+    value: 0
     description: "6 months of complimentary DashPass on DoorDash and Caviar, plus $10 off one non-restaurant DoorDash order each quarter while enrolled."
     frequency: "one_time"
     category: "dining"

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -61,6 +61,7 @@ our_take: >
   Lyft. As a keep-forever no-fee card, it is hard to argue with.
 benefits:
   - name: "DashPass Complimentary Membership"
+    value: 0
     description: "6 months of complimentary DashPass membership with $0 delivery fees on eligible orders."
     frequency: "one_time"
     category: "dining"

--- a/data/cards/chase-ihg-one-rewards-premier-business.yaml
+++ b/data/cards/chase-ihg-one-rewards-premier-business.yaml
@@ -40,6 +40,7 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "DoorDash DashPass"
+    value: 0
     description: "One-year complimentary DashPass membership for DoorDash and Caviar with unlimited deliveries and $0 delivery fees on eligible orders, when activated by Dec 31, 2027"
     frequency: "annual"
     category: "dining"

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -83,6 +83,7 @@ our_take: >
   rate stops mattering much.
 benefits:
   - name: "Instacart+ Membership"
+    value: 0
     description: "Complimentary three-month Instacart+ membership with a $20 Instacart credit each month"
     frequency: "one_time"
     category: "shopping"

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -81,11 +81,13 @@ benefits:
     category: "telecom"
     enrollment_required: false
   - name: "Primary Auto Rental Coverage"
+    value: 0
     description: "Primary collision damage waiver on rentals for business purposes (up to the cash value of the vehicle)"
     frequency: "per_rental"
     category: "travel"
     enrollment_required: false
   - name: "DashPass Membership"
+    value: 0
     description: "Complimentary DashPass for at least one year plus $10/month off non-restaurant DoorDash orders when activated by Dec 31, 2027"
     frequency: "monthly"
     category: "rewards"

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -48,6 +48,7 @@ foreign_transaction_fee: true
 network: "visa"
 benefits:
   - name: "Instacart+ Membership"
+    value: 0
     description: "Complimentary three-month Instacart+ membership with a $20 Instacart credit each month"
     frequency: "one_time"
     category: "shopping"

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -37,6 +37,7 @@ benefits:
     frequency: "ongoing"
     category: "lounge"
   - name: "IHG Platinum Elite Status"
+    value: 0
     description: "Complimentary IHG One Rewards Platinum Elite Status through December 31, 2027."
     frequency: "multi_year"
     frequency_years: 4
@@ -95,6 +96,7 @@ benefits:
     category: "fitness"
     enrollment_required: true
   - name: "Primary Rental Car Coverage"
+    value: 0
     description: "Primary auto rental collision damage waiver with reimbursement up to $75,000 for theft and collision damage in the U.S. and abroad."
     frequency: "ongoing"
     category: "car_rental"

--- a/data/cards/citi-aadvantage-globe.yaml
+++ b/data/cards/citi-aadvantage-globe.yaml
@@ -42,6 +42,7 @@ benefits:
     category: "security"
     enrollment_required: false
   - name: "Companion Certificate"
+    value: 0
     description: "American Airlines Companion Certificate for a single qualifying round-trip main cabin domestic flight starting in the second cardmembership year upon renewal"
     frequency: "annual"
     category: "travel"

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -39,6 +39,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "American Airlines Admirals Club Passes"
+    value: 0
     description: "4 annual Admirals Club lounge access passes for cardmember use at nearly 50 locations ($300 value)"
     frequency: "annual"
     category: "lounge"

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -67,21 +67,25 @@ apr:
     max: 28.49
 benefits:
   - name: "First Checked Bag Free"
+    value: 0
     description: "First checked bag free on domestic American Airlines itineraries for the cardmember and up to 4 companions on the same reservation"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "Preferred Boarding"
+    value: 0
     description: "Group 5 boarding on American Airlines flights for the cardmember and up to 4 companions on the same reservation"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "Companion Certificate"
+    value: 0
     description: "American Airlines Companion Certificate good for domestic main-cabin travel for up to two companions ($99 ticketing fee plus taxes) after $30,000 in purchases each cardmembership year"
     frequency: "annual"
     category: "travel"
     enrollment_required: false
   - name: "25% Inflight Purchase Savings"
+    value: 0
     description: "25% off in-flight food, beverages, and Wi-Fi purchases on American Airlines flights when paid with the card"
     frequency: "per_purchase"
     category: "statement_credit"

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -24,30 +24,36 @@ benefits:
     category: "streaming"
     enrollment_required: true
   - name: "Disney Park Merchandise Discount"
+    value: 0
     description: "10% off select merchandise purchases at Disneyland and Walt Disney World Resort locations"
     frequency: "per_purchase"
     category: "shopping"
     enrollment_required: false
   - name: "Disney Park Dining Discount"
+    value: 0
     description: "10% off select dining locations at Disneyland and Walt Disney World Resort"
     frequency: "per_purchase"
     category: "dining"
     enrollment_required: false
   - name: "Disney Guided Tour Discount"
+    value: 0
     description: "15% off select guided tours at Disneyland and Walt Disney World Resort"
     frequency: "per_purchase"
     category: "entertainment"
     enrollment_required: false
   - name: "DisneyStore.com Discount"
+    value: 0
     description: "10% savings on select purchases at DisneyStore.com"
     frequency: "per_purchase"
     category: "shopping"
     enrollment_required: false
   - name: "Purchase Protection"
+    value: 0
     description: "Covers eligible new purchases for 120 days from date of purchase against damage or theft, up to $500 per item"
     category: "protection"
     enrollment_required: false
   - name: "Baggage Delay Insurance"
+    value: 0
     description: "Reimburses up to $100 a day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -40,35 +40,42 @@ apr:
     max: 27.74
 benefits:
   - name: "Disney Park Merchandise Discount"
+    value: 0
     description: "10% off select merchandise purchases of $50 or more at Disneyland and Walt Disney World Resort locations"
     frequency: "per_purchase"
     category: "shopping"
     enrollment_required: false
   - name: "Disney Park Dining Discount"
+    value: 0
     description: "10% off select dining locations at Disneyland and Walt Disney World Resort on most days"
     frequency: "per_purchase"
     category: "dining"
     enrollment_required: false
   - name: "Disney Guided Tour Discount"
+    value: 0
     description: "15% off non-discounted price for select guided tours at Disneyland and Walt Disney World Resort"
     frequency: "per_purchase"
     category: "entertainment"
     enrollment_required: false
   - name: "Cardmember Photo Locations"
+    value: 0
     description: "Private cardmember photo opportunities with complimentary digital downloads via Disney PhotoPass"
     frequency: "per_visit"
     category: "entertainment"
     enrollment_required: false
   - name: "DisneyStore.com Discount"
+    value: 0
     description: "10% savings on select purchases at shopDisney.com"
     frequency: "per_purchase"
     category: "shopping"
     enrollment_required: false
   - name: "Purchase Protection"
+    value: 0
     description: "Covers eligible new purchases for 120 days from purchase date against damage or theft up to $500 per item"
     category: "protection"
     enrollment_required: false
   - name: "Baggage Delay Insurance"
+    value: 0
     description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -46,29 +46,35 @@ benefits:
     merchants:
       - doordash
   - name: "Purchase Protection"
+    value: 0
     description: "Covers eligible new purchases against damage or theft for 120 days from date of purchase up to $500 per item"
     category: "protection"
     enrollment_required: false
   - name: "Baggage Delay Insurance"
+    value: 0
     description: "Reimburses up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false
   - name: "Disney Park Merchandise Discount"
+    value: 0
     description: "10% off select merchandise purchases at Disneyland and Walt Disney World Resort locations"
     frequency: "per_purchase"
     category: "shopping"
     enrollment_required: false
   - name: "Disney Park Dining Discount"
+    value: 0
     description: "10% off select dining locations at Disneyland and Walt Disney World Resort"
     frequency: "per_purchase"
     category: "dining"
     enrollment_required: false
   - name: "Disney Guided Tour Discount"
+    value: 0
     description: "15% off select guided tours at Disneyland and Walt Disney World Resort"
     frequency: "per_purchase"
     category: "entertainment"
     enrollment_required: false
   - name: "DisneyStore.com Discount"
+    value: 0
     description: "10% savings on select purchases at DisneyStore.com"
     frequency: "per_purchase"
     category: "shopping"

--- a/data/cards/free-spirit-travel-mastercard.yaml
+++ b/data/cards/free-spirit-travel-mastercard.yaml
@@ -32,6 +32,7 @@ benefits:
     value_unit: percent
     category: "travel"
   - name: "Priority boarding"
+    value: 0
     description: "Zone 2 shortcut boarding on Spirit flights."
     category: "travel"
 our_take: >

--- a/data/cards/free-spirit-travel-more-world-elite-mastercard.yaml
+++ b/data/cards/free-spirit-travel-more-world-elite-mastercard.yaml
@@ -31,6 +31,7 @@ rewards:
     unit: points_per_dollar
 benefits:
   - name: "Two free checked bags"
+    value: 0
     description: "Two checked bags at no charge on Spirit flights, added to the card in September 2025."
     category: "travel"
   - name: "Companion flight voucher"
@@ -43,9 +44,11 @@ benefits:
     value_unit: percent
     category: "travel"
   - name: "Priority boarding"
+    value: 0
     description: "Shortcut boarding on Spirit flights."
     category: "travel"
   - name: "Points pooling"
+    value: 0
     description: "Free Spirit points could be pooled with up to eight friends or family members."
     category: "travel"
 our_take: >

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -58,6 +58,7 @@ our_take: >
   and nothing else on the card will.
 benefits:
   - name: "Two Free Checked Bags"
+    value: 0
     description: "First and second checked bags free for the cardmember on eligible Hawaiian Airlines and Alaska Airlines operated flights when the card is used to book"
     frequency: "per_flight"
     category: "travel"

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -94,6 +94,7 @@ benefits:
     category: "hotel"
     enrollment_required: false
   - name: "Cell Phone Protection"
+    value: 0
     description: "Reimburses the lesser of repair or replacement cost after damage or theft, up to $800 per claim and 2 claims per 12 months, with a $50 deductible, when the wireless bill is paid with the card"
     frequency: "per_claim"
     category: "telecom"

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -53,11 +53,13 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "10% Flight Discount"
+    value: 0
     description: "10% off Iberia flights when booking via the designated cardmember website"
     frequency: "per_purchase"
     category: "travel"
     enrollment_required: false
   - name: "DashPass Membership"
+    value: 0
     description: "Complimentary DashPass for at least one year when activated by Dec 31, 2027"
     frequency: "annual"
     category: "rewards"
@@ -65,14 +67,17 @@ benefits:
     merchants:
       - doordash
   - name: "Baggage Delay Insurance"
+    value: 0
     description: "Reimbursement up to $100 per day for up to 3 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false
   - name: "Lost Luggage Reimbursement"
+    value: 0
     description: "Reimbursement up to $3,000 per covered traveler for lost, damaged, or stolen checked or carry-on baggage during a covered trip"
     category: "travel"
     enrollment_required: false
   - name: "Purchase Protection"
+    value: 0
     description: "Coverage for eligible new purchases for 120 days from purchase against damage or theft up to $500 per item"
     category: "protection"
     enrollment_required: false

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -47,6 +47,7 @@ benefits:
     category: "travel"
     enrollment_required: true
   - name: "DoorDash DashPass"
+    value: 0
     description: "One-year complimentary DashPass membership with unlimited deliveries and $0 delivery fees."
     frequency: "annual"
     category: "dining"

--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -12,6 +12,7 @@ benefits:
     frequency: "annual"
     category: "hotel"
   - name: "Fourth Night Free on Reward Stays"
+    value: 0
     description: "Redeem 3 nights and receive a 4th night free when you redeem points for a consecutive four-night IHG hotel stay at that same hotel during that same stay."
     frequency: "per_trip"
     category: "hotel"
@@ -23,6 +24,7 @@ benefits:
     category: "hotel"
     enrollment_required: false
   - name: "Gold Elite Status Qualification"
+    value: 0
     description: "Qualify for Gold Elite Status through December 31st of the following year when purchases total $20,000 or more in a calendar year."
     frequency: "annual"
     category: "travel"
@@ -35,6 +37,7 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "DoorDash DashPass"
+    value: 0
     description: "One-year complimentary DashPass membership for both DoorDash and Caviar providing unlimited deliveries with $0 delivery fees and lower service fees on eligible orders; plus up to $10 off quarterly on non-restaurant DoorDash orders through Dec 31, 2027."
     frequency: "annual"
     category: "dining"

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -60,16 +60,19 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "First Checked Bag Free"
+    value: 0
     description: "First checked bag free for the cardmember and up to 3 traveling companions on JetBlue-operated flights when the card is used to book"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "50% Off Inflight Purchases"
+    value: 0
     description: "50% savings on eligible food, drinks, and Wi-Fi purchased on JetBlue-operated flights"
     frequency: "per_purchase"
     category: "statement_credit"
     enrollment_required: false
   - name: "Mosaic Status Boost"
+    value: 0
     description: "Earn Mosaic elite status after $50,000 in eligible purchases per calendar year"
     frequency: "annual"
     category: "travel"
@@ -88,6 +91,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Group 3 Boarding"
+    value: 0
     description: "Group 3 boarding on JetBlue-operated flights"
     frequency: "per_flight"
     category: "travel"

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -63,16 +63,19 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "First Checked Bag Free"
+    value: 0
     description: "First checked bag free for the cardmember and up to 3 traveling companions on JetBlue-operated flights when the card is used to book"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "50% Off Inflight Purchases"
+    value: 0
     description: "50% savings on eligible food, drinks, and Wi-Fi purchased on JetBlue-operated flights"
     frequency: "per_purchase"
     category: "statement_credit"
     enrollment_required: false
   - name: "Mosaic Status Boost"
+    value: 0
     description: "Earn Mosaic elite status after $50,000 in eligible purchases per calendar year"
     frequency: "annual"
     category: "travel"

--- a/data/cards/jetblue-premier-card.yaml
+++ b/data/cards/jetblue-premier-card.yaml
@@ -71,11 +71,13 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "25-Tile Mosaic Bonus"
+    value: 0
     description: "Annual 25-tile bonus after year-end to fast-track Mosaic status for the next year"
     frequency: "annual"
     category: "travel"
     enrollment_required: false
   - name: "15% Award Flight Rebate"
+    value: 0
     description: "Get 15% of your points back after you redeem for and travel on an award flight on JetBlue or partner airlines"
     frequency: "per_redemption"
     category: "rewards"
@@ -87,11 +89,13 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "BlueHouse Lounge Access"
+    value: 0
     description: "Complimentary access to JetBlue's BlueHouse lounges for cardmembers with eligible fares; primary cardmembers and authorized users may each bring 1 complimentary guest per visit"
     frequency: "ongoing"
     category: "lounge"
     enrollment_required: false
   - name: "Priority Pass"
+    value: 0
     description: "Access to over 1,800 participating lounges and travel experiences in over 700 airports in 146 countries"
     frequency: "ongoing"
     category: "lounge"
@@ -104,6 +108,7 @@ benefits:
     category: "security"
     enrollment_required: false
   - name: "First Checked Bag Free"
+    value: 0
     description: "First checked bag free for the cardmember and up to 3 eligible travel companions on JetBlue-operated flights when the card is used to book"
     frequency: "per_flight"
     category: "travel"
@@ -116,6 +121,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Group 3 Boarding"
+    value: 0
     description: "Group 3 boarding on JetBlue-operated flights"
     frequency: "per_flight"
     category: "travel"

--- a/data/cards/kroger-rewards-world-elite-mastercard.yaml
+++ b/data/cards/kroger-rewards-world-elite-mastercard.yaml
@@ -68,9 +68,11 @@ rewards:
     unit: percent
 benefits:
   - name: "Kroger fuel discount"
+    value: 0
     description: "An extra 5 cents per gallon off at Kroger Family of Companies Fuel Centers on top of earned fuel points, rising to 25 cents per gallon after $6,000 in calendar-year spend when redeeming at least 100 fuel points."
     category: "shopping"
   - name: "Boost Essential membership"
+    value: 0
     description: "Complimentary Kroger Boost Essential membership, which includes free grocery delivery on qualifying orders and doubled fuel points."
     category: "shopping"
 our_take: >

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -25,18 +25,22 @@ benefits:
     merchants:
       - doordash
   - name: "Baggage Delay Insurance"
+    value: 0
     description: "Reimburses up to $100 per day for up to 5 days for essential purchases when baggage is delayed over 6 hours"
     category: "travel"
     enrollment_required: false
   - name: "Lost Luggage Reimbursement"
+    value: 0
     description: "Reimbursement up to $3,000 per covered traveler for lost, damaged, or stolen checked or carry-on baggage during a covered trip"
     category: "travel"
     enrollment_required: false
   - name: "Trip Delay Reimbursement"
+    value: 0
     description: "Up to $500 per ticket for unreimbursed expenses when your trip is delayed more than 12 hours or requires an overnight stay"
     category: "travel"
     enrollment_required: false
   - name: "Purchase Protection"
+    value: 0
     description: "Covers eligible new purchases for 120 days from purchase date against damage or theft, up to $500 per item"
     category: "protection"
     enrollment_required: false

--- a/data/cards/navy-federal-cash-rewards-plus.yaml
+++ b/data/cards/navy-federal-cash-rewards-plus.yaml
@@ -43,10 +43,12 @@ apr:
     max: 18.00
 benefits:
   - name: "No Balance Transfer Fees"
+    value: 0
     description: "Navy Federal does not charge balance transfer fees on this card"
     category: "other"
     enrollment_required: false
   - name: "Collision Damage Waiver"
+    value: 0
     description: "Rental car collision damage waiver coverage when the rental is paid with the card"
     category: "travel"
     enrollment_required: false

--- a/data/cards/navy-federal-cash-rewards-secured.yaml
+++ b/data/cards/navy-federal-cash-rewards-secured.yaml
@@ -22,10 +22,12 @@ apr:
     max: 18.00
 benefits:
   - name: "Upgrade Path to Unsecured cashRewards"
+    value: 0
     description: "Eligible for a credit limit increase after 3 months without adding to the deposit; reviewed monthly for upgrade to the unsecured cashRewards card starting at 6 months, with the security deposit ($200 minimum) returned upon upgrade"
     category: "other"
     enrollment_required: false
   - name: "Collision Damage Waiver"
+    value: 0
     description: "Rental car collision damage waiver coverage when the rental is paid with the card"
     category: "travel"
     enrollment_required: false

--- a/data/cards/navy-federal-cash-rewards.yaml
+++ b/data/cards/navy-federal-cash-rewards.yaml
@@ -31,10 +31,12 @@ apr:
     max: 18.00
 benefits:
   - name: "No Balance Transfer Fees"
+    value: 0
     description: "Navy Federal does not charge balance transfer fees on this card"
     category: "other"
     enrollment_required: false
   - name: "Collision Damage Waiver"
+    value: 0
     description: "Rental car collision damage waiver coverage when the rental is paid with the card"
     category: "travel"
     enrollment_required: false

--- a/data/cards/navy-federal-flagship-rewards.yaml
+++ b/data/cards/navy-federal-flagship-rewards.yaml
@@ -66,14 +66,17 @@ benefits:
     category: "travel"
     enrollment_required: true
   - name: "Travel Accident Insurance"
+    value: 0
     description: "Worldwide automatic travel accident insurance when travel is purchased with the card"
     category: "insurance"
     enrollment_required: false
   - name: "Travel and Emergency Assistance"
+    value: 0
     description: "24/7 travel and emergency assistance services"
     category: "travel"
     enrollment_required: false
   - name: "No Balance Transfer Fees"
+    value: 0
     description: "Navy Federal does not charge balance transfer fees on this card"
     category: "other"
     enrollment_required: false

--- a/data/cards/navy-federal-go-biz-rewards.yaml
+++ b/data/cards/navy-federal-go-biz-rewards.yaml
@@ -20,10 +20,12 @@ apr:
     max: 18.00
 benefits:
   - name: "Multiple Cardholders"
+    value: 0
     description: "Issue cards to multiple employees on one account at no extra cost"
     category: "other"
     enrollment_required: false
   - name: "Purchase Protection"
+    value: 0
     description: "New purchase protection on eligible items bought with the card"
     category: "insurance"
     enrollment_required: false

--- a/data/cards/navy-federal-go-rewards.yaml
+++ b/data/cards/navy-federal-go-rewards.yaml
@@ -29,10 +29,12 @@ apr:
     max: 18.00
 benefits:
   - name: "No Balance Transfer Fees"
+    value: 0
     description: "Navy Federal does not charge balance transfer fees on this card"
     category: "other"
     enrollment_required: false
   - name: "Collision Damage Waiver"
+    value: 0
     description: "Rental car collision damage waiver coverage when the rental is paid with the card"
     category: "travel"
     enrollment_required: false

--- a/data/cards/navy-federal-more-rewards-american-express.yaml
+++ b/data/cards/navy-federal-more-rewards-american-express.yaml
@@ -53,10 +53,12 @@ apr:
     max: 18.00
 benefits:
   - name: "No Balance Transfer Fees"
+    value: 0
     description: "Navy Federal does not charge balance transfer fees on this card"
     category: "other"
     enrollment_required: false
   - name: "Car Rental Discounts"
+    value: 0
     description: "Up to 25% off car rentals with rental loss and damage insurance included"
     category: "travel"
     enrollment_required: false

--- a/data/cards/navy-federal-platinum.yaml
+++ b/data/cards/navy-federal-platinum.yaml
@@ -17,14 +17,17 @@ apr:
     max: 18.00
 benefits:
   - name: "No Balance Transfer Fees"
+    value: 0
     description: "Navy Federal does not charge balance transfer fees, making this card built for paying down balances at its low standard APR"
     category: "other"
     enrollment_required: false
   - name: "Collision Damage Waiver"
+    value: 0
     description: "Rental car collision damage waiver coverage for rentals of 15 days or less paid with the card"
     category: "travel"
     enrollment_required: false
   - name: "Travel and Emergency Assistance"
+    value: 0
     description: "24/7 travel and emergency assistance services"
     category: "travel"
     enrollment_required: false

--- a/data/cards/playstation-visa.yaml
+++ b/data/cards/playstation-visa.yaml
@@ -59,14 +59,18 @@ our_take: >
   earner.
 benefits:
   - name: "PlayStation Plus Premium Membership"
+    value: 0
     description: "12-month PlayStation Plus Premium membership after $6,000 in purchases in a calendar year"
     category: "entertainment"
   - name: "PlayStation Store redemptions"
+    value: 0
     description: "Points redeemable for PlayStation Store codes and digital gift cards via the Account Center"
     category: "rewards"
   - name: "Visa Zero Liability"
+    value: 0
     description: "Protection against unauthorized transactions"
     category: "protection"
   - name: "Roadside Dispatch"
+    value: 0
     description: "24/7 pay-per-use roadside assistance via Visa"
     category: "travel"

--- a/data/cards/schema.json
+++ b/data/cards/schema.json
@@ -251,7 +251,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "description"],
+        "required": ["name", "description", "value"],
         "properties": {
           "name": {
             "type": "string",
@@ -268,7 +268,7 @@
           "value": {
             "type": "number",
             "minimum": 0,
-            "description": "Value of the benefit. Use 0 for non-monetary perks such as lounge access or elite status."
+            "description": "Value of the benefit. REQUIRED — use 0 for non-monetary perks such as lounge access or elite status, never omit the field. The UI splits benefits into `value > 0` credits and `value === 0` perks, so a benefit with no value belongs to neither bucket and renders nowhere. build-cards.js rejects a benefit without it."
           },
           "value_unit": {
             "type": "string",

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -56,26 +56,31 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "First Checked Bag Free"
+    value: 0
     description: "First checked bag free for the cardmember plus up to 8 passengers on the same reservation"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "10% Flight Discount"
+    value: 0
     description: "10% off promo code for one Southwest flight per anniversary year (excludes Basic fare)"
     frequency: "annual"
     category: "travel"
     enrollment_required: false
   - name: "Complimentary Standard Seat"
+    value: 0
     description: "Select a Standard seat within 48 hours prior to departure for the cardmember plus up to 8 passengers on the same reservation, when available"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "25% Inflight Purchase Credit"
+    value: 0
     description: "25% back on inflight drinks and Wi-Fi purchases when paid with the card"
     frequency: "per_purchase"
     category: "statement_credit"
     enrollment_required: false
   - name: "DashPass Membership"
+    value: 0
     description: "Complimentary DashPass for at least one year plus $10 quarterly off non-restaurant DoorDash orders when activated by Dec 31, 2027"
     frequency: "annual"
     category: "rewards"
@@ -83,6 +88,7 @@ benefits:
     merchants:
       - doordash
   - name: "No Foreign Transaction Fees"
+    value: 0
     description: "No foreign transaction fees on purchases made outside the US"
     frequency: "per_purchase"
     category: "travel"

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -87,11 +87,13 @@ benefits:
     merchants:
       - instacart
   - name: "First Checked Bag Free"
+    value: 0
     description: "First checked bag free for the cardmember plus up to 8 passengers on the same reservation"
     frequency: "per_flight"
     category: "travel"
     enrollment_required: false
   - name: "A-List Status TQPs"
+    value: 0
     description: "Earn 1,500 tier qualifying points for every $5,000 spent in purchases annually toward A-List status"
     frequency: "annual"
     category: "rewards"

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -89,6 +89,7 @@ benefits:
     merchants:
       - instacart
   - name: "A-List Status TQPs"
+    value: 0
     description: "Earn 2,500 tier qualifying points for every $5,000 spent in purchases annually toward A-List status"
     frequency: "annual"
     category: "rewards"

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -120,18 +120,22 @@ benefits:
     category: "car_rental"
     enrollment_required: true
   - name: "Trip Delay Insurance"
+    value: 0
     description: "Reimbursement for additional expenses up to $500 per trip when a covered trip is delayed more than 6 hours (maximum 2 claims per 12 months)"
     category: "travel"
     enrollment_required: false
   - name: "Trip Cancellation and Interruption Insurance"
+    value: 0
     description: "Reimbursement for non-refundable trip expenses up to $10,000 per trip and $20,000 per card per 12 months if covered reason cancels or interrupts trip"
     category: "travel"
     enrollment_required: false
   - name: "Baggage Insurance"
+    value: 0
     description: "Coverage for lost, damaged, or stolen baggage up to $3,000 aggregate per trip when entire fare purchased on card"
     category: "travel"
     enrollment_required: false
   - name: "Delta Sky Club Visits"
+    value: 0
     description: "10 complimentary visits per year when flying on an eligible Delta flight"
     frequency: "annual"
     category: "lounge"

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -175,21 +175,25 @@ benefits:
     category: "hotel"
     enrollment_required: false
   - name: "Marriott Bonvoy Gold Elite Status"
+    value: 0
     description: "Automatic Marriott Bonvoy Gold Elite Status."
     frequency: "ongoing"
     category: "travel"
     enrollment_required: true
   - name: "Hilton Honors Gold Status"
+    value: 0
     description: "Automatic Hilton Honors Gold Status."
     frequency: "ongoing"
     category: "travel"
     enrollment_required: true
   - name: "Delta Sky Club Visits"
+    value: 0
     description: "10 complimentary Delta Sky Club visits when flying on an eligible Delta flight."
     frequency: "annual"
     category: "lounge"
     enrollment_required: false
   - name: "Leaders Club Sterling Status"
+    value: 0
     description: "Complimentary Leaders Club Sterling Status from The Leading Hotels of the World, including a 5% Leaders Club points bonus on qualifying stays."
     frequency: "ongoing"
     category: "hotel"

--- a/data/cards/us-bank-split.yaml
+++ b/data/cards/us-bank-split.yaml
@@ -23,6 +23,7 @@ our_take: >
   daily spending on.
 benefits:
   - name: "3-Month Interest-Free Plans"
+    value: 0
     description: "No interest or fees on 3-month payment plans for all purchases of $100 or more."
     frequency: "per_purchase"
     category: "other"

--- a/data/cards/usaa-eagle-navigator.yaml
+++ b/data/cards/usaa-eagle-navigator.yaml
@@ -56,6 +56,7 @@ benefits:
     category: "travel"
     enrollment_required: false
   - name: "Active Duty Military Benefits"
+    value: 0
     description: "$0 annual fee while on active duty plus reduced APR under Servicemembers Civil Relief Act for eligible service members"
     frequency: "annual"
     category: "other"

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -13,14 +13,17 @@ benefits:
     frequency: "ongoing"
     category: "other"
   - name: "Travel Accident Insurance"
+    value: 0
     description: "Up to $1,000,000 in travel accident insurance when purchasing airline or common carrier tickets"
     category: "travel"
     enrollment_required: false
   - name: "Lost Baggage Reimbursement"
+    value: 0
     description: "Up to $3,000 in luggage reimbursement per trip if bags are lost due to theft or misdirection"
     category: "travel"
     enrollment_required: false
   - name: "Trip Cancellation and Interruption Protection"
+    value: 0
     description: "Up to $15,000 reimbursement for lodging, flights, and activities if trip is canceled for a covered reason"
     category: "travel"
     enrollment_required: false

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -65,6 +65,7 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "Choice Privileges Platinum Elite Status"
+    value: 0
     description: "Automatic Platinum Elite membership; earn 25% bonus points on Choice Hotels stays plus elite perks like room upgrades when available"
     frequency: "annual"
     category: "travel"

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -40,6 +40,7 @@ apr:
     max: 24.74
 benefits:
   - name: "Travel Accident Insurance"
+    value: 0
     description: "Up to $250,000 in travel accident insurance coverage when airline or common carrier tickets are purchased with the card"
     category: "travel"
     enrollment_required: false

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -27,6 +27,7 @@ benefits:
     frequency: "annual"
     category: "hotel"
   - name: "DoorDash DashPass"
+    value: 0
     description: "One-year complimentary DashPass membership with unlimited deliveries and $0 delivery fees"
     frequency: "annual"
     category: "dining"

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -70,6 +70,7 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "Wyndham Rewards Diamond Status"
+    value: 0
     description: "Automatic Diamond level status — Wyndham's top elite tier — for as long as you're a cardmember"
     frequency: "annual"
     category: "travel"

--- a/data/cards/wyndham-rewards-earner-card.yaml
+++ b/data/cards/wyndham-rewards-earner-card.yaml
@@ -59,6 +59,7 @@ apr:
     max: 29.99
 benefits:
   - name: "Wyndham Rewards Gold Status"
+    value: 0
     description: "Automatic Gold status with perks like preferred room selection and late checkout."
     frequency: "annual"
     category: "travel"

--- a/data/cards/wyndham-rewards-earner-plus-card.yaml
+++ b/data/cards/wyndham-rewards-earner-plus-card.yaml
@@ -68,6 +68,7 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "Wyndham Rewards Status"
+    value: 0
     description: "Automatic Diamond status in your first year, then Platinum status, with perks like early check-in and late checkout."
     frequency: "annual"
     category: "travel"

--- a/data/cards/wyndham-rewards-earner-premier-card.yaml
+++ b/data/cards/wyndham-rewards-earner-premier-card.yaml
@@ -74,6 +74,7 @@ benefits:
     category: "rewards"
     enrollment_required: false
   - name: "Wyndham Rewards Diamond Status"
+    value: 0
     description: "Automatic Diamond status, Wyndham's top elite tier, with perks like suite upgrades and a welcome amenity at check-in at select hotels."
     frequency: "annual"
     category: "travel"

--- a/scripts/build-cards.js
+++ b/scripts/build-cards.js
@@ -211,6 +211,27 @@ function validateCard(card, schema, categoryIds, storeSlugs) {
     // those credits were treated as non-monetary and amortizedAnnualValue
     // returned 0 for each, understating the card's Total Annual Credits by
     // $2,330 against a $499 annual fee.
+    // Validate benefit value. Nothing checked this before, which let 163
+    // benefits across 67 cards sit with no `value` at all — and a benefit with
+    // no value renders NOWHERE. The UI partitions benefits into exactly two
+    // buckets, `value > 0` (credits) and `value === 0` (perks); an undefined
+    // value satisfies neither, so the perk was silently dropped from the
+    // compare table, the wallet benefits view and every credits rollup. Both
+    // halves of that split now default a missing value to 0, but the data is
+    // the real contract: `0` is the explicit marker for a non-dollar perk
+    // (status, lounge access, free bags), so require it to be written down.
+    for (const benefit of card.benefits) {
+      if (typeof benefit.value !== 'number' || Number.isNaN(benefit.value)) {
+        errors.push(
+          `Missing value for benefit "${benefit.name}": every benefit needs a numeric value. ` +
+          `Use 0 for a non-dollar perk such as elite status or lounge access. ` +
+          `Never invent a dollar amount for a perk that has none.`
+        );
+      } else if (benefit.value < 0) {
+        errors.push(`Invalid value for benefit "${benefit.name}": must be >= 0`);
+      }
+    }
+
     const validUnits = schema.properties.benefits.items.properties.value_unit.enum;
     for (const benefit of card.benefits) {
       if (benefit.value_unit !== undefined && !validUnits.includes(benefit.value_unit)) {

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -1640,9 +1640,12 @@ function renderBenefitBlock(b, indent = '  ') {
   const fieldIndent = indent + '  ';
   const lines = [];
   lines.push(`${indent}- name: ${ymlString(b.name)}`);
-  if (typeof b.value === 'number' && b.value > 0) {
-    lines.push(`${fieldIndent}value: ${b.value}`);
-  }
+  // Always write `value`, including 0. Omitting it for non-dollar perks is
+  // what buried 163 benefits: the site partitions benefits into `value > 0`
+  // credits and `value === 0` perks, and an entry with no value lands in
+  // neither bucket, so it renders nowhere. build-cards.js now rejects a
+  // benefit without a numeric value, so an omission here would also fail CI.
+  lines.push(`${fieldIndent}value: ${typeof b.value === 'number' && b.value > 0 ? b.value : 0}`);
   if (b.value_unit && b.value_unit !== 'usd') {
     lines.push(`${fieldIndent}value_unit: ${ymlString(b.value_unit)}`);
   }


### PR DESCRIPTION
## The bug

A benefit whose YAML omits `value` renders **nowhere**. Every surface splits benefits into exactly two buckets:

```js
const credits = benefits.filter(b => b.value > 0);
const perks   = benefits.filter(b => b.value === 0);
```

`undefined` satisfies neither test, so the benefit falls out of both and is silently dropped. 163 benefits across 67 cards were in that state: The Platinum Card's Marriott Bonvoy Gold Elite Status, Hilton Honors Gold Status, Delta Sky Club Visits and Leaders Club Sterling Status, plus free checked bags, DashPass memberships, elite status tiers and purchase protections across airline and hotel cards. Its sibling `the-business-platinum-card-from-american-express.yaml` gives the identical Car Rental Privileges perk `value: 0` and renders fine. #2054 fixed only the one new entry.

`/best-card-for/[slug]` was unaffected because it already reads `(b.value ?? 0)`.

## The fix

Three layers, so it cannot regress.

**1. Data.** Backfilled `value: 0` on all 163 entries, matching the convention that `0` marks a non-dollar perk. No dollar amounts invented: every one of these is a status tier, a percentage discount, a fee waiver or an insurance protection with no annual dollar total. The insert lands directly after `name:`, the position the repo's own writer uses.

**2. UI.** Added `benefitValue()`, `isCreditBenefit()` and `isPerkBenefit()` to `cardDisplayUtils`, and replaced the six hand-rolled splits with them (`CardBenefits`, `CompareClient` x2, `WalletBenefits` x2, `CardClient`, `ProfileClient`). This matters even after the backfill: `cards.json` is served from CloudFront and cached by ISR, so a payload predating this PR can still reach a browser. It also stops a missing value turning an annual credits rollup into `NaN`, and keeps the credits/perks split in one place rather than seven.

**3. Validation.** `scripts/build-cards.js` now rejects any benefit without a numeric `value >= 0` (it validated `value_unit` and `merchants` but never `value`). `data/cards/schema.json` marks `value` required with a note on why. And `scripts/check-card-rewards-and-benefits.js` now writes `value: 0` instead of omitting it for non-dollar perks, which is what would have re-introduced the problem through the auto-PR path and failed CI at the new gate.

## Verification

- `npm run build:cards`: 224 cards build clean.
- Removing one backfilled `value: 0` fails the build with `Missing value for benefit "Wyndham Rewards Gold Status": every benefit needs a numeric value. Use 0 for a non-dollar perk...`.
- `vitest`: 115 pass, including 4 new cases covering the missing-value path (bucket membership, no NaN in the rollup, `$0` not `$NaN`).
- `tsc --noEmit` and `npm run lint` clean.
- Dev server, `/compare?cards=the-platinum-card,chase-sapphire-reserve`: The Platinum Card now reads **+10 perks** (was +6) and the Sapphire Reserve **+5** (was +3), with the credits column and totals unchanged.

## Note, not fixed here

`apps/web-next/src/components/ui/CardBenefits.tsx` is the only component that renders the perks bucket for a single card, and it is imported nowhere. The card detail page renders `Credits & rebates` only, so zero-value perks still do not appear on `/card/<slug>` at all. That is a separate product decision and is out of scope for this PR.