### PR TITLE
Auto: British Airways Visa Signature rewards/benefits update — 2026-08-30

### DIFF
--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -74,6 +74,13 @@ benefits:
     description: "Coverage for eligible new purchases against damage or theft up to $500 per item for 120 days from purchase date"
     category: "protection"
     enrollment_required: false
+  - name: "Anniversary Avios Bonus"
+    value: 2500
+    value_unit: "miles"
+    description: "2,500 bonus Avios each account anniversary year"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: false
 our_take: >
   The reason to carry this card is the reward flight statement credits: up to
   three per year, $100 for Economy or Premium Economy and $200 for Business or


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **British Airways Visa Signature**.

**Apply link (verify against this):** https://creditcards.chase.com/travel-credit-cards/british-airways

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
