### PR TITLE
Reddit Data Points 2026-08-28

### DIFF
--- a/data/reddit-datapoints/2026-08-28-t3_1vzz4iu.yaml
+++ b/data/reddit-datapoints/2026-08-28-t3_1vzz4iu.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1vzz4iu"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1vzz4iu/wf_signify_business_cash_approval_no_additional/"
+posted: "2026-08-27"
+evidence: "Poster reports approval with a $2500 limit and no extra documents requested, citing 723 Experian direct, 720 TransUnion, and 740 Equifax at the time of application."
+card_name: "Wells Fargo Signify Business Cash"
+result: "approved"
+credit_score: 723
+credit_score_source: 1
+starting_credit_limit: 2500
+date_applied: "2026-08"

--- a/data/reddit-datapoints/2026-08-28-t3_1w001r5.yaml
+++ b/data/reddit-datapoints/2026-08-28-t3_1w001r5.yaml
@@ -1,0 +1,10 @@
+source_id: "t3_1w001r5"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1w001r5/approved_sapphire_preferred_low_credit/"
+posted: "2026-08-27"
+evidence: "Poster reports an approval at a 630 score, down from their usual 690 to 700 because of high utilization that month, at age 19 with about 14 months of credit history."
+card_name: "Chase Sapphire Preferred"
+result: "approved"
+credit_score: 630
+credit_score_source: 0
+length_credit: 1
+date_applied: "2026-08"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-08-28

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1w001r5](https://www.reddit.com/r/CreditCards/comments/1w001r5/approved_sapphire_preferred_low_credit/) | Chase Sapphire Preferred | approved | 630 | — | — | 1 | 2026-08 | `2026-08-28-t3_1w001r5.yaml` |
| [t3_1vzz4iu](https://www.reddit.com/r/CreditCards/comments/1vzz4iu/wf_signify_business_cash_approval_no_additional/) | Wells Fargo Signify Business Cash | approved | 723 | — | $2,500 | — | 2026-08 | `2026-08-28-t3_1vzz4iu.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (13)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [when should i get rid of my lower end cards?](https://www.reddit.com/r/CreditCards/comments/1vssnb1/when_should_i_get_rid_of_my_lower_end_cards/) | Capital One Savor Cash Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Stay away from capital one!](https://www.reddit.com/r/CreditCards/comments/1vva29o/stay_away_from_capital_one/) | Capital One VentureOne Rewards · approved | credit_score, date_applied | What was your score at the time, and which bureau? Roughly when did you apply? |
| [Balance Transfer from Chase to NFCU](https://www.reddit.com/r/CreditCards/comments/1vutbz0/balance_transfer_from_chase_to_nfcu/) | Navy Federal Platinum · approved | credit_score | What was your score at the time, and which bureau? |
| [Amex multiple hard inquiries for BCE](https://www.reddit.com/r/CreditCards/comments/1vvxe1n/amex_multiple_hard_inquiries_for_bce/) | Blue Cash Everyday · approved | credit_score | What was your score at the time, and which bureau? |
| [Need a rec when turned down for cap1 with a high credit scor…](https://www.reddit.com/r/CreditCards/comments/1vvwbx7/need_a_rec_when_turned_down_for_cap1_with_a_high/) | denied | card_name | Which card exactly was it? |
| [Chase Marriott Bonvoy Boundless](https://www.reddit.com/r/CreditCards/comments/1vvltuj/chase_marriott_bonvoy_boundless/) | Marriott Bonvoy Boundless · approved | credit_score | What was your score at the time, and which bureau? |
| [BofA Flying blue Card- possibly denied](https://www.reddit.com/r/CreditCards/comments/1vvk74b/bofa_flying_blue_card_possibly_denied/) | Air France KLM Visa Signature | result | How did it end up, approved or denied? |
| [Debating on next card; to complete C1 setup or try and pivot](https://www.reddit.com/r/CreditCards/comments/1vwstfm/debating_on_next_card_to_complete_c1_setup_or_try/) | Bilt Palladium · denied | credit_score | What was your score at the time, and which bureau? |
| [ITIN holder with 6 months of U.S. credit history—stuck with …](https://www.reddit.com/r/CreditCards/comments/1vxxsog/itin_holder_with_6_months_of_us_credit/) | Amazon Prime Rewards Visa Signature · denied | credit_score, date_applied | What was your score at the time, and which bureau? Roughly when did you apply? |
| [Citi Custom vs. Double Cash Reconsideration](https://www.reddit.com/r/CreditCards/comments/1vx8o5y/citi_custom_vs_double_cash_reconsideration/) | Citi Double Cash · denied | credit_score | What was your score at the time, and which bureau? |
| [Late 2026 / early 2027 card roadmap. (Want to capitalize on …](https://www.reddit.com/r/CreditCards/comments/1vynjsd/late_2026_early_2027_card_roadmap_want_to/) | Chase Freedom Unlimited · denied | credit_score | What was your score at the time, and which bureau? |
| [Trying to get Savor to pair with Venture X to complete setup](https://www.reddit.com/r/CreditCards/comments/1vync0s/trying_to_get_savor_to_pair_with_venture_x_to/) | Capital One Venture X Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Back to back approvals for Altitude Go + MCP](https://www.reddit.com/r/CreditCards/comments/1w068db/back_to_back_approvals_for_altitude_go_mcp/) | US Bank Altitude Go Visa Signature · approved | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 7 | No stated approval or denial (odds question, recommendation request, chatter) |
| `no_score` | 1 | Real outcome but no credit score anywhere, and below the pending bar |
| `pre_qual` | 1 | Pre-qualification or pre-approval result, which is never an outcome |


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
