### PR TITLE
Auto News Update 2026-08-18

### DIFF
--- a/data/news/2026-08-18-chase-edit-back-to-back-language-removed.yaml
+++ b/data/news/2026-08-18-chase-edit-back-to-back-language-removed.yaml
@@ -1,7 +1,7 @@
 id: "chase-edit-back-to-back-language-removed"
 date: "2026-08-18"
 title: "Chase Removes Edit Stacking Restriction"
-summary: "Chase has deleted the sentence that treated back-to-back stays at the same hotel within 24 hours of checkout as a single stay for The Edit benefits. An Internet Archive capture shows the wording was already live on August 7 rather than newly added, and it never appeared in the Sapphire Reserve's binding terms. The two $250 Edit credits carry no published stacking limit as of August 18."
+summary: "Chase has deleted the sentence that treated back-to-back stays at the same hotel within 24 hours of checkout as a single stay for The Edit benefits. Internet Archive captures show the wording had been on the page since at least June 10, so it was not a new restriction, and it never appeared in the Sapphire Reserve's binding terms. The two $250 Edit credits carry no published stacking limit as of August 18."
 tags:
   - "benefit-change"
   - "policy-change"
@@ -27,13 +27,14 @@ body: |
   earlier, at the note that bookings made entirely with points do not qualify.
 
   Two details complicate the version of this story that ran across the points
-  blogs this week. First, the wording was not new. An Internet Archive capture
-  of the same Chase page from **August 7, 2026** already contains it word for
-  word, so it had been published for at least nine days before Doctor of Credit
-  reported it on **August 16**. Second, it never appeared in the card's binding
-  terms. The Sapphire Reserve pricing and terms document conditions the credit
-  only on prepaid bookings of two nights or more, with no back-to-back rule in
-  it. Chase has not commented on either adding or removing the sentence.
+  blogs this week. First, the wording was not new. Internet Archive captures of
+  this Chase page from **June 10**, **July 2** and **August 7, 2026** each
+  contain the sentence word for word. It had been published for more than two
+  months before Doctor of Credit reported it on **August 16**, so Chase did not
+  add a restriction and then withdraw it. Second, it never appeared in the card's binding terms. The
+  Sapphire Reserve pricing and terms document conditions the credit only on
+  prepaid bookings of two nights or more, with no back-to-back rule in it.
+  Chase has not commented on either adding or removing the sentence.
 
   ## What the credit does now
 
@@ -43,8 +44,9 @@ body: |
   Reserve and J.P. Morgan Reserve cardmembers including authorized users, and
   for primary Chase Sapphire Reserve for Business cardmembers.
 
-  Splitting a four-night stay at one property into two two-night reservations is
-  once again unrestricted on paper. Anyone planning that should still allow for
-  the possibility that Chase's booking systems behave differently from the
-  published guide, since no rule change was announced in either direction.
+  Splitting a four-night stay at one property into two two-night reservations
+  carries no published restriction today. Anyone planning that should still
+  allow for the possibility that Chase's booking systems behave differently
+  from the guide, since the sentence stood for over two months without Chase
+  explaining it and came down without any announcement either.
 

--- a/data/news/2026-08-18-chase-edit-back-to-back-language-removed.yaml
+++ b/data/news/2026-08-18-chase-edit-back-to-back-language-removed.yaml
@@ -1,0 +1,50 @@
+id: "chase-edit-back-to-back-language-removed"
+date: "2026-08-18"
+title: "Chase Removes Edit Stacking Restriction"
+summary: "Chase has deleted the sentence that treated back-to-back stays at the same hotel within 24 hours of checkout as a single stay for The Edit benefits. An Internet Archive capture shows the wording was already live on August 7 rather than newly added, and it never appeared in the Sapphire Reserve's binding terms. The two $250 Edit credits carry no published stacking limit as of August 18."
+tags:
+  - "benefit-change"
+  - "policy-change"
+bank: "Chase"
+card_slugs:
+  - "chase-sapphire-reserve"
+  - "chase-sapphire-reserve-business"
+card_names:
+  - "Chase Sapphire Reserve"
+  - "Chase Sapphire Reserve for Business"
+source: "Chase"
+source_url: "https://www.chase.com/travel/guide/hotels/the-edit-chase-travel-credits-benefits"
+body: |
+  Chase has removed the language that blocked cardholders from using both of
+  their $250 The Edit credits on back-to-back stays at the same hotel. As of
+  **August 18, 2026**, the restriction is gone from the Chase travel guide page
+  that carried it.
+
+  The deleted sentence said that back-to-back stays at the same property within
+  **24 hours** of checkout counted as a single stay, and that The Edit program
+  benefits would not apply to the second check-in. It sat inside the guide's
+  answer about statement credit eligibility. That answer now stops one sentence
+  earlier, at the note that bookings made entirely with points do not qualify.
+
+  Two details complicate the version of this story that ran across the points
+  blogs this week. First, the wording was not new. An Internet Archive capture
+  of the same Chase page from **August 7, 2026** already contains it word for
+  word, so it had been published for at least nine days before Doctor of Credit
+  reported it on **August 16**. Second, it never appeared in the card's binding
+  terms. The Sapphire Reserve pricing and terms document conditions the credit
+  only on prepaid bookings of two nights or more, with no back-to-back rule in
+  it. Chase has not commented on either adding or removing the sentence.
+
+  ## What the credit does now
+
+  The Edit gives up to **$500** a year as two separate **$250** statement
+  credits on prepaid bookings of at least two nights, and both can be used at
+  any point in the calendar year. Chase lists the benefit for Chase Sapphire
+  Reserve and J.P. Morgan Reserve cardmembers including authorized users, and
+  for primary Chase Sapphire Reserve for Business cardmembers.
+
+  Splitting a four-night stay at one property into two two-night reservations is
+  once again unrestricted on paper. Anyone planning that should still allow for
+  the possibility that Chase's booking systems behave differently from the
+  published guide, since no rule change was announced in either direction.
+


