### PR TITLE
news: drop card_slug from Walmart tap-to-pay item

### DIFF
--- a/data/news/2026-08-21-walmart-sams-club-tap-to-pay.yaml
+++ b/data/news/2026-08-21-walmart-sams-club-tap-to-pay.yaml
@@ -4,8 +4,6 @@ title: "Walmart Adds Tap to Pay Starting Aug 24"
 summary: "Walmart begins accepting contactless payments at select Walmart and Sam's Club locations on August 24, 2026, with all U.S. stores and clubs covered by the end of the year and fuel stations by mid-2027. Eligible contactless cards, phones and smartwatches will work at checkout. Cards that pay more only when you tap, such as the Apple Card at 2% with Apple Pay versus 1% with the physical card, have been stuck at their floor rate at Walmart."
 tags:
   - "policy-change"
-card_slug: "apple-card"
-card_name: "Apple Card"
 source: "Walmart"
 source_url: "https://corporate.walmart.com/news/2026/08/21/more-ways-to-pay-tap-to-pay-is-coming-to-walmart-and-sams-club"
 body: |


### PR DESCRIPTION
## What

Removes `card_slug: "apple-card"` / `card_name: "Apple Card"` from `data/news/2026-08-21-walmart-sams-club-tap-to-pay.yaml` (merged in #2076).

## Why

I attached the Apple Card to that item to capture the real angle that tap-gated rates were stuck at their floor inside Walmart. That had a downstream side effect I did not anticipate: `scripts/queue-social.js` calls `resolveBanksFromCardNames` on the card fields, which resolved Apple Card to its `bank: "Goldman Sachs"` and appended the issuer handle to the Twitter variant:

```
NEW:
Walmart begins accepting contactless payments at select locations on August 24, 2026.
...
@GoldmanSachs
```

Goldman Sachs is not a party to a Walmart payment-acceptance story, so the mention is misleading. It is also on its way to being stale given the Apple Card issuer transition.

## Effect

- Unlinks the item from the Apple Card page.
- Any re-queue of this item stops tagging the issuer.
- No factual content lost: the 2% via Apple Pay vs 1% physical-card comparison stays in the body, where it reads as context rather than as a card association.

Does **not** retract the already-published tweet (queue post ID 368) — that is separate.

## Note for future runs

Any news item with a `card_slug` will auto-tag that card's issuer. Worth attaching `card_slug` only when the issuer is genuinely a party to the story, not merely when a card is affected by it.