### PR TITLE
Let the rewards check resume a partial sweep

### DIFF
--- a/scripts/check-card-rewards-and-benefits.js
+++ b/scripts/check-card-rewards-and-benefits.js
@@ -86,9 +86,16 @@ const MAX_CONTENT_CHARS = 18000;
 const FETCH_DELAY_MS = 2000;
 const FETCH_TIMEOUT_MS = 15000;
 const PER_CARD_TIMEOUT_MS = 90 * 1000;
-// A full sweep of every active card runs ~20 min. Keep real headroom: hitting
-// this cap stops the run early, silently dropping the tail of the alphabet.
-const SCRIPT_TIMEOUT_MS = 35 * 60 * 1000;
+// A flat 35 min was sized when a full sweep ran ~20. It no longer does: the
+// catalog reached 184 active cards, and on 2026-08-30 the fetch phase averaged
+// ~26s/card and burned the whole 35 min on the first 82, stranding everything
+// past "Discover it Cash Back" unchecked. Give 'fetch' the same larger budget
+// the sibling check-card-pages.js already uses — it runs locally with no job
+// cap. The other phases keep 35 min, which stays under the workflow's
+// `timeout-minutes: 50` so a capped run still exits in time to open its PRs.
+const SCRIPT_TIMEOUT_MS = Number(
+  process.env.CARD_RB_SCRIPT_TIMEOUT_MS || (PHASE === 'fetch' ? 150 * 60 * 1000 : 35 * 60 * 1000)
+);
 
 // ─── Timeout helpers ─────────────────────────────────────────────────────────
 
