### PR TITLE
Card page check: manual fixes for three JS-rendered pages, drop PenFed waiver

### DIFF
--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -61,6 +61,10 @@ signup_bonus:
   spend_requirement: 4000
   timeframe_months: 3
   note: "Get 70,000 bonus points and a $99 Companion Fare (plus taxes and fees from $23) after you make $4,000 or more in purchases within the first 90 days of opening your account."
+apr:
+  regular:
+    min: 19.49
+    max: 27.49
 benefits:
   - name: "Coach Companion Fare"
     value: 0

--- a/data/cards/citi-double-cash.yaml
+++ b/data/cards/citi-double-cash.yaml
@@ -27,8 +27,8 @@ apr:
     rate: 0
     months: 18
   regular:
-    min: 17.49
-    max: 27.49
+    min: 18.24
+    max: 28.49
 apply_link: https://www.citi.com/credit-cards/citi-double-cash-credit-card
 foreign_transaction_fee: true
 network: "mastercard"

--- a/data/cards/penfed-pathfinder-rewards.yaml
+++ b/data/cards/penfed-pathfinder-rewards.yaml
@@ -59,7 +59,7 @@ our_take: >
   checking customers, lose the perk that made this an effectively free travel
   card. Judge it on the $95. The $100 annual domestic airline incidental
   credit covers most of that by itself, and a Global Entry or TSA PreCheck
-  application credit every five years plus a Priority Pass membership fill out
+  application credit every four years plus a Priority Pass membership fill out
   a package that still holds up at this price, though lounge visits carry
   per-visit fees. Honors Advantage members do keep the better earn rates, 4x
   on travel and 3x on dining against 3x and 2x for everyone else, alongside

--- a/data/cards/penfed-pathfinder-rewards.yaml
+++ b/data/cards/penfed-pathfinder-rewards.yaml
@@ -51,17 +51,6 @@ benefits:
     frequency: "annual"
     category: "lounge"
     enrollment_required: true
-  # Ending 2026-09-28: PenFed is mailing cardholders a change-in-terms notice
-  # saying the $95 fee is no longer eligible to be waived. Kept as a marked
-  # entry (value 0, so it stops counting toward Total Annual Credits) rather
-  # than deleted, because the live product page still advertises the waiver
-  # and the rewards checker would otherwise re-propose it. Delete this block
-  # after 2026-09-28.
-  - name: "Annual Fee Waiver (ends September 28, 2026)"
-    value: 0
-    description: "PenFed Honors Advantage members (current or former military, or Access America checking account holders) have had the $95 annual fee waived in full. PenFed is notifying cardholders that the fee is no longer eligible to be waived as of September 28, 2026, so plan on paying the $95."
-    frequency: "annual"
-    category: "other"
 our_take: >
   The PenFed Pathfinder Rewards Visa Signature was built around a fee waiver
   that is going away. PenFed is notifying cardholders that the $95 annual fee

--- a/data/cards/penfed-pathfinder-rewards.yaml
+++ b/data/cards/penfed-pathfinder-rewards.yaml
@@ -41,9 +41,9 @@ benefits:
     category: "travel"
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120
-    description: "Application fee reimbursement of up to $120 for Global Entry or $85 for TSA PreCheck, once every 5 years"
+    description: "Application fee reimbursement of up to $120 for Global Entry or $85 for TSA PreCheck, once every 4 years"
     frequency: "multi_year"
-    frequency_years: 5
+    frequency_years: 4
     category: "security"
   - name: "Priority Pass Membership"
     value: 0

--- a/data/review-declined.yaml
+++ b/data/review-declined.yaml
@@ -106,7 +106,7 @@ benefits:
   - { slug: robinhood-platinum, name: "Eight Sleep Credit",
       why: "dated promo ('valid through 9/15') and benefits have no `expires` field, so nothing would flag it once lapsed (PR #1772)" }
   - { slug: penfed-pathfinder-rewards, name: "Annual Fee Waiver",
-      why: "PenFed ended the Honors Advantage $95 waiver as of 2026-09-28 and the product page no longer advertises it; the dated block was deleted in PR #2085. Git history deny-lists the dated name, this covers the undated variant" }
+      why: "PenFed's Honors Advantage $95 waiver ends on 2026-09-28, and the product page no longer advertises it; the dated block was deleted in PR #2085. Git history deny-lists the dated name, this covers the undated variant" }
 
 # Benefit names declined on EVERY card. Prefer benefit-policy.yaml's
 # `exclude` list for anything the team will never want; this is for names

