### PR TITLE
best-card-for audit fixes: conditional tie-break, Ritz-Carlton valuation, co-brand list catch-up

### DIFF
--- a/apps/api/src/lib/ranker/storeRanking.js
+++ b/apps/api/src/lib/ranker/storeRanking.js
@@ -313,13 +313,29 @@ function rankCards(store, cards, options) {
     }
   }
 
-  // Ties break toward the more store-specific source: the branded card at
-  // its own store, then a curated also_earns rate, then a category bonus,
-  // then a generic flat rate.
+  // Ties break first toward the pick that pays without the cardholder doing
+  // anything: an unconditional rate beats one needing quarterly activation,
+  // which beats an opt-in bonus category, which beats a top-spend dependency.
+  // (Without this, "3% if you select it" cards sat at #1 above unconditional
+  // 3% cards on every long-tail online-shopping page.) Only category
+  // candidates carry a match mode; co_brand / also_earns / flat rates are
+  // unconditional. Then ties break toward the more store-specific source:
+  // the branded card at its own store, then a curated also_earns rate, then
+  // a category bonus, then a generic flat rate.
+  const MODE_TIE_RANK = {
+    direct: 0,
+    user_selected: 0,
+    rotating_current: 1,
+    user_choice: 2,
+    top_spend: 3,
+    rotating_eligible: 4,
+  };
+  const modeTieRank = (c) => (c.match ? MODE_TIE_RANK[c.match.mode] ?? 0 : 0);
   const SOURCE_TIE_RANK = { co_brand: 0, also_earns: 1, category: 2, flat: 3 };
   candidates.sort(
     (a, b) =>
       b.effective - a.effective ||
+      modeTieRank(a) - modeTieRank(b) ||
       SOURCE_TIE_RANK[a.kind] - SOURCE_TIE_RANK[b.kind],
   );
 

--- a/apps/api/src/lib/ranker/stores.json
+++ b/apps/api/src/lib/ranker/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-10T22:27:32.600Z",
+  "generated_at": "2026-08-28T15:07:07.119Z",
   "count": 1117,
   "stores": [
     {
@@ -440,6 +440,9 @@
         "travel"
       ],
       "website": "https://www.airfrance.us",
+      "co_brand_cards": [
+        "air-france-klm-visa-signature"
+      ],
       "intro": "Air France-KLM is the Franco-Dutch parent of Air France (hubbed at Paris-Charles de Gaulle)\nand KLM Royal Dutch Airlines (hubbed at Amsterdam-Schiphol), both SkyTeam members with a\nshared Flying Blue loyalty program. Flying Blue partners with Amex Membership Rewards, Chase\nUltimate Rewards, Capital One miles, Bilt, and Citi ThankYou Points as a 1:1 transfer\npartner, plus periodic transfer bonuses. Air France and KLM ticket purchases code as\nairlines/airfare on US cards, earning the full airfare bonus on any card with that category.\n"
     },
     {
@@ -878,6 +881,10 @@
         "transit"
       ],
       "website": "https://www.amtrak.com",
+      "co_brand_cards": [
+        "amtrak-guest-rewards-mastercard",
+        "amtrak-guest-rewards-preferred-mastercard"
+      ],
       "intro": "Amtrak is the US national passenger rail operator, running the Northeast Corridor and long-distance routes nationwide. Tickets usually code as travel or transit and earn on cards that bonus either, so a card counting trains as travel works best. Amtrak also offers its own Guest Rewards co-brand card for riders who travel the rails frequently.\n"
     },
     {
@@ -1278,6 +1285,9 @@
         "phone"
       ],
       "website": "https://www.att.com",
+      "co_brand_cards": [
+        "att-points-plus-from-citi"
+      ],
       "intro": "AT&T provides wireless service, fiber internet and TV bundles to millions of US customers. Your monthly bill earns a bonus only on cards that reward wireless or telecom spending, otherwise it lands on the flat rate, and certain cards include cell-phone protection if you charge the bill to them.\n"
     },
     {
@@ -3884,7 +3894,9 @@
         "delta-skymiles-gold-american-express-card",
         "delta-skymiles-platinum-american-express-card",
         "delta-skymiles-reserve-american-express-card",
-        "delta-skymiles-gold-business-american-express-card"
+        "delta-skymiles-gold-business-american-express-card",
+        "delta-skymiles-platinum-business-american-express-card",
+        "delta-skymiles-reserve-business-american-express-card"
       ],
       "intro": "Delta Air Lines runs one of the strongest U.S. domestic networks and the SkyMiles\nloyalty program. Delta tickets code as airfare across all major cards. Co-branded\nSkyMiles Amex cards add extra miles per dollar on Delta plus perks like a free\nchecked bag, Sky Club access (Reserve only), and Medallion-status boost spend.\nGeneral travel cards usually beat them on raw cash-equivalent value, but the\nReserve's lounge access and MQD-waiver path can swing the math for frequent flyers.\nOTA bookings still earn miles when your SkyMiles number is attached.\n"
     },
