### PR TITLE
Fix rewards/benefits writer appending a duplicate benefits key

### DIFF
--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -1832,6 +1832,22 @@ function appendBenefits(text, newBenefits) {
   if (newBenefits.length === 0) return { text, changed: false };
   const blocks = newBenefits.map(b => renderBenefitBlock(b)).join('\n');
 
+  // `benefits: []` is an existing block written inline. A bare-`benefits:`
+  // match misses it, and the no-block fallback below would then append a
+  // second `benefits:` key at column 0 — a YAML duplicate-key error that
+  // fails validation and reverts the whole run.
+  const emptyRe = /^benefits:[ \t]*\[[ \t]*\][ \t]*$/m;
+  const emptyM = text.match(emptyRe);
+  if (emptyM) {
+    return {
+      text:
+        text.slice(0, emptyM.index) +
+        `benefits:\n${blocks}` +
+        text.slice(emptyM.index + emptyM[0].length),
+      changed: true,
+    };
+  }
+
   // Locate `^benefits:` at column 0.
   const bRe = /^benefits:\s*$/m;
   const m = text.match(bRe);


### PR DESCRIPTION
The weekly `card-rewards-benefits-local` run failed to publish anything today. `build:cards` rejected `penfed-power-cash-rewards.yaml` with `duplicated mapping key (44:1)`, and the publish script then reverted every card in the run.

## Cause

`appendBenefits()` in `scripts/check-card-rewards-and-benefits.js` locates the existing block with `/^benefits:\s*$/m`, which requires nothing after the colon. A card written with the inline empty form:

```yaml
benefits: []
```

does not match, so the function falls through to its no-existing-block fallback and appends a second `benefits:` key at column 0 at the end of the file. That is a YAML duplicate-key error.

The blast radius is the whole run, not just the one card: `check-card-rewards-benefits-publish.sh` validates all card data before opening any PR and runs `git checkout -- data/cards/` on failure. Today that also discarded a legitimate Capital One Venture X benefit.

## Fix

Match the inline empty array and replace it in place with a block-style header, before the bare-`benefits:` lookup.

Two cards currently use the inline form: `penfed-power-cash-rewards.yaml` and `alliant-cashback-visa-signature.yaml`.

## Verification

Re-ran `--phase=finish` against this run's extractions. `penfed-power-cash-rewards.yaml` now gets a well-formed block, `build:cards` passes, and the per-card PRs open.