### PR TITLE
Benefits review 2026-08-16: drop IHG Traveler phone 3x, file three declines

### DIFF
--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -72,15 +72,11 @@ rewards:
   - category: utilities
     value: 3
     unit: points_per_dollar
-    note: "Utilities, internet, and cable services (combined 3x bucket with phone and select streaming)"
-  - category: phone
-    value: 3
-    unit: points_per_dollar
-    note: "Phone services (combined 3x bucket with utilities/internet/cable and select streaming)"
+    note: "Utilities (combined 3x bucket with dining, gas, and select streaming)"
   - category: streaming
     value: 3
     unit: points_per_dollar
-    note: "Select streaming services (combined 3x bucket with utilities/internet/cable and phone)"
+    note: "Select streaming services (combined 3x bucket with dining, gas, and utilities)"
   - category: everything_else
     value: 2
     unit: points_per_dollar
@@ -100,8 +96,8 @@ network: "mastercard"
 our_take: >
   The Traveler is the no-annual-fee way into the IHG program, and it earns
   better than most free hotel cards: 5x at IHG properties, 3x across dining,
-  gas, utilities, internet and cable, phone, and select streaming, and 2x on
-  everything else, with no foreign transaction fee. The 80,000-point bonus
+  gas, utilities, and select streaming, and 2x on everything else, with no
+  foreign transaction fee. The 80,000-point bonus
   after just $2,000 in three months is a low bar, though it is worth knowing
   the offer ran as high as 125,000 points in June before falling back to
   80,000 in July, so waiting for another spike is reasonable. What you give up

--- a/data/review-declined.yaml
+++ b/data/review-declined.yaml
@@ -57,11 +57,15 @@ rewards_added:
       why: "the same bucket as the existing top_category row" }
   - { slug: chase-ink-business-preferred, category: online_shopping,
       why: "the 3x is advertising with social media sites and search engines, not online retail; an online_shopping row would claim 3x on all online spend (issue #2089)" }
+  - { slug: capital-one-venture-x-business, category: vacation_rentals,
+      why: "the 5x is real (Capital One Travel) but `vacation_rentals` is not in ranker/categoryLabels.js, so the row would never match anything; covered by the travel_portal row's note (issue #2055)" }
 
 # Reward categories flagged as present in YAML but not on the apply page.
 # Every entry below was verified still live on the issuer's page; the
 # detector could not read the earn table (JS-rendered or bot-blocked).
 rewards_removed:
+  - { slug: british-airways-visa-signature-card, category: hotels }
+  - { slug: united-club-business, category: hotels_portal }
   - { slug: citi-aadvantage-globe, category: hotels_portal }
   - { slug: aaa-daily-advantage-visa-signature, category: ev_charging }
   - { slug: robinhood-platinum, category: hotels_portal }


### PR DESCRIPTION
Triage of #2055. All four items checked against the live issuer page in a browser before acting, which **reversed my read on one of them**.

## Removed: IHG One Rewards Traveler `phone: 3x`

I had recommended declining this as another extraction miss. The page says otherwise:

> "Earn 3X total points on dining, utilities, select streaming services, and at gas stations."

No phone. No internet or cable either, and the single mention of "utilities" carries no footnote expanding the definition. The checker was right and I was wrong, so the row is removed rather than declined.

Also cleaned up the collateral damage around it:
- the `utilities` and `streaming` notes both described a "combined 3x bucket with phone and internet/cable" that does not exist
- `our_take` listed "gas, utilities, internet and cable, phone, and select streaming", which would have contradicted the data on the live card page

## Declined: verified still live on the issuer page

| Card | Category | Page says |
|---|---|---|
| British Airways Visa Signature | `hotels: 2x` | "Earn 2 Avios for every $1 spent on hotel accommodations booked directly with the hotel" |
| United Club Business | `hotels_portal: 5x` | "5x miles on hotel stays when you prepay directly through Renowned Hotels and Resorts for United® Cardmembers" |

Both are real earn rates the detector failed to read. Neither should be removed.

## Declined: Capital One Venture X Business `vacation_rentals: 5x`

The benefit is genuine (5x on flights and vacation rentals booked through Capital One Travel), but **`vacation_rentals` is not in `ranker/categoryLabels.js`**. Adding the row as proposed would create data that never matches anything: it would read as coverage on the card page while being inert in wallet picks and /best. The existing `travel_portal` row's note already covers it.

Worth noting as a pattern: the checker proposed a category the ranker cannot consume. Validating proposals against `categoryLabels.js` before they reach a review issue would have filtered this one out automatically.

## Scoreboard for this queue

Four items: one real removal, three declines. The 3-of-4 false-positive rate on "present in YAML but not on apply page" is consistent with #2089, where 1 of 2 in that class was also a false positive — but IHG shows the signal is not pure noise, so it does need a human rather than blanket suppression.

## Verification

`npm run build:cards` passes (224 cards); regenerated `cards.json` not committed, per convention.