@@ -4151,6 +4163,10 @@
         "streaming"
       ],
       "website": "https://www.disneyplus.com",
+      "co_brand_cards": [
+        "disney-inspire-visa",
+        "disney-premier-visa-card"
+      ],
       "intro": "Disney+ is The Walt Disney Company's streaming service, with Disney/Pixar/Marvel/\nStar Wars/National Geographic content. Monthly subscriptions code as streaming on\nevery card we track. Streaming-bonus cards (Blue Cash Preferred 6%, U.S. Bank\nCash+ 5% on selected categories) are the strongest pairings. Disney+ is also\nbundled with Hulu and ESPN+ as the Disney Bundle, often the cheapest path to\nall three services.\n"
     },
     {
@@ -6509,7 +6525,8 @@
       "co_brand_cards": [
         "hilton-honors-american-express-aspire-card",
         "hilton-honors-american-express-surpass-card",
-        "hilton-honors-card"
+        "hilton-honors-card",
+        "hilton-honors-american-express-business-card"
       ],
       "intro": "Hilton Honors covers roughly 8,000 properties worldwide across 22 brands, from budget\nHampton Inn and Tru up through Waldorf Astoria and Conrad luxury. Booking direct at\nhilton.com or in-app earns the full 10x base points plus any co-brand multiplier, while\nthird-party bookings (Expedia, Booking.com) earn nothing in the program and don't count\ntoward elite status. The Hilton co-brand cards lean heavily on perks — free weekend\nnights, automatic Gold or Diamond status, statement credits — rather than headline\nearn rates, so the value calculation depends on whether you'll actually use the\ncertificate and the status. Hilton points typically value around 0.5 cents each.\n"
     },
@@ -8744,7 +8761,9 @@
         "marriott-bonvoy-bevy-american-express",
         "marriott-bonvoy-bold-credit-card",
         "marriott-bonvoy-boundless-credit-card",
-        "marriott-bonvoy-brilliant-american-express"
+        "marriott-bonvoy-brilliant-american-express",
+        "marriott-bonvoy-business-american-express",
+        "chase-ritz-carlton"
       ],
       "intro": "Marriott Bonvoy is the world's largest hotel loyalty program, covering more than 30\nbrands from budget Fairfield Inn through luxury Ritz-Carlton, St. Regis, and W Hotels.\nDirect stays at marriott.com or any Bonvoy property earn the most points and unlock\nelite-night credits, but the math gets nuanced: co-branded Marriott cards layer extra\nBonvoy points on top of base earnings, while general hotel-category cards (Sapphire\nReserve, Venture X) often yield higher cashback-equivalent value if you don't care\nabout Bonvoy status. Stays booked through OTAs like Expedia or Hotels.com forfeit\npoints and elite credit, so the in-program booking is almost always the right call.\n"
     },
@@ -11821,6 +11840,9 @@
         "online_shopping"
       ],
       "website": "https://www.samsung.com",
+      "co_brand_cards": [
+        "samsung-galaxy-card"
+      ],
       "intro": "Samsung sells phones, TVs, appliances and accessories through Samsung.com and its retail partners. Purchases on its site usually code as online shopping or general merchandise, so a card with an online or everyday bonus works best, while in-store buys at third-party retailers often fall to a flat-rate or that store's category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.47773.1000000009&trid=1552713.159074&foc=16&fot=9999&fos=6",
