### PR TITLE
Reddit Data Points 2026-09-01

### DIFF
--- a/data/reddit-datapoints/2026-09-01-t3_1w3ybou.yaml
+++ b/data/reddit-datapoints/2026-09-01-t3_1w3ybou.yaml
@@ -1,0 +1,12 @@
+source_id: "t3_1w3ybou"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1w3ybou/chase_marriott_boundless_denial_reconsideration/"
+posted: "2026-09-01"
+evidence: "Poster reports a Marriott Boundless denial with scores of EX 747 / TU 750 and income in the low thirties, with Chase citing the maximum credit it would extend for that income; a reconsideration call to reallocate existing limits was refused."
+card_name: "Marriott Bonvoy Boundless"
+result: "denied"
+credit_score: 747
+credit_score_source: 0
+listed_income: 32000
+date_applied: "2026-09"
+reason_denied: "Chase had already extended the maximum credit it would offer at this income level."
+reason_denied_code: "too_much_credit_with_issuer"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-09-01

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1w3ybou](https://www.reddit.com/r/CreditCards/comments/1w3ybou/chase_marriott_boundless_denial_reconsideration/) | Marriott Bonvoy Boundless | denied | 747 | $32,000 | — | — | 2026-09 | `2026-09-01-t3_1w3ybou.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (8)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [ITIN holder with 6 months of U.S. credit history—stuck with …](https://www.reddit.com/r/CreditCards/comments/1vxxsog/itin_holder_with_6_months_of_us_credit/) | Amazon Prime Rewards Visa Signature · denied | credit_score, date_applied | What was your score at the time, and which bureau? Roughly when did you apply? |
| [Citi Custom vs. Double Cash Reconsideration](https://www.reddit.com/r/CreditCards/comments/1vx8o5y/citi_custom_vs_double_cash_reconsideration/) | Citi Double Cash · denied | credit_score | What was your score at the time, and which bureau? |
| [Late 2026 / early 2027 card roadmap. (Want to capitalize on …](https://www.reddit.com/r/CreditCards/comments/1vynjsd/late_2026_early_2027_card_roadmap_want_to/) | Chase Freedom Unlimited · denied | credit_score | What was your score at the time, and which bureau? |
| [Trying to get Savor to pair with Venture X to complete setup](https://www.reddit.com/r/CreditCards/comments/1vync0s/trying_to_get_savor_to_pair_with_venture_x_to/) | Capital One Venture X Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Back to back approvals for Altitude Go + MCP](https://www.reddit.com/r/CreditCards/comments/1w068db/back_to_back_approvals_for_altitude_go_mcp/) | US Bank Altitude Go Visa Signature · approved | credit_score | What was your score at the time, and which bureau? |
| [Got my first credit card at 26 after being scared to get one](https://www.reddit.com/r/CreditCards/comments/1w2ri7t/got_my_first_credit_card_at_26_after_being_scared/) | Capital One Quicksilver Secured Cash Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [AMEX Blue Cash Preferred 3x Credit Line Increase Strategy?](https://www.reddit.com/r/CreditCards/comments/1w1xm9d/amex_blue_cash_preferred_3x_credit_line_increase/) | Blue Cash Preferred · approved | credit_score | What was your score at the time, and which bureau? |
| [I got approved for a Chase Freedom Unlimited, now what?](https://www.reddit.com/r/CreditCards/comments/1w3zjrz/i_got_approved_for_a_chase_freedom_unlimited_now/) | Chase Freedom Unlimited · approved | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 13 | No stated approval or denial (odds question, recommendation request, chatter) |


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
