### PR TITLE
Auto: Iberia Visa Signature rewards/benefits update — 2026-08-30

### DIFF
--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -81,4 +81,11 @@ benefits:
     description: "Coverage for eligible new purchases for 120 days from purchase against damage or theft up to $500 per item"
     category: "protection"
     enrollment_required: false
+  - name: "Anniversary Avios Bonus"
+    value: 2500
+    value_unit: "miles"
+    description: "2,500 bonus Avios each account anniversary year"
+    frequency: "annual"
+    category: "rewards"
+    enrollment_required: false
 apply_link: https://creditcards.chase.com/travel-credit-cards/avios/iberia


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Iberia Visa Signature**.

**Apply link (verify against this):** https://creditcards.chase.com/travel-credit-cards/avios/iberia

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