@@ -12597,7 +12619,9 @@
       "co_brand_cards": [
         "southwest-rapid-rewards-plus-credit-card",
         "southwest-rapid-rewards-premier-credit-card",
-        "southwest-rapid-rewards-priority-credit-card"
+        "southwest-rapid-rewards-priority-credit-card",
+        "southwest-rapid-rewards-premier-business-credit-card",
+        "southwest-rapid-rewards-performance-business-credit-card"
       ],
       "intro": "Southwest Airlines is the largest U.S. domestic carrier by passenger volume and the\nhome of the Rapid Rewards program. Tickets code as airfare on every card we track,\nand the Companion Pass — earned by hitting an annual points threshold — is widely\nconsidered the best perk in U.S. domestic travel. Co-branded Chase Rapid Rewards\ncards count signup bonuses toward Companion Pass qualification, which is the main\nreason most travelers carry one. Southwest doesn't sell tickets through OTAs.\n"
     },
@@ -14461,7 +14485,9 @@
         "united-gateway",
         "united-explorer",
         "united-quest",
-        "united-club-infinite"
+        "united-club-infinite",
+        "united-business",
+        "united-club-business"
       ],
       "intro": "United Airlines is one of the three U.S. legacy carriers and runs the MileagePlus\nloyalty program. United tickets code as airfare on every card we track. The Chase\nco-branded ladder ranges from no-fee Gateway to the $525 Club Infinite with United\nClub lounge membership; mid-tier Explorer adds free checked bag and 2 club passes,\nand Quest adds an annual flight credit. General travel cards often outperform on\ncash-equivalent value, but United co-brands waive close-in award fees and add\nstatus-credit boosts that frequent flyers value.\n"
     },
@@ -15398,7 +15424,8 @@
       "co_brand_cards": [
         "wyndham-rewards-earner-card",
         "wyndham-rewards-earner-plus-card",
-        "wyndham-rewards-earner-business-card"
+        "wyndham-rewards-earner-business-card",
+        "wyndham-rewards-earner-premier-card"
       ],
       "intro": "Wyndham Hotels & Resorts is the largest U.S. hotel chain by property count — about\n9,000 hotels — concentrated in mid-scale and economy brands like Days Inn, Super 8,\nLa Quinta, and Ramada, with a smaller upscale presence under Wyndham Grand and the\nRegistry Collection. Wyndham Rewards uses a flat or tiered award chart with redemptions\nstarting at 7,500 points per night, and the program partners with Vacasa for full\nvacation-rental redemptions — a quirk that gives Wyndham points unusual reach for an\neconomy-leaning chain. Direct bookings at wyndhamhotels.com or in the app earn points;\nOTA stays do not. Co-brand cards run lower annual fees than the major chains' cards,\nmatching the program's value-tier identity.\n"
     },

