### PR TITLE
Fix image compression skip guard against a removed sharp metadata field

### DIFF
--- a/scripts/compress-card-images.js
+++ b/scripts/compress-card-images.js
@@ -18,15 +18,21 @@
  * Usage:
  *   node scripts/compress-card-images.js [--dry-run] [--force]
  *
+ *   --dry-run  report which files are already at the target and which would be
+ *              re-encoded, without writing anything. Run it right after a real
+ *              run: it should report 0 to re-encode.
  *   --force  re-encode even files already at the target. Only for a deliberate
  *            requantisation of the whole set; it degrades every image it touches.
  */
 
 const fs = require('fs');
 const path = require('path');
-const { compressPngInPlace, CARD_MAX_WIDTH } = require('./lib/compress-image');
+const { compressPngInPlace, isAtTarget, CARD_MAX_WIDTH } = require('./lib/compress-image');
 
-const IMAGES_DIR = path.join(__dirname, '..', 'data', 'cards', 'images');
+// Overridable so the test can point the script at a scratch directory. Nothing
+// in normal use should set this.
+const IMAGES_DIR =
+  process.env.CARD_IMAGES_DIR || path.join(__dirname, '..', 'data', 'cards', 'images');
 const dryRun = process.argv.includes('--dry-run');
 const force = process.argv.includes('--force');
 