### PR DESCRIPTION
## Proposed News Items

Generated by the local `card-news-local` routine (sources: r/churning News & Updates thread, r/CreditCards, Doctor of Credit, Google News, Brave; triage, source verification, and article writing done in-session). 140 candidates after dedup, 5 shortlisted for source verification, 4 killed, 1 proposed.

### Item: Chase Removes Edit Stacking Restriction

Chase deleted the sentence treating back-to-back stays at the same hotel within 24 hours of checkout as one stay for The Edit benefits.

**Verified at the primary source two independent ways** (raw HTML fetch and rendered-DOM inspection of `chase.com/travel/guide/hotels/the-edit-chase-travel-credits-benefits`): the restriction phrases are absent today, with the surrounding FAQ answer otherwise intact and simply ending one sentence earlier.

**Two findings here are not in any other outlet's coverage:**

1. **The language was not new.** Wayback captures dated **2026-06-10**, **2026-07-02** and **2026-08-07** each contain the sentence verbatim. It had been live for over two months, so this was a long-standing sentence being deleted, not a restriction added and then withdrawn. Every outlet that covered this (DoC, Frequent Miler, Miles to Memories, Upgraded Points, Thrifty Traveler) framed it as a new restriction.
2. **It never entered the binding terms.** Zero hits for "back-to-back" across 85,389 characters of the Sapphire Reserve pricing-and-terms document.

### Reviewer notes, please read before merging

- **This supersedes yesterday's item.** `2026-08-17-chase-edit-credit-back-to-back-stays.yaml` ("Chase Limits Sapphire Edit Credit Stacking") says the restriction appeared in a guide "dated August 10" and that Chase "quietly closed" the loophole. Both are wrong given the June 10 capture. That item is live on the site and still needs a separate fix; this routine cannot hand-edit prior `data/news/` files.
- **A reviewer argued for killing this item** on impact grounds: net change for cardholders versus mid-August is zero, and splitting a four-night stay is enthusiast behavior. Counter-argument is that the June 10 finding makes it novel reporting and the 8/17 item needs correcting. Your call.
- **Deliberately not claimed:** that Chase "reversed a policy." Chase has issued no statement to any outlet, so that would attribute an unsourced decision.
- **Unresolved:** a Frequent Miler reader comment claims a broader same-property exclusion still sits in a Chase "Travel Disclosures" page. Could not be verified (candidate URLs 404'd; `theeditbychase.com` and `chasetravel.com` render client-side). The article therefore scopes its "never in the terms" claim strictly to the Sapphire Reserve pricing-and-terms document.
- Card scope corrected against the live Chase page: The Edit covers Sapphire Reserve and J.P. Morgan Reserve cardmembers including authorized users, and *primary* Sapphire Reserve for Business cardmembers.

### Rejected this run

| Story | Why |
|---|---|
| NASCAR + Avant co-brand card | "Expected to launch January 2027", no fee/network/rewards disclosed. Speculation about future changes. |
| Uber One ride credit 6% to 5% | No card benefit changed (Amex Uber credits verified unchanged). ~$10/yr. The "free additional member" sweetener was announced November 2025. |
| U.S. Bank re-adds Flying Blue | Same continuously-updated DoC URL already cited in the 8/13 item; Qantas still missing. |
| UMass "zombie credit cards" | Needs physical possession of the card, names no vulnerable issuer, and does not show cancelled cards can be charged. |

### How to review
1. Check each YAML file in `data/news/` for accuracy against its `source_url`.
2. Verify the story is not a duplicate and is genuinely newsworthy.
3. Edit titles/summaries/bodies freely before merging.
4. Remove any item that should not ship.
5. To reject everything: add the `news:reject` label and close the PR.

### What merging does
Merging triggers `build-news.yml`: news.json to S3/CloudFront, Amplify rebuild, hero-image generation, social-media queue, and IndexNow ping.