--- a/apps/api/src/lib/ranker/valuations.js
+++ b/apps/api/src/lib/ranker/valuations.js
@@ -16,7 +16,9 @@ const valuations = [
   { program: "Hilton Honors", slug: "hilton-honors", cpp: 0.5, match: ["hilton"], toolSlug: "hilton-honors-points" },
   { program: "World of Hyatt", slug: "world-of-hyatt", cpp: 2.0, match: ["hyatt"], toolSlug: "world-of-hyatt-points" },
   { program: "IHG One Rewards", slug: "ihg-one-rewards", cpp: 0.5, match: ["ihg"], toolSlug: "ihg-one-rewards-points" },
-  { program: "Marriott Bonvoy", slug: "marriott-bonvoy", cpp: 0.7, match: ["marriott", "bonvoy"], toolSlug: "marriott-bonvoy-points" },
+  // "ritz" covers the Chase Ritz-Carlton card, which earns Bonvoy points
+  // but has neither "marriott" nor "bonvoy" in its name.
+  { program: "Marriott Bonvoy", slug: "marriott-bonvoy", cpp: 0.7, match: ["marriott", "bonvoy", "ritz"], toolSlug: "marriott-bonvoy-points" },
   { program: "Capital One Miles", slug: "capital-one-miles", cpp: 1.0, match: ["capital one"], toolSlug: "capital-one-miles" },
   { program: "Bilt Rewards", slug: "bilt-rewards", cpp: 1.0, match: ["bilt"], toolSlug: "bilt-rewards-points" },
   { program: "Citi ThankYou", slug: "citi-thankyou", cpp: 1.0, match: ["citi"], toolSlug: "citi-thankyou-points" },

--- a/apps/api/tests/storeRanking.test.js
+++ b/apps/api/tests/storeRanking.test.js
@@ -35,6 +35,10 @@ describe("valuation program matching", () => {
     // Ink Business Preferred earns transferable UR like the Sapphires.
     ["Ink Business Preferred", 1.25],
     ["Chase Sapphire Preferred", 1.25],
+    // Ritz-Carlton earns Bonvoy despite having neither "marriott" nor
+    // "bonvoy" in its name — it defaulted to 1.0 and ranked #1 at Marriott
+    // at 6.0% while the true Bonvoy earners showed 4.2% for the same 6x.
+    ["Ritz-Carlton", 0.7],
   ])("%s → %scpp", (name, cpp) => {
     expect(getValuation(name)).toBe(cpp);
   });
@@ -129,6 +133,44 @@ describe("flat-rate cards compete on effective rate", () => {
     const slugs = picks.map((p) => p.card.slug);
     expect(slugs.indexOf("rotator")).toBeGreaterThan(slugs.indexOf("strong-flat"));
     expect(picks.find((p) => p.card.slug === "rotator").matchMode).toBe("rotating_eligible");
+  });
+});
+
+describe("conditional tie-break", () => {
+  // At an equal effective rate, a pick the cardholder gets without doing
+  // anything must lead. Before this rank existed, "3% if you select it"
+  // (BofA Customized Cash / Cash Rewards Secured) sat at #1 above the
+  // unconditional 3% cards on ~330 long-tail online-shopping pages.
+  const store = { name: "Framer", slug: "framer", categories: ["online_shopping"] };
+  const chooser = card("choose-3", [
+    {
+      category: "selected_categories",
+      value: 3,
+      unit: "percent",
+      mode: "user_choice",
+      eligible_categories: ["online_shopping"],
+    },
+    pct("everything_else", 1),
+  ]);
+  const direct3 = card("direct-3", [pct("online_shopping", 3), pct("everything_else", 1)]);
+  const flat3 = card("flat-3", [pct("everything_else", 3)]);
+
+  test("equal-rate order is direct category, then flat, then opt-in choice", () => {
+    const picks = rankCards(store, [chooser, direct3, flat3]);
+    expect(picks.map((p) => p.card.slug)).toEqual(["direct-3", "flat-3", "choose-3"]);
+    expect(picks[2].matchMode).toBe("user_choice");
+  });
+
+  test("a saved user selection ranks as unconditional again", () => {
+    const userSelections = new Map([
+      [
+        "choose-3",
+        [{ reward_category: "selected_categories", reward_rate: 3, selected_category: "online_shopping" }],
+      ],
+    ]);
+    const picks = rankCards(store, [chooser, flat3], { userSelections });
+    expect(picks.map((p) => p.card.slug)).toEqual(["choose-3", "flat-3"]);
+    expect(picks[0].matchMode).toBe("user_selected");
   });
 });
 

--- a/data/stores.json
+++ b/data/stores.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-10T22:27:32.600Z",
+  "generated_at": "2026-08-28T15:07:07.119Z",
   "count": 1117,
   "stores": [
     {
@@ -440,6 +440,9 @@
         "travel"
       ],
       "website": "https://www.airfrance.us",
+      "co_brand_cards": [
+        "air-france-klm-visa-signature"
+      ],
       "intro": "Air France-KLM is the Franco-Dutch parent of Air France (hubbed at Paris-Charles de Gaulle)\nand KLM Royal Dutch Airlines (hubbed at Amsterdam-Schiphol), both SkyTeam members with a\nshared Flying Blue loyalty program. Flying Blue partners with Amex Membership Rewards, Chase\nUltimate Rewards, Capital One miles, Bilt, and Citi ThankYou Points as a 1:1 transfer\npartner, plus periodic transfer bonuses. Air France and KLM ticket purchases code as\nairlines/airfare on US cards, earning the full airfare bonus on any card with that category.\n"
     },
     {
@@ -878,6 +881,10 @@
         "transit"
       ],
       "website": "https://www.amtrak.com",
+      "co_brand_cards": [
+        "amtrak-guest-rewards-mastercard",
+        "amtrak-guest-rewards-preferred-mastercard"
+      ],
       "intro": "Amtrak is the US national passenger rail operator, running the Northeast Corridor and long-distance routes nationwide. Tickets usually code as travel or transit and earn on cards that bonus either, so a card counting trains as travel works best. Amtrak also offers its own Guest Rewards co-brand card for riders who travel the rails frequently.\n"
     },
     {
@@ -1278,6 +1285,9 @@
         "phone"
       ],
       "website": "https://www.att.com",
