### PR TITLE
Filter WebKit 'Database deleted by request of the user' IDB noise

### DIFF
--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -69,6 +69,22 @@ describe("isBenignClientError", () => {
     ).toBe(true);
   });
 
+  it("drops WebKit's database-deleted noise (DOMException shape)", () => {
+    expect(
+      isBenignClientError(
+        domException("Database deleted by request of the user", "UnknownError", 0),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops WebKit's database-deleted noise (wrapped-message shape)", () => {
+    expect(
+      isBenignClientError(
+        new Error("UnknownError: Database deleted by request of the user"),
+      ),
+    ).toBe(true);
+  });
+
   it("drops WebKit's closing/hidden IDB-open noise (DOMException shape)", () => {
     expect(
       isBenignClientError(

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -29,6 +29,16 @@
 // internal promises have no handler we can attach to, so the same message can
 // still surface as unhandled noise with nothing to act on.
 //
+// A third WebKit teardown signature: "UnknownError: Database deleted by
+// request of the user" (CREDITODDS-JAVASCRIPT-NEXTJS-1H). Safari deletes the
+// page's IndexedDB while the page still holds a connection — the user clearing
+// website data, or ITP evicting script-writable storage — and Firebase's
+// in-flight idb-get/idb-set operations reject with this message (followed by
+// "database connection is closing" as the doomed connection winds down). Same
+// name/code as connection-lost (UnknownError, code 0), so the AbortError gate
+// misses it and it needs its own unconditional entry. Nothing to act on: the
+// deletion is the browser/user's doing and Firebase falls back gracefully.
+//
 // Firebase Installations also rejects with "installations/app-offline" when
 // navigator.onLine is false during Analytics init. getAnalytics() never awaits
 // that internal registration promise, so a visitor who loses connectivity
@@ -102,6 +112,7 @@ const BENIGN_CLIENT_SIGNATURES = [
 const BENIGN_ANY_ERROR_SIGNATURES = [
   'Invalid call to runtime.sendMessage(). Tab not found.',
   'Connection to Indexed Database server lost',
+  'Database deleted by request of the user',
   'Database is closing/hidden',
   'installations/app-offline',
   'Object Not Found Matching Id:',


### PR DESCRIPTION
## Summary
Sentry issue **CREDITODDS-JAVASCRIPT-NEXTJS-1H** (`UnknownError: Database deleted by request of the user`, Mobile Safari, /best-card-for/the-north-face) is WebKit deleting the page's IndexedDB while the page still holds a connection — the user clearing Safari website data, or ITP evicting script-writable storage. Firebase's internal `app/idb-get`/`app/idb-set` promises have no handler we can attach to, so the rejection surfaces unhandled. The breadcrumbs show Firebase warning on idb-get/idb-set and falling back; the page itself is fine. Nothing actionable on our side.

Same `UnknownError`/code-0 shape as the already-filtered "Connection to Indexed Database server lost", so the AbortError-gated IDB signatures miss it — it needs its own entry in `BENIGN_ANY_ERROR_SIGNATURES`.

## Changes
- Add `Database deleted by request of the user` to `BENIGN_ANY_ERROR_SIGNATURES` in `benignClientError.ts`, with a comment documenting the shape.
- Tests for both the DOMException shape and the wrapped-message shape; existing negative test ("keeps unrelated UnknownErrors") still guards against over-matching.

## Testing
`npx vitest run src/lib/benignClientError.test.ts` — 36/36 pass (34 existing + 2 new).