### PR TITLE
feat(news): searchable full archive on /news

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2658,6 +2658,129 @@
   }
 }
 
+/* ---------- News archive (full list + search results) ---------- */
+.landing-v2 .news-bank-select {
+  flex: 0 0 auto;
+  max-width: 220px;
+  padding: 11px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--line-2);
+  background: var(--paper);
+  font-size: 13.5px;
+  font-family: inherit;
+  color: var(--ink);
+  cursor: pointer;
+  outline: none;
+}
+.landing-v2 .news-bank-select:focus {
+  border-color: var(--accent);
+}
+.landing-v2 .filter-chip:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.landing-v2 .news-clear-btn {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.landing-v2 .news-archive {
+  padding: 8px 0 80px;
+}
+.landing-v2 .news-secondary + .news-archive {
+  padding-top: 0;
+}
+.landing-v2 .news-archive-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 24px 0 4px;
+  border-top: 1px solid var(--line);
+}
+.landing-v2 .news-archive-title {
+  font-family: var(--font-inter-tight), sans-serif;
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+  margin: 0;
+}
+.landing-v2 .news-archive-count {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--muted);
+}
+.landing-v2 .news-archive-filters {
+  padding-top: 12px;
+}
+.landing-v2 .news-archive-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 40px;
+}
+/* .news-item clears its own top border on :first-child only, which would leave
+   the second column's opening row hairline-heavy. Clear both leaders. */
+.landing-v2 .news-archive-list .news-item:nth-child(-n + 2) {
+  border-top: 0;
+  padding-top: 0;
+}
+.landing-v2 .news-archive-empty {
+  padding: 48px 0 8px;
+  font-size: 14px;
+  color: var(--muted);
+}
+.landing-v2 .news-archive-empty p {
+  margin: 0 0 8px;
+}
+.landing-v2 .news-archive-more {
+  display: flex;
+  justify-content: center;
+  padding-top: 28px;
+  border-top: 1px solid var(--line);
+}
+.landing-v2 .news-load-more {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--line-2);
+  background: var(--paper);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  cursor: pointer;
+}
+.landing-v2 .news-load-more:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+@media (max-width: 760px) {
+  .landing-v2 .news-archive-list {
+    grid-template-columns: 1fr;
+  }
+  .landing-v2 .news-archive-list .news-item:nth-child(2) {
+    border-top: 1px solid var(--line);
+    padding-top: 18px;
+  }
+  /* The search input and the issuer select each want the full width here, so
+     wrap them onto separate lines instead of letting the select crush the
+     input. */
+  .landing-v2 .news-archive-filters .search-row {
+    flex-wrap: wrap;
+  }
+  .landing-v2 .news-archive-filters .search-wrap {
+    flex: 1 1 100%;
+  }
+  .landing-v2 .news-bank-select {
+    max-width: none;
+    width: 100%;
+  }
+}
+
 /* ---------- Responsive ---------- */
 @media (max-width: 920px) {
   .landing-v2 .hero-grid,

--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { V2Footer } from '@/components/landing-v2/Chrome';
@@ -10,6 +10,9 @@ import { getNewsCards, type NewsItem, type NewsTag } from '@/lib/news';
 import '../landing.css';
 
 const NEWS_IMG_CDN = 'https://d3ay3etzd1512y.cloudfront.net/news_images';
+
+/** Rows added per "Load more" press in the archive list. */
+const PAGE_SIZE = 24;
 
 interface NewsV2ClientProps {
   items: NewsItem[];
@@ -44,6 +47,8 @@ const TAG_DISPLAY: Record<NewsTag, string> = {
   'general': 'News',
 };
 
+const TAG_KEYS = new Set<string>(TAG_FILTERS.map((t) => t.key));
+
 function formatDate(iso: string) {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
@@ -69,25 +74,149 @@ function readTimeFor(item: NewsItem): string {
   return `${Math.max(1, Math.round(words / 220))} min`;
 }
 
+/**
+ * Summaries occasionally carry inline markdown from the generator (11 of 114 at
+ * time of writing). List rows render plain text, so unwrap emphasis and links
+ * rather than printing the asterisks.
+ */
+function plainSummary(text: string | undefined): string {
+  return (text ?? '')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1');
+}
+
+/**
+ * Everything a search term may match on, lowercased once per item.
+ *
+ * Body text is included because the full article already travels in this page's
+ * payload for the read-time estimate — searching it costs no extra bytes.
+ */
+function searchBlob(item: NewsItem): string {
+  return [
+    item.title,
+    item.summary,
+    item.body ?? '',
+    item.bank ?? '',
+    item.source ?? '',
+    ...getNewsCards(item).map((c) => c.name),
+    ...(item.tags ?? []).map((t) => TAG_DISPLAY[t] ?? t),
+  ]
+    .join(' ')
+    .toLowerCase();
+}
+
 export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
   const [filter, setFilter] = useState<FilterKey>('all');
+  const [query, setQuery] = useState('');
+  const [bank, setBank] = useState('all');
+  const [visible, setVisible] = useState(PAGE_SIZE);
   const viewsOf = (item: NewsItem) => viewCounts[item.id] ?? 0;
 
-  const filtered = useMemo(() => {
-    if (filter === 'all') return items;
-    return items.filter((i) => (i.tags ?? []).includes(filter));
-  }, [filter, items]);
+  // One-time sync from the URL after hydration so /news?bank=Chase and
+  // /news?q=lounge are linkable from card and bank pages. Seeding this in the
+  // useState initializer would mismatch SSR, which has no query string.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get('q');
+    const b = params.get('bank');
+    const t = params.get('tag');
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (q) setQuery(q);
+    if (b) setBank(b);
+    if (t && TAG_KEYS.has(t)) setFilter(t as FilterKey);
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, []);
 
+  const blobs = useMemo(
+    () => new Map(items.map((i) => [i.id, searchBlob(i)])),
+    [items],
+  );
+
+  const banks = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const i of items) {
+      if (!i.bank) continue;
+      counts.set(i.bank, (counts.get(i.bank) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([name, count]) => ({ name, count }));
+  }, [items]);
+
+  const terms = useMemo(
+    () => query.trim().toLowerCase().split(/\s+/).filter(Boolean),
+    [query],
+  );
+
+  // Search + issuer applied but not the tag, so the chip counts below can show
+  // what each tag would yield rather than a frozen all-time number.
+  const preTag = useMemo(
+    () =>
+      items.filter((i) => {
+        if (bank !== 'all' && i.bank !== bank) return false;
+        if (terms.length) {
+          const blob = blobs.get(i.id) ?? '';
+          if (!terms.every((t) => blob.includes(t))) return false;
+        }
+        return true;
+      }),
+    [items, bank, terms, blobs],
+  );
+
+  const tagCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const i of preTag) {
+      for (const t of i.tags ?? []) counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+    return counts;
+  }, [preTag]);
+
+  const filtered = useMemo(
+    () =>
+      filter === 'all'
+        ? preTag
+        : preTag.filter((i) => (i.tags ?? []).includes(filter)),
+    [preTag, filter],
+  );
+
+  const isFiltering = terms.length > 0 || filter !== 'all' || bank !== 'all';
+
+  function applyFilter(next: FilterKey) {
+    setFilter(next);
+    setVisible(PAGE_SIZE);
+  }
+  function applyQuery(next: string) {
+    setQuery(next);
+    setVisible(PAGE_SIZE);
+  }
+  function applyBank(next: string) {
+    setBank(next);
+    setVisible(PAGE_SIZE);
+  }
+  function clearFilters() {
+    setQuery('');
+    setBank('all');
+    setFilter('all');
+    setVisible(PAGE_SIZE);
+  }
+
+  // The editorial blocks always describe the newest stories; search and the tag
+  // chips belong to the archive section below, so filters never reshuffle them.
   // Same source the covers below render from, so an item never gets promoted
   // into a featured slot it has no art for.