+      "co_brand_cards": [
+        "att-points-plus-from-citi"
+      ],
       "intro": "AT&T provides wireless service, fiber internet and TV bundles to millions of US customers. Your monthly bill earns a bonus only on cards that reward wireless or telecom spending, otherwise it lands on the flat rate, and certain cards include cell-phone protection if you charge the bill to them.\n"
     },
     {
@@ -3884,7 +3894,9 @@
         "delta-skymiles-gold-american-express-card",
         "delta-skymiles-platinum-american-express-card",
         "delta-skymiles-reserve-american-express-card",
-        "delta-skymiles-gold-business-american-express-card"
+        "delta-skymiles-gold-business-american-express-card",
+        "delta-skymiles-platinum-business-american-express-card",
+        "delta-skymiles-reserve-business-american-express-card"
       ],
       "intro": "Delta Air Lines runs one of the strongest U.S. domestic networks and the SkyMiles\nloyalty program. Delta tickets code as airfare across all major cards. Co-branded\nSkyMiles Amex cards add extra miles per dollar on Delta plus perks like a free\nchecked bag, Sky Club access (Reserve only), and Medallion-status boost spend.\nGeneral travel cards usually beat them on raw cash-equivalent value, but the\nReserve's lounge access and MQD-waiver path can swing the math for frequent flyers.\nOTA bookings still earn miles when your SkyMiles number is attached.\n"
     },
@@ -4151,6 +4163,10 @@
         "streaming"
       ],
       "website": "https://www.disneyplus.com",
+      "co_brand_cards": [
+        "disney-inspire-visa",
+        "disney-premier-visa-card"
+      ],
       "intro": "Disney+ is The Walt Disney Company's streaming service, with Disney/Pixar/Marvel/\nStar Wars/National Geographic content. Monthly subscriptions code as streaming on\nevery card we track. Streaming-bonus cards (Blue Cash Preferred 6%, U.S. Bank\nCash+ 5% on selected categories) are the strongest pairings. Disney+ is also\nbundled with Hulu and ESPN+ as the Disney Bundle, often the cheapest path to\nall three services.\n"
     },
     {
@@ -6509,7 +6525,8 @@
       "co_brand_cards": [
         "hilton-honors-american-express-aspire-card",
         "hilton-honors-american-express-surpass-card",
-        "hilton-honors-card"
+        "hilton-honors-card",
+        "hilton-honors-american-express-business-card"
       ],
       "intro": "Hilton Honors covers roughly 8,000 properties worldwide across 22 brands, from budget\nHampton Inn and Tru up through Waldorf Astoria and Conrad luxury. Booking direct at\nhilton.com or in-app earns the full 10x base points plus any co-brand multiplier, while\nthird-party bookings (Expedia, Booking.com) earn nothing in the program and don't count\ntoward elite status. The Hilton co-brand cards lean heavily on perks — free weekend\nnights, automatic Gold or Diamond status, statement credits — rather than headline\nearn rates, so the value calculation depends on whether you'll actually use the\ncertificate and the status. Hilton points typically value around 0.5 cents each.\n"
     },
@@ -8744,7 +8761,9 @@
         "marriott-bonvoy-bevy-american-express",
         "marriott-bonvoy-bold-credit-card",
         "marriott-bonvoy-boundless-credit-card",
-        "marriott-bonvoy-brilliant-american-express"
+        "marriott-bonvoy-brilliant-american-express",
+        "marriott-bonvoy-business-american-express",
+        "chase-ritz-carlton"
       ],
       "intro": "Marriott Bonvoy is the world's largest hotel loyalty program, covering more than 30\nbrands from budget Fairfield Inn through luxury Ritz-Carlton, St. Regis, and W Hotels.\nDirect stays at marriott.com or any Bonvoy property earn the most points and unlock\nelite-night credits, but the math gets nuanced: co-branded Marriott cards layer extra\nBonvoy points on top of base earnings, while general hotel-category cards (Sapphire\nReserve, Venture X) often yield higher cashback-equivalent value if you don't care\nabout Bonvoy status. Stays booked through OTAs like Expedia or Hotels.com forfeit\npoints and elite credit, so the in-program booking is almost always the right call.\n"
     },
@@ -11821,6 +11840,9 @@
         "online_shopping"
       ],
       "website": "https://www.samsung.com",
