### PR TITLE
Referral expiry: email notice, dismissible warning, needs-attention chip

### DIFF
--- a/apps/api/src/handlers/referral-validation-complete.js
+++ b/apps/api/src/handlers/referral-validation-complete.js
@@ -13,9 +13,13 @@
 //                      soft signal; auto-archive only after the same N
 //                      consecutive misses).
 //
+// After the DB writes, each user who had a link auto-archived in this run is
+// emailed once (via Brevo transactional) with their full list of currently
+// stale, unreplaced, undismissed links — see lib/referral-expiry-email.js.
+//
 // Invocation contract:
 //   Input  : { results: [{ referral_id, status, reason? }] }
-//   Output : { processed: number, archived: [referral_id, ...], skipped: [...] }
+//   Output : { processed: number, archived: [referral_id, ...], skipped: [...], emailed: number }
 //
 // Audit log: every consequential outcome is recorded in `audit_log` under the
 // actor `system:referral-validation` so the admin Activity tab can monitor the
@@ -25,6 +29,7 @@
 
 const mysql = require("../db");
 const { logAuditAction } = require("../lib/audit-log");
+const expiryEmail = require("../lib/referral-expiry-email");
 
 const ARCHIVE_THRESHOLD = 2; // consecutive failures before auto-archive
 const VALID_STATUSES = new Set(["valid", "expired", "unreachable"]);
