### PR TITLE
Card Page Check 2026-08-27

### DIFF
--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -50,10 +50,10 @@ rewards:
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 80000
+  value: 50000
   type: "miles"
-  spend_requirement: 3500
-  timeframe_months: 4
+  spend_requirement: 2500
+  timeframe_months: 3
 apr:
   regular:
     min: 19.49

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -93,7 +93,7 @@ rewards:
 signup_bonus:
   value: 80000
   type: "miles"
-  spend_requirement: 2000
+  spend_requirement: 3000
   timeframe_months: 6
   note: "Variable offer shown as 'as high as' 80,000 miles; welcome offers vary by applicant and you may not be eligible for an offer"
 apr:

--- a/data/cards/delta-skymiles-gold-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-business-american-express-card.yaml
@@ -49,10 +49,11 @@ rewards:
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 60000
+  value: 90000
   type: "miles"
-  spend_requirement: 4000
+  spend_requirement: 6000
   timeframe_months: 6
+  note: "Offer ends 2026-11-04."
 apr:
   regular:
     min: 19.49

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -122,7 +122,7 @@ rewards:
 signup_bonus:
   value: 90000
   type: "miles"
-  spend_requirement: 3000
+  spend_requirement: 4000
   timeframe_months: 6
   note: "Variable offer shown as 'as high as' 90,000 miles; welcome offers vary by applicant and you may not be eligible for an offer"
 apr:

--- a/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
@@ -41,10 +41,11 @@ rewards:
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 70000
+  value: 100000
   type: "miles"
-  spend_requirement: 6000
+  spend_requirement: 8000
   timeframe_months: 6
+  note: "Offer ends 2026-11-04."
 apr:
   regular:
     min: 19.49

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -17,9 +17,11 @@ our_take: >
   Main Cabin only. Status chasers also get a $2,500 MQD headstart and $1 of
   MQD per $10 spent, the strongest boost in the Delta lineup. What you do not
   get is earning: 3x on Delta purchases and a flat 1x on everything else is
-  thin for a $650 fee. The welcome offer sat at 125,000 miles from early June
-  until mid-July and is now back to 100,000 after $5,000 in six months, and it
-  is an as-high-as figure that varies by applicant. Between $240 in Resy
+  thin for a $650 fee. The welcome offer is now a two-part limited-time deal
+  running through November 4, 2026: two round-trip Delta Comfort certificates
+  plus 50,000 miles after $10,000 in six months. The spend hurdle doubled from
+  the $5,000 it sat at over the summer, but two Comfort round-trips are worth
+  more than the 50,000 miles they replace. Between $240 in Resy
   credits, $200 in Delta Stays, and $120 in rideshare credits you can recover
   a real chunk of the fee, but only if you spend in those exact channels.
 benefits:
@@ -106,11 +108,11 @@ rewards:
     value: 1
     unit: points_per_dollar
 signup_bonus:
-  value: 100000
+  value: 50000
   type: "miles"
-  spend_requirement: 5000
+  spend_requirement: 10000
   timeframe_months: 6
-  note: "Variable offer shown as 'as high as' 100,000 miles; welcome offers vary by applicant and you may not be eligible for an offer"
+  note: "Two-part limited-time offer: two round-trip Delta Comfort Flight Certificates valid to the U.S. 48, Puerto Rico, or the U.S. Virgin Islands, plus 50,000 bonus miles. Certificates require 21+ day advance purchase and taxes and fees up to $80 per person. Offer ends 2026-11-04."
 apr:
   regular:
     min: 19.49

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -37,10 +37,11 @@ rewards:
     unit: points_per_dollar
     note: "All purchases earn 1.5x after $150,000 in eligible purchases in a calendar year"
 signup_bonus:
-  value: 80000
+  value: 200000
   type: "miles"
-  spend_requirement: 12000
+  spend_requirement: 20000
   timeframe_months: 6
+  note: "Offer ends 2026-11-04."
 apr:
   regular:
     min: 19.49


### PR DESCRIPTION
## Card Page Check — 2026-08-27

Detected by fetching official apply pages and extracting card terms with an LLM.
**Verify each change against the source page before merging.**