+      "co_brand_cards": [
+        "samsung-galaxy-card"
+      ],
       "intro": "Samsung sells phones, TVs, appliances and accessories through Samsung.com and its retail partners. Purchases on its site usually code as online shopping or general merchandise, so a card with an online or everyday bonus works best, while in-store buys at third-party retailers often fall to a flat-rate or that store's category.\n",
       "affiliate": {
         "url": "https://track.flexlinkspro.com/g.ashx?foid=1.47773.1000000009&trid=1552713.159074&foc=16&fot=9999&fos=6",
@@ -12597,7 +12619,9 @@
       "co_brand_cards": [
         "southwest-rapid-rewards-plus-credit-card",
         "southwest-rapid-rewards-premier-credit-card",
-        "southwest-rapid-rewards-priority-credit-card"
+        "southwest-rapid-rewards-priority-credit-card",
+        "southwest-rapid-rewards-premier-business-credit-card",
+        "southwest-rapid-rewards-performance-business-credit-card"
       ],
       "intro": "Southwest Airlines is the largest U.S. domestic carrier by passenger volume and the\nhome of the Rapid Rewards program. Tickets code as airfare on every card we track,\nand the Companion Pass — earned by hitting an annual points threshold — is widely\nconsidered the best perk in U.S. domestic travel. Co-branded Chase Rapid Rewards\ncards count signup bonuses toward Companion Pass qualification, which is the main\nreason most travelers carry one. Southwest doesn't sell tickets through OTAs.\n"
     },
@@ -14461,7 +14485,9 @@
         "united-gateway",
         "united-explorer",
         "united-quest",
-        "united-club-infinite"
+        "united-club-infinite",
+        "united-business",
+        "united-club-business"
       ],
       "intro": "United Airlines is one of the three U.S. legacy carriers and runs the MileagePlus\nloyalty program. United tickets code as airfare on every card we track. The Chase\nco-branded ladder ranges from no-fee Gateway to the $525 Club Infinite with United\nClub lounge membership; mid-tier Explorer adds free checked bag and 2 club passes,\nand Quest adds an annual flight credit. General travel cards often outperform on\ncash-equivalent value, but United co-brands waive close-in award fees and add\nstatus-credit boosts that frequent flyers value.\n"
     },
@@ -15398,7 +15424,8 @@
       "co_brand_cards": [
         "wyndham-rewards-earner-card",
         "wyndham-rewards-earner-plus-card",
-        "wyndham-rewards-earner-business-card"
+        "wyndham-rewards-earner-business-card",
+        "wyndham-rewards-earner-premier-card"
       ],
       "intro": "Wyndham Hotels & Resorts is the largest U.S. hotel chain by property count — about\n9,000 hotels — concentrated in mid-scale and economy brands like Days Inn, Super 8,\nLa Quinta, and Ramada, with a smaller upscale presence under Wyndham Grand and the\nRegistry Collection. Wyndham Rewards uses a flat or tiered award chart with redemptions\nstarting at 7,500 points per night, and the program partners with Vacasa for full\nvacation-rental redemptions — a quirk that gives Wyndham points unusual reach for an\neconomy-leaning chain. Direct bookings at wyndhamhotels.com or in the app earn points;\nOTA stays do not. Co-brand cards run lower annual fees than the major chains' cards,\nmatching the program's value-tier identity.\n"
     },

--- a/data/stores/air-france-klm.yaml
+++ b/data/stores/air-france-klm.yaml
@@ -8,6 +8,8 @@ categories:
   - airlines
   - travel
 website: "https://www.airfrance.us"
+co_brand_cards:
+  - air-france-klm-visa-signature
 intro: |
   Air France-KLM is the Franco-Dutch parent of Air France (hubbed at Paris-Charles de Gaulle)
   and KLM Royal Dutch Airlines (hubbed at Amsterdam-Schiphol), both SkyTeam members with a

--- a/data/stores/amtrak.yaml
+++ b/data/stores/amtrak.yaml
@@ -3,5 +3,8 @@ slug: amtrak
 categories:
   - transit
 website: https://www.amtrak.com
+co_brand_cards:
+  - amtrak-guest-rewards-mastercard
+  - amtrak-guest-rewards-preferred-mastercard
 intro: |
   Amtrak is the US national passenger rail operator, running the Northeast Corridor and long-distance routes nationwide. Tickets usually code as travel or transit and earn on cards that bonus either, so a card counting trains as travel works best. Amtrak also offers its own Guest Rewards co-brand card for riders who travel the rails frequently.

