### PR TITLE
Reddit Data Points 2026-08-25

### DIFF
--- a/data/reddit-datapoints/2026-08-25-t3_1vxg1zx.yaml
+++ b/data/reddit-datapoints/2026-08-25-t3_1vxg1zx.yaml
@@ -1,0 +1,11 @@
+source_id: "t3_1vxg1zx"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vxg1zx/two_cards_applications_in_one_day/"
+posted: "2026-08-24"
+evidence: "Poster applied for the Chase Prime Visa hours before posting and was approved, with a 729 FICO, three open cards, and a 1 year 5 month oldest account."
+card_name: "Amazon Prime Rewards Visa Signature"
+result: "approved"
+credit_score: 729
+credit_score_source: 0
+length_credit: 1
+total_open_cards: 3
+date_applied: "2026-08"

--- a/data/reddit-datapoints/2026-08-25-t3_1vxg1zx_2.yaml
+++ b/data/reddit-datapoints/2026-08-25-t3_1vxg1zx_2.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1vxg1zx#2"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vxg1zx/two_cards_applications_in_one_day/"
+posted: "2026-08-24"
+evidence: "Same poster applied for the Sapphire Preferred minutes after the Prime Visa approval and was denied, with reconsideration citing recent account openings."
+card_name: "Chase Sapphire Preferred"
+result: "denied"
+credit_score: 729
+credit_score_source: 0
+length_credit: 1
+date_applied: "2026-08"
+reason_denied: "Chase cited too many recently opened accounts."
+reason_denied_code: "too_many_recent_accounts"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-08-25

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1vxg1zx](https://www.reddit.com/r/CreditCards/comments/1vxg1zx/two_cards_applications_in_one_day/) | Amazon Prime Rewards Visa Signature | approved | 729 | — | — | 1 | 2026-08 | `2026-08-25-t3_1vxg1zx.yaml` |
| [t3_1vxg1zx#2](https://www.reddit.com/r/CreditCards/comments/1vxg1zx/two_cards_applications_in_one_day/) | Chase Sapphire Preferred | denied | 729 | — | — | 1 | 2026-08 | `2026-08-25-t3_1vxg1zx_2.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (16)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [Got denied for the us bank cash+](https://www.reddit.com/r/CreditCards/comments/1vsblxk/got_denied_for_the_us_bank_cash/) | US Bank Cash+ Visa Signature · denied | credit_score | What was your score at the time, and which bureau? |
| [Combine Thank You Points on Brand New Card](https://www.reddit.com/r/CreditCards/comments/1vsae4f/combine_thank_you_points_on_brand_new_card/) | Citi Strata Premier · approved | credit_score | What was your score at the time, and which bureau? |
| [How Accurate is US Bank Preapproval Tool?](https://www.reddit.com/r/CreditCards/comments/1vrwmsr/how_accurate_is_us_bank_preapproval_tool/) | US Bank Altitude Connect · approved | credit_score | What was your score at the time, and which bureau? |
| [Anybody approved for Palladium after being denied but approv…](https://www.reddit.com/r/CreditCards/comments/1vssjau/anybody_approved_for_palladium_after_being_denied/) | Bilt Palladium · denied | credit_score | What was your score at the time, and which bureau? |
| [Any card with good SUB that can be used immediately or near-…](https://www.reddit.com/r/CreditCards/comments/1vtqlku/any_card_with_good_sub_that_can_be_used/) | Capital One Venture Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [General advice/recommendation request](https://www.reddit.com/r/CreditCards/comments/1vtlhs6/general_advicerecommendation_request/) | Chase Sapphire Preferred · approved | credit_score | What was your score at the time, and which bureau? |
| [when should i get rid of my lower end cards?](https://www.reddit.com/r/CreditCards/comments/1vssnb1/when_should_i_get_rid_of_my_lower_end_cards/) | Capital One Savor Cash Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Stay away from capital one!](https://www.reddit.com/r/CreditCards/comments/1vva29o/stay_away_from_capital_one/) | Capital One VentureOne Rewards · approved | credit_score, date_applied | What was your score at the time, and which bureau? Roughly when did you apply? |
| [Balance Transfer from Chase to NFCU](https://www.reddit.com/r/CreditCards/comments/1vutbz0/balance_transfer_from_chase_to_nfcu/) | Navy Federal Platinum · approved | credit_score | What was your score at the time, and which bureau? |
| [Amex multiple hard inquiries for BCE](https://www.reddit.com/r/CreditCards/comments/1vvxe1n/amex_multiple_hard_inquiries_for_bce/) | Blue Cash Everyday · approved | credit_score | What was your score at the time, and which bureau? |
| [Need a rec when turned down for cap1 with a high credit scor…](https://www.reddit.com/r/CreditCards/comments/1vvwbx7/need_a_rec_when_turned_down_for_cap1_with_a_high/) | denied | card_name | Which card exactly was it? |
| [Chase Marriott Bonvoy Boundless](https://www.reddit.com/r/CreditCards/comments/1vvltuj/chase_marriott_bonvoy_boundless/) | Marriott Bonvoy Boundless · approved | credit_score | What was your score at the time, and which bureau? |
| [BofA Flying blue Card- possibly denied](https://www.reddit.com/r/CreditCards/comments/1vvk74b/bofa_flying_blue_card_possibly_denied/) | Air France KLM Visa Signature | result | How did it end up, approved or denied? |
| [Debating on next card; to complete C1 setup or try and pivot](https://www.reddit.com/r/CreditCards/comments/1vwstfm/debating_on_next_card_to_complete_c1_setup_or_try/) | Bilt Palladium · denied | credit_score | What was your score at the time, and which bureau? |
| [ITIN holder with 6 months of U.S. credit history—stuck with …](https://www.reddit.com/r/CreditCards/comments/1vxxsog/itin_holder_with_6_months_of_us_credit/) | Amazon Prime Rewards Visa Signature · denied | credit_score, date_applied | What was your score at the time, and which bureau? Roughly when did you apply? |
| [Citi Custom vs. Double Cash Reconsideration](https://www.reddit.com/r/CreditCards/comments/1vx8o5y/citi_custom_vs_double_cash_reconsideration/) | Citi Double Cash · denied | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 12 | No stated approval or denial (odds question, recommendation request, chatter) |
| `no_score` | 2 | Real outcome but no credit score anywhere, and below the pending bar |
| `pre_qual` | 1 | Pre-qualification or pre-approval result, which is never an outcome |
| `card_not_in_catalog` | 1 | Real outcome and score, but the card is not in data/cards/ |

**Cards in real data points but missing from the catalog:** `Wells Fargo Jewelry Advantage`. Adding one turns every future post about it into publishable odds data.


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
