### PR TITLE
news: hard-fail over-budget titles instead of warning into the void

### DIFF
--- a/scripts/build-news.js
+++ b/scripts/build-news.js
@@ -9,6 +9,18 @@ const OUTPUT_FILE = path.join(__dirname, '..', 'data', 'news.json');
 const SCHEMA_FILE = path.join(NEWS_DIR, 'schema.json');
 const CARDS_FILE = path.join(__dirname, '..', 'data', 'cards.json');
 
+// Keep in sync with TITLE_MAX in apps/web-next/src/lib/seo.ts, which drives the
+// generateMetadata truncation backstop.
+const TITLE_MAX = 47;
+const TITLE_SUFFIX_LEN = ' | CreditOdds'.length;
+// Items dated on or after this are hard-failed on title length; older ones are
+// pre-existing debt and only counted. See validateNewsItem.
+const TITLE_GATE_DATE = '2026-07-16';
+
+// Titles over budget on items predating TITLE_GATE_DATE, collected across the
+// run so the build can report one summary line instead of 70 scattered warnings.
+const legacyLongTitles = [];
+
 const VALID_TAGS = [
   'new-card',
   'discontinued',
@@ -57,11 +69,25 @@ function validateNewsItem(item, schema) {
   }
 
   // SEO: rendered <title> is "${item.title} | CreditOdds" (root layout
-  // template), so item.title above 47 chars overflows the 60-char Bing budget.
-  // generateMetadata truncates as a backstop; warn here so the YAML author can
-  // shorten before the truncation kicks in.
-  if (item.title && item.title.length > 47) {
-    console.warn(`  WARN: title is ${item.title.length} chars (>47 = ${item.title.length + 13} after " | CreditOdds" suffix; SEO budget is 60): ${item.title}`);
+  // template), so item.title above TITLE_MAX overflows the 60-char Bing budget.
+  // generateMetadata truncates as a backstop, but truncation cuts mid-phrase and
+  // drops the payload ("Discover Announces Q2 2026 5% Cash Back..." loses the
+  // categories), so the title still needs to be short at the source.
+  //
+  // This was a bare console.warn until 70 of 123 items had drifted over budget
+  // unnoticed, buried in a build log that prints two lines per item. Items dated
+  // on or after TITLE_GATE_DATE are hard-failed instead; older ones are counted
+  // into a single summary line (see reportTitleBudget) rather than warning
+  // per-item. The cutover is the date the card-news triage prompt started
+  // specifying a title length, and every item since has complied.
+  if (item.title && item.title.length > TITLE_MAX) {
+    const rendered = item.title.length + TITLE_SUFFIX_LEN;
+    const detail = `title is ${item.title.length} chars (${rendered} after " | CreditOdds"; SEO budget is 60, so item.title must be <= ${TITLE_MAX})`;
+    if (item.date && item.date >= TITLE_GATE_DATE) {
+      errors.push(detail);
+    } else {
+      legacyLongTitles.push({ title: item.title, length: item.title.length });
+    }
   }
 
   // Validate date format
@@ -167,6 +193,27 @@ function validateNewsItem(item, schema) {
   }
 
   return errors;
+}
+
+// One line for the whole run, so pre-existing over-budget titles stay visible
+// and countable instead of scrolling past as per-item warnings nobody reads.
+function reportTitleBudget() {
+  if (legacyLongTitles.length === 0) return;
+  const worst = legacyLongTitles
+    .slice()
+    .sort((a, b) => b.length - a.length)
+    .slice(0, 3);
+  console.warn(
+    `\nWARN: ${legacyLongTitles.length} item(s) predating ${TITLE_GATE_DATE} have titles over ` +
+    `${TITLE_MAX} chars. These render truncated mid-phrase in <title>. Longest:`
+  );
+  for (const { title, length } of worst) {
+    console.warn(`  ${length} chars: ${title}`);
+  }
+  console.warn(
+    `Newer items are hard-failed on this, so the count can only go down. ` +
+    `Rewrite them in data/news/ to clear it.`
+  );
 }
 
 function buildNews() {
@@ -308,6 +355,8 @@ function buildNews() {
   }
 
   console.log('\n---');
+  reportTitleBudget();
+
 
   if (errors.length > 0) {
     console.error(`\nValidation failed with ${errors.length} error(s):`);

--- a/scripts/check-card-news.js
+++ b/scripts/check-card-news.js
@@ -618,7 +618,7 @@ ${numbered}
 \`\`\`yaml
 id: "lowercase-hyphen-slug"            # unique, descriptive, no date prefix
 date: "${TODAY}"                        # always today; the finish phase re-forces it
-title: "Factual headline"               # aim for 35–47 chars (SEO budget); hard cap 200
+title: "Factual headline"               # 35-47 chars; over 47 is REJECTED by the finish phase
 summary: "1–3 sentences with concrete numbers/dates."   # max 500 chars
 tags:                                   # 1+ of: ${VALID_TAGS.join(', ')}
   - "benefit-change"
@@ -689,7 +689,7 @@ function validateItem(item, { cards, existingIds, existingUrls, rejectedIds, rej
   if (!item.id || !/^[a-z0-9-]+$/.test(item.id)) errors.push('invalid id (need lowercase-hyphen slug)');
   if (!item.title) errors.push('missing title');
   else if (item.title.length > 200) errors.push('title over 200 chars');
-  else if (item.title.length > 47) warnings.push(`title is ${item.title.length} chars (SEO budget is ~47)`);
+  else if (item.title.length > 47) errors.push(`title is ${item.title.length} chars; must be <= 47 so the rendered "<title> | CreditOdds" stays inside the 60-char SEO budget`);
   if (!item.summary) errors.push('missing summary');
   else if (item.summary.length > 500) errors.push('summary over 500 chars');
   if (!item.tags || !Array.isArray(item.tags) || item.tags.length === 0) {


### PR DESCRIPTION
## Why

While merging today's card-news PR (#2097) the build log surfaced SEO title warnings. Tracing them turned up a wider problem: **70 of 123 news items** have titles over the 47-char budget.

The 47-char budget and the `generateMetadata` truncation backstop both landed in #1130 (Bing SEO audit). But the build-time check was a bare `console.warn` inside a loop that prints two lines per item, so 70 violations accumulated with nobody reading them.

**This was never a compliance bug.** `truncateTitle` caps the rendered `<title>` at 47 + `" | CreditOdds"` = 60, so the budget always held. It is a *copy* bug: the cut lands mid-phrase and drops the payload.

| rendered `<title>` | what got lost |
|---|---|
| `Select Capital One Quicksilver Cards Move… \| CreditOdds` | "to Discover", i.e. the entire story |
| `Discover Announces Q2 2026 5% Cash Back… \| CreditOdds` | the categories |
| `American Express Adds $300 ChatGPT Credits to… \| CreditOdds` | which cards |

## The generator leak is already closed

The old `auto-news.yml` LLM prompt had no length instruction and happily wrote 80-100 char headlines. The local card-news routine (#1757) added `aim for 35-47 chars` on 2026-07-24. Newest offender is **2026-07-15**; all **37** items since have complied. So this PR does not fix the authoring side, it just makes the fix permanent.

## What this changes

- **`build-news.js`** hard-fails items dated `>= 2026-07-16` over `TITLE_MAX`, and collapses the legacy ones into a single end-of-build summary naming the three worst, so remaining debt is visible and countable instead of scrolling past.
- **`check-card-news.js`** promotes the same check from warning to error, so the finish phase rejects a long title *before* a PR is opened, and updates the triage prompt to say the rule is enforced.

The cutover date sits just past the newest offender, so the gate is a **no-op on today's tree** and the count can only go down.

## Verification

- `npm run build:news` → exit 0, 124 items, one summary line reporting 70 legacy.
- Temporary fixture with a 73-char title dated 2026-08-26 → `ERROR: title is 73 chars (86 after " | CreditOdds"...)`, exit 1. Fixture removed.
- Confirmed 0 violations among the 37 post-cutover items, so no existing file needs touching.

## Not included

Rewriting the 70 legacy headlines is editorial work, not a code change, so it is left out deliberately. The summary line is now the tracker for it.