### PR TITLE
Remove hero stat row from /best index

### DIFF
--- a/apps/web-next/src/app/best/BestV2Client.tsx
+++ b/apps/web-next/src/app/best/BestV2Client.tsx
@@ -9,7 +9,6 @@ import '../landing.css';
 interface BestV2ClientProps {
   pages: BestPage[];
   previews: Record<string, { src?: string; alt: string }[]>;
-  totalIssuers: number;
   totalCards: number;
 }
 
@@ -25,14 +24,8 @@ function formatShortDate(iso?: string): string {
 export default function BestV2Client({
   pages,
   previews,
-  totalIssuers,
   totalCards,
 }: BestV2ClientProps) {
-  const latestUpdate = pages
-    .map((p) => p.updated_at || p.date)
-    .sort()
-    .reverse()[0];
-
   return (
     <div className="landing-v2">
       <div className="cj-terminal">
@@ -78,25 +71,6 @@ export default function BestV2Client({
               Find my next card <span aria-hidden>→</span>
             </span>
           </Link>
-        </div>
-
-        <div className="best-hero-stats">
-          <div className="bhs">
-            <div className="k">Issuers covered</div>
-            <div className="v">{totalIssuers}</div>
-          </div>
-          <div className="bhs">
-            <div className="k">Cards ranked</div>
-            <div className="v">{totalCards}</div>
-          </div>
-          <div className="bhs">
-            <div className="k">Ranking pages</div>
-            <div className="v">{pages.length}</div>
-          </div>
-          <div className="bhs">
-            <div className="k">Last refresh</div>
-            <div className="v">{formatShortDate(latestUpdate) || '—'}</div>
-          </div>
         </div>
 
         {pages.length === 0 ? (

--- a/apps/web-next/src/app/best/page.tsx
+++ b/apps/web-next/src/app/best/page.tsx
@@ -32,10 +32,6 @@ export const revalidate = 300;
 export default async function BestIndexPage() {
   const [pages, cards] = await Promise.all([getBestPages(), getAllCards()]);
 
-  const totalIssuers = new Set(
-    cards.map((c) => c.bank?.trim()).filter(Boolean)
-  ).size;
-
   // Top-3 card image previews per ranking page (mirrors the landing page).
   const cardImageBySlug = new Map<string, string | undefined>();
   const cardNameBySlug = new Map<string, string>();
@@ -85,7 +81,7 @@ export default async function BestIndexPage() {
           { name: 'Best Cards', url: 'https://creditodds.com/best' },
         ]}
       />
-      <BestV2Client pages={pages} previews={previews} totalIssuers={totalIssuers} totalCards={cards.length} />
+      <BestV2Client pages={pages} previews={previews} totalCards={cards.length} />
     </>
   );
 }

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -3843,7 +3843,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
-  margin: 24px 0 0;
+  margin: 24px 0 32px;
 }
 .landing-v2 .best-promo {
   display: flex;
@@ -3901,52 +3901,6 @@
 @media (max-width: 640px) {
   .landing-v2 .best-promos {
     grid-template-columns: 1fr;
-  }
-}
-
-.landing-v2 .best-hero-stats {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1px;
-  background: var(--line);
-  margin: 24px 0 40px;
-  border: 1px solid var(--line);
-  border-radius: 0;
-  overflow: hidden;
-}
-.landing-v2 .bhs {
-  background: var(--card);
-  padding: 18px 22px;
-}
-.landing-v2 .bhs .k {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--muted);
-  margin-bottom: 6px;
-}
-.landing-v2 .bhs .v {
-  font-family: var(--font-inter-tight), sans-serif;
-  font-size: 22px;
-  font-weight: 500;
-  letter-spacing: -0.015em;
-  color: var(--ink);
-}
-.landing-v2 .bhs .v.accent {
-  font-size: 14px;
-  color: var(--accent);
-  font-family: var(--font-inter), sans-serif;
-  font-weight: 500;
-}
-.landing-v2 .bhs .v.accent a {
-  color: inherit;
-  text-decoration: none;
-}
-.landing-v2 .bhs .v.accent a:hover {
-  text-decoration: underline;
-}
-@media (max-width: 760px) {
-  .landing-v2 .best-hero-stats {
-    grid-template-columns: 1fr 1fr;
   }
 }
 


### PR DESCRIPTION
Removes the four-tile stat row (Issuers covered / Cards ranked / Ranking pages / Last refresh) from the /best index page.

- Dropped the `best-hero-stats` block from `BestV2Client` along with the now-unused `totalIssuers` prop and its computation in `page.tsx` (the `latestUpdate` used for SEO `dateModified` is untouched).
- Removed the orphaned `.best-hero-stats` / `.bhs` CSS from `landing.css` (no other page uses those classes).
- Gave `.best-promos` a 32px bottom margin — the stat row had been supplying the vertical gap between the promo tiles and the rankings grid.

Verified locally: page renders with promos flowing straight into the grid, no console errors, `tsc --noEmit` clean.