--- a/data/stores/atandt.yaml
+++ b/data/stores/atandt.yaml
@@ -4,5 +4,7 @@ categories:
   - cell_phone_providers
   - phone
 website: https://www.att.com
+co_brand_cards:
+  - att-points-plus-from-citi
 intro: |
   AT&T provides wireless service, fiber internet and TV bundles to millions of US customers. Your monthly bill earns a bonus only on cards that reward wireless or telecom spending, otherwise it lands on the flat rate, and certain cards include cell-phone protection if you charge the bill to them.

--- a/data/stores/delta-air-lines.yaml
+++ b/data/stores/delta-air-lines.yaml
@@ -13,6 +13,8 @@ co_brand_cards:
   - delta-skymiles-platinum-american-express-card
   - delta-skymiles-reserve-american-express-card
   - delta-skymiles-gold-business-american-express-card
+  - delta-skymiles-platinum-business-american-express-card
+  - delta-skymiles-reserve-business-american-express-card
 intro: |
   Delta Air Lines runs one of the strongest U.S. domestic networks and the SkyMiles
   loyalty program. Delta tickets code as airfare across all major cards. Co-branded

--- a/data/stores/disney-plus.yaml
+++ b/data/stores/disney-plus.yaml
@@ -5,6 +5,9 @@ aliases:
 categories:
   - streaming
 website: "https://www.disneyplus.com"
+co_brand_cards:
+  - disney-inspire-visa
+  - disney-premier-visa-card
 intro: |
   Disney+ is The Walt Disney Company's streaming service, with Disney/Pixar/Marvel/
   Star Wars/National Geographic content. Monthly subscriptions code as streaming on

--- a/data/stores/hilton.yaml
+++ b/data/stores/hilton.yaml
@@ -27,6 +27,7 @@ co_brand_cards:
   - hilton-honors-american-express-aspire-card
   - hilton-honors-american-express-surpass-card
   - hilton-honors-card
+  - hilton-honors-american-express-business-card
 intro: |
   Hilton Honors covers roughly 8,000 properties worldwide across 22 brands, from budget
   Hampton Inn and Tru up through Waldorf Astoria and Conrad luxury. Booking direct at

--- a/data/stores/marriott.yaml
+++ b/data/stores/marriott.yaml
@@ -31,6 +31,8 @@ co_brand_cards:
   - marriott-bonvoy-bold-credit-card
   - marriott-bonvoy-boundless-credit-card
   - marriott-bonvoy-brilliant-american-express
+  - marriott-bonvoy-business-american-express
+  - chase-ritz-carlton
 intro: |
   Marriott Bonvoy is the world's largest hotel loyalty program, covering more than 30
   brands from budget Fairfield Inn through luxury Ritz-Carlton, St. Regis, and W Hotels.

--- a/data/stores/samsung.yaml
+++ b/data/stores/samsung.yaml
@@ -3,5 +3,7 @@ slug: samsung
 categories:
   - online_shopping
 website: https://www.samsung.com
+co_brand_cards:
+  - samsung-galaxy-card
 intro: |
   Samsung sells phones, TVs, appliances and accessories through Samsung.com and its retail partners. Purchases on its site usually code as online shopping or general merchandise, so a card with an online or everyday bonus works best, while in-store buys at third-party retailers often fall to a flat-rate or that store's category.

--- a/data/stores/southwest-airlines.yaml
+++ b/data/stores/southwest-airlines.yaml
@@ -11,6 +11,8 @@ co_brand_cards:
   - southwest-rapid-rewards-plus-credit-card
   - southwest-rapid-rewards-premier-credit-card
   - southwest-rapid-rewards-priority-credit-card
+  - southwest-rapid-rewards-premier-business-credit-card
+  - southwest-rapid-rewards-performance-business-credit-card
 intro: |
   Southwest Airlines is the largest U.S. domestic carrier by passenger volume and the
   home of the Rapid Rewards program. Tickets code as airfare on every card we track,

--- a/data/stores/united-airlines.yaml
+++ b/data/stores/united-airlines.yaml
@@ -12,6 +12,8 @@ co_brand_cards:
   - united-explorer
   - united-quest
   - united-club-infinite