@@ -150,7 +157,15 @@ function filterCardsForCheck(allCards, slugFilter) {
     c => c.data.accepting_applications !== false && c.data.apply_link
   );
   if (slugFilter) {
-    cards = cards.filter(c => c.slug === slugFilter);
+    // CARD_SLUG accepts a single slug or a comma-separated list, so a run can be
+    // scoped to just the cards a previous run never reached (recovery pass)
+    // without re-fetching the whole catalog. Matches the sibling
+    // check-card-pages.js, and pairs with the `not_reached` list the fetch
+    // phase writes into fetch-state.json.
+    const wanted = new Set(
+      slugFilter.split(',').map(s => s.trim()).filter(Boolean)
+    );
+    cards = cards.filter(c => wanted.has(c.slug));
     if (cards.length === 0) {
       console.warn(`Warning: No active card with apply_link found for slug "${slugFilter}"`);
     }
@@ -2113,6 +2128,11 @@ async function main() {
     fetched: 0,
     extractFailed: 0,
     fetchFailed: 0,
+    // Cards the run never got to because it ran out of clock. Non-zero means
+    // this sweep was partial: those cards were not checked and not skipped,
+    // they simply never came up. Re-run scoped to the `not_reached` list in
+    // fetch-state.json to finish the catalog.
+    notReached: 0,
     cardsModified: 0,
     autoChanges: 0,
     reviewItems: 0,
@@ -2128,10 +2148,18 @@ async function main() {
   };
 
   const startMs = Date.now();
+  let notReached = [];
 
-  for (const card of cards) {
+  for (const [i, card] of cards.entries()) {
     if (Date.now() - startMs > SCRIPT_TIMEOUT_MS) {
-      console.warn(`Script-level timeout reached, stopping early.`);
+      // Record the cards we never reached. Without this the loop just breaks and
+      // they vanish — absent from the fetched set and from the summary — so a
+      // truncated run is indistinguishable from a clean one. That is exactly how
+      // the 2026-08-30 run reported a tidy 80-card sweep while 102 cards went
+      // unchecked.
+      notReached = cards.slice(i).map(c => c.slug);
+      const mins = SCRIPT_TIMEOUT_MS / 60000;
+      console.warn(`\nScript timeout reached (${mins} min) — stopping early; ${notReached.length} card(s) never checked.`);
       break;
     }
 
@@ -2204,14 +2232,26 @@ async function main() {
   await closeBrowser();
 
   if (PHASE === 'fetch') {
+    summary.notReached = notReached.length;
     fs.writeFileSync(FETCH_STATE_FILE, JSON.stringify({
       fetched_at: new Date().toISOString(),
       slug_filter: slugFilter || null,
       fetched: fetchedSlugs,
       fetch_failed: summary.fetchFailed,
+      not_reached: notReached,
     }, null, 2));
     console.log(`\nWrote ${fetchedSlugs.length} prompt(s) to ${path.relative(process.cwd(), PROMPTS_DIR)}`);
     console.log(`${summary.fetchFailed} card(s) could not be fetched.`);
+    if (notReached.length > 0) {
+      // The work dir is wiped at the start of every fetch, so a recovery pass
+      // has to be scoped or it will re-fetch the cards already answered here
+      // and time out in the same place.
+      console.log(`\n⚠️  ${notReached.length} card(s) never checked — this sweep is PARTIAL.`);
+      console.log('Answer and finish this batch first (the next fetch wipes the work dir),');
+      console.log('then run the rest with:');
+      console.log(`  CARD_SLUG="${notReached.join(',')}" \\`);
+      console.log('    node scripts/check-card-rewards-and-benefits.js --phase=fetch');
+    }
     console.log('\nNext: answer each prompt and write {"<slug>": {...}} to');
     console.log(`  ${path.relative(process.cwd(), EXTRACTIONS_FILE)}`);
     console.log('then run: node scripts/check-card-rewards-and-benefits.js --phase=finish');
@@ -2253,6 +2293,11 @@ function finishPhase({ cards, policy, sharedUrls }) {
     fetched: fetched.size,
     extractFailed: 0,
     fetchFailed: fetchState.fetch_failed || 0,
+    // Carried through from the fetch phase so the published summary reports the
+    // partial sweep too. finish only ever sees the cards fetch reached, so
+    // without this the final numbers look complete no matter how early the
+    // fetch stopped.
+    notReached: (fetchState.not_reached || []).length,
     cardsModified: 0,
     autoChanges: 0,
     reviewItems: 0,
@@ -2397,6 +2442,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  filterCardsForCheck,
   isSpendGatedDollarValue,
   editRewardCapFields,
   findRewardBlock,

--- a/scripts/check-card-rewards-and-benefits.test.js
+++ b/scripts/check-card-rewards-and-benefits.test.js
@@ -31,6 +31,7 @@ const {
   buildSharedUrlMap,
   isDeclined,
   loadDeclined,
+  filterCardsForCheck,
 } = require('./check-card-rewards-and-benefits');
 
 const NOOP_POLICY = { exclude: [], borderline: [], exampleCards: [] };
@@ -1012,6 +1013,53 @@ test('ignores an unconditional credit', () => {
 
 test('ignores a zero-valued perk even when the copy is gated', () => {
   assert.equal(gated('Companion certificate after $30,000 in purchases', 0), false);
+});
+
+console.log('\nCARD_SLUG filtering:');
+
+// A card as loadAllCards yields it: only the fields filterCardsForCheck reads.
+function card(slug, extra = {}) {
+  return { slug, data: { apply_link: `https://example.com/${slug}`, ...extra } };
+}
+
+const CATALOG = [
+  card('alpha'),
+  card('bravo'),
+  card('charlie'),
+  card('archived', { accepting_applications: false }),
+  card('no-link', { apply_link: undefined }),
+];
+
+test('no filter returns every active card with an apply_link', () => {
+  const got = filterCardsForCheck(CATALOG, '').map(c => c.slug);
+  assert.deepEqual(got, ['alpha', 'bravo', 'charlie']);
+});
+
+test('a single slug still works (the pre-list behavior)', () => {
+  const got = filterCardsForCheck(CATALOG, 'bravo').map(c => c.slug);
+  assert.deepEqual(got, ['bravo']);
+});
+
+test('a comma-separated list scopes the run to those cards', () => {
+  const got = filterCardsForCheck(CATALOG, 'alpha,charlie').map(c => c.slug);
+  assert.deepEqual(got, ['alpha', 'charlie']);
+});
+
+test('tolerates whitespace and trailing commas in the list', () => {
+  // The recovery command is copy-pasted from the fetch phase's own output, so
+  // stray separators must not silently drop a card.
+  const got = filterCardsForCheck(CATALOG, ' alpha , charlie ,').map(c => c.slug);
+  assert.deepEqual(got, ['alpha', 'charlie']);
+});
+
+test('a listed slug that is archived or link-less stays excluded', () => {
+  // The active/apply_link filter runs first; naming a card cannot force it in.
+  assert.deepEqual(filterCardsForCheck(CATALOG, 'archived,no-link'), []);
+});
+
+test('unknown slugs are dropped rather than throwing', () => {
+  const got = filterCardsForCheck(CATALOG, 'alpha,does-not-exist').map(c => c.slug);
+  assert.deepEqual(got, ['alpha']);
 });
 
 console.log('\nDone.\n');


### PR DESCRIPTION
## Why

The weekly rewards-and-benefits fetch has outgrown its 35-minute cap. With 184 active cards and apply pages averaging ~26s each, the 2026-08-30 run spent the entire budget on the first 82 cards and stopped at "Discover it Cash Back".

The bigger problem was not the truncation, it was the silence. The run wrote a summary reporting a tidy 80-card sweep. Nothing anywhere recorded that 102 cards had never been looked at, and there was no way to check just those cards afterwards: `CARD_SLUG` matched a single slug, and `--phase=fetch` wipes the work dir on start, so any second pass re-fetched the same first 82 and died in the same place.

## What changed

All three mirror conventions the sibling `check-card-pages.js` already uses.

**`SCRIPT_TIMEOUT_MS` is env-overridable and phase-aware.** The fetch phase gets 150 min (it runs locally from the `card-rewards-benefits-local` task, with no job cap); every other phase keeps the current 35 min, which stays under the workflow's `timeout-minutes: 50` so a capped run still exits in time to open its PRs. **CI behavior is unchanged** — the workflow dispatches `--phase=all`, which still resolves to 35 min. Override with `CARD_RB_SCRIPT_TIMEOUT_MS`.

**`CARD_SLUG` accepts a comma-separated list.** A recovery pass can be scoped to exactly the cards a previous run missed. Single-slug remains valid, so the workflow's `card_slug` dispatch input is untouched.

**A truncated fetch now says so.** It records a `notReached` count in the summary and a `not_reached` slug list in `fetch-state.json`, carries the count through to the finish phase, and prints the ready-to-paste recovery command:

```
⚠️  102 card(s) never checked — this sweep is PARTIAL.
Answer and finish this batch first (the next fetch wipes the work dir),
then run the rest with:
  CARD_SLUG="discover-it-for-students-card,discover-it-miles,..." \
    node scripts/check-card-rewards-and-benefits.js --phase=fetch
```

## Testing

`node scripts/check-card-rewards-and-benefits.test.js` — 92 pass, 0 fail. Six new cases cover the slug filter: no filter, single slug, comma list, whitespace and trailing commas, archived/link-less cards staying excluded even when named, and unknown slugs dropping rather than throwing. `filterCardsForCheck` is now exported to make that testable.

Verified the timeout resolves to 150 min for `--phase=fetch`, 35 min for `finish` and `all`, and honors the env override.

## Note

The 2026-08-30 catalog was completed by hand using exactly this mechanism (patched into throwaway worktrees), which is what these changes make permanent. Cards checked that day: 173 of 184. The 11 that failed to fetch or extract are listed in review issues #2122, #2125, and #2126.
