### PR TITLE
Auto: Citi AAdvantage Executive World Legend Mastercard rewards/benefits update — 2026-08-30

### DIFF
--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -68,6 +68,12 @@ benefits:
     frequency: "annual"
     category: "rewards"
     enrollment_required: false
+  - name: "Omni Free Night Award"
+    value: 0
+    description: "Once per calendar year, primary cardmembers earn an Omni Free Night Award after completing a stay of two or more consecutive nights booked directly on omnihotels.com."
+    frequency: "annual"
+    category: "hotel"
+    enrollment_required: true
 tags:
   - travel
   - airline


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Citi AAdvantage Executive World Legend Mastercard**.

**Apply link (verify against this):** https://www.citi.com/credit-cards/citi-aadvantage-executive-world-legend-mastercard

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
