### PR TITLE
Close two gaps that let declined benefits back into auto-PRs

### DIFF
--- a/data/benefit-policy.yaml
+++ b/data/benefit-policy.yaml
@@ -110,6 +110,12 @@ exclude:
   # manual-decision item (Atmos Rewards Business "Travel Accident Insurance"
   # in issue #1774) despite the same reasoning applying to all of them.
   - "Travel Accident Insurance"
+  # Issuers name this one inconsistently, and matching is substring-based, so
+  # "Insurance" alone does not cover "Coverage". PenFed Power Cash Rewards
+  # auto-PRed a "$250,000 Travel Accident Coverage" line through this gap
+  # (PR #2088).
+  - "Travel Accident Coverage"
+  - "Travel Accident Protection"
   - "Travel & Emergency Assistance"
   - "Travel and Emergency Assistance"
   - "Extended Warranty"

--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -237,7 +237,11 @@ function loadDeclined() {
       if (e?.slug && e?.name) empty.benefits.add(key(e.slug, e.name));
     }
     for (const n of raw.benefits_global || []) {
-      if (n) empty.benefitsGlobal.add(String(n).toLowerCase());
+      // Entries are `{ name, why }` like every other section of the file.
+      // `String(n)` on the object yields "[object Object]", so the set held
+      // one useless key and the global filter never matched anything.
+      const name = typeof n === 'string' ? n : n?.name;
+      if (name) empty.benefitsGlobal.add(String(name).toLowerCase());
     }
   } catch (err) {
     // A missing or malformed file must not silently disable the filter —


### PR DESCRIPTION
Found while verifying #2088 against the live PenFed apply page. Two independent gaps, both of which let benefits the team already declined come back as auto-PRs.

## 1. `Travel Accident Coverage` slipped past the insurance exclusion

`data/benefit-policy.yaml` excludes the whole insurance class (trip cancellation, auto rental CDW, purchase protection, extended warranty) with the reasoning spelled out in that block: the benefit model is built on a concrete annual dollar value, and insurance coverage has an expected value near zero, so a "$10,000 trip cancellation" line gets modeled as $10,000 of value.

The list carried only `"Travel Accident Insurance"`. Matching is case-insensitive substring, and that is not a substring of `"Travel Accident Coverage"`, which is what PenFed calls theirs. So it classified as `auto`:

```
Travel Accident Coverage    -> AUTO (would be PR'd)
Travel Accident Insurance   -> exclude via "travel accident insurance"
```

That is how #2088 got opened with a `$250,000 Travel Accident Coverage` line. The comment on that block already records the same recurrence problem biting once before (Atmos Rewards Business, issue #1774).

Added the `Coverage` and `Protection` name variants. Verified the change does not over-exclude: `Cell Phone Protection` and `Global Entry Credit` still classify `auto`.

## 2. `benefits_global` in review-declined.yaml has never matched anything

`loadDeclined()` did:

```js
for (const n of raw.benefits_global || []) {
  if (n) empty.benefitsGlobal.add(String(n).toLowerCase());
}
```

But those entries are `{ name, why }` objects, like every other section of the file and as its own header documents. `String(n)` yields `"[object Object]"`, so the set held exactly one useless key:

```
benefitsGlobal set contents: [ '[object object]' ]
would match "American Express Venue Collection"? false
```

Both entries there (American Express Venue Collection and its Amex variant, triaged away in issue #1916 and removed from all 7 carrying cards) have been re-proposable on every card since the file was added. Now reads `n.name`, still accepting a bare string.

After the fix:

```
benefitsGlobal: [ 'american express venue collection', 'amex venue collection' ]
matches Venue Collection? true
```

The per-card `benefits:` list was never affected. Only `benefits_global` was broken.

## Follow-up

#2088 should be closed rather than merged. The benefit is genuinely stated on the apply page, but it belongs to the excluded class and only reached a PR through gap 1.

Stacks cleanly with #2086 (separate area of the same script).
