### PR TITLE
Reddit Data Points 2026-08-24

### DIFF
--- a/data/reddit-datapoints/2026-08-24-t3_1vwj81r.yaml
+++ b/data/reddit-datapoints/2026-08-24-t3_1vwj81r.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1vwj81r"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vwj81r/denied_for_bilt_paladium_what_to_do/"
+posted: "2026-08-23"
+evidence: "Poster reports a recent Bilt Palladium denial at a 760 plus score while holding four cards, with the adverse action citing recently opened accounts first, then the age of a mortgage taken out in May and inquiry count."
+card_name: "Bilt Palladium"
+result: "denied"
+credit_score: 760
+credit_score_source: 0
+total_open_cards: 4
+date_applied: "2026-08"
+reason_denied: "Too high a proportion of recently opened accounts, plus mortgage age and inquiries."
+reason_denied_code: "too_many_recent_accounts"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-08-24

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vwj81r](https://www.reddit.com/r/CreditCards/comments/1vwj81r/denied_for_bilt_paladium_what_to_do/) | Bilt Palladium | denied | 760 | — | — | — | 2026-08 | `2026-08-24-t3_1vwj81r.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (15)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [Applied and approved for WF Autograph card. Credit limit too…](https://www.reddit.com/r/CreditCards/comments/1vq5uue/applied_and_approved_for_wf_autograph_card_credit/) | Wells Fargo Autograph · approved | credit_score | What was your score at the time, and which bureau? |
| [Got denied for the us bank cash+](https://www.reddit.com/r/CreditCards/comments/1vsblxk/got_denied_for_the_us_bank_cash/) | US Bank Cash+ Visa Signature · denied | credit_score | What was your score at the time, and which bureau? |
| [Combine Thank You Points on Brand New Card](https://www.reddit.com/r/CreditCards/comments/1vsae4f/combine_thank_you_points_on_brand_new_card/) | Citi Strata Premier · approved | credit_score | What was your score at the time, and which bureau? |
| [How Accurate is US Bank Preapproval Tool?](https://www.reddit.com/r/CreditCards/comments/1vrwmsr/how_accurate_is_us_bank_preapproval_tool/) | US Bank Altitude Connect · approved | credit_score | What was your score at the time, and which bureau? |
| [Anybody approved for Palladium after being denied but approv…](https://www.reddit.com/r/CreditCards/comments/1vssjau/anybody_approved_for_palladium_after_being_denied/) | Bilt Palladium · denied | credit_score | What was your score at the time, and which bureau? |
| [Any card with good SUB that can be used immediately or near-…](https://www.reddit.com/r/CreditCards/comments/1vtqlku/any_card_with_good_sub_that_can_be_used/) | Capital One Venture Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [General advice/recommendation request](https://www.reddit.com/r/CreditCards/comments/1vtlhs6/general_advicerecommendation_request/) | Chase Sapphire Preferred · approved | credit_score | What was your score at the time, and which bureau? |
| [when should i get rid of my lower end cards?](https://www.reddit.com/r/CreditCards/comments/1vssnb1/when_should_i_get_rid_of_my_lower_end_cards/) | Capital One Savor Cash Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Stay away from capital one!](https://www.reddit.com/r/CreditCards/comments/1vva29o/stay_away_from_capital_one/) | Capital One VentureOne Rewards · approved | credit_score, date_applied | What was your score at the time, and which bureau? Roughly when did you apply? |
| [Balance Transfer from Chase to NFCU](https://www.reddit.com/r/CreditCards/comments/1vutbz0/balance_transfer_from_chase_to_nfcu/) | Navy Federal Platinum · approved | credit_score | What was your score at the time, and which bureau? |
| [Amex multiple hard inquiries for BCE](https://www.reddit.com/r/CreditCards/comments/1vvxe1n/amex_multiple_hard_inquiries_for_bce/) | Blue Cash Everyday · approved | credit_score | What was your score at the time, and which bureau? |
| [Need a rec when turned down for cap1 with a high credit scor…](https://www.reddit.com/r/CreditCards/comments/1vvwbx7/need_a_rec_when_turned_down_for_cap1_with_a_high/) | denied | card_name | Which card exactly was it? |
| [Chase Marriott Bonvoy Boundless](https://www.reddit.com/r/CreditCards/comments/1vvltuj/chase_marriott_bonvoy_boundless/) | Marriott Bonvoy Boundless · approved | credit_score | What was your score at the time, and which bureau? |
| [BofA Flying blue Card- possibly denied](https://www.reddit.com/r/CreditCards/comments/1vvk74b/bofa_flying_blue_card_possibly_denied/) | Air France KLM Visa Signature | result | How did it end up, approved or denied? |
| [Debating on next card; to complete C1 setup or try and pivot](https://www.reddit.com/r/CreditCards/comments/1vwstfm/debating_on_next_card_to_complete_c1_setup_or_try/) | Bilt Palladium · denied | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 9 | No stated approval or denial (odds question, recommendation request, chatter) |
| `other` | 2 | Anything else (a note is required) |
| `no_score` | 1 | Real outcome but no credit score anywhere, and below the pending bar |
| `score_too_vague` | 1 | Score only as a wide range or a description ("mid 700s") |
| `pre_qual` | 1 | Pre-qualification or pre-approval result, which is never an outcome |


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