### Term Changes

| Card | Field | Current | Detected | Source |
|------|-------|---------|----------|--------|
| Citi AAdvantage Platinum Select World Elite Mastercard | signup_bonus.value | 80000 | 50000 | [apply page](https://www.citi.com/credit-cards/citi-aadvantage-platinum-select-world-elite-mastercard) |
| Citi AAdvantage Platinum Select World Elite Mastercard | signup_bonus.spend_requirement | 3500 | 2500 | [apply page](https://www.citi.com/credit-cards/citi-aadvantage-platinum-select-world-elite-mastercard) |
| Citi AAdvantage Platinum Select World Elite Mastercard | signup_bonus.timeframe_months | 4 | 3 | [apply page](https://www.citi.com/credit-cards/citi-aadvantage-platinum-select-world-elite-mastercard) |
| Delta SkyMiles Gold American Express | signup_bonus.spend_requirement | 2000 | 3000 | [apply page](https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-gold-american-express-card/) |
| Delta SkyMiles Gold Business American Express | signup_bonus.value | 60000 | 90000 | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-gold) |
| Delta SkyMiles Gold Business American Express | signup_bonus.spend_requirement | 4000 | 6000 | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-gold) |
| Delta SkyMiles Gold Business American Express | signup_bonus.note | — | Offer ends 2026-11-04. | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-gold) |
| Delta SkyMiles Platinum American Express | signup_bonus.spend_requirement | 3000 | 4000 | [apply page](https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-platinum-american-express-card/) |
| Delta SkyMiles Platinum Business American Express | signup_bonus.value | 70000 | 100000 | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-platinum/) |
| Delta SkyMiles Platinum Business American Express | signup_bonus.spend_requirement | 6000 | 8000 | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-platinum/) |
| Delta SkyMiles Platinum Business American Express | signup_bonus.note | — | Offer ends 2026-11-04. | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-platinum/) |
| Delta SkyMiles Reserve Business American Express | signup_bonus.value | 80000 | 200000 | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/) |
| Delta SkyMiles Reserve Business American Express | signup_bonus.spend_requirement | 12000 | 20000 | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/) |
| Delta SkyMiles Reserve Business American Express | signup_bonus.note | — | Offer ends 2026-11-04. | [apply page](https://www.americanexpress.com/en-us/business/credit-cards/delta-skymiles-reserve/) |
| Delta SkyMiles Reserve American Express | signup_bonus.value | 100000 | 50000 | [apply page](https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-reserve-american-express-card/) |
| Delta SkyMiles Reserve American Express | signup_bonus.spend_requirement | 5000 | 10000 | [apply page](https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-reserve-american-express-card/) |
| Delta SkyMiles Reserve American Express | signup_bonus.note | 'as high as' 100,000, varies by applicant | Two-part: 2x Delta Comfort round-trip certificates + 50,000 miles. Offer ends 2026-11-04. | [apply page](https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-reserve-american-express-card/) |

### Manually Added After the Automated Run

The run **suppressed** the Delta SkyMiles Reserve change as a likely offer-variant downgrade (`100000 -> 50000` reads as a decrease on a host that serves session-targeted offers). It was then verified in a clean browser session and **added to this PR by hand**:

- The captured fetch text and a fresh session show byte-identical offer copy, so there is no targeted/public split.
- The offer was **restructured, not cut**: two round-trip Delta Comfort Flight Certificates **plus** 50,000 miles after $10,000 in six months.
- It ends `2026-11-04`, the same date applied to Delta SkyMiles Gold Business, Platinum Business, and Reserve Business above, all of which got increases. Amex is running a Delta-wide promo through that date.
- The spend requirement doubles ($5,000 -> $10,000), which the original extraction missed since it only proposed the miles field.
- `our_take` was updated in the same commit; it still described the old 100,000/$5,000 offer.

Two Comfort round-trips are worth more than the 50,000-mile gap, so read as value this is an upgrade.

### How to Review
1. Click each source link and verify the detected value on the issuer's page
2. Remove any YAML changes that look incorrect before merging
3. Run `npm run build:cards` to validate

---
*Automated PR — review carefully before merging.*

