### PR TITLE
Square the left-accent callout bars in the expiry email and profile banner

### DIFF
--- a/apps/api/src/lib/referral-expiry-email.js
+++ b/apps/api/src/lib/referral-expiry-email.js
@@ -206,7 +206,9 @@ function buildEmail(cards) {
         ${cardRows}
       </table>
 
-      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 18px;"><tr><td style="background-color:#f7f5fc;border:1px solid #ddd7ec;border-left:3px solid #6d3fe8;border-radius:8px;padding:14px 16px;font-family:${FONT_BODY};font-size:14px;line-height:1.6;color:#3a2f55;"><strong style="color:#1a1330;">This is normal.</strong> Issuers rotate and retire referral links all the time. Any impressions and clicks the old ${many ? "links" : "link"} earned stay on your profile.</td></tr></table>
+      <!-- Callout: square corners on purpose — a border-radius next to the
+           left accent bar rounds the bar into a "fingernail" shape. -->
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 18px;"><tr><td style="background-color:#f7f5fc;border:1px solid #ddd7ec;border-left:3px solid #6d3fe8;padding:14px 16px;font-family:${FONT_BODY};font-size:14px;line-height:1.6;color:#3a2f55;"><strong style="color:#1a1330;">This is normal.</strong> Issuers rotate and retire referral links all the time. Any impressions and clicks the old ${many ? "links" : "link"} earned stay on your profile.</td></tr></table>
 
       <p style="font-family:${FONT_BODY};font-size:15px;line-height:1.6;color:#3a2f55;margin:0 0 18px;">If you have a fresh link, add a replacement from the Referrals tab of your profile. If you would rather not replace it, you can dismiss the notice there instead.</p>
 

--- a/apps/web-next/src/app/profile/ProfileClient.tsx
+++ b/apps/web-next/src/app/profile/ProfileClient.tsx
@@ -1576,7 +1576,9 @@ function ReferralsTab(props: ReferralsTabProps) {
       </div>
 
       {autoArchived.length > 0 && (
-        <div style={{ marginTop: 16, border: '1px solid var(--line-2)', borderLeft: '3px solid #a8792a', background: '#fef9e8', borderRadius: 6, padding: '12px 14px' }}>
+        // Square corners on purpose: border-radius next to the left accent
+        // bar rounds it into a "fingernail" shape.
+        <div style={{ marginTop: 16, border: '1px solid var(--line-2)', borderLeft: '3px solid #a8792a', background: '#fef9e8', padding: '12px 14px' }}>
           <div style={{ fontSize: 13, fontWeight: 600, color: '#5c4318', marginBottom: 8 }}>
             {autoArchived.length === 1
               ? '1 referral link looks like it expired'


### PR DESCRIPTION
Removes border-radius from the two rounded left-accent callouts: the expiry email's "This is normal" box and the profile Referrals tab's expired-links banner. Rounded corners next to a 3px left accent bar curve the bar into a fingernail shape; the rest of the design system already keeps accent bars square (cj-take, cj-verdict, cj-callout, page-body blockquotes), so this also makes these two consistent with everything else.

Verified the rendered email locally; profile change is the same one-property removal.