-  const imaged = filtered.filter((i) => Boolean(i.news_image || getNewsCards(i)[0]?.image));
+  const imaged = items.filter((i) => Boolean(i.news_image || getNewsCards(i)[0]?.image));
   const featured = imaged[0];
   const secondary = imaged.slice(1, 4);
   const usedIds = new Set(
     [featured?.id, ...secondary.map((s) => s.id)].filter(Boolean),
   );
-  const topStories = filtered.filter((i) => !usedIds.has(i.id)).slice(0, 5);
-  const newest = filtered[0];
+  const topStories = items.filter((i) => !usedIds.has(i.id)).slice(0, 5);
+  const newest = items[0];
+
+  // Unfiltered, the archive really is every story — the handful repeated from
+  // the blocks above cost less than a list that silently omits them.
+  const shown = filtered.slice(0, visible);
 
   return (
     <div className="landing-v2">
@@ -122,31 +251,7 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
           </span>
           <span className="news-wire-cta-link">View the wire &rarr;</span>
         </Link>
-        <div className="filter-bar" style={{ paddingTop: 20 }}>
-          <div className="filter-chip-row">
-            {TAG_FILTERS.map((t) => (
-              <button
-                key={t.key}
-                type="button"
-                className={'filter-chip ' + (filter === t.key ? 'active' : '')}
-                onClick={() => setFilter(t.key)}
-              >
-                {t.label}
-              </button>
-            ))}
-          </div>
-          <div className="filter-spacer" />
-          <span className="filter-summary">
-            {filtered.length} article{filtered.length === 1 ? '' : 's'}
-            {newest ? ` · ${formatDate(newest.date)}` : ''}
-          </span>
-        </div>
-
-        {filtered.length === 0 ? (
-          <div className="empty-state" style={{ padding: '60px 0' }}>
-            No articles match this filter.
-          </div>
-        ) : featured ? (
+        {featured ? (
           <div className="news-grid">
             <Link href={`/news/${featured.id}`} className="feat-article">
               <div className="feat-cover">
@@ -187,12 +292,12 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
                   )}
                 </div>
                 <h2 className="feat-title">{featured.title}</h2>
-                <p className="feat-excerpt">{featured.summary}</p>
+                <p className="feat-excerpt">{plainSummary(featured.summary)}</p>
               </div>
             </Link>
 
             <div className="news-side">
-              <div className="news-side-label">Top stories this week</div>
+              <div className="news-side-label">Latest stories</div>
               {topStories.map((item) => (
                 <Link key={item.id} href={`/news/${item.id}`} className="news-item">
                   <div className="ni-meta">
@@ -203,7 +308,7 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
                     {viewsOf(item) > 100 && <> · {viewsOf(item).toLocaleString('en-US')} views</>}
                   </div>
                   <h3 className="ni-title">{item.title}</h3>
-                  <p className="ni-excerpt">{item.summary}</p>
+                  <p className="ni-excerpt">{plainSummary(item.summary)}</p>
                 </Link>
               ))}
             </div>
@@ -219,7 +324,7 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
                   {viewsOf(item) > 100 && <> · {viewsOf(item).toLocaleString('en-US')} views</>}
                 </div>
                 <h3 className="ni-title">{item.title}</h3>
-                <p className="ni-excerpt">{item.summary}</p>
+                <p className="ni-excerpt">{plainSummary(item.summary)}</p>
               </Link>
             ))}
           </div>