--- a/data/review-declined.yaml
+++ b/data/review-declined.yaml
@@ -105,6 +105,8 @@ benefits:
       why: "standard network insurance — same class declined in #1636, #1666, #1731, #1743 (issue #1774)" }
   - { slug: robinhood-platinum, name: "Eight Sleep Credit",
       why: "dated promo ('valid through 9/15') and benefits have no `expires` field, so nothing would flag it once lapsed (PR #1772)" }
+  - { slug: penfed-pathfinder-rewards, name: "Annual Fee Waiver",
+      why: "PenFed ended the Honors Advantage $95 waiver as of 2026-09-28 and the product page no longer advertises it; the dated block was deleted in PR #2085. Git history deny-lists the dated name, this covers the undated variant" }
 
 # Benefit names declined on EVERY card. Prefer benefit-policy.yaml's
 # `exclude` list for anything the team will never want; this is for names


### PR DESCRIPTION
Manual follow-up to the 2026-08-23 card-page check. That run verified 182/183 cards and found no diffs, but several pages render their numbers via JS and came back blank, which the extractor correctly records as `null` rather than guessing. A blank field produces no diff, so a stale value can hide behind a clean run. Max verified the affected pages by hand; these are the corrections.

## Changes

| Card | Field | Stored | Live page |
|---|---|---|---|
| Citi Double Cash | regular APR | 17.49% - 27.49% | **18.24% - 28.49%** |
| PenFed Pathfinder Rewards | Global Entry credit cadence | every 5 years | **every 4 years** |
| PenFed Pathfinder Rewards | Annual Fee Waiver benefit block | present (value 0, marked for 9/28) | **not advertised - removed** |
| Atmos Rewards Business | `apr` block | *(missing)* | **19.49% - 27.49% regular** |

The Citi one is a genuine rate change that the automation could not have caught in its current form.

The Atmos page also states a 27.74% cash advance APR. Omitted deliberately: there is no `cash_advance` field in the build-cards schema and no other card records one.

## On the PenFed waiver removal

The block was held as a marked value-0 entry with a comment reasoning that the live product page still advertised the waiver, to be deleted after 2026-09-28. The page no longer advertises it, so the premise is gone and the block is removed now.

Deleting it puts the dated name in git history, which `getRemovedBenefitsForCard` already deny-lists for this card. That match is exact, though, so an undated "Annual Fee Waiver" variant could still surface. `data/review-declined.yaml` gains an entry to close that gap.

`our_take` still narrates the waiver ending on 2026-09-28. That remains accurate as a description of the change-in-terms notice, so it is left alone; the twice-monthly regeneration will refresh the framing on its own.

## Verified unchanged in the same pass

- **Sam's Club Mastercard** - the one card the fetcher has never been able to read (samsclub.com serves a JS-only shell to automated clients). Checked by hand and fully accurate: \$0 fee, \$30 after \$30 in 30 days, 20.15%/28.15% APR, 5% gas and EV to \$6,000, 3% dining, 3% Sam's Club for Plus members, \$5,000 annual cap.
- **PNC Cash Rewards** - the page advertises both a \$200 and a \$250 bonus. \$200 after \$1,000 in 3 months is correct, which is what was already stored.
- **PenFed Power Cash Rewards** - all terms match.
- **Atmos Rewards Business welcome offer** - 70,000 points plus \$99 Companion Fare confirmed, matches stored value.

## Left out

Atmos Business has a 10% rewards bonus on all points earned, for companies holding an eligible Bank of America small business account. Not recorded here, to keep this diff narrow.

## Validation

`npm run build:cards` passes (224 cards). Regenerated `cards.json` not committed, per repo convention.