### PR TITLE
Reddit product changes for review — 2026-08-18

### DIFF
--- a/data/reddit-product-changes/2026-03-t3_1vq7zet.yaml
+++ b/data/reddit-product-changes/2026-03-t3_1vq7zet.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vq7zet
+permalink: https://www.reddit.com/r/CreditCards/comments/1vq7zet/product_change_csr_strategy/
+posted: "2026-08-16"
+evidence: >-
+  Poster describes having product changed up from the Preferred to the Reserve, noting their travel
+  credit still resets in March because that is when the change was made, and that they avoided a
+  Reserve annual fee the prior year for the same reason.
+from_card: Chase Sapphire Preferred
+to_card: Chase Sapphire Reserve
+change_month: 2026-03
+reason: voluntary

--- a/data/reddit-product-changes/2026-06-t3_1vl1mtu.yaml
+++ b/data/reddit-product-changes/2026-06-t3_1vl1mtu.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vl1mtu
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1vl1mtu/denied_aadvantage_platinum_select_when_to_reapply/
+posted: "2026-08-11"
+evidence: >-
+  Poster recounts being approved for a Strata on June 10 and then successfully product changing it
+  into a Custom Cash a few days later, as part of building out a Citi centered setup.
+from_card: Citi Strata
+to_card: Citi Custom Cash
+change_month: 2026-06
+reason: voluntary

--- a/data/reddit-product-changes/2026-07-t3_1vrejj7.yaml
+++ b/data/reddit-product-changes/2026-07-t3_1vrejj7.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vrejj7
+permalink: https://www.reddit.com/r/CreditCards/comments/1vrejj7/downgrade_a_card_i_just_downgraded/
+posted: "2026-08-18"
+evidence: >-
+  Poster says they downgraded their Reserve to a Preferred about a month ago and now regrets it,
+  because the Preferred annual fee showed up only a month later and they think they gave up a chance
+  at an elevated Preferred welcome offer.
+from_card: Chase Sapphire Reserve
+to_card: Chase Sapphire Preferred
+change_month: 2026-07
+reason: voluntary

--- a/data/reddit-product-changes/2026-08-t3_1vr37wk.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vr37wk.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vr37wk
+permalink: https://www.reddit.com/r/CreditCards/comments/1vr37wk/kroger_card_instantly_converted_to_smartly/
+posted: "2026-08-17"
+evidence: >-
+  Poster warns that their Kroger card was converted automatically online before the replacement
+  cards even arrived, with no action on their part, and that the old rewards redemption path
+  disappeared along with it.
+from_card: Kroger Rewards World Elite Mastercard
+to_card: Smartly Visa Signature
+change_month: 2026-08
+reason: forced

--- a/data/reddit-product-changes/2026-08-t3_1vr7hzh.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vr7hzh.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vr7hzh
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1vr7hzh/new_card_set_up_with_previous_set_and_future/
+posted: "2026-08-17"
+evidence: >-
+  Poster lays out their card lineup before and after a rebuild and lists the Cash+ in the current
+  set annotated as upgraded from their Shield, so the Shield account became the Cash+ rather than
+  being a separate new approval.
+from_card: US Bank Shield
+to_card: US Bank Cash+ Visa Signature
+change_month: 2026-08


### PR DESCRIPTION
Product changes extracted from r/CreditCards.

| From | To | Month | Reason | Source |
|---|---|---|---|---|
| Citi Strata | Citi Custom Cash | 2026-06 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vl1mtu/denied_aadvantage_platinum_select_when_to_reapply/) |
| Chase Sapphire Preferred | Chase Sapphire Reserve | 2026-03 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vq7zet/product_change_csr_strategy/) |
| Kroger Rewards World Elite Mastercard | Smartly Visa Signature | 2026-08 | forced | [src](https://www.reddit.com/r/CreditCards/comments/1vr37wk/kroger_card_instantly_converted_to_smartly/) |
| US Bank Shield | US Bank Cash+ Visa Signature | 2026-08 | — | [src](https://www.reddit.com/r/CreditCards/comments/1vr7hzh/new_card_set_up_with_previous_set_and_future/) |
| Chase Sapphire Reserve | Chase Sapphire Preferred | 2026-07 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vrejj7/downgrade_a_card_i_just_downgraded/) |

