### PR TITLE
Benefits review 2026-08-23: wholesale clubs, Ink category fix, two declines

### DIFF
--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -28,7 +28,14 @@ rewards:
   - category: groceries
     value: 2
     unit: percent
-    note: "Also includes wholesale clubs; cap is combined with choice category"
+    note: "Grocery stores; cap is combined with the choice category and wholesale clubs"
+    spend_cap: 2500
+    cap_period: quarterly
+    rate_after_cap: 1
+  - category: wholesale_clubs
+    value: 2
+    unit: percent
+    note: "Wholesale clubs; cap is combined with choice category and grocery stores"
     spend_cap: 2500
     cap_period: quarterly
     rate_after_cap: 1

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -30,7 +30,14 @@ rewards:
   - category: groceries
     value: 2
     unit: percent
-    note: "Also includes wholesale clubs; cap is combined with choice category"
+    note: "Grocery stores; cap is combined with the choice category and wholesale clubs"
+    spend_cap: 2500
+    cap_period: quarterly
+    rate_after_cap: 1
+  - category: wholesale_clubs
+    value: 2
+    unit: percent
+    note: "Wholesale clubs; cap is combined with choice category and grocery stores"
     spend_cap: 2500
     cap_period: quarterly
     rate_after_cap: 1

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -17,7 +17,7 @@ rewards:
     spend_cap: 25000
     cap_period: annual
     rate_after_cap: 1
-  - category: utilities
+  - category: tv_internet_streaming
     value: 5
     unit: percent
     note: "Internet and cable services; combined $25,000/year cap with office supplies and phone services; 1% thereafter"

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -27,7 +27,7 @@ rewards:
     spend_cap: 150000
     cap_period: annual
     rate_after_cap: 1
-  - category: utilities
+  - category: tv_internet_streaming
     value: 3
     unit: points_per_dollar
     note: "Internet and cable services (combined $150,000/yr cap with travel, shipping, phone, and advertising)"

--- a/data/review-declined.yaml
+++ b/data/review-declined.yaml
@@ -55,11 +55,14 @@ rewards_added:
       why: "local transit 2x expired 2025-12-31; Chase still quotes the dated text on the page. Delete this entry if Chase renews with a new date" }
   - { slug: world-of-hyatt-business-credit-card, category: selected_categories,
       why: "the same bucket as the existing top_category row" }
+  - { slug: chase-ink-business-preferred, category: online_shopping,
+      why: "the 3x is advertising with social media sites and search engines, not online retail; an online_shopping row would claim 3x on all online spend (issue #2089)" }
 
 # Reward categories flagged as present in YAML but not on the apply page.
 # Every entry below was verified still live on the issuer's page; the
 # detector could not read the earn table (JS-rendered or bot-blocked).
 rewards_removed:
+  - { slug: citi-aadvantage-globe, category: hotels_portal }
   - { slug: aaa-daily-advantage-visa-signature, category: ev_charging }
   - { slug: robinhood-platinum, category: hotels_portal }
   - { slug: robinhood-platinum, category: car_rentals_portal }


### PR DESCRIPTION
Triage of #2089. Five items, three outcomes.

## Added: `wholesale_clubs` on both BofA cards

Bank of America Cash Rewards Secured and Customized Cash Rewards both pay 2% at wholesale clubs. That was only recorded as prose inside the groceries row's note:

```yaml
note: "Also includes wholesale clubs; cap is combined with choice category"
```

**The ranker reads categories, not notes.** So neither card surfaced for a Costco or Sam's Club purchase despite actually earning 2% there. Promoted to an explicit `wholesale_clubs` row sharing the same $2,500 quarterly cap. The category is already supported by `storeRanking.js:32` and appears in `stores.json`, so this closes a live wallet-picks gap rather than just tidying data.

## Fixed: `utilities` was the wrong category on both Ink cards

Chase's benefit is *internet, cable and phone services* — which is exactly what each row's own note already said. `utilities` reads as electric/gas/water, so the tag contradicted the note.

Retagged `utilities` → `tv_internet_streaming` (supported in `categoryLabels.js:37`) on Ink Business Cash (5%) and Ink Business Preferred (3x). The `phone` rows stay, since phone service is genuinely part of the benefit.

This was one taxonomy error showing up on two cards, not two card-level mistakes.

## Declined

**Ink Business Preferred `online_shopping: 3x`** — this is the one worth catching. Chase's 3x is on *advertising purchases made with social media sites and search engines*. Modelling that as `online_shopping` would claim 3x on all online retail and inflate the card across /best and wallet picks. There's no supported category for ad spend; it belongs in a `merchant_specific` row or nowhere.

**Citi AAdvantage Globe `hotels_portal: 6x`**, flagged as "present in YAML but not on apply page" — false positive. Verified live in a browser:

> "Earn 6 AAdvantage® miles for every $1 spent on eligible AAdvantage Hotels™ bookings"

Citi serves its pages with every numeral stripped, so the detector structurally cannot read a Citi earn table. Same root cause that masked the Executive rebrand and blanked Citi Double Cash in this morning's card-page run.

## Not touched

The four items in #2055 are out of scope here and still need a decision.

## Verification

`npm run build:cards` passes (224 cards); regenerated `cards.json` not committed, per convention.