### PR TITLE
Handle Brevo 429s in newsletter sync: client retry + paced upserts

### DIFF
--- a/apps/api/src/handlers/newsletter-sync.js
+++ b/apps/api/src/handlers/newsletter-sync.js
@@ -17,7 +17,12 @@
 const { initFirebase } = require('../lib/firebase-init');
 const brevo = require('../lib/brevo');
 
-const UPSERT_CONCURRENCY = 5; // Brevo free tier allows ~10 req/s
+const UPSERT_CONCURRENCY = 5;
+// Brevo free tier allows ~10 req/s; pace batches so sustained throughput
+// stays at half that, leaving headroom for retries and other API traffic.
+const BATCH_MIN_MS = 1000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function listAllFirebaseUsers(admin) {
   const users = [];
@@ -53,6 +58,7 @@ exports.NewsletterSyncHandler = async () => {
   let upserted = 0;
   const failures = [];
   for (let i = 0; i < eligible.length; i += UPSERT_CONCURRENCY) {
+    const batchStarted = Date.now();
     const batch = eligible.slice(i, i + UPSERT_CONCURRENCY);
     const results = await Promise.allSettled(
       batch.map((u) =>
@@ -69,6 +75,10 @@ exports.NewsletterSyncHandler = async () => {
         failures.push({ email: batch[idx].email, error: r.reason?.message });
       }
     });
+    if (i + UPSERT_CONCURRENCY < eligible.length) {
+      const elapsed = Date.now() - batchStarted;
+      if (elapsed < BATCH_MIN_MS) await sleep(BATCH_MIN_MS - elapsed);
+    }
   }
   if (failures.length) {
     console.error('newsletter-sync: upsert failures:', JSON.stringify(failures));

--- a/apps/api/src/lib/brevo.js
+++ b/apps/api/src/lib/brevo.js
@@ -23,23 +23,36 @@ function isConfigured() {
   return Boolean(apiKey()) && listId() !== null;
 }
 
-async function request(method, path, body) {
-  const res = await fetch(`${BASE}${path}`, {
-    method,
-    headers: {
-      'api-key': apiKey(),
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
-  const text = await res.text();
-  if (!res.ok) {
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Rate-limited (429) responses are retried with backoff before surfacing as
+// an error: Brevo's Retry-After header when present, exponential otherwise.
+async function request(method, path, body, { retries = 3 } = {}) {
+  for (let attempt = 0; ; attempt += 1) {
+    const res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: {
+        'api-key': apiKey(),
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    if (res.ok) return text ? JSON.parse(text) : null;
+    if (res.status === 429 && attempt < retries) {
+      const retryAfter = Number(res.headers.get('retry-after'));
+      const waitMs =
+        Number.isFinite(retryAfter) && retryAfter > 0
+          ? Math.min(retryAfter * 1000, 30000)
+          : Math.min(1000 * 2 ** attempt, 30000);
+      await sleep(waitMs);
+      continue;
+    }
     const err = new Error(`Brevo ${method} ${path} -> ${res.status}: ${text}`);
     err.status = res.status;
     throw err;
   }
-  return text ? JSON.parse(text) : null;
 }
 
 // Brevo contact attributes from a Firebase displayName: first word becomes

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -489,7 +489,7 @@ Resources:
       Handler: src/handlers/newsletter-sync.NewsletterSyncHandler
       Runtime: nodejs22.x
       MemorySize: 256
-      Timeout: 300
+      Timeout: 600
       Description: Daily sync of Firebase users into the Brevo newsletter list
       Environment:
         Variables:


### PR DESCRIPTION
## Problem

The nightly `NewsletterSyncFunction` crashed on Brevo rate limits (Sentry issue CREDITODDS-NODE-AWSLAMBDA-3, 2026-08-23 06:15 UTC run):

- The upsert loop fires batches of 5 `POST /contacts` back-to-back with no pacing, so the instantaneous rate far exceeds Brevo's ~10 req/s free-tier cap once the Firebase user list is big enough.
- The tail of the upserts 429'd (caught, logged as upsert failures — those users just missed one daily sync).
- The immediately-following `getListEmails` GET also got 429'd, and that one is **unhandled**, so the run crashed before the stale-member prune step.

## Fix

- **`brevo.js` `request()`**: retry 429s up to 3 times with backoff — honors Brevo's `Retry-After` header when present, exponential (1s/2s/4s) otherwise, capped at 30s per wait. Non-429 errors still throw immediately, and `err.status` is preserved so the existing 404 handling in `getContact`/`deleteContact` is unaffected. This also covers the user-facing handlers (`newsletter-settings`, `newsletter-register`, `delete-account`) that share the client.
- **`newsletter-sync.js`**: pace upsert batches to ≥1s each, holding sustained throughput at ~5 req/s — half the cap, leaving headroom for retries and any concurrent Brevo traffic.
- **`template.yml`**: bump the function timeout 300 → 600s; the paced sync handles ~3000 eligible users within that, well above the current list size.

## Verification

Exercised the retry logic against a stubbed `fetch`:
- two 429s (with `Retry-After: 0.05`) then 200 → succeeds after 3 calls, waits honored
- persistent 429 → throws after 4 calls (1 + 3 retries) with `status` intact
- 400 → throws immediately, no retry

No behavior change for successful requests; `node --check` passes on both files.