### PR TITLE
Match rebranded cards on previous_names during DB sync

### DIFF
--- a/apps/api/src/handlers/update-cards-github.js
+++ b/apps/api/src/handlers/update-cards-github.js
@@ -15,6 +15,109 @@ function extractMetrics(cdnCard) {
   };
 }
 
+// Card names are the join key between cards.json and the `cards` table, so a
+// rebrand is the one edit that can silently destroy data: if the renamed card
+// reaches the CDN before the DB row is renamed, the sync finds no match,
+// INSERTs a second row under a fresh card_id, and the original row keeps the
+// ratings, card_stats and card_wire history that now belong to nothing. That
+// hazard is why renames used to require a hand-run migration ahead of the
+// merge. Matching on `previous_names` (already carried in cards.json and
+// rendered as the "Previously ..." subtitle) removes the manual step.
+const NAME_SUFFIXES = [" Card", " Credit Card", " card", " credit card"];
+
+// Resolve one name against the DB rows, tolerating the legacy suffix drift
+// from before name standardization (DB may carry a suffix the CDN dropped, or
+// the reverse).
+function resolveDirect(name, existingByName) {
+  if (!name) return null;
+  if (existingByName[name]) return existingByName[name];
+  for (const suffix of NAME_SUFFIXES) {
+    if (existingByName[name + suffix]) return existingByName[name + suffix];
+  }
+  for (const suffix of NAME_SUFFIXES) {
+    if (name.endsWith(suffix) && existingByName[name.slice(0, -suffix.length)]) {
+      return existingByName[name.slice(0, -suffix.length)];
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the CDN-card -> DB-row matcher for one sync run.
+ *
+ * Resolution order per card: current name (exact, then suffix-tolerant), then
+ * `previous_names`. Three guards keep the rename fallback from stealing rows:
+ *
+ *  - A row claimed by some card's CURRENT name is never available to another
+ *    card's previous_names. Reviving a retired name for a different product
+ *    must lose to the card actually called that today.
+ *  - A row claimed by two or more cards' previous_names is left unmatched, so
+ *    an ambiguous split gets a clean INSERT and a warning instead of an
+ *    arbitrary winner silently absorbing another card's history.
+ *  - A row already consumed earlier in this run cannot be matched twice.
+ *
+ * Returns a stateful function; build one per run.
+ */
+function buildCardMatcher(existingCards, cdnCards) {
+  const existingByName = {};
+  for (const card of existingCards) {
+    existingByName[card.card_name] = card;
+  }
+
+  const directlyClaimed = new Set();
+  for (const cdnCard of cdnCards) {
+    const row = resolveDirect(cdnCard.name, existingByName);
+    if (row) directlyClaimed.add(row.card_id);
+  }
+
+  // card_id -> set of CDN card names claiming it via previous_names
+  const previousClaimants = new Map();
+  for (const cdnCard of cdnCards) {
+    for (const prev of cdnCard.previous_names || []) {
+      const row = resolveDirect(prev, existingByName);
+      if (!row || directlyClaimed.has(row.card_id)) continue;
+      if (!previousClaimants.has(row.card_id)) {
+        previousClaimants.set(row.card_id, new Set());
+      }
+      previousClaimants.get(row.card_id).add(cdnCard.name);
+    }
+  }
+
+  const consumed = new Set();
+
+  return function findExistingCard(cdnCard) {
+    const direct = resolveDirect(cdnCard.name, existingByName);
+    if (direct) {
+      consumed.add(direct.card_id);
+      return direct;
+    }
+
+    for (const prev of cdnCard.previous_names || []) {
+      const row = resolveDirect(prev, existingByName);
+      if (!row) continue;
+      if (directlyClaimed.has(row.card_id)) continue;
+      if (consumed.has(row.card_id)) continue;
+
+      const claimants = previousClaimants.get(row.card_id);
+      if (claimants && claimants.size > 1) {
+        console.warn(
+          `Ambiguous rebrand: "${prev}" is claimed by ${claimants.size} cards ` +
+            `(${[...claimants].join(", ")}); leaving card_id ${row.card_id} unmatched`
+        );
+        continue;
+      }
+
+      consumed.add(row.card_id);
+      console.info(
+        `Rebrand matched: "${prev}" -> "${cdnCard.name}" (card_id ${row.card_id})`
+      );
+      return row;
+    }
+
+    return null;
+  };
+}
+
 // Compare old and new metrics, insert card_wire rows for any changes
 async function detectAndRecordChanges(cardId, oldMetrics, newMetrics) {
   const trackedFields = [
@@ -99,28 +202,7 @@ async function syncCardsToDatabase(cdnCards) {
        FROM cards`
     );
 
-    // Create lookup map by card_name
-    const existingByName = {};
-    for (const card of existingCards) {
-      existingByName[card.card_name] = card;
-    }
-
-    // Helper: find existing card by exact name, or fuzzy match (with/without suffix)
-    function findExistingCard(name) {
-      if (existingByName[name]) return existingByName[name];
-      // Try common suffixes that may still be in the DB from before name standardization
-      const suffixes = [' Card', ' Credit Card', ' card', ' credit card'];
-      for (const suffix of suffixes) {
-        if (existingByName[name + suffix]) return existingByName[name + suffix];
-      }
-      // Try stripping suffixes in case CDN has suffix but DB doesn't
-      for (const suffix of suffixes) {
-        if (name.endsWith(suffix) && existingByName[name.slice(0, -suffix.length)]) {
-          return existingByName[name.slice(0, -suffix.length)];
-        }
-      }
-      return null;
-    }
+    const findExistingCard = buildCardMatcher(existingCards, cdnCards);
 
     for (const cdnCard of cdnCards) {
       try {
@@ -128,8 +210,8 @@ async function syncCardsToDatabase(cdnCards) {
         const bank = cdnCard.bank;
         const acceptingApplications = cdnCard.accepting_applications ? 1 : 0;
 
-        // Check if card exists by name (with fuzzy suffix matching)
-        const existingCard = findExistingCard(name);
+        // Match by current name, falling back to previous_names for rebrands
+        const existingCard = findExistingCard(cdnCard);
 
         // Convert tags array to JSON string for database storage
         const tagsJson = cdnCard.tags ? JSON.stringify(cdnCard.tags) : null;
@@ -293,3 +375,6 @@ exports.updateCardsGitHubHandler = async (event) => {
     };
   }
 };
+
+// Exported for unit tests.
+exports._buildCardMatcher = buildCardMatcher;

--- a/apps/api/tests/card-matcher.test.js
+++ b/apps/api/tests/card-matcher.test.js
@@ -1,0 +1,95 @@
+// Unit tests for the CDN-card -> DB-row matcher in update-cards-github.js.
+//
+// Written when `previous_names` matching was added. Card names are the join key
+// between cards.json and the `cards` table, so an unmatched rebrand INSERTs a
+// duplicate row under a fresh card_id and strands the original's ratings,
+// card_stats and card_wire history. These tests pin the resolution order and,
+// more importantly, the guards that stop the rename fallback from letting one
+// card absorb another's history.
+
+const { _buildCardMatcher } = require("../src/handlers/update-cards-github");
+
+const row = (id, name) => ({ card_id: id, card_name: name });
+
+describe("buildCardMatcher", () => {
+  test("matches on exact current name", () => {
+    const match = _buildCardMatcher([row(1, "Chase Sapphire Preferred")], []);
+    expect(match({ name: "Chase Sapphire Preferred" })).toEqual(row(1, "Chase Sapphire Preferred"));
+  });
+
+  test("still tolerates legacy suffix drift in both directions", () => {
+    const dbHasSuffix = _buildCardMatcher([row(1, "Amazon Store Card")], []);
+    expect(dbHasSuffix({ name: "Amazon Store" }).card_id).toBe(1);
+
+    const cdnHasSuffix = _buildCardMatcher([row(2, "Amazon Store")], []);
+    expect(cdnHasSuffix({ name: "Amazon Store Card" }).card_id).toBe(2);
+  });
+
+  test("returns null for a genuinely new card", () => {
+    const match = _buildCardMatcher([row(1, "Existing")], []);
+    expect(match({ name: "Brand New Card" })).toBeNull();
+  });
+
+  test("matches a rebrand via previous_names", () => {
+    const cdn = [
+      {
+        name: "Citi AAdvantage Executive World Legend Mastercard",
+        previous_names: ["Citi AAdvantage Executive World Elite Mastercard"],
+      },
+    ];
+    const match = _buildCardMatcher(
+      [row(7, "Citi AAdvantage Executive World Elite Mastercard")],
+      cdn
+    );
+    // The whole point: the renamed card keeps card_id 7 rather than being
+    // inserted fresh, so its ratings and wire history survive the rename.
+    expect(match(cdn[0]).card_id).toBe(7);
+  });
+
+  test("a card's CURRENT name beats another card's previous_names", () => {
+    // "Chase Freedom Student" was retired into Chase Freedom Rise. If a card
+    // called "Chase Freedom Student" ever exists again, the row belongs to the
+    // card actually named that today, not to Rise.
+    const revived = { name: "Chase Freedom Student" };
+    const rise = { name: "Chase Freedom Rise", previous_names: ["Chase Freedom Student"] };
+    const cdn = [rise, revived];
+    const match = _buildCardMatcher([row(3, "Chase Freedom Student")], cdn);
+
+    expect(match(rise)).toBeNull();
+    expect(match(revived).card_id).toBe(3);
+  });
+
+  test("an old name claimed by two cards matches neither", () => {
+    // A split (one product becoming two) must not let whichever card is
+    // processed first silently absorb the shared history.
+    const a = { name: "Split A", previous_names: ["Original"] };
+    const b = { name: "Split B", previous_names: ["Original"] };
+    const cdn = [a, b];
+    const match = _buildCardMatcher([row(9, "Original")], cdn);
+
+    expect(match(a)).toBeNull();
+    expect(match(b)).toBeNull();
+  });
+
+  test("one row is never matched twice in a run", () => {
+    const a = { name: "New A", previous_names: ["Old"] };
+    const b = { name: "New B", previous_names: ["Old"] };
+    // Only `a` declares it at build time, so `b` is added after the ambiguity
+    // scan; the consumed-set guard is what stops the double match.
+    const match = _buildCardMatcher([row(4, "Old")], [a]);
+
+    expect(match(a).card_id).toBe(4);
+    expect(match(b)).toBeNull();
+  });
+
+  test("previous_names entries tolerate suffix drift too", () => {
+    const cdn = [{ name: "Renamed", previous_names: ["Old Name"] }];
+    const match = _buildCardMatcher([row(5, "Old Name Credit Card")], cdn);
+    expect(match(cdn[0]).card_id).toBe(5);
+  });
+
+  test("handles cards with no previous_names field", () => {
+    const match = _buildCardMatcher([row(1, "Whatever")], [{ name: "Unrelated" }]);
+    expect(match({ name: "Unrelated" })).toBeNull();
+  });
+});


### PR DESCRIPTION
Piece **A** from the CardWire rebrand discovery: the cheap change that removes a live data-loss risk, independent of any UI work.

## The problem

Card names are the join key between `cards.json` and the `cards` table. `findExistingCard` matched only on the current `card_name` (plus a legacy suffix-drift fallback) and never consulted `previous_names` — even though cards.json already carries it and the card page already renders it as the "Previously ..." subtitle.

So a rebrand that reaches the CDN before the DB row is renamed finds no match, falls to the `else` branch, and **INSERTs a second row under a fresh `card_id`**. The original row keeps the ratings, `card_stats` and `card_wire` history that now belong to nothing.

That is the entire reason renames have required a hand-run migration ahead of the merge, most recently `056` for the Citi AAdvantage Executive World Legend rebrand.

## The change

Resolution order per card is now:

1. current name, exact
2. current name, existing suffix-tolerant fallback (unchanged)
3. `previous_names`, same suffix tolerance

Three guards keep the fallback from letting one card absorb another's history:

| Guard | Why |
|---|---|
| A row claimed by any card's **current** name is never available to another card's `previous_names` | Reviving a retired name must lose to the card actually called that today. If "Chase Freedom Student" ever returns, it beats Freedom Rise's claim on it. |
| A row claimed by **two or more** cards' `previous_names` matches neither | A product split gets a clean INSERT plus a warning, rather than whichever card is processed first silently absorbing the shared history |
| A row already **consumed** this run cannot match again | Belt-and-braces against double-matching |

The matcher is extracted to `buildCardMatcher(existingCards, cdnCards)` and exported so it can be unit tested; it was previously a closure inside `syncCardsToDatabase`.

## Verification

Dry-run against real `cards.json` (224 cards):

- **DB in its current state** — all 224 match by current name and the fallback fires **zero** times. This change is a no-op until a rename actually lands.
- **DB rewound to the pre-056 state** — all five cards carrying `previous_names` are recovered by the fallback, with **zero** duplicate INSERTs. Under the old code all five would have duplicated:

```
Air France KLM World Elite Mastercard        -> Air France KLM Visa Signature
Chase Freedom Student                        -> Chase Freedom Rise
CitiBusiness AAdvantage Platinum Select      -> Citi AAdvantage Business World Elite
Citi AAdvantage Executive World Elite        -> Citi AAdvantage Executive World Legend
Princess Cruises Rewards Visa                -> Princess Rewards Visa
```

9 new unit tests in `apps/api/tests/card-matcher.test.js` pin the resolution order and each guard. Full API suite green (56 tests, 5 suites).

## Scope

Deliberately does **not** record the rename as a card_wire event (piece B) or change how history renders identity (piece C).

This makes the migration-first dance unnecessary for *future* rebrands. It does not retroactively fix anything, and a rename still applies silently with no wire event until B lands.