### PR TITLE
Auto: PenFed Power Cash Rewards Visa Signature rewards/benefits update — 2026-08-23

### DIFF
--- a/data/cards/penfed-power-cash-rewards.yaml
+++ b/data/cards/penfed-power-cash-rewards.yaml
@@ -28,7 +28,13 @@ apr:
   regular:
     min: 17.99
     max: 17.99
-benefits: []
+benefits:
+  - name: "Travel Accident Coverage"
+    value: 0
+    description: "Up to $250,000 in travel accident coverage when you purchase your travel ticket with the card"
+    frequency: "per_trip"
+    category: "travel"
+    enrollment_required: false
 our_take: >
   This is a flat-rate cash back card whose real rate depends on who you are:
   2% on everything for PenFed Honors Advantage members, meaning current or


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **PenFed Power Cash Rewards Visa Signature**.

**Apply link (verify against this):** https://www.penfed.org/credit-cards/power-cash-rewards-visa

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
