### PR TITLE
Card Page Check 2026-08-31

### DIFF
--- a/data/cards/target-circle-card.yaml
+++ b/data/cards/target-circle-card.yaml
@@ -17,11 +17,11 @@ rewards:
     unit: "percent"
     note: "Instant 5% discount at Target stores and Target.com, including in-store Starbucks and Target subscriptions; excludes Target GiftCards, prescriptions, and some services. A Mastercard version issued to well-qualified applicants also earns 2% on gas and dining and 1% everywhere else outside Target."
 signup_bonus:
-  value: 100
+  value: 50
   type: "cash"
   spend_requirement: 500
   timeframe_months: 2
-  note: "Get $50 in Target Circle Rewards when you are approved for a Target Circle credit card, plus an extra $50 in Target Circle Rewards when you spend $500 within 60 days of approval. Approval bonus offer ends 2026-09-26; spend bonus offer ends 2026-08-29."
+  note: "$50 in Target Circle Rewards deposited into your Target Circle account within 30 minutes of approval for a Target Circle credit card. Must apply by 2026-09-26."
 apr:
   regular:
     min: 27.4


### PR DESCRIPTION
## Card Page Check — 2026-08-31

Detected by fetching official apply pages and extracting card terms with an LLM.
**Verify each change against the source page before merging.**

### Term Changes

| Card | Field | Current | Detected | Source |
|------|-------|---------|----------|--------|
| Target Circle Card | signup_bonus.value | 100 | 50 | [apply page](https://www.target.com/circlecard) |
| Target Circle Card | signup_bonus.note | Get $50 in Target Circle Rewards when you are approved for a Target Circle credit card, plus an extra $50 in Target Circle Rewards when you spend $500 within 60 days of approval. Approval bonus offer ends 2026-09-26; spend bonus offer ends 2026-08-29. | $50 in Target Circle Rewards deposited into your Target Circle account within 30 minutes of approval for a Target Circle credit card. Must apply by 2026-09-26. | [apply page](https://www.target.com/circlecard) |

### How to Review
1. Click each source link and verify the detected value on the issuer's page
2. Remove any YAML changes that look incorrect before merging
3. Run `npm run build:cards` to validate

---
*Automated PR — review carefully before merging.*