@@ -264,6 +369,122 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
             ))}
           </div>
         )}
+
+        <section className="news-archive" aria-label="News archive">
+          <div className="news-archive-head">
+            <h2 className="news-archive-title">
+              {isFiltering ? 'Results' : 'Every story, newest first'}
+            </h2>
+            <span className="news-archive-count">
+              {filtered.length === 0
+                ? 'Nothing to show'
+                : `Showing ${shown.length} of ${filtered.length}${isFiltering ? ' matches' : ''}`}
+            </span>
+          </div>
+
+          <div className="filter-bar news-archive-filters">
+            <div className="search-row">
+              <div className="search-wrap">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <circle cx="11" cy="11" r="7" />
+                  <path d="m21 21-4.3-4.3" />
+                </svg>
+                <input
+                  type="search"
+                  placeholder="Search all news by card, issuer, or keyword…"
+                  value={query}
+                  onChange={(e) => applyQuery(e.target.value)}
+                  aria-label="Search news"
+                />
+              </div>
+              <select
+                className="news-bank-select"
+                value={bank}
+                onChange={(e) => applyBank(e.target.value)}
+                aria-label="Filter news by issuer"
+              >
+                <option value="all">All issuers</option>
+                {banks.map((b) => (
+                  <option key={b.name} value={b.name}>
+                    {b.name} ({b.count})
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="filter-chip-row">
+              {TAG_FILTERS.map((t) => {
+                const count = t.key === 'all' ? preTag.length : tagCounts.get(t.key) ?? 0;
+                return (
+                  <button
+                    key={t.key}
+                    type="button"
+                    className={'filter-chip ' + (filter === t.key ? 'active' : '')}
+                    onClick={() => applyFilter(t.key)}
+                    disabled={count === 0 && filter !== t.key}
+                  >
+                    {t.label}
+                    <span className="ct">{count}</span>
+                  </button>
+                );
+              })}
+            </div>
+            <div className="filter-spacer" />
+            <span className="filter-summary">
+              {isFiltering ? (
+                <button type="button" className="news-clear-btn" onClick={clearFilters}>
+                  Clear filters
+                </button>
+              ) : newest ? (
+                `Updated ${formatDate(newest.date)}`
+              ) : null}
+            </span>
+          </div>
+
+          {filtered.length === 0 ? (
+            <div className="news-archive-empty">
+              <p>No stories match this search.</p>
+              <button type="button" className="news-clear-btn" onClick={clearFilters}>
+                Clear filters
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className="news-archive-list">
+                {shown.map((item) => (
+                  <Link key={item.id} href={`/news/${item.id}`} className="news-item">
+                    <div className="ni-meta">
+                      <span className="news-tag">{TAG_DISPLAY[primaryTag(item)]}</span>
+                      <span>{formatDate(item.date)}</span>
+                      {item.bank ? <> · {item.bank}</> : null}
+                      {viewsOf(item) > 100 && <> · {viewsOf(item).toLocaleString('en-US')} views</>}
+                    </div>
+                    <h3 className="ni-title">{item.title}</h3>
+                    <p className="ni-excerpt">{plainSummary(item.summary)}</p>
+                  </Link>
+                ))}
+              </div>
+
+              {shown.length < filtered.length && (
+                <div className="news-archive-more">
+                  <button
+                    type="button"
+                    className="news-load-more"
+                    onClick={() => setVisible((v) => v + PAGE_SIZE)}
+                  >
+                    Load {Math.min(PAGE_SIZE, filtered.length - shown.length)} more
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </section>
       </div>
       <V2Footer />
     </div>


### PR DESCRIPTION
## Problem

`/news` rendered at most **9 of 114 stories**: one featured item, three cover cards, and five sidebar rows. The tag chips changed *which* 9 appeared, but nothing on the page ever revealed story 10, so everything older than about two weeks was reachable only from Google, the sitemap, or a bank page. The header meanwhile advertised "114 stories · live".

There was also no search of any kind.

## Change

A new archive section below the editorial blocks holds **every story, newest first**, 24 rows at a time in two columns. Its filter bar carries:

- **Search** over title, summary, body, issuer, source, card names, and tag labels. Body text was already in the page payload for the read-time estimate, so full-text search adds no bytes.
- **Issuer select** built from the data with counts (American Express 23, Chase 18, Citi 11, Bilt 8, ...).
- **The tag chips**, moved down from above the featured block, now with live counts that recompute against the current search and issuer, and disabled at zero.

The editorial top keeps its previous layout and always shows the newest stories, so filtering never reshuffles the hero.

`?q=`, `?bank=`, and `?tag=` seed the controls after hydration (same post-hydration pattern as `/explore`), so card and bank pages can deep-link into a filtered view. `/news?bank=Chase&tag=policy-change` lands on 8 results.

Also strips inline markdown from summaries in list rows: 11 of 114 carry `**bold**` from the generator, which the wider archive would print literally. The underlying data still has it, worth cleaning in the generator separately.

## Verification

Local dev server against the 114-item `news.json`:

| Check | Result |
| --- | --- |
| Default archive | Showing 24 of 114, "Load 24 more" advances 48 then 72 |
| Search "lounge" | 9 matches, chips recount, 4 tags disabled |
| Search "priority pass" | 9 matches |
| Issuer = Bilt | 8 matches, Fees/Discontinued/Rumor disabled |
| `?bank=Chase&tag=policy-change` | select and chip pre-set, 8 results |
| No matches | Empty state with a Clear filters button |
| Markdown summaries | No literal asterisks anywhere in rendered text |
| Mobile 375px | Search and select stack full-width, chips scroll, single column, no horizontal overflow |

`tsc --noEmit` clean, `eslint --max-warnings=0` clean, no console errors, production build passes.

## Not included

Month/year archive grouping, pushing filter state back into the URL on change, and crawlable `/news/tag/[tag]` + archive routes for the 105 news URLs that currently hang off a single index page.