@@ -46,6 +51,9 @@ exports.ReferralValidationCompleteHandler = async (event) => {
   const archived = [];
   const skipped = [];
   let processed = 0;
+  // submitter uid -> referral ids auto-archived in THIS run. Drives the
+  // expiry notification: one email per affected user per run.
+  const newlyArchivedBySubmitter = new Map();
 
   try {
     for (const r of results) {
@@ -62,7 +70,7 @@ exports.ReferralValidationCompleteHandler = async (event) => {
       // that were archived between list and complete — those are someone
       // else's concern now.
       const rows = await mysql.query(
-        "SELECT validation_consecutive_failures, archived_at FROM referrals WHERE referral_id = ?",
+        "SELECT validation_consecutive_failures, archived_at, submitter_id FROM referrals WHERE referral_id = ?",
         [referralId],
       );
 
@@ -111,6 +119,11 @@ exports.ReferralValidationCompleteHandler = async (event) => {
           [status, nextFailures, `auto: ${status}`, referralId],
         );
         archived.push(referralId);
+        if (rows[0].submitter_id) {
+          const ids = newlyArchivedBySubmitter.get(rows[0].submitter_id) || [];
+          ids.push(referralId);
+          newlyArchivedBySubmitter.set(rows[0].submitter_id, ids);
+        }
         await logAuditAction(AUDIT_ACTOR, "AUTO_ARCHIVE", "referral", referralId, {
           status,
           consecutive_failures: nextFailures,
@@ -137,12 +150,41 @@ exports.ReferralValidationCompleteHandler = async (event) => {
       processed += 1;
     }
 
+    // Email each user whose link(s) died this run. Best-effort: a failed or
+    // unconfigured send never fails the run, and the DB updates above are
+    // already committed. The email lists every currently stale card for the
+    // user, so two links dying in the same run produce one combined email.
+    let emailed = 0;
+    if (newlyArchivedBySubmitter.size > 0) {
+      if (!expiryEmail.isEnabled()) {
+        console.info(
+          "ReferralValidationComplete: expiry email not configured (BREVO_API_KEY / BREVO_SENDER_EMAIL / FIREBASE_SERVICE_ACCOUNT_B64), skipping notifications",
+        );
+      } else {
+        for (const [submitterId, referralIds] of newlyArchivedBySubmitter) {
+          const result = await expiryEmail.sendExpiryNotification(submitterId);
+          if (result.sent) {
+            emailed += 1;
+            await logAuditAction(AUDIT_ACTOR, "EXPIRY_EMAIL", "referral", referralIds[0], {
+              submitter_id: submitterId,
+              newly_archived_referral_ids: referralIds,
+              emailed_cards: result.cardNames,
+            });
+          } else {
+            console.info(
+              `ReferralValidationComplete: no expiry email for uid ${submitterId} (${result.reason})`,
+            );
+          }
+        }
+      }
+    }
+
     await mysql.end();
 
     console.info(
-      `ReferralValidationComplete: processed=${processed} archived=${archived.length} skipped=${skipped.length}`,
+      `ReferralValidationComplete: processed=${processed} archived=${archived.length} skipped=${skipped.length} emailed=${emailed}`,
     );
-    return { processed, archived, skipped };
+    return { processed, archived, skipped, emailed };
   } catch (error) {
     console.error("ReferralValidationComplete error:", error);
     await mysql.end();

--- a/apps/api/src/handlers/user-referrals.js
+++ b/apps/api/src/handlers/user-referrals.js
@@ -164,6 +164,34 @@ exports.UserReferralsHandler = async (event) => {
         const patchBody = JSON.parse(event.body);
         const patchUserId = event.requestContext.authorizer.sub;
 
+        // Dismiss the "expired link" warning for a card: the user chose not
+        // to submit a replacement. Rewrites the auto-archive reason prefix
+        // (`auto:` -> `dismissed-auto:`) so the profile banner and the
+        // needs-attention chip stop counting these rows and the expiry email
+        // query skips them. Covers every auto-archived link for the card,
+        // since the banner groups per card. Scoped to the caller's own rows.
+        if (patchBody.action === "dismiss") {
+          if (!patchBody.card_id) {
+            throw new Error("card_id is required to dismiss");
+          }
+          const dismissed = await mysql.query(
+            `UPDATE referrals
+             SET archived_reason = CONCAT('dismissed-', archived_reason)
+             WHERE submitter_id = ?
+               AND card_id = ?
+               AND archived_at IS NOT NULL
+               AND archived_reason LIKE 'auto:%'`,
+            [patchUserId, patchBody.card_id]
+          );
+          await mysql.end();
+          response = {
+            statusCode: 200,
+            headers: responseHeaders,
+            body: JSON.stringify({ message: "Warning dismissed", dismissed: dismissed.affectedRows || 0 }),
+          };
+          break;
+        }
+
         if (!patchBody.referral_id) {
           throw new Error("referral_id is required");
         }

--- a/apps/api/src/lib/brevo.js
+++ b/apps/api/src/lib/brevo.js
@@ -23,6 +23,16 @@ function isConfigured() {
   return Boolean(apiKey()) && listId() !== null;
 }
 
+// Sender identity for transactional sends. Separate gate from isConfigured():
+// transactional email needs a verified sender but not the newsletter list.
+function senderEmail() {
+  return process.env.BREVO_SENDER_EMAIL || '';
+}
+
+function canSendTransactional() {
+  return Boolean(apiKey()) && Boolean(senderEmail());
+}
+
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Rate-limited (429) responses are retried with backoff before surfacing as
@@ -133,8 +143,26 @@ async function removeFromList(id, emails) {
   }
 }
 
+// One-off transactional email via Brevo's SMTP API. Sends immediately to a
+// single recipient and does not touch list membership or unsubscribe state.
+// Callers gate on canSendTransactional().
+async function sendTransactionalEmail({ to, subject, htmlContent, textContent }) {
+  return request('POST', '/smtp/email', {
+    sender: {
+      email: senderEmail(),
+      name: process.env.BREVO_SENDER_NAME || 'CreditOdds',
+    },
+    to: [{ email: to }],
+    subject,
+    htmlContent,
+    textContent,
+  });
+}
+
 module.exports = {
   isConfigured,
+  canSendTransactional,
+  sendTransactionalEmail,
   listId,
   nameAttributes,
   upsertContact,

--- a/apps/api/src/lib/referral-expiry-email.js
+++ b/apps/api/src/lib/referral-expiry-email.js
@@ -1,0 +1,134 @@
+// Referral expiry notification email.
+//
+// Sent by the referral validator (referral-validation-complete) when one or
+// more of a user's links are auto-archived in a validation run. One email per
+// user per run: it lists every card whose link is currently stale and
+// unreplaced, not just the ones archived this run, so a user with two dead
+// links gets a single email naming both. A link only crosses the archive
+// threshold once (archived rows are skipped by later runs), so a user is
+// never re-emailed about the same link.
+//
+// Requires BREVO_API_KEY + BREVO_SENDER_EMAIL (stack params BrevoApiKey /
+// BrevoSenderEmail) and FIREBASE_SERVICE_ACCOUNT_B64 for the uid -> email
+// lookup. No-ops with a log line when any of those are missing. This is a
+// service notice about the user's own submitted content, not marketing, so it
+// intentionally does not consult the newsletter unsubscribe list.
+
+const mysql = require("../db");
+const brevo = require("./brevo");
+const { initFirebase } = require("./firebase-init");
+
+const PROFILE_URL = "https://www.creditodds.com/profile";
+
+function isEnabled() {
+  return brevo.canSendTransactional() && Boolean(process.env.FIREBASE_SERVICE_ACCOUNT_B64);
+}
+
+// Cards (not links) belonging to this user whose referral was auto-archived
+// by the validator, has no active replacement, and was not dismissed by the
+// user (dismissal rewrites the reason prefix to `dismissed-auto:`).
+async function getStaleCardsForSubmitter(submitterId) {
+  return mysql.query(
+    `
+    SELECT c.card_name, MAX(r.last_validated_at) AS flagged_at
+    FROM referrals r
+    JOIN cards c ON c.card_id = r.card_id
+    WHERE r.submitter_id = ?
+      AND r.archived_at IS NOT NULL
+      AND r.archived_reason LIKE 'auto:%'
+      AND NOT EXISTS (
+        SELECT 1 FROM referrals r2
+        WHERE r2.submitter_id = r.submitter_id
+          AND r2.card_id = r.card_id
+          AND r2.archived_at IS NULL
+      )
+    GROUP BY c.card_id, c.card_name
+    ORDER BY flagged_at DESC
+    `,
+    [submitterId],
+  );
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(cardNames) {
+  const many = cardNames.length > 1;
+  const subject = many
+    ? `${cardNames.length} of your CreditOdds referral links stopped working`
+    : `Your ${cardNames[0]} referral link stopped working`;
+
+  const intro = many
+    ? "Our automated link check could no longer open these referral links, so we have stopped showing them on card pages:"
+    : "Our automated link check could no longer open your referral link, so we have stopped showing it on the card page:";
+
+  const textContent = [
+    "Hi,",
+    "",
+    intro,
+    "",
+    ...cardNames.map((n) => `  - ${n}`),
+    "",
+    "Issuers rotate or retire referral links from time to time, so this is normal. If you have a fresh link, you can add a replacement from the Referrals tab of your profile. If you would rather not replace it, you can dismiss the notice there instead:",
+    "",
+    PROFILE_URL,
+    "",
+    "Any impressions and clicks the old links earned stay on your profile.",
+    "",
+    "CreditOdds",
+  ].join("\n");
+
+  const htmlContent = `
+<p>Hi,</p>
+<p>${escapeHtml(intro)}</p>
+<ul>
+${cardNames.map((n) => `  <li>${escapeHtml(n)}</li>`).join("\n")}
+</ul>
+<p>Issuers rotate or retire referral links from time to time, so this is normal. If you have a fresh link, you can add a replacement from the Referrals tab of your profile. If you would rather not replace it, you can dismiss the notice there instead.</p>
+<p><a href="${PROFILE_URL}">Open your profile</a></p>
+<p>Any impressions and clicks the old links earned stay on your profile.</p>
+<p>CreditOdds</p>
+`.trim();
+
+  return { subject, textContent, htmlContent };
+}
+
+// Sends one notification email to the given submitter. Returns a small
+// status object for logging; throws only on unexpected coding errors, since
+// the caller treats notification as best-effort.
+async function sendExpiryNotification(submitterId) {
+  const staleCards = await getStaleCardsForSubmitter(submitterId);
+  if (staleCards.length === 0) {
+    // The newly archived link was already replaced or dismissed between the
+    // archive UPDATE and this query. Nothing worth emailing about.
+    return { sent: false, reason: "no stale cards" };
+  }
+
+  let email;
+  try {
+    const user = await initFirebase().auth().getUser(submitterId);
+    if (user.disabled) return { sent: false, reason: "user disabled" };
+    email = user.email;
+  } catch (err) {
+    console.error(`referral-expiry-email: getUser(${submitterId}) failed:`, err.message);
+    return { sent: false, reason: "firebase lookup failed" };
+  }
+  if (!email) return { sent: false, reason: "no email on account" };
+
+  const cardNames = staleCards.map((c) => c.card_name);
+  const { subject, textContent, htmlContent } = buildEmail(cardNames);
+  try {
+    await brevo.sendTransactionalEmail({ to: email, subject, textContent, htmlContent });
+  } catch (err) {
+    console.error(`referral-expiry-email: send to uid ${submitterId} failed:`, err.message);
+    return { sent: false, reason: "brevo send failed" };
+  }
+  return { sent: true, cardNames };
+}
+
+module.exports = { isEnabled, sendExpiryNotification };

--- a/apps/api/src/lib/referral-expiry-email.js
+++ b/apps/api/src/lib/referral-expiry-email.js
@@ -57,6 +57,14 @@ function escapeHtml(s) {
     .replace(/"/g, "&quot;");
 }
 
+// Font stacks and palette mirror the newsletter templates in
+// creditodds-newsletters/ so every email from us looks like one family.
+// Everything critical is inlined; the <style> block (with the Google Fonts
+// @import) is progressive enhancement only, since Gmail strips @import and
+// most clients drop <head> styles.
+const FONT_BODY = "'Inter',Helvetica,Arial,sans-serif";
+const FONT_HEAD = "'Inter Tight','Inter',Helvetica,Arial,sans-serif";
+
 function buildEmail(cardNames) {
   const many = cardNames.length > 1;
   const subject = many
@@ -83,17 +91,90 @@ function buildEmail(cardNames) {
     "CreditOdds",
   ].join("\n");
 
-  const htmlContent = `
-<p>Hi,</p>
-<p>${escapeHtml(intro)}</p>
-<ul>
-${cardNames.map((n) => `  <li>${escapeHtml(n)}</li>`).join("\n")}
-</ul>
-<p>Issuers rotate or retire referral links from time to time, so this is normal. If you have a fresh link, you can add a replacement from the Referrals tab of your profile. If you would rather not replace it, you can dismiss the notice there instead.</p>
-<p><a href="${PROFILE_URL}">Open your profile</a></p>
-<p>Any impressions and clicks the old links earned stay on your profile.</p>
-<p>CreditOdds</p>
-`.trim();
+  const headline = many
+    ? `${cardNames.length} of your referral links stopped working`
+    : `Your ${escapeHtml(cardNames[0])} referral link stopped working`;
+
+  const preheader = many
+    ? "Our link check could no longer open these referral links. Add replacements or dismiss the notice from your profile."
+    : "Our link check could no longer open your referral link. Add a replacement or dismiss the notice from your profile.";
+
+  const cardRows = cardNames
+    .map(
+      (n) => `<tr><td valign="top" width="26" style="padding:4px 0 0;"><div style="width:14px;height:14px;border-radius:50%;background-color:#6d3fe8;font-size:0;line-height:0;">&nbsp;</div></td><td style="font-family:${FONT_BODY};font-size:15px;line-height:1.6;color:#1a1330;font-weight:600;padding:0 0 10px;">${escapeHtml(n)}</td></tr>`,
+    )
+    .join("\n        ");
+
+  const htmlContent = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light">
+<title>${escapeHtml(subject)}</title>
+<style>
+  /* Progressive enhancement only - all critical styles are inlined.
+     Gmail ignores @import and CSS variables, so none are used below. */
+  @import url('https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+  body{margin:0;padding:0;}
+  @media (max-width:600px){
+    .px{padding-left:20px!important;padding-right:20px!important;}
+    .h1{font-size:24px!important;}
+  }
+</style>
+</head>
+<body style="margin:0;padding:0;background-color:#f7f5fc;">
+<div style="display:none;visibility:hidden;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">${escapeHtml(preheader)}</div>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f7f5fc;">
+<tr><td align="center" style="padding:24px 12px;">
+
+  <table role="presentation" width="640" cellpadding="0" cellspacing="0" border="0" style="max-width:640px;width:100%;background-color:#ffffff;border:1px solid #ece8f5;border-radius:16px;">
+
+    <!-- MASTHEAD -->
+    <tr><td class="px" style="padding:22px 32px;border-bottom:1px solid #ece8f5;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+          <td align="left" style="font-family:${FONT_HEAD};">
+            <a href="https://creditodds.com" style="font-weight:700;font-size:20px;letter-spacing:-0.02em;color:#1a1330;text-decoration:none;">credit<span style="color:#6d3fe8;">odds</span></a>
+          </td>
+          <td align="right" style="font-family:${FONT_BODY};font-size:11px;font-weight:600;letter-spacing:0.14em;text-transform:uppercase;color:#6b6384;">Referral Update</td>
+        </tr>
+      </table>
+    </td></tr>
+
+    <!-- BODY -->
+    <tr><td class="px" style="padding:32px;">
+      <p style="font-family:${FONT_BODY};font-size:12px;font-weight:600;letter-spacing:0.1em;text-transform:uppercase;color:#6d3fe8;margin:0 0 10px;">Your Referral Links</p>
+      <h1 class="h1" style="font-family:${FONT_HEAD};font-weight:700;font-size:28px;line-height:1.2;letter-spacing:-0.02em;color:#1a1330;margin:0 0 16px;">${headline}</h1>
+
+      <p style="font-family:${FONT_BODY};font-size:15px;line-height:1.6;color:#3a2f55;margin:0 0 14px;">${escapeHtml(intro)}</p>
+
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 8px;">
+        ${cardRows}
+      </table>
+
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 18px;"><tr><td style="background-color:#f7f5fc;border:1px solid #ddd7ec;border-left:3px solid #6d3fe8;border-radius:8px;padding:14px 16px;font-family:${FONT_BODY};font-size:14px;line-height:1.6;color:#3a2f55;"><strong style="color:#1a1330;">This is normal.</strong> Issuers rotate and retire referral links all the time. Any impressions and clicks the old ${many ? "links" : "link"} earned stay on your profile.</td></tr></table>
+
+      <p style="font-family:${FONT_BODY};font-size:15px;line-height:1.6;color:#3a2f55;margin:0 0 18px;">If you have a fresh link, add a replacement from the Referrals tab of your profile. If you would rather not replace it, you can dismiss the notice there instead.</p>
+
+      <a href="${PROFILE_URL}" style="display:inline-block;background-color:#6d3fe8;color:#ffffff;text-decoration:none;font-family:${FONT_HEAD};font-weight:600;font-size:15px;padding:13px 26px;border-radius:10px;">Open Your Referrals &#8594;</a>
+
+      <p style="font-family:${FONT_BODY};font-size:15px;line-height:1.6;color:#3a2f55;margin:26px 0 0;">&#8212; The CreditOdds Team</p>
+    </td></tr>
+
+    <!-- FOOTER -->
+    <tr><td class="px" style="padding:24px 32px 30px;border-top:1px solid #ece8f5;background-color:#f7f5fc;border-radius:0 0 16px 16px;">
+      <p style="font-family:${FONT_BODY};font-size:12px;color:#6b6384;line-height:1.6;margin:0 0 10px;text-align:center;">You're receiving this service notice because you <strong style="color:#1a1330;">submitted a referral link</strong> at creditodds.com. We only send it when one of your links stops working.</p>
+      <p style="font-family:${FONT_BODY};font-size:11px;color:#a49fb8;line-height:1.6;margin:0;text-align:center;">CreditOdds &#183; 400 E 75th St, New York, NY &#183; <a href="https://creditodds.com/privacy" style="color:#6b6384;">Privacy Policy</a></p>
+    </td></tr>
+
+  </table>
+
+</td></tr>
+</table>
+</body>
+</html>`;
 
   return { subject, textContent, htmlContent };
 }

--- a/apps/api/src/lib/referral-expiry-email.js
+++ b/apps/api/src/lib/referral-expiry-email.js
@@ -30,7 +30,7 @@ function isEnabled() {
 async function getStaleCardsForSubmitter(submitterId) {
   return mysql.query(
     `
-    SELECT c.card_name, MAX(r.last_validated_at) AS flagged_at
+    SELECT c.card_name, c.card_image_link, MAX(r.last_validated_at) AS flagged_at
     FROM referrals r
     JOIN cards c ON c.card_id = r.card_id
     WHERE r.submitter_id = ?
@@ -42,7 +42,7 @@ async function getStaleCardsForSubmitter(submitterId) {
           AND r2.card_id = r.card_id
           AND r2.archived_at IS NULL
       )
-    GROUP BY c.card_id, c.card_name
+    GROUP BY c.card_id, c.card_name, c.card_image_link
     ORDER BY flagged_at DESC
     `,
     [submitterId],
@@ -65,7 +65,14 @@ function escapeHtml(s) {
 const FONT_BODY = "'Inter',Helvetica,Arial,sans-serif";
 const FONT_HEAD = "'Inter Tight','Inter',Helvetica,Arial,sans-serif";
 
-function buildEmail(cardNames) {
+// Same public CDN the site's CardImage component uses; card_image_link in the
+// DB is the bare filename. Absolute URLs are required in email clients.
+const CARD_IMAGE_CDN = "https://d3ay3etzd1512y.cloudfront.net/card_images";
+
+// cards: [{ card_name, card_image_link }] — card_image_link may be null, in
+// which case the row falls back to the newsletter-style purple dot.
+function buildEmail(cards) {
+  const cardNames = cards.map((c) => c.card_name);
   const many = cardNames.length > 1;
   const subject = many
     ? `${cardNames.length} of your CreditOdds referral links stopped working`
@@ -99,10 +106,17 @@ function buildEmail(cardNames) {
     ? "Our link check could no longer open these referral links. Add replacements or dismiss the notice from your profile."
     : "Our link check could no longer open your referral link. Add a replacement or dismiss the notice from your profile.";
 
-  const cardRows = cardNames
-    .map(
-      (n) => `<tr><td valign="top" width="26" style="padding:4px 0 0;"><div style="width:14px;height:14px;border-radius:50%;background-color:#6d3fe8;font-size:0;line-height:0;">&nbsp;</div></td><td style="font-family:${FONT_BODY};font-size:15px;line-height:1.6;color:#1a1330;font-weight:600;padding:0 0 10px;">${escapeHtml(n)}</td></tr>`,
-    )
+  // One row per card: card art thumbnail (alt text carries the name for
+  // clients that block remote images) next to the bold card name. Cards
+  // without art keep the newsletter-style purple dot.
+  const cardRows = cards
+    .map((c) => {
+      const name = escapeHtml(c.card_name);
+      const thumb = c.card_image_link
+        ? `<img src="${CARD_IMAGE_CDN}/${escapeHtml(c.card_image_link)}" width="64" alt="${name}" style="display:block;width:64px;height:auto;border:0;border-radius:4px;">`
+        : `<div style="width:14px;height:14px;border-radius:50%;background-color:#6d3fe8;font-size:0;line-height:0;">&nbsp;</div>`;
+      return `<tr><td valign="middle" width="78" style="padding:0 14px 12px 0;">${thumb}</td><td valign="middle" style="font-family:${FONT_BODY};font-size:15px;line-height:1.6;color:#1a1330;font-weight:600;padding:0 0 12px;">${name}</td></tr>`;
+    })
     .join("\n        ");
 
   const htmlContent = `<!doctype html>
@@ -201,15 +215,14 @@ async function sendExpiryNotification(submitterId) {
   }
   if (!email) return { sent: false, reason: "no email on account" };
 
-  const cardNames = staleCards.map((c) => c.card_name);
-  const { subject, textContent, htmlContent } = buildEmail(cardNames);
+  const { subject, textContent, htmlContent } = buildEmail(staleCards);
   try {
     await brevo.sendTransactionalEmail({ to: email, subject, textContent, htmlContent });
   } catch (err) {
     console.error(`referral-expiry-email: send to uid ${submitterId} failed:`, err.message);
     return { sent: false, reason: "brevo send failed" };
   }
-  return { sent: true, cardNames };
+  return { sent: true, cardNames: staleCards.map((c) => c.card_name) };
 }
 
 module.exports = { isEnabled, sendExpiryNotification };

--- a/apps/api/src/lib/referral-expiry-email.js
+++ b/apps/api/src/lib/referral-expiry-email.js
@@ -106,14 +106,20 @@ function buildEmail(cards) {
     ? "Our link check could no longer open these referral links. Add replacements or dismiss the notice from your profile."
     : "Our link check could no longer open your referral link. Add a replacement or dismiss the notice from your profile.";
 
-  // One row per card: card art thumbnail (alt text carries the name for
-  // clients that block remote images) next to the bold card name. Cards
-  // without art keep the newsletter-style purple dot.
+  // One row per card: card art thumbnail next to the bold card name. The
+  // thumbnail is built to fail gracefully when a client blocks or cannot
+  // load remote images: fixed 64x40 box with a lavender background and
+  // rounded corners renders as a clean card-shaped chip instead of a torn
+  // icon, and alt is intentionally empty because the card name is already
+  // real text in the adjacent cell (the image is decorative). object-fit
+  // keeps off-ratio art unstretched in clients that support it; Outlook
+  // ignores it and the stretch is imperceptible at this size. Cards without
+  // art keep the newsletter-style purple dot.
   const cardRows = cards
     .map((c) => {
       const name = escapeHtml(c.card_name);
       const thumb = c.card_image_link
-        ? `<img src="${CARD_IMAGE_CDN}/${escapeHtml(c.card_image_link)}" width="64" alt="${name}" style="display:block;width:64px;height:auto;border:0;border-radius:4px;">`
+        ? `<img src="${CARD_IMAGE_CDN}/${escapeHtml(c.card_image_link)}" width="64" height="40" alt="" style="display:block;width:64px;height:40px;object-fit:contain;border:0;border-radius:4px;background-color:#f0e9ff;font-size:0;line-height:0;color:transparent;">`
         : `<div style="width:14px;height:14px;border-radius:50%;background-color:#6d3fe8;font-size:0;line-height:0;">&nbsp;</div>`;
       return `<tr><td valign="middle" width="78" style="padding:0 14px 12px 0;">${thumb}</td><td valign="middle" style="font-family:${FONT_BODY};font-size:15px;line-height:1.6;color:#1a1330;font-weight:600;padding:0 0 12px;">${name}</td></tr>`;
     })

--- a/apps/api/template.yml
+++ b/apps/api/template.yml
@@ -47,6 +47,10 @@ Parameters:
     Type: String
     Description: Numeric id of the Brevo contact list that mirrors Firebase users (the weekly-newsletter audience).
     Default: ""
+  BrevoSenderEmail:
+    Type: String
+    Description: Verified Brevo sender address for transactional email (referral expiry notices). Empty disables transactional sends.
+    Default: ""
   FirebaseServiceAccountB64:
     Type: String
     Description: Base64-encoded Firebase service-account JSON. Needed for privileged Admin API calls (listUsers in newsletter-sync, deleteUser in delete-account); token verification works without it.
@@ -1812,28 +1816,27 @@ Resources:
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
 
+  # No esbuild here: this handler pulls in firebase-admin (for the uid ->
+  # email lookup behind expiry notices), which the esbuild functions avoid.
+  # Plain zip packaging, same as NewsletterSyncFunction / DeleteAccountFunction.
   ReferralValidationCompleteFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: esbuild
-      BuildProperties:
-        EntryPoints:
-          - src/handlers/referral-validation-complete.js
-        Target: node22
-        Sourcemap: false
-        Minify: false
     Properties:
       Handler: src/handlers/referral-validation-complete.ReferralValidationCompleteHandler
       Runtime: nodejs22.x
       MemorySize: 256
       Timeout: 300
-      Description: Records referral validation results; auto-archives after consecutive failures
+      Description: Records referral validation results; auto-archives after consecutive failures and emails affected users
       Environment:
         Variables:
           ENDPOINT: !Ref ENDPOINT
           DATABASE: !Ref DATABASE
           USERNAME: !Ref USERNAME
           PASSWORD: !Ref PASSWORD
+          FIREBASE_PROJECT_ID: creditodds
+          FIREBASE_SERVICE_ACCOUNT_B64: !Ref FirebaseServiceAccountB64
+          BREVO_API_KEY: !Ref BrevoApiKey
+          BREVO_SENDER_EMAIL: !Ref BrevoSenderEmail
 
   RefreshCardStatsFunction:
     Type: AWS::Serverless::Function

--- a/apps/web-next/src/app/admin/page.tsx
+++ b/apps/web-next/src/app/admin/page.tsx
@@ -1545,7 +1545,9 @@ function ReferralsTab({
                 </span>
                 {referral.archived_at && (
                   <span className="av-pill av-pill-arch">
-                    {referral.archived_reason?.startsWith('auto:') ? 'Auto-archived' : 'Archived'}
+                    {referral.archived_reason?.startsWith('auto:') ? 'Auto-archived'
+                      : referral.archived_reason?.startsWith('dismissed-auto:') ? 'Auto-archived (dismissed)'
+                      : 'Archived'}
                   </span>
                 )}
               </div>

--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -4282,6 +4282,22 @@
   font-weight: 500;
   margin-left: 2px;
 }
+/* Needs-attention chip on the Referrals tab: count of cards whose referral
+   link the validator flagged as expired and the user has not yet replaced
+   or dismissed. Amber, matching the expired-links banner accent. */
+.landing-v2.profile-v2 .cj-main-tab-chip {
+  align-self: center;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: #a8792a;
+  color: #fff;
+  font-size: 10.5px;
+  font-weight: 700;
+  line-height: 17px;
+  text-align: center;
+}
 
 /* Section block — no border-bottom inside tabs */
 .landing-v2.profile-v2 .cj-main-content .cj-section {
@@ -4331,6 +4347,23 @@
   font-family: inherit;
 }
 .landing-v2.profile-v2 .cj-inline-cta:hover { background: var(--accent-deep); }
+/* Quiet sibling of cj-inline-cta for secondary actions next to a filled CTA
+   (e.g. "dismiss" beside "add replacement" in the expired-links banner). */
+.landing-v2.profile-v2 .cj-inline-cta-ghost {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+.landing-v2.profile-v2 .cj-inline-cta-ghost:hover { color: var(--ink); border-color: var(--muted); }
+.landing-v2.profile-v2 .cj-inline-cta-ghost:disabled { opacity: 0.6; cursor: default; }
 
 /* Compact wallet rows */
 .landing-v2.profile-v2 .cj-wallet-tape { border: 1px solid var(--line-2); }
@@ -5866,6 +5899,18 @@
     height: 7px;
     border-radius: 50%;
     background: var(--accent);
+    border: 1.5px solid var(--paper);
+  }
+  /* Needs-attention dot on More (Referrals live there on mobile) — amber to
+     match the expired-links banner, distinct from the red beta dot. */
+  .landing-v2.profile-v2 .cj-mob-tab-alert {
+    position: absolute;
+    top: 4px;
+    right: 22%;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #a8792a;
     border: 1.5px solid var(--paper);
   }
 

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -9,7 +9,7 @@ import { useAuth } from "@/auth/AuthProvider";
 import { useUserSettings } from "@/user-settings/UserSettingsProvider";
 import UserAvatar from "@/components/user/UserAvatar";
 import { V2Footer } from "@/components/landing-v2/Chrome";
-import { getAllCards, getRecords, getReferrals, deleteRecord, archiveReferral, getWallet, getWalletEvents, deleteAccount, reorderWallet, getNewsletterSettings, updateNewsletterSettings, NewsletterSettings, WalletCard, WalletCardEvent, Card } from "@/lib/api";
+import { getAllCards, getRecords, getReferrals, deleteRecord, archiveReferral, dismissExpiredReferralWarning, getWallet, getWalletEvents, deleteAccount, reorderWallet, getNewsletterSettings, updateNewsletterSettings, NewsletterSettings, WalletCard, WalletCardEvent, Card } from "@/lib/api";
 import "../landing.css";
 import { getNews, getNewsCards, NewsItem, NewsTag, tagLabels } from "@/lib/news";
 import { ProfileSkeleton } from "@/components/ui/Skeleton";
@@ -210,6 +210,7 @@ export default function ProfileClient() {
   const [showWalletModal, setShowWalletModal] = useState(false);
   const [deletingRecordId, setDeletingRecordId] = useState<number | null>(null);
   const [archivingReferralId, setArchivingReferralId] = useState<number | null>(null);
+  const [dismissingCardId, setDismissingCardId] = useState<string | null>(null);
   const [deletingAccount, setDeletingAccount] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
   const [openWalletId, setOpenWalletId] = useState<number | null>(null);
@@ -468,6 +469,29 @@ export default function ProfileClient() {
     } finally { setArchivingReferralId(null); }
   };
 
+  // Dismiss the expired-link warning for a card without submitting a
+  // replacement. The server rewrites the archive reason (`auto:` ->
+  // `dismissed-auto:`) on every auto-archived link for the card; the local
+  // state mirrors that so the banner row and chip disappear immediately.
+  const handleDismissExpiredWarning = async (cardId: string) => {
+    setDismissingCardId(cardId);
+    try {
+      const token = await getToken();
+      if (!token) return;
+      await dismissExpiredReferralWarning(cardId, token);
+      const dismissed = referrals.find(r => String(r.card_id) === cardId && isAutoArchivedReferral(r));
+      posthog.capture("referral_expired_warning_dismissed", { card_name: dismissed?.card_name });
+      setReferrals(referrals.map(r =>
+        String(r.card_id) === cardId && isAutoArchivedReferral(r)
+          ? { ...r, archived_reason: `dismissed-${r.archived_reason}` }
+          : r
+      ));
+    } catch (e) {
+      console.error("Error dismissing expired referral warning:", e);
+      alert("Failed to dismiss the warning. Please try again.");
+    } finally { setDismissingCardId(null); }
+  };
+
   const handleDeleteAccount = async () => {
     if (deleteConfirmText !== 'DELETE') return;
     setDeletingAccount(true);
@@ -502,14 +526,14 @@ export default function ProfileClient() {
   const expiredReferralsCount = groupUnreplacedAutoArchivedByCard(referrals).length;
   const visibleWalletCards = activeWalletCards;
 
-  const tabs: { key: TabKey; num: string; label: string; count: string }[] = [
+  const tabs: { key: TabKey; num: string; label: string; count: string; badge?: number }[] = [
     { key: 'cards', num: '01', label: 'Cards', count: walletCards.length ? `${walletCards.length} cards` : '' },
     { key: 'rewards', num: '02', label: 'Earn', count: '' },
     { key: 'benefits', num: '03', label: 'Benefits', count: '' },
     { key: 'applications', num: '04', label: 'Applications', count: records.length ? `${records.length} data point${records.length === 1 ? '' : 's'}` : '' },
-    { key: 'referrals', num: '05', label: 'Referrals', count: expiredReferralsCount
-        ? `${expiredReferralsCount} needs attention`
-        : (activeReferralsCount ? `${activeReferralsCount} links` : '') },
+    { key: 'referrals', num: '05', label: 'Referrals',
+      count: activeReferralsCount ? `${activeReferralsCount} link${activeReferralsCount === 1 ? '' : 's'}` : '',
+      badge: expiredReferralsCount },
     { key: 'settings', num: '06', label: 'Settings', count: '' },
   ];
 
@@ -650,6 +674,15 @@ export default function ProfileClient() {
                 <span className="cj-main-tab-num">{it.num}</span>
                 {it.label}
                 {it.count && <span className="cj-main-tab-count">· {it.count}</span>}
+                {it.badge ? (
+                  <span
+                    className="cj-main-tab-chip"
+                    title={`${it.badge} expired link${it.badge === 1 ? '' : 's'} need${it.badge === 1 ? 's' : ''} attention`}
+                    aria-label={`${it.badge} need${it.badge === 1 ? 's' : ''} attention`}
+                  >
+                    {it.badge}
+                  </span>
+                ) : null}
               </button>
             ))}
           </div>
@@ -767,6 +800,8 @@ export default function ProfileClient() {
                 onReplace={(cardId) => { setReplacementForCardId(cardId); setShowReferralModal(true); }}
                 onArchive={handleArchiveReferral}
                 archivingReferralId={archivingReferralId}
+                onDismiss={handleDismissExpiredWarning}
+                dismissingCardId={dismissingCardId}
               />
             )}
 
@@ -820,6 +855,8 @@ export default function ProfileClient() {
                   onReplace={(cardId) => { setReplacementForCardId(cardId); setShowReferralModal(true); }}
                   onArchive={handleArchiveReferral}
                   archivingReferralId={archivingReferralId}
+                  onDismiss={handleDismissExpiredWarning}
+                  dismissingCardId={dismissingCardId}
                 />
                 <div className="cj-mob-more-h">Account</div>
                 <SettingsTab
@@ -931,7 +968,7 @@ export default function ProfileClient() {
       </div>
 
       {/* Mobile bottom tab bar — Variant B (App Tabs). Hidden ≥641px via CSS. */}
-      <MobileTabBar activeTab={activeTab} onSelect={setActiveTab} />
+      <MobileTabBar activeTab={activeTab} onSelect={setActiveTab} needsAttention={expiredReferralsCount > 0} />
 
       <V2Footer />
 
@@ -1495,10 +1532,12 @@ interface ReferralsTabProps {
   onReplace: (cardId: string) => void;
   onArchive: (id: number) => void;
   archivingReferralId: number | null;
+  onDismiss: (cardId: string) => void;
+  dismissingCardId: string | null;
 }
 
 function ReferralsTab(props: ReferralsTabProps) {
-  const { referralsLoaded, referrals, eligibleReferralCards, onAddReferral, onReplace, onArchive, archivingReferralId } = props;
+  const { referralsLoaded, referrals, eligibleReferralCards, onAddReferral, onReplace, onArchive, archivingReferralId, onDismiss, dismissingCardId } = props;
   if (!referralsLoaded) return <LoadingPanel />;
 
   const active = referrals.filter(r => !r.archived_at);
@@ -1544,7 +1583,7 @@ function ReferralsTab(props: ReferralsTabProps) {
               : `${autoArchived.length} referral links look like they expired`}
           </div>
           <div style={{ fontSize: 12, color: '#5c4318', marginBottom: 10 }}>
-            Our link check stopped serving {autoArchived.length === 1 ? 'this one' : 'these'} on card pages. Add a replacement to start collecting clicks again. The old stats below stay yours.
+            Our link check stopped serving {autoArchived.length === 1 ? 'this one' : 'these'} on card pages. Add a replacement to start collecting clicks again, or dismiss if you are done referring that card. The old stats below stay yours.
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             {autoArchived.map((g) => {
@@ -1553,11 +1592,13 @@ function ReferralsTab(props: ReferralsTabProps) {
               const eligible = eligibleCardIds.has(cardIdStr);
               const validatedDate = r.last_validated_at ? r.last_validated_at.slice(0, 10) : null;
               return (
-                <div key={r.referral_id} style={{ display: 'flex', alignItems: 'center', gap: 10, paddingTop: 8, borderTop: '1px solid rgba(168, 121, 42, 0.18)' }}>
+                <div key={r.referral_id} style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 10, paddingTop: 8, borderTop: '1px solid rgba(168, 121, 42, 0.18)' }}>
                   <span className="cj-tape-thumb" style={{ flexShrink: 0 }}>
                     <CardImage cardImageLink={r.card_image_link} alt={r.card_name} fill sizes="36px" className="object-contain" />
                   </span>
-                  <div style={{ minWidth: 0, flex: 1 }}>
+                  {/* flex-basis floor lets the two action buttons wrap to their
+                      own line on narrow screens instead of crushing the text */}
+                  <div style={{ minWidth: 0, flex: '1 1 180px' }}>
                     <div style={{ fontSize: 13, fontWeight: 500, color: '#2a2a2a' }}>{r.card_name}</div>
                     <div style={{ fontSize: 11, color: '#7a6035' }}>
                       flagged {validatedDate || 'recently'} · {g.impressions.toLocaleString()} impr · {g.clicks} click{g.clicks === 1 ? '' : 's'} {g.linkCount === 1 ? 'on the old link' : `across ${g.linkCount} expired links`}
@@ -1571,6 +1612,15 @@ function ReferralsTab(props: ReferralsTabProps) {
                     title={eligible ? '' : 'You no longer hold this card in your wallet or data points, so a new referral cannot be submitted.'}
                   >
                     {eligible ? 'add replacement' : 'card not held'}
+                  </button>
+                  <button
+                    type="button"
+                    className="cj-inline-cta-ghost"
+                    onClick={() => onDismiss(cardIdStr)}
+                    disabled={dismissingCardId === cardIdStr}
+                    title="Hide this warning without adding a replacement. You can still add a new referral for this card anytime."
+                  >
+                    {dismissingCardId === cardIdStr ? 'dismissing…' : 'dismiss'}
                   </button>
                 </div>
               );
@@ -2004,7 +2054,7 @@ function MobileNewsView({ relevantNews, walletCardsCount }: { relevantNews: News
 }
 
 /* ========== Mobile-only: Bottom tab bar (Variant B · App Tabs) ========== */
-function MobileTabBar({ activeTab, onSelect }: { activeTab: TabKey; onSelect: (k: TabKey) => void }) {
+function MobileTabBar({ activeTab, onSelect, needsAttention }: { activeTab: TabKey; onSelect: (k: TabKey) => void; needsAttention?: boolean }) {
   // Map the desktop's 6 tabs to the 5 in-profile mobile tabs:
   //   cards → cards | rewards → rewards | news → news (wallet-filtered) |
   //   benefits → benefits | applications/referrals/settings → more
@@ -2075,6 +2125,9 @@ function MobileTabBar({ activeTab, onSelect }: { activeTab: TabKey; onSelect: (k
           </svg>
         </span>
         More
+        {/* Referrals live under More on mobile, so the needs-attention dot
+            (expired referral links) surfaces here. */}
+        {needsAttention && <span className="cj-mob-tab-alert" aria-hidden="true" />}
       </button>
     </nav>
   );

--- a/apps/web-next/src/lib/api.ts
+++ b/apps/web-next/src/lib/api.ts
@@ -450,6 +450,22 @@ export async function archiveReferral(referralId: number, token: string) {
   return res.json();
 }
 
+// Dismisses the "expired link" warning for a card the user chose not to
+// replace. Server-side this rewrites the auto-archive reason on every
+// auto-archived link for the card, so the warning stays gone across devices.
+export async function dismissExpiredReferralWarning(cardId: string, token: string) {
+  const res = await fetch(`${API_BASE}/referrals`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ action: 'dismiss', card_id: cardId }),
+  });
+  if (!res.ok) throw new Error('Failed to dismiss warning');
+  return res.json();
+}
+
 // Wallet types and API functions
 // One user pick for a selectable reward block on a held card. Cash+ (5%
 // quarterly) stores two rows per wallet card; Custom Cash stores one.


### PR DESCRIPTION
## What

Three follow-ups to the referral validity check, which previously only surfaced expired links passively on the profile page:

### 1. Email users when their link stops working (Brevo transactional)
- `ReferralValidationCompleteHandler` now sends one email per affected user per validation run, at the moment a link crosses the 2-failure auto-archive threshold.
- The email lists **every** currently stale card for that user (auto-archived, no active replacement, not dismissed), so two links dying in the same check produce a single combined email, and a link that died earlier is re-mentioned rather than double-emailed. Because a link only crosses the threshold once, no user is ever emailed twice about the same link.
- Sent through Brevo's transactional SMTP API (`POST /v3/smtp/email`) via a new `sendTransactionalEmail` in `lib/brevo.js`. This is a service notice about the user's own submitted content, so it intentionally does not consult the newsletter unsubscribe list.
- uid -> email lookup uses firebase-admin `getUser`, so the function needs `FIREBASE_SERVICE_ACCOUNT_B64` and switches from esbuild to plain zip packaging (same as NewsletterSync / DeleteAccount, the other firebase-admin functions).
- Fully best-effort: any email failure logs and never fails the run; audit log gets an `EXPIRY_EMAIL` entry per send.

**Deploy note:** sending is disabled until the new `BrevoSenderEmail` stack param is set to a verified Brevo sender (e.g. on the authenticated creditodds.com domain). One deploy with `--parameter-overrides BrevoSenderEmail=...` (or set it in samconfig) turns it on; empty keeps today's behavior.

### 2. Dismiss the warning without replacing
- New `action: dismiss` on `PATCH /referrals` (scoped to the caller's own rows): rewrites `archived_reason` from `auto: X` to `dismissed-auto: X` on every auto-archived link for that card. No schema change needed.
- Dismissed links drop out of the profile banner, the needs-attention count, and the expiry-email stale list. Stats stay intact; admin console shows them as "Auto-archived (dismissed)".
- Banner rows now have a quiet "dismiss" button next to "add replacement" (which stays primary), and rows wrap on narrow screens so two buttons no longer crush the text.

### 3. Needs-attention chip
- The Referrals tab label no longer swaps its count text for "3 needs attention"; it always shows the active-link count plus an amber numeric chip when any expired links await action. Mobile bottom bar gets a matching amber dot on "More" (where Referrals lives).

## Screenshots
Verified locally with seeded data: chip shows 2, banner lists both cards with add replacement / card not held + dismiss, dismissing removes the row and drops the chip to 1, mobile shows the amber dot on More.

## Testing
- `tsc --noEmit` clean, `npm test` 117/117, `sam validate --lint` passes, `node --check` on all touched handlers.
- Existing lint errors in admin/page.tsx and ProfileClient are pre-existing (untouched lines).