### PR TITLE
fix(news): space the archive list off the filter divider

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2722,6 +2722,9 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   column-gap: 40px;
+  /* The filter bar above ends in a divider; the leading rows zero out their
+     own top padding, so the breathing room has to come from the list. */
+  padding-top: 22px;
 }
 /* .news-item clears its own top border on :first-child only, which would leave
    the second column's opening row hairline-heavy. Clear both leaders. */


### PR DESCRIPTION
Follow-up to #2062.

The archive list's two leading rows set `padding-top: 0` so they do not stack their own hairline on top of the filter bar's bottom border. That also left the first stories sitting flush against the divider.

Moves the breathing room onto the list itself (`padding-top: 22px`), so the rows keep their border reset and gain a 22px gap below the divider.

Verified at 1280px (two columns) and 375px (single column): 22px between the divider and the first row in both, second row keeps its 1px border and 18px padding on mobile, no horizontal overflow.
