### PR TITLE
Refresh our_take on three Delta business cards after the SUB changes

### DIFF
--- a/data/cards/delta-skymiles-gold-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-business-american-express-card.yaml
@@ -12,10 +12,11 @@ our_take: >
   Main Cabin 1 boarding, and 15% off award flights booked with Delta. The
   business twist is 2x on U.S. shipping providers up to $50,000 a year,
   alongside 2x on Delta purchases and restaurants worldwide, with everything
-  else at 1x. The welcome offer has been unusually volatile, swinging from
-  90,000 down to 60,000 in May, back to 90,000 in early July, then down to
-  60,000 miles after $4,000 in six months by mid-July, so it is worth waiting
-  for a higher window if you are not in a hurry. Watch the $200 Delta flight
+  else at 1x. The welcome offer has been unusually volatile, swinging
+  between 60,000 and 90,000 miles through the spring and summer, and it
+  currently sits at the top of that range: 90,000 miles after $6,000 in six
+  months, as a limited-time offer running through November 4, 2026. If you have
+  been holding out for a better window, this is one. Watch the $200 Delta flight
   credit too: it takes $10,000 in calendar-year purchases, which many
   businesses will clear but casual users will not. The $150 Delta Stays credit
   and up to $120 a year in rideshare credits help, though the rideshare credit

--- a/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
@@ -124,10 +124,11 @@ our_take: >
   with taxes and fees of $22 to $250 left to you. Business spending picks up
   1.5x on transit, U.S. shipping, and single purchases of $5,000 or more, up
   to a combined $100,000 a year before it drops to 1x, on top of 3x on Delta
-  purchases and hotels booked directly. The welcome offer is 70,000 miles
-  after $6,000 in six months, a heavier hurdle than the Gold Business but with
-  a deeper benefits stack behind it, including a $2,500 MQD headstart and a
-  Global Entry credit every four years. Recurring credits run up to $200 at
+  purchases and hotels booked directly. The welcome offer is currently
+  100,000 miles after $8,000 in six months, a limited-time raise from the usual
+  70,000 that runs through November 4, 2026. It is a heavier hurdle than the
+  Gold Business but with a deeper benefits stack behind it, including a $2,500
+  MQD headstart and a Global Entry credit every four years. Recurring credits run up to $200 at
   Delta Stays, $120 at Resy, and $120 on rideshares, but they are metered out
   monthly or tied to delta.com bookings, so treat them as a discount on the
   fee rather than cash. Everything outside the bonus categories earns 1x,

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -126,9 +126,11 @@ our_take: >
   Delta First, Premium Select, Comfort+, or Main Cabin. It earns more broadly
   than the personal Reserve, with 1.5x on transit, U.S. shipping, and U.S.
   office supply stores, and every purchase moving to 1.5x once you pass
-  $150,000 in a calendar year. The catch is the welcome offer: 80,000 miles
-  requires $12,000 of spending in six months, the steepest hurdle in the Delta
-  lineup, so only take it on if that spend is already on the calendar.
+  $150,000 in a calendar year. The welcome offer is at a high-water mark
+  through November 4, 2026: 200,000 miles after $20,000 in six months. That is
+  the steepest spend hurdle in the Delta lineup by a wide margin, so it only
+  makes sense if that spend is already on the calendar, but the payout is more
+  than double the usual 80,000.
   Recurring credits cover up to $250 at Delta Stays, $240 at Resy, and $120 on
   rideshares, plus a Global Entry credit every four years and a $2,500 MQD
   headstart toward status. If your company does not fly Delta regularly, the


### PR DESCRIPTION
## What

[#2110](https://github.com/CreditOdds/creditodds/pull/2110) updated `signup_bonus` on the three Delta business cards but left `our_take` describing the old offers. The live card pages now contradict themselves: the header renders the new bonus while the editorial paragraph quotes the old one, and the CardWire timeline below shows the change.

| Card | our_take said | Actual |
|---|---|---|
| Delta Gold Business | 60,000 / $4,000 | **90,000 / $6,000** |
| Delta Platinum Business | 70,000 / $6,000 | **100,000 / $8,000** |
| Delta Reserve Business | 80,000 / $12,000 | **200,000 / $20,000** |

**Gold Business was the worst of the three.** It read "down to 60,000 miles after \$4,000 ... so it is worth waiting for a higher window" while the higher window is live right now. The copy was steering readers away from the better offer.

All three rewrites name the `2026-11-04` campaign end date. The consumer Reserve was already handled in #2110. `npm run build:cards` passes (225 cards); regenerated `cards.json` not committed.

## Pipeline gap worth a follow-up

`check-card-pages.js` updates `signup_bonus` but never touches `our_take`, so **every** SUB change ships this contradiction until the twice-monthly `our_take` regen catches up. Options: have the finish phase flag cards whose `our_take` mentions a number that just changed, or trigger a targeted regen for changed cards.