@@ -60,7 +66,16 @@ async function main() {
     totalBefore += before;
 
     if (dryRun) {
+      // Classify without encoding. This is the same question the real run asks
+      // before it touches anything, so a dry run straight after a real run is
+      // the cheapest proof that the run was idempotent.
       totalAfter += before;
+      if (await isAtTarget(full, { maxWidth: CARD_MAX_WIDTH })) {
+        skippedCount++;
+      } else {
+        changedCount++;
+        process.stdout.write(`  ${file}: would re-encode (${kb(before)})\n`);
+      }
       continue;
     }
 
@@ -83,7 +98,7 @@ async function main() {
   }
 
   process.stdout.write(
-    `\n${files.length} file(s) scanned, ${changedCount} rewritten, ` +
+    `\n${files.length} file(s) scanned, ${changedCount} ${dryRun ? 'to re-encode' : 'rewritten'}, ` +
       `${skippedCount} already at target\n` +
       `total ${kb(totalBefore)} → ${kb(totalAfter)}\n`
   );

--- a/scripts/compress-card-images.test.js
+++ b/scripts/compress-card-images.test.js
@@ -1,0 +1,163 @@
+// End-to-end test for compress-card-images.js: a second consecutive run must
+// report zero files rewritten.
+//
+// Why this exists on top of the unit tests in scripts/lib/compress-image.test.js:
+// the failure that shipped was invisible at the call site. compressPngInPlace's
+// skip guard asked sharp for a metadata field that sharp no longer emits, so
+// the check quietly evaluated false for every file and the script re-quantised
+// all ~180 card images on every run — each pass throwing away more colour, and
+// each pass dragging the whole directory into the diff. The script is documented
+// as the thing to run after adding new art, so following the instructions was
+// what degraded the set.
+//
+// The unit tests cover the guard's logic; this one covers the promise the
+// docstring actually makes, through the real CLI, on real encoder output.
+//
+// Run: `node scripts/compress-card-images.test.js`. Exits non-zero on failure.
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const sharp = require('sharp');
+
+const SCRIPT = path.join(__dirname, 'compress-card-images.js');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'compress-card-images-test-'));
+
+const digest = (p) => crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+const listing = (dir) =>
+  Object.fromEntries(fs.readdirSync(dir).map((f) => [f, digest(path.join(dir, f))]));
+
+// Flat colour quantises to a stable palette on the first pass, which would hide
+// the bug. Noise leaves enough distinct colours that a second pass has more to
+// throw away — which is what the real card art looks like to the encoder.
+async function writeSource(dir, name, { width, height = 400, format = 'png', palette = false }) {
+  const px = Buffer.alloc(width * height * 3);
+  for (let i = 0; i < px.length; i++) px[i] = (i * 2654435761) % 256;
+  const img = sharp(px, { raw: { width, height, channels: 3 } });
+  const file = path.join(dir, name);
+  await (format === 'png' ? img.png({ palette }) : img.jpeg()).toFile(file);
+  return file;
+}
+
+const run = (dir, args = []) =>
+  execFileSync(process.execPath, [SCRIPT, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, CARD_IMAGES_DIR: dir },
+  });
+
+// "N file(s) scanned, M rewritten, K already at target"
+function parseSummary(out) {
+  const m = out.match(/(\d+) file\(s\) scanned, (\d+) (?:rewritten|to re-encode), (\d+) already at target/);
+  assert.ok(m, `could not parse summary from:\n${out}`);
+  return { scanned: +m[1], changed: +m[2], skipped: +m[3] };
+}
+
+let failures = 0;
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+// A directory that mirrors what data/cards/images/ actually holds: oversized
+// press-kit art, art already at the target, and the odd file that is not really
+// a PNG despite the extension.
+async function makeImagesDir(name) {
+  const dir = path.join(tmp, name);
+  fs.mkdirSync(dir);
+  await writeSource(dir, 'oversized.png', { width: 2400 });
+  await writeSource(dir, 'truecolor.png', { width: 600 });
+  await writeSource(dir, 'already-palette.png', { width: 500, palette: true });
+  await writeSource(dir, 'actually-jpeg.png', { width: 500, format: 'jpeg' });
+  return dir;
+}
+
+test('a second consecutive run rewrites nothing', async () => {
+  const dir = await makeImagesDir('second-run');
+
+  const first = parseSummary(run(dir));
+  assert.equal(first.scanned, 4);
+  assert.ok(first.changed > 0, 'first run should have had work to do');
+
+  const before = listing(dir);
+  const second = parseSummary(run(dir));
+
+  assert.equal(second.changed, 0, 'second run rewrote files');
+  assert.equal(second.skipped, second.scanned, 'every file should be at target');
+  assert.deepEqual(listing(dir), before, 'second run changed bytes on disk');
+});
+
+test('a third run is still a no-op', async () => {
+  // One clean pass could be luck — a file that happens to re-encode identically.
+  // The regression was compounding, so check it stays put.
+  const dir = await makeImagesDir('third-run');
+  run(dir);
+  run(dir);
+  const before = listing(dir);
+  const third = parseSummary(run(dir));
+  assert.equal(third.changed, 0);
+  assert.deepEqual(listing(dir), before);
+});
+
+test('--dry-run reports nothing to re-encode after a real run', async () => {
+  const dir = await makeImagesDir('dry-run');
+  run(dir);
+  const before = listing(dir);
+
+  const dry = parseSummary(run(dir, ['--dry-run']));
+  assert.equal(dry.changed, 0, '--dry-run found work after a completed run');
+  assert.equal(dry.skipped, dry.scanned);
+  assert.deepEqual(listing(dir), before, '--dry-run wrote to disk');
+});
+
+test('--dry-run does see work on an untouched directory', async () => {
+  // Otherwise the assertion above would pass just as well against a dry run
+  // that reports nothing no matter what — which is what it used to do.
+  const dir = await makeImagesDir('dry-run-pending');
+  const before = listing(dir);
+  const dry = parseSummary(run(dir, ['--dry-run']));
+  assert.ok(dry.changed > 0, '--dry-run reported no work on uncompressed art');
+  assert.deepEqual(listing(dir), before, '--dry-run wrote to disk');
+});
+
+test('--force re-encodes files a plain run would skip', async () => {
+  const dir = await makeImagesDir('forced');
+  run(dir);
+  const forced = parseSummary(run(dir, ['--force']));
+  assert.ok(forced.changed > 0, '--force skipped everything');
+});
+
+test('new art is compressed without disturbing the files already there', async () => {
+  // The scenario from the bug report: one image added to a settled directory.
+  const dir = await makeImagesDir('new-art');
+  run(dir);
+  const before = listing(dir);
+
+  await writeSource(dir, 'brand-new-card.png', { width: 1800 });
+  const out = run(dir);
+  const summary = parseSummary(out);
+
+  assert.equal(summary.changed, 1, `expected exactly the new file to change:\n${out}`);
+  for (const [file, hash] of Object.entries(before)) {
+    assert.equal(digest(path.join(dir, file)), hash, `${file} was rewritten`);
+  }
+});
+
+(async () => {
+  for (const [name, fn] of tests) {
+    try {
+      await fn();
+      console.log(`  ok   ${name}`);
+    } catch (err) {
+      failures++;
+      console.error(`  FAIL ${name}\n       ${err.message}`);
+    }
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+  if (failures) {
+    console.error(`\n${failures} test(s) failed.`);
+    process.exit(1);
+  }
+  console.log('\nAll tests passed.');
+})();

--- a/scripts/lib/compress-image.js
+++ b/scripts/lib/compress-image.js
@@ -25,6 +25,51 @@ const sharp = require('sharp');
 const CARD_MAX_WIDTH = 1000;
 const EDITORIAL_MAX_WIDTH = 1600;
 
+const PNG_SIGNATURE = Buffer.from('89504e470d0a1a0a', 'hex');
+const PNG_COLOR_TYPE_PALETTE = 3;
+
+/**
+ * True when `buf` holds a PNG whose IHDR declares colour type 3 (palette).
+ *
+ * Read from the bytes rather than from sharp's metadata on purpose. The first
+ * version of this guard asked `meta.paletteBitDepth !== undefined`, which is a
+ * field sharp stopped emitting; the check then silently evaluated false for
+ * every file, nothing was ever skipped, and each run re-quantised the whole
+ * card set. Absence of a metadata key is indistinguishable from "not a
+ * palette", so that shape of check fails open — towards re-encoding — and does
+ * it without a word. The IHDR layout is fixed by the PNG spec, so this cannot
+ * drift out from under us on a dependency bump.
+ *
+ * @param {Buffer} buf
+ * @returns {boolean}
+ */
+function isPalettePng(buf) {
+  // signature(8) + chunk length(4) + type(4) + width(4) + height(4)
+  // + bit depth(1) + colour type(1): 26 bytes before the answer is readable.
+  if (buf.length < 26) return false;
+  if (!buf.subarray(0, 8).equals(PNG_SIGNATURE)) return false;
+  // IHDR is required by the spec to be the first chunk.
+  if (buf.subarray(12, 16).toString('latin1') !== 'IHDR') return false;
+  return buf[25] === PNG_COLOR_TYPE_PALETTE;
+}
+
+/**
+ * Whether `filePath` is already a palette PNG no wider than `maxWidth`, i.e.
+ * whether compressPngInPlace would skip it. Cheap — it reads the header, it
+ * does not encode — so a dry run can classify the whole set quickly.
+ *
+ * @param {string} filePath
+ * @param {{maxWidth?: number}} [opts]
+ * @returns {Promise<boolean>}
+ */
+async function isAtTarget(filePath, opts = {}) {
+  const { maxWidth = EDITORIAL_MAX_WIDTH } = opts;
+  const source = fs.readFileSync(filePath);
+  if (!isPalettePng(source)) return false;
+  const meta = await sharp(source).metadata();
+  return (meta.width || 0) <= maxWidth;
+}
+
 /**
  * @param {string} filePath  PNG to rewrite in place.
  * @param {{maxWidth?: number, quality?: number, force?: boolean}} [opts]
@@ -32,8 +77,9 @@ const EDITORIAL_MAX_WIDTH = 1600;
  */
 async function compressPngInPlace(filePath, opts = {}) {
   const { maxWidth = EDITORIAL_MAX_WIDTH, quality = 90, force = false } = opts;
-  const before = fs.statSync(filePath).size;
-  const meta = await sharp(filePath).metadata();
+  const source = fs.readFileSync(filePath);
+  const before = source.length;
+  const meta = await sharp(source).metadata();
 
   // Every caller here writes .png and uploads under Content-Type image/png, so
   // a file whose bytes are not actually PNG is served under a type it does not
@@ -49,21 +95,36 @@ async function compressPngInPlace(filePath, opts = {}) {
   //
   // So the operation has to be "ensure this file is a palette PNG no wider than
   // maxWidth", not "quantise this file". A file already in that state is done,
-  // and doing it again can only take something away. `paletteBitDepth` is set
-  // only on palette PNGs, which makes it an exact marker of our own output.
+  // and doing it again can only take something away. Colour type 3 in the IHDR
+  // is an exact marker of our own output; see isPalettePng for why this reads
+  // the header instead of trusting a sharp metadata field.
   const oversized = (meta.width || 0) > maxWidth;
-  const alreadyAtTarget = !converted && meta.paletteBitDepth !== undefined && !oversized;
+  const alreadyAtTarget = isPalettePng(source) && !oversized;
   if (alreadyAtTarget && !force) {
     return { before, after: before, changed: false, converted: false, skipped: true };
   }
 
-  const buf = await sharp(filePath)
+  const buf = await sharp(source)
     .resize({
       width: Math.min(meta.width || maxWidth, maxWidth),
       withoutEnlargement: true,
     })
     .png({ palette: true, quality, effort: 9 })
     .toBuffer();
+
+  // The skip above only holds if what we write is actually recognisable as the
+  // target on the next run. If the encoder ever stops emitting a palette — a
+  // sharp build without libimagequant quietly ignores `palette: true` — then
+  // every future run would re-encode this file forever, which is the exact
+  // silent, compounding degradation this module exists to prevent. Refuse to
+  // write instead, and say why.
+  if (!isPalettePng(buf)) {
+    throw new Error(
+      `${filePath}: palette encode produced a non-palette PNG, so this file ` +
+        'would be re-quantised on every future run. Refusing to write. This ' +
+        'usually means the installed sharp has no quantisation support.'
+    );
+  }
 
   // Re-encoding is not guaranteed to win: an already-tuned small PNG can come
   // back bigger. Keep whichever is smaller so this is always safe to run.
@@ -88,6 +149,8 @@ async function compressPngInPlace(filePath, opts = {}) {
 
 module.exports = {
   compressPngInPlace,
+  isAtTarget,
+  isPalettePng,
   CARD_MAX_WIDTH,
   EDITORIAL_MAX_WIDTH,
 };

--- a/scripts/lib/compress-image.test.js
+++ b/scripts/lib/compress-image.test.js
@@ -17,7 +17,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const sharp = require('sharp');
-const { compressPngInPlace, CARD_MAX_WIDTH } = require('./compress-image');
+const { compressPngInPlace, isAtTarget, isPalettePng, CARD_MAX_WIDTH } = require('./compress-image');
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'compress-image-test-'));
 const digest = (p) => crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
@@ -98,6 +98,34 @@ test('a converted file settles on the next pass', async () => {
   await compressPngInPlace(f, { maxWidth: CARD_MAX_WIDTH });
   const res = await compressPngInPlace(f, { maxWidth: CARD_MAX_WIDTH });
   assert.equal(res.skipped, true, 'a converted file must not re-convert forever');
+});
+
+test('the skip recognises this encoder\'s own output', async () => {
+  // The bug: the guard asked sharp for `paletteBitDepth`, a metadata field this
+  // sharp does not emit, so it read false for every file and nothing was ever
+  // skipped. Assert against the bytes the encoder actually produces — if the
+  // two ever disagree again, every run re-quantises the whole set in silence.
+  const f = await makeSource('recognised.png', { width: 1400 });
+  await compressPngInPlace(f, { maxWidth: CARD_MAX_WIDTH });
+  assert.ok(isPalettePng(fs.readFileSync(f)), 'compressed output is not a palette PNG');
+  assert.equal(await isAtTarget(f, { maxWidth: CARD_MAX_WIDTH }), true);
+});
+
+test('isAtTarget agrees with the skip decision', async () => {
+  // --dry-run answers with isAtTarget while the real run answers inside
+  // compressPngInPlace. A dry run is only useful if the two never diverge.
+  const cases = [
+    ['agree-oversized.png', { width: 2400 }],
+    ['agree-truecolor.png', { width: 600 }],
+    ['agree-palette.png', { width: 500, palette: true }],
+    ['agree-jpeg.png', { width: 500, format: 'jpeg' }],
+  ];
+  for (const [name, opts] of cases) {
+    const f = await makeSource(name, opts);
+    const predicted = await isAtTarget(f, { maxWidth: CARD_MAX_WIDTH });
+    const res = await compressPngInPlace(f, { maxWidth: CARD_MAX_WIDTH });
+    assert.equal(predicted, res.skipped, `${name}: dry run and real run disagree`);
+  }
 });
 
 test('force re-encodes a file that would otherwise be skipped', async () => {


### PR DESCRIPTION
## The bug

`scripts/compress-card-images.js` is documented as safe to re-run: a file already at the target (palette PNG, no wider than `CARD_MAX_WIDTH`) is skipped, so repeated runs are a no-op.

The skip never fired. It asked:

```js
const alreadyAtTarget = !converted && meta.paletteBitDepth !== undefined && !oversized;
```

sharp dropped `paletteBitDepth` in 0.34 in favour of `isPalette`. This repo has been on `>= 0.34.5` since before the guard was written (currently `^0.35.3`), so the expression was `undefined !== undefined` for every file and nothing was ever skipped.

The "keep whichever is smaller" backstop can't catch this: re-quantising an already-quantised image lands on a **smaller** file, which reads as a win. So every run re-encoded the whole directory and degraded it another notch — and anyone following the documented "run this after adding new card art" step took the entire set down with them.

Reported after adding one image and watching ~180 tracked files land in the diff. Reproduced on the current 192-file set with the old code:

```
PRE-FIX, same 192 files: 186 rewritten, 0 skipped, 1489k of picture thrown away
```

## The fix

Read the palette flag out of the PNG bytes (IHDR colour type 3) rather than trusting a sharp field name. The absence of a metadata key is indistinguishable from "not a palette", so that shape of check fails open — towards re-encoding — and does it silently. The IHDR layout is fixed by the PNG spec and can't drift on a dependency bump.

Two hardening changes alongside it:

- **Refuse to write a non-palette encode.** A sharp build without quantisation support ignores `palette: true`, which would put us straight back to re-encoding forever. Throw instead of writing.
- **Make `--dry-run` work.** It incremented no counters and reported `0 rewritten, 0 already at target` whatever the directory held, so it couldn't have caught this either. It now classifies each file without encoding.

## Verification

Against a copy of the real `data/cards/images/` (working tree never touched):

```
192 file(s) scanned, 0 rewritten, 192 already at target   # every sha256 identical
193 file(s) scanned, 1 rewritten, 192 already at target   # after adding one new image
```

`scripts/lib/compress-image.test.js` already covered this property and was **already failing 5 of 8** — nothing in `.github/workflows/` runs it, which is why it shipped and stayed broken. Those 8 pass again, plus 2 new ones asserting the guard recognises the encoder's own output and that `--dry-run` never disagrees with the real run.

New `scripts/compress-card-images.test.js` drives the actual CLI end-to-end over a temp directory (via a `CARD_IMAGES_DIR` override), asserting on both the summary line and the sha256 of every file — including the reported scenario of adding one image to a settled directory.

```bash
node scripts/lib/compress-image.test.js && node scripts/compress-card-images.test.js
```

16 tests, all green. Reinstating the old predicate fails 3 of the 6 new ones (`5 !== 1` on the add-one-image case), so they genuinely bite.

## Notes

- `sync-news-images.js` and `sync-article-images.js` share this lib but compress freshly-generated images once before upload, so they lost a redundant encode per image, not cumulative quality. No repair needed there.
- The images on `main` have already been through an unknown number of degradation passes. This stops the bleeding; it does not undo it. Restoring them would mean re-pulling originals.
- **Follow-up:** no workflow runs any of the repo's 11 `*.test.js` files. That gap is what let this survive.