### PR TITLE
Auto: Capital One Venture X Rewards rewards/benefits update — 2026-08-23

### DIFF
--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -74,6 +74,12 @@ benefits:
     frequency: "per_trip"
     category: "hotel"
     enrollment_required: false
+  - name: "Cell Phone Protection"
+    value: 0
+    description: "Reimbursement of up to $800 if your phone is stolen or damaged when you pay your cell phone bill with the card."
+    frequency: "per_claim"
+    category: "telecom"
+    enrollment_required: false
 tags:
   - travel
   - premium


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Capital One Venture X Rewards**.

**Apply link (verify against this):** https://www.capitalone.com/credit-cards/venture-x/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