+  - united-business
+  - united-club-business
 intro: |
   United Airlines is one of the three U.S. legacy carriers and runs the MileagePlus
   loyalty program. United tickets code as airfare on every card we track. The Chase

--- a/data/stores/wyndham.yaml
+++ b/data/stores/wyndham.yaml
@@ -27,6 +27,7 @@ co_brand_cards:
   - wyndham-rewards-earner-card
   - wyndham-rewards-earner-plus-card
   - wyndham-rewards-earner-business-card
+  - wyndham-rewards-earner-premier-card
 intro: |
   Wyndham Hotels & Resorts is the largest U.S. hotel chain by property count — about
   9,000 hotels — concentrated in mid-scale and economy brands like Days Inn, Super 8,


### PR DESCRIPTION
Three fixes from the 2026-08-28 audit of /best-card-for/[slug] (follow-up to the July audit in #1766).

## 1. Conditional picks no longer win rate ties (~332 pages)

The candidate sort was effective rate, then source kind only. At an equal rate, an opt-in "if you select it" category bonus could sit above an unconditional earner — and on ~332 long-tail online-shopping pages the site-wide #1 answer was **Bank of America Cash Rewards Secured, "3% if you select it as a bonus category"**, above the unconditional Blue Cash Everyday 3% and the 3% flat-rate cards.

`rankCards` now breaks rate ties by match mode first (direct/user_selected → rotating_current → user_choice → top_spend), then the existing source rank. Saved wallet selections (`user_selected`) still rank as unconditional, and co-brand cards still lead exact ties at their own store.

**Before → after at a typical long-tail store (arttoframes):**

| # | Before | After |
|---|--------|-------|
| 1 | BofA Cash Rewards Secured — 3% *if you select it* | Blue Cash Everyday — 3% online shopping |
| 2 | BofA Customized Cash — 3% *if you select it* | Robinhood Gold — 3% flat |
| 3 | Blue Cash Everyday — 3% | BofA Cash Rewards Secured — 3% *if you select it* |

## 2. Ritz-Carlton priced as Bonvoy (0.7cpp), not the 1.0 default

The card name "Ritz-Carlton" matched no valuation entry, so it defaulted to 1.0cpp despite earning Marriott Bonvoy points. It ranked **#1 at /best-card-for/marriott at 6.0%** while the identical 6x Bonvoy earners (Bevy/Boundless/Brilliant) showed 4.2%, and its 3x rewards were inflated to 3.0% (vs 2.1%) at #3 on seven car-rental pages. Added `"ritz"` to the Bonvoy match list; it now ranks with its Bonvoy siblings at 4.2%.

## 3. co_brand_cards catch-up for cards added since July

Cards added since #1766 were properly `merchant_gate`d (rates were already correct) but missing from their stores' `co_brand_cards` lists, so they rendered as generic category rows instead of highlighted "Co-branded X card" rows and lost co-brand tie-breaks/prerender priority. Added:

- **delta-air-lines**: Delta Platinum Business, Delta Reserve Business
- **southwest-airlines**: Premier Business, Performance Business
- **united-airlines**: United Business, United Club Business
- **hilton**: Hilton Honors Business
- **marriott**: Bonvoy Business, Ritz-Carlton
- **amtrak**: both Amtrak Guest Rewards cards
- **air-france-klm**: Air France KLM Visa Signature
- **wyndham**: Earner Premier
- **samsung**: Samsung Galaxy Card
- **atandt**: AT&T Points Plus from Citi
- **disney-plus**: Disney Inspire Visa, Disney Premier Visa

Deliberately skipped: the Disney cards on hulu/espn-plus and Aer Lingus/Iberia on british-airways (the co-brand row label would read "Co-branded Hulu card" etc., which is wrong), and the Atmos/Hawaiian cross-listings (deliberate cross-brand gates from the merger, not co-brands).

## Verification

- 22/22 ranker tests pass (2 new tie-break tests + Ritz valuation case); full apps/api suite 59/59.
- `audit-store-rankings.js --validate-only` passes (all gates/refs resolve).
- Re-ran rankings across all 1117 stores: no zero-pick stores, no fallback-banner regressions; spot-checked marriott, samsung, disney-plus, hilton, southwest, united, wyndham, atandt, amtrak, air-france-klm, and a long-tail online-shopping page.
- stores.json rebuilt and committed (both copies).