### PR TITLE
Reddit product changes for review — 2026-08-26

### DIFF
--- a/data/reddit-product-changes/2026-08-t3_1vv1fuv.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vv1fuv.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vv1fuv
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1vv1fuv/looking_for_a_sixth_card_feels_like_there_are/
+posted: "2026-08-22"
+evidence: >-
+  In their current card list the poster shows a Chase Freedom Unlimited opened January 2025
+  annotated as upgraded to Sapphire Preferred, so that account now carries the Preferred. The
+  upgrade date and who initiated it are not stated.
+from_card: Chase Freedom Unlimited
+to_card: Chase Sapphire Preferred
+change_month: 2026-08

--- a/data/reddit-product-changes/2026-08-t3_1vx9k9p.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vx9k9p.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vx9k9p
+permalink: https://www.reddit.com/r/CreditCards/comments/1vx9k9p/chase_welcome_offers_and_product_changes/
+posted: "2026-08-24"
+evidence: >-
+  The poster says they held the Sapphire Reserve and, once the annual fee went up, decided to
+  product change down to the Sapphire Preferred. They are now asking whether they could do a further
+  downgrade later, so the Reserve to Preferred step already happened at their own request.
+from_card: Chase Sapphire Reserve
+to_card: Chase Sapphire Preferred
+change_month: 2026-08
+reason: voluntary

--- a/data/reddit-product-changes/2026-08-t3_1vz7479-1.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vz7479-1.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1vz7479#1
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1vz7479/venture_75k_300_hotel_credit_vs_csp_100k_sub/
+posted: "2026-08-26"
+evidence: >-
+  In their card profile the poster lists a Wells Fargo Autograph opened May 2025 and notes it was
+  previously their Bilt card, so the existing Wells Fargo account now carries the Autograph product.
+  They do not say who initiated the switch.
+from_card: Bilt Mastercard
+to_card: Wells Fargo Autograph
+change_month: 2026-08

--- a/data/reddit-product-changes/2026-08-t3_1vz7479-2.yaml
+++ b/data/reddit-product-changes/2026-08-t3_1vz7479-2.yaml
@@ -1,0 +1,10 @@
+source_id: t3_1vz7479#2
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1vz7479/venture_75k_300_hotel_credit_vs_csp_100k_sub/
+posted: "2026-08-26"
+evidence: >-
+  The poster lists a Citi Custom Cash with a December 2025 open date and states in parentheses that
+  it was product changed from Double Cash. No date or initiator is given for the change.
+from_card: Citi Double Cash
+to_card: Citi Custom Cash
+change_month: 2026-08


### PR DESCRIPTION
Product changes extracted from r/CreditCards.

| From | To | Month | Reason | Source |
|---|---|---|---|---|
| Chase Freedom Unlimited | Chase Sapphire Preferred | 2026-08 | — | [src](https://www.reddit.com/r/CreditCards/comments/1vv1fuv/looking_for_a_sixth_card_feels_like_there_are/) |
| Chase Sapphire Reserve | Chase Sapphire Preferred | 2026-08 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1vx9k9p/chase_welcome_offers_and_product_changes/) |
| Bilt Mastercard | Wells Fargo Autograph | 2026-08 | — | [src](https://www.reddit.com/r/CreditCards/comments/1vz7479/venture_75k_300_hotel_credit_vs_csp_100k_sub/) |
| Citi Double Cash | Citi Custom Cash | 2026-08 | — | [src](https://www.reddit.com/r/CreditCards/comments/1vz7479/venture_75k_300_hotel_credit_vs_csp_100k_sub/) |

